### PR TITLE
Added Security.SetMarket

### DIFF
--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Text.RegularExpressions;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities.Equity;
@@ -424,6 +425,9 @@ namespace QuantConnect.Securities
         {
             if (string.IsNullOrWhiteSpace(market))
                 throw new ArgumentException("The market cannot be an empty string.");
+
+            if (!Regex.IsMatch(market, @"^[a-zA-Z]+$"))
+                throw new ArgumentException("The market must only contain letters A-Z.");
 
             _config.Market = market;
         }

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -417,5 +417,16 @@ namespace QuantConnect.Securities
             _config.DataNormalizationMode = mode;
         }
 
+        /// <summary>
+        /// Sets the market / scope for this security
+        /// </summary>
+        public void SetMarket(string market)
+        {
+            if (string.IsNullOrWhiteSpace(market))
+                throw new ArgumentException("The market cannot be an empty string.");
+
+            _config.Market = market;
+        }
+
     } // End Security
 } // End QC Namespace


### PR DESCRIPTION
This enables users to download, convert and use data from providers currently unsupported by Lean (e.g. Oanda, Alpari, etc.)

The location of the custom data is, as usual, \data-folder\security-type\market\resolution\symbol\...

Usage example, in algorithm Initialize():

```
AddSecurity(SecurityType.Forex, "EURUSD", Resolution.Tick);
Securities["EURUSD"].SetMarket("Alpari");
```
