### PR TITLE
FxcmBrokerage bug fixes and improvements

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
@@ -34,6 +34,22 @@ namespace QuantConnect.Brokerages.Fxcm
     {
         private readonly IList<BaseData> _lastHistoryChunk = new List<BaseData>();
 
+        /// <summary>
+        /// Gets/sets a timeout for history requests (in milliseconds)
+        /// </summary>
+        public int HistoryResponseTimeout { get; set; }
+
+        /// <summary>
+        /// Gets/sets the maximum number of retries for a history request
+        /// </summary>
+        public int MaximumHistoryRetryAttempts { get; set; }
+
+        /// <summary>
+        /// Gets/sets a value to enable only history requests to this brokerage
+        /// Set to true in parallel downloaders to avoid loading accounts, orders, positions etc. at connect time
+        /// </summary>
+        public bool EnableOnlyHistoryRequests { get; set; }
+
         #region IHistoryProvider implementation
 
         /// <summary>
@@ -69,6 +85,7 @@ namespace QuantConnect.Brokerages.Fxcm
 
                 var end = request.EndTimeUtc;
 
+                var attempt = 1;
                 while (end > request.StartTimeUtc)
                 {
                     _lastHistoryChunk.Clear();
@@ -93,21 +110,30 @@ namespace QuantConnect.Brokerages.Fxcm
                         _mapRequestsToAutoResetEvents[_currentRequest] = autoResetEvent;
                         _pendingHistoryRequests.Add(_currentRequest);
                     }
-                    if (!autoResetEvent.WaitOne(ResponseTimeout))
+                    if (!autoResetEvent.WaitOne(HistoryResponseTimeout))
                     {
-                        // no response, exit
-                        Log.Trace("FxcmBrokerage.GetHistory(): history request timed out");
-                        break;
+                        // no response
+                        if (++attempt > MaximumHistoryRetryAttempts)
+                        {
+                            break;
+                        }
+                        continue;
                     }
 
                     // Add data
-                    history.InsertRange(0, _lastHistoryChunk);
+                    lock (_locker)
+                    {
+                        history.InsertRange(0, _lastHistoryChunk);
+                    }
 
                     var firstDateUtc = _lastHistoryChunk[0].Time.ConvertToUtc(_configTimeZone);
                     if (end != firstDateUtc)
                     {
                         // new end date = first datapoint date.
                         end = request.Resolution == Resolution.Tick ? firstDateUtc.AddMilliseconds(-1) : firstDateUtc.AddSeconds(-1);
+
+                        if (request.StartTimeUtc.AddSeconds(1) >= end)
+                            break;
                     }
                     else
                     {

--- a/Brokerages/Fxcm/FxcmBrokerage.Util.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Util.cs
@@ -189,7 +189,7 @@ namespace QuantConnect.Brokerages.Fxcm
             }
 
             // Convert javaDate to UTC Instant (Epoch)
-            var instant = Instant.FromSecondsSinceUnixEpoch(javaDate.getTime() / 1000);
+            var instant = Instant.FromMillisecondsSinceUnixEpoch(javaDate.getTime());
 
             // Convert to configured TZ then to a .Net DateTime
             return instant.InZone(_configTimeZone).ToDateTimeUnspecified();

--- a/Brokerages/Fxcm/FxcmBrokerage.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.cs
@@ -148,6 +148,8 @@ namespace QuantConnect.Brokerages.Fxcm
                     err.Message.Contains("ORA-20003") ? "API connections are not available on Mini accounts. If you have a standard account contact api@fxcm.com to enable API access" :
                     err.Message;
 
+                _cancellationTokenSource.Cancel();
+
                 throw new BrokerageException(message, err.InnerException);
             }
 

--- a/Brokerages/Fxcm/FxcmBrokerage.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.cs
@@ -76,6 +76,9 @@ namespace QuantConnect.Brokerages.Fxcm
             _userName = userName;
             _password = password;
             _accountId = accountId;
+
+            HistoryResponseTimeout = 5000;
+            MaximumHistoryRetryAttempts = 1;
         }
 
         #region IBrokerage implementation
@@ -209,9 +212,12 @@ namespace QuantConnect.Brokerages.Fxcm
 
                                 // load instruments, accounts, orders, positions
                                 LoadInstruments();
-                                LoadAccounts();
-                                LoadOpenOrders();
-                                LoadOpenPositions();
+                                if (!EnableOnlyHistoryRequests)
+                                {
+                                    LoadAccounts();
+                                    LoadOpenOrders();
+                                    LoadOpenPositions();
+                                }
 
                                 _connectionError = false;
                                 _connectionLost = false;
@@ -240,9 +246,12 @@ namespace QuantConnect.Brokerages.Fxcm
 
             // load instruments, accounts, orders, positions
             LoadInstruments();
-            LoadAccounts();
-            LoadOpenOrders();
-            LoadOpenPositions();
+            if (!EnableOnlyHistoryRequests)
+            {
+                LoadAccounts();
+                LoadOpenOrders();
+                LoadOpenPositions();
+            }
         }
 
         /// <summary>

--- a/Brokerages/Fxcm/FxcmBrokerage.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.cs
@@ -267,21 +267,23 @@ namespace QuantConnect.Brokerages.Fxcm
         /// </summary>
         public override void Disconnect()
         {
-            if (!IsConnected) return;
-
             Log.Trace("FxcmBrokerage.Disconnect()");
 
-            // log out
-            _gateway.logout();
+            if (_gateway != null)
+            {
+                // log out
+                if (_gateway.isConnected())
+                    _gateway.logout();
 
-            // remove the message listeners
-            _gateway.removeGenericMessageListener(this);
-            _gateway.removeStatusMessageListener(this);
+                // remove the message listeners
+                _gateway.removeGenericMessageListener(this);
+                _gateway.removeStatusMessageListener(this);
+            }
 
             // request and wait for thread to stop
-            _cancellationTokenSource.Cancel();
-            _orderEventThread.Join();
-            _connectionMonitorThread.Join();
+            if (_cancellationTokenSource != null) _cancellationTokenSource.Cancel();
+            if (_orderEventThread != null) _orderEventThread.Join();
+            if (_connectionMonitorThread != null) _connectionMonitorThread.Join();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR contains a few bug fixes and adds a few settings for usage in parallel downloaders:
- In DataQueueHandler and HistoryProvider, ticks were timestamped without milliseconds
- After calling Disconnect while being already disconnected for any other reason, the connection monitor thread kept trying to reconnect anyway
- After a failed login, the order event thread kept running preventing a clean shutdown
- The history provider had a timezone bug and was not robust enough to be used in a parallel downloader