### PR TITLE
Ability to switch between internal feeds and normal feeds

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -221,7 +221,6 @@ namespace QuantConnect.Lean.Engine.Setup
                 brokerage.Message += brokerageOnMessage;
 
                 algorithm.Transactions.SetOrderProcessor(transactionHandler);
-                algorithm.PostInitialize();
 
                 Log.Trace("BrokerageSetupHandler.Setup(): Connecting to brokerage...");
                 try
@@ -330,6 +329,8 @@ namespace QuantConnect.Lean.Engine.Setup
                     AddInitializationError("Error getting account holdings from brokerage: " + err.Message);
                     return false;
                 }
+
+                algorithm.PostInitialize();
 
                 //Set the starting portfolio value for the strategy to calculate performance:
                 StartingPortfolioValue = algorithm.Portfolio.TotalPortfolioValue;


### PR DESCRIPTION
This PR solves two problems:

1. In live trading, if in the existing holdings at the brokerage there is also the benchmark symbol (SPY), the data feed is still marked as internal (so OnData does not fire for this symbol)

2. The same problem happens if the benchmark symbol is selected by universe selection or added manually with AddSecurity in OnData