### PR TITLE
Bug fix in ImmediateFillModel market fills with tick resolution

### DIFF
--- a/Common/Orders/Fills/ImmediateFillModel.cs
+++ b/Common/Orders/Fills/ImmediateFillModel.cs
@@ -390,14 +390,7 @@ namespace QuantConnect.Orders.Fills
             var tick = asset.Cache.GetData<Tick>();
             if (tick != null)
             {
-                if (direction == OrderDirection.Sell && tick.BidPrice != 0)
-                {
-                    current = tick.BidPrice;
-                }
-                else if (direction == OrderDirection.Buy && tick.AskPrice != 0)
-                {
-                    current = tick.AskPrice;
-                }
+                return new Prices(current, open, high, low, close);
             }
 
             var quoteBar = asset.Cache.GetData<QuoteBar>();

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Data.Market;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Forex;
+
+namespace QuantConnect.Tests.Common.Orders.Fills
+{
+    [TestFixture]
+    public class ImmediateFillModelTests
+    {
+        [TestCase(OrderDirection.Buy)]
+        [TestCase(OrderDirection.Sell)]
+        public void MarketOrderFillsAtBidAsk(OrderDirection direction)
+        {
+            var symbol = Symbol.Create("EURUSD", SecurityType.Forex, "fxcm");
+            var exchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork);
+            var quoteCash = new Cash("USD", 1000, 1);
+            var symbolProperties = SymbolProperties.GetDefault("USD");
+            var security = new Forex(symbol, exchangeHours, quoteCash, symbolProperties);
+
+            var reference = DateTime.Now;
+            var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
+            var timeKeeper = new TimeKeeper(referenceUtc);
+            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            var brokerageModel = new FxcmBrokerageModel();
+            var fillModel = brokerageModel.GetFillModel(security);
+
+            const decimal bidPrice = 1.13739m;
+            const decimal askPrice = 1.13746m;
+
+            security.SetMarketPrice(new Tick(DateTime.Now, symbol, bidPrice, askPrice));
+
+            var quantity = direction == OrderDirection.Buy ? 1 : -1;
+            var order = new MarketOrder(symbol, quantity, DateTime.Now);
+            var fill = fillModel.MarketFill(security, order);
+
+            var expected = direction == OrderDirection.Buy ? askPrice : bidPrice;
+            Assert.AreEqual(expected, fill.FillPrice);
+        }
+
+
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Common\Data\SubscriptionDataSourceTests.cs" />
     <Compile Include="Common\Data\TickQuoteBarConsolidatorTests.cs" />
     <Compile Include="Common\MarketTests.cs" />
+    <Compile Include="Common\Orders\Fills\ImmediateFillModelTests.cs" />
     <Compile Include="Common\Orders\Fills\PartialMarketFillModelTests.cs" />
     <Compile Include="Common\Orders\OrderJsonConverterTests.cs" />
     <Compile Include="Common\Orders\OrderTests.cs" />


### PR DESCRIPTION
Fill prices were higher (lower) for market buy (sell) orders

Thanks to Levitikon for reporting the bug: https://www.quantconnect.com/forum/discussion/1262/supported-forex-pairs/p1