### PR TITLE
Changed FXCM hedging warning message

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -89,7 +89,8 @@ namespace QuantConnect.Brokerages.Fxcm
             // Hedging MUST be disabled on the account
             if (_accounts[_accountId].getParties().getFXCMPositionMaintenance() == "Y")
             {
-                throw new NotSupportedException("FxcmBrokerage.LoadAccounts(): The Lean engine does not support accounts with Hedging enabled. Please contact FXCM support to disable Hedging.");
+                throw new NotSupportedException("FxcmBrokerage.LoadAccounts(): The Lean engine does not support accounts with Hedging enabled. " +
+                                                "Please contact FXCM Active Trader support to disable Hedging. They can be reached at 646.432.2970 or by email, activetrader@fxcm.com.");
             }
         }
 
@@ -131,7 +132,7 @@ namespace QuantConnect.Brokerages.Fxcm
             {
                 Symbol = _symbolMapper.GetLeanSymbol(
                     x.getInstrument().getSymbol(),
-                    _symbolMapper.GetBrokerageSecurityType(x.getInstrument().getSymbol()), 
+                    _symbolMapper.GetBrokerageSecurityType(x.getInstrument().getSymbol()),
                     Market.FXCM),
                 BidPrice = (decimal) x.getBidClose(),
                 AskPrice = (decimal) x.getAskClose()


### PR DESCRIPTION
Changed warning message for FXCM brokerage when user is required to disable hedging. 

From:
"Please contact FXCM support to disable Hedging"

To:
"Please contact FXCM Active Trader support to disable Hedging. They can be reached at 646.432.2970 or by email, activetrader@fxcm.com"