### PR TITLE
Minor fixes in Python Support (ref to issue #279)

### DIFF
--- a/Algorithm.Python/build.bat
+++ b/Algorithm.Python/build.bat
@@ -6,10 +6,10 @@ SET pyc="C:\Program Files (x86)\IronPython 2.7\Tools\Scripts\pyc.py"
 
 REM Clean the output directory
 del "QuantConnect.Algorithm.Python.dll"
-del "../../../Engine/bin/Debug/QuantConnect.Algorithm.Python.dll"
+del "../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll"
 
 REM IronPython Compile the Algorithm
 ipy %pyc% /target:dll /out:QuantConnect.Algorithm.Python main.py
 
 REM Copy to the Lean Algorithm Project
-echo f|xcopy /Y "QuantConnect.Algorithm.Python.dll" "../../../Engine/bin/Debug/QuantConnect.Algorithm.Python.dll"
+echo f|xcopy /Y "QuantConnect.Algorithm.Python.dll" "../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll"

--- a/Algorithm.Python/main.py
+++ b/Algorithm.Python/main.py
@@ -1,6 +1,18 @@
-﻿import clr
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import clr
 clr.AddReference("System")
-clr.AddReference("QuantConnect.Interfaces")
 clr.AddReference("QuantConnect.Algorithm")
 clr.AddReference("QuantConnect.Indicators")
 clr.AddReference("QuantConnect.Common")
@@ -10,16 +22,24 @@ from QuantConnect import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Indicators import *
 
+
 class BasicTemplateAlgorithm(QCAlgorithm):
+    '''Basic template algorithm simply initializes the date range and cash'''
 
-	def Initialize(self):
-		self.SetCash(100000)
-		self.SetStartDate(2013,10,07)
-		self.SetEndDate(2013,10,11)
-		self.AddSecurity(SecurityType.Equity, "SPY")
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+        
+        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetEndDate(2013,10,11)    #Set End Date
+        self.SetCash(100000)           #Set Strategy Cash
+        # Find more symbols here: http://quantconnect.com/data
+        self.AddSecurity(SecurityType.Equity, "SPY", Resolution.Second)
 
-	def OnData(self, slice):
-
-		if not self.Portfolio.Invested:
-			self.SetHoldings("SPY", 1)	
-			
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        
+        Arguments:
+            data: Slice object keyed by symbol containing the stock data
+        '''
+        if not self.Portfolio.Invested:
+            self.SetHoldings("SPY", 1)


### PR DESCRIPTION
- Update build.bat to account that since 30 Nov 2015 Lean executable is Lean.Launcher.exe, therefore QuantConnect.Algorithm.Python.dll must be copied into Lean.Launcher project.
- Adds documentation in main.py.
- Removing `clr.AddReference(QuantConnect.Interfaces)` fixes issue #279 on Windows.