### PR TITLE
Added Fxcm Brokerage live mode string-long check

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
@@ -111,7 +111,9 @@ namespace QuantConnect.Brokerages.Fxcm
             AutoResetEvent autoResetEvent;
             lock (_locker)
             {
-                _currentRequest = _gateway.requestOpenPositions(_accountId);
+                _currentRequest = _terminal.Equals("Demo") ?
+                    _gateway.requestOpenPositions(Convert.ToInt64(_accountId)) :
+                    _gateway.requestOpenPositions(_accountId);
                 autoResetEvent = new AutoResetEvent(false);
                 _mapRequestsToAutoResetEvents[_currentRequest] = autoResetEvent;
             }


### PR DESCRIPTION
Added a check for the live mode which if in demo mode changes the accountID type to long or else keep it as a string.