### PR TITLE
The logic regarding the initial trade bar in TradeBarConsolidatorBase.cs:Update

### DIFF
--- a/Common/Data/Consolidators/TradeBarConsolidatorBase.cs
+++ b/Common/Data/Consolidators/TradeBarConsolidatorBase.cs
@@ -86,6 +86,9 @@ namespace QuantConnect.Data.Consolidators
         /// <summary>
         /// Updates this consolidator with the specified data. This method is
         /// responsible for raising the DataConsolidated event
+        /// In time span mode, the bar range is closed on the left and open on the right: [T, T+TimeSpan).
+        /// For example, if time span is 1 minute, we have [10:00, 10:01): so data at 10:01 is not 
+        /// included in the bar starting at 10:00.
         /// </summary>
         /// <param name="data">The new data for the consolidator</param>
         public override void Update(T data)
@@ -94,7 +97,7 @@ namespace QuantConnect.Data.Consolidators
             var fireDataConsolidated = false;
 
             // decide to aggregate data before or after firing OnDataConsolidated event
-            // always aggregate before firing if in counting mode
+            // always aggregate before firing in counting mode
             bool aggregateBeforeFire = _maxCount.HasValue; 
 
             if (_maxCount.HasValue)
@@ -122,7 +125,7 @@ namespace QuantConnect.Data.Consolidators
                     fireDataConsolidated = true;
                 }
 
-                // special case: always fire before event trigger when TimeSpan is zero
+                // special case: always aggregate before event trigger when TimeSpan is zero
                 if (_period.Value == TimeSpan.Zero)
                 {
                     aggregateBeforeFire = true;

--- a/Tests/Common/Data/TradeBarConsolidatorTests.cs
+++ b/Tests/Common/Data/TradeBarConsolidatorTests.cs
@@ -310,7 +310,11 @@ namespace QuantConnect.Tests.Common.Data
         }
 
         [Test]
-        public void TimeSpanConsolidatorDelayedAggregationTest()
+        /// Testing the behavious where, the bar range is closed on the left and open on 
+        /// the right in time span mode: [T, T+TimeSpan).
+        /// For example, if time span is 1 minute, we have [10:00, 10:01): so data at 
+        /// 10:01 is not included in the bar starting at 10:00.
+        public void ClosedLeftOpenRightInTimeSpanModeTest()
         {
             // define a three minute consolidator 
             int timeSpanUnits = 3;
@@ -325,23 +329,24 @@ namespace QuantConnect.Tests.Common.Data
             var refDateTime = new DateTime(2014, 12, 1, 10, 00, 0);
 
             // loop for 3 times the timeSpanUnits + 1, so it would consolidate the bars 3 times
-            for (int i=1; i <= timeSpanUnits * 3 + 1 ; ++i) 
+            for (int i=0; i < 3*timeSpanUnits + 1 ; ++i) 
             {
-                refDateTime = refDateTime.AddMinutes(1);
                 consolidator.Update(new TradeBar { Time = refDateTime });
 
-                if (i <= timeSpanUnits)  // before initial consolidation happens
+                if (i < timeSpanUnits)  // before initial consolidation happens
                 {
                     Assert.IsNull(consolidated);
                 }
                 else 
                 {
                     Assert.IsNotNull(consolidated);
-                    if (i-1 % timeSpanUnits == 0) // i = 4, 7, 10
+                    if (i % timeSpanUnits == 0) // i = 3, 6, 9
                     {
-                        Assert.AreEqual(refDateTime.AddMinutes(-(timeSpanUnits-1)), consolidated.Time);
+                        Assert.AreEqual(refDateTime.AddMinutes(-timeSpanUnits), consolidated.Time);
                     }
                 }
+
+                refDateTime = refDateTime.AddMinutes(1);
             }
         }
 

--- a/Tests/Common/Data/TradeBarConsolidatorTests.cs
+++ b/Tests/Common/Data/TradeBarConsolidatorTests.cs
@@ -130,11 +130,11 @@ namespace QuantConnect.Tests.Common.Data
 
             consolidator.Update(new TradeBar {Close = 2m, Time = reference.AddMinutes(1)});
             Assert.IsNotNull(consolidated);
-            Assert.AreEqual(2, consolidated.Close);
+            Assert.AreEqual(1, consolidated.Close);
 
             consolidator.Update(new TradeBar {Close = 3m, Time = reference.AddMinutes(2)});
             Assert.IsNotNull(consolidated);
-            Assert.AreEqual(3, consolidated.Close);
+            Assert.AreEqual(2, consolidated.Close);
         }
 
         [Test]
@@ -222,27 +222,27 @@ namespace QuantConnect.Tests.Common.Data
 
             //10:02 - new/fire
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(2)});
-            Assert.AreEqual(reference.AddMinutes(2), consolidated.Time);
+            Assert.AreEqual(reference.AddMinutes(1), consolidated.Time);
 
             //10:03 - new/fire
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(3)});
-            Assert.AreEqual(reference.AddMinutes(3), consolidated.Time);
+            Assert.AreEqual(reference.AddMinutes(2), consolidated.Time);
 
             //10:05 - new/fire
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(5)});
-            Assert.AreEqual(reference.AddMinutes(5), consolidated.Time);
+            Assert.AreEqual(reference.AddMinutes(3), consolidated.Time);
 
             //10:08 - new/fire
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(8)});
-            Assert.AreEqual(reference.AddMinutes(8), consolidated.Time);
+            Assert.AreEqual(reference.AddMinutes(5), consolidated.Time);
 
             //10:08:01 - new
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(8).AddSeconds(1)});
-            Assert.AreEqual(reference.AddMinutes(8), consolidated.Time);
+            Assert.AreEqual(reference.AddMinutes(5), consolidated.Time);
 
-            //10:08 - new/fire
+            //10:09 - new/fire
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(9)});
-            Assert.AreEqual(reference.AddMinutes(8).AddSeconds(1), consolidated.Time);
+            Assert.AreEqual(reference.AddMinutes(8), consolidated.Time);
 
         }
 
@@ -306,6 +306,42 @@ namespace QuantConnect.Tests.Common.Data
             foreach (var bar in StreamTradeBars(start, end, TimeSpan.FromMinutes(1)))
             {
                 consolidator.Update(bar);
+            }
+        }
+
+        [Test]
+        public void TimeSpanConsolidatorDelayedAggregationTest()
+        {
+            // define a three minute consolidator 
+            int timeSpanUnits = 3;
+            var consolidator = new TradeBarConsolidator(TimeSpan.FromMinutes(timeSpanUnits));
+
+            TradeBar consolidated = null;
+            consolidator.DataConsolidated += (sender, bar) =>
+            {
+                consolidated = bar;
+            };
+
+            var refDateTime = new DateTime(2014, 12, 1, 10, 00, 0);
+
+            // loop for 3 times the timeSpanUnits + 1, so it would consolidate the bars 3 times
+            for (int i=1; i <= timeSpanUnits * 3 + 1 ; ++i) 
+            {
+                refDateTime = refDateTime.AddMinutes(1);
+                consolidator.Update(new TradeBar { Time = refDateTime });
+
+                if (i <= timeSpanUnits)  // before initial consolidation happens
+                {
+                    Assert.IsNull(consolidated);
+                }
+                else 
+                {
+                    Assert.IsNotNull(consolidated);
+                    if (i-1 % timeSpanUnits == 0) // i = 4, 7, 10
+                    {
+                        Assert.AreEqual(refDateTime.AddMinutes(-(timeSpanUnits-1)), consolidated.Time);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
The AggregateBar() was always called before the OnDataConsolidated event was fired. This may result in an additional trade bar aggregated in TimeSpan-only mode.

The proposed logic is to aggregate the bars after firing the OnDataConsolidated event for TimeSpan-only consolidators, except when TimeSpan is TimeSpan.Zero.

Note that two test cases were updated to reflect the logic change, and an additional test case was written to verify the updated logic.