### PR TITLE
Fixes desktop not displaying charts

### DIFF
--- a/Messaging/EventMessagingHandler.cs
+++ b/Messaging/EventMessagingHandler.cs
@@ -121,6 +121,17 @@ namespace QuantConnect.Messaging
         }
 
         /// <summary>
+        /// Send any message with a base type of Packet that has been enqueued.
+        /// </summary>
+        public void SendEnqueuedPackets()
+        {
+            while (_queue.Count > 0 && _loaded)
+            {
+                ProcessPacket(_queue.Dequeue());
+            }
+        }
+
+        /// <summary>
         /// Packet processing implementation
         /// </summary>
         private void ProcessPacket(Packet packet)

--- a/UserInterface/WinForms/LeanWinForm.cs
+++ b/UserInterface/WinForms/LeanWinForm.cs
@@ -49,6 +49,7 @@ namespace QuantConnect.Views.WinForms
 
             _geckoBrowser = new GeckoWebBrowser { Dock = DockStyle.Fill, Name = "browser" };
             _geckoBrowser.DOMContentLoaded += BrowserOnDomContentLoaded;
+            _geckoBrowser.Load += (s, e) => { _messaging.SendEnqueuedPackets(); };
             _geckoBrowser.Navigate(url);
             splitPanel.Panel1.Controls.Add(_geckoBrowser);
 #else


### PR DESCRIPTION
When algorithm run ends before the message system is loaded (it depends on the UX loading), enqueued packets used on charting are never sent to the UX.