### PR TITLE
increases symbol limit on Lean local and also adds a config option to…

### DIFF
--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -37,6 +37,11 @@
   "map-file-provider": "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider",
   "factor-file-provider": "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider",
 
+  // limits on number of symbols to allow
+  "symbol-minute-limit": 10000, 
+  "symbol-second-limit": 10000,
+  "symbol-tick-limit": 10000,
+
   // if one uses "true" as string in following token, market hours
   // will remain open all hours and all days.
   // Any other string beside "true" will make lean operate
@@ -106,11 +111,6 @@
     "live-paper": {
       "live-mode": "true",
 
-      // limits on number of symbols to allow
-      "symbol-minute-limit": 10000, 
-      "symbol-second-limit": 10000,
-      "symbol-tick-limit": 10000,
-
       // the paper brokerage requires the BacktestingTransactionHandler
       "live-mode-brokerage": "PaperBrokerage",
 
@@ -125,11 +125,6 @@
     // defines the 'live-tradier' environment
     "live-tradier": {
       "live-mode": true,
-
-      // limits on number of symbols to allow
-      "symbol-minute-limit": 10000, 
-      "symbol-second-limit": 10000,
-      "symbol-tick-limit": 10000,
 
       // this setting will save tradier access/refresh tokens to a tradier-tokens.txt file
       // that can be read in next time, this makes it easier to start/stop a tradier algorithm
@@ -150,11 +145,6 @@
     "live-interactive": {
       "live-mode": true,
 
-      // limits on number of symbols to allow
-      "symbol-minute-limit": 10000, 
-      "symbol-second-limit": 10000,
-      "symbol-tick-limit": 10000,
-
       // real brokerage implementations require the BrokerageTransactionHandler
       "live-mode-brokerage": "InteractiveBrokersBrokerage",
       "data-queue-handler": "InteractiveBrokersBrokerage",
@@ -168,11 +158,6 @@
     // defines the 'live-fxcm' environment
     "live-fxcm": {
       "live-mode": true,
-
-      // limits on number of symbols to allow
-      "symbol-minute-limit": 10000, 
-      "symbol-second-limit": 10000,
-      "symbol-tick-limit": 10000,
 
       // real brokerage implementations require the BrokerageTransactionHandler
       "live-mode-brokerage": "FxcmBrokerage",
@@ -207,11 +192,6 @@
     "live-desktop": {
       "live-mode": true,
       "send-via-api": true,
-
-      // limits on number of symbols to allow
-      "symbol-minute-limit": 10000, 
-      "symbol-second-limit": 10000,
-      "symbol-tick-limit": 10000,
 
       //Required for local charting.
       // To get your api access token go to quantconnect.com/account

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -106,6 +106,11 @@
     "live-paper": {
       "live-mode": "true",
 
+      // limits on number of symbols to allow
+      "symbol-minute-limit": 10000, 
+      "symbol-second-limit": 10000,
+      "symbol-tick-limit": 10000,
+
       // the paper brokerage requires the BacktestingTransactionHandler
       "live-mode-brokerage": "PaperBrokerage",
 
@@ -120,6 +125,11 @@
     // defines the 'live-tradier' environment
     "live-tradier": {
       "live-mode": true,
+
+      // limits on number of symbols to allow
+      "symbol-minute-limit": 10000, 
+      "symbol-second-limit": 10000,
+      "symbol-tick-limit": 10000,
 
       // this setting will save tradier access/refresh tokens to a tradier-tokens.txt file
       // that can be read in next time, this makes it easier to start/stop a tradier algorithm
@@ -140,6 +150,11 @@
     "live-interactive": {
       "live-mode": true,
 
+      // limits on number of symbols to allow
+      "symbol-minute-limit": 10000, 
+      "symbol-second-limit": 10000,
+      "symbol-tick-limit": 10000,
+
       // real brokerage implementations require the BrokerageTransactionHandler
       "live-mode-brokerage": "InteractiveBrokersBrokerage",
       "data-queue-handler": "InteractiveBrokersBrokerage",
@@ -153,6 +168,11 @@
     // defines the 'live-fxcm' environment
     "live-fxcm": {
       "live-mode": true,
+
+      // limits on number of symbols to allow
+      "symbol-minute-limit": 10000, 
+      "symbol-second-limit": 10000,
+      "symbol-tick-limit": 10000,
 
       // real brokerage implementations require the BrokerageTransactionHandler
       "live-mode-brokerage": "FxcmBrokerage",
@@ -187,6 +207,11 @@
     "live-desktop": {
       "live-mode": true,
       "send-via-api": true,
+
+      // limits on number of symbols to allow
+      "symbol-minute-limit": 10000, 
+      "symbol-second-limit": 10000,
+      "symbol-tick-limit": 10000,
 
       //Required for local charting.
       // To get your api access token go to quantconnect.com/account

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -93,6 +93,12 @@ namespace QuantConnect.Queues
                     RamAllocation = int.MaxValue,
                     Parameters = parameters,
                     Language = Language,
+                    Controls = new Controls()
+                    {
+                        MinuteLimit = Config.GetInt("symbol-minute-limit", 10000),
+                        SecondLimit = Config.GetInt("symbol-second-limit", 10000),
+                        TickLimit = Config.GetInt("symbol-tick-limit", 10000)
+                    }
                 };
 
                 try


### PR DESCRIPTION
… alter the limits

Set default to 10000. int.MaxValue would have caused the RAM limit calculations to wrap as they are double. 
