### PR TITLE
Scripts includes all python script files in the DLL

### DIFF
--- a/Algorithm.Python/build.bat
+++ b/Algorithm.Python/build.bat
@@ -7,13 +7,16 @@ SET pyc="C:\Program Files (x86)\IronPython 2.7\Tools\Scripts\pyc.py"
 REM Clean the output directory
 del "QuantConnect.Algorithm.Python.dll"
 del "../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll"
+del "../Tests/bin/Debug/QuantConnect.Algorithm.Python.dll"
 
-REM Get algorithm-type-name from config.json
-setlocal EnableDelayedExpansion
-for /f "tokens=2 delims=:, " %%a in (' find "algorithm-type-name" ^< "../Launcher/config.json" ') do ( set pyfile=%%~a.py )
+REM Collect the names of all files in current directory
+setlocal EnableDelayedExpansion EnableExtensions
+SET pyfiles=
+for %%f in (*.py) do SET pyfiles=!pyfiles! %%f
 
-REM IronPython Compile the Algorithm
-ipy %pyc% /target:dll /out:QuantConnect.Algorithm.Python !pyfile!
+REM IronPython Compile the Algorithmwith all the files in current directory
+ipy %pyc% /target:dll /out:QuantConnect.Algorithm.Python !pyfiles!
 
 REM Copy to the Lean Algorithm Project
 echo f|xcopy /Y "QuantConnect.Algorithm.Python.dll" "../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll"
+echo f|xcopy /Y "QuantConnect.Algorithm.Python.dll" "../Tests/bin/Debug/QuantConnect.Algorithm.Python.dll"

--- a/Algorithm.Python/build.sh
+++ b/Algorithm.Python/build.sh
@@ -3,16 +3,15 @@
 # Clean output directory
 rm QuantConnect.Algorithm.Python.dll
 rm ../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll
+rm ../Tests/bin/Debug/QuantConnect.Algorithm.Python.dll
 
 # Set the script variables: assuming installing the ./compiler/library/ and the caller is in ./compiler/bin/Debug/build.sh
 ipy="../../IronPython-2.7.5/ipy.exe"
 pyc="../../IronPython-2.7.5/Tools/Scripts/pyc.py"
 
-# Get algorithm-type-name from config.json
-pyfile=$(grep -Po '(?<="algorithm-type-name": ")[^"]*' ../Launcher/config.json).py
-
-# Call the compiler:
-mono $ipy $pyc /target:dll /out:QuantConnect.Algorithm.Python $pyfile
+# Call the compiler with all the files in current directory
+echo mono $ipy $pyc /target:dll /out:QuantConnect.Algorithm.Python $(ls *.py)
 
 # Copy to the Lean Algorithm Project
 cp QuantConnect.Algorithm.Python.dll ../Launcher/bin/Debug/QuantConnect.Algorithm.Python.dll
+cp QuantConnect.Algorithm.Python.dll ../Tests/bin/Debug/QuantConnect.Algorithm.Python.dll


### PR DESCRIPTION
We may need use classes and methods that are stored in other files in the directory (like we do in the C# Algorithms project)
Also, we need all Python Algorithms in the correspondent DLL to run unit tests of all the algorithms in a row
The dll is now copied to the Tests project

Ref #294 