### PR TITLE
Fixed bug in MarketHoursDatabaseJsonConverter

### DIFF
--- a/Common/Util/MarketHoursDatabaseJsonConverter.cs
+++ b/Common/Util/MarketHoursDatabaseJsonConverter.cs
@@ -174,7 +174,7 @@ namespace QuantConnect.Util
                 SetSegmentsForDay(hours, DayOfWeek.Thursday, out Thursday);
                 SetSegmentsForDay(hours, DayOfWeek.Friday, out Friday);
                 SetSegmentsForDay(hours, DayOfWeek.Saturday, out Saturday);
-                Holidays = hours.Holidays.Select(x => x.ToShortDateString()).ToList();
+                Holidays = hours.Holidays.Select(x => x.ToString("M/d/yyyy")).ToList();
             }
 
             /// <summary>


### PR DESCRIPTION
In the constructor, holiday dates were formatted using the default date format set in the system preferences, instead of always using the fixed US format (as in the Convert method).