### PR TITLE
Issue #95: Add custom chart line colors and scatter plot symbols

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -41,6 +41,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -76,6 +76,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/Common/Charting.cs
+++ b/Common/Charting.cs
@@ -135,6 +135,16 @@ namespace QuantConnect
         /// </summary>
         public SeriesType SeriesType = SeriesType.Line;
 
+        /// <summary>
+        /// Color the series 
+        /// </summary>
+        public SeriesColor SeriesColor = SeriesColor.Black;
+        
+        /// <summary>
+        /// Shape or symbol for the marker in a scatter plot
+        /// </summary>
+        public ScatterMarkerSymbol ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
+
         /// Get the index of the last fetch update request to only retrieve the "delta" of the previous request.
         private int _updatePosition;
 
@@ -153,6 +163,8 @@ namespace QuantConnect
             SeriesType = SeriesType.Line;
             Unit = "$";
             Index = 0;
+            SeriesColor = SeriesColor.Black;
+            ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
         /// <summary>
@@ -166,6 +178,8 @@ namespace QuantConnect
             SeriesType = type;
             Index = 0;
             Unit = "$";
+            SeriesColor = SeriesColor.Black;
+            ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
         /// <summary>
@@ -180,6 +194,8 @@ namespace QuantConnect
             SeriesType = type;
             Index = index;
             Unit = "$";
+            SeriesColor = SeriesColor.Black;
+            ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
         /// <summary>
@@ -195,6 +211,8 @@ namespace QuantConnect
             SeriesType = type;
             Index = index;
             Unit = unit;
+            SeriesColor = SeriesColor.Black;
+            ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
         /// <summary>
@@ -210,6 +228,45 @@ namespace QuantConnect
             SeriesType = type;
             Unit = unit;
             Index = 0;
+            SeriesColor = SeriesColor.Black;
+            ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
+        }
+
+        /// <summary>
+        /// Constructor method for Chart Series
+        /// </summary>
+        /// <param name="name">Name of the chart series</param>
+        /// <param name="type">Type of the chart series</param>
+        /// <param name="unit">Unit of the serier</param>
+        /// <param name="color">Color of the series</param>
+        public Series(string name, SeriesType type = SeriesType.Line, string unit = "$", SeriesColor color = SeriesColor.Black)
+        {
+            Name = name;
+            Values = new List<ChartPoint>();
+            SeriesType = type;
+            Unit = unit;
+            Index = 0;
+            SeriesColor = color;
+            ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
+        }
+
+        /// <summary>
+        /// Constructor method for Chart Series
+        /// </summary>
+        /// <param name="name">Name of the chart series</param>
+        /// <param name="type">Type of the chart series</param>
+        /// <param name="unit">Unit of the serier</param>
+        /// <param name="color">Color of the series</param>
+        /// <param name="symbol">Symbol for the marker in a scatter plot series</param>
+        public Series(string name, SeriesType type = SeriesType.Line, string unit = "$", SeriesColor color = SeriesColor.Black, ScatterMarkerSymbol symbol = ScatterMarkerSymbol.Circle)
+        {
+            Name = name;
+            Values = new List<ChartPoint>();
+            SeriesType = type;
+            Unit = unit;
+            Index = 0;
+            SeriesColor = color;
+            ScatterMarkerSymbol = symbol;
         }
 
         /// <summary>
@@ -333,5 +390,62 @@ namespace QuantConnect
         Overlay,
         /// Stacked series on top of each other.
         Stacked
+    }
+
+    /// <summary>
+    /// Color to the series object
+    /// Basic colors
+    /// </summary>
+    public enum SeriesColor
+    {
+        /// Black	#000000	(0,0,0)
+        Black,
+ 	    /// White	#FFFFFF	(255,255,255)
+        White,
+ 	    /// Red	    #FF0000	(255,0,0)
+        Red,
+ 	    /// Lime	#00FF00	(0,255,0)
+        Lime,
+ 	    /// Blue	#0000FF	(0,0,255)
+        Blue,
+ 	    /// Yellow	#FFFF00	(255,255,0)
+        Yellow,
+ 	    /// Cyan 	#00FFFF	(0,255,255) aka Aqua
+        Cyan,
+ 	    /// Magenta #FF00FF	(255,0,255) aka Fuchsia
+        Magenta,
+ 	    /// Silver	#C0C0C0	(192,192,192)
+        Silver,
+ 	    /// Gray	#808080	(128,128,128)
+        Gray,
+ 	    /// Maroon	#800000	(128,0,0)
+        Maroon,
+ 	    /// Olive	#808000	(128,128,0)
+        Olive,
+ 	    /// Green	#008000	(0,128,0)
+        Green,
+ 	    /// Purple	#800080	(128,0,128)
+        Purple,
+ 	    /// Teal	#008080	(0,128,128)
+        Teal,
+ 	    /// Navy	#000080	(0,0,128)
+        Navy
+    }
+
+    /// <summary>
+    /// Shape or symbol for the marker in a scatter plot
+    /// </summary>
+    public enum ScatterMarkerSymbol
+    {
+        /// Circle symbol
+        Circle,
+        /// Square symbol
+        Square, 
+        /// Diamond symbol
+        Diamond,
+        /// Triangle symbol
+        Triangle,
+        /// Triangle-down symbol
+        TriangleDown,
     }
 }

--- a/Common/Charting.cs
+++ b/Common/Charting.cs
@@ -143,7 +143,7 @@ namespace QuantConnect
         /// Color the series 
         /// </summary>
         [JsonConverter(typeof(ColorJsonConverter))]
-        public Color Color = Color.Black;
+        public Color Color = Color.Empty;
 
         /// <summary>
         /// Shape or symbol for the marker in a scatter plot
@@ -168,7 +168,7 @@ namespace QuantConnect
             SeriesType = SeriesType.Line;
             Unit = "$";
             Index = 0;
-            Color = Color.Black;
+            Color = Color.Empty;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -183,7 +183,7 @@ namespace QuantConnect
             SeriesType = type;
             Index = 0;
             Unit = "$";
-            Color = Color.Black;
+            Color = Color.Empty;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -199,7 +199,7 @@ namespace QuantConnect
             SeriesType = type;
             Index = index;
             Unit = "$";
-            Color = Color.Black;
+            Color = Color.Empty;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -216,7 +216,7 @@ namespace QuantConnect
             SeriesType = type;
             Index = index;
             Unit = unit;
-            Color = Color.Black;
+            Color = Color.Empty;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -233,7 +233,7 @@ namespace QuantConnect
             SeriesType = type;
             Unit = unit;
             Index = 0;
-            Color = Color.Black;
+            Color = Color.Empty;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 

--- a/Common/Charting.cs
+++ b/Common/Charting.cs
@@ -20,6 +20,7 @@ using QuantConnect.Logging;
 using System.Drawing;
 using Newtonsoft.Json.Converters;
 using System.Runtime.Serialization;
+using QuantConnect.Util;
 
 namespace QuantConnect 
 {
@@ -141,8 +142,9 @@ namespace QuantConnect
         /// <summary>
         /// Color the series 
         /// </summary>
+        [JsonConverter(typeof(ColorJsonConverter))]
         public Color Color = Color.Black;
-        
+
         /// <summary>
         /// Shape or symbol for the marker in a scatter plot
         /// </summary>

--- a/Common/Charting.cs
+++ b/Common/Charting.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using QuantConnect.Logging;
+using System.Drawing;
 
 namespace QuantConnect 
 {
@@ -138,7 +139,7 @@ namespace QuantConnect
         /// <summary>
         /// Color the series 
         /// </summary>
-        public SeriesColor SeriesColor = SeriesColor.Black;
+        public Color Color = Color.Black;
         
         /// <summary>
         /// Shape or symbol for the marker in a scatter plot
@@ -163,7 +164,7 @@ namespace QuantConnect
             SeriesType = SeriesType.Line;
             Unit = "$";
             Index = 0;
-            SeriesColor = SeriesColor.Black;
+            Color = Color.Black;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -178,7 +179,7 @@ namespace QuantConnect
             SeriesType = type;
             Index = 0;
             Unit = "$";
-            SeriesColor = SeriesColor.Black;
+            Color = Color.Black;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -194,7 +195,7 @@ namespace QuantConnect
             SeriesType = type;
             Index = index;
             Unit = "$";
-            SeriesColor = SeriesColor.Black;
+            Color = Color.Black;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -211,7 +212,7 @@ namespace QuantConnect
             SeriesType = type;
             Index = index;
             Unit = unit;
-            SeriesColor = SeriesColor.Black;
+            Color = Color.Black;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -228,7 +229,7 @@ namespace QuantConnect
             SeriesType = type;
             Unit = unit;
             Index = 0;
-            SeriesColor = SeriesColor.Black;
+            Color = Color.Black;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -239,14 +240,14 @@ namespace QuantConnect
         /// <param name="type">Type of the chart series</param>
         /// <param name="unit">Unit of the serier</param>
         /// <param name="color">Color of the series</param>
-        public Series(string name, SeriesType type = SeriesType.Line, string unit = "$", SeriesColor color = SeriesColor.Black)
+        public Series(string name, SeriesType type, string unit, Color color)
         {
             Name = name;
             Values = new List<ChartPoint>();
             SeriesType = type;
             Unit = unit;
             Index = 0;
-            SeriesColor = color;
+            Color = color;
             ScatterMarkerSymbol = ScatterMarkerSymbol.Circle;
         }
 
@@ -258,14 +259,14 @@ namespace QuantConnect
         /// <param name="unit">Unit of the serier</param>
         /// <param name="color">Color of the series</param>
         /// <param name="symbol">Symbol for the marker in a scatter plot series</param>
-        public Series(string name, SeriesType type = SeriesType.Line, string unit = "$", SeriesColor color = SeriesColor.Black, ScatterMarkerSymbol symbol = ScatterMarkerSymbol.Circle)
+        public Series(string name, SeriesType type, string unit, Color color, ScatterMarkerSymbol symbol = ScatterMarkerSymbol.Circle)
         {
             Name = name;
             Values = new List<ChartPoint>();
             SeriesType = type;
             Unit = unit;
             Index = 0;
-            SeriesColor = color;
+            Color = color;
             ScatterMarkerSymbol = symbol;
         }
 
@@ -390,46 +391,6 @@ namespace QuantConnect
         Overlay,
         /// Stacked series on top of each other.
         Stacked
-    }
-
-    /// <summary>
-    /// Color to the series object
-    /// Basic colors
-    /// </summary>
-    public enum SeriesColor
-    {
-        /// Black	#000000	(0,0,0)
-        Black,
- 	    /// White	#FFFFFF	(255,255,255)
-        White,
- 	    /// Red	    #FF0000	(255,0,0)
-        Red,
- 	    /// Lime	#00FF00	(0,255,0)
-        Lime,
- 	    /// Blue	#0000FF	(0,0,255)
-        Blue,
- 	    /// Yellow	#FFFF00	(255,255,0)
-        Yellow,
- 	    /// Cyan 	#00FFFF	(0,255,255) aka Aqua
-        Cyan,
- 	    /// Magenta #FF00FF	(255,0,255) aka Fuchsia
-        Magenta,
- 	    /// Silver	#C0C0C0	(192,192,192)
-        Silver,
- 	    /// Gray	#808080	(128,128,128)
-        Gray,
- 	    /// Maroon	#800000	(128,0,0)
-        Maroon,
- 	    /// Olive	#808000	(128,128,0)
-        Olive,
- 	    /// Green	#008000	(0,128,0)
-        Green,
- 	    /// Purple	#800080	(128,0,128)
-        Purple,
- 	    /// Teal	#008080	(0,128,128)
-        Teal,
- 	    /// Navy	#000080	(0,0,128)
-        Navy
     }
 
     /// <summary>

--- a/Common/Charting.cs
+++ b/Common/Charting.cs
@@ -18,6 +18,8 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using QuantConnect.Logging;
 using System.Drawing;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
 
 namespace QuantConnect 
 {
@@ -396,17 +398,23 @@ namespace QuantConnect
     /// <summary>
     /// Shape or symbol for the marker in a scatter plot
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ScatterMarkerSymbol
     {
         /// Circle symbol
+        [EnumMember(Value = "circle")]
         Circle,
         /// Square symbol
-        Square, 
+        [EnumMember(Value = "square")]
+        Square,
         /// Diamond symbol
+        [EnumMember(Value = "diamond")]
         Diamond,
         /// Triangle symbol
+        [EnumMember(Value = "triangle")]
         Triangle,
         /// Triangle-down symbol
+        [EnumMember(Value = "triangle-down")]
         TriangleDown,
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -373,6 +373,7 @@
     <Compile Include="Util\MarketHoursDatabaseJsonConverter.cs" />
     <Compile Include="Util\ParallelRunner.cs" />
     <Compile Include="Util\ParallelRunnerWorker.cs" />
+    <Compile Include="Util\ColorJsonConverter.cs" />
     <Compile Include="Util\SecurityIdentifierJsonConverter.cs" />
     <Compile Include="Util\TypeChangeJsonConverter.cs" />
     <Compile Include="Util\LinqExtensions.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Securities\Cfd\CfdMarginModel.cs" />
     <Compile Include="Securities\Cfd\CfdPortfolioModel.cs" />
     <Compile Include="Securities\ConstantFeeTransactionModel.cs" />
+    <Compile Include="Securities\Equity\PatternDayTraderMarginModel.cs" />
     <Compile Include="Securities\Equity\EquityMarginModel.cs" />
     <Compile Include="Securities\Equity\EquityPortfolioModel.cs" />
     <Compile Include="Securities\DelayedSettlementModel.cs" />

--- a/Common/Util/ColorJsonConverter.cs
+++ b/Common/Util/ColorJsonConverter.cs
@@ -14,15 +14,15 @@
  *
 */
 
-using Newtonsoft.Json;
-using QuantConnect.Logging;
 using System;
 using System.Drawing;
+using System.Globalization;
+using Newtonsoft.Json;
 
 namespace QuantConnect.Util
 {
     /// <summary>
-    /// A <see cref="JsonConverter"/> implementation that serializes a <see cref="Color"/> as a string.
+    /// A <see cref="JsonConverter" /> implementation that serializes a <see cref="Color" /> as a string.
     /// If Color is empty, string is also empty and vice-versa. Meaning that color is autogen.
     /// </summary>
     public class ColorJsonConverter : TypeChangeJsonConverter<Color, string>
@@ -55,14 +55,13 @@ namespace QuantConnect.Util
             {
                 return Color.Empty;
             }
-            else if (value.Length == 7)
+            if (value.Length == 7)
             {
-                return Color.FromArgb(HexToInt(value.Substring(1, 2)), HexToInt(value.Substring(3, 2)), HexToInt(value.Substring(5, 2)));
+                return Color.FromArgb(HexToInt(value.Substring(1, 2)), HexToInt(value.Substring(3, 2)),
+                    HexToInt(value.Substring(5, 2)));
             }
-            else
-            {
-                throw new FormatException("Unable to convert '" + value + "' to a Color. Requires string length of 7 including the leading hashtag.");
-            }
+            throw new FormatException("Unable to convert '" + value +
+                                      "' to a Color. Requires string length of 7 including the leading hashtag.");
         }
 
         /// <summary>
@@ -72,20 +71,16 @@ namespace QuantConnect.Util
         /// <returns>Integer representation of the hexadecimal</returns>
         private int HexToInt(string hexValue)
         {
-            if (hexValue.Length == 2)
+            if (hexValue.Length != 2)
+                throw new FormatException("Unable to convert '" + hexValue +
+                                          "' to an Integer. Requires string length of 2.");
+            try
             {
-                try
-                {
-                    return int.Parse(hexValue, System.Globalization.NumberStyles.HexNumber);
-                }
-                catch (Exception)
-                {
-                    throw new FormatException("Invalid hex number " + hexValue);
-                }
+                return int.Parse(hexValue, NumberStyles.HexNumber);
             }
-            else
+            catch (Exception)
             {
-                throw new FormatException("Unable to convert '" + hexValue + "' to an Integer. Requires string length of 2.");
+                throw new FormatException("Invalid hex number " + hexValue);
             }
         }
     }

--- a/Common/Util/ColorJsonConverter.cs
+++ b/Common/Util/ColorJsonConverter.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using Newtonsoft.Json;
+using QuantConnect.Logging;
+using System;
+using System.Drawing;
+
+namespace QuantConnect.Util
+{
+    /// <summary>
+    /// A <see cref="JsonConverter"/> implementation that serializes a <see cref="Color"/> as a string
+    /// </summary>
+    public class ColorJsonConverter : TypeChangeJsonConverter<Color, string>
+    {
+        /// <summary>
+        /// Converts a .NET Color to a hexadecimal as a string
+        /// </summary>
+        /// <param name="value">The input value to be converted before serialization</param>
+        /// <returns>Hexadecimal number as a string. If .NET Color is null, returns default #000000</returns>
+        protected override string Convert(Color value)
+        {
+            try
+            {
+                return string.Format("#{0:X2}{1:X2}{2:X2}", value.R, value.G, value.B);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e.Message);
+                return "#000000";
+            }
+        }
+
+        /// <summary>
+        /// Converts the input string to a .NET Color object
+        /// </summary>
+        /// <param name="value">The deserialized value that needs to be converted to T</param>
+        /// <returns>The converted value</returns>
+        protected override Color Convert(string value)
+        {
+            return Color.FromArgb(HexToint(value.Substring(1, 2)), HexToint(value.Substring(3, 2)), HexToint(value.Substring(5, 2)));
+        }
+
+        /// <summary>
+        /// Converts hexadecimal number to integer
+        /// </summary>
+        /// <param name="hexValue">Hexadecimal number</param>
+        /// <returns>Integer representation of the hexadecimal</returns>
+        private int HexToint(string hexValue)
+        {
+            int x = 0;
+
+            try
+            {
+                x = hexValue.Length == 2 ? int.Parse(hexValue, System.Globalization.NumberStyles.HexNumber) : 0;
+            }
+            catch (Exception)
+            {
+                Log.Error("Invalid hex number " + hexValue);
+            }
+
+            return x;
+        }
+    }
+}

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -167,6 +167,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/Tests/Common/Util/ColorJsonConverterTests.cs
+++ b/Tests/Common/Util/ColorJsonConverterTests.cs
@@ -1,0 +1,81 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Drawing;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Common.Util
+{
+    [TestFixture]
+    public class ColorJsonConverterTests
+    {
+        /// <summary>
+        /// Convert .NET Color to Json
+        /// </summary>
+        /// <param name="expected">String object that we expect to return after conversion</param>
+        private static void ConvertColorToJson(string expected)
+        {
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                Converters = {new ColorJsonConverter()}
+            };
+
+            var color = JsonConvert.DeserializeObject<Color>(expected);
+            var actual = JsonConvert.SerializeObject(color);
+
+            Assert.IsInstanceOf<Color>(color);
+            Assert.IsInstanceOf<string>(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// Convert Json to .NET Color
+        /// </summary>
+        /// <param name="expected">.NET Color object that we expect to return after conversion</param>
+        private static void ConvertJsonToColor(Color expected)
+        {
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                Converters = {new ColorJsonConverter()}
+            };
+
+            var json = JsonConvert.SerializeObject(expected);
+            var actual = JsonConvert.DeserializeObject<Color>(json);
+
+            Assert.IsInstanceOf<Color>(actual);
+            Assert.AreEqual(expected.IsEmpty, actual.IsEmpty);
+            if (!expected.IsEmpty)
+            {
+                Assert.AreEqual(expected.ToArgb(), actual.ToArgb());
+            }
+        }
+
+        [Test]
+        public void ConvertColorToJsonTest()
+        {
+            ConvertColorToJson("\"\"");
+            ConvertColorToJson("\"#0000FF\"");
+        }
+
+        [Test]
+        public void ConvertJsonToColorTest()
+        {
+            ConvertJsonToColor(Color.Empty);
+            ConvertJsonToColor(Color.Blue);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Common\TimeZoneOffsetProviderTests.cs" />
     <Compile Include="Common\TimeZonesTest.cs" />
     <Compile Include="Common\Util\BusyBlockingCollectionTests.cs" />
+    <Compile Include="Common\Util\ColorJsonConverterTests.cs" />
     <Compile Include="Common\Util\MarketHoursDatabaseJsonConverterTests.cs" />
     <Compile Include="Common\Util\MemoizingEnumerableTests.cs" />
     <Compile Include="Common\Util\ObjectActivatorTests.cs" />


### PR DESCRIPTION
public enum SeriesColor was added with the 16 basic colors. @jaredbroad wants 20, but I could not find a good 20-color palette. Suggestions?
The enum members are named after the color names: Black, White, Blue, Teal, etc. If those are converted to string: "Black", "White", etc; HighStock recognize the strings, therefore there is no need for hexadecimal. 

public enum ScatterMarkerSymbol was added with the highStock five predefined symbols: Circle, Square, Diamond, Triangle and TriangleDown. In this case, if these values are converted to strings, it won't work, because HighStock need them to be lowercase and TringleDown must be renamed to "triangle-down".