### PR TITLE
Prevent non-equity data feeds from looking for a map file resolver

### DIFF
--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -21,6 +21,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
 using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
@@ -374,7 +375,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
             }
 
-            var mapFileResolver = _mapFileProvider.Get(request.Security.Symbol.ID.Market);
+            var mapFileResolver = request.Configuration.SecurityType == SecurityType.Equity
+                ? _mapFileProvider.Get(request.Security.Symbol.ID.Market) 
+                : MapFileResolver.Empty;
 
             return new PostCreateConfigureSubscriptionEnumeratorFactory(
                 new SubscriptionDataReaderSubscriptionEnumeratorFactory(_resultHandler, mapFileResolver, _factorFileProvider, false, true),


### PR DESCRIPTION
A directory not found error was logged when adding a Forex symbol