### PR TITLE
Questions about Roundup

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -311,7 +311,8 @@ namespace QuantConnect
                 // divide by zero exception
                 return time;
             }
-            return new DateTime(((time.Ticks + d.Ticks - 1) / d.Ticks) * d.Ticks);
+            //return new DateTime(((time.Ticks + d.Ticks - 1) / d.Ticks) * d.Ticks);
+            return time.AddTicks(time.Ticks / d.Ticks);
         }
 
         /// <summary>


### PR DESCRIPTION
line 314, the equation divide d.Ticks and then multiple it again? Or should it just be the reverse of "RoundDown" method:
return time.AddTicks(time.Ticks / d.Ticks);
Could anyone look into it?