### PR TITLE
Lot size rounding to zero causes Order to timeout

### DIFF
--- a/Common/Orders/OrderResponse.cs
+++ b/Common/Orders/OrderResponse.cs
@@ -154,8 +154,9 @@ namespace QuantConnect.Orders
         /// </summary>
         public static OrderResponse ZeroQuantity(OrderRequest request)
         {
-            const string format = "Unable to {0} order to have zero quantity.";
-            return Error(request, OrderResponseErrorCode.OrderQuantityZero, string.Format(format, request.OrderRequestType.ToString().ToLower()));
+            const string format = "Unable to {0} order with id {1} that have zero quantity.";
+            return Error(request, OrderResponseErrorCode.OrderQuantityZero,
+                string.Format(format, request.OrderRequestType.ToString().ToLower(), request.OrderId));
         }
 
         /// <summary>

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -618,11 +618,6 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             // rounds off the order towards 0 to the nearest multiple of lot size
             order.Quantity = RoundOffOrder(order, security);
 
-            if (order.Quantity == 0)
-            {
-                return OrderResponse.ZeroQuantity(request);
-            }
-
             if (!_orders.TryAdd(order.Id, order))
             {
                 Log.Error("BrokerageTransactionHandler.HandleSubmitOrderRequest(): Unable to add new order, order not processed.");
@@ -636,6 +631,15 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
             // update the ticket's internal storage with this new order reference
             ticket.SetOrder(order);
+
+            if (order.Quantity == 0)
+            {
+                order.Status = OrderStatus.Invalid;
+                var response = OrderResponse.ZeroQuantity(request);
+                _algorithm.Error(response.ErrorMessage);
+                HandleOrderEvent(new OrderEvent(order, _algorithm.UtcTime, 0m, "Unable to add order for zero quantity"));
+                return response;
+            }
 
             // check to see if we have enough money to place the order
             bool sufficientCapitalForOrder;

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -123,9 +123,10 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.IsTrue(orderTicket.Status == OrderStatus.New);
             transactionHandler.HandleOrderRequest(orderRequest);
 
-            Assert.IsTrue(orderRequest.Response.IsProcessed);
             // 600 after round off becomes 0 -> order is not placed
-            Assert.IsFalse(orderRequest.Response.IsSuccess);
+            Assert.IsTrue(orderRequest.Response.IsProcessed);
+            Assert.IsTrue(orderRequest.Response.IsError);
+            Assert.IsTrue(orderTicket.Status == OrderStatus.Invalid);
         }
     }
 }


### PR DESCRIPTION
- HandleOrderEvent() should be called when lot is rounded to zero quantity
- Added case to unit test