### PR TITLE
Updated the GetCashBalance to reflect the correct cash in the cashbook and Updated the PerformCashSync

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Brokerages.Fxcm
 
         private readonly object _locker = new object();
         private string _currentRequest;
-        private const int ResponseTimeout = 2500;
+        private const int ResponseTimeout = 5000;
         private bool _isOrderUpdateOrCancelRejected;
         private bool _isOrderSubmitRejected;
 

--- a/Brokerages/Fxcm/FxcmBrokerage.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.cs
@@ -304,11 +304,55 @@ namespace QuantConnect.Brokerages.Fxcm
         public override List<Cash> GetCashBalance()
         {
             Log.Trace("FxcmBrokerage.GetCashBalance()");
+            var cashBook = new List<Cash>();
 
-            return new List<Cash>
+            //Adds the account currency USD to the cashbook.
+            cashBook.Add(new Cash(_fxcmAccountCurrency,
+                        Convert.ToDecimal(_accounts[_accountId].getCashOutstanding()),
+                        GetUsdConversion(_fxcmAccountCurrency)));
+
+            foreach (var trade in _openPositions.Values)
             {
-                new Cash(_fxcmAccountCurrency, Convert.ToDecimal(_accounts[_accountId].getCashOutstanding()), GetUsdConversion(_fxcmAccountCurrency))
-            };
+                //settlement price for the trade
+                var settlementPrice = Convert.ToDecimal(trade.getSettlPrice());
+                //direction of trade
+                var direction = trade.getPositionQty().getLongQty() > 0 ? 1 : -1;
+                //quantity of the asset
+                var quantity = Convert.ToDecimal(trade.getPositionQty().getQty());
+                //quantity of base currency
+                var baseQuantity = direction * quantity;
+                //quantity of quote currency
+                var quoteQuantity = -direction * quantity * settlementPrice;
+                //base currency
+                var baseCurrency = trade.getCurrency();
+                //quote currency
+                var quoteCurrency = trade.getInstrument().getSymbol().Substring(4, 3);
+
+                var baseCurrencyObject = (from cash in cashBook where cash.Symbol == baseCurrency select cash).FirstOrDefault();
+                //update the value of the base currency
+                if (baseCurrencyObject != null)
+                {
+                    baseCurrencyObject.AddAmount(baseQuantity);
+                }
+                else
+                {
+                    //add the base currency if not present
+                    cashBook.Add(new Cash(baseCurrency, baseQuantity, GetUsdConversion(baseCurrency)));
+                }
+
+                var quoteCurrencyObject = (from cash in cashBook where cash.Symbol == quoteCurrency select cash).FirstOrDefault();
+                //update the value of the quote currency
+                if (quoteCurrencyObject != null)
+                {
+                    quoteCurrencyObject.AddAmount(quoteQuantity);
+                }
+                else
+                {
+                    //add the quote currency if not present
+                    cashBook.Add(new Cash(quoteCurrency, quoteQuantity, GetUsdConversion(quoteCurrency)));
+                }
+            }
+            return cashBook;
         }
 
         /// <summary>

--- a/Brokerages/Fxcm/FxcmBrokerage.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.cs
@@ -326,7 +326,8 @@ namespace QuantConnect.Brokerages.Fxcm
                 //base currency
                 var baseCurrency = trade.getCurrency();
                 //quote currency
-                var quoteCurrency = trade.getInstrument().getSymbol().Substring(4, 3);
+                var quoteCurrency = FxcmSymbolMapper.ConvertFxcmSymbolToLeanSymbol(trade.getInstrument().getSymbol());
+                quoteCurrency = quoteCurrency.Substring(quoteCurrency.Length - 3);
 
                 var baseCurrencyObject = (from cash in cashBook where cash.Symbol == baseCurrency select cash).FirstOrDefault();
                 //update the value of the base currency

--- a/Brokerages/Fxcm/FxcmSymbolMapper.cs
+++ b/Brokerages/Fxcm/FxcmSymbolMapper.cs
@@ -228,7 +228,7 @@ namespace QuantConnect.Brokerages.Fxcm
         /// <summary>
         /// Converts an FXCM symbol to a Lean symbol string
         /// </summary>
-        private static string ConvertFxcmSymbolToLeanSymbol(string fxcmSymbol)
+        public static string ConvertFxcmSymbolToLeanSymbol(string fxcmSymbol)
         {
             string leanSymbol;
             return MapFxcmToLean.TryGetValue(fxcmSymbol, out leanSymbol) ? leanSymbol : string.Empty;

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -536,6 +536,17 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                     return;
                 }
 
+                //Adds currency to the cashbook that the user might have deposited
+                foreach (var balance in balances)
+                {
+                    Cash cash;
+                    if (!_algorithm.Portfolio.CashBook.TryGetValue(balance.Symbol, out cash))
+                    {
+                        Log.LogHandler.Trace("BrokerageTransactionHandler.PerformCashSync(): Unexpected cash found {0} {1}", balance.Amount, balance.Symbol);
+                        _algorithm.Portfolio.SetCash(balance.Symbol, balance.Amount, balance.ConversionRate);
+                    }
+                }
+
                 // if we were returned our balances, update everything and flip our flag as having performed sync today
                 foreach (var cash in _algorithm.Portfolio.CashBook.Values)
                 {

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -536,17 +536,6 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                     return;
                 }
 
-                //Adds currency to the cashbook that the user might have deposited
-                foreach (var balance in balances)
-                {
-                    Cash cash;
-                    if (!_algorithm.Portfolio.CashBook.TryGetValue(balance.Symbol, out cash))
-                    {
-                        Log.LogHandler.Trace("BrokerageTransactionHandler.PerformCashSync(): Unexpected cash found {0} {1}", balance.Amount, balance.Symbol);
-                        _algorithm.Portfolio.SetCash(balance.Symbol, balance.Amount, balance.ConversionRate);
-                    }
-                }
-
                 // if we were returned our balances, update everything and flip our flag as having performed sync today
                 foreach (var cash in _algorithm.Portfolio.CashBook.Values)
                 {

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -545,7 +545,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                     {
                         // compare in dollars
                         var delta = cash.Amount - balanceCash.Amount;
-                        if (Math.Abs(delta) > _algorithm.Portfolio.CashBook.ConvertToAccountCurrency(delta, cash.Symbol))
+                        if (Math.Abs(_algorithm.Portfolio.CashBook.ConvertToAccountCurrency(delta, cash.Symbol)) > 5)
                         {
                             // log the delta between 
                             Log.LogHandler.Trace("BrokerageTransactionHandler.PerformCashSync(): {0} Delta: {1}", balanceCash.Symbol,

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -543,7 +543,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                     //update the cash if the entry if found in the balances
                     if (balanceCash != null)
                     {
-                        //compare in dollars
+                        // compare in dollars
                         var delta = cash.Amount - balanceCash.Amount;
                         if (Math.Abs(delta) > _algorithm.Portfolio.CashBook.ConvertToAccountCurrency(delta, cash.Symbol))
                         {


### PR DESCRIPTION
1. Updated the response timeout for the FXCM brokerage from 2.5 seconds to 5 seconds.

2. Changed the GetCashBalane() for FXCM brokerage to reflect the correct value of cash for the cashbook.

3. Updated the PerformCashSync() to sync the correct values for the portfolio.

 