### PR TITLE
Feature/daily quotes

### DIFF
--- a/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
+++ b/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
@@ -50,11 +50,9 @@ namespace QuantConnect.ToolBox.GoogleDownloader
                 case Resolution.Minute:
                 case Resolution.Hour:
                     return GetMinuteOrHour(symbol, resolution, startUtc, endUtc);
-                    break;
 
                 case Resolution.Daily:
                     return GetDaily(symbol, resolution, startUtc, endUtc);
-                    break;
 
                 default:
                     throw new NotSupportedException("Resolution not available: " + resolution);
@@ -240,7 +238,7 @@ namespace QuantConnect.ToolBox.GoogleDownloader
                 return "NYSEARCA:SPY";
             }
 
-            return symbol;
+            return symbol.Value;
         }
     }
 }

--- a/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
+++ b/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
@@ -207,17 +207,6 @@ namespace QuantConnect.ToolBox.GoogleDownloader
             return epoch.AddSeconds(unixTime);
         }
 
-        private static string ConvertTicker(Symbol symbol)
-        {
-            // FIXME: this is a hack to make sure google finds our index:
-            if (symbol.Value == "SPY")
-            {
-                return "NYSEARCA:SPY";
-            }
-
-            return symbol.Value;
-        }
-
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>

--- a/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
+++ b/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
@@ -29,36 +29,6 @@ namespace QuantConnect.ToolBox.GoogleDownloader
     /// </summary>
     public class GoogleDataDownloader : IDataDownloader
     {
-        /// <summary>
-        /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
-        /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
-        /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
-        {
-            if (symbol.ID.SecurityType != SecurityType.Equity)
-                throw new NotSupportedException("SecurityType not available: " + symbol.ID.SecurityType);
-
-            if (endUtc < startUtc)
-                throw new ArgumentException("The end date must be greater or equal than the start date.");
-
-            switch (resolution)
-            {
-                case Resolution.Minute:
-                case Resolution.Hour:
-                    return GetMinuteOrHour(symbol, resolution, startUtc, endUtc);
-
-                case Resolution.Daily:
-                    return GetDaily(symbol, resolution, startUtc, endUtc);
-
-                default:
-                    throw new NotSupportedException("Resolution not available: " + resolution);
-            }
-        }
-
         // q = SYMBOL
         // startdate = Mon+D%2C+YYYY, e.g. Jan+1%2C+2005
         // enddate = Mon+D%2C+YYYY, e.g. Sep+29%2C+2016
@@ -89,7 +59,7 @@ namespace QuantConnect.ToolBox.GoogleDownloader
                 + @"%2C+" + endUtc.Year.ToString();
 
             // Create the Google formatted URL.
-            var url = string.Format(UrlPrototypeDaily, ConvertTicker(symbol), startdate, enddate);
+            var url = string.Format(UrlPrototypeDaily, symbol.Value, startdate, enddate);
 
             // Download the data from Google.
             string[] lines;
@@ -239,6 +209,36 @@ namespace QuantConnect.ToolBox.GoogleDownloader
             }
 
             return symbol.Value;
+        }
+
+        /// <summary>
+        /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
+        /// </summary>
+        /// <param name="symbol">Symbol for the data we're looking for.</param>
+        /// <param name="resolution">Resolution of the data request</param>
+        /// <param name="startUtc">Start time of the data in UTC</param>
+        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <returns>Enumerable of base data for this symbol</returns>
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        {
+            if (symbol.ID.SecurityType != SecurityType.Equity)
+                throw new NotSupportedException("SecurityType not available: " + symbol.ID.SecurityType);
+
+            if (endUtc < startUtc)
+                throw new ArgumentException("The end date must be greater or equal than the start date.");
+
+            switch (resolution)
+            {
+                case Resolution.Minute:
+                case Resolution.Hour:
+                    return GetMinuteOrHour(symbol, resolution, startUtc, endUtc);
+
+                case Resolution.Daily:
+                    return GetDaily(symbol, resolution, startUtc, endUtc);
+
+                default:
+                    throw new NotSupportedException("Resolution not available: " + resolution);
+            }
         }
     }
 }

--- a/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
+++ b/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
@@ -17,8 +17,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Logging;
 
 namespace QuantConnect.ToolBox.GoogleDownloader
 {
@@ -27,13 +29,6 @@ namespace QuantConnect.ToolBox.GoogleDownloader
     /// </summary>
     public class GoogleDataDownloader : IDataDownloader
     {
-        // q = SYMBOL
-        // i = resolution in seconds
-        // p = period in days
-        // ts = start time
-        // Strangely Google forces CHLO format instead of normal OHLC.
-        private const string UrlPrototype = @"http://www.google.com/finance/getprices?q={0}&i={1}&p={2}d&f=d,c,h,l,o,v&ts={3}";
-
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
@@ -44,21 +39,124 @@ namespace QuantConnect.ToolBox.GoogleDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
         {
-            if (resolution != Resolution.Minute && resolution != Resolution.Hour)
-                throw new NotSupportedException("Resolution not available: " + resolution);
-
             if (symbol.ID.SecurityType != SecurityType.Equity)
                 throw new NotSupportedException("SecurityType not available: " + symbol.ID.SecurityType);
 
             if (endUtc < startUtc)
                 throw new ArgumentException("The end date must be greater or equal than the start date.");
 
+            switch (resolution)
+            {
+                case Resolution.Minute:
+                case Resolution.Hour:
+                    return GetMinuteOrHour(symbol, resolution, startUtc, endUtc);
+                    break;
+
+                case Resolution.Daily:
+                    return GetDaily(symbol, resolution, startUtc, endUtc);
+                    break;
+
+                default:
+                    throw new NotSupportedException("Resolution not available: " + resolution);
+            }
+        }
+
+        // q = SYMBOL
+        // startdate = Mon+D%2C+YYYY, e.g. Jan+1%2C+2005
+        // enddate = Mon+D%2C+YYYY, e.g. Sep+29%2C+2016
+        private const string UrlPrototypeDaily = @"http://www.google.com/finance/historical?q={0}&startdate={1}&enddate={2}&output=csv";
+        private enum ConvertMonths
+        {
+            Jan = 1,
+            Feb = 2,
+            Mar = 3,
+            Apr = 4,
+            May = 5,
+            Jun = 6,
+            Jul = 7,
+            Aug = 8,
+            Sep = 9,
+            Oct = 10,
+            Nov = 11,
+            Dec = 12
+        };
+
+        private IEnumerable<BaseData> GetDaily(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        {
+            var startdate = ((ConvertMonths)startUtc.Month).ToString()
+                + @"+" + startUtc.Day.ToString()
+                + @"%2C+" + startUtc.Year.ToString();
+            var enddate = ((ConvertMonths)endUtc.Month).ToString()
+                + @"+" + endUtc.Day.ToString()
+                + @"%2C+" + endUtc.Year.ToString();
+
+            // Create the Google formatted URL.
+            var url = string.Format(UrlPrototypeDaily, ConvertTicker(symbol), startdate, enddate);
+
+            // Download the data from Google.
+            string[] lines;
+            using (var client = new WebClient())
+            {
+                var data = client.DownloadString(url);
+                lines = data.Split('\n');
+            }
+
+            // first line is header
+            var currentLine = 1;
+
+            while (currentLine < lines.Length - 1)
+            {
+                // Format: Date,Open,High,Low,Close,Volume
+                var columns = lines[currentLine].Split(',');
+
+                // date format: DD-Mon-YY, e.g. 27-Sep-16
+                var DMY = columns[0].Split('-');
+
+                // date = 20160927
+                var day = DMY[0].ToInt32();
+                var month = (int)Enum.Parse(typeof(ConvertMonths), DMY[1]);
+                var year = (DMY[2].ToInt32() > 70) ? 1900 + DMY[2].ToInt32() : 2000 + DMY[2].ToInt32();
+                var time = new DateTime(year, month, day, 0, 0, 0);
+
+                // occasionally, the columns will have a '-' instead of a proper value
+                List<Decimal?> ohlc = new List<Decimal?>()
+                {
+                    columns[1] != "-" ? (Decimal?)columns[1].ToDecimal() : null,
+                    columns[2] != "-" ? (Decimal?)columns[2].ToDecimal() : null,
+                    columns[3] != "-" ? (Decimal?)columns[3].ToDecimal() : null,
+                    columns[4] != "-" ? (Decimal?)columns[4].ToDecimal() : null
+                };
+
+                // let's try hard to fix any issues as good as we can
+                // this code assumes that there is at least 1 good value
+                if (ohlc[1] == null) ohlc[1] = ohlc.Where(val => val != null).Max();
+                if (ohlc[2] == null) ohlc[2] = ohlc.Where(val => val != null).Min();
+                if (ohlc[0] == null) ohlc[0] = ohlc.Where(val => val != null).Average();
+                if (ohlc[3] == null) ohlc[3] = ohlc.Where(val => val != null).Average();
+
+                long volume = columns[5].ToInt64();
+
+                yield return new TradeBar(time, symbol, (Decimal)ohlc[0], (Decimal)ohlc[1], (Decimal)ohlc[2], (Decimal)ohlc[3], volume, resolution.ToTimeSpan());
+
+                currentLine++;
+            }
+        }
+
+        // q = SYMBOL
+        // i = resolution in seconds
+        // p = period in days
+        // ts = start time
+        // Strangely Google forces CHLO format instead of normal OHLC.
+        private const string UrlPrototypeMinuteOrHour = @"http://www.google.com/finance/getprices?q={0}&i={1}&p={2}d&f=d,c,h,l,o,v&ts={3}";
+
+        private IEnumerable<BaseData> GetMinuteOrHour(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        {
             var numberOfDays = (int)(endUtc - startUtc).TotalDays;
             var resolutionSeconds = (int)resolution.ToTimeSpan().TotalSeconds;
             var endUnixTime = ToUnixTime(endUtc);
 
             // Create the Google formatted URL.
-            var url = string.Format(UrlPrototype, symbol.Value, resolutionSeconds, numberOfDays, endUnixTime);
+            var url = string.Format(UrlPrototypeMinuteOrHour, symbol.Value, resolutionSeconds, numberOfDays, endUnixTime);
 
             // Download the data from Google.
             string[] lines;
@@ -134,5 +232,15 @@ namespace QuantConnect.ToolBox.GoogleDownloader
             return epoch.AddSeconds(unixTime);
         }
 
+        private static string ConvertTicker(Symbol symbol)
+        {
+            // FIXME: this is a hack to make sure google finds our index:
+            if (symbol.Value == "SPY")
+            {
+                return "NYSEARCA:SPY";
+            }
+
+            return symbol;
+        }
     }
 }

--- a/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
+++ b/ToolBox/GoogleDownloader/GoogleDataDownloader.cs
@@ -95,12 +95,19 @@ namespace QuantConnect.ToolBox.GoogleDownloader
                     columns[4] != "-" ? (Decimal?)columns[4].ToDecimal() : null
                 };
 
-                // let's try hard to fix any issues as good as we can
-                // this code assumes that there is at least 1 good value
-                if (ohlc[1] == null) ohlc[1] = ohlc.Where(val => val != null).Max();
-                if (ohlc[2] == null) ohlc[2] = ohlc.Where(val => val != null).Min();
-                if (ohlc[0] == null) ohlc[0] = ohlc.Where(val => val != null).Average();
-                if (ohlc[3] == null) ohlc[3] = ohlc.Where(val => val != null).Average();
+                if (ohlc.Where(val => val == null).Count() > 0)
+                {
+                    // let's try hard to fix any issues as good as we can
+                    // this code assumes that there is at least 1 good value
+                    if (ohlc[1] == null) ohlc[1] = ohlc.Where(val => val != null).Max();
+                    if (ohlc[2] == null) ohlc[2] = ohlc.Where(val => val != null).Min();
+                    if (ohlc[0] == null) ohlc[0] = ohlc.Where(val => val != null).Average();
+                    if (ohlc[3] == null) ohlc[3] = ohlc.Where(val => val != null).Average();
+
+                    Log.Error(string.Format("Corrupt bar on {0}: {1},{2},{3},{4}. Saved as {5},{6},{7},{8}.",
+                        columns[0], columns[1], columns[2], columns[3], columns[4],
+                        ohlc[0], ohlc[1], ohlc[2], ohlc[3]));
+                }
 
                 long volume = columns[5].ToInt64();
 

--- a/ToolBox/GoogleDownloader/Program.cs
+++ b/ToolBox/GoogleDownloader/Program.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.ToolBox.GoogleDownloader
             {
                 Console.WriteLine("Usage: GoogleDownloader SYMBOLS RESOLUTION FROMDATE TODATE");
                 Console.WriteLine("SYMBOLS = eg SPY,AAPL");
-                Console.WriteLine("RESOLUTION = Minute/Hour");
+                Console.WriteLine("RESOLUTION = Minute/Hour/Daily");
                 Console.WriteLine("FROMDATE = yyyymmdd");
                 Console.WriteLine("TODATE = yyyymmdd");
                 Environment.Exit(1);


### PR DESCRIPTION
these changes implement download of daily quotes for the Google downloader. The code includes 2 workarounds worth mentioning:

(1) Google seems to taint their data by replacing some quotes with '-'. The code tries its best to put reasonable values in, but of course cannot recover what was really lost here.

(2) Google does not recognize SPY, but requires NYSEARCA:SPY instead. There is a function for translating this, I am sure there will be a dict requires at some point in the future.

Cheers, Felix