### PR TITLE
BaseData.Bridge is now a bounded BlockingCollection

### DIFF
--- a/Engine/DataFeeds/DatabaseDataFeed.cs
+++ b/Engine/DataFeeds/DatabaseDataFeed.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// Cross-threading queue so the datafeed pushes data into the queue and the primary algorithm thread reads it out.
         /// </summary>
-        public ConcurrentQueue<TimeSlice> Bridge { get; private set; }
+        public BlockingCollection<TimeSlice> Bridge { get; private set; }
 
         /// <summary>
         /// End of Stream for Each Bridge:
@@ -105,7 +105,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="resultHandler"></param>
         public void Initialize(IAlgorithm algorithm, AlgorithmNodePacket job, IResultHandler resultHandler)
         {
-            Bridge = new ConcurrentQueue<TimeSlice>();
+            Bridge = new BlockingCollection<TimeSlice>();
 
             //Save the data subscriptions
             Subscriptions = algorithm.SubscriptionManager.Subscriptions;
@@ -226,7 +226,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 Dictionary<int, List<BaseData>> timeSlice;
                 if (items.TryGetValue(frontier, out timeSlice))
                 {
-                    Bridge.Enqueue(new TimeSlice(frontier, timeSlice));
+                    Bridge.Add(new TimeSlice(frontier, timeSlice));
                 }
             }
             LoadingComplete = true;
@@ -268,7 +268,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public void Exit()
         {
             _exitTriggered = true;
-            Bridge.Clear();
+            Bridge.Dispose();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/IDataFeed.cs
+++ b/Engine/DataFeeds/IDataFeed.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// Cross-threading queue so the datafeed pushes data into the queue and the primary algorithm thread reads it out.
         /// </summary>
-        ConcurrentQueue<TimeSlice> Bridge
+        BlockingCollection<TimeSlice> Bridge
         {
             get;
         }

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// Cross-threading queue so the datafeed pushes data into the queue and the primary algorithm thread reads it out.
         /// </summary>
-        public ConcurrentQueue<TimeSlice> Bridge
+        public BlockingCollection<TimeSlice> Bridge
         {
             get; private set;
         }
@@ -106,7 +106,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             //Subscription Count:
             _subscriptions = algorithm.SubscriptionManager.Subscriptions;
 
-            Bridge = new ConcurrentQueue<TimeSlice>();
+            Bridge = new BlockingCollection<TimeSlice>();
 
             //Set Properties:
             _isActive = true;
@@ -244,7 +244,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     }
                 }
 
-                Bridge.Enqueue(new TimeSlice(triggerTime, items));
+                Bridge.Add(new TimeSlice(triggerTime, items));
             });
 
             //Start the realtime sampler above
@@ -320,7 +320,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                                 //If its not a tick, inject directly into bridge for this symbol:
                                 //Bridge[i].Enqueue(new List<BaseData> {point});
-                                Bridge.Enqueue(new TimeSlice(DateTime.Now, new Dictionary<int, List<BaseData>>
+                                Bridge.Add(new TimeSlice(DateTime.Now, new Dictionary<int, List<BaseData>>
                                 {
                                     {i, new List<BaseData> {point}}
                                 }));

--- a/Engine/DataStream.cs
+++ b/Engine/DataStream.cs
@@ -52,14 +52,13 @@ namespace QuantConnect.Lean.Engine
         {
             do
             {
-                TimeSlice timeSlice;
-                while (_feed.Bridge.TryDequeue(out timeSlice))
+                foreach (var timeSlice in _feed.Bridge.GetConsumingEnumerable())
                 {
                     AlgorithmTime = timeSlice.Time;
                     yield return timeSlice.Data;
                 }
-            }
-            while (!_feed.LoadingComplete && !_feed.Bridge.IsEmpty);
+            } 
+            while (!_feed.Bridge.IsCompleted);
 
             Log.Trace("DataStream.GetData(): All Streams Completed.");
         }


### PR DESCRIPTION
This update uses a [BlockingCollection\<T\>](https://msdn.microsoft.com/en-us/library/dd267312(v=vs.110).aspx) in place of a *ConcurrentQueue\<T\>* for the bridges (by default the BlockingCollection uses a ConcurrentQueue under the hood anyway).

The bounding option works well, so it solves the high RAM usage, with fast data feeds (as binary) or slow algorithms. As a by-product, we get a nice speed improvement as well.

