### PR TITLE
Fixes SecurityPortfolioManager.GetBuyingPower leverage bug

### DIFF
--- a/Common/Securities/Equity/Equity.cs
+++ b/Common/Securities/Equity/Equity.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.Securities.Equity
         {
             //Holdings for new Vehicle:
             Cache = new EquityCache();
-            Holdings = new EquityHolding(symbol, this.Model);
+            Holdings = new EquityHolding(symbol, leverage, this.Model);
             Exchange = new EquityExchange();
 
             //Set the Equity Transaction Model

--- a/Common/Securities/Equity/EquityHolding.cs
+++ b/Common/Securities/Equity/EquityHolding.cs
@@ -41,8 +41,8 @@ namespace QuantConnect.Securities.Equity
         /// <summary>
         /// Constructor for equities holdings.
         /// </summary>
-        public EquityHolding(string symbol, ISecurityTransactionModel transactionModel)
-            : base(symbol, SecurityType.Equity, transactionModel)
+        public EquityHolding(string symbol, decimal leverage, ISecurityTransactionModel transactionModel)
+            : base(symbol, SecurityType.Equity, leverage,  transactionModel)
         {
         }
 

--- a/Common/Securities/Forex/Forex.cs
+++ b/Common/Securities/Forex/Forex.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Securities.Forex
         {
             //Holdings for new Vehicle:
             Cache = new ForexCache();
-            Holdings = new ForexHolding(symbol, this.Model);
+            Holdings = new ForexHolding(symbol, leverage, this.Model);
             Exchange = new ForexExchange();
             Model = new ForexTransactionModel();
         }

--- a/Common/Securities/Forex/ForexHolding.cs
+++ b/Common/Securities/Forex/ForexHolding.cs
@@ -41,8 +41,8 @@ namespace QuantConnect.Securities.Forex
         /// <summary>
         /// Forex Holding Class
         /// </summary>
-        public ForexHolding(string symbol, ISecurityTransactionModel transactionModel)
-            : base(symbol, SecurityType.Forex, transactionModel)
+        public ForexHolding(string symbol, decimal leverage, ISecurityTransactionModel transactionModel)
+            : base(symbol, SecurityType.Forex, leverage, transactionModel)
         {
             //Nothing to do.
         }

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -214,7 +214,7 @@ namespace QuantConnect.Securities
 
             //Holdings for new Vehicle:
             Cache = new SecurityCache();
-            Holdings = new SecurityHolding(symbol, type, Model);
+            Holdings = new SecurityHolding(symbol, type, leverage, Model);
             Exchange = new SecurityExchange();
         }
 

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -36,6 +36,7 @@ namespace QuantConnect.Securities
         private decimal _averagePrice = 0;
         private int     _quantity = 0;
         private decimal _price = 0;
+        private decimal _leverage = 1;
         private readonly string  _symbol = "";
         private readonly SecurityType _securityType;
         private decimal _totalSaleVolume = 0;
@@ -51,20 +52,20 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Create a new holding class instance setting the initial properties to $0.
         /// </summary>
-        public SecurityHolding(string symbol, ISecurityTransactionModel transactionModel)
-            : this(symbol, SecurityType.Equity, transactionModel)
+        public SecurityHolding(string symbol, decimal leverage, ISecurityTransactionModel transactionModel)
+            : this(symbol, SecurityType.Equity, leverage, transactionModel)
         {
         }
 
         /// <summary>
         /// Create a new holding class instance setting the initial properties to $0.
         /// </summary>
-        public SecurityHolding(string symbol, SecurityType type, ISecurityTransactionModel transactionModel)
+        public SecurityHolding(string symbol, SecurityType type, decimal leverage, ISecurityTransactionModel transactionModel)
         {
             _model = transactionModel;
             _symbol = symbol;
+            _leverage = leverage;
             _securityType = type;
-
             //Total Sales Volume for the day
             _totalSaleVolume = 0;
             _lastTradeProfit = 0;
@@ -109,7 +110,17 @@ namespace QuantConnect.Securities
                 return _symbol;
             }
         }
-        
+
+        /// <summary>
+        /// Leverage of the underlying security.
+        /// </summary>
+        public virtual decimal Leverage
+        {
+            get
+            {
+                return _leverage;
+            }
+        }
 
         /// <summary>
         /// Acquisition cost of the security total holdings.
@@ -119,6 +130,17 @@ namespace QuantConnect.Securities
             get 
             {
                 return AveragePrice * Convert.ToDecimal(Quantity);
+            }
+        }
+
+        /// <summary>
+        /// Unlevered Acquisition cost of the security total holdings.
+        /// </summary>
+        public virtual decimal UnleveredHoldingsCost
+        {
+            get
+            {
+                return AveragePrice * Convert.ToDecimal(Quantity) / _leverage;
             }
         }
 
@@ -134,7 +156,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Absolute unlevered holdings cost for current holdings.
+        /// Absolute holdings cost for current holdings.
         /// </summary>
         /// <seealso cref="HoldingsCost"/>
         public virtual decimal AbsoluteHoldingsCost 
@@ -142,6 +164,17 @@ namespace QuantConnect.Securities
             get 
             {
                 return Math.Abs(HoldingsCost);
+            }
+        }
+
+        /// <summary>
+        /// Unlevered absolute acquisition cost of the security total holdings.
+        /// </summary>
+        public virtual decimal UnleveredAbsoluteHoldingsCost
+        {
+            get
+            {
+                return Math.Abs(UnleveredHoldingsCost);
             }
         }
 
@@ -178,7 +211,6 @@ namespace QuantConnect.Securities
                 return (AbsoluteQuantity > 0);
             }
         }
-
 
         /// <summary>
         /// Boolean flat indicating if we hold any of the security

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -140,7 +140,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return AveragePrice * Convert.ToDecimal(Quantity) / _leverage;
+                return AveragePrice * Convert.ToDecimal(Quantity) / Leverage;
             }
         }
 

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -313,7 +313,7 @@ namespace QuantConnect.Securities
         /// <returns>True if suficient capital.</returns>
         public bool GetSufficientCapitalForOrder(SecurityPortfolioManager portfolio, Order order)
         {
-            if (Math.Abs(GetOrderRequiredBuyingPower(order)) > portfolio.GetBuyingPower(order.Symbol, order.Direction)) 
+            if (Math.Abs(GetOrderCashImpact(order)) > portfolio.GetFreeCash(order.Symbol, order.Direction)) 
             {
                 //Log.Debug("Symbol: " + order.Symbol + " Direction: " + order.Direction.ToString() + " Quantity: " + order.Quantity);
                 //Log.Debug("GetOrderRequiredBuyingPower(): " + Math.Abs(GetOrderRequiredBuyingPower(order)) + " PortfolioGetBuyingPower(): " + portfolio.GetBuyingPower(order.Symbol, order.Direction)); 
@@ -327,7 +327,7 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="order">Order to check</param>
         /// <returns>decimal cash required to purchase order</returns>
-        private decimal GetOrderRequiredBuyingPower(Order order)
+        private decimal GetOrderCashImpact(Order order)
         {
             try
             {
@@ -335,8 +335,8 @@ namespace QuantConnect.Securities
                 //Market order is approximated from the current security price and set in the MarketOrder Method in QCAlgorithm.
                 var orderFees = _securities[order.Symbol].Model.GetOrderFee(order.Quantity, order.Price);
 
-                //Return the total buying power for the order, including fees:
-                return Math.Abs(order.Value) + orderFees; 
+                //Return the total cash impact for the order, including fees:
+                return Math.Abs(order.Value) / _securities[order.Symbol].Leverage + orderFees; 
             } 
             catch(Exception err)
             {

--- a/Common/Securities/SecurityTransactionModel.cs
+++ b/Common/Securities/SecurityTransactionModel.cs
@@ -322,7 +322,7 @@ namespace QuantConnect.Securities
         /// <param name="asset">Security asset we're checking</param>
         /// <param name="minimumPrice">Minimum price in the last data bar</param>
         /// <param name="maximumPrice">Minimum price in the last data bar</param>
-        public void DataMinMaxPrices(Security asset, out decimal minimumPrice, out decimal maximumPrice)
+        public virtual void DataMinMaxPrices(Security asset, out decimal minimumPrice, out decimal maximumPrice)
         {
             var marketData = asset.GetLastData();
 


### PR DESCRIPTION
Hi, 
This fixes the buying power issue we talked about earlier. I renamed the methods GetFreeCash and GetOrderCashImpact as we discussed. 

(I also made the DataMinMaxPrices method in SecurityTransactionManager virtual)
