### PR TITLE
Warnings/new keyword with symbol

### DIFF
--- a/Algorithm.CSharp/UpdateOrderLiveTestAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderLiveTestAlgorithm.cs
@@ -176,7 +176,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
-        private void Log(string msg)
+        private new void Log(string msg)
         {
             // redirect live logs to debug window
             if (LiveMode)

--- a/Algorithm.CSharp/UpdateOrderLiveTestAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderLiveTestAlgorithm.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Algorithm.CSharp
         private const decimal LimitPercentage = 0.025m;
         private const decimal LimitPercentageDelta = 0.005m;
 
-        private const string Symbol = "SPY";
+        private new const string Symbol = "SPY";
         private const SecurityType SecType = SecurityType.Equity;
 
         private readonly CircularQueue<OrderType> _orderTypesQueue = new CircularQueue<OrderType>(new []


### PR DESCRIPTION
Symbol variable was already declared in base class, QCAlgorithm.cs, so in
order to declare again in UpdateOrderLiveTestAlgorithm.cs, must use "new"
keyword

Warning Code: CS0108
UpdateOrderLiveTestAlgorithm.cs Line 45