### PR TITLE
Fix for indicators to support custom data based on TradeBar class

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -316,7 +316,7 @@ namespace QuantConnect.Algorithm
             {
                 // find our subscription to this symbol
                 var subscription = SubscriptionManager.Subscriptions.First(x => x.Symbol == symbol);
-                if (subscription.Type == typeof(TradeBar))
+                if (subscription.Type == typeof(TradeBar) || subscription.Type.IsSubclassOf(typeof(TradeBar)))
                 {
                     if (!resolution.HasValue)
                     {


### PR DESCRIPTION
Custom HLOCV data that inherits from TradeBar class now supports auto-updates auf indicators.