### PR TITLE
Fix for tick data paths doubling

### DIFF
--- a/ToolBox/LeanDataWriter.cs
+++ b/ToolBox/LeanDataWriter.cs
@@ -99,8 +99,6 @@ namespace QuantConnect.ToolBox
             var sb = new StringBuilder();
             var lastTime = new DateTime();
 
-            // Determine file path
-            var baseDirectory = Path.Combine(_dataDirectory, _securityType.ToString().ToLower(), _market);
 
             // Loop through all the data and write to file as we go
             foreach (var data in source)
@@ -112,7 +110,7 @@ namespace QuantConnect.ToolBox
                 if (lastTime != DateTime.MinValue && data.Time.Date > lastTime.Date)
                 {
                     // Write and clear the file contents
-                    var outputFile = GetZipOutputFileName(baseDirectory, lastTime);
+                    var outputFile = GetZipOutputFileName(_dataDirectory, lastTime);
                     WriteFile(outputFile, sb.ToString(), lastTime);
                     sb.Clear();
                 }
@@ -126,7 +124,7 @@ namespace QuantConnect.ToolBox
             // Write the last file
             if (sb.Length > 0)
             {
-                var outputFile = GetZipOutputFileName(baseDirectory, lastTime);
+                var outputFile = GetZipOutputFileName(_dataDirectory, lastTime);
                 WriteFile(outputFile, sb.ToString(), lastTime);
             }
         }


### PR DESCRIPTION
Tick data path was being doubled eg:

bitcoin\forex\btcusd\biitcoin\forex\btcusd

The method GetZipOutputFileName already build the desired path so baseDirectory variable was not needed.