### PR TITLE
Quandl.Reader method returns null for void points

### DIFF
--- a/Common/Data/Custom/Quandl.cs
+++ b/Common/Data/Custom/Quandl.cs
@@ -100,7 +100,8 @@ namespace QuantConnect.Data.Custom
                     data.SetProperty(property, 0m);
                     _propertyNames.Add(property);
                 }
-                return data;
+                // Returns null at this point where we are only reading the properties names
+                return null;
             }
 
             data.Time = DateTime.ParseExact(csv[0], "yyyy-MM-dd", CultureInfo.InvariantCulture);


### PR DESCRIPTION
The first line of a Quandl file is the header. When it is read, returns null instead of a Quandl type.
Trying to fix #373 