### PR TITLE
Fixed bug when aggregating ticks + fixed issues #90 and #91

### DIFF
--- a/Common/Data/Consolidators/BaseDataConsolidator.cs
+++ b/Common/Data/Consolidators/BaseDataConsolidator.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Data.Consolidators
                 workingBar = new TradeBar
                 {
                     Symbol = data.Symbol,
-                    Time = data.Time,
+                    Time = GetRoundedBarTime(data.Time),
                     Close = data.Value,
                     High = data.Value,
                     Low = data.Value,

--- a/Common/Data/Consolidators/DynamicDataConsolidator.cs
+++ b/Common/Data/Consolidators/DynamicDataConsolidator.cs
@@ -112,7 +112,7 @@ namespace QuantConnect.Data.Consolidators
                 workingBar = new TradeBar
                 {
                     Symbol = data.Symbol,
-                    Time = data.Time,
+                    Time = GetRoundedBarTime(data.Time),
                     Open = open,
                     High = high,
                     Low = low,

--- a/Common/Data/Consolidators/TickConsolidator.cs
+++ b/Common/Data/Consolidators/TickConsolidator.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Data.Consolidators
                 workingBar = new TradeBar
                 {
                     Symbol = data.Symbol,
-                    Time = data.Time,
+                    Time = GetRoundedBarTime(data.Time),
                     Close = data.Value,
                     High = data.Value,
                     Low = data.Value,

--- a/Common/Data/Consolidators/TradeBarConsolidator.cs
+++ b/Common/Data/Consolidators/TradeBarConsolidator.cs
@@ -78,7 +78,7 @@ namespace QuantConnect.Data.Consolidators
             {
                 workingBar = new TradeBar
                 {
-                    Time = data.Time,
+                    Time = GetRoundedBarTime(data.Time),
                     Symbol = data.Symbol,
                     Open = data.Open,
                     High = data.High,

--- a/Tests/Common/Data/BaseDataConsolidatorTests.cs
+++ b/Tests/Common/Data/BaseDataConsolidatorTests.cs
@@ -151,5 +151,37 @@ namespace QuantConnect.Tests.Common.Data
             Assert.IsNotNull(consolidated);
             Assert.AreEqual(TimeSpan.FromDays(1), consolidated.Period);
         }
+
+        [Test]
+        public void AggregatesPeriodInPeriodModeWithDailyDataAndRoundedTime()
+        {
+            TradeBar consolidated = null;
+            var consolidator = new BaseDataConsolidator(TimeSpan.FromDays(1));
+            consolidator.DataConsolidated += (sender, bar) =>
+            {
+                consolidated = bar;
+            };
+
+            var reference = new DateTime(2015, 04, 13);
+            consolidator.Update(new Tick { Time = reference.AddSeconds(45) });
+            Assert.IsNull(consolidated);
+
+            consolidator.Update(new Tick { Time = reference.AddDays(1).AddMinutes(1) });
+            Assert.IsNotNull(consolidated);
+            Assert.AreEqual(TimeSpan.FromDays(1), consolidated.Period);
+            Assert.AreEqual(reference, consolidated.Time);
+            consolidated = null;
+
+            consolidator.Update(new Tick { Time = reference.AddDays(2).AddHours(1).AddMinutes(1).AddSeconds(1) });
+            Assert.IsNotNull(consolidated);
+            Assert.AreEqual(TimeSpan.FromDays(1), consolidated.Period);
+            Assert.AreEqual(reference.AddDays(1), consolidated.Time);
+            consolidated = null;
+
+            consolidator.Update(new Tick { Time = reference.AddDays(3) });
+            Assert.IsNotNull(consolidated);
+            Assert.AreEqual(TimeSpan.FromDays(1), consolidated.Period);
+            Assert.AreEqual(reference.AddDays(2), consolidated.Time);
+        }
     }
 }

--- a/Tests/Common/Data/TickConsolidatorTests.cs
+++ b/Tests/Common/Data/TickConsolidatorTests.cs
@@ -140,5 +140,112 @@ namespace QuantConnect.Tests.Common.Data
             Assert.IsNotNull(consolidated);
             Assert.AreEqual(TimeSpan.FromDays(1), consolidated.Period);
         }
+
+        [Test]
+        public void AggregatesPeriodInPeriodModeWithDailyDataAndRoundedTime()
+        {
+            TradeBar consolidated = null;
+            var consolidator = new TickConsolidator(TimeSpan.FromDays(1));
+            consolidator.DataConsolidated += (sender, bar) =>
+            {
+                consolidated = bar;
+            };
+
+            var reference = new DateTime(2015, 04, 13);
+            consolidator.Update(new Tick { Time = reference.AddSeconds(5) });
+            Assert.IsNull(consolidated);
+
+            consolidator.Update(new Tick { Time = reference.AddDays(1).AddSeconds(15) });
+            Assert.IsNotNull(consolidated);
+            Assert.AreEqual(TimeSpan.FromDays(1), consolidated.Period);
+            Assert.AreEqual(reference, consolidated.Time);
+            consolidated = null;
+
+            consolidator.Update(new Tick { Time = reference.AddDays(2).AddMinutes(1) });
+            Assert.IsNotNull(consolidated);
+            Assert.AreEqual(TimeSpan.FromDays(1), consolidated.Period);
+            Assert.AreEqual(reference.AddDays(1), consolidated.Time);
+            consolidated = null;
+
+            consolidator.Update(new Tick { Time = reference.AddDays(3).AddMinutes(5) });
+            Assert.IsNotNull(consolidated);
+            Assert.AreEqual(TimeSpan.FromDays(1), consolidated.Period);
+            Assert.AreEqual(reference.AddDays(2), consolidated.Time);
+        }
+
+        [Test]
+        public void AggregatesNewTicksInPeriodWithRoundedTime()
+        {
+            TradeBar consolidated = null;
+            var consolidator = new TickConsolidator(TimeSpan.FromMinutes(1));
+            consolidator.DataConsolidated += (sender, bar) =>
+            {
+                consolidated = bar;
+            };
+
+            var reference = new DateTime(2015, 06, 02);
+            var tick1 = new Tick
+            {
+                Symbol = "EURUSD",
+                Time = reference.AddSeconds(3),
+                Value = 1.1000m
+            };
+            consolidator.Update(tick1);
+            Assert.IsNull(consolidated);
+
+            var tick2 = new Tick
+            {
+                Symbol = "EURUSD",
+                Time = reference.AddSeconds(10),
+                Value = 1.1005m
+            };
+            consolidator.Update(tick2);
+            Assert.IsNull(consolidated);
+
+            var tick3 = new Tick
+            {
+                Symbol = "EURUSD",
+                Time = reference.AddSeconds(61),
+                Value = 1.1010m
+            };
+            consolidator.Update(tick3);
+            Assert.IsNotNull(consolidated);
+
+            Assert.AreEqual(consolidated.Time, reference);
+            Assert.AreEqual(consolidated.Open, tick1.Value);
+            Assert.AreEqual(consolidated.Close, tick2.Value);
+
+            var tick4 = new Tick
+            {
+                Symbol = "EURUSD",
+                Time = reference.AddSeconds(70),
+                Value = 1.1015m
+            };
+            consolidator.Update(tick4);
+            Assert.IsNotNull(consolidated);
+
+            var tick5 = new Tick
+            {
+                Symbol = "EURUSD",
+                Time = reference.AddSeconds(118),
+                Value = 1.1020m
+            };
+            consolidator.Update(tick5);
+            Assert.IsNotNull(consolidated);
+
+            var tick6 = new Tick
+            {
+                Symbol = "EURUSD",
+                Time = reference.AddSeconds(140),
+                Value = 1.1025m
+            };
+            consolidator.Update(tick6);
+            Assert.IsNotNull(consolidated);
+
+            Assert.AreEqual(consolidated.Time, reference.AddSeconds(60));
+            Assert.AreEqual(consolidated.Open, tick3.Value);
+            Assert.AreEqual(consolidated.Close, tick5.Value);
+        }
+
     }
 }


### PR DESCRIPTION
With this update the TickConsolidator now aggregates ticks correctly (previously ticks were increasingly shifted forward - to the following bars).