### PR TITLE
Changed BrokerageId from int to long

### DIFF
--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -928,7 +928,7 @@ namespace QuantConnect.Brokerages.Tradier
             var cachedOpenOrder = _cachedOpenOrdersByTradierOrderID.FirstOrDefault(x => x.Value.Symbol == order.Symbol.Value).Value;
             if (cachedOpenOrder != null)
             {
-                var qcOrder = _orderProvider.GetOrderByBrokerageId((int) cachedOpenOrder.Id);
+                var qcOrder = _orderProvider.GetOrderByBrokerageId(cachedOpenOrder.Id);
                 if (qcOrder == null)
                 {
                     // clean up our mess, this should never be encountered.
@@ -1376,7 +1376,7 @@ namespace QuantConnect.Brokerages.Tradier
                         {
                             // verify we don't have them in the order provider
                             Log.Trace("TradierBrokerage.CheckForFills(): Verifying missing brokerage IDs: " + string.Join(",", localUnknownTradierOrderIDs));
-                            var orders = localUnknownTradierOrderIDs.Select(x => _orderProvider.GetOrderByBrokerageId((int) x)).Where(x => x != null);
+                            var orders = localUnknownTradierOrderIDs.Select(x => _orderProvider.GetOrderByBrokerageId(x)).Where(x => x != null);
                             var stillUnknownOrderIDs = localUnknownTradierOrderIDs.Where(x => !orders.Any(y => y.BrokerId.Contains(x))).ToList();
                             if (stillUnknownOrderIDs.Count > 0)
                             {
@@ -1441,7 +1441,7 @@ namespace QuantConnect.Brokerages.Tradier
             if (updatedOrder.RemainingQuantity != cachedOrder.RemainingQuantity 
              || ConvertStatus(updatedOrder.Status) != ConvertStatus(cachedOrder.Status))
             {
-                var qcOrder = _orderProvider.GetOrderByBrokerageId((int)updatedOrder.Id);
+                var qcOrder = _orderProvider.GetOrderByBrokerageId(updatedOrder.Id);
                 const int orderFee = 0;
                 var fill = new OrderEvent(qcOrder, DateTime.UtcNow, orderFee, "Tradier Fill Event")
                 {
@@ -1609,7 +1609,7 @@ namespace QuantConnect.Brokerages.Tradier
             qcOrder.BrokerId.Add(order.Id);
             //qcOrder.ContingentId =
             qcOrder.Duration = ConvertDuration(order.Duration);
-            var orderByBrokerageId = _orderProvider.GetOrderByBrokerageId((int) order.Id);
+            var orderByBrokerageId = _orderProvider.GetOrderByBrokerageId(order.Id);
             if (orderByBrokerageId != null)
             {
                 qcOrder.Id = orderByBrokerageId.Id;

--- a/Common/Securities/IOrderProvider.cs
+++ b/Common/Securities/IOrderProvider.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="brokerageId">The brokerage id to fetch</param>
         /// <returns>The first order matching the brokerage id, or null if no match is found</returns>
-        Order GetOrderByBrokerageId(int brokerageId);
+        Order GetOrderByBrokerageId(long brokerageId);
 
         /// <summary>
         /// Gets and enumerable of <see cref="OrderTicket"/> matching the specified <paramref name="filter"/>

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -229,7 +229,7 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="brokerageId">The brokerage id to fetch</param>
         /// <returns>The first order matching the brokerage id, or null if no match is found</returns>
-        public Order GetOrderByBrokerageId(int brokerageId)
+        public Order GetOrderByBrokerageId(long brokerageId)
         {
             return _orderProcessor.GetOrderByBrokerageId(brokerageId);
         }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -336,7 +336,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// </summary>
         /// <param name="brokerageId">The brokerage id to fetch</param>
         /// <returns>The first order matching the brokerage id, or null if no match is found</returns>
-        public Order GetOrderByBrokerageId(int brokerageId)
+        public Order GetOrderByBrokerageId(long brokerageId)
         {
             // this function can be invoked by brokerages when getting open orders, guard against null ref
             if (_orders == null) return null;

--- a/Tests/Brokerages/OrderProvider.cs
+++ b/Tests/Brokerages/OrderProvider.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Tests.Brokerages
             return _orders.FirstOrDefault(x => x.Id == orderId);
         }
 
-        public Order GetOrderByBrokerageId(int brokerageId)
+        public Order GetOrderByBrokerageId(long brokerageId)
         {
             return _orders.FirstOrDefault(x => x.BrokerId.Contains(brokerageId));
         }


### PR DESCRIPTION
IOrderProvider.GetOrderByBrokerageId now accepts a long value (as required by Oanda and Tradier brokerages)