### PR TITLE
Removed 1024 MB ram limit for desktop Lean

### DIFF
--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Lean.Engine
         /// </summary>
         /// <param name="job">The algorithm job</param>
         /// <returns>The ram size in MB</returns>
-        public int GetRamAllocation(AlgorithmNodePacket job)
+        private int GetRamAllocation(AlgorithmNodePacket job)
         {
             return (job.UserPlan == UserPlan.Free && !_isLocal) ? Math.Min(1024, MaximumRamAllocation) : MaximumRamAllocation;
         }

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -51,7 +51,7 @@ namespace QuantConnect.Tests
             // run the algorithm in its own thread
             var systemHandlers = LeanEngineSystemHandlers.FromConfiguration(Composer.Instance);
             var algorithmHandlers = LeanEngineAlgorithmHandlers.FromConfiguration(Composer.Instance);
-            var engine = new Lean.Engine.Engine(systemHandlers, algorithmHandlers, false);
+            var engine = new Lean.Engine.Engine(systemHandlers, algorithmHandlers, true, false);
             Task.Factory.StartNew(() =>
             {
                 engine.Run();

--- a/UserInterface/WinForms/LeanEngineWinForm.cs
+++ b/UserInterface/WinForms/LeanEngineWinForm.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.Views.WinForms
 
             var systemHandlers = LeanEngineSystemHandlers.FromConfiguration(Composer.Instance);
             var algorithmHandlers = LeanEngineAlgorithmHandlers.FromConfiguration(Composer.Instance);
-            var engine = new Engine(systemHandlers, algorithmHandlers, Config.GetBool("live-mode"));
+            var engine = new Engine(systemHandlers, algorithmHandlers, Config.GetBool("local"), Config.GetBool("live-mode"));
             _leanEngineThread = new Thread(() =>
             {
                 engine.Run();


### PR DESCRIPTION
On a local (desktop) installation of Lean, currently there is a limit of 1024 MB of ram usage.

With large backtests (more than 20-30K orders) this limit can be easily hit.

This change removes this limitation.