### PR TITLE
Fixes minor bug on LiveTradingResultHandler.StoreResult

### DIFF
--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -840,17 +840,6 @@ namespace QuantConnect.Lean.Engine.Results
 
                         var highResolutionCharts = new Dictionary<string, Chart>(live.Results.Charts);
 
-                        // 10 minute resolution data, save today
-                        var tenminuteSampler = new SeriesSampler(TimeSpan.FromMinutes(10));
-                        var tenminuteCharts = tenminuteSampler.SampleCharts(live.Results.Charts, start, stop);
-
-                        live.Results.Charts = tenminuteCharts;
-                        data_keys.Add(new
-                        {
-                            Key = CreateKey("10minute"),
-                            Serialized = JsonConvert.SerializeObject(live.Results)
-                        });
-
                         // minute resoluton data, save today
                         var minuteSampler = new SeriesSampler(TimeSpan.FromMinutes(1));
                         var minuteCharts = minuteSampler.SampleCharts(live.Results.Charts, start, stop);
@@ -860,6 +849,17 @@ namespace QuantConnect.Lean.Engine.Results
                         data_keys.Add(new
                         {
                             Key = CreateKey("minute"),
+                            Serialized = JsonConvert.SerializeObject(live.Results)
+                        });
+
+                        // 10 minute resolution data, save today
+                        var tenminuteSampler = new SeriesSampler(TimeSpan.FromMinutes(10));
+                        var tenminuteCharts = tenminuteSampler.SampleCharts(live.Results.Charts, start, stop);
+
+                        live.Results.Charts = tenminuteCharts;
+                        data_keys.Add(new
+                        {
+                            Key = CreateKey("10minute"),
                             Serialized = JsonConvert.SerializeObject(live.Results)
                         });
 


### PR DESCRIPTION
10-minute resampling was computed before 1-minute resampling and its result was used to resample to 1-minute losing information in the process. Now, 1-minute resampling is performed prior to 10-minute.