### PR TITLE
Default security markets are determined from BrokerageModel.DefaultMarkets

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1251,12 +1251,12 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="ticker">The equity ticker symbol</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="market">The equity's market, <seealso cref="Market"/>. Default is <see cref="Market.USA"/></param>
+        /// <param name="market">The equity's market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">True to send data during pre and post market sessions. Default is <value>false</value></param>
         /// <returns>The new <see cref="Equity"/> security</returns>
-        public Equity AddEquity(string ticker, Resolution resolution = Resolution.Minute, string market = Market.USA, bool fillDataForward = true, decimal leverage = 0m, bool extendedMarketHours = false)
+        public Equity AddEquity(string ticker, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = 0m, bool extendedMarketHours = false)
         {
             return AddSecurity<Equity>(SecurityType.Equity, ticker, resolution, market, fillDataForward, leverage, extendedMarketHours);
         }
@@ -1266,11 +1266,11 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="underlying">The underlying equity symbol</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="market">The equity's market, <seealso cref="Market"/>. Default is <see cref="Market.USA"/></param>
+        /// <param name="market">The equity's market, <seealso cref="Market"/>. Default is value null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Option"/> security</returns>
-        public Option AddOption(string underlying, Resolution resolution = Resolution.Minute, string market = Market.USA, bool fillDataForward = true, decimal leverage = 0m)
+        public Option AddOption(string underlying, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = 0m)
         {
             if (market == null)
             {
@@ -1312,11 +1312,11 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="ticker">The currency pair</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="market">The foreign exchange trading market, <seealso cref="Market"/>. Default is <see cref="Market.FXCM"/></param>
+        /// <param name="market">The foreign exchange trading market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Forex"/> security</returns>
-        public Forex AddForex(string ticker, Resolution resolution = Resolution.Minute, string market = Market.FXCM, bool fillDataForward = true, decimal leverage = 0m)
+        public Forex AddForex(string ticker, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = 0m)
         {
             return AddSecurity<Forex>(SecurityType.Forex, ticker, resolution, market, fillDataForward, leverage, false);
         }
@@ -1326,11 +1326,11 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="ticker">The currency pair</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="market">The cfd trading market, <seealso cref="Market"/>. Default is <see cref="Market.FXCM"/></param>
+        /// <param name="market">The cfd trading market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Cfd"/> security</returns>
-        public Cfd AddCfd(string ticker, Resolution resolution = Resolution.Minute, string market = Market.FXCM, bool fillDataForward = true, decimal leverage = 0m)
+        public Cfd AddCfd(string ticker, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = 0m)
         {
             return AddSecurity<Cfd>(SecurityType.Cfd, ticker, resolution, market, fillDataForward, leverage, false);
         }

--- a/Tests/Algorithm/AlgorithmSetBrokerageTests.cs
+++ b/Tests/Algorithm/AlgorithmSetBrokerageTests.cs
@@ -5,7 +5,9 @@ using QuantConnect.Algorithm;
 namespace QuantConnect.Tests.Algorithm
 {
     /// <summary>
-    /// Test class for setting brokerage model on securities and QCAlgorithm
+    /// Test class for 
+    ///  - SetBrokerageModel() in QCAlgorithm
+    ///  - Default market for new securities
     /// </summary>
     [TestFixture]
     public class AlgorithmSetBrokerageTests

--- a/Tests/Algorithm/AlgorithmSetBrokerageTests.cs
+++ b/Tests/Algorithm/AlgorithmSetBrokerageTests.cs
@@ -1,0 +1,144 @@
+﻿using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Algorithm;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    /// <summary>
+    /// Test class for setting brokerage model on securities and QCAlgorithm
+    /// </summary>
+    [TestFixture]
+    public class AlgorithmSetBrokerageTests
+    {
+        private QCAlgorithm _algo;
+        private const string ForexSym = "EURUSD";
+        private const string Sym = "SPY";
+
+        /// <summary>
+        /// Instatiate a new algorithm before each test.
+        /// Clear the <see cref="SymbolCache"/> so that no symbols and associated brokerage models are cached between test
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            _algo = new QCAlgorithm();
+            SymbolCache.TryRemove(ForexSym);
+            SymbolCache.TryRemove(Sym);
+        }
+
+        /// <summary>
+        /// The default market for FOREX should be FXCM
+        /// </summary>
+        [Test]
+        public void DefaultBrokerageModel_IsFXCM_ForForex()
+        {
+            var forex = _algo.AddForex(ForexSym);
+
+
+            Assert.IsTrue(forex.Symbol.ID.Market == Market.FXCM);
+            Assert.IsTrue(_algo.BrokerageModel.GetType() == typeof(DefaultBrokerageModel));
+        }
+
+        /// <summary>
+        /// The default market for equities should be USA
+        /// </summary>
+        [Test]
+        public void DefaultBrokerageModel_IsUSA_ForEquity()
+        {
+            var equity = _algo.AddEquity(Sym);
+
+
+            Assert.IsTrue(equity.Symbol.ID.Market == Market.USA);
+            Assert.IsTrue(_algo.BrokerageModel.GetType() == typeof(DefaultBrokerageModel));
+        }
+
+        /// <summary>
+        /// The default market for options should be USA
+        /// </summary>
+        [Test]
+        public void DefaultBrokerageModel_IsUSA_ForOption()
+        {
+            var option = _algo.AddOption(Sym);
+
+
+            Assert.IsTrue(option.Symbol.ID.Market == Market.USA);
+            Assert.IsTrue(_algo.BrokerageModel.GetType() == typeof(DefaultBrokerageModel));
+        }
+
+        /// <summary>
+        /// Brokerage model for an algorithm can be changed using <see cref="QCAlgorithm.SetBrokerageModel(IBrokerageModel)"/>
+        /// This changes the brokerage models used when forex currency pairs are added via AddForex and no brokerage is specified. 
+        /// </summary>
+        [Test]
+        public void BrokerageModel_CanBeSpecifiedWith_SetBrokerageModel()
+        {
+            _algo.SetBrokerageModel(BrokerageName.OandaBrokerage);
+            var forex = _algo.AddForex(ForexSym);
+
+            string brokerage = GetDefaultBrokerageForSecurityType(SecurityType.Forex);
+
+
+            Assert.IsTrue(forex.Symbol.ID.Market == Market.Oanda);
+            Assert.IsTrue(_algo.BrokerageModel.GetType() == typeof(OandaBrokerageModel));
+            Assert.IsTrue(brokerage == Market.Oanda);
+        }
+
+        /// <summary>
+        /// Specifying the market in <see cref="QCAlgorithm.AddForex"/> will change the market of the security created.
+        /// </summary>
+        [Test]
+        public void BrokerageModel_CanBeSpecifiedWith_AddForex()
+        {
+            var forex = _algo.AddForex(ForexSym, Resolution.Minute, Market.Oanda);
+
+            string brokerage = GetDefaultBrokerageForSecurityType(SecurityType.Forex);
+
+
+            Assert.IsTrue(forex.Symbol.ID.Market == Market.Oanda);
+            Assert.IsTrue(_algo.BrokerageModel.GetType() == typeof(DefaultBrokerageModel));
+            Assert.IsTrue(brokerage == Market.FXCM);  // Doesn't change brokerage defined in BrokerageModel.DefaultMarkets
+        }
+
+        /// <summary>
+        /// The method <see cref="QCAlgorithm.AddSecurity(SecurityType, string, Resolution, bool, bool)"/> should use the default brokerage for the sepcific security.
+        /// Setting the brokerage with <see cref="QCAlgorithm.SetBrokerageModel(IBrokerageModel)"/> will affect the market of securities added with  <see cref="QCAlgorithm.AddSecurity(SecurityType, string, Resolution, bool, bool)"/>
+        /// </summary>
+        [Test]
+        public void AddSecurity_Follows_SetBrokerageModel()
+        {
+            // No brokerage set
+            var equity = _algo.AddSecurity(SecurityType.Equity, Sym);
+
+            string equityBrokerage = GetDefaultBrokerageForSecurityType(SecurityType.Equity);
+
+
+            Assert.IsTrue(equity.Symbol.ID.Market == Market.USA);
+            Assert.IsTrue(_algo.BrokerageModel.GetType() == typeof(DefaultBrokerageModel));
+            Assert.IsTrue(equityBrokerage == Market.USA);
+
+            // Set Brokerage
+            _algo.SetBrokerageModel(BrokerageName.OandaBrokerage);
+
+            var sec = _algo.AddSecurity(SecurityType.Forex, ForexSym, Resolution.Daily, false, 1, false);
+
+            string forexBrokerage = GetDefaultBrokerageForSecurityType(SecurityType.Forex);
+
+
+            Assert.IsTrue(sec.Symbol.ID.Market == Market.Oanda);
+            Assert.IsTrue(_algo.BrokerageModel.GetType() == typeof(OandaBrokerageModel));
+            Assert.IsTrue(forexBrokerage ==  Market.Oanda);
+        }
+
+        /// <summary>
+        /// Returns the default market for a security type
+        /// </summary>
+        /// <param name="secType">The type of security</param>
+        /// <returns>A string representing the default market of a security</returns>
+        private string GetDefaultBrokerageForSecurityType(SecurityType secType)
+        {
+            string brokerage;
+            _algo.BrokerageModel.DefaultMarkets.TryGetValue(secType, out brokerage);
+            return brokerage;
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -95,6 +95,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AlgorithmRunner.cs" />
+    <Compile Include="Algorithm\AlgorithmSetBrokerageTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetHoldingsTests.cs" />
     <Compile Include="Algorithm\AlgorithmTradingTests.cs" />
     <Compile Include="API\Api.cs" />


### PR DESCRIPTION
- The default value for the market parameter in AddForex(), AddOption(), AddEquity() and AddCfd() is  now null.  
- When new securities are added and no market is specified, the market is determined from  BrokerageModel.DefaultMarkets.
- Fixes #555