### PR TITLE
User-frieldly warning misspecification of algorithm name

### DIFF
--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -287,7 +287,7 @@ namespace QuantConnect.AlgorithmFactory
 
                     if (string.IsNullOrEmpty(types[0]))
                     {
-                        errorMessage = "Unable to resolve multiple algorithm types to a single type.";
+                        errorMessage = "Unable to resolve multiple algorithm types to a single type. Please verify algorithm name in the config file for misspecification";
                         Log.Error("Loader.TryCreateILAlgorithm(): Failed resolving multiple algorithm types to a single type.");
                         return false;
                     }

--- a/Engine/Setup/ConsoleSetupHandler.cs
+++ b/Engine/Setup/ConsoleSetupHandler.cs
@@ -89,7 +89,7 @@ namespace QuantConnect.Lean.Engine.Setup
 
             // don't force load times to be fast here since we're running locally, this allows us to debug
             // and step through some code that may take us longer than the default 10 seconds
-            var loader = new Loader(language, TimeSpan.FromHours(1), names => names.Single(name => MatchTypeName(name, algorithmName)));
+            var loader = new Loader(language, TimeSpan.FromHours(1), names => names.SingleOrDefault(name => MatchTypeName(name, algorithmName)));
             var complete = loader.TryCreateAlgorithmInstanceWithIsolator(assemblyPath, out algorithm, out error);
             if (!complete) throw new Exception(error + ": try re-building algorithm.");
 


### PR DESCRIPTION
Defines a new resolver function to return null instead of throwing so that Loader can return a user-friedly error message.
Ref.: issue #456 