### PR TITLE
FxcmBrokerage.ConvertSymbol exception with CFD symbols

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.Util.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Util.cs
@@ -126,9 +126,13 @@ namespace QuantConnect.Brokerages.Fxcm
         {
             var symbol = instrument.getSymbol().Replace("/", "");
             var securityType = GetSecurityType(instrument);
-            if (securityType == SecurityType.Forex)
+            switch (securityType)
             {
-                return new Symbol(SecurityIdentifier.GenerateForex(symbol, Market.FXCM), symbol);
+                case SecurityType.Forex:
+                    return new Symbol(SecurityIdentifier.GenerateForex(symbol, Market.FXCM), symbol);
+
+                case SecurityType.Cfd:
+                    return new Symbol(SecurityIdentifier.GenerateCfd(symbol, Market.FXCM), symbol);
             }
 
             throw new ArgumentException("The specified security type is not supported: " + securityType);


### PR DESCRIPTION
The Fxcm brokerage implementation during logon receives all symbols (Forex and CFD) so this bug caused a timeout in the Connect method.