### PR TITLE
Tradier orders fix

### DIFF
--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -1895,7 +1895,7 @@ namespace QuantConnect.Brokerages.Tradier
                 case OrderType.StopLimit:
                     return TradierOrderType.StopLimit;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException(order.Type + " not supported");
             }
         }
 

--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -964,32 +964,7 @@ namespace QuantConnect.Brokerages.Tradier
                     CancelOrder(qcOrder);
                 }
             }
-
-
-            // tradier supports market on open by allowing placement of market orders after hours
-            // however, tradier does not support market on close orders, so we need to simulate it
-            // we'll place the market order at 3:59:45 PM, this allows 15 seconds for process and fill
-            if (order.Type == OrderType.MarketOnClose && DateTime.Now < DateTime.Today.Add(new TimeSpan(12+3, 59, 40))) // stop this behavior at 3:59:40
-            {
-                // just recall this PlaceOrder function so it can go through the normal path
-                Timer t = null;
-                t = new Timer(state =>
-                {
-                    PlaceOrder(order);
-                    // be sure to dispose of this
-                    t.Dispose();
-                });
-
-                // Figure how much time until 3:59:45
-                var now = DateTime.Now;
-                var placeOrderTime = now.Date.Add(new TimeSpan(12+3, 59, 45));
-
-                // set timer for delta between now and when we want it to execute
-                int milliseconds = (int)((placeOrderTime - now).TotalMilliseconds);
-                t.Change(milliseconds, Timeout.Infinite);
-                // even though 't' goes out of scope here, the internal scheduler (TimerQueue) maintains a reference
-            }
-
+            
             var holdingQuantity = _securityProvider.GetHoldingsQuantity(order.Symbol);
 
             var orderRequest = new TradierPlaceOrderRequest(order, TradierOrderClass.Equity,  holdingQuantity);

--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -1645,8 +1645,6 @@ namespace QuantConnect.Brokerages.Tradier
             switch (type)
             {
                 case OrderType.Market:
-                case OrderType.MarketOnOpen:
-                case OrderType.MarketOnClose:
                     return TradierOrderType.Market;
 
                 case OrderType.Limit:
@@ -1895,7 +1893,7 @@ namespace QuantConnect.Brokerages.Tradier
                 case OrderType.StopLimit:
                     return TradierOrderType.StopLimit;
                 default:
-                    throw new ArgumentOutOfRangeException(order.Type + " not supported");
+                    throw new ArgumentOutOfRangeException("type", order.Type, order.Type + " not supported");
             }
         }
 

--- a/Common/Brokerages/TradierBrokerageModel.cs
+++ b/Common/Brokerages/TradierBrokerageModel.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Brokerages
             if (order.Type == OrderType.MarketOnOpen || order.Type == OrderType.MarketOnClose)
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
-                    "This model only supports Market orders. MarketOnOpen or MarketOnClose orders not supported."
+                    "Tradier brokerage only supports Market orders. MarketOnOpen and MarketOnClose orders not supported."
                     );
 
                 return false;

--- a/Common/Brokerages/TradierBrokerageModel.cs
+++ b/Common/Brokerages/TradierBrokerageModel.cs
@@ -67,6 +67,15 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
+            if (order.Type == OrderType.MarketOnOpen || order.Type == OrderType.MarketOnClose)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    "This model only supports Market orders. No MarketOnOpen or MarketOnClose order supported."
+                    );
+
+                return false;
+            }
+
             if (!CanExecuteOrder(security, order))
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "ExtendedMarket",

--- a/Common/Brokerages/TradierBrokerageModel.cs
+++ b/Common/Brokerages/TradierBrokerageModel.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Brokerages
             if (order.Type == OrderType.MarketOnOpen || order.Type == OrderType.MarketOnClose)
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
-                    "This model only supports Market orders. No MarketOnOpen or MarketOnClose order supported."
+                    "This model only supports Market orders. MarketOnOpen or MarketOnClose orders not supported."
                     );
 
                 return false;

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -664,7 +664,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
             // verify that our current brokerage can actually take the order
             BrokerageMessageEvent message;
-            if (!_algorithm.LiveMode && !_algorithm.BrokerageModel.CanSubmitOrder(security, order, out message))
+            if (!_algorithm.BrokerageModel.CanSubmitOrder(security, order, out message))
             {
                 // if we couldn't actually process the order, mark it as invalid and bail
                 order.Status = OrderStatus.Invalid;


### PR DESCRIPTION
This fix the support for MarketOnOpen and MarketOnClose order which aren't natively supported by tradier which caused the algorithm to crash and throw errors. 

Removed the code to handle MarketOnClose orders for tradier and also added warning messages.  