### PR TITLE
Better error message in Oanda and Fxcm brokerage models

### DIFF
--- a/Common/Brokerages/FxcmBrokerageModel.cs
+++ b/Common/Brokerages/FxcmBrokerageModel.cs
@@ -136,11 +136,12 @@ namespace QuantConnect.Brokerages
             switch (security.Type)
             {
                 case SecurityType.Forex:
-                case SecurityType.Cfd:
                     return new FxcmTransactionModel();
 
+                case SecurityType.Cfd:
                 default:
-                    throw new ArgumentOutOfRangeException("securityType", security.Type, null);
+                    throw new Exception("FXCM does not support the asset type " + security.Type + ". " +
+                                        "Please ensure your algorithm only uses Forex (CFD assets are not currently supported).");
             }
         }
 

--- a/Common/Brokerages/OandaBrokerageModel.cs
+++ b/Common/Brokerages/OandaBrokerageModel.cs
@@ -50,11 +50,12 @@ namespace QuantConnect.Brokerages
             switch (security.Type)
             {
                 case SecurityType.Forex:
-                case SecurityType.Cfd:
                     return new OandaTransactionModel();
 
+                case SecurityType.Cfd:
                 default:
-                    throw new ArgumentOutOfRangeException("securityType", security.Type, null);
+                    throw new Exception("Oanda does not support the asset type " + security.Type + ". " +
+                                        "Please ensure your algorithm only uses Forex (CFD assets are not currently supported).");
             }
         }
     }


### PR DESCRIPTION
GetTransactionModel now also gives error for CFD security type (which is not supported yet)