### PR TITLE
Python algos in a file with the algo name like C#

### DIFF
--- a/Algorithm.Python/BasicTemplateAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateAlgorithm.py
@@ -1,0 +1,45 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import clr
+clr.AddReference("System")
+clr.AddReference("QuantConnect.Algorithm")
+clr.AddReference("QuantConnect.Indicators")
+clr.AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Indicators import *
+
+
+class BasicTemplateAlgorithm(QCAlgorithm):
+    '''Basic template algorithm simply initializes the date range and cash'''
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+        
+        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetEndDate(2013,10,11)    #Set End Date
+        self.SetCash(100000)           #Set Strategy Cash
+        # Find more symbols here: http://quantconnect.com/data
+        self.AddSecurity(SecurityType.Equity, "SPY", Resolution.Second)
+
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        
+        Arguments:
+            data: Slice object keyed by symbol containing the stock data
+        '''
+        if not self.Portfolio.Invested:
+            self.SetHoldings("SPY", 1)

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -96,9 +96,6 @@
     </None>
     <None Include="Lib\ensurepip\_bundled\pip-1.5.6-py2.py3-none-any.whl" />
     <None Include="Lib\ensurepip\_bundled\setuptools-3.6-py2.py3-none-any.whl" />
-    <None Include="main.py">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="build.bat">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -106,6 +103,7 @@
     <None Include="readme.md" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="BasicTemplateAlgorithm.py" />
     <Content Include="Lib\abc.py" />
     <Content Include="Lib\aifc.py" />
     <Content Include="Lib\antigravity.py" />

--- a/Algorithm.Python/build.bat
+++ b/Algorithm.Python/build.bat
@@ -8,8 +8,12 @@ REM Clean the output directory
 del "QuantConnect.Algorithm.Python.dll"
 del "../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll"
 
+REM Get algorithm-type-name from config.json
+setlocal EnableDelayedExpansion
+for /f "tokens=2 delims=:, " %%a in (' find "algorithm-type-name" ^< "../Launcher/config.json" ') do ( set pyfile=%%~a.py )
+
 REM IronPython Compile the Algorithm
-ipy %pyc% /target:dll /out:QuantConnect.Algorithm.Python main.py
+ipy %pyc% /target:dll /out:QuantConnect.Algorithm.Python !pyfile!
 
 REM Copy to the Lean Algorithm Project
 echo f|xcopy /Y "QuantConnect.Algorithm.Python.dll" "../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll"

--- a/Algorithm.Python/build.sh
+++ b/Algorithm.Python/build.sh
@@ -7,9 +7,12 @@ rm ../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll
 # Set the script variables: assuming installing the ./compiler/library/ and the caller is in ./compiler/bin/Debug/build.sh
 ipy="../../IronPython-2.7.5/ipy.exe"
 pyc="../../IronPython-2.7.5/Tools/Scripts/pyc.py"
- 
+
+# Get algorithm-type-name from config.json
+pyfile=$(grep -Po '(?<="algorithm-type-name": ")[^"]*' ../Launcher/config.json).py
+
 # Call the compiler:
-mono $ipy $pyc /target:dll /out:QuantConnect.Algorithm.Python main.py
+mono $ipy $pyc /target:dll /out:QuantConnect.Algorithm.Python $pyfile
 
 # Copy to the Lean Algorithm Project
 cp QuantConnect.Algorithm.Python.dll ../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll

--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -162,7 +162,8 @@ namespace QuantConnect.AlgorithmFactory
                 try
                 {
                     Log.Trace("Loader.TryCreatePythonAlgorithm(): Importing python module...");
-                    var scope = engine.Runtime.ImportModule("main");
+                    var algorithmName = Config.Get("algorithm-type-name");
+                    var scope = engine.Runtime.ImportModule(algorithmName);
                     items = (List<KeyValuePair<string, dynamic>>)scope.GetItems();
                 }
                 catch (Exception err)


### PR DESCRIPTION
build.bat (batch.sh in Linux) includes the code inside the file with the desired algorithm (set in config.json by "algorithm-type-name") in the python DLL (QuantConnect.Algorithm.Python.dll) via IronPython.
In the AlgorithmFactory,  Loader.TryCreatePythonAlgorithm imports the module with the algorithm name instead of "main".