### PR TITLE
Delistings bugfix

### DIFF
--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -450,6 +450,13 @@ namespace QuantConnect.Interfaces
         Security AddSecurity(SecurityType securityType, string symbol, Resolution resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours);
 
         /// <summary>
+        /// Removes the security with the specified symbol. This will cancel all
+        /// open orders and then liquidate any existing holdings
+        /// </summary>
+        /// <param name="symbol">The symbol of the security to be removed</param>
+        bool RemoveSecurity(Symbol symbol);
+
+        /// <summary>
         /// Set the starting capital for the strategy
         /// </summary>
         /// <param name="startingCash">decimal starting capital, default $100,000</param>

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Lean.Engine
             var settlementScanFrequency = TimeSpan.FromMinutes(30);
             var nextSettlementScanTime = DateTime.MinValue;
 
-            var delistingTickets = new List<OrderTicket>();
+            var delistings = new List<Delisting>();
 
             //Initialize Properties:
             _algorithmId = job.AlgorithmId;
@@ -331,17 +331,32 @@ namespace QuantConnect.Lean.Engine
                 // process fill models on the updated data before entering algorithm, applies to all non-market orders
                 transactions.ProcessSynchronousEvents();
 
-                if (delistingTickets.Count != 0)
+                if (delistings.Count != 0)
                 {
-                    for (int i = 0; i < delistingTickets.Count; i++)
+                    for (int i = 0; i < delistings.Count; i++)
                     {
-                        var ticket = delistingTickets[i];
-                        if (ticket.Status == OrderStatus.Filled)
+                        var symbol = delistings[i].Symbol;
+                        var ticket = delistings[i].Ticket;
+                        var security = algorithm.Securities[symbol];
+
+                        if (ticket != null && ticket.Status == OrderStatus.Filled)
                         {
-                            delistingTickets.RemoveAt(i--);
+                            // If invested after market on close order is filled, liquidate
+                            if (security.Invested) algorithm.Liquidate(symbol);
+                            delistings.RemoveAt(i--);
+                        }
+
+                        // Submit an order to liquidate on market close when invested after the delisting warning
+                        if (ticket == null && security.Invested)
+                        {
+                            var submitOrderRequest = new SubmitOrderRequest(OrderType.MarketOnClose, security.Type, security.Symbol,
+                                -security.Holdings.Quantity, 0, 0, algorithm.UtcTime, "Liquidate from delisting");
+                            ticket = algorithm.Transactions.ProcessRequest(submitOrderRequest);
+                            delistings[i].SetOrderTicket(ticket);
                         }
                     }
                 }
+
 
                 //Check if the user's signalled Quit: loop over data until day changes.
                 if (algorithm.Status == AlgorithmStatus.Stopped)
@@ -538,7 +553,7 @@ namespace QuantConnect.Lean.Engine
                 }
 
                 // run the delisting logic after firing delisting events
-                HandleDelistedSymbols(algorithm, timeSlice.Slice.Delistings, delistingTickets);
+                HandleDelistedSymbols(algorithm, timeSlice.Slice.Delistings, delistings);
 
                 //After we've fired all other events in this second, fire the pricing events:
                 try
@@ -846,31 +861,33 @@ namespace QuantConnect.Lean.Engine
         /// <summary>
         /// Performs delisting logic for the securities specified in <paramref name="newDelistings"/> that are marked as <see cref="DelistingType.Delisted"/>. 
         /// This includes liquidating the position and removing the security from the algorithm's collection.
-        /// If we're unable to liquidate the position (maybe daily data or EOD already) then we'll add it to the <paramref name="delistingTickets"/>
+        /// If we're unable to liquidate the position (maybe daily data or EOD already) then we'll add it to the <paramref name="delistings"/>
         /// for the algo manager time loop to check later
         /// </summary>
-        private static void HandleDelistedSymbols(IAlgorithm algorithm, Delistings newDelistings, ICollection<OrderTicket> delistingTickets)
+        private static void HandleDelistedSymbols(IAlgorithm algorithm, Delistings newDelistings, ICollection<Delisting> delistings)
         {
             foreach (var delisting in newDelistings.Values)
             {
                 // submit an order to liquidate on market close
                 if (delisting.Type == DelistingType.Warning)
                 {
-                    Log.Trace("AlgorithmManager.Run(): Security delisting warning: " + delisting.Symbol.ToString());
+                    delistings.Add(delisting);
+                    Log.Trace("AlgorithmManager.Run(): Security delisting warning: " + delisting.Symbol.ID);
                     var security = algorithm.Securities[delisting.Symbol];
-                    if (security.Holdings.Quantity == 0)
-                    {
-                        continue;
-                    }
+                    if (security.Holdings.Quantity == 0) continue;
                     var submitOrderRequest = new SubmitOrderRequest(OrderType.MarketOnClose, security.Type, security.Symbol,
                         -security.Holdings.Quantity, 0, 0, algorithm.UtcTime, "Liquidate from delisting");
                     var ticket = algorithm.Transactions.ProcessRequest(submitOrderRequest);
                     delisting.SetOrderTicket(ticket);
-                    delistingTickets.Add(ticket);
                 }
                 else
                 {
-                    Log.Trace("AlgorithmManager.Run(): Security delisted: " + delisting.Symbol.ToString());
+                    Log.Trace("AlgorithmManager.Run(): Security delisted: " + delisting.Symbol.ID);
+                    var cancelledOrders = algorithm.Transactions.CancelOpenOrders(delisting.Symbol);
+                    foreach (var cancelledOrder in cancelledOrders)
+                    {
+                        Log.Trace("AlgorithmManager.Run(): " + cancelledOrder);
+                    }
                 }
             }
         }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -338,9 +338,7 @@ namespace QuantConnect.Lean.Engine
                         var ticket = delistingTickets[i];
                         if (ticket.Status == OrderStatus.Filled)
                         {
-                            algorithm.RemoveSecurity(ticket.Symbol);
                             delistingTickets.RemoveAt(i--);
-                            Log.Trace("AlgorithmManager.Run(): Delisted Security removed: " + ticket.Symbol.ToString());
                         }
                     }
                 }
@@ -862,7 +860,6 @@ namespace QuantConnect.Lean.Engine
                     var security = algorithm.Securities[delisting.Symbol];
                     if (security.Holdings.Quantity == 0)
                     {
-                        algorithm.RemoveSecurity(delisting.Symbol);
                         continue;
                     }
                     var submitOrderRequest = new SubmitOrderRequest(OrderType.MarketOnClose, security.Type, security.Symbol,
@@ -874,8 +871,6 @@ namespace QuantConnect.Lean.Engine
                 else
                 {
                     Log.Trace("AlgorithmManager.Run(): Security delisted: " + delisting.Symbol.ToString());
-                    algorithm.RemoveSecurity(delisting.Symbol);
-                    Log.Trace("AlgorithmManager.Run(): Security removed: " + delisting.Symbol.ToString());
                 }
             }
         }

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -349,9 +349,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     var universe = (UserDefinedUniverse) request.Universe;
                     universe.CollectionChanged += (sender, args) =>
                     {
-                        IList items =
-                            args.Action == NotifyCollectionChangedAction.Add ? items = args.NewItems :
-                            args.Action == NotifyCollectionChangedAction.Remove ? items = args.OldItems : null;
+                        var items =
+                            args.Action == NotifyCollectionChangedAction.Add ? args.NewItems :
+                            args.Action == NotifyCollectionChangedAction.Remove ? args.OldItems : null;
 
                         if (items == null || _frontierUtc == DateTime.MinValue) return;
 

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -345,13 +345,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             {
                 if (request.Universe is UserDefinedUniverse)
                 {
-                    // Trigger universe selection when security added manually after Initialize
+                    // Trigger universe selection when security added/removed after Initialize
                     var universe = (UserDefinedUniverse) request.Universe;
                     universe.CollectionChanged += (sender, args) =>
                     {
-                        if (args.NewItems == null || _frontierUtc == DateTime.MinValue) return;
+                        IList items =
+                            args.Action == NotifyCollectionChangedAction.Add ? items = args.NewItems :
+                            args.Action == NotifyCollectionChangedAction.Remove ? items = args.OldItems : null;
 
-                        var symbol = args.NewItems.OfType<Symbol>().FirstOrDefault();
+                        if (items == null || _frontierUtc == DateTime.MinValue) return;
+
+                        var symbol = items.OfType<Symbol>().FirstOrDefault();
                         if (symbol == null) return;
 
                         var collection = new BaseDataCollection(_frontierUtc, symbol);

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -501,12 +501,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 _customExchange.AddEnumerator(new EnumeratorHandler(config.Symbol, enumerator, enqueueable));
                 enumerator = enqueueable;
 
-                // Trigger universe selection when security added manually after Initialize
+                // Trigger universe selection when security added/removed after Initialize
                 userDefined.CollectionChanged += (sender, args) =>
                 {
-                    if (args.NewItems == null || _frontierUtc == DateTime.MinValue) return;
+                    IList items =
+                           args.Action == NotifyCollectionChangedAction.Add ? items = args.NewItems :
+                           args.Action == NotifyCollectionChangedAction.Remove ? items = args.OldItems : null;
 
-                    var symbol = args.NewItems.OfType<Symbol>().FirstOrDefault();
+                    if (items == null || _frontierUtc == DateTime.MinValue) return;
+
+                    var symbol = items.OfType<Symbol>().FirstOrDefault();
                     if (symbol == null) return;
 
                     var collection = new BaseDataCollection(_frontierUtc, symbol);

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -504,9 +504,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // Trigger universe selection when security added/removed after Initialize
                 userDefined.CollectionChanged += (sender, args) =>
                 {
-                    IList items =
-                           args.Action == NotifyCollectionChangedAction.Add ? items = args.NewItems :
-                           args.Action == NotifyCollectionChangedAction.Remove ? items = args.OldItems : null;
+                    var items =
+                           args.Action == NotifyCollectionChangedAction.Add ? args.NewItems :
+                           args.Action == NotifyCollectionChangedAction.Remove ? args.OldItems : null;
 
                     if (items == null || _frontierUtc == DateTime.MinValue) return;
 

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -471,6 +471,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 date = _tradeableDates.Current;
 
                 CheckForDelisting(date);
+                if (_delisted)
+                {
+                    return true;
+                }
 
                 if (!_mapFile.HasData(date))
                 {


### PR DESCRIPTION
On SubscriptionDataReader.TryGetNextDate, the day after the delisting was not been considered an event date, thus the algorithm kept receiving quotes after the security was delisted.
Ref #542 