### PR TITLE
Faster TradeBar Clone method

### DIFF
--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -349,5 +349,11 @@ namespace QuantConnect.Data.Market
             var source = Path.Combine(Constants.DataFolder, securityTypePath, resolutionPath, symbolPath, filename);
             return new SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile);
         }
+
+        public override BaseData Clone()
+        {
+            return (BaseData)MemberwiseClone();
+        }
+
     } // End Trade Bar Class
 }


### PR DESCRIPTION
The BaseData.Clone() method uses Reflection for object cloning which is very slow. 

The TradeBar class does not have any reference type fields, so a fast shallow copy using MemberwiseClone() can be safely used.

This change alone gives a BenchmarkAlgo speed improvement (from 251k to 265k points/sec.)

In general, it would be better if possible to avoid using reflection at all.
The faster way of doing a deep copy of any BaseData-derived object (assuming it has reference type fields in it) is to call MemberwiseClone() first and then copy the reference type fields manually (in a Clone() override).