### PR TITLE
changed tradier accountID type from int to string

### DIFF
--- a/Brokerages/Tradier/Balances.cs
+++ b/Brokerages/Tradier/Balances.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Brokerages.Tradier
     {
         ///Account Number
         [JsonProperty(PropertyName = "account_number")]
-        public long AccountNumber;
+        public string AccountNumber;
 
         ///Account Type (margin, cash, pdt)
         [JsonProperty(PropertyName = "account_type")]

--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Brokerages.Tradier
     /// </summary>
     public class TradierBrokerage : Brokerage
     {
-        private readonly long _accountID;
+        private readonly string _accountID;
 
         // we're reusing the equity exchange here to grab typical exchange hours
         private static readonly EquityExchange Exchange =
@@ -124,7 +124,7 @@ namespace QuantConnect.Brokerages.Tradier
         /// <summary>
         /// Create a new Tradier Object:
         /// </summary>
-        public TradierBrokerage(IOrderProvider orderProvider, ISecurityProvider securityProvider, long accountID)
+        public TradierBrokerage(IOrderProvider orderProvider, ISecurityProvider securityProvider, string accountID)
             : base("Tradier Brokerage")
         {
             _orderProvider = orderProvider;
@@ -400,7 +400,7 @@ namespace QuantConnect.Brokerages.Tradier
         /// Returns null if the request was unsucessful
         /// </remarks>
         /// <returns>Balance</returns>
-        public TradierBalanceDetails GetBalanceDetails(long accountId)
+        public TradierBalanceDetails GetBalanceDetails(string accountId)
         {
             var request = new RestRequest("accounts/{accountId}/balances", Method.GET);
             request.AddParameter("accountId", accountId, ParameterType.UrlSegment);
@@ -514,7 +514,7 @@ namespace QuantConnect.Brokerages.Tradier
         /// Place Order through API.
         /// accounts/{account-id}/orders
         /// </summary>
-        public TradierOrderResponse PlaceOrder(long accountId,
+        public TradierOrderResponse PlaceOrder(string accountId,
             TradierOrderClass classification,
             TradierOrderDirection direction,
             string symbol,
@@ -551,7 +551,7 @@ namespace QuantConnect.Brokerages.Tradier
         /// <summary>
         /// Update an exiting Tradier Order:
         /// </summary>
-        public TradierOrderResponse ChangeOrder(long accountId,
+        public TradierOrderResponse ChangeOrder(string accountId,
             long orderId,
             TradierOrderType type = TradierOrderType.Market,
             TradierOrderDuration duration = TradierOrderDuration.GTC,
@@ -577,7 +577,7 @@ namespace QuantConnect.Brokerages.Tradier
         /// <summary>
         /// Cancel the order with this account and id number
         /// </summary>
-        public TradierOrderResponse CancelOrder(long accountId, long orderId)
+        public TradierOrderResponse CancelOrder(string accountId, long orderId)
         {
             //Compose Request:
             var request = new RestRequest("accounts/{accountId}/orders/{orderId}");

--- a/Brokerages/Tradier/TradierBrokerageFactory.cs
+++ b/Brokerages/Tradier/TradierBrokerageFactory.cs
@@ -47,9 +47,9 @@ namespace QuantConnect.Brokerages.Tradier
             /// <summary>
             /// Gets the account ID to be used when instantiating a brokerage
             /// </summary>
-            public static long AccountID
+            public static string AccountID
             {
-                get { return Config.GetInt("tradier-account-id"); }
+                get { return Config.Get("tradier-account-id"); }
             }
 
             /// <summary>
@@ -155,7 +155,7 @@ namespace QuantConnect.Brokerages.Tradier
         public override IBrokerage CreateBrokerage(LiveNodePacket job, IAlgorithm algorithm)
         {
             var errors = new List<string>();
-            var accountID = Read<long>(job.BrokerageData, "tradier-account-id", errors);
+            var accountID = Read<string>(job.BrokerageData, "tradier-account-id", errors);
             var accessToken = Read<string>(job.BrokerageData, "tradier-access-token", errors);
             var refreshToken = Read<string>(job.BrokerageData, "tradier-refresh-token", errors);
             var issuedAt = Read<DateTime>(job.BrokerageData, "tradier-issued-at", errors);


### PR DESCRIPTION
Changed the dataType of the Account ID for Tradier from an 'int' to a 'string' due to the changes made in the API by tradier.