### PR TITLE
Prevents changes in previous bar

### DIFF
--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -1022,6 +1022,9 @@ namespace QuantConnect.Lean.Engine.Results
                             var last = security.GetLastData();
                             if (last != null)
                             {
+                                // Prevents changes in previous bar
+                                last = last.Clone(last.IsFillForward);
+
                                 last.Value = price;
                                 security.SetRealTimePrice(last);
 


### PR DESCRIPTION
When using the last bar to update a security realtime price, inadvertently the last bar close/value was changed despite the bar been closed. 
Now updates the security object with a clone of last bar, preventing last bar to be changed.
Ref. #454 
