### PR TITLE
Enable FineFundamental to be used with AddData

### DIFF
--- a/Common/Data/Fundamental/FineFundamental.cs
+++ b/Common/Data/Fundamental/FineFundamental.cs
@@ -65,7 +65,13 @@ namespace QuantConnect.Data.Fundamental
         /// </summary>
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
-            return JsonConvert.DeserializeObject<FineFundamental>(line);
+            var data = JsonConvert.DeserializeObject<FineFundamental>(line);
+
+            data.DataType = MarketDataType.Auxiliary;
+            data.Symbol = config.Symbol;
+            data.Time = date;
+
+            return data;
         }
     }
 }


### PR DESCRIPTION
Example algorithm:

```
using QuantConnect.Data.Fundamental;
using QuantConnect.Data.Market;

namespace QuantConnect.Algorithm.CSharp
{
    public class BasicTemplateAlgorithm : QCAlgorithm
    {
        private string[] _symbols = { "AAPL", "IBM" };

        public override void Initialize()
        {
            SetStartDate(2016, 1, 1);
            SetEndDate(2016, 10, 31);
            SetCash(100000);

            foreach (var ticker in _symbols)
            {
                AddEquity(ticker, Resolution.Daily, Market.USA);
                AddData<FineFundamental>(ticker, Resolution.Daily);
            }
        }

        public void OnData(FineFundamental data)
        {
            Log(Time + " ==> " + data.Symbol.Value + " " + data.EndTime + " PERatio = " + data.ValuationRatios.PERatio);
        }

        public void OnData(TradeBars tradeBars)
        {
            foreach (var kvp in tradeBars)
            {
                Log(Time + " ==> " + kvp.Key.Value + " " + kvp.Value.Close);
            }
        }
    }
}

```