### PR TITLE
API Updates

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -314,12 +314,7 @@ namespace QuantConnect.Api
                 return false;
 
             // Save csv in same folder heirarchy as Lean
-            string path;
-            
-            if (resolution == Resolution.Daily || resolution == Resolution.Hour)
-                path = Config.Get("data-folder") + "/" + symbol.ID.SecurityType.ToLower() + "/" + symbol.ID.Market.ToLower() + "/" + resolution.ToLower() + "/" + symbol.Value.ToLower() + ".zip";
-            else
-                path = Config.Get("data-folder") + "/" + symbol.ID.SecurityType.ToLower() + "/" + symbol.ID.Market.ToLower() + "/" + resolution.ToLower() + "/" + symbol.Value.ToLower() + "/" + date.ToString("yyyyMMdd") + "_quote.zip";
+            var path = CreatePathForDownloadedData(symbol, resolution, date);
 
             // Make sure the directory exist before writing
             (new FileInfo(path)).Directory.Create();
@@ -415,6 +410,28 @@ namespace QuantConnect.Api
             {
                 yield return segment;
             }
+        }
+
+        /// <summary>
+        /// Creates the path for the downloaded data to be saved in the same folder heirarchy as Lean
+        /// </summary>
+        /// <param name="symbol">Symbol of security of which data will be requested.</param>
+        /// <param name="resolution">Resolution of data requested.</param>
+        /// <param name="date">Date of the data requested.</param>
+        /// <returns>Path that specifies where data will be downloaded</returns>
+        private string CreatePathForDownloadedData(Symbol symbol, Resolution resolution, DateTime date)
+        {
+            string path;
+
+            if (resolution == Resolution.Daily || resolution == Resolution.Hour)
+                path = Config.Get("data-folder") + symbol.ID.SecurityType.ToLower() + "/" + symbol.ID.Market.ToLower() +
+                       "/" + resolution.ToLower() + "/" + symbol.Value.ToLower() + ".zip";
+            else
+                path = Config.Get("data-folder") + symbol.ID.SecurityType.ToLower() + "/" + symbol.ID.Market.ToLower() +
+                       "/" + resolution.ToLower() + "/" + symbol.Value.ToLower() + "/" + date.ToString("yyyyMMdd") +
+                       "_quote.zip";
+
+            return path;
         }
 
         /// <summary>

--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -275,6 +275,25 @@ namespace QuantConnect.Api
         }
 
         /// <summary>
+        /// Gets the logs of a specific live algorithm 
+        /// </summary>
+        /// <param name="projectId">Project Id of the live running algorithm</param>
+        /// <param name="algorithmId">Algorithm Id of the live running algorithm</param>
+        /// <returns>List of strings that represent the logs of the algorithm</returns>
+        public LiveLog ReadLiveLogs(int projectId, string algorithmId)
+        {
+            var request = new RestRequest("live/read/log", Method.GET);
+
+            request.AddParameter("format", "json");
+            request.AddParameter("projectId", projectId);
+            request.AddParameter("algorithmId", algorithmId);
+            
+            LiveLog result;
+            _connection.TryRequest(request, out result);
+            return result;
+        }
+
+        /// <summary>
         /// Gets the link to the downloadable data.
         /// </summary>
         /// <param name="symbol">Symbol of security of which data will be requested.</param>

--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -271,6 +271,29 @@ namespace QuantConnect.Api
             return result;
         }
 
+        /// <summary>
+        /// Gets the link to the downloadable data.
+        /// </summary>
+        /// <param name="symbol">Symbol of security of which data will be requested.</param>
+        /// <param name="resolution">Resolution of data requested.</param>
+        /// <param name="date">Date of the data requested.</param>
+        /// <returns>Link to the downloadable data.</returns>
+        public Link ReadDataLink(Symbol symbol, Resolution resolution, DateTime date)
+        {
+            var request = new RestRequest("data/read", Method.GET);
+
+            request.AddParameter("format", "link");
+            request.AddParameter("ticker", symbol.Value.ToLower());
+            request.AddParameter("type", symbol.ID.SecurityType.ToLower());
+            request.AddParameter("market", symbol.ID.Market);
+            request.AddParameter("resolution", resolution);
+            request.AddParameter("date", date.ToString("yyyyMMdd"));
+
+            Link result;
+            _connection.TryRequest(request, out result);
+            return result;
+        }
+
 
         /// <summary>
         /// Calculate the remaining bytes of user log allowed based on the user's cap and daily cumulative usage.

--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -281,15 +281,22 @@ namespace QuantConnect.Api
         /// </summary>
         /// <param name="projectId">Project Id of the live running algorithm</param>
         /// <param name="algorithmId">Algorithm Id of the live running algorithm</param>
+        /// <param name="startTime">No logs will be returned before this time</param>
+        /// <param name="endTime">No logs will be returned after this time</param>
         /// <returns>List of strings that represent the logs of the algorithm</returns>
-        public LiveLog ReadLiveLogs(int projectId, string algorithmId)
+        public LiveLog ReadLiveLogs(int projectId, string algorithmId, DateTime? startTime = null, DateTime? endTime = null)
         {
+            var epochStartTime = startTime == null ? 0 : DateTimeToUnixTimestamp(startTime.Value);
+            var epochEndTime   = endTime   == null ? DateTimeToUnixTimestamp(DateTime.UtcNow) : DateTimeToUnixTimestamp(endTime.Value);
+
             var request = new RestRequest("live/read/log", Method.GET);
 
             request.AddParameter("format", "json");
             request.AddParameter("projectId", projectId);
             request.AddParameter("algorithmId", algorithmId);
-            
+            request.AddParameter("start", epochStartTime);
+            request.AddParameter("end", epochEndTime);
+
             LiveLog result;
             _connection.TryRequest(request, out result);
             return result;
@@ -455,6 +462,17 @@ namespace QuantConnect.Api
 
             return path;
         }
+
+        /// <summary>
+        /// Convert C# dateTime to Unix Epoch DateTime
+        /// </summary>
+        /// <param name="dateTime">DateTime to be converted</param>
+        /// <returns>The total number of seconds since Jan 1, 1970</returns>
+        private static long DateTimeToUnixTimestamp(DateTime dateTime)
+        {
+            return (long) (dateTime - new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc)).TotalSeconds;
+        }
+
 
         /// <summary>
         /// Store logs with these authentication type

--- a/Common/API/Link.cs
+++ b/Common/API/Link.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace QuantConnect.Api
+{
+    /// <summary>
+    /// Response from reading purchased data
+    /// </summary>
+    public class Link : RestResponse
+    {
+        /// <summary>
+        /// Link to the data
+        /// </summary>
+        [JsonProperty(PropertyName = "link")]
+        public string DataLink { get; set; }
+    }
+}

--- a/Common/API/LiveLog.cs
+++ b/Common/API/LiveLog.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using QuantConnect.Api;
+
+namespace QuantConnect.API
+{
+    /// <summary>
+    /// Logs from a live algorithm
+    /// </summary>
+    public class LiveLog : RestResponse
+    {
+        /// <summary>
+        /// List of logs from the live algorithm
+        /// </summary>
+        [JsonProperty(PropertyName = "LiveLogs")]
+        public List<string> Logs { get; set; }
+    }
+}

--- a/Common/Interfaces/IApi.cs
+++ b/Common/Interfaces/IApi.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Initialize the control system
         /// </summary>
-        void Initialize(int userId, string token);
+        void Initialize(int userId, string token, string dataFolder);
 
         /// <summary>
         /// Create a project with the specified name and language via QuantConnect.com API

--- a/Common/Interfaces/IApi.cs
+++ b/Common/Interfaces/IApi.cs
@@ -138,8 +138,10 @@ namespace QuantConnect.Interfaces
         /// </summary>
         /// <param name="projectId">Project Id of the live running algorithm</param>
         /// <param name="algorithmId">Algorithm Id of the live running algorithm</param>
+        /// <param name="startTime">No logs will be returned before this time. Should be in UTC</param>
+        /// <param name="endTime">No logs will be returned after this time. Should be in UTC</param>
         /// <returns>List of strings that represent the logs of the algorithm</returns>
-        LiveLog ReadLiveLogs(int projectId, string algorithmId);
+        LiveLog ReadLiveLogs(int projectId, string algorithmId, DateTime? startTime = null, DateTime? endTime = null);
 
         /// <summary>
         /// Gets the link to the downloadable data.

--- a/Common/Interfaces/IApi.cs
+++ b/Common/Interfaces/IApi.cs
@@ -132,7 +132,24 @@ namespace QuantConnect.Interfaces
         /// </summary>
         /// <returns>List of live algorithm instances</returns>
         LiveList LiveList();
-        
+
+        /// <summary>
+        /// Gets the link to the downloadable data.
+        /// </summary>
+        /// <param name="symbol">Symbol of security of which data will be requested.</param>
+        /// <param name="resolution">Resolution of data requested.</param>
+        /// <param name="date">Date of the data requested.</param>
+        /// <returns>Link to the downloadable data.</returns>
+        Link ReadDataLink(Symbol symbol, Resolution resolution, DateTime date);
+
+        /// <summary>
+        /// Method to download and save the data purchased through QuantConnect
+        /// </summary>
+        /// <param name="symbol">Symbol of security of which data will be requested.</param>
+        /// <param name="resolution">Resolution of data requested.</param>
+        /// <param name="date">Date of the data requested.</param>
+        /// <returns>A bool indicating whether the data was successfully downloaded or not.</returns>
+        bool DownloadData(Symbol symbol, Resolution resolution, DateTime date);
 
 
 

--- a/Common/Interfaces/IApi.cs
+++ b/Common/Interfaces/IApi.cs
@@ -134,6 +134,14 @@ namespace QuantConnect.Interfaces
         LiveList LiveList();
 
         /// <summary>
+        /// Gets the logs of a specific live algorithm 
+        /// </summary>
+        /// <param name="projectId">Project Id of the live running algorithm</param>
+        /// <param name="algorithmId">Algorithm Id of the live running algorithm</param>
+        /// <returns>List of strings that represent the logs of the algorithm</returns>
+        LiveLog ReadLiveLogs(int projectId, string algorithmId);
+
+        /// <summary>
         /// Gets the link to the downloadable data.
         /// </summary>
         /// <param name="symbol">Symbol of security of which data will be requested.</param>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -123,6 +123,7 @@
     <Compile Include="API\CompileState.cs" />
     <Compile Include="API\Link.cs" />
     <Compile Include="API\Live.cs" />
+    <Compile Include="API\LiveLog.cs" />
     <Compile Include="API\Project.cs" />
     <Compile Include="API\ProjectFile.cs" />
     <Compile Include="API\RestResponse.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -121,6 +121,7 @@
     <Compile Include="API\Backtest.cs" />
     <Compile Include="API\Compile.cs" />
     <Compile Include="API\CompileState.cs" />
+    <Compile Include="API\Link.cs" />
     <Compile Include="API\Live.cs" />
     <Compile Include="API\Project.cs" />
     <Compile Include="API\ProjectFile.cs" />

--- a/Engine/LeanEngineSystemHandlers.cs
+++ b/Engine/LeanEngineSystemHandlers.cs
@@ -101,7 +101,7 @@ namespace QuantConnect.Lean.Engine
         /// </summary>
         public void Initialize()
         {
-            Api.Initialize(Config.GetInt("job-user-id", 0), Config.Get("api-access-token", ""));
+            Api.Initialize(Config.GetInt("job-user-id", 0), Config.Get("api-access-token", ""), Config.Get("data-folder"));
             Notify.Initialize();
             JobQueue.Initialize();
         }

--- a/Tests/API/Api.cs
+++ b/Tests/API/Api.cs
@@ -180,7 +180,9 @@ namespace QuantConnect.Tests.API
 
 
         /// <summary>
-        /// Live algorithm tests
+        /// Live algorithm tests 
+        ///   - Get a list of live algorithms
+        ///   - Test getting the logs for a live algorithm
         /// </summary>
         [Test]
         public void ListAccountLiveAlgorithms()
@@ -189,8 +191,19 @@ namespace QuantConnect.Tests.API
 
             // List all previously deployed algorithms
             var liveAlgorithms = api.LiveList();
+            
+            // Get the first live algorithm
+            var firstLiveAlgo = liveAlgorithms.Algorithms[0];
+
+            // Get the logs for the first algorithm
+            var liveLogs = api.ReadLiveLogs(firstLiveAlgo.ProjectId.ToInt32(), firstLiveAlgo.DeployId);
+
+
             Assert.IsTrue(liveAlgorithms.Success);
             Assert.IsTrue(liveAlgorithms.Algorithms.Any());
+
+            Assert.IsTrue(liveLogs.Success);
+            Assert.IsTrue(liveLogs.Logs.Any());
         }
 
         /// <summary>

--- a/Tests/API/Api.cs
+++ b/Tests/API/Api.cs
@@ -30,6 +30,7 @@ namespace QuantConnect.Tests.API
         //Test Authentication Credentials
         private int _testAccount = 1;
         private string _testToken = "ec87b337ac970da4cbea648f24f1c851";
+        private string _dataFolder = Config.Get("data-folder");
 
         /// <summary>
         /// Test successfully authenticates with the API using valid credentials.
@@ -256,8 +257,8 @@ namespace QuantConnect.Tests.API
             Assert.IsTrue(downloadedMinuteData);
             Assert.IsTrue(downloadedDailyData);
             
-            Assert.IsTrue(File.Exists(Config.Get("data-folder") + "forex/oanda/daily/eurusd.zip"));
-            Assert.IsTrue(File.Exists(Config.Get("data-folder") + "forex/oanda/minute/eurusd/20131011_quote.zip"));
+            Assert.IsTrue(File.Exists(_dataFolder + "forex/oanda/daily/eurusd.zip"));
+            Assert.IsTrue(File.Exists(_dataFolder + "forex/oanda/minute/eurusd/20131011_quote.zip"));
         }
 
         /// <summary>
@@ -281,7 +282,7 @@ namespace QuantConnect.Tests.API
         /// <returns></returns>
         private IApi CreateApiAccessor()
         {
-            return CreateApiAccessor(_testAccount, _testToken);
+            return CreateApiAccessor(_testAccount, _testToken, _dataFolder);
         }
 
         /// <summary>
@@ -289,11 +290,12 @@ namespace QuantConnect.Tests.API
         /// </summary>
         /// <param name="uid">User id</param>
         /// <param name="token">Token string</param>
+        /// <param name="dataFolder">Folder to save the downloaded data to</param>
         /// <returns>API class for placing calls</returns>
-        private IApi CreateApiAccessor(int uid, string token)
+        private IApi CreateApiAccessor(int uid, string token, string dataFolder)
         {
             var api = new Api.Api();
-            api.Initialize(uid, token);
+            api.Initialize(uid, token, dataFolder);
             return api;
         }
 

--- a/Tests/API/Api.cs
+++ b/Tests/API/Api.cs
@@ -245,6 +245,14 @@ namespace QuantConnect.Tests.API
         public void Download_AndSave_DataCorrectly()
         {
             var api = CreateApiAccessor();
+            var minutePath = Path.Combine(_dataFolder, "forex/oanda/minute/eurusd/20131011_quote.zip");
+            var dailyPath  = Path.Combine(_dataFolder, "forex/oanda/daily/eurusd.zip");
+
+            if (File.Exists(dailyPath))
+                File.Delete(dailyPath);
+
+            if (File.Exists(minutePath))
+                File.Delete(minutePath);
 
             var downloadedMinuteData = api.DownloadData(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.Oanda), "EURUSD"),
                 Resolution.Minute, new DateTime(2013, 10, 11));
@@ -254,8 +262,8 @@ namespace QuantConnect.Tests.API
             Assert.IsTrue(downloadedMinuteData);
             Assert.IsTrue(downloadedDailyData);
             
-            Assert.IsTrue(File.Exists(_dataFolder + "forex/oanda/daily/eurusd.zip"));
-            Assert.IsTrue(File.Exists(_dataFolder + "forex/oanda/minute/eurusd/20131011_quote.zip"));
+            Assert.IsTrue(File.Exists(dailyPath));
+            Assert.IsTrue(File.Exists(minutePath));
         }
 
         /// <summary>

--- a/Tests/API/Api.cs
+++ b/Tests/API/Api.cs
@@ -193,6 +193,74 @@ namespace QuantConnect.Tests.API
             Assert.IsTrue(liveAlgorithms.Algorithms.Any());
         }
 
+        /// <summary>
+        /// Test getting links to forex data for FXCM
+        /// </summary>
+        [Test]
+        public void GetLinks_ToDownloadData_ForFXCM()
+        {
+            var api = CreateApiAccessor();
+
+            var minuteDataLink = api.ReadDataLink(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.FXCM), "EURUSD"),
+                Resolution.Minute, new DateTime(2013, 10, 07));
+            var dailyDataLink = api.ReadDataLink(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.FXCM), "EURUSD"),
+                Resolution.Daily, new DateTime(2013, 10, 07));
+
+            Assert.IsTrue(minuteDataLink.Success);
+            Assert.IsTrue(dailyDataLink.Success);
+        }
+
+        /// <summary>
+        /// Test getting links to forex data for Oanda
+        /// </summary>
+        [Test]
+        public void GetLinks_ToDownloadData_ForOanda()
+        {
+            var api = CreateApiAccessor();
+
+            var minuteDataLink = api.ReadDataLink(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.Oanda), "EURUSD"),
+                Resolution.Minute, new DateTime(2013, 10, 07));
+            var dailyDataLink = api.ReadDataLink(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.Oanda), "EURUSD"),
+                Resolution.Daily, new DateTime(2013, 10, 07));
+
+            Assert.IsTrue(minuteDataLink.Success);
+            Assert.IsTrue(dailyDataLink.Success);
+        }
+
+        /// <summary>
+        /// Test downloading data that does not come with the repo (Oanda)
+        /// </summary>
+        [Test]
+        public void Download_AndSave_DataCorrectly()
+        {
+            var api = CreateApiAccessor();
+
+            var downloadedMinuteData = api.DownloadData(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.Oanda), "EURUSD"),
+                Resolution.Minute, new DateTime(2013, 10, 11));
+            var downloadedDailyData = api.DownloadData(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.Oanda), "EURUSD"),
+                Resolution.Daily, new DateTime(2013, 10, 07));
+
+            Assert.IsTrue(downloadedMinuteData);
+            Assert.IsTrue(downloadedDailyData);
+            
+            Assert.IsTrue(File.Exists(Config.Get("data-folder") + "forex/oanda/daily/eurusd.zip"));
+            Assert.IsTrue(File.Exists(Config.Get("data-folder") + "forex/oanda/minute/eurusd/20131011_quote.zip"));
+        }
+
+        /// <summary>
+        /// Test downloading non existent data
+        /// </summary>
+        [Test]
+        public void TryDownload_NonExistent_Data()
+        {
+            var api = CreateApiAccessor();
+
+            var nonExistentData = api.DownloadData(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.Oanda), "EURUSD"),
+               Resolution.Minute, new DateTime(1989, 10, 11));
+
+            Assert.IsFalse(nonExistentData);
+        }
+
 
         /// <summary>
         /// Create an authenticated API accessor object.

--- a/Tests/API/Api.cs
+++ b/Tests/API/Api.cs
@@ -183,30 +183,27 @@ namespace QuantConnect.Tests.API
         /// <summary>
         /// Live algorithm tests 
         ///   - Get a list of live algorithms
-        ///   - Test getting the logs for a live algorithm
+        ///   - Get logs for the first algorithm returned
         /// </summary>
         [Test]
-        public void ListAccountLiveAlgorithms()
+        public void LiveAlgorithms_AndLiveLogs_CanBeRead()
         {
             var api = CreateApiAccessor();
 
-            // List all previously deployed algorithms
+            // Read all previously deployed algorithms
             var liveAlgorithms = api.LiveList();
-            
-            // Get the first live algorithm
-            var firstLiveAlgo = liveAlgorithms.Algorithms[0];
-
-            // Get the logs for the first algorithm
-            var liveLogs = api.ReadLiveLogs(firstLiveAlgo.ProjectId.ToInt32(), firstLiveAlgo.DeployId);
-
 
             Assert.IsTrue(liveAlgorithms.Success);
             Assert.IsTrue(liveAlgorithms.Algorithms.Any());
 
+            // Read the logs of the first live algorithm
+            var firstLiveAlgo = liveAlgorithms.Algorithms[0];
+            var liveLogs = api.ReadLiveLogs(firstLiveAlgo.ProjectId.ToInt32(), firstLiveAlgo.DeployId);
+
             Assert.IsTrue(liveLogs.Success);
             Assert.IsTrue(liveLogs.Logs.Any());
         }
-
+        
         /// <summary>
         /// Test getting links to forex data for FXCM
         /// </summary>


### PR DESCRIPTION
This PR adds the ability to reach two new endpoints introduced in QC API v2.

The first of the endpoints allows users to download data they have purchased from QuantConnect.  The data is stored to disk in the same folder-hierarchy as Lean uses to store data.

The second endpoint allows users to read logs of live running algorithms.