### PR TITLE
Update build.sh

### DIFF
--- a/Algorithm.Python/build.sh
+++ b/Algorithm.Python/build.sh
@@ -2,6 +2,7 @@
 
 # Clean output directory
 rm QuantConnect.Algorithm.Python.dll
+rm ../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll
 
 # Set the script variables: assuming installing the ./compiler/library/ and the caller is in ./compiler/bin/Debug/build.sh
 ipy="../../IronPython-2.7.5/ipy.exe"
@@ -9,3 +10,6 @@ pyc="../../IronPython-2.7.5/Tools/Scripts/pyc.py"
  
 # Call the compiler:
 mono $ipy $pyc /target:dll /out:QuantConnect.Algorithm.Python main.py
+
+# Copy to the Lean Algorithm Project
+cp QuantConnect.Algorithm.Python.dll ../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll


### PR DESCRIPTION
In order to account that since 30 Nov 2015 Lean executable is Lean.Launcher.exe QuantConnect.Algorithm.Python.dll must be copied into Lean.Launcher project.