### PR TITLE
Updated QuandlFuturesDataAlgorithm sample

### DIFF
--- a/Algorithm.CSharp/QuandlFuturesDataAlgorithm.cs
+++ b/Algorithm.CSharp/QuandlFuturesDataAlgorithm.cs
@@ -14,10 +14,9 @@
 */
 
 using System;
-using QuantConnect.Algorithm;
 using QuantConnect.Data.Custom;
 
-namespace QuantConnect
+namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
     /// QuantConnect University: Futures Example
@@ -28,7 +27,7 @@ namespace QuantConnect
     /// QuantConnect has a special deal with Quandl giving you access to Stevens Continuous Futurs (SCF) for free.
     /// If you'd like to download SCF for local backtesting, you can download it through Quandl.com.
     /// </summary>
-    public class QCUQuandlFutures : QCAlgorithm
+    public class QuandlFuturesDataAlgorithm : QCAlgorithm
     {
         string _crude = "SCF/CME_CL1_ON";
 
@@ -51,23 +50,9 @@ namespace QuantConnect
         {
             if (!Portfolio.HoldStock)
             {
-                SetHoldings(_crude, 1);
+                SetHoldings(Symbol(_crude), 1);
                 Debug(Time.ToString("u") + " Purchased Crude Oil: " + _crude);
             }
-        }
-    }
-
-    /// <summary>
-    /// Custom quandl data type for setting customized value column name. Value column is used for the primary trading calculations and charting.
-    /// </summary>
-    public class QuandlFuture : Quandl
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QuantConnect.QuandlFuture"/> class.
-        /// </summary>
-        public QuandlFuture()
-            : base(valueColumnName: "Settle")
-        {
         }
     }
 }

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -93,6 +93,7 @@
     <Compile Include="OpeningBreakoutAlgorithm.cs" />
     <Compile Include="DropboxUniverseSelectionAlgorithm.cs" />
     <Compile Include="ParameterizedAlgorithm.cs" />
+    <Compile Include="QuandlFuturesDataAlgorithm.cs" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.cs" />
     <Compile Include="UserDefinedUniverseAlgorithm.cs" />
     <Compile Include="WarmupAlgorithm.cs" />
@@ -103,7 +104,6 @@
     <Compile Include="MovingAverageCrossAlgorithm.cs" />
     <Compile Include="MultipleSymbolConsolidationAlgorithm.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="QuandlFuturesDataAlgorithm.cs" />
     <Compile Include="QuandlImporterAlgorithm.cs" />
     <Compile Include="RegressionAlgorithm.cs" />
     <Compile Include="RenkoConsolidatorAlgorithm.cs" />

--- a/Common/Data/Custom/QuandlFuture.cs
+++ b/Common/Data/Custom/QuandlFuture.cs
@@ -1,0 +1,13 @@
+﻿namespace QuantConnect.Data.Custom
+{
+    /// <summary>
+    /// Custom quandl data type for setting customized value column name. Value column is used for the primary trading calculations and charting.
+    /// </summary>
+    public class QuandlFuture : Quandl
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuandlFuture"/> class.
+        /// </summary>
+        public QuandlFuture() : base("Settle") { }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Commands\QuitCommand.cs" />
     <Compile Include="Commands\UpdateOrderCommand.cs" />
     <Compile Include="Data\Custom\DailyFx.cs" />
+    <Compile Include="Data\Custom\QuandlFuture.cs" />
     <Compile Include="Data\Market\FirstOrderGreeks.cs" />
     <Compile Include="Data\Market\OptionChain.cs" />
     <Compile Include="Data\Market\OptionChains.cs" />


### PR DESCRIPTION
- QuandlFutures data type was moved to Custom/Data folder because it's reused on multiple places outside the sample
- Name of class is matching the filename and is now consistent with rest of samples
- Added Symbol() call to remove compilation warning