### PR TITLE
Move lean data path components to common

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -446,6 +446,7 @@
     <Compile Include="Util\FuncTextWriter.cs" />
     <Compile Include="Util\IParallelRunnerWorkItem.cs" />
     <Compile Include="Util\LeanData.cs" />
+    <Compile Include="Util\LeanDataPathComponents.cs" />
     <Compile Include="Util\MarketHoursDatabaseJsonConverter.cs" />
     <Compile Include="Util\ParallelRunner.cs" />
     <Compile Include="Util\ParallelRunnerWorker.cs" />

--- a/Common/Util/LeanDataPathComponents.cs
+++ b/Common/Util/LeanDataPathComponents.cs
@@ -16,7 +16,7 @@
 using System;
 using System.IO;
 
-namespace QuantConnect.ToolBox
+namespace QuantConnect.Util
 {
     /// <summary>
     /// Type representing the various pieces of information emebedded into a lean data file path

--- a/Tests/Common/Util/LeanDataPathComponentsTests.cs
+++ b/Tests/Common/Util/LeanDataPathComponentsTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Common.Util
+{
+    [TestFixture]
+    public class LeanDataPathComponentsTests
+    {
+        public sealed class Arguments
+        {
+            public Symbol Symbol;
+            public DateTime Date;
+            public Resolution Resolution;
+            public TickType TickType;
+            public string Market;
+
+            public Arguments(Symbol symbol, DateTime date, Resolution resolution, string market, TickType tickType)
+            {
+                Symbol = symbol;
+                Date = date;
+                Resolution = resolution;
+                TickType = tickType;
+                Market = market;
+                if (symbol.ID.SecurityType != SecurityType.Option && (resolution == Resolution.Hour || resolution == Resolution.Daily))
+                {
+                    // for the time being this is true, eventually I'm sure we'd like to support hourly/daily quote data in other security types
+                    TickType = TickType.Trade;
+                }
+            }
+        }
+
+        public TestCaseData[] GetTestCases()
+        {
+            var referenceDate = new DateTime(2016, 11, 1);
+
+            var tickTypes = Enum.GetValues(typeof(TickType)).Cast<TickType>();
+            var resolutions = Enum.GetValues(typeof (Resolution)).Cast<Resolution>();
+            var securityTypes = Enum.GetValues(typeof (SecurityType)).Cast<SecurityType>();
+            var markets = typeof (Market).GetFields().Where(f => f.IsLiteral && !f.IsInitOnly)
+                .Select(f => (string) f.GetValue(null));
+
+            var results = (
+                from securityType in securityTypes
+                from market in markets
+                from resolution in resolutions
+                from tickType in tickTypes
+                let date = resolution == Resolution.Hour || resolution == Resolution.Daily ? DateTime.MinValue : referenceDate
+                let name = string.Format("{0}-{1}-{2}-{3}", securityType.ToLower(), market.ToLower(), resolution.ToLower(), tickType.ToLower())
+                where TryInvoke(() => Symbol.Create(name, securityType, market))
+                let symbol = securityType != SecurityType.Option
+                    ? Symbol.Create(name, securityType, market)
+                    : Symbol.CreateOption(name, market, OptionStyle.American, OptionRight.Put, 0, SecurityIdentifier.DefaultDate)
+                select new TestCaseData(new Arguments(symbol, date, resolution, market, tickType))
+                                .SetName(name)
+                ).ToArray();
+
+            return results;
+        }
+
+        [Test, TestCaseSource("GetTestCases")]
+        public void DecomposesAccordingToLeanDataFileGeneration(Arguments args)
+        {
+            var sourceString = LeanData.GenerateRelativeZipFilePath(args.Symbol, args.Date, args.Resolution, args.TickType);
+            var decomposed = LeanDataPathComponents.Parse(sourceString);
+
+            var expectedFileName = LeanData.GenerateZipFileName(args.Symbol, args.Date, args.Resolution, args.TickType);
+
+            Assert.AreEqual(args.Symbol, decomposed.Symbol);
+            Assert.AreEqual(args.Date, decomposed.Date);
+            Assert.AreEqual(expectedFileName, decomposed.Filename);
+            Assert.AreEqual(args.Symbol.ID.SecurityType, decomposed.SecurityType);
+            Assert.AreEqual(args.Symbol.ID.Market, decomposed.Market);
+            Assert.AreEqual(args.TickType, decomposed.TickType);
+            Assert.AreEqual(args.Market, decomposed.Market);
+        }
+
+        private static bool TryInvoke(Action action)
+        {
+            try
+            {
+                action();
+                return true;
+            }
+            catch
+            {
+                return false;
+                throw;
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Common\Util\BusyBlockingCollectionTests.cs" />
     <Compile Include="Common\Util\ColorJsonConverterTests.cs" />
     <Compile Include="Common\Util\DisposableExtensionsTests.cs" />
+    <Compile Include="Common\Util\LeanDataPathComponentsTests.cs" />
     <Compile Include="Common\Util\LeanDataTests.cs" />
     <Compile Include="Common\Util\LinqExtensionsTests.cs" />
     <Compile Include="Common\Util\MarketHoursDatabaseJsonConverterTests.cs" />

--- a/ToolBox/LeanParser.cs
+++ b/ToolBox/LeanParser.cs
@@ -19,6 +19,7 @@ using System.IO;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.ToolBox.AlgoSeekOptionsConverter;
+using QuantConnect.Util;
 
 namespace QuantConnect.ToolBox
 {

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -173,7 +173,6 @@
     <Compile Include="IQFeed\IQ\SocketClient.cs" />
     <Compile Include="IStreamParser.cs" />
     <Compile Include="IStreamProvider.cs" />
-    <Compile Include="LeanDataPathComponents.cs" />
     <Compile Include="LeanDataWriter.cs" />
     <Compile Include="LeanInstrument.cs" />
     <Compile Include="LeanParser.cs" />


### PR DESCRIPTION
`LeanDataPathComponents` is a nice little utility that has potential usages outside of the toolbox. The reason for not wanting to reference `QuantConnect.ToolBox` directly is because of the heavy dependencies that come along for the ride.

Certainly not the prettiest parsing code but it does work and comes in handy ;)