### PR TITLE
Added a check for non-USD currencies while updating cashbook

### DIFF
--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -84,6 +84,7 @@ namespace QuantConnect.Securities
         public void Update(BaseData data)
         {
             if (_isBaseCurrency) return;
+            if (!data.Symbol.Value.Contains(CashBook.AccountCurrency)) return;
             
             var rate = data.Value;
             if (_invertRealTimePrice)

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -84,7 +84,6 @@ namespace QuantConnect.Securities
         public void Update(BaseData data)
         {
             if (_isBaseCurrency) return;
-            if (!data.Symbol.Value.Contains(CashBook.AccountCurrency)) return;
             
             var rate = data.Value;
             if (_invertRealTimePrice)

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -1029,9 +1029,11 @@ namespace QuantConnect.Lean.Engine.Results
                                 security.SetRealTimePrice(last);
 
                                 // Update CashBook for Forex securities
-                                Cash cash;
-                                var forex = security as Forex;
-                                if (forex != null && _algorithm.Portfolio.CashBook.TryGetValue(forex.BaseCurrencySymbol, out cash))
+                                var cash = (from c in _algorithm.Portfolio.CashBook.Values
+                                    where c.SecuritySymbol == last.Symbol
+                                    select c).SingleOrDefault();
+
+                                if (cash != null)
                                 {
                                     cash.Update(last);
                                 }


### PR DESCRIPTION
This is a proposed fix for the strange jumps in the equity when the trade gets made. #498  
 
The problem is that when a 'non-USD' currency comes in (for eg. EURGBP), the Cash.Update() replaces the rate for EUR with the rate for the 'non-USD' currency(EURGBP).

The proposed fix here is to have a check for the non-USD currency which comes in. The rate for the other currencies would already have been updated and this would prevent the over-writing of the conversion rates.

After testing this, the equity jumping has stopped by using this fix.

I would like to know what the others think about the fix. 

P.S. I have used the term 'non-USD' because the Account Currency is USD. So it's actually 'non-AccountCurrency'