### PR TITLE
Add DisposeSafely extension methods

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -436,6 +436,7 @@
     <Compile Include="Util\BusyBlockingCollection.cs" />
     <Compile Include="Util\CircularQueue.cs" />
     <Compile Include="Util\Composer.cs" />
+    <Compile Include="Util\DisposableExtensions.cs" />
     <Compile Include="Util\ExpressionBuilder.cs" />
     <Compile Include="Util\FixedSizeQueue.cs" />
     <Compile Include="Util\FixedSizeHashQueue.cs" />

--- a/Common/Util/DisposableExtensions.cs
+++ b/Common/Util/DisposableExtensions.cs
@@ -1,0 +1,49 @@
+using System;
+using QuantConnect.Logging;
+
+namespace QuantConnect.Util
+{
+    /// <summary>
+    /// Provides extensions methods for <see cref="IDisposable"/>
+    /// </summary>
+    public static class DisposableExtensions
+    {
+        /// <summary>
+        /// Calls <see cref="IDisposable.Dispose"/> within a try/catch and logs any errors.
+        /// </summary>
+        /// <param name="disposable">The <see cref="IDisposable"/> to be disposed</param>
+        /// <returns>True if the object was successfully disposed, false if an error was thrown</returns>
+        public static bool DisposeSafely(this IDisposable disposable)
+        {
+            return disposable.DisposeSafely(error => Log.Error(error));
+        }
+
+        /// <summary>
+        /// Calls <see cref="IDisposable.Dispose"/> within a try/catch and invokes the 
+        /// <paramref name="errorHandler"/> on any errors.
+        /// </summary>
+        /// <param name="disposable">The <see cref="IDisposable"/> to be disposed</param>
+        /// <param name="errorHandler">Error handler delegate invoked if an exception is thrown
+        /// while calling <see cref="IDisposable.Dispose"/></param> on <paramref name="disposable"/>
+        /// <returns>True if the object was successfully disposed, false if an error was thrown or
+        /// the specified disposable was null</returns>
+        public static bool DisposeSafely(this IDisposable disposable, Action<Exception> errorHandler)
+        {
+            if (disposable == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                disposable.Dispose();
+                return true;
+            }
+            catch (Exception error)
+            {
+                errorHandler(error);
+                return false;
+            }
+        }
+    }
+}

--- a/Tests/Common/Util/DisposableExtensionsTests.cs
+++ b/Tests/Common/Util/DisposableExtensionsTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using NUnit.Framework;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Common.Util
+{
+    [TestFixture]
+    public class DisposableExtensionsTests
+    {
+        [Test]
+        public void ReturnsFalseForNullDisposable()
+        {
+            IDisposable disposable = null;
+            var result = disposable.DisposeSafely();
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ReturnsTrueOnSuccessfulDisposal()
+        {
+            var disposable = new Disposable();
+            var result = disposable.DisposeSafely();
+            Assert.IsTrue(result);
+            Assert.IsTrue(disposable.DisposeWasCalled);
+        }
+
+        [Test]
+        public void InvokesErrorHandlerOnExceptionDuringDispose()
+        {
+            var errorHandlerWasInvoked = false;
+            var disposable = new Disposable(throwException: true);
+            var result = disposable.DisposeSafely(error => errorHandlerWasInvoked = true);
+            Assert.IsFalse(result);
+            Assert.IsTrue(errorHandlerWasInvoked);
+            Assert.IsTrue(disposable.DisposeWasCalled);
+        }
+
+        private sealed class Disposable : IDisposable
+        {
+            private readonly bool _throwException;
+            public bool DisposeWasCalled { get; private set; }
+
+            public Disposable(bool throwException = false)
+            {
+                _throwException = throwException;
+            }
+
+            public void Dispose()
+            {
+                DisposeWasCalled = true;
+                if (_throwException)
+                {
+                    throw new Exception();
+                }
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Common\TimeZonesTest.cs" />
     <Compile Include="Common\Util\BusyBlockingCollectionTests.cs" />
     <Compile Include="Common\Util\ColorJsonConverterTests.cs" />
+    <Compile Include="Common\Util\DisposableExtensionsTests.cs" />
     <Compile Include="Common\Util\LeanDataTests.cs" />
     <Compile Include="Common\Util\LinqExtensionsTests.cs" />
     <Compile Include="Common\Util\MarketHoursDatabaseJsonConverterTests.cs" />


### PR DESCRIPTION
I had originally written these elsewhere, but feel that they're general enough
to be moved into Util. Let me know if you think they don't belong here.

Add `DisposableExtensions` to hold extension methods for `IDisposable`.
Add two overloads of `DisposeSafely`. This will allow you to call
`myDisposable.DisposeSafely()` and it will wrap the `Dispose` call in a
try/catch and log the error. The other overload allows you to
handler the error using an `Action<Exception> errorHandler` parameter