### PR TITLE
Implements the RegressionChannel indicator

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
+    <Compile Include="RegressionChannelAlgorithm.cs" />
     <Compile Include="CoarseFineFundamentalRegressionAlgorithm.cs" />
     <Compile Include="CoarseFineFundamentalComboAlgorithm.cs" />
     <Compile Include="FuzzyInferenceAlgorithm.cs" />

--- a/Algorithm.CSharp/RegressionChannelAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionChannelAlgorithm.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression Channel algorithm simply initializes the date range and cash
+    /// </summary>
+    public class RegressionChannelAlgorithm : QCAlgorithm
+    {
+        private Symbol _spy = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+        private SecurityHolding _holdings;
+        private RegressionChannel _rc;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2009, 1, 1);  //Set Start Date
+            SetEndDate(2015, 1, 1);    //Set End Date
+            SetCash(100000);           //Set Strategy Cash
+            // Find more symbols here: http://quantconnect.com/data
+            var equity = AddEquity(_spy, Resolution.Minute);
+            _holdings = equity.Holdings;
+            _rc = RC(_spy, 30, 2, Resolution.Daily);
+
+            var stockPlot = new Chart("Trade Plot");
+            stockPlot.AddSeries(new Series("Buy", SeriesType.Scatter, 0));
+            stockPlot.AddSeries(new Series("Sell", SeriesType.Scatter, 0));
+            stockPlot.AddSeries(new Series("UpperChannel", SeriesType.Line, 0));
+            stockPlot.AddSeries(new Series("LowerChannel", SeriesType.Line, 0));
+            stockPlot.AddSeries(new Series("Regression", SeriesType.Line, 0));
+            AddChart(stockPlot);
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public void OnData(TradeBars data)
+        {
+            if (!_rc.IsReady || !data.ContainsKey(_spy)) return;
+            var value = data[_spy].Value;
+
+            if (_holdings.Quantity <= 0 && value < _rc.LowerChannel)
+            {
+                SetHoldings(_spy, 1);
+                Plot("Trade Plot", "Buy", value);
+            }
+
+            if (_holdings.Quantity >= 0 && value > _rc.UpperChannel)
+            {
+                SetHoldings(_spy, -1);
+                Plot("Trade Plot", "Sell", value);
+            }
+        }
+
+        public override void OnEndOfDay()
+        {
+            Plot("Trade Plot", "UpperChannel", _rc.UpperChannel);
+            Plot("Trade Plot", "LowerChannel", _rc.LowerChannel);
+            Plot("Trade Plot", "Regression", _rc.LinearRegression);
+        }
+    }
+}

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1051,6 +1051,23 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Creates a new RegressionChannel indicator which will compute the LinearRegression, UpperChannel and LowerChannel lines, the intercept and slope
+        /// </summary>
+        /// <param name="symbol">The symbol whose RegressionChannel we seek</param>
+        /// <param name="period">The period of the standard deviation and least square moving average (linear regression line)</param>
+        /// <param name="k">The number of standard deviations specifying the distance between the linear regression and upper or lower channel lines</param>
+        /// <param name="resolution">The resolution</param>
+        /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
+        /// <returns>A Regression Channel configured with the specied period and number of standard deviation</returns>
+        public RegressionChannel RC(Symbol symbol, int period, decimal k, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        {
+            var name = CreateIndicatorName(symbol, string.Format("RC({0},{1})", period, k), resolution);
+            var rc = new RegressionChannel(name, period, k);
+            RegisterIndicator(symbol, rc, resolution, selector);
+            return rc;
+        }
+
+        /// <summary>
         /// Creates and registers a new consolidator to receive automatic updates at the specified resolution as well as configures
         /// the indicator to receive updates from the consolidator.
         /// </summary>

--- a/Indicators/LeastSquaresMovingAverage.cs
+++ b/Indicators/LeastSquaresMovingAverage.cs
@@ -36,12 +36,12 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// The point where the regression line crosses the y-axis (price-axis)
         /// </summary>
-        public WindowIndicator<IndicatorDataPoint> Intercept { get; private set; }
+        public IndicatorBase<IndicatorDataPoint> Intercept { get; private set; }
         
         /// <summary>
         /// The regression line slope
         /// </summary>
-        public WindowIndicator<IndicatorDataPoint> Slope { get; private set; }
+        public IndicatorBase<IndicatorDataPoint> Slope { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LeastSquaresMovingAverage"/> class.
@@ -52,8 +52,8 @@ namespace QuantConnect.Indicators
             : base(name, period)
         {
             t = Vector<double>.Build.Dense(period, i => i + 1).ToArray();
-            Intercept = new WindowIdentity(name + "_Intercept", period);
-            Slope = new WindowIdentity(name + "_Slope", period);
+            Intercept = new Identity(name + "_Intercept");
+            Slope = new Identity(name + "_Slope");
         }
 
         /// <summary>
@@ -88,8 +88,8 @@ namespace QuantConnect.Indicators
             Intercept.Update(input.Time, (decimal)ols.Item1);
             Slope.Update(input.Time, (decimal)ols.Item2);
 
-            // Make the projection.
-            return Intercept + Slope * Period;
+            // Calculate the fitted value corresponding to the input
+            return Intercept.Plus(Slope.Times(Period));
         }
 
         /// <summary>

--- a/Indicators/LeastSquaresMovingAverage.cs
+++ b/Indicators/LeastSquaresMovingAverage.cs
@@ -89,7 +89,7 @@ namespace QuantConnect.Indicators
             Slope.Update(input.Time, (decimal)ols.Item2);
 
             // Calculate the fitted value corresponding to the input
-            return Intercept.Plus(Slope.Times(Period));
+            return Intercept + Slope * Period;
         }
 
         /// <summary>

--- a/Indicators/LeastSquaresMovingAverage.cs
+++ b/Indicators/LeastSquaresMovingAverage.cs
@@ -34,6 +34,16 @@ namespace QuantConnect.Indicators
         private readonly double[] t;
 
         /// <summary>
+        /// The point where the regression line crosses the y-axis (price-axis)
+        /// </summary>
+        public WindowIndicator<IndicatorDataPoint> Intercept { get; private set; }
+        
+        /// <summary>
+        /// The regression line slope
+        /// </summary>
+        public WindowIndicator<IndicatorDataPoint> Slope { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LeastSquaresMovingAverage"/> class.
         /// </summary>
         /// <param name="name">The name of this indicator</param>
@@ -42,6 +52,8 @@ namespace QuantConnect.Indicators
             : base(name, period)
         {
             t = Vector<double>.Build.Dense(period, i => i + 1).ToArray();
+            Intercept = new WindowIdentity(name + "_Intercept", period);
+            Slope = new WindowIdentity(name + "_Slope", period);
         }
 
         /// <summary>
@@ -63,23 +75,31 @@ namespace QuantConnect.Indicators
         /// </returns>
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
-            // Until the windows is ready, the indicator returns the input value.
-            decimal output = input;
-            if (IsReady)
-            {
-                // Sort the windows by time, convert the observations ton double and transform it to a double array
-                double[] series = window
-                    .OrderBy(i => i.Time)
-                    .Select(i => Convert.ToDouble(i.Value))
-                    .ToArray<double>();
-                // Fit OLS
-                Tuple<double, double> ols = Fit.Line(x: t, y: series);
-                var alfa = (decimal)ols.Item1;
-                var beta = (decimal)ols.Item2;
-                // Make the projection.
-                output = alfa + beta * (Period);
-            }
-            return output;
+            // Until the window is ready, the indicator returns the input value.
+            if (!IsReady) return input;
+
+            // Sort the window by time, convert the observations to double and transform it to an array
+            var series = window
+                .OrderBy(i => i.Time)
+                .Select(i => Convert.ToDouble(i.Value))
+                .ToArray();
+            // Fit OLS
+            var ols = Fit.Line(x: t, y: series);
+            Intercept.Update(input.Time, (decimal)ols.Item1);
+            Slope.Update(input.Time, (decimal)ols.Item2);
+
+            // Make the projection.
+            return Intercept + Slope * Period;
+        }
+
+        /// <summary>
+        /// Resets this indicator and all sub-indicators (Intercept, Slope)
+        /// </summary>
+        public override void Reset()
+        {
+            Intercept.Reset();
+            Slope.Reset();
+            base.Reset();
         }
     }
 }

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -120,6 +120,7 @@
     <Compile Include="DonchianChannel.cs" />
     <Compile Include="DoubleExponentialMovingAverage.cs" />
     <Compile Include="FractalAdaptiveMovingAverage.cs" />
+    <Compile Include="RegressionChannel.cs" />
     <Compile Include="SwissArmyKnife.cs" />
     <Compile Include="VolumeWeightedAveragePriceIndicator.cs" />
     <Compile Include="FisherTransform.cs" />

--- a/Indicators/RegressionChannel.cs
+++ b/Indicators/RegressionChannel.cs
@@ -1,0 +1,117 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Indicators
+{
+    /// <summary>
+    /// The Regression Channel indicator extends the <see cref="LeastSquaresMovingAverage"/>
+    /// with the inclusion of two (upper and lower) channel lines that are distanced from
+    /// the linear regression line by a user defined number of standard deviations. 
+    /// </summary>
+    public class RegressionChannel : Indicator
+    {
+        /// <summary>
+        /// Gets the standard deviation
+        /// </summary>
+        private IndicatorBase<IndicatorDataPoint> _standardDeviation;
+
+        /// <summary>
+        /// Gets the linear regression line
+        /// </summary>
+        public LeastSquaresMovingAverage LinearRegressionLine { get; private set; }
+        
+        /// <summary>
+        /// Gets the upper channel line (linear regression line + k * stdDev)
+        /// </summary>
+        public IndicatorBase<IndicatorDataPoint> UpperChannelLine { get; private set; }
+        
+        /// <summary>
+        /// Gets the lower channel line (linear regression line - k * stdDev)
+        /// </summary>
+        public IndicatorBase<IndicatorDataPoint> LowerChannelLine { get; private set; }
+
+        /// <summary>
+        /// The point where the regression line crosses the y-axis (price-axis)
+        /// </summary>
+        public WindowIndicator<IndicatorDataPoint> Intercept { get { return LinearRegressionLine.Intercept; } }
+
+        /// <summary>
+        /// The regression line slope
+        /// </summary>
+        public WindowIndicator<IndicatorDataPoint> Slope { get { return LinearRegressionLine.Slope; } }
+
+        /// <summary>
+        /// Gets a flag indicating when this indicator is ready and fully initialized
+        /// </summary>
+        public override bool IsReady
+        {
+            get { return _standardDeviation.IsReady && LinearRegressionLine.IsReady && UpperChannelLine.IsReady && LowerChannelLine.IsReady; }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegressionChannel"/> class.
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="period">The number of data points to hold in the window</param>
+        /// <param name="k">The number of standard deviations specifying the distance between the linear regression and upper or lower channel lines</param>
+        public RegressionChannel(string name, int period, decimal k)
+            : base(name)
+        {
+            _standardDeviation = new StandardDeviation(period);
+            LinearRegressionLine = new LeastSquaresMovingAverage(name + "_LinearRegressionLine", period);
+            LowerChannelLine = LinearRegressionLine.Minus(_standardDeviation.Times(k), name + "_LowerChannelLine");
+            UpperChannelLine = LinearRegressionLine.Plus(_standardDeviation.Times(k), name + "_UpperChannelLine");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeastSquaresMovingAverage"/> class.
+        /// </summary>
+        /// <param name="period">The number of data points to hold in the window.</param>
+        /// <param name="k">The number of standard deviations specifying the distance between the linear regression and upper or lower channel lines</param>
+        public RegressionChannel(int period, decimal k)
+            : this(string.Format("RC({0},{1})", period, k), period, k)
+        {
+        }
+
+        /// <summary>
+        /// Computes the next value of this indicator from the given state
+        /// </summary>
+        /// <param name="input">The input given to the indicator</param>
+        /// <returns>
+        /// A new value for this indicator
+        /// </returns>
+        protected override decimal ComputeNextValue(IndicatorDataPoint input)
+        {
+            _standardDeviation.Update(input);
+            LinearRegressionLine.Update(input);
+            LowerChannelLine.Update(input);
+            UpperChannelLine.Update(input);
+
+            return LinearRegressionLine.Current;
+        }
+
+        /// <summary>
+        /// Resets this indicator and all sub-indicators (StandardDeviation, LowerBand, MiddleBand, UpperBand)
+        /// </summary>
+        public override void Reset()
+        {
+            _standardDeviation.Reset();
+            LinearRegressionLine.Reset();
+            LowerChannelLine.Reset();
+            UpperChannelLine.Reset();
+            base.Reset();
+        }
+    }
+}

--- a/Indicators/RegressionChannel.cs
+++ b/Indicators/RegressionChannel.cs
@@ -46,12 +46,12 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// The point where the regression line crosses the y-axis (price-axis)
         /// </summary>
-        public WindowIndicator<IndicatorDataPoint> Intercept { get { return LinearRegression.Intercept; } }
+        public IndicatorBase<IndicatorDataPoint> Intercept { get { return LinearRegression.Intercept; } }
 
         /// <summary>
         /// The regression line slope
         /// </summary>
-        public WindowIndicator<IndicatorDataPoint> Slope { get { return LinearRegression.Slope; } }
+        public IndicatorBase<IndicatorDataPoint> Slope { get { return LinearRegression.Slope; } }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized

--- a/Indicators/RegressionChannel.cs
+++ b/Indicators/RegressionChannel.cs
@@ -71,9 +71,9 @@ namespace QuantConnect.Indicators
             : base(name)
         {
             _standardDeviation = new StandardDeviation(period);
-            LinearRegression = new LeastSquaresMovingAverage(name + "_LinearRegressionLine", period);
-            LowerChannel = LinearRegression.Minus(_standardDeviation.Times(k), name + "_LowerChannelLine");
-            UpperChannel = LinearRegression.Plus(_standardDeviation.Times(k), name + "_UpperChannelLine");
+            LinearRegression = new LeastSquaresMovingAverage(name + "_LinearRegression", period);
+            LowerChannel = LinearRegression.Minus(_standardDeviation.Times(k), name + "_LowerChannel");
+            UpperChannel = LinearRegression.Plus(_standardDeviation.Times(k), name + "_UpperChannel");
         }
 
         /// <summary>

--- a/Indicators/RegressionChannel.cs
+++ b/Indicators/RegressionChannel.cs
@@ -18,7 +18,8 @@ namespace QuantConnect.Indicators
     /// <summary>
     /// The Regression Channel indicator extends the <see cref="LeastSquaresMovingAverage"/>
     /// with the inclusion of two (upper and lower) channel lines that are distanced from
-    /// the linear regression line by a user defined number of standard deviations. 
+    /// the linear regression line by a user defined number of standard deviations.
+    /// Reference: http://www.onlinetradingconcepts.com/TechnicalAnalysis/LinRegChannel.html
     /// </summary>
     public class RegressionChannel : Indicator
     {
@@ -28,36 +29,36 @@ namespace QuantConnect.Indicators
         private IndicatorBase<IndicatorDataPoint> _standardDeviation;
 
         /// <summary>
-        /// Gets the linear regression line
+        /// Gets the linear regression
         /// </summary>
-        public LeastSquaresMovingAverage LinearRegressionLine { get; private set; }
+        public LeastSquaresMovingAverage LinearRegression { get; private set; }
         
         /// <summary>
-        /// Gets the upper channel line (linear regression line + k * stdDev)
+        /// Gets the upper channel (linear regression + k * stdDev)
         /// </summary>
-        public IndicatorBase<IndicatorDataPoint> UpperChannelLine { get; private set; }
+        public IndicatorBase<IndicatorDataPoint> UpperChannel { get; private set; }
         
         /// <summary>
-        /// Gets the lower channel line (linear regression line - k * stdDev)
+        /// Gets the lower channel (linear regression - k * stdDev)
         /// </summary>
-        public IndicatorBase<IndicatorDataPoint> LowerChannelLine { get; private set; }
+        public IndicatorBase<IndicatorDataPoint> LowerChannel { get; private set; }
 
         /// <summary>
         /// The point where the regression line crosses the y-axis (price-axis)
         /// </summary>
-        public WindowIndicator<IndicatorDataPoint> Intercept { get { return LinearRegressionLine.Intercept; } }
+        public WindowIndicator<IndicatorDataPoint> Intercept { get { return LinearRegression.Intercept; } }
 
         /// <summary>
         /// The regression line slope
         /// </summary>
-        public WindowIndicator<IndicatorDataPoint> Slope { get { return LinearRegressionLine.Slope; } }
+        public WindowIndicator<IndicatorDataPoint> Slope { get { return LinearRegression.Slope; } }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
         public override bool IsReady
         {
-            get { return _standardDeviation.IsReady && LinearRegressionLine.IsReady && UpperChannelLine.IsReady && LowerChannelLine.IsReady; }
+            get { return _standardDeviation.IsReady && LinearRegression.IsReady && UpperChannel.IsReady && LowerChannel.IsReady; }
         }
 
         /// <summary>
@@ -70,9 +71,9 @@ namespace QuantConnect.Indicators
             : base(name)
         {
             _standardDeviation = new StandardDeviation(period);
-            LinearRegressionLine = new LeastSquaresMovingAverage(name + "_LinearRegressionLine", period);
-            LowerChannelLine = LinearRegressionLine.Minus(_standardDeviation.Times(k), name + "_LowerChannelLine");
-            UpperChannelLine = LinearRegressionLine.Plus(_standardDeviation.Times(k), name + "_UpperChannelLine");
+            LinearRegression = new LeastSquaresMovingAverage(name + "_LinearRegressionLine", period);
+            LowerChannel = LinearRegression.Minus(_standardDeviation.Times(k), name + "_LowerChannelLine");
+            UpperChannel = LinearRegression.Plus(_standardDeviation.Times(k), name + "_UpperChannelLine");
         }
 
         /// <summary>
@@ -95,11 +96,11 @@ namespace QuantConnect.Indicators
         protected override decimal ComputeNextValue(IndicatorDataPoint input)
         {
             _standardDeviation.Update(input);
-            LinearRegressionLine.Update(input);
-            LowerChannelLine.Update(input);
-            UpperChannelLine.Update(input);
+            LinearRegression.Update(input);
+            LowerChannel.Update(input);
+            UpperChannel.Update(input);
 
-            return LinearRegressionLine.Current;
+            return LinearRegression.Current;
         }
 
         /// <summary>
@@ -108,9 +109,9 @@ namespace QuantConnect.Indicators
         public override void Reset()
         {
             _standardDeviation.Reset();
-            LinearRegressionLine.Reset();
-            LowerChannelLine.Reset();
-            UpperChannelLine.Reset();
+            LinearRegression.Reset();
+            LowerChannel.Reset();
+            UpperChannel.Reset();
             base.Reset();
         }
     }

--- a/Tests/Indicators/LeastSquaresMovingAverageTest.cs
+++ b/Tests/Indicators/LeastSquaresMovingAverageTest.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Tests.Indicators
         #region Array input
 
         // Real AAPL minute data rounded to 2 decimals.
-        private decimal[] prices = new decimal[40]
+        public static decimal[] prices = new decimal[40]
         {
             125.99m, 125.91m, 125.75m, 125.62m, 125.54m, 125.45m, 125.47m,
             125.4m , 125.43m, 125.45m, 125.42m, 125.36m, 125.23m, 125.32m,
@@ -40,25 +40,25 @@ namespace QuantConnect.Tests.Indicators
 
         #endregion Array input
 
+        #region Array expected
+
+        public static decimal[] expected = new decimal[40]
+        {
+                125.99m  , 125.91m  , 125.75m  , 125.62m  , 125.54m  , 125.45m  , 125.47m  , 125.4m   , 125.43m  , 125.45m  ,
+                125.42m  , 125.36m  , 125.23m  , 125.32m  , 125.26m  , 125.31m  , 125.41m  , 125.5m   , 125.51m  , 125.41m  ,
+                125.328m , 125.381m , 125.4423m, 125.4591m, 125.4689m, 125.4713m, 125.4836m, 125.4834m, 125.4803m, 125.4703m,
+                125.4494m, 125.4206m, 125.3669m, 125.3521m, 125.3214m, 125.2986m, 125.2909m, 125.2723m, 125.2619m, 125.2224m,
+        };
+
+        #endregion Array input
+
         [Test]
         public void LSMAComputesCorrectly()
         {
             int LSMAPeriod = 20;
             LeastSquaresMovingAverage LSMA = new LeastSquaresMovingAverage(LSMAPeriod);
             DateTime time = DateTime.Now;
-
-            #region Array input
-
-            decimal[] expected = new decimal[40]
-            {
-                125.99m  , 125.91m  , 125.75m  , 125.62m  , 125.54m  , 125.45m  , 125.47m  , 125.4m   , 125.43m  , 125.45m  ,
-                125.42m  , 125.36m  , 125.23m  , 125.32m  , 125.26m  , 125.31m  , 125.41m  , 125.5m   , 125.51m  , 125.41m  ,
-                125.328m , 125.381m , 125.4423m, 125.4591m, 125.4689m, 125.4713m, 125.4836m, 125.4834m, 125.4803m, 125.4703m,
-                125.4494m, 125.4206m, 125.3669m, 125.3521m, 125.3214m, 125.2986m, 125.2909m, 125.2723m, 125.2619m, 125.2224m,
-            };
-
-            #endregion Array input
-
+            
             decimal[] actual = new decimal[prices.Length];
 
             for (int i = 0; i < prices.Length; i++)
@@ -67,7 +67,6 @@ namespace QuantConnect.Tests.Indicators
                 decimal LSMAValue = Math.Round(LSMA.Current.Value, 4);
                 actual[i] = LSMAValue;
 
-                //Console.WriteLine(string.Format("Bar : {0} | {1}, Is ready? {2}", i, LSMA.ToString(), LSMA.IsReady));
                 time = time.AddMinutes(1);
             }
             Assert.AreEqual(expected, actual);

--- a/Tests/Indicators/RegressionChannelTest.cs
+++ b/Tests/Indicators/RegressionChannelTest.cs
@@ -30,6 +30,7 @@ namespace QuantConnect.Tests.Indicators
         {
             var period = 20;
             var indicator = new RegressionChannel(period, 2);
+            var stdDev = new StandardDeviation(period);
             var time = DateTime.Now;
 
             var prices = LeastSquaresMovingAverageTest.prices;
@@ -40,10 +41,16 @@ namespace QuantConnect.Tests.Indicators
             for (int i = 0; i < prices.Length; i++)
             {
                 indicator.Update(time, prices[i]);
+                stdDev.Update(time, prices[i]);
                 actual[i] = Math.Round(indicator.Current.Value, 4);
                 time = time.AddMinutes(1);
             }
             Assert.AreEqual(expected, actual);
+
+            var expectedUpper = indicator.Current + stdDev.Current * 2;
+            Assert.AreEqual(expectedUpper, indicator.UpperChannel);
+            var expectedLower = indicator.Current - stdDev.Current * 2;
+            Assert.AreEqual(expectedLower, indicator.LowerChannel);
         }
 
         [Test]

--- a/Tests/Indicators/RegressionChannelTest.cs
+++ b/Tests/Indicators/RegressionChannelTest.cs
@@ -1,0 +1,67 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Indicators;
+using System;
+
+namespace QuantConnect.Tests.Indicators
+{
+    /// <summary>
+    /// Result tested vs. Python available at: http://tinyurl.com/o7redso
+    /// </summary>
+    [TestFixture]
+    public class RegressionChannelTest
+    {
+        [Test]
+        public void RegressionChannelComputesCorrectly()
+        {
+            var period = 20;
+            var indicator = new RegressionChannel(period, 2);
+            var time = DateTime.Now;
+
+            var prices = LeastSquaresMovingAverageTest.prices;
+            var expected = LeastSquaresMovingAverageTest.expected;
+
+            var actual = new decimal[prices.Length];
+
+            for (int i = 0; i < prices.Length; i++)
+            {
+                indicator.Update(time, prices[i]);
+                actual[i] = Math.Round(indicator.Current.Value, 4);
+                time = time.AddMinutes(1);
+            }
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ResetsProperly()
+        {
+            var period = 10;
+            var time = DateTime.Now;
+
+            var indicator = new RegressionChannel(period, 2);
+
+            for (int i = 0; i < period + 1; i++)
+            {
+                indicator.Update(time, 1m);
+                time.AddMinutes(1);
+            }
+            Assert.IsTrue(indicator.IsReady, "Regression Channel ready");
+            indicator.Reset();
+            TestHelper.AssertIndicatorIsInDefaultState(indicator);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Indicators\HeikinAshiTests.cs" />
     <Compile Include="Indicators\IchimokuKinkoHyoTests.cs" />
     <Compile Include="Indicators\KeltnerChannelsTests.cs" />
+    <Compile Include="Indicators\RegressionChannelTest.cs" />
     <Compile Include="Indicators\LeastSquaresMovingAverageTest.cs" />
     <Compile Include="Indicators\LogReturnTests.cs" />
     <Compile Include="Indicators\MidPriceTests.cs" />


### PR DESCRIPTION
The Regression Channel indicator extends the LeastSquaresMovingAverage with the inclusion of two (upper and lower) channel lines that are distanced from the linear regression line by a user defined number of standard deviations.
Ref.: #474 