### PR TITLE
Remove "algorithm-location" from config.json

### DIFF
--- a/Algorithm.Python/readme.md
+++ b/Algorithm.Python/readme.md
@@ -4,7 +4,6 @@ QuantConnect Python Algorithm Project:
 To run algorithms in Lean your primary modules must be called "main.py".
 
 Set your config "algorithm-language" property to "Python".
-Set your config "algorithm-location" property to "QuantConnect.Algorithm.Python.dll".
 
 WINDOWS:
 1. Install Iron Python: http://ironpython.codeplex.com/releases/view/169382

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -14,13 +14,6 @@
     // Algorithm language selector - options CSharp, FSharp, VisualBasic, Python, Java
     "algorithm-language": "CSharp",
 
-    //Physical DLL location
-    "algorithm-location": "QuantConnect.Algorithm.CSharp.dll",
-    //"algorithm-location": "QuantConnect.Algorithm.Python.dll",
-    //"algorithm-location": "QuantConnect.Algorithm.FSharp.dll",
-    //"algorithm-location": "QuantConnect.Algorithm.VisualBasic.dll",
-    //"algorithm-location": "QuantConnect.Algorithm.Java.dll",
-
     // engine
     "data-folder": "../../../Data/",
 

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Queues
             get
             {
                 // we expect this dll to be copied into the output directory
-                return Config.Get("algorithm-location", "QuantConnect.Algorithm.CSharp.dll"); 
+                return String.Format("QuantConnect.Algorithm.{0}.dll", Language);
             }
         }
 

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -47,8 +47,7 @@ namespace QuantConnect.Tests
                 Config.Set("api-handler", "QuantConnect.Api.Api");
                 Config.Set("result-handler", "QuantConnect.Lean.Engine.Results.BacktestingResultHandler");
                 Config.Set("algorithm-language", language.ToString());
-                Config.Set("algorithm-location", "QuantConnect.Algorithm." + language + ".dll");
-
+                
                 using (Log.LogHandler = new CompositeLogHandler(new ILogHandler[]
                 {
                     new ConsoleLogHandler(),


### PR DESCRIPTION
The algorithm location can be determined by "algorithm-language" key from config.json, therefore "algorithm-location" did not provide original information.
Also, this change prevents conflits between "algorithm-language" and "algorithm-location". For exemple, the user could set  "algorithm-language": "FSharp" and "algorithm-location": "QuantConnect.Algorithm.CSharp.dll"