### PR TITLE
Use .NET zip implementation for ZipBytes

### DIFF
--- a/Compression/Compression.cs
+++ b/Compression/Compression.cs
@@ -246,15 +246,16 @@ namespace QuantConnect
         /// <returns>The zipped file as a byte array</returns>
         public static byte[] ZipBytes(byte[] bytes, string zipEntryName)
         {
-            using (var memoryStream = new MemoryStream())
-            using (var stream = new ZipOutputStream(memoryStream))
+            var memoryStream = new MemoryStream();
+            using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
             {
-                var entry = new ZipEntry(zipEntryName);
-                stream.PutNextEntry(entry);
-                var buffer = new byte[16*1024];
-                StreamUtils.Copy(new MemoryStream(bytes), stream, buffer);
-                return memoryStream.GetBuffer();
+                var entry = archive.CreateEntry(zipEntryName);
+                using (var entryStream = entry.Open())
+                {
+                    entryStream.Write(bytes, 0, bytes.Length);
+                }
             }
+            return memoryStream.GetBuffer();
         }
 
         /// <summary>

--- a/Tests/Compression/CompressionTests.cs
+++ b/Tests/Compression/CompressionTests.cs
@@ -42,10 +42,12 @@ namespace QuantConnect.Tests.Compression
             var fileBytes = Encoding.ASCII.GetBytes(fileContents); // using asci because UnzipData uses 1byte=1char
             var zippedBytes = QuantConnect.Compression.ZipBytes(fileBytes, "entry");
             File.WriteAllBytes("entry.zip", zippedBytes);
-            var unzipped = QuantConnect.Compression.Unzip("entry.zip").ToList();
-            Assert.AreEqual(1, unzipped.Count);
-            Assert.AreEqual("entry", unzipped[0].Key);
-            Assert.AreEqual(fileContents, unzipped[0].Value.Single());
+
+            using (var streamReader = QuantConnect.Compression.UnzipStream(File.OpenRead("entry.zip")))
+            {
+                var contents = streamReader.ReadToEnd();
+                Assert.AreEqual(fileContents, contents);
+            }
         }
 
         [Test]


### PR DESCRIPTION
The replaced zip implementation had issues in high performance,
multi-threaded scenarios. The exact cause of the issue was not
determined, but invalid zip files were being generated when using this
method directly.

The replacement uses the built in .NET zip archive implementation
which should (in theory) have better cross-platform characteristics
than 3rd party implementations.

The unit test was also update as it made incorrect usage of the
Compression.Unzip routine. It has been replaced with a more reliable
method that unzips the first entry and returns a stream reader.
