### PR TITLE
Send Runtime Statistics Along with Final Result Packet.

### DIFF
--- a/Common/Packets/BacktestResultPacket.cs
+++ b/Common/Packets/BacktestResultPacket.cs
@@ -248,12 +248,13 @@ namespace QuantConnect.Packets
         /// <summary>
         /// Constructor for the result class using dictionary objects.
         /// </summary>
-        public BacktestResult(IDictionary<string, Chart> charts, IDictionary<int, Order> orders, IDictionary<DateTime, decimal> profitLoss, IDictionary<string, string> statistics, Dictionary<string, AlgorithmPerformance> rollingWindow, AlgorithmPerformance totalPerformance = null)
+        public BacktestResult(IDictionary<string, Chart> charts, IDictionary<int, Order> orders, IDictionary<DateTime, decimal> profitLoss, IDictionary<string, string> statistics, IDictionary<string, string> runtimeStatistics, Dictionary<string, AlgorithmPerformance> rollingWindow, AlgorithmPerformance totalPerformance = null)
         {
             Charts = charts;
             Orders = orders;
             ProfitLoss = profitLoss;
             Statistics = statistics;
+            RuntimeStatistics = runtimeStatistics;
             RollingWindow = rollingWindow;
             TotalPerformance = totalPerformance;
         }

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -293,6 +293,20 @@ namespace QuantConnect.Lean.Engine
 
                                 statisticsResults = StatisticsBuilder.Generate(trades, profitLoss, equity, performance, benchmark,
                                     _algorithmHandlers.Setup.StartingPortfolioValue, algorithm.Portfolio.TotalFees, totalTransactions);
+
+                                //Some users have $0 in their brokerage account / starting cash of $0. Prevent divide by zero errors
+                                var netReturn = _algorithmHandlers.Setup.StartingPortfolioValue > 0 ?
+                                                (algorithm.Portfolio.TotalPortfolioValue - _algorithmHandlers.Setup.StartingPortfolioValue) / _algorithmHandlers.Setup.StartingPortfolioValue
+                                                : 0;
+
+                                //Add other fixed parameters.
+                                banner.Add("Unrealized:", "$" + algorithm.Portfolio.TotalUnrealizedProfit.ToString("N2"));
+                                banner.Add("Fees:", "-$" + algorithm.Portfolio.TotalFees.ToString("N2"));
+                                banner.Add("Net Profit:", "$" + algorithm.Portfolio.TotalProfit.ToString("N2"));
+                                banner.Add("Return:", netReturn.ToString("P"));
+                                banner.Add("Equity:", "$" + algorithm.Portfolio.TotalPortfolioValue.ToString("N2"));
+                                banner.Add("Holdings:", "$" + algorithm.Portfolio.TotalHoldingsValue.ToString("N2"));
+                                banner.Add("Volume:", "$" + algorithm.Portfolio.TotalSaleVolume.ToString("N2"));
                             }
                         }
                         catch (Exception err)

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -338,7 +338,7 @@ namespace QuantConnect.Lean.Engine.Results
                 if (progress > 0.999m) progress = 0.999m;
 
                 //1. Cloud Upload -> Upload the whole packet to S3  Immediately:
-                var completeResult = new BacktestResult(Charts, _transactionHandler.Orders, Algorithm.Transactions.TransactionRecord, new Dictionary<string, string>(), new Dictionary<string, AlgorithmPerformance>());
+                var completeResult = new BacktestResult(Charts, _transactionHandler.Orders, Algorithm.Transactions.TransactionRecord, new Dictionary<string, string>(), runtimeStatistics, new Dictionary<string, AlgorithmPerformance>());
                 var complete = new BacktestResultPacket(_job, completeResult, progress);
 
                 if (DateTime.Now > _nextS3Update)
@@ -460,10 +460,8 @@ namespace QuantConnect.Lean.Engine.Results
 
                 //Create a result packet to send to the browser.
                 var result = new BacktestResultPacket((BacktestNodePacket) job,
-                    new BacktestResult(charts, orders, profitLoss, statisticsResults.Summary, statisticsResults.RollingPerformances, statisticsResults.TotalPerformance)
-                    {
-                        RuntimeStatistics = _runtimeStatistics
-                    }, 1m)
+                    new BacktestResult(charts, orders, profitLoss, statisticsResults.Summary, banner, statisticsResults.RollingPerformances, statisticsResults.TotalPerformance)
+                    , 1m)
                 {
                     ProcessingTime = (DateTime.Now - _startTime).TotalSeconds,
                     DateFinished = DateTime.Now,


### PR DESCRIPTION
Keep rolling/saved version of the runtime statistics.
Adds runtimeStatistics parameter to pass runtime statistics to Backtest result packet.
Runtime Statistics calculated at Engine.cs prior to SendFinalResult call to be sent along.