### PR TITLE
changed mapping of USD/CNH to USDCNH from USDCNY

### DIFF
--- a/Brokerages/Fxcm/FxcmSymbolMapper.cs
+++ b/Brokerages/Fxcm/FxcmSymbolMapper.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Brokerages.Fxcm
             { "USDOLLAR", "DXYUSD" },
             { "USD/CAD", "USDCAD" },
             { "USD/CHF", "USDCHF" },
-            { "USD/CNH", "USDCNY" },
+            { "USD/CNH", "USDCNH" },
             { "USD/HKD", "USDHKD" },
             { "USD/JPY", "USDJPY" },
             { "USD/NOK", "USDNOK" },


### PR DESCRIPTION
changed mapping of USD/CNH to USDCNH from USDCNY

USDCNY is not supported by FXCM and USDCNY is an onshore currency pair

