### PR TITLE
Renames PipSize to MinimumPriceVariation

### DIFF
--- a/Common/Securities/Cfd/Cfd.cs
+++ b/Common/Securities/Cfd/Cfd.cs
@@ -82,20 +82,17 @@ namespace QuantConnect.Securities.Cfd
         /// <summary>
         /// Gets the contract multiplier for this CFD security
         /// </summary>
-        /// <remarks>
-        /// PipValue := ContractMultiplier * PipSize
-        /// </remarks>
         public decimal ContractMultiplier
         {
             get { return SymbolProperties.ContractMultiplier; }
         }
 
         /// <summary>
-        /// Gets the pip size for this CFD security
+        /// Gets the minimum price variation for this CFD security
         /// </summary>
-        public decimal PipSize
+        public decimal MinimumPriceVariation
         {
-            get { return SymbolProperties.PipSize; }
+            get { return SymbolProperties.MinimumPriceVariation; }
         }
     }
 }

--- a/Common/Securities/SymbolProperties.cs
+++ b/Common/Securities/SymbolProperties.cs
@@ -48,9 +48,9 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// The pip size (tick size) for the security
+        /// The minimum price variation (tick size) for the security
         /// </summary>
-        public decimal PipSize
+        public decimal MinimumPriceVariation
         {
             get; 
             private set;
@@ -68,12 +68,12 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Creates an instance of the <see cref="SymbolProperties"/> class
         /// </summary>
-        public SymbolProperties(string description, string quoteCurrency, decimal contractMultiplier, decimal pipSize, decimal lotSize)
+        public SymbolProperties(string description, string quoteCurrency, decimal contractMultiplier, decimal minimumPriceVariation, decimal lotSize)
         {
             Description = description;
             QuoteCurrency = quoteCurrency;
             ContractMultiplier = contractMultiplier;
-            PipSize = pipSize;
+            MinimumPriceVariation = minimumPriceVariation;
             LotSize = lotSize;
         }
 

--- a/Common/Securities/SymbolPropertiesDatabase.cs
+++ b/Common/Securities/SymbolPropertiesDatabase.cs
@@ -128,8 +128,8 @@ namespace QuantConnect.Securities
             return new SymbolProperties(
                 description: csv[3], 
                 quoteCurrency: csv[4],
-                contractMultiplier: csv[5].ToDecimal(), 
-                pipSize: csv[6].ToDecimal(),
+                contractMultiplier: csv[5].ToDecimal(),
+                minimumPriceVariation: csv[6].ToDecimal(),
                 lotSize: csv[7].ToDecimal());
         }
 

--- a/Data/symbol-properties/symbol-properties-database.csv
+++ b/Data/symbol-properties/symbol-properties-database.csv
@@ -1,123 +1,195 @@
-market,symbol,type,description,quote_currency,contract_multiplier,pip_size,lot_size
+market,symbol,type,description,quote_currency,contract_multiplier,minimum_price_variation,lot_size
 
 #
 # Use # signs for comments
 #
 
-fxcm,AU200AUD,cfd,S&P/ASX index of Australian listed shares,USD,0.1,1,1
-fxcm,DE10YBEUR,cfd,Euro-Bund,EUR,10,0.01,1
-fxcm,XCUUSD,cfd,Copper,USD,100,0.001,1
-fxcm,ES35EUR,cfd,IBEX 35 index of Spanish listed shares,EUR,0.1,1,1
-fxcm,EU50EUR,cfd,Euro Stoxx 50 index of European listed shares,EUR,0.1,1,1
-fxcm,FR40EUR,cfd,CAC 40 index of French listed shares,EUR,0.1,1,1
-fxcm,DE30EUR,cfd,DAX index of German listed shares,EUR,0.1,1,1
-fxcm,HK33HKD,cfd,Hang Seng index of Hong Kong listed shares,HKD,1,1,1
-fxcm,IT40EUR,cfd,FTSE MIB index of Italian listed shares,EUR,0.1,1,1
-fxcm,JP225JPY,cfd,Nikkei 225 index of Japanese listed shares,JPY,1,1,10
-fxcm,NAS100USD,cfd,TECH 100 index of US listed shares,USD,0.1,1,1
-fxcm,NATGASUSD,cfd,Natural Gas (Henry Hub),USD,100,0.001,1
-fxcm,SPX500USD,cfd,S&P 500 index of US listed shares,USD,1,0.1,1
-fxcm,CH20CHF,cfd,Swiss Market Index of Swiss listed shares,CHF,0.1,1,1
-fxcm,UK100GBP,cfd,FTSE 100 index of UK listed shares,GBP,0.1,1,1
-fxcm,BCOUSD,cfd,Crude Oil (Brent),USD,10,0.01,1
-fxcm,US30USD,cfd,Index of top 30 shares on Wall Street,USD,0.1,1,1
-fxcm,DXYUSD,cfd,Dow Jones FXCM Dollar Index Basket,USD,1,1,1
-fxcm,WTICOUSD,cfd,Crude Oil (WTI),USD,10,0.01,1
-fxcm,XAGUSD,cfd,Silver,USD,1,0.01,50
-fxcm,XAUUSD,cfd,Gold,USD,1,0.01,1
-fxcm,XPDUSD,cfd,Palladium,USD,1,0.1,1
-fxcm,XPTUSD,cfd,Platinum,USD,1,0.1,1
+fxcm,AU200AUD,cfd,S&P/ASX index of Australian listed shares,USD,0.1,0.1,1
+fxcm,DE10YBEUR,cfd,Euro-Bund,EUR,10,0.001,1
+fxcm,XCUUSD,cfd,Copper,USD,100,0.0001,1
+fxcm,ES35EUR,cfd,IBEX 35 index of Spanish listed shares,EUR,0.1,0.1,1
+fxcm,EU50EUR,cfd,Euro Stoxx 50 index of European listed shares,EUR,0.1,0.1,1
+fxcm,FR40EUR,cfd,CAC 40 index of French listed shares,EUR,0.1,0.1,1
+fxcm,DE30EUR,cfd,DAX index of German listed shares,EUR,0.1,0.1,1
+fxcm,HK33HKD,cfd,Hang Seng index of Hong Kong listed shares,HKD,1,0.1,1
+fxcm,IT40EUR,cfd,FTSE MIB index of Italian listed shares,EUR,0.1,0.1,1
+fxcm,JP225JPY,cfd,Nikkei 225 index of Japanese listed shares,JPY,1,0.1,10
+fxcm,NAS100USD,cfd,TECH 100 index of US listed shares,USD,0.1,0.1,1
+fxcm,NATGASUSD,cfd,Natural Gas (Henry Hub),USD,100,0.0001,1
+fxcm,SPX500USD,cfd,S&P 500 index of US listed shares,USD,1,0.01,1
+fxcm,CH20CHF,cfd,Swiss Market Index of Swiss listed shares,CHF,0.1,0.1,1
+fxcm,UK100GBP,cfd,FTSE 100 index of UK listed shares,GBP,0.1,0.1,1
+fxcm,BCOUSD,cfd,Crude Oil (Brent),USD,10,0.001,1
+fxcm,US30USD,cfd,Index of top 30 shares on Wall Street,USD,0.1,0.1,1
+fxcm,DXYUSD,cfd,Dow Jones FXCM Dollar Index Basket,USD,1,0.1,1
+fxcm,WTICOUSD,cfd,Crude Oil (WTI),USD,10,0.001,1
+fxcm,XAGUSD,cfd,Silver,USD,1,0.001,50
+fxcm,XAUUSD,cfd,Gold,USD,1,0.001,1
+fxcm,XPDUSD,cfd,Palladium,USD,1,0.01,1
+fxcm,XPTUSD,cfd,Platinum,USD,1,0.01,1
 
-oanda,AU200AUD,cfd,Australia 200,AUD,1,1,1
-oanda,BCOUSD,cfd,Brent Crude Oil,USD,1,0.01,1
-oanda,CH20CHF,cfd,Swiss 20,CHF,1,1,1
-oanda,CORNUSD,cfd,Corn,USD,1,0.01,1
-oanda,DE10YBEUR,cfd,Bund,EUR,1,0.01,1
-oanda,DE30EUR,cfd,Germany 30,EUR,1,1,1
-oanda,EU50EUR,cfd,Europe 50,EUR,1,1,1
-oanda,FR40EUR,cfd,France 40,EUR,1,1,1
-oanda,HK33HKD,cfd,Hong Kong 33,HKD,1,1,1
-oanda,JP225USD,cfd,Japan 225,USD,1,1,1
-oanda,NAS100USD,cfd,US Nas 100,USD,1,1,1
-oanda,NATGASUSD,cfd,Natural Gas,USD,1,0.01,1
-oanda,NL25EUR,cfd,Netherlands 25,EUR,1,0.01,1
-oanda,SG30SGD,cfd,Singapore 30,SGD,1,0.1,1
-oanda,SOYBNUSD,cfd,Soybeans,USD,1,0.01,1
-oanda,SPX500USD,cfd,US SPX 500,USD,1,1,1
-oanda,SUGARUSD,cfd,Sugar,USD,1,0.0001,1
-oanda,UK100GBP,cfd,UK 100,GBP,1,1,1
-oanda,UK10YBGBP,cfd,UK 10Y Gilt,GBP,1,0.01,1
-oanda,US2000USD,cfd,US Russ 2000,USD,1,0.01,1
-oanda,US30USD,cfd,US Wall St 30,USD,1,1,1
-oanda,USB02YUSD,cfd,US 2Y T-Note,USD,1,0.01,1
-oanda,USB05YUSD,cfd,US 5Y T-Note,USD,1,0.01,1
-oanda,USB10YUSD,cfd,US 10Y T-Note,USD,1,0.01,1
-oanda,USB30YUSD,cfd,US T-Bond,USD,1,0.01,1
-oanda,WHEATUSD,cfd,Wheat,USD,1,0.01,1
-oanda,WTICOUSD,cfd,West Texas Oil,USD,1,0.01,1
-oanda,XAGAUD,cfd,Silver/AUD,AUD,1,0.0001,1
-oanda,XAGCAD,cfd,Silver/CAD,CAD,1,0.0001,1
-oanda,XAGCHF,cfd,Silver/CHF,CHF,1,0.0001,1
-oanda,XAGEUR,cfd,Silver/EUR,EUR,1,0.0001,1
-oanda,XAGGBP,cfd,Silver/GBP,GBP,1,0.0001,1
-oanda,XAGHKD,cfd,Silver/HKD,HKD,1,0.0001,1
-oanda,XAGJPY,cfd,Silver/JPY,JPY,1,1,1
-oanda,XAGNZD,cfd,Silver/NZD,NZD,1,0.0001,1
-oanda,XAGSGD,cfd,Silver/SGD,SGD,1,0.0001,1
-oanda,XAGUSD,cfd,Silver,USD,1,0.0001,1
-oanda,XAUAUD,cfd,Gold/AUD,AUD,1,0.01,1
-oanda,XAUCAD,cfd,Gold/CAD,CAD,1,0.01,1
-oanda,XAUCHF,cfd,Gold/CHF,CHF,1,0.01,1
-oanda,XAUEUR,cfd,Gold/EUR,EUR,1,0.01,1
-oanda,XAUGBP,cfd,Gold/GBP,GBP,1,0.01,1
-oanda,XAUHKD,cfd,Gold/HKD,HKD,1,0.01,1
-oanda,XAUJPY,cfd,Gold/JPY,JPY,1,10,1
-oanda,XAUNZD,cfd,Gold/NZD,NZD,1,0.01,1
-oanda,XAUSGD,cfd,Gold/SGD,SGD,1,0.01,1
-oanda,XAUUSD,cfd,Gold,USD,1,0.01,1
-oanda,XAUXAG,cfd,Gold/Silver,XAG,1,0.01,1
-oanda,XCUUSD,cfd,Copper,USD,1,0.0001,1
-oanda,XPDUSD,cfd,Palladium,USD,1,0.01,1
-oanda,XPTUSD,cfd,Platinum,USD,1,0.01,1
+oanda,AU200AUD,cfd,Australia 200,AUD,1,0.1,1
+oanda,BCOUSD,cfd,Brent Crude Oil,USD,1,0.001,1
+oanda,CH20CHF,cfd,Swiss 20,CHF,1,0.1,1
+oanda,CORNUSD,cfd,Corn,USD,1,0.001,1
+oanda,DE10YBEUR,cfd,Bund,EUR,1,0.001,1
+oanda,DE30EUR,cfd,Germany 30,EUR,1,0.1,1
+oanda,EU50EUR,cfd,Europe 50,EUR,1,0.1,1
+oanda,FR40EUR,cfd,France 40,EUR,1,0.1,1
+oanda,HK33HKD,cfd,Hong Kong 33,HKD,1,0.1,1
+oanda,JP225USD,cfd,Japan 225,USD,1,0.1,1
+oanda,NAS100USD,cfd,US Nas 100,USD,1,0.1,1
+oanda,NATGASUSD,cfd,Natural Gas,USD,1,0.001,1
+oanda,NL25EUR,cfd,Netherlands 25,EUR,1,0.001,1
+oanda,SG30SGD,cfd,Singapore 30,SGD,1,0.01,1
+oanda,SOYBNUSD,cfd,Soybeans,USD,1,0.001,1
+oanda,SPX500USD,cfd,US SPX 500,USD,1,0.1,1
+oanda,SUGARUSD,cfd,Sugar,USD,1,0.00001,1
+oanda,UK100GBP,cfd,UK 100,GBP,1,0.1,1
+oanda,UK10YBGBP,cfd,UK 10Y Gilt,GBP,1,0.001,1
+oanda,US2000USD,cfd,US Russ 2000,USD,1,0.001,1
+oanda,US30USD,cfd,US Wall St 30,USD,1,0.1,1
+oanda,USB02YUSD,cfd,US 2Y T-Note,USD,1,0.001,1
+oanda,USB05YUSD,cfd,US 5Y T-Note,USD,1,0.001,1
+oanda,USB10YUSD,cfd,US 10Y T-Note,USD,1,0.001,1
+oanda,USB30YUSD,cfd,US T-Bond,USD,1,0.001,1
+oanda,WHEATUSD,cfd,Wheat,USD,1,0.001,1
+oanda,WTICOUSD,cfd,West Texas Oil,USD,1,0.001,1
+oanda,XAGAUD,cfd,Silver/AUD,AUD,1,0.00001,1
+oanda,XAGCAD,cfd,Silver/CAD,CAD,1,0.00001,1
+oanda,XAGCHF,cfd,Silver/CHF,CHF,1,0.00001,1
+oanda,XAGEUR,cfd,Silver/EUR,EUR,1,0.00001,1
+oanda,XAGGBP,cfd,Silver/GBP,GBP,1,0.00001,1
+oanda,XAGHKD,cfd,Silver/HKD,HKD,1,0.00001,1
+oanda,XAGJPY,cfd,Silver/JPY,JPY,1,0.1,1
+oanda,XAGNZD,cfd,Silver/NZD,NZD,1,0.00001,1
+oanda,XAGSGD,cfd,Silver/SGD,SGD,1,0.00001,1
+oanda,XAGUSD,cfd,Silver,USD,1,0.00001,1
+oanda,XAUAUD,cfd,Gold/AUD,AUD,1,0.001,1
+oanda,XAUCAD,cfd,Gold/CAD,CAD,1,0.001,1
+oanda,XAUCHF,cfd,Gold/CHF,CHF,1,0.001,1
+oanda,XAUEUR,cfd,Gold/EUR,EUR,1,0.001,1
+oanda,XAUGBP,cfd,Gold/GBP,GBP,1,0.001,1
+oanda,XAUHKD,cfd,Gold/HKD,HKD,1,0.001,1
+oanda,XAUJPY,cfd,Gold/JPY,JPY,1,1,1
+oanda,XAUNZD,cfd,Gold/NZD,NZD,1,0.001,1
+oanda,XAUSGD,cfd,Gold/SGD,SGD,1,0.001,1
+oanda,XAUUSD,cfd,Gold,USD,1,0.001,1
+oanda,XAUXAG,cfd,Gold/Silver,XAG,1,0.001,1
+oanda,XCUUSD,cfd,Copper,USD,1,0.00001,1
+oanda,XPDUSD,cfd,Palladium,USD,1,0.001,1
+oanda,XPTUSD,cfd,Platinum,USD,1,0.001,1
 
 usa,[*],option,,USD,100,0.01,1
 
-fxcm,AUDCAD,forex,,CAD,1,0.0001,1000
-fxcm,AUDCHF,forex,,CHF,1,0.0001,1000
-fxcm,AUDJPY,forex,,JPY,1,0.01,1000
-fxcm,AUDNZD,forex,,NZD,1,0.0001,1000
-fxcm,AUDUSD,forex,,USD,1,0.0001,1000
-fxcm,CADCHF,forex,,CHF,1,0.0001,1000
-fxcm,CADJPY,forex,,JPY,1,0.01,1000
-fxcm,CHFJPY,forex,,JPY,1,0.01,1000
-fxcm,EURAUD,forex,,AUD,1,0.0001,1000
-fxcm,EURCAD,forex,,CAD,1,0.0001,1000
-fxcm,EURCHF,forex,,CHF,1,0.0001,1000
-fxcm,EURGBP,forex,,GBP,1,0.0001,1000
-fxcm,EURJPY,forex,,JPY,1,0.01,1000
-fxcm,EURNOK,forex,,NOK,1,0.0001,1000
-fxcm,EURNZD,forex,,NZD,1,0.0001,1000
-fxcm,EURSEK,forex,,SEK,1,0.0001,1000
-fxcm,EURTRY,forex,,TRY,1,0.0001,1000
-fxcm,EURUSD,forex,,USD,1,0.0001,1000
-fxcm,GBPAUD,forex,,AUD,1,0.0001,1000
-fxcm,GBPCAD,forex,,CAD,1,0.0001,1000
-fxcm,GBPCHF,forex,,CHF,1,0.0001,1000
-fxcm,GBPJPY,forex,,JPY,1,0.01,1000
-fxcm,GBPNZD,forex,,NZD,1,0.0001,1000
-fxcm,GBPUSD,forex,,USD,1,0.0001,1000
-fxcm,NZDCAD,forex,,CAD,1,0.0001,1000
-fxcm,NZDCHF,forex,,CHF,1,0.0001,1000
-fxcm,NZDJPY,forex,,JPY,1,0.01,1000
-fxcm,NZDUSD,forex,,USD,1,0.0001,1000
-fxcm,TRYJPY,forex,,JPY,1,0.01,1000
-fxcm,USDCAD,forex,,CAD,1,0.0001,1000
-fxcm,USDCHF,forex,,CHF,1,0.0001,1000
-fxcm,USDCNH,forex,,CNH,1,0.0001,1000
-fxcm,USDJPY,forex,,JPY,1,0.01,1000
-fxcm,USDMXN,forex,,MXN,1,0.0001,1000
-fxcm,USDNOK,forex,,NOK,1,0.0001,1000
-fxcm,USDSEK,forex,,SEK,1,0.0001,1000
-fxcm,USDTRY,forex,,TRY,1,0.0001,1000
-fxcm,USDZAR,forex,,ZAR,1,0.0001,1000
-fxcm,ZARJPY,forex,,JPY,1,0.01,1000
+fxcm,AUDCAD,forex,,CAD,1,0.00001,1000
+fxcm,AUDCHF,forex,,CHF,1,0.00001,1000
+fxcm,AUDJPY,forex,,JPY,1,0.001,1000
+fxcm,AUDNZD,forex,,NZD,1,0.00001,1000
+fxcm,AUDUSD,forex,,USD,1,0.00001,1000
+fxcm,CADCHF,forex,,CHF,1,0.00001,1000
+fxcm,CADJPY,forex,,JPY,1,0.001,1000
+fxcm,CHFJPY,forex,,JPY,1,0.001,1000
+fxcm,EURAUD,forex,,AUD,1,0.00001,1000
+fxcm,EURCAD,forex,,CAD,1,0.00001,1000
+fxcm,EURCHF,forex,,CHF,1,0.00001,1000
+fxcm,EURGBP,forex,,GBP,1,0.00001,1000
+fxcm,EURJPY,forex,,JPY,1,0.001,1000
+fxcm,EURNOK,forex,,NOK,1,0.00001,1000
+fxcm,EURNZD,forex,,NZD,1,0.00001,1000
+fxcm,EURSEK,forex,,SEK,1,0.00001,1000
+fxcm,EURTRY,forex,,TRY,1,0.00001,1000
+fxcm,EURUSD,forex,,USD,1,0.00001,1000
+fxcm,GBPAUD,forex,,AUD,1,0.00001,1000
+fxcm,GBPCAD,forex,,CAD,1,0.00001,1000
+fxcm,GBPCHF,forex,,CHF,1,0.00001,1000
+fxcm,GBPJPY,forex,,JPY,1,0.001,1000
+fxcm,GBPNZD,forex,,NZD,1,0.00001,1000
+fxcm,GBPUSD,forex,,USD,1,0.00001,1000
+fxcm,NZDCAD,forex,,CAD,1,0.00001,1000
+fxcm,NZDCHF,forex,,CHF,1,0.00001,1000
+fxcm,NZDJPY,forex,,JPY,1,0.001,1000
+fxcm,NZDUSD,forex,,USD,1,0.00001,1000
+fxcm,TRYJPY,forex,,JPY,1,0.001,1000
+fxcm,USDCAD,forex,,CAD,1,0.00001,1000
+fxcm,USDCHF,forex,,CHF,1,0.00001,1000
+fxcm,USDCNH,forex,,CNH,1,0.00001,1000
+fxcm,USDJPY,forex,,JPY,1,0.001,1000
+fxcm,USDMXN,forex,,MXN,1,0.00001,1000
+fxcm,USDNOK,forex,,NOK,1,0.00001,1000
+fxcm,USDSEK,forex,,SEK,1,0.00001,1000
+fxcm,USDTRY,forex,,TRY,1,0.00001,1000
+fxcm,USDZAR,forex,,ZAR,1,0.00001,1000
+fxcm,ZARJPY,forex,,JPY,1,0.001,1000
+
+oanda,AUDCAD,forex,AUD/CAD,CAD,1,0.00001,1
+oanda,AUDCHF,forex,AUD/CHF,CHF,1,0.00001,1
+oanda,AUDHKD,forex,AUD/HKD,HKD,1,0.00001,1
+oanda,AUDJPY,forex,AUD/JPY,JPY,1,0.001,1
+oanda,AUDNZD,forex,AUD/NZD,NZD,1,0.00001,1
+oanda,AUDSGD,forex,AUD/SGD,SGD,1,0.00001,1
+oanda,AUDUSD,forex,AUD/USD,USD,1,0.00001,1
+oanda,CADCHF,forex,CAD/CHF,CHF,1,0.00001,1
+oanda,CADHKD,forex,CAD/HKD,HKD,1,0.00001,1
+oanda,CADJPY,forex,CAD/JPY,JPY,1,0.001,1
+oanda,CADSGD,forex,CAD/SGD,SGD,1,0.00001,1
+oanda,CHFHKD,forex,CHF/HKD,HKD,1,0.00001,1
+oanda,CHFJPY,forex,CHF/JPY,JPY,1,0.001,1
+oanda,CHFZAR,forex,CHF/ZAR,ZAR,1,0.00001,1
+oanda,EURAUD,forex,EUR/AUD,AUD,1,0.00001,1
+oanda,EURCAD,forex,EUR/CAD,CAD,1,0.00001,1
+oanda,EURCHF,forex,EUR/CHF,CHF,1,0.00001,1
+oanda,EURCZK,forex,EUR/CZK,CZK,1,0.00001,1
+oanda,EURDKK,forex,EUR/DKK,DKK,1,0.00001,1
+oanda,EURGBP,forex,EUR/GBP,GBP,1,0.00001,1
+oanda,EURHKD,forex,EUR/HKD,HKD,1,0.00001,1
+oanda,EURHUF,forex,EUR/HUF,HUF,1,0.001,1
+oanda,EURJPY,forex,EUR/JPY,JPY,1,0.001,1
+oanda,EURNOK,forex,EUR/NOK,NOK,1,0.00001,1
+oanda,EURNZD,forex,EUR/NZD,NZD,1,0.00001,1
+oanda,EURPLN,forex,EUR/PLN,PLN,1,0.00001,1
+oanda,EURSEK,forex,EUR/SEK,SEK,1,0.00001,1
+oanda,EURSGD,forex,EUR/SGD,SGD,1,0.00001,1
+oanda,EURTRY,forex,EUR/TRY,TRY,1,0.00001,1
+oanda,EURUSD,forex,EUR/USD,USD,1,0.00001,1
+oanda,EURZAR,forex,EUR/ZAR,ZAR,1,0.00001,1
+oanda,GBPAUD,forex,GBP/AUD,AUD,1,0.00001,1
+oanda,GBPCAD,forex,GBP/CAD,CAD,1,0.00001,1
+oanda,GBPCHF,forex,GBP/CHF,CHF,1,0.00001,1
+oanda,GBPHKD,forex,GBP/HKD,HKD,1,0.00001,1
+oanda,GBPJPY,forex,GBP/JPY,JPY,1,0.001,1
+oanda,GBPNZD,forex,GBP/NZD,NZD,1,0.00001,1
+oanda,GBPPLN,forex,GBP/PLN,PLN,1,0.00001,1
+oanda,GBPSGD,forex,GBP/SGD,SGD,1,0.00001,1
+oanda,GBPUSD,forex,GBP/USD,USD,1,0.00001,1
+oanda,GBPZAR,forex,GBP/ZAR,ZAR,1,0.00001,1
+oanda,HKDJPY,forex,HKD/JPY,JPY,1,0.00001,1
+oanda,NZDCAD,forex,NZD/CAD,CAD,1,0.00001,1
+oanda,NZDCHF,forex,NZD/CHF,CHF,1,0.00001,1
+oanda,NZDHKD,forex,NZD/HKD,HKD,1,0.00001,1
+oanda,NZDJPY,forex,NZD/JPY,JPY,1,0.001,1
+oanda,NZDSGD,forex,NZD/SGD,SGD,1,0.00001,1
+oanda,NZDUSD,forex,NZD/USD,USD,1,0.00001,1
+oanda,SGDCHF,forex,SGD/CHF,CHF,1,0.00001,1
+oanda,SGDHKD,forex,SGD/HKD,HKD,1,0.00001,1
+oanda,SGDJPY,forex,SGD/JPY,JPY,1,0.001,1
+oanda,TRYJPY,forex,TRY/JPY,JPY,1,0.001,1
+oanda,USDCAD,forex,USD/CAD,CAD,1,0.00001,1
+oanda,USDCHF,forex,USD/CHF,CHF,1,0.00001,1
+oanda,USDCNH,forex,USD/CNH,CNH,1,0.00001,1
+oanda,USDCZK,forex,USD/CZK,CZK,1,0.00001,1
+oanda,USDDKK,forex,USD/DKK,DKK,1,0.00001,1
+oanda,USDHKD,forex,USD/HKD,HKD,1,0.00001,1
+oanda,USDHUF,forex,USD/HUF,HUF,1,0.001,1
+oanda,USDINR,forex,USD/INR,INR,1,0.001,1
+oanda,USDJPY,forex,USD/JPY,JPY,1,0.001,1
+oanda,USDMXN,forex,USD/MXN,MXN,1,0.00001,1
+oanda,USDNOK,forex,USD/NOK,NOK,1,0.00001,1
+oanda,USDPLN,forex,USD/PLN,PLN,1,0.00001,1
+oanda,USDSAR,forex,USD/SAR,SAR,1,0.00001,1
+oanda,USDSEK,forex,USD/SEK,SEK,1,0.00001,1
+oanda,USDSGD,forex,USD/SGD,SGD,1,0.00001,1
+oanda,USDTHB,forex,USD/THB,THB,1,0.001,1
+oanda,USDTRY,forex,USD/TRY,TRY,1,0.00001,1
+oanda,USDZAR,forex,USD/ZAR,ZAR,1,0.00001,1
+oanda,ZARJPY,forex,ZAR/JPY,JPY,1,0.001,1


### PR DESCRIPTION
Renames SymbolProperties.PipSize to SymbolProperties.MinimumPriceVariation, since the term pip does not refer to a minimum price variation.
Updates symbol-properties-database to include minimum price variations intead of pips.