### PR TITLE
Fixed an issue where TimeSlice was duplicating ticks

### DIFF
--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -245,7 +245,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     List<Tick> ticksList;
                     if (!ticks.TryGetValue(symbol, out ticksList))
                     {
-                        ticksList = new List<Tick> {(Tick) baseData};
+                        ticksList = new List<Tick>();
                         ticks[symbol] = ticksList;
                     }
                     ticksList.Add((Tick) baseData);

--- a/Tests/Engine/DataFeeds/TimeSliceTests.cs
+++ b/Tests/Engine/DataFeeds/TimeSliceTests.cs
@@ -1,8 +1,22 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;

--- a/Tests/Engine/DataFeeds/TimeSliceTests.cs
+++ b/Tests/Engine/DataFeeds/TimeSliceTests.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -58,7 +57,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             IEnumerable<TimeSlice> timeSlices = rawTicks.Select(t => TimeSlice.Create(
                 t.Time,
-                DateTimeZone.Utc,
+                TimeZones.Utc,
                 new CashBook(),
                 new List<DataFeedPacket> {new DataFeedPacket(security, new List<BaseData>() {t})},
                 new SecurityChanges(Enumerable.Empty<Security>(), Enumerable.Empty<Security>())));

--- a/Tests/Engine/DataFeeds/TimeSliceTests.cs
+++ b/Tests/Engine/DataFeeds/TimeSliceTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture]
+    public class TimeSliceTests
+    {
+        [Test]
+        public void HandlesTicks_ExpectInOrderWithNoDuplicates()
+        {
+            var subscriptionDataConfig = new SubscriptionDataConfig(
+                typeof(Tick), 
+                Symbols.EURUSD, 
+                Resolution.Tick, 
+                TimeZones.Utc, 
+                TimeZones.Utc, 
+                true, 
+                true, 
+                false);
+
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), 
+                subscriptionDataConfig, 
+                new Cash(CashBook.AccountCurrency, 0, 1m), 
+                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+
+            DateTime refTime = DateTime.UtcNow;
+
+            Tick[] rawTicks = Enumerable
+                .Range(0, 10)
+                .Select(i => new Tick(refTime.AddSeconds(i), Symbols.EURUSD, 1.3465m, 1.34652m))
+                .ToArray();
+
+            IEnumerable<TimeSlice> timeSlices = rawTicks.Select(t => TimeSlice.Create(
+                t.Time,
+                DateTimeZone.Utc,
+                new CashBook(),
+                new List<DataFeedPacket> {new DataFeedPacket(security, new List<BaseData>() {t})},
+                new SecurityChanges(Enumerable.Empty<Security>(), Enumerable.Empty<Security>())));
+
+            Tick[] timeSliceTicks = timeSlices.SelectMany(ts => ts.Slice.Ticks.Values.SelectMany(x => x)).ToArray();
+
+            Assert.AreEqual(rawTicks.Length, timeSliceTicks.Length);
+            for (int i = 0; i < rawTicks.Length; i++)
+            {
+                Assert.IsTrue(Compare(rawTicks[i], timeSliceTicks[i]));
+            }
+        }
+
+        private bool Compare(Tick expected, Tick actual)
+        {
+            return expected.Time == actual.Time
+                   && expected.BidPrice == actual.BidPrice
+                   && expected.AskPrice == actual.AskPrice
+                   && expected.Quantity == actual.Quantity;
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Engine\DataFeeds\RestApiBaseData.cs" />
     <Compile Include="Engine\DataFeeds\FuncDataQueueHandler.cs" />
     <Compile Include="Engine\DataFeeds\LiveTradingDataFeedTests.cs" />
+    <Compile Include="Engine\DataFeeds\TimeSliceTests.cs" />
     <Compile Include="Engine\DataFeeds\Transport\LocalFileSubscriptionStreamReaderTests.cs" />
     <Compile Include="Engine\DataFeeds\ZipEntryNameSubsciptionFactoryTests.cs" />
     <Compile Include="Engine\DefaultBrokerageMessageHandler.cs" />


### PR DESCRIPTION
Addresses #387 

Disclaimer: Last time I sent a pull request the build failed with what seemed to be some compiler differences between mono and native .Net. I'm not expecting issues here because the changes are simple, but in case those become famous last words here is a standard developer excuse:

![image](https://cloud.githubusercontent.com/assets/17696925/14761814/0cf0bc6c-099d-11e6-958c-3dc39188caba.png)
