### PR TITLE
Changed Padded Performance log Error to Trace

### DIFF
--- a/Common/Statistics/StatisticsBuilder.cs
+++ b/Common/Statistics/StatisticsBuilder.cs
@@ -287,12 +287,12 @@ namespace QuantConnect.Statistics
             while (listPerformance.Count < listBenchmark.Count)
             {
                 listPerformance.Add(0);
-                Log.Error("StatisticsBuilder.EnsureSameLength(): Padded Performance");
+                Log.Trace("StatisticsBuilder.EnsureSameLength(): Padded Performance");
             }
             while (listPerformance.Count > listBenchmark.Count)
             {
                 listBenchmark.Add(0);
-                Log.Error("StatisticsBuilder.EnsureSameLength(): Padded Benchmark");
+                Log.Trace("StatisticsBuilder.EnsureSameLength(): Padded Benchmark");
             }
         }
 


### PR DESCRIPTION
ERROR:: StatisticsBuilder.EnsureSameLength(): Padded Performance

This message is now more frequent, due to rolling statistics, and is not really an error.
