### PR TITLE
Thread safety in ConsoleResultHandler.Sample

### DIFF
--- a/Engine/Results/ConsoleResultHandler.cs
+++ b/Engine/Results/ConsoleResultHandler.cs
@@ -242,12 +242,14 @@ namespace QuantConnect.Lean.Engine.Results
         public void Sample(string chartName, ChartType chartType, string seriesName, SeriesType seriesType, DateTime time, decimal value, string unit = "$")
         {
             var chartFilename = Path.Combine(_chartDirectory, chartName + "-" + seriesName + ".csv");
-            using (var writer = new StreamWriter(File.Open(chartFilename, FileMode.Append)))
-            {
-                writer.WriteLine(time + "," + value);
-            }
+
             lock (_chartLock)
             {
+                using (var writer = new StreamWriter(File.Open(chartFilename, FileMode.Append)))
+                {
+                    writer.WriteLine(time + "," + value);
+                }
+
                 //Add a copy locally:
                 if (!Charts.ContainsKey(chartName))
                 {


### PR DESCRIPTION
The function is not thread-safe. Occasionally the following error occurs:

Engine.Run(): The process cannot access the file 'C:\...\Lean\Charts\...\...\Strategy Equity-Daily Performance.csv' because it is being used by another process.