### PR TITLE
Decouple QuantConnect.Views build configuration

### DIFF
--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -87,11 +87,7 @@ namespace QuantConnect.Lean.Launcher
 
             if (environment.EndsWith("-desktop"))
             {
-                Application.EnableVisualStyles();
-                var messagingHandler = leanEngineSystemHandlers.Notify;
-                var thread = new Thread(() => LaunchUX(messagingHandler, job));
-                thread.SetApartmentState(ApartmentState.STA);
-                thread.Start();
+
             }
 
             // log the job endpoints
@@ -135,17 +131,6 @@ namespace QuantConnect.Lean.Launcher
                 leanEngineAlgorithmHandlers.Dispose();
                 Log.LogHandler.Dispose();
             }
-        }
-
-        /// <summary>
-        /// Form launcher method for thread.
-        /// </summary>
-        static void LaunchUX(IMessagingHandler messaging, AlgorithmNodePacket job)
-        {
-            //Launch the UX
-            //var form = Composer.Instance.GetExportedValueByTypeName<Form>("desktop-ux-classname");
-            var form = new Views.WinForms.LeanWinForm(messaging, job);
-            Application.Run(form);
         }
     }
 }

--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Windows.Forms;
 using QuantConnect.Configuration;
@@ -87,7 +89,9 @@ namespace QuantConnect.Lean.Launcher
 
             if (environment.EndsWith("-desktop"))
             {
-
+                // Handle both Linux and Windows paths
+                var exePath = Config.Get("desktop-exe").Replace('/', Path.DirectorySeparatorChar);
+                Process.Start(exePath, Config.Get("desktop-http-port"));
             }
 
             // log the job endpoints

--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -89,9 +89,13 @@ namespace QuantConnect.Lean.Launcher
 
             if (environment.EndsWith("-desktop"))
             {
-                // Handle both Linux and Windows paths
-                var exePath = Config.Get("desktop-exe").Replace('/', Path.DirectorySeparatorChar);
-                Process.Start(exePath, Config.Get("desktop-http-port"));
+                var info = new ProcessStartInfo
+                {
+                    UseShellExecute = false,
+                    FileName  = Config.Get("desktop-exe"),
+                    Arguments = Config.Get("desktop-http-port")
+                };
+                Process.Start(info);
             }
 
             // log the job endpoints

--- a/Launcher/QuantConnect.Lean.Launcher.csproj
+++ b/Launcher/QuantConnect.Lean.Launcher.csproj
@@ -148,10 +148,6 @@
       <Project>{ac9a142c-b485-44d7-91ff-015c22c43d05}</Project>
       <Name>QuantConnect.ToolBox</Name>
     </ProjectReference>
-    <ProjectReference Include="..\UserInterface\QuantConnect.Views.csproj">
-      <Project>{c68beeed-b0c0-4002-94d4-1e871133d02a}</Project>
-      <Name>QuantConnect.Views</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -179,7 +179,7 @@
       "data-feed-handler": "QuantConnect.Lean.Engine.DataFeeds.FileSystemDataFeed",
       "real-time-handler": "QuantConnect.Lean.Engine.RealTime.BacktestingRealTimeHandler",
       "transaction-handler": "QuantConnect.Lean.Engine.TransactionHandlers.BacktestingTransactionHandler",
-      "messaging-handler": "QuantConnect.Messaging.EventMessagingHandler",
+      "messaging-handler": "QuantConnect.Messaging.StreamingMessageHandler",
         "log-handler": "QuantConnect.Logging.QueueLogHandler",
         "desktop-http-port": "1234",
         "desktop-exe": "../../../UserInterface/bin/Debug/QuantConnect.Views.exe"
@@ -204,7 +204,7 @@
       "data-feed-handler": "QuantConnect.Lean.Engine.DataFeeds.LiveTradingDataFeed",
       "real-time-handler": "QuantConnect.Lean.Engine.RealTime.LiveTradingRealTimeHandler",
       "transaction-handler": "QuantConnect.Lean.Engine.TransactionHandlers.BrokerageTransactionHandler",
-      "messaging-handler": "QuantConnect.Messaging.EventMessagingHandler",
+      "messaging-handler": "QuantConnect.Messaging.StreamingMessageHandler",
         "log-handler": "QuantConnect.Logging.QueueLogHandler",
         "desktop-http-port": "1234",
         "desktop-exe": "../../../UserInterface/bin/Release/QuantConnect.Views.exe"

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -180,7 +180,9 @@
       "real-time-handler": "QuantConnect.Lean.Engine.RealTime.BacktestingRealTimeHandler",
       "transaction-handler": "QuantConnect.Lean.Engine.TransactionHandlers.BacktestingTransactionHandler",
       "messaging-handler": "QuantConnect.Messaging.EventMessagingHandler",
-      "log-handler": "QuantConnect.Logging.QueueLogHandler"
+        "log-handler": "QuantConnect.Logging.QueueLogHandler",
+        "desktop-http-port": "1234",
+        "desktop-exe": "../../../UserInterface/bin/Debug/QuantConnect.Views.exe"
     },
 
     // defines the 'live-desktop' environment
@@ -203,7 +205,9 @@
       "real-time-handler": "QuantConnect.Lean.Engine.RealTime.LiveTradingRealTimeHandler",
       "transaction-handler": "QuantConnect.Lean.Engine.TransactionHandlers.BrokerageTransactionHandler",
       "messaging-handler": "QuantConnect.Messaging.EventMessagingHandler",
-      "log-handler": "QuantConnect.Logging.QueueLogHandler"
+        "log-handler": "QuantConnect.Logging.QueueLogHandler",
+        "desktop-http-port": "1234",
+        "desktop-exe": "../../../UserInterface/bin/Release/QuantConnect.Views.exe"
     }
   }
 }

--- a/Messaging/QuantConnect.Messaging.csproj
+++ b/Messaging/QuantConnect.Messaging.csproj
@@ -32,6 +32,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AsyncIO, Version=0.1.20.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncIO.0.1.20.0\lib\net40\AsyncIO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetMQ, Version=3.3.3.4, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetMQ.3.3.3.4\lib\net40\NetMQ.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -55,6 +63,7 @@
     <Compile Include="Messaging.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StreamingApi.cs" />
+    <Compile Include="StreamingMessageHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\QuantConnect.csproj">

--- a/Messaging/StreamingMessageHandler.cs
+++ b/Messaging/StreamingMessageHandler.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+using Newtonsoft.Json;
+using QuantConnect.Configuration;
+using QuantConnect.Interfaces;
+using QuantConnect.Logging;
+using QuantConnect.Notifications;
+using QuantConnect.Packets;
+using NetMQ;
+using NetMQ.Sockets;
+
+namespace QuantConnect.Messaging
+{
+    /// <summary>
+    /// Message handler that sends messages over tcp using NetMQ.
+    /// </summary>
+    public class StreamingMessageHandler : IMessagingHandler
+    {
+        private string _port;
+        private PushSocket _server;
+        private AlgorithmNodePacket _job;
+
+        /// <summary>
+        /// Gets or sets whether this messaging handler has any current subscribers.
+        /// This is not used in this message handler.  Messages are sent via tcp as they arrive
+        /// </summary>
+        public bool HasSubscribers { get; set; }
+
+        /// <summary>
+        /// Initialize the messaging system
+        /// </summary>
+        public void Initialize()
+        {
+            _port = Config.Get("desktop-http-port");
+            CheckPort();
+            _server = new PushSocket("@tcp://*:" + _port);
+        }
+
+        /// <summary>
+        /// Set the user communication channel
+        /// </summary>
+        /// <param name="job"></param>
+        public void SetAuthentication(AlgorithmNodePacket job)
+        {
+            _job = job;
+
+            if (_job is LiveNodePacket)
+            {
+                Transmit(_job, typeof(LiveNodePacket).Name);
+            }
+            Transmit(_job, typeof(BacktestNodePacket).Name);
+        }
+
+        /// <summary>
+        /// Send any notification with a base type of Notification.
+        /// </summary>
+        /// <param name="notification">The notification to be sent.</param>
+        public void SendNotification(Notification notification)
+        {
+            var type = notification.GetType();
+            if (type == typeof(NotificationEmail) || type == typeof(NotificationWeb) || type == typeof(NotificationSms))
+            {
+                Log.Error("Messaging.SendNotification(): Send not implemented for notification of type: " + type.Name);
+                return;
+            }
+            notification.Send();
+        }
+
+        /// <summary>
+        /// Send certain types of messages with a base type of Packet.
+        /// </summary>
+        public void Send(Packet packet)
+        {
+            //Packets we handled in the UX.
+            switch (packet.Type)
+            {
+                case PacketType.Debug:
+                    var debug = (DebugPacket)packet;
+                    Transmit(debug, typeof(DebugPacket).Name);
+                    break;
+
+                case PacketType.Log:
+                    var log = (LogPacket)packet;
+                    Transmit(log, typeof(LogPacket).Name);
+                    break;
+
+                case PacketType.RuntimeError:
+                    var runtime = (RuntimeErrorPacket)packet;
+                    Transmit(runtime, typeof(RuntimeErrorPacket).Name);
+                    break;
+
+                case PacketType.HandledError:
+                    var handled = (HandledErrorPacket)packet;
+                    Transmit(handled, typeof(HandledErrorPacket).Name);
+                    break;
+
+                case PacketType.BacktestResult:
+                    var result = (BacktestResultPacket)packet;
+                    Transmit(result, typeof(BacktestResultPacket).Name);
+                    break;
+            }
+
+            if (StreamingApi.IsEnabled)
+            {
+                StreamingApi.Transmit(_job.UserId, _job.Channel, packet);
+            }
+        }
+
+        /// <summary>
+        /// Send a message to the _server using ZeroMQ
+        /// </summary>
+        /// <param name="packet">Packet to transmit</param>
+        /// <param name="resource">The resource where the packet will be sent</param>
+        public void Transmit(Packet packet, string resource)
+        {
+            var payload = JsonConvert.SerializeObject(packet);
+
+            var message = new NetMQMessage();
+
+            message.Append(resource);
+            message.Append(payload);
+
+            _server.SendMultipartMessage(message);
+        }
+
+        /// <summary>
+        /// Check if port to be used by the desktop application is available.
+        /// </summary>
+        private void CheckPort()
+        {
+            try
+            {
+                TcpListener tcpListener = new TcpListener(IPAddress.Any, _port.ToInt32());
+                tcpListener.Start();
+                tcpListener.Stop();
+            }
+            catch
+            {
+                throw new Exception("The port configured in config.json is either being used or blocked by a firewall." +
+                    "Please choose a new port or open the port in the firewall.");
+            }
+        }
+    }
+}

--- a/Messaging/StreamingMessageHandler.cs
+++ b/Messaging/StreamingMessageHandler.cs
@@ -44,12 +44,7 @@ namespace QuantConnect.Messaging
         public void SetAuthentication(AlgorithmNodePacket job)
         {
             _job = job;
-
-            if (_job is LiveNodePacket)
-            {
-                Transmit(_job, typeof(LiveNodePacket).Name);
-            }
-            Transmit(_job, typeof(BacktestNodePacket).Name);
+            Transmit(_job);
         }
 
         /// <summary>
@@ -68,38 +63,11 @@ namespace QuantConnect.Messaging
         }
 
         /// <summary>
-        /// Send certain types of messages with a base type of Packet.
+        /// Send all types of packets
         /// </summary>
         public void Send(Packet packet)
         {
-            //Packets we handled in the UX.
-            switch (packet.Type)
-            {
-                case PacketType.Debug:
-                    var debug = (DebugPacket)packet;
-                    Transmit(debug, typeof(DebugPacket).Name);
-                    break;
-
-                case PacketType.Log:
-                    var log = (LogPacket)packet;
-                    Transmit(log, typeof(LogPacket).Name);
-                    break;
-
-                case PacketType.RuntimeError:
-                    var runtime = (RuntimeErrorPacket)packet;
-                    Transmit(runtime, typeof(RuntimeErrorPacket).Name);
-                    break;
-
-                case PacketType.HandledError:
-                    var handled = (HandledErrorPacket)packet;
-                    Transmit(handled, typeof(HandledErrorPacket).Name);
-                    break;
-
-                case PacketType.BacktestResult:
-                    var result = (BacktestResultPacket)packet;
-                    Transmit(result, typeof(BacktestResultPacket).Name);
-                    break;
-            }
+           Transmit(packet);
 
             if (StreamingApi.IsEnabled)
             {
@@ -111,14 +79,12 @@ namespace QuantConnect.Messaging
         /// Send a message to the _server using ZeroMQ
         /// </summary>
         /// <param name="packet">Packet to transmit</param>
-        /// <param name="resource">The resource where the packet will be sent</param>
-        public void Transmit(Packet packet, string resource)
+        public void Transmit(Packet packet)
         {
             var payload = JsonConvert.SerializeObject(packet);
 
             var message = new NetMQMessage();
 
-            message.Append(resource);
             message.Append(payload);
 
             _server.SendMultipartMessage(message);

--- a/Messaging/packages.config
+++ b/Messaging/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AsyncIO" version="0.1.20.0" targetFramework="net45" />
+  <package id="NetMQ" version="3.3.3.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="RestSharp" version="105.2.3" targetFramework="net45" />
 </packages>

--- a/Tests/Messaging/StreamingMessageHandlerTests.cs
+++ b/Tests/Messaging/StreamingMessageHandlerTests.cs
@@ -1,0 +1,146 @@
+﻿using System.Collections.Generic;
+using NetMQ;
+using NetMQ.Sockets;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using QuantConnect.Configuration;
+using QuantConnect.Messaging;
+using QuantConnect.Packets;
+
+namespace QuantConnect.Tests.Messaging
+{
+    [TestFixture, Ignore("This tests requires an open TCP port.")]
+    public class StreamingMessageHandlerTests
+    {
+        private readonly string _port = "1234";
+        private StreamingMessageHandler _messageHandler;
+
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            Config.Set("desktop-http-port", _port);
+
+            _messageHandler = new StreamingMessageHandler();
+            _messageHandler.Initialize();
+        }
+
+        [TestFixtureTearDown]
+        public void TearDown()
+        {
+            //
+        }
+
+        [Test]
+        public void MessageHandler_WillSend_MultipartMessage()
+        {
+            var resource = typeof(LogPacket).Name;
+
+            using (var pullSocket = new PullSocket(">tcp://localhost:" + _port))
+            {
+                var logPacket = new LogPacket
+                {
+                    Message = "1"
+                };
+
+                var tx = JsonConvert.SerializeObject(logPacket);
+
+                _messageHandler.Transmit(logPacket, resource);
+
+                var message = pullSocket.ReceiveMultipartMessage();
+
+                Assert.IsTrue(message.FrameCount == 2);
+                Assert.IsTrue(message[0].ConvertToString() == resource);
+                Assert.IsTrue(message[1].ConvertToString() == tx);
+            }
+        }
+
+        [Test]
+        public void MessageHandler_SendsCorrectPackets_ToCorrectRoutes()
+        {
+            var debug = new DebugPacket();
+            var log = new LogPacket();
+            var backtest = new BacktestResultPacket();
+            var handled = new HandledErrorPacket();
+            var error = new RuntimeErrorPacket();
+            var packetList = new List<Packet>
+                {
+                    log,
+                    debug,
+                    backtest,
+                    handled,
+                    error
+                };
+
+            using (var pullSocket = new PullSocket(">tcp://localhost:" + _port))
+            {
+                var count = 0;
+                while (count < packetList.Count)
+                {
+                    _messageHandler.Send(packetList[count]);
+
+                    var message = pullSocket.ReceiveMultipartMessage();
+
+                    var resource = message[0].ConvertToString();
+                    var packet = message[1].ConvertToString();
+
+                    Assert.IsTrue(message.FrameCount == 2);
+
+                    if (typeof(DebugPacket).Name == resource)
+                        Assert.IsTrue(packet == JsonConvert.SerializeObject(debug));
+
+                    if (typeof(HandledErrorPacket).Name == resource)
+                        Assert.IsTrue(packet == JsonConvert.SerializeObject(handled));
+
+                    if (typeof(BacktestResultPacket).Name == resource)
+                        Assert.IsTrue(packet == JsonConvert.SerializeObject(backtest));
+
+                    if (typeof(RuntimeErrorPacket).Name == resource)
+                        Assert.IsTrue(packet == JsonConvert.SerializeObject(error));
+
+                    if (typeof(LogPacket).Name == resource)
+                        Assert.IsTrue(packet == JsonConvert.SerializeObject(log));
+
+                    count++;
+                }
+            }
+        }
+
+        [Test]
+        public void MessageHandler_WillSend_NewBackTestJob_ToCorrectRoute()
+        {
+            var backtest = new BacktestNodePacket();
+
+            using (var pullSocket = new PullSocket(">tcp://localhost:" + _port))
+            {
+                _messageHandler.SetAuthentication(backtest);
+
+                var message = pullSocket.ReceiveMultipartMessage();
+
+                var resource = message[0].ConvertToString();
+                var packet = message[1].ConvertToString();
+
+                Assert.IsTrue(message.FrameCount == 2);
+                Assert.IsTrue(resource == typeof(BacktestNodePacket).Name);
+                Assert.IsTrue(packet == JsonConvert.SerializeObject(backtest));
+            }
+        }
+
+        [Test]
+        public void MessageHandler_WillSend_NewLiveJob_ToCorrectRoute()
+        {
+            using (var pullSocket = new PullSocket(">tcp://localhost:" + _port))
+            {
+                _messageHandler.SetAuthentication(new LiveNodePacket());
+
+                var message = pullSocket.ReceiveMultipartMessage();
+
+                var resource = message[0].ConvertToString();
+                var packet = message[1].ConvertToString();
+
+                Assert.IsTrue(message.FrameCount == 2);
+                Assert.IsTrue(resource == typeof(LiveNodePacket).Name);
+                Assert.IsTrue(packet == JsonConvert.SerializeObject(new LiveNodePacket()));
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -33,6 +33,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AsyncIO, Version=0.1.20.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncIO.0.1.20.0\lib\net40\AsyncIO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
@@ -51,6 +55,10 @@
     </Reference>
     <Reference Include="Moq, Version=4.5.10.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.5.10\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetMQ, Version=3.3.3.4, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetMQ.3.3.3.4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -243,6 +251,7 @@
     <Compile Include="Indicators\RateOfChangePercentTests.cs" />
     <Compile Include="Indicators\RateOfChangeTests.cs" />
     <Compile Include="Indicators\StochasticTests.cs" />
+    <Compile Include="Messaging\StreamingMessageHandlerTests.cs" />
     <Compile Include="Queues\FileCommandQueueHandlerTests.cs" />
     <Compile Include="RegressionTests.cs" />
     <Compile Include="Symbols.cs" />
@@ -332,7 +341,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Adapters\" />
-    <Folder Include="Messaging\" />
     <Folder Include="Tasks\" />
     <Folder Include="UserInterface\" />
   </ItemGroup>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AsyncIO" version="0.1.20.0" targetFramework="net45" />
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="CloneExtensions" version="1.2" targetFramework="net45" />
   <package id="DotNetZip" version="1.9.3" targetFramework="net45" />
   <package id="IKVM-WithExes" version="7.3.4830.1" />
   <package id="Moq" version="4.5.10" targetFramework="net45" />
+  <package id="NetMQ" version="3.3.3.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NodaTime" version="1.3.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />

--- a/UserInterface/DesktopClient.cs
+++ b/UserInterface/DesktopClient.cs
@@ -1,0 +1,98 @@
+﻿using Newtonsoft.Json;
+using QuantConnect.Orders;
+using QuantConnect.Packets;
+using NetMQ;
+using NetMQ.Sockets;
+
+namespace QuantConnect.Views
+{
+    public class DesktopClient
+    {
+        private bool _stopServer = false;
+
+        /// <summary>
+        /// This 0MQ Pull socket accepts certain messages from a 0MQ Push socket
+        /// </summary>
+        /// <param name="port">The port on which to listen</param>
+        /// <param name="handler">The handler which will display the repsonses</param>
+        public void Run(string port, IDesktopMessageHandler handler)
+        {
+            //Allow proper decoding of orders.
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                Converters = { new OrderJsonConverter() }
+            };
+
+            using (var pullSocket = new PullSocket(">tcp://localhost:" + port))
+            {
+                while (!_stopServer)
+                {
+                    var message = pullSocket.ReceiveMultipartMessage();
+
+                    // There should only be 2 part messages
+                    if (message.FrameCount != 2) continue;
+
+                    var resource = message[0].ConvertToString();
+                    var packet = message[1].ConvertToString();
+
+
+                    if (typeof(LiveNodePacket).Name == resource)
+                    {
+                        var liveJobModel = JsonConvert.DeserializeObject<LiveNodePacket>(packet);
+                        handler.Initialize(liveJobModel);
+                        continue;
+                    }
+                    if (typeof(BacktestNodePacket).Name == resource)
+                    {
+                        var backtestJobModel = JsonConvert.DeserializeObject<BacktestNodePacket>(packet);
+                        handler.Initialize(backtestJobModel);
+                        continue;
+                    }
+                    if (typeof(DebugPacket).Name == resource)
+                    {
+                        var debugEventModel = JsonConvert.DeserializeObject<DebugPacket>(packet);
+                        handler.DisplayDebugPacket(debugEventModel);
+                        continue;
+                    }
+
+                    if (typeof(HandledErrorPacket).Name == resource)
+                    {
+                        var handleErrorEventModel = JsonConvert.DeserializeObject<HandledErrorPacket>(packet);
+                        handler.DisplayHandledErrorPacket(handleErrorEventModel);
+                        continue;
+                    }
+
+                    if (typeof(BacktestResultPacket).Name == resource)
+                    {
+                        var backtestResultEventModel = JsonConvert.DeserializeObject<BacktestResultPacket>(packet);
+                        handler.DisplayBacktestResultsPacket(backtestResultEventModel);
+                        continue;
+                    }
+
+
+                    if (typeof(RuntimeErrorPacket).Name == resource)
+                    {
+                        var runtimeErrorEventModel = JsonConvert.DeserializeObject<RuntimeErrorPacket>(packet);
+                        handler.DisplayRuntimeErrorPacket(runtimeErrorEventModel);
+                        continue;
+                    }
+
+
+                    if (typeof(LogPacket).Name == resource)
+                    {
+                        var logEventModel = JsonConvert.DeserializeObject<LogPacket>(packet);
+                        handler.DisplayLogPacket(logEventModel);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Stop the running of the loop
+        /// </summary>
+        public void StopServer()
+        {
+            _stopServer = true;
+        }
+    }
+}

--- a/UserInterface/DesktopClient.cs
+++ b/UserInterface/DesktopClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Newtonsoft.Json;
 using QuantConnect.Orders;
 using QuantConnect.Packets;
@@ -9,7 +10,7 @@ namespace QuantConnect.Views
 {
     public class DesktopClient
     {
-        private bool _stopServer = false;
+        private volatile bool _stopServer = false;
 
         /// <summary>
         /// This 0MQ Pull socket accepts certain messages from a 0MQ Push socket

--- a/UserInterface/DesktopClient.cs
+++ b/UserInterface/DesktopClient.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using QuantConnect.Orders;
 using QuantConnect.Packets;
 using NetMQ;
@@ -29,59 +30,43 @@ namespace QuantConnect.Views
                 {
                     var message = pullSocket.ReceiveMultipartMessage();
 
-                    // There should only be 2 part messages
-                    if (message.FrameCount != 2) continue;
+                    // There should only be 1 part messages
+                    if (message.FrameCount != 1) continue;
 
-                    var resource = message[0].ConvertToString();
-                    var packet = message[1].ConvertToString();
+                    var payload = message[0].ConvertToString();
 
+                    var packet = JsonConvert.DeserializeObject<Packet>(payload);
 
-                    if (typeof(LiveNodePacket).Name == resource)
+                    switch (packet.Type)
                     {
-                        var liveJobModel = JsonConvert.DeserializeObject<LiveNodePacket>(packet);
-                        handler.Initialize(liveJobModel);
-                        continue;
-                    }
-                    if (typeof(BacktestNodePacket).Name == resource)
-                    {
-                        var backtestJobModel = JsonConvert.DeserializeObject<BacktestNodePacket>(packet);
-                        handler.Initialize(backtestJobModel);
-                        continue;
-                    }
-                    if (typeof(DebugPacket).Name == resource)
-                    {
-                        var debugEventModel = JsonConvert.DeserializeObject<DebugPacket>(packet);
-                        handler.DisplayDebugPacket(debugEventModel);
-                        continue;
-                    }
-
-                    if (typeof(HandledErrorPacket).Name == resource)
-                    {
-                        var handleErrorEventModel = JsonConvert.DeserializeObject<HandledErrorPacket>(packet);
-                        handler.DisplayHandledErrorPacket(handleErrorEventModel);
-                        continue;
-                    }
-
-                    if (typeof(BacktestResultPacket).Name == resource)
-                    {
-                        var backtestResultEventModel = JsonConvert.DeserializeObject<BacktestResultPacket>(packet);
-                        handler.DisplayBacktestResultsPacket(backtestResultEventModel);
-                        continue;
-                    }
-
-
-                    if (typeof(RuntimeErrorPacket).Name == resource)
-                    {
-                        var runtimeErrorEventModel = JsonConvert.DeserializeObject<RuntimeErrorPacket>(packet);
-                        handler.DisplayRuntimeErrorPacket(runtimeErrorEventModel);
-                        continue;
-                    }
-
-
-                    if (typeof(LogPacket).Name == resource)
-                    {
-                        var logEventModel = JsonConvert.DeserializeObject<LogPacket>(packet);
-                        handler.DisplayLogPacket(logEventModel);
+                        case PacketType.BacktestNode:
+                            var backtestJobModel = JsonConvert.DeserializeObject<BacktestNodePacket>(payload);
+                            handler.Initialize(backtestJobModel);
+                            break;
+                        case PacketType.LiveNode:
+                            var liveJobModel = JsonConvert.DeserializeObject<LiveNodePacket>(payload);
+                            handler.Initialize(liveJobModel);
+                            break;
+                        case PacketType.Debug:
+                            var debugEventModel = JsonConvert.DeserializeObject<DebugPacket>(payload);
+                            handler.DisplayDebugPacket(debugEventModel);
+                            break;
+                        case PacketType.HandledError:
+                            var handleErrorEventModel = JsonConvert.DeserializeObject<HandledErrorPacket>(payload);
+                            handler.DisplayHandledErrorPacket(handleErrorEventModel);
+                            break;
+                        case PacketType.BacktestResult:
+                            var backtestResultEventModel = JsonConvert.DeserializeObject<BacktestResultPacket>(payload);
+                            handler.DisplayBacktestResultsPacket(backtestResultEventModel);
+                            break;
+                        case PacketType.RuntimeError:
+                            var runtimeErrorEventModel = JsonConvert.DeserializeObject<RuntimeErrorPacket>(payload);
+                            handler.DisplayRuntimeErrorPacket(runtimeErrorEventModel);
+                            break;
+                        case PacketType.Log:
+                            var logEventModel = JsonConvert.DeserializeObject<LogPacket>(payload);
+                            handler.DisplayLogPacket(logEventModel);
+                            break;
                     }
                 }
             }

--- a/UserInterface/IDesktopMessageHandler.cs
+++ b/UserInterface/IDesktopMessageHandler.cs
@@ -1,0 +1,43 @@
+﻿using QuantConnect.Packets;
+
+namespace QuantConnect.Views
+{
+    /// <summary>
+    /// Messaging System Plugin Interface for the UI. 
+    /// Provides a common messaging pattern between the desktop client and the UI.
+    /// </summary>
+    public interface IDesktopMessageHandler
+    {
+        /// <summary>
+        /// This method should be called first when a new job is recieved.
+        /// </summary>
+        /// <param name="job">The job that is being executed</param>
+        void Initialize(AlgorithmNodePacket job);
+
+        /// <summary>
+        /// Display the Handled error packet
+        /// </summary>
+        /// <param name="packet">Handled error packet to be displayed</param>
+        void DisplayHandledErrorPacket(HandledErrorPacket packet);
+        /// <summary>
+        /// Method to display the runtime error packet
+        /// </summary>
+        /// <param name="packet">Runtime error packet to be displayed</param>
+        void DisplayRuntimeErrorPacket(RuntimeErrorPacket packet);
+        /// <summary>
+        /// Method to display the Log packets
+        /// </summary>
+        /// <param name="packet">Log packet to be displayed</param>
+        void DisplayLogPacket(LogPacket packet);
+        /// <summary>
+        /// Method to display the debug packet
+        /// </summary>
+        /// <param name="packet">Debug packet to be displayed</param>
+        void DisplayDebugPacket(DebugPacket packet);
+        /// <summary>
+        /// Displays the Backtest results packet
+        /// </summary>
+        /// <param name="packet">Backtest results</param>
+        void DisplayBacktestResultsPacket(BacktestResultPacket packet);
+    }
+}

--- a/UserInterface/Program.cs
+++ b/UserInterface/Program.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using QuantConnect.Views.WinForms;
 
@@ -14,7 +10,27 @@ namespace QuantConnect.Views
         [STAThread]
         static void Main(string[] args)
         {
-        
+            if (args.Length != 1)
+            {
+                throw new Exception(
+                    "Error: You must specify the port on which the application will open a TCP socket.");
+            }
+
+            var port = args[0];
+
+            var form = new LeanWinForm();
+
+            var desktopClient = new DesktopClient();
+
+            var thread = new Thread(() => desktopClient.Run(port, form));
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+
+            Application.Run(form);
+
+            // The above code is blocking.
+            // Once it finishes, close the NetMQ client
+            desktopClient.StopServer();
         }
     }
 }

--- a/UserInterface/Program.cs
+++ b/UserInterface/Program.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using QuantConnect.Views.WinForms;
+
+namespace QuantConnect.Views
+{
+    public class Program
+    {
+        [STAThread]
+        static void Main(string[] args)
+        {
+        
+        }
+    }
+}

--- a/UserInterface/QuantConnect.Views.csproj
+++ b/UserInterface/QuantConnect.Views.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{C68BEEED-B0C0-4002-94D4-1E871133D02A}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>QuantConnect.Views</RootNamespace>
     <AssemblyName>QuantConnect.Views</AssemblyName>
@@ -83,6 +83,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/UserInterface/QuantConnect.Views.csproj
+++ b/UserInterface/QuantConnect.Views.csproj
@@ -83,6 +83,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IDesktopMessageHandler.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/UserInterface/QuantConnect.Views.csproj
+++ b/UserInterface/QuantConnect.Views.csproj
@@ -64,6 +64,10 @@
       <HintPath>..\packages\AsyncIO.0.1.20.0\lib\net40\AsyncIO.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Geckofx-Core, Version=45.0.6.0, Culture=neutral, PublicKeyToken=3209ac31600d1857, processorArchitecture=x86">
       <HintPath>..\packages\GeckoFX.1.0.5\lib\Geckofx-Core.dll</HintPath>
       <Private>True</Private>
@@ -72,12 +76,20 @@
       <HintPath>..\packages\GeckoFX.1.0.5\lib\Geckofx-Winforms.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NetMQ, Version=3.3.3.4, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
       <HintPath>..\packages\NetMQ.3.3.3.4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -100,6 +112,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tests\DesktopClientTests.cs" />
     <Compile Include="WinForms\LeanWinForm.Extensions.cs" />
     <Compile Include="WinForms\LeanWinForm.cs">
       <SubType>Form</SubType>

--- a/UserInterface/QuantConnect.Views.csproj
+++ b/UserInterface/QuantConnect.Views.csproj
@@ -60,12 +60,20 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AsyncIO, Version=0.1.20.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncIO.0.1.20.0\lib\net40\AsyncIO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Geckofx-Core, Version=45.0.6.0, Culture=neutral, PublicKeyToken=3209ac31600d1857, processorArchitecture=x86">
       <HintPath>..\packages\GeckoFX.1.0.5\lib\Geckofx-Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Geckofx-Winforms, Version=45.0.6.0, Culture=neutral, PublicKeyToken=3209ac31600d1857, processorArchitecture=MSIL">
       <HintPath>..\packages\GeckoFX.1.0.5\lib\Geckofx-Winforms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetMQ, Version=3.3.3.4, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetMQ.3.3.3.4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -83,6 +91,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DesktopClient.cs" />
     <Compile Include="IDesktopMessageHandler.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/UserInterface/Tests/DesktopClientTests.cs
+++ b/UserInterface/Tests/DesktopClientTests.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using Moq;
+using NetMQ;
+using NetMQ.Sockets;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using QuantConnect.Packets;
+
+namespace QuantConnect.Views.Tests
+{
+    [TestFixture]
+    class DesktopClientTests
+    {
+        private string _port = "1235";
+        private DesktopClient _desktopMessageHandler;
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            _desktopMessageHandler = new DesktopClient();
+        }
+
+        [TestFixtureTearDown]
+        public void TearDown()
+        {
+            _desktopMessageHandler.StopServer();
+        }
+
+        private void StartClientThread(IDesktopMessageHandler messageHandler)
+        {
+            var thread = new Thread(() => _desktopMessageHandler.Run(_port, messageHandler));
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+        }
+
+        [Test]
+        public void DesktopClient_WillNotAccept_SinglePartMessages()
+        {
+            Queue<Packet> packets = new Queue<Packet>();
+            // Mock the the message handler processor
+            var messageHandler = new Mock<IDesktopMessageHandler>();
+            messageHandler.Setup(mh => mh.DisplayBacktestResultsPacket(It.IsAny<BacktestResultPacket>())).Callback(
+                (BacktestResultPacket packet) =>
+                {
+                    packets.Enqueue(packet);
+                }).Verifiable();
+
+            // Setup Client
+            StartClientThread(messageHandler.Object);
+
+            using (PushSocket server = new PushSocket("@tcp://*:" + _port))
+            {
+                var message = new NetMQMessage();
+
+                message.Append(typeof(BacktestResultPacket).Name);
+
+                server.SendMultipartMessage(message);
+            }
+
+            // Give NetMQ time to send the message
+            Thread.Sleep(500);
+
+            Assert.IsTrue(packets.Count == 0);
+        }
+
+        [Test]
+        public void DesktopClient_WillAccept_TwoPartMessages()
+        {
+            Queue<Packet> packets = new Queue<Packet>();
+            // Mock the the message handler processor
+            var messageHandler = new Mock<IDesktopMessageHandler>();
+            messageHandler.Setup(mh => mh.DisplayLogPacket(It.IsAny<LogPacket>()))
+                .Callback((LogPacket packet) =>
+                {
+                    packets.Enqueue(packet);
+                })
+                .Verifiable();
+
+            // Setup Client
+            StartClientThread(messageHandler.Object);
+
+            using (PushSocket server = new PushSocket("@tcp://*:" + _port))
+            {
+                var message = new NetMQMessage();
+
+                message.Append(typeof(LogPacket).Name);
+                message.Append(JsonConvert.SerializeObject(new LogPacket()));
+
+                server.SendMultipartMessage(message);
+            }
+
+            // Give NetMQ time to send the message
+            Thread.Sleep(500);
+
+            Assert.IsTrue(packets.Count == 1);
+        }
+
+        [Test]
+        public void DesktopClient_WillNotAccept_MoreThanTwoPartMessages()
+        {
+            Queue<Packet> packets = new Queue<Packet>();
+            // Mock the the message handler processor
+            var messageHandler = new Mock<IDesktopMessageHandler>();
+            messageHandler.Setup(mh => mh.DisplayLogPacket(It.IsAny<LogPacket>()))
+                .Callback((LogPacket packet) =>
+                {
+                    packets.Enqueue(packet);
+                })
+                .Verifiable();
+
+            // Setup Client
+            StartClientThread(messageHandler.Object);
+
+            using (PushSocket server = new PushSocket("@tcp://*:" + _port))
+            {
+                var message = new NetMQMessage();
+
+                message.Append(typeof(LogPacket).Name);
+                message.Append(JsonConvert.SerializeObject(new LogPacket()));
+                message.Append("hello!");
+
+                server.SendMultipartMessage(message);
+            }
+
+            // Give NetMQ time to send the message
+            Thread.Sleep(500);
+
+            Assert.IsTrue(packets.Count == 0);
+        }
+    }
+}

--- a/UserInterface/WinForms/LeanWinForm.cs
+++ b/UserInterface/WinForms/LeanWinForm.cs
@@ -12,21 +12,19 @@ using Gecko.JQuery;
 
 namespace QuantConnect.Views.WinForms
 {
-    public partial class LeanWinForm : Form
+    public partial class LeanWinForm : Form, IDesktopMessageHandler
     {
+        private readonly GeckoWebBrowser _geckoBrowser;
         private readonly WebBrowser _monoBrowser;
-        private readonly AlgorithmNodePacket _job;
         private readonly QueueLogHandler _logging;
-        private readonly EventMessagingHandler _messaging;
-        private readonly bool _liveMode = false;
-        private GeckoWebBrowser _geckoBrowser;
+
+        private bool _liveMode = false;
+        private AlgorithmNodePacket _job;
 
         /// <summary>
         /// Create the UX.
         /// </summary>
-        /// <param name="notificationHandler">Messaging system</param>
-        /// <param name="job">Job to use for URL generation</param>
-        public LeanWinForm(IMessagingHandler notificationHandler, AlgorithmNodePacket job)
+        public LeanWinForm()
         {
             InitializeComponent();
 
@@ -35,12 +33,6 @@ namespace QuantConnect.Views.WinForms
             WindowState = FormWindowState.Maximized;
             Text = "QuantConnect Lean Algorithmic Trading Engine: v" + Globals.Version;
 
-            //Save off the messaging event handler we need:
-            _job = job;
-            _liveMode = job is LiveNodePacket;
-            _messaging = (EventMessagingHandler)notificationHandler;
-            var url = GetUrl(job, _liveMode);
-
             //GECKO WEB BROWSER: Create the browser control
             // https://www.nuget.org/packages/GeckoFX/
             // -> If you don't have IE.
@@ -48,26 +40,24 @@ namespace QuantConnect.Views.WinForms
             Gecko.Xpcom.Initialize();
 
             _geckoBrowser = new GeckoWebBrowser { Dock = DockStyle.Fill, Name = "browser" };
-            _geckoBrowser.DOMContentLoaded += BrowserOnDomContentLoaded;
-            _geckoBrowser.Load += (s, e) => { _messaging.SendEnqueuedPackets(); };
-            _geckoBrowser.Navigate(url);
             splitPanel.Panel1.Controls.Add(_geckoBrowser);
 #else
             // MONO WEB BROWSER: Create the browser control
             // Default shipped with VS and Mono. Works OK in Windows, and compiles in linux.
             _monoBrowser = new WebBrowser() {Dock = DockStyle.Fill, Name = "Browser"};
-            _monoBrowser.DocumentCompleted += MonoBrowserOnDocumentCompleted;
-            _monoBrowser.Navigate(url);
             splitPanel.Panel1.Controls.Add(_monoBrowser);
 #endif
-            //Setup Event Handlers:
-            _messaging.DebugEvent += MessagingOnDebugEvent;
-            _messaging.LogEvent += MessagingOnLogEvent;
-            _messaging.RuntimeErrorEvent += MessagingOnRuntimeErrorEvent;
-            _messaging.HandledErrorEvent += MessagingOnHandledErrorEvent;
-            _messaging.BacktestResultEvent += MessagingOnBacktestResultEvent;
 
-            _logging = Log.LogHandler as QueueLogHandler;
+            _logging = new QueueLogHandler();
+        }
+
+        /// <summary>
+        /// This method is called when a new job is received.
+        /// </summary>
+        /// <param name="job">The job that is being executed</param>
+        public void Initialize(AlgorithmNodePacket job)
+        {
+            _job = job;
 
             //Show warnings if the API token and UID aren't set.
             if (_job.UserId == 0)
@@ -78,78 +68,24 @@ namespace QuantConnect.Views.WinForms
             {
                 MessageBox.Show("Your API token is not set. Please check your config.json file 'api-access-token' property.", "LEAN Algorithmic Trading", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
-        }
 
+            _liveMode = job is LiveNodePacket;
+            var url = GetUrl(job, _liveMode);
 
-        /// <summary>
-        /// Get the URL for the embedded charting
-        /// </summary>
-        /// <param name="job">Job packet for the URL</param>
-        /// <param name="liveMode">Is this a live mode chart?</param>
-        /// <param name="holdReady">Hold the ready signal to inject data</param>
-        private static string GetUrl(AlgorithmNodePacket job, bool liveMode = false, bool holdReady = false)
-        {
-            var url = "";
-            var hold = holdReady == false ? "0" : "1";
-            var embedPage = liveMode ? "embeddedLive" : "embedded";
+#if !__MonoCS__
 
-            url = string.Format(
-                "https://www.quantconnect.com/terminal/{0}?user={1}&token={2}&pid={3}&version={4}&holdReady={5}&bid={6}",
-                embedPage, job.UserId, job.Channel, job.ProjectId, Globals.Version, hold, job.AlgorithmId);
+            _geckoBrowser.Navigate(url);
+#else
+            _monoBrowser.Navigate(url);
+#endif
 
-            return url;
         }
 
         /// <summary>
-        /// MONO BROWSER: Browser content has completely loaded.
+        /// Displays the Backtest results packet
         /// </summary>
-        private void MonoBrowserOnDocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs webBrowserDocumentCompletedEventArgs)
-        {
-            _messaging.OnConsumerReadyEvent();
-        }
-
-        /// <summary>
-        /// GECKO BROWSER: Browser content has completely loaded.
-        /// </summary>
-        private void BrowserOnDomContentLoaded(object sender, DomEventArgs domEventArgs)
-        {
-            _messaging.OnConsumerReadyEvent();
-        }
-        
-        /// <summary>
-        /// Update the status label at the bottom of the form
-        /// </summary>
-        private void timer_Tick(object sender, EventArgs e)
-        {
-            StatisticsToolStripStatusLabel.Text = string.Concat("Performance: CPU: ", OS.CpuUsage.NextValue().ToString("0.0"), "%",
-                                                                " Ram: ", OS.TotalPhysicalMemoryUsed, " Mb");
-
-            if (_logging == null) return;
-
-            LogEntry log;
-            while (_logging.Logs.TryDequeue(out log))
-            {
-                switch (log.MessageType)
-                {
-                    case LogType.Debug:
-                        LogTextBox.AppendText(log.ToString(), Color.Black);
-                        break;
-                    default:
-                    case LogType.Trace:
-                        LogTextBox.AppendText(log.ToString(), Color.Black);
-                        break;
-                    case LogType.Error:
-                        LogTextBox.AppendText(log.ToString(), Color.DarkRed);
-                        break;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Backtest result packet
-        /// </summary>
-        /// <param name="packet"></param>
-        private void MessagingOnBacktestResultEvent(BacktestResultPacket packet)
+        /// <param name="packet">Backtest results</param>
+        public void DisplayBacktestResultsPacket(BacktestResultPacket packet)
         {
             if (packet.Progress != 1) return;
 
@@ -200,7 +136,7 @@ namespace QuantConnect.Views.WinForms
         /// <summary>
         /// Display a handled error
         /// </summary>
-        private void MessagingOnHandledErrorEvent(HandledErrorPacket packet)
+        public void DisplayHandledErrorPacket(HandledErrorPacket packet)
         {
             var hstack = (!string.IsNullOrEmpty(packet.StackTrace) ? (Environment.NewLine + " " + packet.StackTrace) : string.Empty);
             _logging.Error(packet.Message + hstack);
@@ -209,7 +145,7 @@ namespace QuantConnect.Views.WinForms
         /// <summary>
         /// Display a runtime error
         /// </summary>
-        private void MessagingOnRuntimeErrorEvent(RuntimeErrorPacket packet)
+        public void DisplayRuntimeErrorPacket(RuntimeErrorPacket packet)
         {
             var rstack = (!string.IsNullOrEmpty(packet.StackTrace) ? (Environment.NewLine + " " + packet.StackTrace) : string.Empty);
             _logging.Error(packet.Message + rstack);
@@ -218,7 +154,7 @@ namespace QuantConnect.Views.WinForms
         /// <summary>
         /// Display a log packet
         /// </summary>
-        private void MessagingOnLogEvent(LogPacket packet)
+        public void DisplayLogPacket(LogPacket packet)
         {
             _logging.Trace(packet.Message);
         }
@@ -227,9 +163,57 @@ namespace QuantConnect.Views.WinForms
         /// Display a debug packet
         /// </summary>
         /// <param name="packet"></param>
-        private void MessagingOnDebugEvent(DebugPacket packet)
+        public void DisplayDebugPacket(DebugPacket packet)
         {
             _logging.Trace(packet.Message);
+        }
+
+        /// <summary>
+        /// Get the URL for the embedded charting
+        /// </summary>
+        /// <param name="job">Job packet for the URL</param>
+        /// <param name="liveMode">Is this a live mode chart?</param>
+        /// <param name="holdReady">Hold the ready signal to inject data</param>
+        private static string GetUrl(AlgorithmNodePacket job, bool liveMode = false, bool holdReady = false)
+        {
+            var url = "";
+            var hold = holdReady == false ? "0" : "1";
+            var embedPage = liveMode ? "embeddedLive" : "embedded";
+
+            url = string.Format(
+                "https://www.quantconnect.com/terminal/{0}?user={1}&token={2}&pid={3}&version={4}&holdReady={5}&bid={6}",
+                embedPage, job.UserId, job.Channel, job.ProjectId, Globals.Version, hold, job.AlgorithmId);
+
+            return url;
+        }
+
+        /// <summary>
+        /// Update the status label at the bottom of the form
+        /// </summary>
+        private void timer_Tick(object sender, EventArgs e)
+        {
+            StatisticsToolStripStatusLabel.Text = string.Concat("Performance: CPU: ", OS.CpuUsage.NextValue().ToString("0.0"), "%",
+                                                                " Ram: ", OS.TotalPhysicalMemoryUsed, " Mb");
+
+            if (_logging == null) return;
+
+            LogEntry log;
+            while (_logging.Logs.TryDequeue(out log))
+            {
+                switch (log.MessageType)
+                {
+                    case LogType.Debug:
+                        LogTextBox.AppendText(log.ToString(), Color.Black);
+                        break;
+                    default:
+                    case LogType.Trace:
+                        LogTextBox.AppendText(log.ToString(), Color.Black);
+                        break;
+                    case LogType.Error:
+                        LogTextBox.AppendText(log.ToString(), Color.DarkRed);
+                        break;
+                }
+            }
         }
 
         /// <summary>

--- a/UserInterface/packages.config
+++ b/UserInterface/packages.config
@@ -2,7 +2,10 @@
 <packages>
   <package id="AsyncIO" version="0.1.20.0" targetFramework="net45" />
   <package id="Baseclass.Contrib.Nuget.Output" version="2.2.0-xbuild02" targetFramework="net45" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="GeckoFX" version="1.0.5" targetFramework="net45" />
+  <package id="Moq" version="4.5.21" targetFramework="net45" />
   <package id="NetMQ" version="3.3.3.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="NUnit" version="3.4.1" targetFramework="net45" />
 </packages>

--- a/UserInterface/packages.config
+++ b/UserInterface/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AsyncIO" version="0.1.20.0" targetFramework="net45" />
   <package id="Baseclass.Contrib.Nuget.Output" version="2.2.0-xbuild02" targetFramework="net45" />
   <package id="GeckoFX" version="1.0.5" targetFramework="net45" />
+  <package id="NetMQ" version="3.3.3.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The purpose of this pull request is to decouple the QuantConnect.Views build configuration from the rest of the solution. This is achieved by changing QuantConnect.Views 'Output Type' to 'Console Application' and removing the QuantConnect.Views reference in the QuantConnect.Launcher project. 

This will enable QuantConnect.Views to run as a separate 32 bit process (which it must because of its dependency on GeckoFX) and allow the rest of the solution to run as a 64 bit process. 

The interprocess communication between Lean and the UI is achieved over tcp sockets and leverages the NetMQ library - a 100% native C# implementation of ZeroMQ for .NET. NetMQ was chosen because of it’s ability to asynchronously send messages over tcp, while preserving the message order. 

A new message handler, StreamingMessageHandler, is added which processes the messages in-line using a NetMQ Push Socket. This is now the default message handler for the desktop environments.  The port on which the NetMQ communicates, as well as the location of the UI executable, is now configurable in config.json.

The UI uses a NetMQ Pull Socket in a new class called DesktopClient.cs.  The desktop client uses an instance of a new interface, IDesktopMessageHandler, to push messages to the UI.  LeanWinForms.cs now implements this interface. 