### PR TITLE
Tidying brokerage factories

### DIFF
--- a/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
@@ -67,7 +67,8 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <summary>
         ///Initializes a new instance of the <see cref="BacktestingBrokerageFactory"/> class
         /// </summary>
-        public BacktestingBrokerageFactory() : base(typeof(BacktestingBrokerageFactory))
+        public BacktestingBrokerageFactory() 
+            : base(typeof(BacktestingBrokerage))
         {
         }
     }

--- a/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
@@ -23,16 +23,8 @@ namespace QuantConnect.Brokerages.Backtesting
     /// <summary>
     /// Factory type for the <see cref="BacktestingBrokerage"/>
     /// </summary>
-    public class BacktestingBrokerageFactory : IBrokerageFactory
+    public class BacktestingBrokerageFactory : BrokerageFactory
     {
-        /// <summary>
-        /// Gets the type of brokerage produced by this factory
-        /// </summary>
-        public Type BrokerageType
-        {
-            get { return typeof(BacktestingBrokerage); }
-        }
-
         /// <summary>
         /// Gets the brokerage data required to run the IB brokerage from configuration
         /// </summary>
@@ -40,7 +32,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// The implementation of this property will create the brokerage data dictionary required for
         /// running live jobs. See <see cref="IJobQueueHandler.NextJob"/>
         /// </remarks>
-        public Dictionary<string, string> BrokerageData
+        public override Dictionary<string, string> BrokerageData
         {
             get { return new Dictionary<string, string>(); }
         }
@@ -48,7 +40,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        public IBrokerageModel BrokerageModel
+        public override IBrokerageModel BrokerageModel
         {
             get { return new InteractiveBrokersBrokerageModel(); }
         }
@@ -59,7 +51,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <param name="job">The job packet to create the brokerage for</param>
         /// <param name="algorithm">The algorithm instance</param>
         /// <returns>A new brokerage instance</returns>
-        public IBrokerage CreateBrokerage(LiveNodePacket job, IAlgorithm algorithm)
+        public override IBrokerage CreateBrokerage(LiveNodePacket job, IAlgorithm algorithm)
         {
             return new BacktestingBrokerage(algorithm);
         }
@@ -68,9 +60,16 @@ namespace QuantConnect.Brokerages.Backtesting
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         /// <filterpriority>2</filterpriority>
-        public void Dispose()
+        public override void Dispose()
         {
             // NOP
+        }
+
+        /// <summary>
+        ///Initializes a new instance of the <see cref="BacktestingBrokerageFactory"/> class
+        /// </summary>
+        public BacktestingBrokerageFactory() : base(typeof(BacktestingBrokerageFactory))
+        {
         }
     }
 }

--- a/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;

--- a/Brokerages/Paper/PaperBrokerageFactory.cs
+++ b/Brokerages/Paper/PaperBrokerageFactory.cs
@@ -15,8 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using QuantConnect.Brokerages.Backtesting;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
 
@@ -25,16 +23,8 @@ namespace QuantConnect.Brokerages.Paper
     /// <summary>
     /// The factory type for the <see cref="PaperBrokerage"/>
     /// </summary>
-    public class PaperBrokerageFactory : IBrokerageFactory
+    public class PaperBrokerageFactory : BrokerageFactory
     {
-        /// <summary>
-        /// Gets the type of brokerage produced by this factory
-        /// </summary>
-        public Type BrokerageType
-        {
-            get { return typeof(PaperBrokerage); }
-        }
-
         /// <summary>
         /// Gets the brokerage data required to run the IB brokerage from configuration
         /// </summary>
@@ -42,7 +32,7 @@ namespace QuantConnect.Brokerages.Paper
         /// The implementation of this property will create the brokerage data dictionary required for
         /// running live jobs. See <see cref="IJobQueueHandler.NextJob"/>
         /// </remarks>
-        public Dictionary<string, string> BrokerageData
+        public override Dictionary<string, string> BrokerageData
         {
             get { return new Dictionary<string, string>(); }
         }
@@ -50,7 +40,7 @@ namespace QuantConnect.Brokerages.Paper
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        public IBrokerageModel BrokerageModel
+        public override IBrokerageModel BrokerageModel
         {
             get { return new DefaultBrokerageModel(); }
         }
@@ -61,7 +51,7 @@ namespace QuantConnect.Brokerages.Paper
         /// <param name="job">The job packet to create the brokerage for</param>
         /// <param name="algorithm">The algorithm instance</param>
         /// <returns>A new brokerage instance</returns>
-        public IBrokerage CreateBrokerage(LiveNodePacket job, IAlgorithm algorithm)
+        public override IBrokerage CreateBrokerage(LiveNodePacket job, IAlgorithm algorithm)
         {
             return new PaperBrokerage(algorithm, job);
         }
@@ -70,9 +60,17 @@ namespace QuantConnect.Brokerages.Paper
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         /// <filterpriority>2</filterpriority>
-        public void Dispose()
+        public override void Dispose()
         {
             // NOP
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PaperBrokerageFactory"/> class
+        /// </summary>
+        public PaperBrokerageFactory()
+            : base(typeof(PaperBrokerageFactory))
+        {
         }
     }
 }

--- a/Brokerages/Paper/PaperBrokerageFactory.cs
+++ b/Brokerages/Paper/PaperBrokerageFactory.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Brokerages.Paper
         /// Initializes a new instance of the <see cref="PaperBrokerageFactory"/> class
         /// </summary>
         public PaperBrokerageFactory()
-            : base(typeof(PaperBrokerageFactory))
+            : base(typeof(PaperBrokerage))
         {
         }
     }

--- a/Engine/DefaultBrokerageMessageHandler.cs
+++ b/Engine/DefaultBrokerageMessageHandler.cs
@@ -41,7 +41,6 @@ namespace QuantConnect.Lean.Engine
 
         private readonly IApi _api;
         private readonly IAlgorithm _algorithm;
-        private readonly IResultHandler _results;
         private readonly TimeSpan _openThreshold;
         private readonly AlgorithmNodePacket _job;
         private readonly TimeSpan _initialDelay;
@@ -56,11 +55,10 @@ namespace QuantConnect.Lean.Engine
         /// <param name="api">The api for the algorithm</param>
         /// <param name="initialDelay"></param>
         /// <param name="openThreshold">Defines how long before market open to re-check for brokerage reconnect message</param>
-        public DefaultBrokerageMessageHandler(IAlgorithm algorithm, AlgorithmNodePacket job, IResultHandler results, IApi api, TimeSpan? initialDelay = null, TimeSpan? openThreshold = null)
+        public DefaultBrokerageMessageHandler(IAlgorithm algorithm, AlgorithmNodePacket job, IApi api, TimeSpan? initialDelay = null, TimeSpan? openThreshold = null)
         {
             _api = api;
             _job = job;
-            _results = results;
             _algorithm = algorithm;
             _connected = true;
             _openThreshold = openThreshold ?? DefaultOpenThreshold;
@@ -77,16 +75,16 @@ namespace QuantConnect.Lean.Engine
             switch (message.Type)
             {
                 case BrokerageMessageType.Information:
-                    _results.DebugMessage("Brokerage Info: " + message.Message);
+                    _algorithm.Debug("Brokerage Info: " + message.Message);
                     break;
                 
                 case BrokerageMessageType.Warning:
-                    _results.ErrorMessage("Brokerage Warning: " + message.Message);
+                    _algorithm.Error("Brokerage Warning: " + message.Message);
                     _api.SendUserEmail(_job.AlgorithmId, "Brokerage Warning", message.Message);
                     break;
 
                 case BrokerageMessageType.Error:
-                    _results.ErrorMessage("Brokerage Error: " + message.Message);
+                    _algorithm.Error("Brokerage Error: " + message.Message);
                     _algorithm.RunTimeError = new Exception(message.Message);
                     break;
 
@@ -172,7 +170,7 @@ namespace QuantConnect.Lean.Engine
             if (!_connected)
             {
                 Log.Error("DefaultBrokerageMessageHandler.Handle(): Still disconnected, goodbye.");
-                _results.ErrorMessage("Brokerage Disconnect: " + message.Message);
+                _algorithm.Error("Brokerage Disconnect: " + message.Message);
                 _algorithm.RunTimeError = new Exception(message.Message);
             }
         }

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -131,7 +131,7 @@ namespace QuantConnect.Lean.Engine
                     algorithm.HistoryProvider = _algorithmHandlers.HistoryProvider;
 
                     // initialize the default brokerage message handler
-                    algorithm.BrokerageMessageHandler = new DefaultBrokerageMessageHandler(algorithm, job, _algorithmHandlers.Results, _systemHandlers.Api);
+                    algorithm.BrokerageMessageHandler = new DefaultBrokerageMessageHandler(algorithm, job, _systemHandlers.Api);
 
                     //Initialize the internal state of algorithm and job: executes the algorithm.Initialize() method.
                     initializeComplete = _algorithmHandlers.Setup.Setup(algorithm, brokerage, job, _algorithmHandlers.Results, _algorithmHandlers.Transactions, _algorithmHandlers.RealTime);

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -179,7 +179,7 @@
       "log-handler": "QuantConnect.Logging.QueueLogHandler"
     },
 
-    // defines the 'backtesting-desktop' environment
+    // defines the 'live-desktop' environment
     "live-desktop": {
       "live-mode": true,
       "send-via-api": true,

--- a/Tests/Engine/DefaultBrokerageMessageHandler.cs
+++ b/Tests/Engine/DefaultBrokerageMessageHandler.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Tests.Engine
             var job = new LiveNodePacket();
             var results = new TestResultHandler();//packet => Console.WriteLine(FieldsToString(packet)));
             var api = new Api.Api();
-            var handler = new DefaultBrokerageMessageHandler(algorithm, job, results, api, TimeSpan.FromMinutes(15));
+            var handler = new DefaultBrokerageMessageHandler(algorithm, job, api, TimeSpan.FromMinutes(15));
 
             Assert.IsNull(algorithm.RunTimeError);
 
@@ -65,7 +65,7 @@ namespace QuantConnect.Tests.Engine
             var job = new LiveNodePacket();
             var results = new TestResultHandler();//packet => Console.WriteLine(FieldsToString(packet)));
             var api = new Api.Api();
-            var handler = new DefaultBrokerageMessageHandler(algorithm, job, results, api, TimeSpan.FromMinutes(15), TimeSpan.FromSeconds(.25));
+            var handler = new DefaultBrokerageMessageHandler(algorithm, job, api, TimeSpan.FromMinutes(15), TimeSpan.FromSeconds(.25));
 
             Assert.IsNull(algorithm.RunTimeError);
 


### PR DESCRIPTION
1. Changed the base classes for PaperBrokerageFactory and BacktestingBrokerageFactory from IBrokerageFactory to BrokerageFactory to make it consistent with the others.

2. Removed the IResultHandler from the constructor for DefaultBrokerageMessageHandler

Also removed a couple of used directives.