### PR TITLE
Added a check for 0 price due to delay by fxcm

### DIFF
--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -1020,7 +1020,7 @@ namespace QuantConnect.Lean.Engine.Results
                             var price = subscription.RealtimePrice;
 
                             var last = security.GetLastData();
-                            if (last != null)
+                            if (last != null && price > 0)
                             {
                                 // Prevents changes in previous bar
                                 last = last.Clone(last.IsFillForward);


### PR DESCRIPTION
Added a check to see if the realtime price is greater than 0. This check is placed due to the delay from fxcm in setting the price for the symbols. 

In case of inverted symbols when the price came in as 0, the value of 1/rate caused the algorithm to crash due to division by 0 exception. 

This check just waits for the price to be set by fxcm.  