### PR TITLE
FXCM Tick level timezone read from market-hours config file

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.Util.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Util.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Brokerages.Fxcm
     /// </summary>
     public partial class FxcmBrokerage
     {
-        private static DateTimeZone configTimeZone = null;
+        private static DateTimeZone _configTimeZone = null;
 
         /// <summary>
         /// Converts an FXCM order to a QuantConnect order.
@@ -180,17 +180,17 @@ namespace QuantConnect.Brokerages.Fxcm
         /// <returns></returns>
         private static DateTime FromJavaDate(java.util.Date javaDate)
         {
-            if (configTimeZone == null)
+            if (_configTimeZone == null)
             {
                 // Read time zone from market-hours-config
-                configTimeZone = MarketHoursDatabase.FromDataFolder().GetDataTimeZone("fxcm", "*", SecurityType.Forex);
+                _configTimeZone = MarketHoursDatabase.FromDataFolder().GetDataTimeZone("fxcm", "*", SecurityType.Forex);
             }
 
             // Convert javaDate to UTC Instant (Epoch)
-            Instant instant = Instant.FromSecondsSinceUnixEpoch(javaDate.getTime() / 1000);
+            var instant = Instant.FromSecondsSinceUnixEpoch(javaDate.getTime() / 1000);
 
             // Convert to configured TZ then to a .Net DateTime
-            return instant.InZone(configTimeZone).ToDateTimeUnspecified();
+            return instant.InZone(_configTimeZone).ToDateTimeUnspecified();
         }
 
 

--- a/Brokerages/Fxcm/FxcmBrokerage.Util.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Util.cs
@@ -190,8 +190,7 @@ namespace QuantConnect.Brokerages.Fxcm
             Instant instant = Instant.FromSecondsSinceUnixEpoch(javaDate.getTime() / 1000);
 
             // Convert to configured TZ then to a .Net DateTime
-            var dt = instant.InZone(configTimeZone).ToDateTimeUnspecified();
-            return dt;
+            return instant.InZone(configTimeZone).ToDateTimeUnspecified();
         }
 
 


### PR DESCRIPTION
FXCM tick level events time value is converted to EST via the setting in market-hours-database.json (currently UTC-05) rather than hard coding EST