### PR TITLE
Enables AddSecurity in OnData Events Handler in Live Mode

### DIFF
--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -166,6 +166,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             if (_subscriptions.Contains(request.Configuration))
             {
+                // changes in a subscription
+                var userDefined = request.Universe as UserDefinedUniverse;
+                if (userDefined != null && request.IsUniverseSubscription)
+                {
+                    var collection = new BaseDataCollection(_frontierUtc, request.Configuration.Symbol);
+                    _universeSelection.ApplyUniverseSelection(userDefined, _frontierUtc, collection);
+                    return true;
+                }
                 // duplicate subscription request
                 return false;
             }


### PR DESCRIPTION
In Live mode, when we call AddSecurity in OnData event handlers, the added security wasn't being subscribed. While this procedure works properly in backtesting mode.