### PR TITLE
Fixes universe subscription creation bug in LiveTradingDataFeed

### DIFF
--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -24,7 +23,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
-using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
@@ -126,7 +124,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     case NotifyCollectionChangedAction.Add:
                         foreach (var universe in args.NewItems.OfType<Universe>())
                         {
-                            _subscriptions.TryAdd(CreateUniverseSubscription(universe, start, Time.EndOfTime));
+                            if (!_subscriptions.Contains(universe.Configuration))
+                            {
+                                _subscriptions.TryAdd(CreateUniverseSubscription(universe, start, Time.EndOfTime));
+                            }
+
+                            // Not sure if this is needed but left here because of this:
+                            // https://github.com/QuantConnect/Lean/commit/029d70bde6ca83a1eb0c667bb5cc4444bea05678
                             UpdateFillForwardResolution();
                         }
                         break;


### PR DESCRIPTION
*Occasionally when running EURUSD + Custom Data together the custom data would not get subscribed.*

1. LTDF.CreateUniverseSubscription is being called three times instead of twice, although only the first two of them are being added: https://github.com/QuantConnect/Lean/blob/master/Engine/DataFeeds/LiveTradingDataFeed.cs#L129
2. LTDF.CreateUniverseSubscription always adds the enumerator to the custom exchange even if it is a duplicate: https://github.com/QuantConnect/Lean/blob/master/Engine/DataFeeds/LiveTradingDataFeed.cs#L501
3. We always end up with two universe subscriptions, but the second one could have its enumerator replaced by the third "ghost" one.

My solution: check if existing first, then create and add (now it creates, then adds if not existing)
                               if (!_subscriptions.Contains(universe.Configuration))
                               {
                                   _subscriptions.TryAdd(CreateUniverseSubscription(universe, start, Time.EndOfTime));
                                   UpdateFillForwardResolution();
                               }

I tried many runs with this fix and was not able to repeat the problem.