### PR TITLE
Updated Quandl API to version 3

### DIFF
--- a/Common/Data/Custom/Quandl.cs
+++ b/Common/Data/Custom/Quandl.cs
@@ -60,11 +60,10 @@ namespace QuantConnect.Data.Custom
         /// <summary>
         /// Default quandl constructor uses Close as its value column
         /// </summary>
-        public Quandl()
+        public Quandl() : this("Close")
         {
-            _valueColumn = "Close";
         }
-        
+
         /// <summary>
         /// Constructor for creating customized quandl instance which doesn't use "Close" as its value item.
         /// </summary>
@@ -127,7 +126,7 @@ namespace QuantConnect.Data.Custom
         /// <returns>STRING API Url for Quandl.</returns>
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
-            var source = @"https://www.quandl.com/api/v1/datasets/" + config.Symbol.Value + ".csv?sort_order=asc&exclude_headers=false&auth_token=" + _authCode;
+            var source = @"https://www.quandl.com/api/v3/datasets/" + config.Symbol.Value + ".csv?order=asc&api_key=" + _authCode;
             return new SubscriptionDataSource(source, SubscriptionTransportMedium.RemoteFile);
         }
 
@@ -137,6 +136,8 @@ namespace QuantConnect.Data.Custom
         /// <param name="authCode"></param>
         public static void SetAuthCode(string authCode)
         {
+            if (string.IsNullOrWhiteSpace(authCode)) return;
+
             _authCode = authCode;
             IsAuthCodeSet = true;
         }


### PR DESCRIPTION
- Quandl is currently supporting REST API for data in version 3. This change reflects new syntax of the API.
- IsAuthCodeSet property was incorrectly set to true if API token in config file is empty.