### PR TITLE
Fixes TimeSlice bug preventing multiple custom symbols of same type

### DIFF
--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -16,15 +16,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Scripting.Utils;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
-using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -181,12 +178,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         if (packet.Configuration.IsCustomData)
                         {
                             // This is all the custom data
-                            // Add the list to the custom data when its unique.
-                            var exists = custom.Any(x => x.DataType == packet.Configuration.Type);
-                            if (!exists)
-                            {
-                                custom.Add(new UpdateData<Security>(packet.Security, packet.Configuration.Type, list));
-                            }
+                            custom.Add(new UpdateData<Security>(packet.Security, packet.Configuration.Type, list));
                         }
                     }
                     // don't add internal feed data to ticks/bars objects

--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -166,6 +166,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     count += list.Count;
                 }
 
+                if (!packet.Configuration.IsInternalFeed && packet.Configuration.IsCustomData)
+                {
+                    // This is all the custom data
+                    custom.Add(new UpdateData<Security>(packet.Security, packet.Configuration.Type, list));
+                }
+
                 var securityUpdate = new List<BaseData>(list.Count);
                 var consolidatorUpdate = new List<BaseData>(list.Count);
                 for (int i = 0; i < list.Count; i++)
@@ -175,11 +181,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     {
                         // this is all the data that goes into the algorithm
                         allDataForAlgorithm.Add(baseData);
-                        if (packet.Configuration.IsCustomData)
-                        {
-                            // This is all the custom data
-                            custom.Add(new UpdateData<Security>(packet.Security, packet.Configuration.Type, list));
-                        }
                     }
                     // don't add internal feed data to ticks/bars objects
                     if (baseData.DataType != MarketDataType.Auxiliary)


### PR DESCRIPTION
With this configuration in `Initialize`:

```
AddData<QuandlFuture>("SCF/CBOE_VX1_EW", Resolution.Daily);
AddData<QuandlFuture>("SCF/CBOE_VX2_EW", Resolution.Daily);
```
`OnData(QuandlFuture)` was called only for one of the symbols in each time step.