### PR TITLE
Fix Broken Unit Test

### DIFF
--- a/Tests/Common/Util/FuncTextWriterTests.cs
+++ b/Tests/Common/Util/FuncTextWriterTests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.IO;
 using System.Collections.Generic;
 using NUnit.Framework;
 using QuantConnect.Util;
@@ -23,6 +24,15 @@ namespace QuantConnect.Tests.Common.Util
     [TestFixture]
     public class FuncTextWriterTests
     {
+        [SetUp]
+        public void Setup()
+        {
+            // clear any existing output
+            var standardOut = new StreamWriter(Console.OpenStandardError()) { AutoFlush = true };
+            Console.SetError(standardOut);
+            Console.SetOut(standardOut);
+        }
+        
         [Test]
         public void RedirectsWriteAndWriteLine()
         {


### PR DESCRIPTION
Test failing due to existing messages in the Console output.

Receiving this when running the unit tests via Resharper.