### PR TITLE
Optimization in DataStream.GetData

### DIFF
--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -349,5 +349,11 @@ namespace QuantConnect.Data.Market
             var source = Path.Combine(Constants.DataFolder, securityTypePath, resolutionPath, symbolPath, filename);
             return new SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile);
         }
+
+        public override BaseData Clone()
+        {
+            return (BaseData)MemberwiseClone();
+        }
+
     } // End Trade Bar Class
 }

--- a/Engine/DataStream.cs
+++ b/Engine/DataStream.cs
@@ -101,13 +101,15 @@ namespace QuantConnect.Lean.Engine
                             // if there's no item skip to the next subscription
                             break;
                         }
-                        if (result.Count > 0 && result[0].EndTime > frontier)
+
+                        DateTime endTime = result[0].EndTime;
+                        if (result.Count > 0 && endTime > frontier)
                         {
                             // we have at least one item, check to see if its in ahead of the frontier,
                             // if so, keep track of how many ticks in the future it is
-                            if (earlyBirdTicks == 0 || earlyBirdTicks > result[0].EndTime.Ticks)
+                            if (earlyBirdTicks == 0 || earlyBirdTicks > endTime.Ticks)
                             {
-                                earlyBirdTicks = result[0].EndTime.Ticks;
+                                earlyBirdTicks = endTime.Ticks;
                             }
                             break;
                         }
@@ -115,9 +117,9 @@ namespace QuantConnect.Lean.Engine
                         {
                             // we have at least one item, check to see if its in ahead of the frontier,
                             // if so, keep track of how many ticks in the future it is
-                            if (earlyBirdTicks == 0 || earlyBirdTicks > result[0].EndTime.Ticks)
+                            if (earlyBirdTicks == 0 || earlyBirdTicks > endTime.Ticks)
                             {
-                                earlyBirdTicks = result[0].EndTime.Ticks;
+                                earlyBirdTicks = endTime.Ticks;
                             }
                         }
 


### PR DESCRIPTION
This method is performance-critical, so even the simple caching of the EndTime property value can give a speed improvement.

Benchmark Algo: from 265k to 273k points/sec