### PR TITLE
fix for ticks in IB connector

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1358,49 +1358,25 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                     tick.Value = tick.AskPrice;
                     break;
-
-                case IB.TickType.Volume:
-
-                    bool bSend = true;
-                    int lastVolume;
-                    decimal lastPrice; 
-
-                    tick.TickType = TickType.Trade;
-
-                    if (!_lastVolumes.TryGetValue(symbol, out lastVolume))
-                    {
-                        bSend = false;
-                    }
-                    else if (e.Size <= lastVolume)
-                    {
-                        bSend = false;
-                    }
-                    else if (!_lastPrices.TryGetValue(symbol, out lastPrice))
-                    {
-                        bSend = false;
-                    }
-                    else
-                    {
-                        tick.Value = lastPrice;
-                    };
-
-                    if (bSend)
-                        tick.Quantity = AdjustQuantity(symbol.Item1, e.Size - lastVolume);
-
-                    if (e.Size > 0)
-                    {
-                        _lastVolumes[symbol] = e.Size;
-                    }
-
-                    break;
+                
                 
                 case IB.TickType.LastSize:
+                    tick.TickType = TickType.Trade;
+
+                    decimal lastPrice;
+                    _lastPrices.TryGetValue(symbol, out lastPrice);
+                    _lastVolumes[symbol] = tick.Quantity;
+
+                    tick.Value = lastPrice;
+                        
+                    break;
+
                 default:
                     return;
             }
-
             lock (_ticks)
                 if (tick.IsValid()) _ticks.Add(tick);
+
         }
 
         private ConcurrentDictionary<SymbolCacheKey, int> _subscribedSymbols = new ConcurrentDictionary<SymbolCacheKey, int>();

--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -330,6 +330,15 @@ namespace QuantConnect.Data.Market
             Quantity = Convert.ToInt32(volume);
         }
 
+        /// <summary>
+        /// Check if tick contains valid data (either a trade, or a bid or ask)
+        /// </summary>
+        public bool IsValid()
+        {
+            return (TickType == TickType.Trade && LastPrice > 0.0m && Quantity > 0) ||
+                   (TickType == TickType.Quote && AskPrice > 0.0m && Quantity > 0) ||
+                   (TickType == TickType.Quote && BidPrice > 0.0m && Quantity > 0);
+        }
 
         /// <summary>
         /// Clone implementation for tick class:


### PR DESCRIPTION
I think that previous merge was not good:

* in terms of ticks accumulating in the _ticks you were right - GetNextTicks could loop infitintely in the high load. it is fixed now.

* as for your modification of HandleTickPrice, it is not correct. Just imagine what would happen if as a market participant you are making the market and you have the standing limit buy order at 1,5 size 10 (that is bid in the market depth for other participants), and you then moved your order to 1.4. This case wont be reflected in your system at all since size has not changed. so the information is getting lost. This is fixed now.

I defined a valid tick in the system: the one that either is a nonzero trade, or ask or bid. I admit that your Tick class is designed to hold one of those, but not all at once. 