### PR TITLE
Fixed typo bug in LiveTradingDataFeed.RemoveSubscription

### DIFF
--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -229,6 +229,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>True if the subscription was successfully removed, false otherwise</returns>
         public bool RemoveSubscription(SubscriptionDataConfig configuration)
         {
+            // remove the subscription from our collection
             Subscription subscription;
             if (!_subscriptions.TryRemove(configuration, out subscription))
             {

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -211,8 +211,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             // remove the subscription from our collection
             Subscription subscription;
-            if (!_subscriptions.TryGetValue(configuration, out subscription))
+            if (!_subscriptions.TryRemove(configuration, out subscription))
             {
+                Log.Error("LiveTradingDataFeed.RemoveSubscription(): Unable to remove: " + configuration.ToString());
                 return false;
             }
 


### PR DESCRIPTION
Also added Log.Error if not found, so we have same behavior as FileSystemDataFeed