### PR TITLE
Fixes bug for data feeds for non-usd forex currencies

### DIFF
--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -198,7 +198,7 @@ namespace QuantConnect.Securities
                     }
                     else
                     {
-                        security = new Forex.Forex(exchangeHours, this, config, symbolProperties);
+                        security = new Forex.Forex(exchangeHours, quoteCash, config, symbolProperties);
                     }
                     securities.Add(config.Symbol, security);
                     Log.Trace("Cash.EnsureCurrencyDataFeed(): Adding " + symbol.Value + " for cash " + Symbol + " currency feed");


### PR DESCRIPTION
Fixes bug for data feeds for non-USD forex currencies for the entries added in the Symbol Properties database. Quote currency mismatch.

Solution for #453 