### PR TITLE
Makes IAlgorithm Debug/Error/LogMessages a ConcurrentQueue

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -38,6 +38,7 @@ using QuantConnect.Securities.Option;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
 using SecurityTypeMarket = System.Tuple<QuantConnect.SecurityType, string>;
+using System.Collections.Concurrent;
 
 namespace QuantConnect.Algorithm
 {
@@ -57,9 +58,9 @@ namespace QuantConnect.Algorithm
         private bool _locked;
         private bool _liveMode;
         private string _algorithmId = "";
-        private List<string> _debugMessages = new List<string>();
-        private List<string> _logMessages = new List<string>();
-        private List<string> _errorMessages = new List<string>();
+        private ConcurrentQueue<string> _debugMessages = new ConcurrentQueue<string>();
+        private ConcurrentQueue<string> _logMessages = new ConcurrentQueue<string>();
+        private ConcurrentQueue<string> _errorMessages = new ConcurrentQueue<string>();
         
         //Error tracking to avoid message flooding:
         private string _previousDebugMessage = "";
@@ -371,7 +372,7 @@ namespace QuantConnect.Algorithm
         /// Storage for debugging messages before the event handler has passed control back to the Lean Engine.
         /// </summary>
         /// <seealso cref="Debug(string)"/>
-        public List<string> DebugMessages
+        public ConcurrentQueue<string> DebugMessages
         {
             get
             {
@@ -387,7 +388,7 @@ namespace QuantConnect.Algorithm
         /// Storage for log messages before the event handlers have passed control back to the Lean Engine.
         /// </summary>
         /// <seealso cref="Log(string)"/>
-        public List<string> LogMessages
+        public ConcurrentQueue<string> LogMessages
         {
             get
             {
@@ -409,7 +410,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <remarks>This method is best used within a try-catch bracket to handle any runtime errors from a user algorithm.</remarks>
         /// <see cref="Error(string)"/>
-        public List<string> ErrorMessages
+        public ConcurrentQueue<string> ErrorMessages
         {
             get
             {
@@ -1432,7 +1433,7 @@ namespace QuantConnect.Algorithm
         public void Debug(string message)
         {
             if (!_liveMode && (message == "" || _previousDebugMessage == message)) return;
-            _debugMessages.Add(message);
+            _debugMessages.Enqueue(message);
             _previousDebugMessage = message;
         }
 
@@ -1445,7 +1446,7 @@ namespace QuantConnect.Algorithm
         public void Log(string message) 
         {
             if (!_liveMode && message == "") return;
-            _logMessages.Add(message);
+            _logMessages.Enqueue(message);
         }
 
         /// <summary>
@@ -1457,7 +1458,7 @@ namespace QuantConnect.Algorithm
         public void Error(string message)
         {
             if (!_liveMode && (message == "" || _previousErrorMessage == message)) return;
-            _errorMessages.Add(message);
+            _errorMessages.Enqueue(message);
             _previousErrorMessage = message;
         }
 
@@ -1471,7 +1472,7 @@ namespace QuantConnect.Algorithm
         {
             var message = error.Message;
             if (!_liveMode && (message == "" || _previousErrorMessage == message)) return;
-            _errorMessages.Add(message);
+            _errorMessages.Enqueue(message);
             _previousErrorMessage = message;
         }
 

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -25,6 +25,7 @@ using QuantConnect.Orders;
 using QuantConnect.Scheduling;
 using QuantConnect.Securities;
 using QuantConnect.Statistics;
+using System.Collections.Concurrent;
 
 namespace QuantConnect.Interfaces
 {
@@ -216,7 +217,7 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Debug messages from the strategy:
         /// </summary>
-        List<string> DebugMessages
+        ConcurrentQueue<string> DebugMessages
         {
             get;
         }
@@ -224,7 +225,7 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Error messages from the strategy:
         /// </summary>
-        List<string> ErrorMessages
+        ConcurrentQueue<string> ErrorMessages
         {
             get;
         }
@@ -232,7 +233,7 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Log messages from the strategy:
         /// </summary>
-        List<string> LogMessages
+        ConcurrentQueue<string> LogMessages
         {
             get;
         }

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -865,18 +865,36 @@ namespace QuantConnect.Lean.Engine.Results
                 }
             }
 
-            //Send out the debug messages:
-            _algorithm.DebugMessages.ForEach(x => DebugMessage(x));
-            _algorithm.DebugMessages.Clear();
+            //Send out the debug messages:            
+            while (_algorithm.DebugMessages.Count > 0)
+            {
+                string message;
+                if (_algorithm.DebugMessages.TryDequeue(out message))
+                {
+                    DebugMessage(message);
+                }
+            }
 
             //Send out the error messages:
-            _algorithm.ErrorMessages.ForEach(x => ErrorMessage(x));
-            _algorithm.ErrorMessages.Clear();
+            while (_algorithm.ErrorMessages.Count > 0)
+            {
+                string message;
+                if (_algorithm.ErrorMessages.TryDequeue(out message))
+                {
+                    ErrorMessage(message);
+                }
+            }
 
             //Send out the log messages:
-            _algorithm.LogMessages.ForEach(x => LogMessage(x));
-            _algorithm.LogMessages.Clear();
-
+            while (_algorithm.LogMessages.Count > 0)
+            {
+                string message;
+                if (_algorithm.LogMessages.TryDequeue(out message))
+                {
+                    LogMessage(message);
+                }
+            }
+            
             //Set the running statistics:
             foreach (var pair in _algorithm.RuntimeStatistics)
             {

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -31,6 +31,7 @@ using QuantConnect.Orders;
 using QuantConnect.Packets;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
+using System.Diagnostics;
 
 namespace QuantConnect.Lean.Engine.Results
 {
@@ -865,8 +866,9 @@ namespace QuantConnect.Lean.Engine.Results
                 }
             }
 
-            //Send out the debug messages:            
-            while (_algorithm.DebugMessages.Count > 0)
+            //Send out the debug messages:
+            var debugStopWatch = Stopwatch.StartNew();
+            while (_algorithm.DebugMessages.Count > 0 && debugStopWatch.ElapsedMilliseconds < 250)
             {
                 string message;
                 if (_algorithm.DebugMessages.TryDequeue(out message))
@@ -876,7 +878,8 @@ namespace QuantConnect.Lean.Engine.Results
             }
 
             //Send out the error messages:
-            while (_algorithm.ErrorMessages.Count > 0)
+            var errorStopWatch = Stopwatch.StartNew();
+            while (_algorithm.ErrorMessages.Count > 0 && errorStopWatch.ElapsedMilliseconds < 250)
             {
                 string message;
                 if (_algorithm.ErrorMessages.TryDequeue(out message))
@@ -886,7 +889,8 @@ namespace QuantConnect.Lean.Engine.Results
             }
 
             //Send out the log messages:
-            while (_algorithm.LogMessages.Count > 0)
+            var logStopWatch = Stopwatch.StartNew();
+            while (_algorithm.LogMessages.Count > 0 && logStopWatch.ElapsedMilliseconds < 250)
             {
                 string message;
                 if (_algorithm.LogMessages.TryDequeue(out message))
@@ -894,7 +898,7 @@ namespace QuantConnect.Lean.Engine.Results
                     LogMessage(message);
                 }
             }
-            
+
             //Set the running statistics:
             foreach (var pair in _algorithm.RuntimeStatistics)
             {

--- a/Engine/Results/DesktopResultHandler.cs
+++ b/Engine/Results/DesktopResultHandler.cs
@@ -456,17 +456,35 @@ namespace QuantConnect.Lean.Engine.Results
                 }
             }
 
-            //Send out the debug messages:
-            _algorithm.DebugMessages.ForEach(x => DebugMessage(x));
-            _algorithm.DebugMessages.Clear();
+            //Send out the debug messages:            
+            while (_algorithm.DebugMessages.Count > 0)
+            {
+                string message;
+                if (_algorithm.DebugMessages.TryDequeue(out message))
+                {
+                    DebugMessage(message);
+                }
+            }
 
             //Send out the error messages:
-            _algorithm.ErrorMessages.ForEach(x => ErrorMessage(x));
-            _algorithm.ErrorMessages.Clear();
+            while (_algorithm.ErrorMessages.Count > 0)
+            {
+                string message;
+                if (_algorithm.ErrorMessages.TryDequeue(out message))
+                {
+                    ErrorMessage(message);
+                }
+            }
 
             //Send out the log messages:
-            _algorithm.LogMessages.ForEach(x => LogMessage(x));
-            _algorithm.LogMessages.Clear();
+            while (_algorithm.LogMessages.Count > 0)
+            {
+                string message;
+                if (_algorithm.LogMessages.TryDequeue(out message))
+                {
+                    LogMessage(message);
+                }
+            }
 
             //Set the running statistics:
             foreach (var pair in _algorithm.RuntimeStatistics)

--- a/Engine/Results/DesktopResultHandler.cs
+++ b/Engine/Results/DesktopResultHandler.cs
@@ -26,6 +26,7 @@ using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Packets;
 using QuantConnect.Statistics;
+using System.Diagnostics;
 
 namespace QuantConnect.Lean.Engine.Results
 {
@@ -456,8 +457,9 @@ namespace QuantConnect.Lean.Engine.Results
                 }
             }
 
-            //Send out the debug messages:            
-            while (_algorithm.DebugMessages.Count > 0)
+            //Send out the debug messages:
+            var debugStopWatch = Stopwatch.StartNew();
+            while (_algorithm.DebugMessages.Count > 0 && debugStopWatch.ElapsedMilliseconds < 250)
             {
                 string message;
                 if (_algorithm.DebugMessages.TryDequeue(out message))
@@ -467,7 +469,8 @@ namespace QuantConnect.Lean.Engine.Results
             }
 
             //Send out the error messages:
-            while (_algorithm.ErrorMessages.Count > 0)
+            var errorStopWatch = Stopwatch.StartNew();
+            while (_algorithm.ErrorMessages.Count > 0 && errorStopWatch.ElapsedMilliseconds < 250)
             {
                 string message;
                 if (_algorithm.ErrorMessages.TryDequeue(out message))
@@ -477,7 +480,8 @@ namespace QuantConnect.Lean.Engine.Results
             }
 
             //Send out the log messages:
-            while (_algorithm.LogMessages.Count > 0)
+            var logStopWatch = Stopwatch.StartNew();
+            while (_algorithm.LogMessages.Count > 0 && logStopWatch.ElapsedMilliseconds < 250)
             {
                 string message;
                 if (_algorithm.LogMessages.TryDequeue(out message))

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -1064,28 +1064,34 @@ namespace QuantConnect.Lean.Engine.Results
                 _api.SetAlgorithmStatus(_job.AlgorithmId, AlgorithmStatus.Running);
             }
 
-            //Send out the debug messages:
-            var debugMessage = _algorithm.DebugMessages.ToList();
-            _algorithm.DebugMessages.Clear();
-            foreach (var source in debugMessage)
+            //Send out the debug messages:            
+            while (_algorithm.DebugMessages.Count > 0)
             {
-                DebugMessage(source);
+                string message;
+                if (_algorithm.DebugMessages.TryDequeue(out message))
+                {
+                    DebugMessage(message);
+                }
             }
 
             //Send out the error messages:
-            var errorMessage = _algorithm.ErrorMessages.ToList();
-            _algorithm.ErrorMessages.Clear();
-            foreach (var source in errorMessage)
+            while (_algorithm.ErrorMessages.Count > 0)
             {
-                ErrorMessage(source);
+                string message;
+                if (_algorithm.ErrorMessages.TryDequeue(out message))
+                {
+                    ErrorMessage(message);
+                }
             }
 
             //Send out the log messages:
-            var logMessage = _algorithm.LogMessages.ToList();
-            _algorithm.LogMessages.Clear();
-            foreach (var source in logMessage)
+            while (_algorithm.LogMessages.Count > 0)
             {
-                LogMessage(source);
+                string message;
+                if (_algorithm.LogMessages.TryDequeue(out message))
+                {
+                    LogMessage(message);
+                }
             }
 
             //Set the running statistics:

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -1064,8 +1064,9 @@ namespace QuantConnect.Lean.Engine.Results
                 _api.SetAlgorithmStatus(_job.AlgorithmId, AlgorithmStatus.Running);
             }
 
-            //Send out the debug messages:            
-            while (_algorithm.DebugMessages.Count > 0)
+            //Send out the debug messages:
+            var debugStopWatch = Stopwatch.StartNew();
+            while (_algorithm.DebugMessages.Count > 0 && debugStopWatch.ElapsedMilliseconds < 250)
             {
                 string message;
                 if (_algorithm.DebugMessages.TryDequeue(out message))
@@ -1075,7 +1076,8 @@ namespace QuantConnect.Lean.Engine.Results
             }
 
             //Send out the error messages:
-            while (_algorithm.ErrorMessages.Count > 0)
+            var errorStopWatch = Stopwatch.StartNew();
+            while (_algorithm.ErrorMessages.Count > 0 && errorStopWatch.ElapsedMilliseconds < 250)
             {
                 string message;
                 if (_algorithm.ErrorMessages.TryDequeue(out message))
@@ -1085,7 +1087,8 @@ namespace QuantConnect.Lean.Engine.Results
             }
 
             //Send out the log messages:
-            while (_algorithm.LogMessages.Count > 0)
+            var logStopWatch = Stopwatch.StartNew();
+            while (_algorithm.LogMessages.Count > 0 && logStopWatch.ElapsedMilliseconds < 250)
             {
                 string message;
                 if (_algorithm.LogMessages.TryDequeue(out message))


### PR DESCRIPTION
IAlgorithm DebugMessage, ErrorMessage and LogMessage are now ConcurrentQueue<string> instead of List<string> because List.Add is not thread safe.
Copying a list (using ToList()) at LiveTradingResultHandler while adding an element to it at QCAlgorithm caused a runtime error.