### PR TITLE
Update NuGet packages on OSx

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,8 @@ git clone git@github.com:QuantConnect/Lean.git
 cd Lean
 ```
 
+Open the project in Xamarin Studio, then in the menu bar, click `Project > Update NuGet Packages`.
+
 In OS X `mdtool` is not added to the PATH environment. Either set up the PATH manually or reference the binary directly.
 
 If you are running Xamarin Studio:


### PR DESCRIPTION
On OSx, if you don't update the package dependencies before building the project, it will fail with errors like:

```
The type or namespace nameNewtonsoft' could not be found. Are you missing an assembly reference?
```

This explains how to solve it and adds it to the Readme so others don't run into the same issue.