### PR TITLE
Invalid statistics for UniverseSelectionRegressionAlgorithm

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -331,20 +331,6 @@ namespace QuantConnect.Lean.Engine
                 // process fill models on the updated data before entering algorithm, applies to all non-market orders
                 transactions.ProcessSynchronousEvents();
 
-                if (delistingTickets.Count != 0)
-                {
-                    for (int i = 0; i < delistingTickets.Count; i++)
-                    {
-                        var ticket = delistingTickets[i];
-                        if (ticket.Status == OrderStatus.Filled)
-                        {
-                            algorithm.Securities.Remove(ticket.Symbol);
-                            delistingTickets.RemoveAt(i--);
-                            Log.Trace("AlgorithmManager.Run(): Delisted Security removed: " + ticket.Symbol.ToString());
-                        }
-                    }
-                }
-
                 //Check if the user's signalled Quit: loop over data until day changes.
                 if (algorithm.Status == AlgorithmStatus.Stopped)
                 {

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -119,7 +119,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     security = universe.CreateSecurity(symbol, _algorithm, _marketHoursDatabase, _symbolPropertiesDatabase);
                 }
 
-                universe.AddMember(dateTimeUtc, security);
+                var addedMember = universe.AddMember(dateTimeUtc, security);
 
                 var addedSubscription = false;
                 foreach (var request in universe.GetSubscriptionRequests(security, dateTimeUtc, algorithmEndDateUtc))
@@ -141,7 +141,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // only update our security changes if we actually added data
                     if (!request.IsUniverseSubscription)
                     {
-                        addedSubscription = true;
+                        addedSubscription = addedMember;
                     }
                 }
 

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -148,25 +148,25 @@ namespace QuantConnect.Tests
 
             var universeSelectionRegressionStatistics = new Dictionary<string, string>
             {
-                {"Total Trades", "4"},
+                {"Total Trades", "5"},
                 {"Average Win", "0.70%"},
                 {"Average Loss", "0%"},
-                {"Compounding Annual Return", "-56.034%"},
-                {"Drawdown", "3.800%"},
+                {"Compounding Annual Return", "-73.872%"},
+                {"Drawdown", "6.600%"},
                 {"Expectancy", "0"},
-                {"Net Profit", "-3.755%"},
-                {"Sharpe Ratio", "-3.629"},
+                {"Net Profit", "-6.060%"},
+                {"Sharpe Ratio", "-3.562"},
                 {"Loss Rate", "0%"},
                 {"Win Rate", "100%"},
                 {"Profit-Loss Ratio", "0"},
-                {"Alpha", "-0.424"},
-                {"Beta", "1.25"},
-                {"Annual Standard Deviation", "0.173"},
-                {"Annual Variance", "0.03"},
-                {"Information Ratio", "-3.62"},
-                {"Tracking Error", "0.128"},
+                {"Alpha", "-0.681"},
+                {"Beta", "2.014"},
+                {"Annual Standard Deviation", "0.284"},
+                {"Annual Variance", "0.08"},
+                {"Information Ratio", "-3.67"},
+                {"Tracking Error", "0.231"},
                 {"Treynor Ratio", "-0.502"},
-                {"Total Fees", "$2.00"}
+                {"Total Fees", "$5.00"}
             };
 
             var customDataRegressionStatistics = new Dictionary<string, string>


### PR DESCRIPTION
Universe Selection Regression Algorithm exposed two problems:
- Universe Selection added symbols that were already listed (were part of the universe);
- Delisted securities were removed from the portfolio, causing loss of information (e.g.: payed fees).
Ref.: #521  