### PR TITLE
Oanda DataQueueHandler streams no data with more than one Subscribe request

### DIFF
--- a/Brokerages/Oanda/OandaBrokerage.Rest.cs
+++ b/Brokerages/Oanda/OandaBrokerage.Rest.cs
@@ -22,7 +22,6 @@ using System.Linq;
 using System.Net;
 using System.Runtime.Serialization.Json;
 using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 using QuantConnect.Brokerages.Oanda.DataType;
 using QuantConnect.Brokerages.Oanda.DataType.Communications;
@@ -233,7 +232,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// <param name="instruments">list of instruments to stream rates for</param>
         /// <param name="accountId">the account ID you want to stream on</param>
         /// <returns>the WebResponse object that can be used to retrieve the rates as they stream</returns>
-        public async Task<WebResponse> StartRatesSession(List<Instrument> instruments, int accountId)
+        public WebResponse StartRatesSession(List<Instrument> instruments, int accountId)
         {
             var instrumentList = string.Join(",", instruments.Select(x => x.instrument));
 
@@ -246,7 +245,7 @@ namespace QuantConnect.Brokerages.Oanda
 
             try
             {
-                var response = await request.GetResponseAsync();
+                var response = request.GetResponse();
                 return response;
             }
             catch (WebException ex)
@@ -263,7 +262,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// </summary>
         /// <param name="accountId">the account IDs you want to stream on</param>
         /// <returns>the WebResponse object that can be used to retrieve the events as they stream</returns>
-        public async Task<WebResponse> StartEventsSession(List<int> accountId = null)
+        public WebResponse StartEventsSession(List<int> accountId = null)
         {
             var requestString = EndpointResolver.ResolveEndpoint(_environment, Server.StreamingEvents) + "events";
 
@@ -279,7 +278,7 @@ namespace QuantConnect.Brokerages.Oanda
 
             try
             {
-                var response = await request.GetResponseAsync();
+                var response = request.GetResponse();
                 return response;
             }
             catch (WebException ex)

--- a/Brokerages/Oanda/Session/EventsSession.cs
+++ b/Brokerages/Oanda/Session/EventsSession.cs
@@ -19,7 +19,6 @@
 
 using System.Collections.Generic;
 using System.Net;
-using System.Threading.Tasks;
 using QuantConnect.Brokerages.Oanda.DataType;
 
 namespace QuantConnect.Brokerages.Oanda.Session
@@ -38,9 +37,9 @@ namespace QuantConnect.Brokerages.Oanda.Session
             _brokerage = brokerage;
         }
 
-        protected override async Task<WebResponse> GetSession()
+        protected override WebResponse GetSession()
         {
-            return await _brokerage.StartEventsSession(new List<int> {_accountId});
+            return _brokerage.StartEventsSession(new List<int> {_accountId});
         }
     }
 #pragma warning restore 1591

--- a/Brokerages/Oanda/Session/RatesSession.cs
+++ b/Brokerages/Oanda/Session/RatesSession.cs
@@ -19,7 +19,6 @@
 
 using System.Collections.Generic;
 using System.Net;
-using System.Threading.Tasks;
 using QuantConnect.Brokerages.Oanda.DataType;
 using QuantConnect.Brokerages.Oanda.DataType.Communications;
 
@@ -38,9 +37,9 @@ namespace QuantConnect.Brokerages.Oanda.Session
             _instruments = instruments;
         }
 
-        protected override async Task<WebResponse> GetSession()
+        protected override WebResponse GetSession()
         {
-            return await _brokerage.StartRatesSession(_instruments, _accountId);
+            return _brokerage.StartRatesSession(_instruments, _accountId);
         }
     }
 #pragma warning restore 1591

--- a/Brokerages/Oanda/Session/StreamSession.cs
+++ b/Brokerages/Oanda/Session/StreamSession.cs
@@ -53,12 +53,12 @@ namespace QuantConnect.Brokerages.Oanda.Session
             if (handler != null) handler(data);
         }
 
-        protected abstract Task<WebResponse> GetSession();
+        protected abstract WebResponse GetSession();
 
-        public async void StartSession()
+        public void StartSession()
         {
             _shutdown = false;
-            _response = await GetSession();
+            _response = GetSession();
 
             _runningTask = Task.Run(() =>
             {

--- a/Tests/Brokerages/Oanda/OandaBrokerageDataQueueHandlerTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageDataQueueHandlerTests.cs
@@ -35,7 +35,6 @@ namespace QuantConnect.Tests.Brokerages.Oanda
                 Symbol.Create("EURJPY", SecurityType.Forex, Market.Oanda),
                 Symbol.Create("AUDUSD", SecurityType.Forex, Market.Oanda),
             });
-            Thread.Sleep(1000);
 
             brokerage.Subscribe(null, new List<Symbol>
             {


### PR DESCRIPTION
Oanda only supports a maximum of two streaming rates sessions per token so we are reusing the same session for all subscriptions. In the case of multiple symbols to subscribe, on subsequent requests we have to close the previous session and start a new one, so requests must be synchronous.