### PR TITLE
Declare variable 'Log' with 'new' keyword

### DIFF
--- a/Algorithm.CSharp/UpdateOrderLiveTestAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderLiveTestAlgorithm.cs
@@ -176,7 +176,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
-        private void Log(string msg)
+        private new void Log(string msg)
         {
             // redirect live logs to debug window
             if (LiveMode)

--- a/Algorithm.CSharp/UpdateOrderLiveTestAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderLiveTestAlgorithm.cs
@@ -32,9 +32,10 @@ namespace QuantConnect.Algorithm.CSharp
 
         private const decimal ImmediateCancelPercentage = 0.05m;
 
-        private int LastMinute = -1;
-        private Security Security;
-        private int Quantity = 5;
+        private int _lastMinute = -1;
+        private Security _security;
+        private int _quantity = 5;
+        private string _symbol = "SPY";
         private const int DeltaQuantity = 1;
 
         private const decimal StopPercentage = 0.025m;
@@ -42,7 +43,6 @@ namespace QuantConnect.Algorithm.CSharp
         private const decimal LimitPercentage = 0.025m;
         private const decimal LimitPercentageDelta = 0.005m;
 
-        private const string Symbol = "SPY";
         private const SecurityType SecType = SecurityType.Equity;
 
         private readonly CircularQueue<OrderType> _orderTypesQueue = new CircularQueue<OrderType>(new []
@@ -68,13 +68,13 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 07);    //Set End Date
             SetCash(100000);             //Set Strategy Cash
             // Find more symbols here: http://quantconnect.com/data
-            AddSecurity(SecType, Symbol, Resolution.Second);
-            Security = Securities[Symbol];
+            AddSecurity(SecType, _symbol, Resolution.Second);
+            _security = Securities[_symbol];
 
             _orderTypesQueue.CircleCompleted += (sender, args) =>
             {
                 // flip our signs
-                Quantity *= -1;
+                _quantity *= -1;
             };
         }
 
@@ -84,30 +84,30 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="data">Slice object keyed by symbol containing the stock data</param>
         public override void OnData(Slice data)
         {
-            if (!Security.HasData)
+            if (!_security.HasData)
             {
                 Log("::::: NO DATA :::::");
                 return;
             }
 
             // each month make an action
-            if (Time.Minute != LastMinute && Time.Second == 0)
+            if (Time.Minute != _lastMinute && Time.Second == 0)
             {
                 Log("");
                 Log("--------------Minute: " + Time.Minute);
                 Log("");
-                LastMinute = Time.Minute;
+                _lastMinute = Time.Minute;
                 // we'll submit the next type of order from the queue
                 var orderType = _orderTypesQueue.Dequeue();
                 Log("ORDER TYPE:: " + orderType);
-                var isLong = Quantity > 0;
-                var stopPrice = isLong ? (1 + StopPercentage) * Security.High : (1 - StopPercentage) * Security.Low;
+                var isLong = _quantity > 0;
+                var stopPrice = isLong ? (1 + StopPercentage) * _security.High : (1 - StopPercentage) * _security.Low;
                 var limitPrice = isLong ? (1 - LimitPercentage) * stopPrice : (1 + LimitPercentage) * stopPrice;
                 if (orderType == OrderType.Limit)
                 {
-                    limitPrice = !isLong ? (1 + LimitPercentage) * Security.High : (1 - LimitPercentage) * Security.Low;
+                    limitPrice = !isLong ? (1 + LimitPercentage) * _security.High : (1 - LimitPercentage) * _security.Low;
                 }
-                var request = new SubmitOrderRequest(orderType, SecType, Symbol, Quantity, stopPrice, limitPrice, Time, orderType.ToString());
+                var request = new SubmitOrderRequest(orderType, SecType, Securities[_symbol].Symbol, _quantity, stopPrice, limitPrice, Time, orderType.ToString());
                 var ticket = Transactions.AddOrder(request);
                 _tickets.Add(ticket);
                 if ((decimal)Random.NextDouble() < ImmediateCancelPercentage)
@@ -126,7 +126,7 @@ namespace QuantConnect.Algorithm.CSharp
                         Log(ticket.ToString());
                         ticket.Update(new UpdateOrderFields
                         {
-                            Quantity = ticket.Quantity + Math.Sign(Quantity) * DeltaQuantity,
+                            Quantity = ticket.Quantity + Math.Sign(_quantity) * DeltaQuantity,
                             Tag = "Change quantity: " + Time
                         });
                         Log("UPDATE1:: " + ticket.UpdateRequests.Last());
@@ -139,8 +139,8 @@ namespace QuantConnect.Algorithm.CSharp
                         Log(ticket.ToString());
                         ticket.Update(new UpdateOrderFields
                         {
-                            LimitPrice = Security.Price * (1 - Math.Sign(ticket.Quantity) * LimitPercentageDelta),
-                            StopPrice = Security.Price * (1 + Math.Sign(ticket.Quantity) * StopPercentageDelta),
+                            LimitPrice = _security.Price * (1 - Math.Sign(ticket.Quantity) * LimitPercentageDelta),
+                            StopPrice = _security.Price * (1 + Math.Sign(ticket.Quantity) * StopPercentageDelta),
                             Tag = "Change prices: " + Time
                         });
                         Log("UPDATE2:: " + ticket.UpdateRequests.Last());


### PR DESCRIPTION
Log variable was already declared in base class, QCAlgorithm.cs, so in order to declare again in UpdateOrderLiveTestAlgorithm.cs, must use "new" keyword

Warning Code: CS0108
UpdateOrderLiveTestAlgorithm.cs Line 179