### PR TITLE
Use market price for market orders when calculating required buying power.

### DIFF
--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -329,9 +329,13 @@ namespace QuantConnect.Securities
         /// <returns>decimal cash required to purchase order</returns>
         private decimal GetOrderRequiredBuyingPower(Order order)
         {
-            try 
+            try
             {
-                return Math.Abs(order.Value) / _securities[order.Symbol].Leverage;    
+                //If this is a market order, use the current market price to calculate order value
+                var orderValue = order.Type == OrderType.Market
+                    ? order.Quantity*_securities[order.Symbol].Price
+                    : order.Value;
+                return Math.Abs(orderValue) / _securities[order.Symbol].Leverage;    
             } 
             catch(Exception err)
             {


### PR DESCRIPTION
Since market orders are created with no price, the `Order.Value` property always returns 0. `SecurityTransactionManager.GetOrderRequiredBuyingPower` method was using `Order.Value` and always returned 0 for market orders. This resulted in market orders always being filled until cash becomes negative during backtests.  I've modified this method to use the current market price to determine order value. (Maybe transaction fees should be added here as well. )
