### PR TITLE
Synchronous results time set to UTC

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -826,7 +826,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <remarks>Prime candidate for putting into a base class. Is identical across all result handlers.</remarks>
         public void ProcessSynchronousEvents(bool forceProcess = false)
         {
-            var time = _algorithm.Time;
+            var time = _algorithm.UtcTime;
 
             if (time > _nextSample || forceProcess)
             {


### PR DESCRIPTION
In the Backtesting results handler class, the synchronous result events, sampling and message reading uses the time informed by the algorithm in UTC instead of local. The former way was messing up statistics when Lean was executed in other countries.