### PR TITLE
Fix for History<Tick>

### DIFF
--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Data
     /// </summary>
     public class Slice : IEnumerable<KeyValuePair<Symbol, BaseData>>
     {
-        private readonly Ticks _ticks; 
+        private readonly Ticks _ticks;
         private readonly TradeBars _bars;
 
         // aux data
@@ -207,10 +207,18 @@ namespace QuantConnect.Data
             Lazy<object> dictionary;
             if (!_dataByType.TryGetValue(typeof(T), out dictionary))
             {
-                dictionary = new Lazy<object>(() => new DataDictionary<T>(_data.Value.Values.Select(x => x.GetData()).OfType<T>(), x => x.Symbol));
-                _dataByType[typeof (T)] = dictionary;
+                if (typeof(T) == typeof(Tick))
+                {
+                    dictionary = new Lazy<object>(() => new DataDictionary<T>(_data.Value.Values.SelectMany<dynamic, dynamic>(x => x.GetData()).OfType<T>(), x => x.Symbol));
+                }
+                else
+                {
+                    dictionary = new Lazy<object>(() => new DataDictionary<T>(_data.Value.Values.Select(x => x.GetData()).OfType<T>(), x => x.Symbol));
+                }
+
+                _dataByType[typeof(T)] = dictionary;
             }
-            return (DataDictionary<T>) dictionary.Value;
+            return (DataDictionary<T>)dictionary.Value;
         }
 
         /// <summary>
@@ -277,12 +285,12 @@ namespace QuantConnect.Data
 
                     case MarketDataType.TradeBar:
                         symbolData.Type = SubscriptionType.TradeBar;
-                        symbolData.TradeBar = (TradeBar) datum;
+                        symbolData.TradeBar = (TradeBar)datum;
                         break;
 
                     case MarketDataType.Tick:
                         symbolData.Type = SubscriptionType.Tick;
-                        symbolData.Ticks.Add((Tick) datum);
+                        symbolData.Ticks.Add((Tick)datum);
                         break;
 
                     case MarketDataType.Auxiliary:
@@ -322,7 +330,7 @@ namespace QuantConnect.Data
             where TItem : BaseData
         {
             if (collection != null) return collection;
-            collection = new T(); 
+            collection = new T();
 #pragma warning disable 618 // This assignment is left here until the Time property is removed.
             collection.Time = Time;
 #pragma warning restore 618

--- a/Tests/Common/Data/SliceTests.cs
+++ b/Tests/Common/Data/SliceTests.cs
@@ -87,7 +87,7 @@ namespace QuantConnect.Tests.Common.Data
         }
 
         [Test]
-        public void AccessesGenericallyByType()
+        public void AccessesCustomGenericallyByType()
         {
             Quandl quandlSpy = new Quandl { Symbol = Symbols.SPY, Time = DateTime.Now };
             Quandl quandlAapl = new Quandl { Symbol = Symbols.AAPL, Time = DateTime.Now };
@@ -95,6 +95,29 @@ namespace QuantConnect.Tests.Common.Data
 
             DataDictionary<Quandl> quandlData = slice.Get<Quandl>();
             Assert.AreEqual(2, quandlData.Count);
+        }
+
+        [Test]
+        public void AccessesTickGenericallyByType()
+        {
+            Tick TickSpy = new Tick { Symbol = Symbols.SPY, Time = DateTime.Now };
+            Tick TickAapl = new Tick { Symbol = Symbols.AAPL, Time = DateTime.Now };
+            Slice slice = new Slice(DateTime.Now, new[] { TickSpy, TickAapl });
+
+            DataDictionary<Tick> TickData = slice.Get<Tick>();
+            Assert.AreEqual(2, TickData.Count);
+        }
+
+
+        [Test]
+        public void AccessesTradeBarGenericallyByType()
+        {
+            TradeBar TradeBarSpy = new TradeBar { Symbol = Symbols.SPY, Time = DateTime.Now };
+            TradeBar TradeBarAapl = new TradeBar { Symbol = Symbols.AAPL, Time = DateTime.Now };
+            Slice slice = new Slice(DateTime.Now, new[] { TradeBarSpy, TradeBarAapl });
+
+            DataDictionary<TradeBar> TradeBarData = slice.Get<TradeBar>();
+            Assert.AreEqual(2, TradeBarData.Count);
         }
 
         [Test]


### PR DESCRIPTION
Revisited change that fixes calls to History<Tick> that were previously returning nothing.