### PR TITLE
Fixes bug: RealTime price not set every second

### DIFF
--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -576,7 +576,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Update any security properties based on the lastest market data and time
+        /// Update any security properties based on the latest market data and time
         /// </summary>
         /// <param name="data">New data packet from LEAN</param>
         public void SetMarketPrice(BaseData data)
@@ -589,7 +589,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Update any security properties based on the lastest realtime data and time
+        /// Update any security properties based on the latest realtime data and time
         /// </summary>
         /// <param name="data">New data packet from LEAN</param>
         public void SetRealTimePrice(BaseData data)

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -574,18 +574,30 @@ namespace QuantConnect.Securities
                 Exchange.SetLocalDateTimeFrontier(args.Time);
             };
         }
-        
+
         /// <summary>
         /// Update any security properties based on the lastest market data and time
         /// </summary>
         /// <param name="data">New data packet from LEAN</param>
-        public void SetMarketPrice(BaseData data) 
+        public void SetMarketPrice(BaseData data)
         {
             //Add new point to cache:
             if (data == null) return;
             Cache.AddData(data);
             Holdings.UpdateMarketPrice(Price);
             VolatilityModel.Update(this, data);
+        }
+
+        /// <summary>
+        /// Update any security properties based on the lastest realtime data and time
+        /// </summary>
+        /// <param name="data">New data packet from LEAN</param>
+        public void SetRealTimePrice(BaseData data)
+        {
+            //Add new point to cache:
+            if (data == null) return;
+            Cache.AddData(data);
+            Holdings.UpdateMarketPrice(Price);
         }
 
         /// <summary>

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -33,6 +33,7 @@ using QuantConnect.Packets;
 using QuantConnect.Securities;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
+using QuantConnect.Securities.Forex;
 
 namespace QuantConnect.Lean.Engine.Results
 {
@@ -1022,6 +1023,15 @@ namespace QuantConnect.Lean.Engine.Results
                             if (last != null)
                             {
                                 last.Value = price;
+                                security.SetRealTimePrice(last);
+
+                                // Update CashBook for Forex securities
+                                Cash cash;
+                                var forex = security as Forex;
+                                if (forex != null && _algorithm.Portfolio.CashBook.TryGetValue(forex.BaseCurrencySymbol, out cash))
+                                {
+                                    cash.Update(last);
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
On LiveTradingResultHandler.ProcessSynchronousEvents, realtime price was assigned to Security.Cache._lastData.Value and that assignment did not change Security.Price used to update Portfolio statistics (eg. TotalPortfolioValue).
For Forex securities, adds Portfolio.CashBook updates with realtime price.