### PR TITLE
FileSystemDataFeed.ScheduleEnumerator performance fix

### DIFF
--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -148,7 +148,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // schedule the work on the controller
             var firstLoop = true;
             FuncParallelRunnerWorkItem workItem = null;
-            workItem = new FuncParallelRunnerWorkItem(() => enqueueable.Count < lowerThreshold, () =>
+            workItem = new FuncParallelRunnerWorkItem(() => true, () =>
             {
                 var count = 0;
                 while (enumerator.MoveNext())


### PR DESCRIPTION
On Windows, backtesting speed improvements ranged from 3x to 8x (especially with single symbol algorithms)