### PR TITLE
Updates FXCM error message

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.cs
@@ -142,7 +142,7 @@ namespace QuantConnect.Brokerages.Fxcm
             {
                 var message =
                     err.Message.Contains("ORA-20101") ? "Incorrect login credentials" :
-                    err.Message.Contains("ORA-20003") ? "API connections are not available on Mini accounts" :
+                    err.Message.Contains("ORA-20003") ? "API connections are not available on Mini accounts. If you have a standard account contact api@fxcm.com to enable API access" :
                     err.Message;
 
                 throw new BrokerageException(message, err.InnerException);


### PR DESCRIPTION
It was a back office setting that was not enabled to allow for a FIX API connection when they changed back the account to standard. If a connection issue arises it would better to have clients send issues or questions to api@fxcm.com. The API department can check settings and contact our back office for any setting issues.