### PR TITLE
Changes related to #428 allowing conditional push of cash balances

### DIFF
--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -174,5 +174,13 @@ namespace QuantConnect.Brokerages
         /// </summary>
         /// <returns>The current cash balance for each currency available for trading</returns>
         public abstract List<Cash> GetCashBalance();
+
+        /// <summary>
+        /// Specifies whether the brokerage will instantly update account balances
+        /// </summary>
+        public virtual bool AccountInstantlyUpdated
+        {
+            get { return false; }
+        }
     }
 }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -246,5 +246,13 @@ namespace QuantConnect.Brokerages
             return new ImmediateSettlementModel();
         }
 
+        /// <summary>
+        /// Allows the brokerage to push cashbook updates. This is disabled by default.
+        /// </summary>
+        public virtual bool AllowAccountUpdates
+        {
+            get { return false; }
+        }
+
     }
 }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -246,13 +246,5 @@ namespace QuantConnect.Brokerages
             return new ImmediateSettlementModel();
         }
 
-        /// <summary>
-        /// Allows the brokerage to push cashbook updates. This is disabled by default.
-        /// </summary>
-        public virtual bool AllowAccountUpdates
-        {
-            get { return false; }
-        }
-
     }
 }

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -120,6 +120,11 @@ namespace QuantConnect.Brokerages
         /// <param name="accountType">The account type</param>
         /// <returns>The settlement model for this brokerage</returns>
         ISettlementModel GetSettlementModel(Security security, AccountType accountType);
+
+        /// <summary>
+        /// Allows the brokerage to push cashbook updates. This is disabled by default.
+        /// </summary>
+        bool AllowAccountUpdates { get; }
     }
 
     /// <summary>

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -121,10 +121,6 @@ namespace QuantConnect.Brokerages
         /// <returns>The settlement model for this brokerage</returns>
         ISettlementModel GetSettlementModel(Security security, AccountType accountType);
 
-        /// <summary>
-        /// Allows the brokerage to push cashbook updates. This is disabled by default.
-        /// </summary>
-        bool AllowAccountUpdates { get; }
     }
 
     /// <summary>

--- a/Common/Interfaces/IBrokerage.cs
+++ b/Common/Interfaces/IBrokerage.cs
@@ -100,5 +100,10 @@ namespace QuantConnect.Interfaces
         /// Disconnects the client from the broker's remote servers
         /// </summary>
         void Disconnect();
+
+        /// <summary>
+        /// Specifies whether the brokerage will instantly update account balances
+        /// </summary>
+        bool AccountInstantlyUpdated { get; }
     }
 }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -898,9 +898,12 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 Log.Trace(string.Format("BrokerageTransactionHandler.HandleAccountChanged(): {0} Cash Delta: {1}", account.CurrencySymbol, delta));
             }
 
-            // we don't actually want to do this, this data can be delayed
-            // override the current cash value to we're always gauranted to be in sync with the brokerage's push updates
-            //_algorithm.Portfolio.CashBook[account.CurrencySymbol].Quantity = account.CashBalance;
+            // maybe we don't actually want to do this, this data can be delayed. Must be explicitly allowed by brokerage
+            if (_algorithm.BrokerageModel.AllowAccountUpdates)
+            {
+                // override the current cash value so we're always gauranteed to be in sync with the brokerage's push updates
+                _algorithm.Portfolio.CashBook[account.CurrencySymbol].SetAmount(account.CashBalance);
+            }
         }
 
         /// <summary>

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -898,10 +898,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 Log.Trace(string.Format("BrokerageTransactionHandler.HandleAccountChanged(): {0} Cash Delta: {1}", account.CurrencySymbol, delta));
             }
 
-            // maybe we don't actually want to do this, this data can be delayed. Must be explicitly allowed by brokerage
-            if (_algorithm.BrokerageModel.AllowAccountUpdates)
+            // maybe we don't actually want to do this, this data can be delayed. Must be explicitly supported by brokerage
+            if (_brokerage.AccountInstantlyUpdated)
             {
-                // override the current cash value so we're always gauranteed to be in sync with the brokerage's push updates
+                // override the current cash value so we're always guaranteed to be in sync with the brokerage's push updates
                 _algorithm.Portfolio.CashBook[account.CurrencySymbol].SetAmount(account.CashBalance);
             }
         }


### PR DESCRIPTION
Very minor changes that re-enable existing feature for brokerage to push cash balance updates. This is disabled by default.

This was much too easy: it must be wrong. There is no direct test of the ITransactionHandler that might cover these changes. It's no problem to prove it's disabled by default, but where to add the test method?