### PR TITLE
Added missing quandl-auth-token to config.json

### DIFF
--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -79,6 +79,10 @@
   "iqfeed-productName": "",
   "iqfeed-version": "1.0",
 
+  // Required to access data from Quandl
+  // To get your access token go to https://www.quandl.com/account/api
+  "quandl-auth-token": "",
+
   // parameters to set in the algorithm (the below are just samples)
   "parameters": {
     "ema-fast": 10,


### PR DESCRIPTION
Quandl cannot be configured if you develop on desktop environment because config file is missing the configuration property.