### PR TITLE
Use IBaseData in type constraints

### DIFF
--- a/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
@@ -198,7 +198,7 @@ namespace QuantConnect
         /// <summary>
         /// Function used to select a trade bar that has double the values of the input trade bar
         /// </summary>
-        private static TradeBar SelectorDoubleTradeBar(BaseData baseData)
+        private static TradeBar SelectorDoubleTradeBar(IBaseData baseData)
         {
             var bar = (TradeBar)baseData;
             return new TradeBar

--- a/Algorithm/CandlestickPatterns.cs
+++ b/Algorithm/CandlestickPatterns.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public TwoCrows TwoCrows(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public TwoCrows TwoCrows(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "TWOCROWS", resolution);
             var pattern = new TwoCrows(name);
@@ -61,7 +61,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeBlackCrows ThreeBlackCrows(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ThreeBlackCrows ThreeBlackCrows(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREEBLACKCROWS", resolution);
             var pattern = new ThreeBlackCrows(name);
@@ -77,7 +77,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeInside ThreeInside(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ThreeInside ThreeInside(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREEINSIDE", resolution);
             var pattern = new ThreeInside(name);
@@ -93,7 +93,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeLineStrike ThreeLineStrike(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ThreeLineStrike ThreeLineStrike(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREELINESTRIKE", resolution);
             var pattern = new ThreeLineStrike(name);
@@ -109,7 +109,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeOutside ThreeOutside(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ThreeOutside ThreeOutside(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREEOUTSIDE", resolution);
             var pattern = new ThreeOutside(name);
@@ -125,7 +125,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeStarsInSouth ThreeStarsInSouth(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ThreeStarsInSouth ThreeStarsInSouth(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREESTARSINSOUTH", resolution);
             var pattern = new ThreeStarsInSouth(name);
@@ -141,7 +141,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeWhiteSoldiers ThreeWhiteSoldiers(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ThreeWhiteSoldiers ThreeWhiteSoldiers(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREEWHITESOLDIERS", resolution);
             var pattern = new ThreeWhiteSoldiers(name);
@@ -158,7 +158,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public AbandonedBaby AbandonedBaby(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public AbandonedBaby AbandonedBaby(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "ABANDONEDBABY", resolution);
             var pattern = new AbandonedBaby(name, penetration);
@@ -174,7 +174,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public AdvanceBlock AdvanceBlock(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public AdvanceBlock AdvanceBlock(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "ADVANCEBLOCK", resolution);
             var pattern = new AdvanceBlock(name);
@@ -190,7 +190,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public BeltHold BeltHold(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public BeltHold BeltHold(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "BELTHOLD", resolution);
             var pattern = new BeltHold(name);
@@ -206,7 +206,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Breakaway Breakaway(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Breakaway Breakaway(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "BREAKAWAY", resolution);
             var pattern = new Breakaway(name);
@@ -222,7 +222,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ClosingMarubozu ClosingMarubozu(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ClosingMarubozu ClosingMarubozu(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "CLOSINGMARUBOZU", resolution);
             var pattern = new ClosingMarubozu(name);
@@ -238,7 +238,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ConcealedBabySwallow ConcealedBabySwallow(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ConcealedBabySwallow ConcealedBabySwallow(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "CONCEALEDBABYSWALLOW", resolution);
             var pattern = new ConcealedBabySwallow(name);
@@ -254,7 +254,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Counterattack Counterattack(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Counterattack Counterattack(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "COUNTERATTACK", resolution);
             var pattern = new Counterattack(name);
@@ -271,7 +271,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public DarkCloudCover DarkCloudCover(Symbol symbol, decimal penetration = 0.5m, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public DarkCloudCover DarkCloudCover(Symbol symbol, decimal penetration = 0.5m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "DARKCLOUDCOVER", resolution);
             var pattern = new DarkCloudCover(name, penetration);
@@ -287,7 +287,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Doji Doji(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Doji Doji(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "DOJI", resolution);
             var pattern = new Doji(name);
@@ -303,7 +303,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public DojiStar DojiStar(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public DojiStar DojiStar(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "DOJISTAR", resolution);
             var pattern = new DojiStar(name);
@@ -319,7 +319,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public DragonflyDoji DragonflyDoji(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public DragonflyDoji DragonflyDoji(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "DRAGONFLYDOJI", resolution);
             var pattern = new DragonflyDoji(name);
@@ -335,7 +335,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Engulfing Engulfing(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Engulfing Engulfing(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "ENGULFING", resolution);
             var pattern = new Engulfing(name);
@@ -352,7 +352,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public EveningDojiStar EveningDojiStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public EveningDojiStar EveningDojiStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "EVENINGDOJISTAR", resolution);
             var pattern = new EveningDojiStar(name, penetration);
@@ -369,7 +369,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public EveningStar EveningStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public EveningStar EveningStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "EVENINGSTAR", resolution);
             var pattern = new EveningStar(name, penetration);
@@ -385,7 +385,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public GapSideBySideWhite GapSideBySideWhite(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public GapSideBySideWhite GapSideBySideWhite(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "GAPSIDEBYSIDEWHITE", resolution);
             var pattern = new GapSideBySideWhite(name);
@@ -401,7 +401,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public GravestoneDoji GravestoneDoji(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public GravestoneDoji GravestoneDoji(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "GRAVESTONEDOJI", resolution);
             var pattern = new GravestoneDoji(name);
@@ -417,7 +417,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Hammer Hammer(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Hammer Hammer(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HAMMER", resolution);
             var pattern = new Hammer(name);
@@ -433,7 +433,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HangingMan HangingMan(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public HangingMan HangingMan(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HANGINGMAN", resolution);
             var pattern = new HangingMan(name);
@@ -449,7 +449,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Harami Harami(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Harami Harami(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HARAMI", resolution);
             var pattern = new Harami(name);
@@ -465,7 +465,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HaramiCross HaramiCross(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public HaramiCross HaramiCross(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HARAMICROSS", resolution);
             var pattern = new HaramiCross(name);
@@ -481,7 +481,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HighWaveCandle HighWaveCandle(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public HighWaveCandle HighWaveCandle(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HIGHWAVECANDLE", resolution);
             var pattern = new HighWaveCandle(name);
@@ -497,7 +497,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Hikkake Hikkake(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Hikkake Hikkake(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HIKKAKE", resolution);
             var pattern = new Hikkake(name);
@@ -513,7 +513,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HikkakeModified HikkakeModified(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public HikkakeModified HikkakeModified(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HIKKAKEMODIFIED", resolution);
             var pattern = new HikkakeModified(name);
@@ -529,7 +529,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HomingPigeon HomingPigeon(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public HomingPigeon HomingPigeon(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HOMINGPIGEON", resolution);
             var pattern = new HomingPigeon(name);
@@ -545,7 +545,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public IdenticalThreeCrows IdenticalThreeCrows(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public IdenticalThreeCrows IdenticalThreeCrows(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "IDENTICALTHREECROWS", resolution);
             var pattern = new IdenticalThreeCrows(name);
@@ -561,7 +561,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public InNeck InNeck(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public InNeck InNeck(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "INNECK", resolution);
             var pattern = new InNeck(name);
@@ -577,7 +577,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public InvertedHammer InvertedHammer(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public InvertedHammer InvertedHammer(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "INVERTEDHAMMER", resolution);
             var pattern = new InvertedHammer(name);
@@ -593,7 +593,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Kicking Kicking(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Kicking Kicking(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "KICKING", resolution);
             var pattern = new Kicking(name);
@@ -609,7 +609,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public KickingByLength KickingByLength(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public KickingByLength KickingByLength(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "KICKINGBYLENGTH", resolution);
             var pattern = new KickingByLength(name);
@@ -625,7 +625,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public LadderBottom LadderBottom(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public LadderBottom LadderBottom(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "LADDERBOTTOM", resolution);
             var pattern = new LadderBottom(name);
@@ -641,7 +641,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public LongLeggedDoji LongLeggedDoji(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public LongLeggedDoji LongLeggedDoji(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "LONGLEGGEDDOJI", resolution);
             var pattern = new LongLeggedDoji(name);
@@ -657,7 +657,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public LongLineCandle LongLineCandle(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public LongLineCandle LongLineCandle(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "LONGLINECANDLE", resolution);
             var pattern = new LongLineCandle(name);
@@ -673,7 +673,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Marubozu Marubozu(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Marubozu Marubozu(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MARUBOZU", resolution);
             var pattern = new Marubozu(name);
@@ -689,7 +689,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public MatchingLow MatchingLow(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public MatchingLow MatchingLow(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MATCHINGLOW", resolution);
             var pattern = new MatchingLow(name);
@@ -706,7 +706,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public MatHold MatHold(Symbol symbol, decimal penetration = 0.5m, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public MatHold MatHold(Symbol symbol, decimal penetration = 0.5m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MATHOLD", resolution);
             var pattern = new MatHold(name, penetration);
@@ -723,7 +723,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public MorningDojiStar MorningDojiStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public MorningDojiStar MorningDojiStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MORNINGDOJISTAR", resolution);
             var pattern = new MorningDojiStar(name, penetration);
@@ -740,7 +740,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public MorningStar MorningStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public MorningStar MorningStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MORNINGSTAR", resolution);
             var pattern = new MorningStar(name, penetration);
@@ -756,7 +756,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public OnNeck OnNeck(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public OnNeck OnNeck(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "ONNECK", resolution);
             var pattern = new OnNeck(name);
@@ -772,7 +772,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Piercing Piercing(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Piercing Piercing(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "PIERCING", resolution);
             var pattern = new Piercing(name);
@@ -788,7 +788,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public RickshawMan RickshawMan(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public RickshawMan RickshawMan(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "RICKSHAWMAN", resolution);
             var pattern = new RickshawMan(name);
@@ -804,7 +804,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public RiseFallThreeMethods RiseFallThreeMethods(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public RiseFallThreeMethods RiseFallThreeMethods(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "RISEFALLTHREEMETHODS", resolution);
             var pattern = new RiseFallThreeMethods(name);
@@ -820,7 +820,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public SeparatingLines SeparatingLines(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public SeparatingLines SeparatingLines(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "SEPARATINGLINES", resolution);
             var pattern = new SeparatingLines(name);
@@ -836,7 +836,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ShootingStar ShootingStar(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ShootingStar ShootingStar(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "SHOOTINGSTAR", resolution);
             var pattern = new ShootingStar(name);
@@ -852,7 +852,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ShortLineCandle ShortLineCandle(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ShortLineCandle ShortLineCandle(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "SHORTLINECANDLE", resolution);
             var pattern = new ShortLineCandle(name);
@@ -868,7 +868,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public SpinningTop SpinningTop(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public SpinningTop SpinningTop(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "SPINNINGTOP", resolution);
             var pattern = new SpinningTop(name);
@@ -884,7 +884,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public StalledPattern StalledPattern(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public StalledPattern StalledPattern(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "STALLEDPATTERN", resolution);
             var pattern = new StalledPattern(name);
@@ -900,7 +900,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public StickSandwich StickSandwich(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public StickSandwich StickSandwich(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "STICKSANDWICH", resolution);
             var pattern = new StickSandwich(name);
@@ -916,7 +916,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Takuri Takuri(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Takuri Takuri(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "TAKURI", resolution);
             var pattern = new Takuri(name);
@@ -932,7 +932,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public TasukiGap TasukiGap(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public TasukiGap TasukiGap(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "TASUKIGAP", resolution);
             var pattern = new TasukiGap(name);
@@ -948,7 +948,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Thrusting Thrusting(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Thrusting Thrusting(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THRUSTING", resolution);
             var pattern = new Thrusting(name);
@@ -964,7 +964,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Tristar Tristar(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public Tristar Tristar(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "TRISTAR", resolution);
             var pattern = new Tristar(name);
@@ -980,7 +980,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public UniqueThreeRiver UniqueThreeRiver(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public UniqueThreeRiver UniqueThreeRiver(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "UNIQUETHREERIVER", resolution);
             var pattern = new UniqueThreeRiver(name);
@@ -996,7 +996,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public UpsideGapTwoCrows UpsideGapTwoCrows(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public UpsideGapTwoCrows UpsideGapTwoCrows(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "UPSIDEGAPTWOCROWS", resolution);
             var pattern = new UpsideGapTwoCrows(name);
@@ -1012,7 +1012,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public UpDownGapThreeMethods UpDownGapThreeMethods(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public UpDownGapThreeMethods UpDownGapThreeMethods(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "UPDOWNGAPTHREEMETHODS", resolution);
             var pattern = new UpDownGapThreeMethods(name);

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<DataDictionary<T>> History<T>(TimeSpan span, Resolution? resolution = null)
-            where T : BaseData
+            where T : IBaseData
         {
             return History<T>(Securities.Keys, span, resolution).Memoize();
         }
@@ -167,7 +167,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, TimeSpan span, Resolution? resolution = null)
-            where T : BaseData
+            where T : IBaseData
         {
             return History<T>(symbols, Time - span, Time, resolution).Memoize();
         }
@@ -183,7 +183,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null) 
-            where T : BaseData
+            where T : IBaseData
         {
             var requests = symbols.Select(x =>
             {
@@ -209,7 +209,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, DateTime start, DateTime end, Resolution? resolution = null) 
-            where T : BaseData
+            where T : IBaseData
         {
             var requests = symbols.Select(x =>
             {
@@ -232,7 +232,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<T> History<T>(Symbol symbol, TimeSpan span, Resolution? resolution = null)
-            where T : BaseData
+            where T : IBaseData
         {
             return History<T>(symbol, Time - span, Time, resolution).Memoize();
         }
@@ -262,7 +262,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<T> History<T>(Symbol symbol, int periods, Resolution? resolution = null)
-            where T : BaseData
+            where T : IBaseData
         {
             if (resolution == Resolution.Tick) throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
             var security = Securities[symbol];
@@ -288,7 +288,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<T> History<T>(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null)
-            where T : BaseData
+            where T : IBaseData
         {
             var security = Securities[symbol];
             // verify the types match

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData, if null defaults to the .Value property (x => x.Value)</param>
         /// <param name="fieldName">The name of the field being selected</param>
         /// <returns>A new Identity indicator for the specified symbol and selector</returns>
-        public Identity Identity(Symbol symbol, Func<BaseData, decimal> selector = null, string fieldName = null)
+        public Identity Identity(Symbol symbol, Func<IBaseData, decimal> selector = null, string fieldName = null)
         {
             var resolution = GetSubscription(symbol).Resolution;
             return Identity(symbol, resolution, selector, fieldName);
@@ -47,7 +47,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData, if null defaults to the .Value property (x => x.Value)</param>
         /// <param name="fieldName">The name of the field being selected</param>
         /// <returns>A new Identity indicator for the specified symbol and selector</returns>
-        public Identity Identity(Symbol symbol, Resolution resolution, Func<BaseData, decimal> selector = null, string fieldName = null)
+        public Identity Identity(Symbol symbol, Resolution resolution, Func<IBaseData, decimal> selector = null, string fieldName = null)
         {
             string name = CreateIndicatorName(symbol, fieldName ?? "close", resolution);
             var identity = new Identity(name);
@@ -64,7 +64,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData, if null defaults to the .Value property (x => x.Value)</param>
         /// <param name="fieldName">The name of the field being selected</param>
         /// <returns>A new Identity indicator for the specified symbol and selector</returns>
-        public Identity Identity(Symbol symbol, TimeSpan resolution, Func<BaseData, decimal> selector = null, string fieldName = null)
+        public Identity Identity(Symbol symbol, TimeSpan resolution, Func<IBaseData, decimal> selector = null, string fieldName = null)
         {
             string name = string.Format("{0}({1}_{2})", symbol, fieldName ?? "close", resolution);
             var identity = new Identity(name);
@@ -103,7 +103,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>A new AverageTrueRange indicator with the specified smoothing type and period</returns>
-        public AverageTrueRange ATR(Symbol symbol, int period, MovingAverageType type = MovingAverageType.Simple, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public AverageTrueRange ATR(Symbol symbol, int period, MovingAverageType type = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             string name = CreateIndicatorName(symbol, "ATR" + period, resolution);
             var atr = new AverageTrueRange(name, period, type);
@@ -120,7 +120,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The ExponentialMovingAverage for the given parameters</returns>
-        public ExponentialMovingAverage EMA(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public ExponentialMovingAverage EMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "EMA" + period, resolution);
             var ema = new ExponentialMovingAverage(name, period);
@@ -137,7 +137,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The SimpleMovingAverage for the given parameters</returns>
-        public SimpleMovingAverage SMA(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public SimpleMovingAverage SMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "SMA" + period, resolution);
             var sma = new SimpleMovingAverage(name, period);
@@ -156,7 +156,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The moving average convergence divergence between the fast and slow averages</returns>
-        public MovingAverageConvergenceDivergence MACD(Symbol symbol, int fastPeriod, int slowPeriod, int signalPeriod, MovingAverageType type = MovingAverageType.Simple, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public MovingAverageConvergenceDivergence MACD(Symbol symbol, int fastPeriod, int slowPeriod, int signalPeriod, MovingAverageType type = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("MACD({0},{1})", fastPeriod, slowPeriod), resolution);
             var macd = new MovingAverageConvergenceDivergence(name, fastPeriod, slowPeriod, signalPeriod, type);
@@ -173,7 +173,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null and the symbol is of type TradeBar defaults to the High property, 
         /// otherwise it defaults to Value property of BaseData (x => x.Value)</param>
         /// <returns>A Maximum indicator that compute the max value and the periods since the max value</returns>
-        public Maximum MAX(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public Maximum MAX(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MAX" + period, resolution);
             var max = new Maximum(name, period);
@@ -202,7 +202,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null and the symbol is of type TradeBar defaults to the Low property, 
         /// otherwise it defaults to Value property of BaseData (x => x.Value)</param>
         /// <returns>A Minimum indicator that compute the in value and the periods since the min value</returns>
-        public Minimum MIN(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public Minimum MIN(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MIN" + period, resolution);
             var min = new Minimum(name, period);
@@ -230,7 +230,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>An AroonOscillator configured with the specied periods</returns>
-        public AroonOscillator AROON(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public AroonOscillator AROON(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             return AROON(symbol, period, period, resolution, selector);
         }
@@ -244,7 +244,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>An AroonOscillator configured with the specified periods</returns>
-        public AroonOscillator AROON(Symbol symbol, int upPeriod, int downPeriod, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public AroonOscillator AROON(Symbol symbol, int upPeriod, int downPeriod, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("AROON({0},{1})", upPeriod, downPeriod), resolution);
             var aroon = new AroonOscillator(name, upPeriod, downPeriod);
@@ -261,7 +261,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The momentum indicator for the requested symbol over the specified period</returns>
-        public Momentum MOM(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public Momentum MOM(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "MOM" + period, resolution);
             var momentum = new Momentum(name, period);
@@ -278,7 +278,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The momentum indicator for the requested symbol over the specified period</returns>
-        public MomentumPercent MOMP(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public MomentumPercent MOMP(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "MOMP" + period, resolution);
             var momentum = new MomentumPercent(name, period);
@@ -296,7 +296,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RelativeStrengthIndex indicator for the requested symbol over the specified period</returns>
-        public RelativeStrengthIndex RSI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public RelativeStrengthIndex RSI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "RSI" + period, resolution);
             var rsi = new RelativeStrengthIndex(name, period, movingAverageType);
@@ -314,7 +314,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The CommodityChannelIndex indicator for the requested symbol over the specified period</returns>
-        public CommodityChannelIndex CCI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public CommodityChannelIndex CCI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "CCI" + period, resolution);
             var cci = new CommodityChannelIndex(name, period, movingAverageType);
@@ -331,7 +331,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MoneyFlowIndex indicator for the requested symbol over the specified period</returns>
-        public MoneyFlowIndex MFI(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public MoneyFlowIndex MFI(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MFI" + period, resolution);
             var mfi = new MoneyFlowIndex(name, period);
@@ -347,7 +347,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The StandardDeviation indicator for the requested symbol over the speified period</returns>
-        public StandardDeviation STD(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public StandardDeviation STD(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "STD" + period, resolution);
             var std = new StandardDeviation(name, period);
@@ -365,7 +365,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>A BollingerBands configured with the specied period</returns>
-        public BollingerBands BB(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public BollingerBands BB(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("BB({0},{1})", period, k), resolution);
             var bb = new BollingerBands(name, period, k, movingAverageType);
@@ -382,7 +382,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RateOfChange indicator for the requested symbol over the specified period</returns>
-        public RateOfChange ROC(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public RateOfChange ROC(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "ROC" + period, resolution);
             var rateofchange = new RateOfChange(name, period);
@@ -399,7 +399,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RateOfChangePercent indicator for the requested symbol over the specified period</returns>
-        public RateOfChangePercent ROCP(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public RateOfChangePercent ROCP(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "ROCP" + period, resolution);
             var rateofchangepercent = new RateOfChangePercent(name, period);
@@ -417,7 +417,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The rateofchangepercent indicator for the requested symbol over the specified period</returns>
-        public WilliamsPercentR WILR(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public WilliamsPercentR WILR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             string name = CreateIndicatorName(symbol, "WILR" + period, resolution);
             var williamspercentr = new WilliamsPercentR(name, period);
@@ -434,7 +434,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns></returns>
-        public LinearWeightedMovingAverage LWMA(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public LinearWeightedMovingAverage LWMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "LWMA" + period, resolution);
             var lwma = new LinearWeightedMovingAverage(name, period);
@@ -451,7 +451,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The On Balance Volume indicator for the requested symbol.</returns>
-        public OnBalanceVolume OBV(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public OnBalanceVolume OBV(Symbol symbol, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "OBV", resolution);
             var onBalanceVolume = new OnBalanceVolume(name);
@@ -468,7 +468,7 @@ namespace QuantConnect.Algorithm
         /// <param name="period">The period over which to compute the Average Directional Index</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Average Directional Index indicator for the requested symbol.</returns>
-        public AverageDirectionalIndex ADX(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public AverageDirectionalIndex ADX(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "ADX", resolution);
             var averageDirectionalIndex = new AverageDirectionalIndex(name, period);
@@ -487,7 +487,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param> 
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Keltner Channel indicator for the requested symbol.</returns>
-        public KeltnerChannels KCH(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public KeltnerChannels KCH(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "KCH", resolution);
             var keltnerChannels = new KeltnerChannels(name, period, k, movingAverageType);
@@ -505,7 +505,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Donchian Channel indicator for the requested symbol.</returns>
-        public DonchianChannel DCH(Symbol symbol, int upperPeriod, int lowerPeriod, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public DonchianChannel DCH(Symbol symbol, int upperPeriod, int lowerPeriod, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "DCH", resolution);
             var donchianChannel = new DonchianChannel(name, upperPeriod, lowerPeriod);
@@ -522,7 +522,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Donchian Channel indicator for the requested symbol.</returns>
-        public DonchianChannel DCH(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public DonchianChannel DCH(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             return DCH(symbol, period, period, resolution, selector);
         }
@@ -564,7 +564,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar.</param>
         /// <returns>log return indicator for the requested symbol.</returns>
-        public LogReturn LOGR(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public LogReturn LOGR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "LOGR", resolution);
             var logr = new LogReturn(name, period);
@@ -580,7 +580,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar.</param>
         /// <returns>A LeastSquaredMovingAverage configured with the specified period</returns>
-        public LeastSquaresMovingAverage LSMA(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public LeastSquaresMovingAverage LSMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "LSMA" + period, resolution);
             var lsma = new LeastSquaresMovingAverage(name, period);
@@ -598,7 +598,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>A ParabolicStopAndReverse configured with the specified periods</returns>
-        public ParabolicStopAndReverse PSAR(Symbol symbol, decimal afStart = 0.02m, decimal afIncrement = 0.02m, decimal afMax = 0.2m, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public ParabolicStopAndReverse PSAR(Symbol symbol, decimal afStart = 0.02m, decimal afIncrement = 0.02m, decimal afMax = 0.2m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("PSAR({0},{1},{2})", afStart, afIncrement, afMax), resolution);
             var psar = new ParabolicStopAndReverse(name, afStart, afIncrement, afMax);
@@ -614,7 +614,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Balance Of Power indicator for the requested symbol.</returns>
-        public BalanceOfPower BOP(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public BalanceOfPower BOP(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "BOP", resolution);
             var bop = new BalanceOfPower(name);
@@ -630,7 +630,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Variance indicator for the requested symbol over the speified period</returns>
-        public Variance VAR(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public Variance VAR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "VAR" + period, resolution);
             var variance = new Variance(name, period);
@@ -645,7 +645,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AccumulationDistribution indicator for the requested symbol over the speified period</returns>
-        public AccumulationDistribution AD(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public AccumulationDistribution AD(Symbol symbol, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "AD", resolution);
             var ad = new AccumulationDistribution(name);
@@ -662,7 +662,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AccumulationDistributionOscillator indicator for the requested symbol over the speified period</returns>
-        public AccumulationDistributionOscillator ADOSC(Symbol symbol, int fastPeriod, int slowPeriod, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public AccumulationDistributionOscillator ADOSC(Symbol symbol, int fastPeriod, int slowPeriod, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ADOSC({0},{1})", fastPeriod, slowPeriod), resolution);
             var adOsc = new AccumulationDistributionOscillator(name, fastPeriod, slowPeriod);
@@ -677,7 +677,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The TrueRange indicator for the requested symbol.</returns>
-        public TrueRange TR(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public TrueRange TR(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TR", resolution);
             var tr = new TrueRange(name);
@@ -693,7 +693,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The ChandeMomentumOscillator indicator for the requested symbol over the specified period</returns>
-        public ChandeMomentumOscillator CMO(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public ChandeMomentumOscillator CMO(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "CMO" + period, resolution);
             var cmo = new ChandeMomentumOscillator(name, period);
@@ -709,7 +709,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The DoubleExponentialMovingAverage indicator for the requested symbol over the specified period</returns>
-        public DoubleExponentialMovingAverage DEMA(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public DoubleExponentialMovingAverage DEMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "DEMA" + period, resolution);
             var dema = new DoubleExponentialMovingAverage(name, period);
@@ -725,7 +725,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The TripleExponentialMovingAverage indicator for the requested symbol over the specified period</returns>
-        public TripleExponentialMovingAverage TEMA(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public TripleExponentialMovingAverage TEMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TEMA" + period, resolution);
             var tema = new TripleExponentialMovingAverage(name, period);
@@ -741,7 +741,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The TriangularMovingAverage indicator for the requested symbol over the specified period</returns>
-        public TriangularMovingAverage TRIMA(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public TriangularMovingAverage TRIMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TRIMA" + period, resolution);
             var trima = new TriangularMovingAverage(name, period);
@@ -757,7 +757,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RateOfChangeRatio indicator for the requested symbol over the specified period</returns>
-        public RateOfChangeRatio ROCR(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public RateOfChangeRatio ROCR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "ROCR" + period, resolution);
             var rocr = new RateOfChangeRatio(name, period);
@@ -773,7 +773,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MeanAbsoluteDeviation indicator for the requested symbol over the specified period</returns>
-        public MeanAbsoluteDeviation MAD(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public MeanAbsoluteDeviation MAD(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MAD" + period, resolution);
             var mad = new MeanAbsoluteDeviation(name, period);
@@ -790,7 +790,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Momersion indicator for the requested symbol over the specified period</returns>
-        public MomersionIndicator MOMERSION(Symbol symbol, int minPeriod, int fullPeriod, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public MomersionIndicator MOMERSION(Symbol symbol, int minPeriod, int fullPeriod, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("MOMERSION({0},{1})", minPeriod, fullPeriod), resolution);
             var momersion = new MomersionIndicator(name, minPeriod, fullPeriod);
@@ -806,7 +806,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Sum indicator for the requested symbol over the specified period</returns>
-        public Sum SUM(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public Sum SUM(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "SUM" + period, resolution);
             var sum = new Sum(name, period);
@@ -823,7 +823,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The T3MovingAverage indicator for the requested symbol over the specified period</returns>
-        public T3MovingAverage T3(Symbol symbol, int period, decimal volumeFactor = 0.7m, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public T3MovingAverage T3(Symbol symbol, int period, decimal volumeFactor = 0.7m, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("T3({0},{1})", period, volumeFactor), resolution);
             var t3 = new T3MovingAverage(name, period, volumeFactor);
@@ -839,7 +839,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The NormalizedAverageTrueRange indicator for the requested symbol over the specified period</returns>
-        public NormalizedAverageTrueRange NATR(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public NormalizedAverageTrueRange NATR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "NATR" + period, resolution);
             var natr = new NormalizedAverageTrueRange(name, period);
@@ -854,7 +854,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Heikin-Ashi indicator for the requested symbol over the specified period</returns>
-        public HeikinAshi HeikinAshi(Symbol symbol, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public HeikinAshi HeikinAshi(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "HA", resolution);
             var ha = new HeikinAshi(name);
@@ -870,7 +870,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AverageDirectionalMovementIndexRating indicator for the requested symbol over the specified period</returns>
-        public AverageDirectionalMovementIndexRating ADXR(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public AverageDirectionalMovementIndexRating ADXR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "ADXR" + period, resolution);
             var adxr = new AverageDirectionalMovementIndexRating(name, period);
@@ -886,7 +886,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The KaufmanAdaptiveMovingAverage indicator for the requested symbol over the specified period</returns>
-        public KaufmanAdaptiveMovingAverage KAMA(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public KaufmanAdaptiveMovingAverage KAMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "KAMA" + period, resolution);
             var kama = new KaufmanAdaptiveMovingAverage(name, period);
@@ -902,7 +902,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MidPoint indicator for the requested symbol over the specified period</returns>
-        public MidPoint MIDPOINT(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public MidPoint MIDPOINT(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MIDPOINT" + period, resolution);
             var midpoint = new MidPoint(name, period);
@@ -920,7 +920,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The UltimateOscillator indicator for the requested symbol over the specified period</returns>
-        public UltimateOscillator ULTOSC(Symbol symbol, int period1, int period2, int period3, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public UltimateOscillator ULTOSC(Symbol symbol, int period1, int period2, int period3, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ULTOSC({0},{1},{2})", period1, period2, period3), resolution);
             var ultosc = new UltimateOscillator(name, period1, period2, period3);
@@ -936,7 +936,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Trix indicator for the requested symbol over the specified period</returns>
-        public Trix TRIX(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public Trix TRIX(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TRIX" + period, resolution);
             var trix = new Trix(name, period);
@@ -952,7 +952,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MidPrice indicator for the requested symbol over the specified period</returns>
-        public MidPrice MIDPRICE(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public MidPrice MIDPRICE(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MIDPRICE" + period, resolution);
             var midprice = new MidPrice(name, period);
@@ -970,7 +970,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AbsolutePriceOscillator indicator for the requested symbol over the specified period</returns>
-        public AbsolutePriceOscillator APO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public AbsolutePriceOscillator APO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("APO({0},{1})", fastPeriod, slowPeriod), resolution);
             var apo = new AbsolutePriceOscillator(name, fastPeriod, slowPeriod, movingAverageType);
@@ -988,7 +988,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The PercentagePriceOscillator indicator for the requested symbol over the specified period</returns>
-        public PercentagePriceOscillator PPO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public PercentagePriceOscillator PPO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("PPO({0},{1})", fastPeriod, slowPeriod), resolution);
             var ppo = new PercentagePriceOscillator(name, fastPeriod, slowPeriod, movingAverageType);
@@ -1005,7 +1005,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The VolumeWeightedAveragePrice for the given parameters</returns>
-        public VolumeWeightedAveragePriceIndicator VWAP(Symbol symbol, int period, Resolution? resolution = null, Func<BaseData, TradeBar> selector = null)
+        public VolumeWeightedAveragePriceIndicator VWAP(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "VWAP" + period, resolution);
             var vwap = new VolumeWeightedAveragePriceIndicator(name, period);
@@ -1042,7 +1042,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">elects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The calculation using the given tool</returns>
-        public SwissArmyKnife SWISS(Symbol symbol, int period, double delta, SwissArmyKnifeTool tool, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public SwissArmyKnife SWISS(Symbol symbol, int period, double delta, SwissArmyKnifeTool tool, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "SWISS" + period, resolution);
             var swiss = new SwissArmyKnife(name, period, delta, tool);
@@ -1059,7 +1059,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>A Regression Channel configured with the specied period and number of standard deviation</returns>
-        public RegressionChannel RC(Symbol symbol, int period, decimal k, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public RegressionChannel RC(Symbol symbol, int period, decimal k, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("RC({0},{1})", period, k), resolution);
             var rc = new RegressionChannel(name, period, k);
@@ -1075,7 +1075,7 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="resolution">The resolution at which to send data to the indicator, null to use the same resolution as the subscription</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
-        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, Resolution? resolution = null, Func<BaseData, decimal> selector = null)
+        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution), selector ?? (x => x.Value));
         }
@@ -1088,7 +1088,7 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="resolution">The resolution at which to send data to the indicator, null to use the same resolution as the subscription</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
-        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, TimeSpan? resolution = null, Func<BaseData, decimal> selector = null)
+        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, TimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution), selector ?? (x => x.Value));
         }
@@ -1101,7 +1101,7 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="consolidator">The consolidator to receive raw subscription data</param>
         /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
-        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, IDataConsolidator consolidator, Func<BaseData, decimal> selector = null)
+        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, IDataConsolidator consolidator, Func<IBaseData, decimal> selector = null)
         {
             // default our selector to the Value property on BaseData
             selector = selector ?? (x => x.Value);
@@ -1125,7 +1125,7 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="resolution">The resolution at which to send data to the indicator, null to use the same resolution as the subscription</param>
         public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, Resolution? resolution = null)
-            where T : BaseData
+            where T : IBaseData
         {
             RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution));
         }
@@ -1138,8 +1138,8 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="resolution">The resolution at which to send data to the indicator, null to use the same resolution as the subscription</param>
         /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to a cast (x => (T)x)</param>
-        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, Resolution? resolution, Func<BaseData, T> selector)
-            where T : BaseData
+        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, Resolution? resolution, Func<IBaseData, T> selector)
+            where T : IBaseData
         {
             RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution), selector);
         }
@@ -1152,8 +1152,8 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="resolution">The resolution at which to send data to the indicator, null to use the same resolution as the subscription</param>
         /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to a cast (x => (T)x)</param>
-        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, TimeSpan? resolution, Func<BaseData, T> selector = null)
-            where T : BaseData
+        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, TimeSpan? resolution, Func<IBaseData, T> selector = null)
+            where T : IBaseData
         {
             RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution), selector);
         }
@@ -1166,8 +1166,8 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="consolidator">The consolidator to receive raw subscription data</param>
         /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to a cast (x => (T)x)</param>
-        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, IDataConsolidator consolidator, Func<BaseData, T> selector = null) 
-            where T : BaseData
+        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, IDataConsolidator consolidator, Func<IBaseData, T> selector = null) 
+            where T : IBaseData
         {
             // assign default using cast
             selector = selector ?? (x => (T) x);

--- a/Algorithm/QCAlgorithm.Plotting.cs
+++ b/Algorithm/QCAlgorithm.Plotting.cs
@@ -202,7 +202,7 @@ namespace QuantConnect.Algorithm
         /// <param name="indicators">The indicatorsto plot</param>
         /// <seealso cref="Plot(string,string,decimal)"/>
         public void Plot<T>(string chart, params IndicatorBase<T>[] indicators)
-            where T : BaseData
+            where T : IBaseData
         {
             foreach (var indicator in indicators)
             {
@@ -214,7 +214,7 @@ namespace QuantConnect.Algorithm
         /// Automatically plots each indicator when a new value is available
         /// </summary>
         public void PlotIndicator<T>(string chart, params IndicatorBase<T>[] indicators)
-            where T : BaseData
+            where T : IBaseData
         {
             foreach (var i in indicators)
             {
@@ -231,7 +231,7 @@ namespace QuantConnect.Algorithm
         /// Automatically plots each indicator when a new value is available, optionally waiting for indicator.IsReady to return true
         /// </summary>
         public void PlotIndicator<T>(string chart, bool waitForReady, params IndicatorBase<T>[] indicators)
-            where T : BaseData
+            where T : IBaseData
         {
             foreach (var i in indicators)
             {

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1363,7 +1363,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">Resolution of the data</param>
         /// <remarks>Generic type T must implement base data</remarks>
         public void AddData<T>(string symbol, Resolution resolution = Resolution.Minute)
-            where T : BaseData, new()
+            where T : IBaseData, new()
         {
             if (_locked) return;
 
@@ -1384,7 +1384,7 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">Custom leverage per security</param>
         /// <remarks>Generic type T must implement base data</remarks>
         public void AddData<T>(string symbol, Resolution resolution, bool fillDataForward, decimal leverage = 1.0m)
-            where T : BaseData, new()
+            where T : IBaseData, new()
         {
             if (_locked) return;
 
@@ -1401,7 +1401,7 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">Custom leverage per security</param>
         /// <remarks>Generic type T must implement base data</remarks>
         public void AddData<T>(string symbol, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
-            where T : BaseData, new()
+            where T : IBaseData, new()
         {
             if (_locked) return;
 

--- a/Common/Data/Consolidators/DataConsolidator.cs
+++ b/Common/Data/Consolidators/DataConsolidator.cs
@@ -24,20 +24,19 @@ namespace QuantConnect.Data.Consolidators
     /// </summary>
     /// <typeparam name="TInput">The type consumed by the consolidator</typeparam>
     public abstract class DataConsolidator<TInput> : IDataConsolidator
-        where TInput : class, IBaseData
+        where TInput : IBaseData
     {
         /// <summary>
         /// Updates this consolidator with the specified data
         /// </summary>
         /// <param name="data">The new data for the consolidator</param>
-        public void Update(BaseData data)
+        public void Update(IBaseData data)
         {
-            var typedData = data as TInput;
-            if (typedData == null)
+            if (!(data is TInput))
             {
-                throw new ArgumentNullException("data", "Received type of " + data.GetType().Name + " but expected " + typeof(TInput).Name);
+                throw new ArgumentNullException("data", "Received type of " + data.GetType().Name + " but expected " + typeof (TInput).Name);
             }
-            Update(typedData);
+            Update((TInput)data);
         }
 
         /// <summary>
@@ -55,7 +54,7 @@ namespace QuantConnect.Data.Consolidators
         /// Gets the most recently consolidated piece of data. This will be null if this consolidator
         /// has not produced any data yet.
         /// </summary>
-        public BaseData Consolidated
+        public IBaseData Consolidated
         {
             get; private set;
         }
@@ -63,7 +62,7 @@ namespace QuantConnect.Data.Consolidators
         /// <summary>
         /// Gets a clone of the data being currently consolidated
         /// </summary>
-        public abstract BaseData WorkingData
+        public abstract IBaseData WorkingData
         {
             get;
         }
@@ -96,7 +95,7 @@ namespace QuantConnect.Data.Consolidators
         /// by derived classes when they have consolidated a new piece of data.
         /// </summary>
         /// <param name="consolidated">The newly consolidated data</param>
-        protected virtual void OnDataConsolidated(BaseData consolidated)
+        protected virtual void OnDataConsolidated(IBaseData consolidated)
         {
             var handler = DataConsolidated;
             if (handler != null) handler(this, consolidated);

--- a/Common/Data/Consolidators/IDataConsolidator.cs
+++ b/Common/Data/Consolidators/IDataConsolidator.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Data.Consolidators
     /// </summary>
     /// <param name="sender">The consolidator that fired the event</param>
     /// <param name="consolidated">The consolidated piece of data</param>
-    public delegate void DataConsolidatedHandler(object sender, BaseData consolidated);
+    public delegate void DataConsolidatedHandler(object sender, IBaseData consolidated);
 
     /// <summary>
     /// Represents a type capable of taking BaseData updates and firing events containing new
@@ -36,12 +36,12 @@ namespace QuantConnect.Data.Consolidators
         /// Gets the most recently consolidated piece of data. This will be null if this consolidator
         /// has not produced any data yet.
         /// </summary>
-        BaseData Consolidated { get; }
+        IBaseData Consolidated { get; }
 
         /// <summary>
         /// Gets a clone of the data being currently consolidated
         /// </summary>
-        BaseData WorkingData { get; }
+        IBaseData WorkingData { get; }
 
         /// <summary>
         /// Gets the type consumed by this consolidator
@@ -57,7 +57,7 @@ namespace QuantConnect.Data.Consolidators
         /// Updates this consolidator with the specified data
         /// </summary>
         /// <param name="data">The new data for the consolidator</param>
-        void Update(BaseData data);
+        void Update(IBaseData data);
 
         /// <summary>
         /// Scans this consolidator to see if it should emit a bar due to time passing

--- a/Common/Data/Consolidators/IdentityDataConsolidator.cs
+++ b/Common/Data/Consolidators/IdentityDataConsolidator.cs
@@ -24,7 +24,7 @@ namespace QuantConnect.Data.Consolidators
     /// </summary>
     /// <typeparam name="T">The type of data</typeparam>
     public class IdentityDataConsolidator<T> : DataConsolidator<T>
-        where T : BaseData
+        where T : IBaseData
     {
         private static readonly bool IsTick = typeof (T) == typeof (Tick);
 
@@ -33,7 +33,7 @@ namespace QuantConnect.Data.Consolidators
         /// <summary>
         /// Gets a clone of the data being currently consolidated
         /// </summary>
-        public override BaseData WorkingData
+        public override IBaseData WorkingData
         {
             get { return _last == null ? null : _last.Clone(); }
         }

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Data.Consolidators
     /// <typeparam name="T">The input type of the consolidator</typeparam>
     /// <typeparam name="TConsolidated">The output type of the consolidator</typeparam>
     public abstract class PeriodCountConsolidatorBase<T, TConsolidated> : DataConsolidator<T>
-        where T : class, IBaseData
+        where T : IBaseData
         where TConsolidated : BaseData
     {
         //The minimum timespan between creating new bars.
@@ -80,7 +80,7 @@ namespace QuantConnect.Data.Consolidators
         /// <summary>
         /// Gets a clone of the data being currently consolidated
         /// </summary>
-        public override BaseData WorkingData
+        public override IBaseData WorkingData
         {
             get { return _workingBar != null ? _workingBar.Clone() : null; }
         }

--- a/Common/Data/Consolidators/SequentialConsolidator.cs
+++ b/Common/Data/Consolidators/SequentialConsolidator.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Data.Consolidators
         /// 
         /// For a SequentialConsolidator, this is the output from the 'Second' consolidator.
         /// </summary>
-        public BaseData Consolidated
+        public IBaseData Consolidated
         {
             get { return Second.Consolidated; }
         }
@@ -55,7 +55,7 @@ namespace QuantConnect.Data.Consolidators
         /// <summary>
         /// Gets a clone of the data being currently consolidated
         /// </summary>
-        public BaseData WorkingData
+        public IBaseData WorkingData
         {
             get { return Second.WorkingData; }
         }
@@ -80,7 +80,7 @@ namespace QuantConnect.Data.Consolidators
         /// Updates this consolidator with the specified data
         /// </summary>
         /// <param name="data">The new data for the consolidator</param>
-        public void Update(BaseData data)
+        public void Update(IBaseData data)
         {
             First.Update(data);
         }
@@ -127,7 +127,7 @@ namespace QuantConnect.Data.Consolidators
         /// by derived classes when they have consolidated a new piece of data.
         /// </summary>
         /// <param name="consolidated">The newly consolidated data</param>
-        protected virtual void OnDataConsolidated(BaseData consolidated)
+        protected virtual void OnDataConsolidated(IBaseData consolidated)
         {
             var handler = DataConsolidated;
             if (handler != null) handler(this, consolidated);

--- a/Common/Data/Consolidators/TradeBarConsolidatorBase.cs
+++ b/Common/Data/Consolidators/TradeBarConsolidatorBase.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Data.Consolidators
     /// </summary>
     /// <typeparam name="T">The input type into the consolidator's Update method</typeparam>
     public abstract class TradeBarConsolidatorBase<T> : PeriodCountConsolidatorBase<T, TradeBar>
-        where T : BaseData
+        where T : IBaseData
     {
         /// <summary>
         /// Creates a consolidator to produce a new 'TradeBar' representing the period

--- a/Common/Data/IBaseData.cs
+++ b/Common/Data/IBaseData.cs
@@ -39,6 +39,12 @@ namespace QuantConnect.Data
             get;
             set;
         }
+
+        DateTime EndTime
+        {
+            get;
+            set;
+        }
         
         
         /// <summary>

--- a/Common/Data/Market/IBaseDataBar.cs
+++ b/Common/Data/Market/IBaseDataBar.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  * 
@@ -13,28 +13,12 @@
  * limitations under the License.
 */
 
-using NUnit.Framework;
-using QuantConnect.Data.Market;
-using QuantConnect.Indicators;
-
-namespace QuantConnect.Tests.Indicators
+namespace QuantConnect.Data.Market
 {
-    [TestFixture]
-    public class MidPriceTests : CommonIndicatorTests<IBaseDataBar>
+    /// <summary>
+    /// Represents a type that is both a bar and base data
+    /// </summary>
+    public interface IBaseDataBar : IBaseData, IBar
     {
-        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
-        {
-            return new MidPrice(5);
-        }
-
-        protected override string TestFileName
-        {
-            get { return "spy_midprice.txt"; }
-        }
-
-        protected override string TestColumnName
-        {
-            get { return "MIDPRICE_5"; }
-        }
     }
 }

--- a/Common/Data/Market/QuoteBar.cs
+++ b/Common/Data/Market/QuoteBar.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Data.Market
     /// QuoteBar class for second and minute resolution data: 
     /// An OHLC implementation of the QuantConnect BaseData class with parameters for candles.
     /// </summary>
-    public class QuoteBar : BaseData, IBar
+    public class QuoteBar : BaseData, IBaseDataBar
     {
         // scale factor used in QC equity/forex data files
         private const decimal _scaleFactor = 1 / 10000m;

--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Data.Market
     /// TradeBar class for second and minute resolution data: 
     /// An OHLC implementation of the QuantConnect BaseData class with parameters for candles.
     /// </summary>
-    public class TradeBar : BaseData, IBar
+    public class TradeBar : BaseData, IBaseDataBar
     {
         // scale factor used in QC equity/forex data files
         private const decimal _scaleFactor = 1/10000m;

--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -224,7 +224,7 @@ namespace QuantConnect.Data
         /// <typeparam name="T">The type of data we want, for example, <see cref="TradeBar"/> or <see cref="Quandl"/>, ect...</typeparam>
         /// <returns>The <see cref="DataDictionary{T}"/> containing the data of the specified type</returns>
         public DataDictionary<T> Get<T>()
-            where T : BaseData
+            where T : IBaseData
         {
             Lazy<object> dictionary;
             if (!_dataByType.TryGetValue(typeof(T), out dictionary))

--- a/Common/Data/SliceExtensions.cs
+++ b/Common/Data/SliceExtensions.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Data
         /// <param name="symbol">The symbol to retrieve</param>
         /// <returns>An enumerable of T for the matching symbol, if no T is found for symbol, empty enumerable is returned</returns>
         public static IEnumerable<T> Get<T>(this IEnumerable<DataDictionary<T>> dataDictionaries, Symbol symbol)
-            where T : BaseData
+            where T : IBaseData
         {
             return dataDictionaries.Where(x => x.ContainsKey(symbol)).Select(x => x[symbol]);
         }
@@ -120,7 +120,7 @@ namespace QuantConnect.Data
         /// <param name="slices">The enumerable of slice</param>
         /// <returns>An enumerable of data dictionary of the requested type</returns>
         public static IEnumerable<DataDictionary<T>> Get<T>(this IEnumerable<Slice> slices)
-            where T : BaseData
+            where T : IBaseData
         {
             return slices.Select(x => x.Get<T>()).Where(x => x.Count > 0);
         }
@@ -133,7 +133,7 @@ namespace QuantConnect.Data
         /// <param name="symbol">The symbol to retrieve</param>
         /// <returns>An enumerable of T by accessing each slice for the requested symbol</returns>
         public static IEnumerable<T> Get<T>(this IEnumerable<Slice> slices, Symbol symbol)
-            where T : BaseData
+            where T : IBaseData
         {
             return slices.Select(x => x.Get<T>()).Where(x => x.ContainsKey(symbol)).Select(x => x[symbol]);
         }

--- a/Common/Field.cs
+++ b/Common/Field.cs
@@ -27,7 +27,7 @@ namespace QuantConnect
         /// <summary>
         /// Gets a selector that selects the Open value
         /// </summary>
-        public static Func<BaseData, decimal> Open
+        public static Func<IBaseData, decimal> Open
         {
             get { return TradeBarPropertyOrValue(x => x.Open); }
         }
@@ -35,7 +35,7 @@ namespace QuantConnect
         /// <summary>
         /// Gets a selector that selects the High value
         /// </summary>
-        public static Func<BaseData, decimal> High
+        public static Func<IBaseData, decimal> High
         {
             get { return TradeBarPropertyOrValue(x => x.High); }
         }
@@ -43,7 +43,7 @@ namespace QuantConnect
         /// <summary>
         /// Gets a selector that selects the Low value
         /// </summary>
-        public static Func<BaseData, decimal> Low
+        public static Func<IBaseData, decimal> Low
         {
             get { return TradeBarPropertyOrValue(x => x.Low); }
         }
@@ -51,7 +51,7 @@ namespace QuantConnect
         /// <summary>
         /// Gets a selector that selects the Close value
         /// </summary>
-        public static Func<BaseData, decimal> Close
+        public static Func<IBaseData, decimal> Close
         {
             get { return x => x.Value; }
         }
@@ -59,7 +59,7 @@ namespace QuantConnect
         /// <summary>
         /// Defines an average price that is equal to (O + H + L + C) / 4
         /// </summary>
-        public static Func<BaseData, decimal> Average
+        public static Func<IBaseData, decimal> Average
         {
             get { return TradeBarPropertyOrValue(x => (x.Open + x.High + x.Low + x.Close) / 4m); }
         }
@@ -67,7 +67,7 @@ namespace QuantConnect
         /// <summary>
         /// Defines an average price that is equal to (H + L) / 2
         /// </summary>
-        public static Func<BaseData, decimal> Median
+        public static Func<IBaseData, decimal> Median
         {
             get { return TradeBarPropertyOrValue(x => (x.High + x.Low) / 2m); }
         }
@@ -75,7 +75,7 @@ namespace QuantConnect
         /// <summary>
         /// Defines an average price that is equal to (H + L + C) / 3
         /// </summary>
-        public static Func<BaseData, decimal> Typical
+        public static Func<IBaseData, decimal> Typical
         {
             get { return TradeBarPropertyOrValue(x => (x.High + x.Low + x.Close) / 3m); }
         }
@@ -83,7 +83,7 @@ namespace QuantConnect
         /// <summary>
         /// Defines an average price that is equal to (H + L + 2*C) / 4
         /// </summary>
-        public static Func<BaseData, decimal> Weighted
+        public static Func<IBaseData, decimal> Weighted
         {
             get { return TradeBarPropertyOrValue(x => (x.High + x.Low + 2 * x.Close) / 4m); }
         }
@@ -91,7 +91,7 @@ namespace QuantConnect
         /// <summary>
         /// Defines an average price that is equal to (2*O + H + L + 3*C)/7
         /// </summary>
-        public static Func<BaseData, decimal> SevenBar
+        public static Func<IBaseData, decimal> SevenBar
         {
             get { return TradeBarPropertyOrValue(x => (2*x.Open + x.High + x.Low + 3*x.Close)/7m); }
         }
@@ -99,12 +99,12 @@ namespace QuantConnect
         /// <summary>
         /// Gets a selector that selectors the Volume value
         /// </summary>
-        public static Func<BaseData, decimal> Volume
+        public static Func<IBaseData, decimal> Volume
         {
             get { return TradeBarPropertyOrValue(x => x.Volume, x => 0m); }
         }
 
-        private static Func<BaseData, decimal> TradeBarPropertyOrValue(Func<TradeBar, decimal> selector, Func<BaseData, decimal> defaultSelector = null)
+        private static Func<IBaseData, decimal> TradeBarPropertyOrValue(Func<TradeBar, decimal> selector, Func<IBaseData, decimal> defaultSelector = null)
         {
             return x =>
             {

--- a/Common/Indicators/IIndicator.cs
+++ b/Common/Indicators/IIndicator.cs
@@ -24,7 +24,7 @@ namespace QuantConnect.Indicators
     /// </summary>
     /// <typeparam name="T">The indicators input data type for the <see cref="Update"/> method</typeparam>
     public interface IIndicator<T> : IComparable<IIndicator<T>>, IComparable
-        where T : BaseData
+        where T : IBaseData
     {
         /// <summary>
         /// Event handler that fires after this indicator is updated

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Commands\OrderCommand.cs" />
     <Compile Include="Commands\QuitCommand.cs" />
     <Compile Include="Commands\UpdateOrderCommand.cs" />
+    <Compile Include="Data\Market\IBaseDataBar.cs" />
     <Compile Include="Data\Market\RenkoType.cs" />
     <Compile Include="Data\Custom\DailyFx.cs" />
     <Compile Include="Data\Fundamental\FineFundamental.cs" />

--- a/Indicators/AroonOscillator.cs
+++ b/Indicators/AroonOscillator.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     /// is positive, and a negative trend bias is present when the oscillator is negative. AroonUp/Down
     /// values over 75 identify strong trends in their respective direction.
     /// </summary>
-    public class AroonOscillator : TradeBarIndicator
+    public class AroonOscillator : BarIndicator
     {
         /// <summary>
         /// Gets the AroonUp indicator
@@ -82,7 +82,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             AroonUp.Update(input.Time, input.High);
             AroonDown.Update(input.Time, input.Low);

--- a/Indicators/AverageDirectionalIndex.cs
+++ b/Indicators/AverageDirectionalIndex.cs
@@ -25,17 +25,17 @@ namespace QuantConnect.Indicators
     /// From these accumulated values we are therefore able to derived the 'Positive Directional Index' (+DI) and 'Negative Directional Index' (-DI)
     /// which is used to calculate the Average Directional Index.
     /// </summary>
-    public class AverageDirectionalIndex : IndicatorBase<TradeBar>
+    public class AverageDirectionalIndex : BarIndicator
     {
-        private TradeBar _previousInput;
+        private IBaseDataBar _previousInput;
 
         private readonly int _period;
 
-        private IndicatorBase<TradeBar> TrueRange { get; set; }
+        private IndicatorBase<IBaseDataBar> TrueRange { get; set; }
 
-        private IndicatorBase<TradeBar> DirectionalMovementPlus { get; set; }
+        private IndicatorBase<IBaseDataBar> DirectionalMovementPlus { get; set; }
 
-        private IndicatorBase<TradeBar> DirectionalMovementMinus { get; set; }
+        private IndicatorBase<IBaseDataBar> DirectionalMovementMinus { get; set; }
 
         private IndicatorBase<IndicatorDataPoint> SmoothedDirectionalMovementPlus { get; set; }
 
@@ -69,7 +69,7 @@ namespace QuantConnect.Indicators
         {
             _period = period;
 
-            TrueRange = new FunctionalIndicator<TradeBar>(name + "_TrueRange",
+            TrueRange = new FunctionalIndicator<IBaseDataBar>(name + "_TrueRange",
                 currentBar =>
                 {
                     var value = ComputeTrueRange(currentBar);
@@ -78,7 +78,7 @@ namespace QuantConnect.Indicators
                 isReady => _previousInput != null
                 );
 
-            DirectionalMovementPlus = new FunctionalIndicator<TradeBar>(name + "_PositiveDirectionalMovement",
+            DirectionalMovementPlus = new FunctionalIndicator<IBaseDataBar>(name + "_PositiveDirectionalMovement",
                 currentBar =>
                 {
                     var value = ComputePositiveDirectionalMovement(currentBar);
@@ -88,7 +88,7 @@ namespace QuantConnect.Indicators
                 );
 
 
-            DirectionalMovementMinus = new FunctionalIndicator<TradeBar>(name + "_NegativeDirectionalMovement",
+            DirectionalMovementMinus = new FunctionalIndicator<IBaseDataBar>(name + "_NegativeDirectionalMovement",
                 currentBar =>
                 {
                     var value = ComputeNegativeDirectionalMovement(currentBar);
@@ -210,7 +210,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input.</param>
         /// <returns></returns>
-        private decimal ComputeTrueRange(TradeBar input)
+        private decimal ComputeTrueRange(IBaseDataBar input)
         {
             var trueRange = new decimal(0.0);
 
@@ -226,7 +226,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input.</param>
         /// <returns></returns>
-        private decimal ComputePositiveDirectionalMovement(TradeBar input)
+        private decimal ComputePositiveDirectionalMovement(IBaseDataBar input)
         {
             var postiveDirectionalMovement = new decimal(0.0);
 
@@ -248,7 +248,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input.</param>
         /// <returns></returns>
-        private decimal ComputeNegativeDirectionalMovement(TradeBar input)
+        private decimal ComputeNegativeDirectionalMovement(IBaseDataBar input)
         {
             var negativeDirectionalMovement = new decimal(0.0);
 
@@ -270,7 +270,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             TrueRange.Update(input);
             DirectionalMovementPlus.Update(input);

--- a/Indicators/AverageDirectionalMovementIndexRating.cs
+++ b/Indicators/AverageDirectionalMovementIndexRating.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     /// The Average Directional Movement Index Rating is calculated with the following formula:
     /// ADXR[i] = (ADX[i] + ADX[i - period + 1]) / 2
     /// </summary>
-    public class AverageDirectionalMovementIndexRating : TradeBarIndicator
+    public class AverageDirectionalMovementIndexRating : BarIndicator
     {
         private readonly int _period;
         private readonly AverageDirectionalIndex _adx;
@@ -64,7 +64,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             _adx.Update(input);
             _adxHistory.Add(_adx);

--- a/Indicators/AverageTrueRange.cs
+++ b/Indicators/AverageTrueRange.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Indicators
     ///   ABS(High - PreviousClose)
     ///   ABS(Low  - PreviousClose)
     /// </summary>
-    public class AverageTrueRange : TradeBarIndicator
+    public class AverageTrueRange : BarIndicator
     {
         /// <summary>This indicator is used to smooth the TrueRange computation</summary>
         /// <remarks>This is not exposed publicly since it is the same value as this indicator, meaning
@@ -38,7 +38,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets the true range which is the more volatile calculation to be smoothed by this indicator
         /// </summary>
-        public IndicatorBase<TradeBar> TrueRange { get; private set; } 
+        public IndicatorBase<IBaseDataBar> TrueRange { get; private set; } 
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
@@ -59,8 +59,8 @@ namespace QuantConnect.Indicators
         {
             _smoother = movingAverageType.AsIndicator(string.Format("{0}_{1}", name, movingAverageType), period);
 
-            TradeBar previous = null;
-            TrueRange = new FunctionalIndicator<TradeBar>(name + "_TrueRange", currentBar =>
+            IBaseDataBar previous = null;
+            TrueRange = new FunctionalIndicator<IBaseDataBar>(name + "_TrueRange", currentBar =>
             {
                 // in our ComputeNextValue function we'll just call the ComputeTrueRange
                 var nextValue = ComputeTrueRange(previous, currentBar);
@@ -92,7 +92,7 @@ namespace QuantConnect.Indicators
         /// <param name="previous">The previous trade bar</param>
         /// <param name="current">The current trade bar</param>
         /// <returns>The true range</returns>
-        public static decimal ComputeTrueRange(TradeBar previous, TradeBar current)
+        public static decimal ComputeTrueRange(IBaseDataBar previous, IBaseDataBar current)
         {
             var range1 = current.High - current.Low;
             if (previous == null)
@@ -111,7 +111,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             // compute the true range and then send it to our smoother
             TrueRange.Update(input);

--- a/Indicators/BalanceOfPower.cs
+++ b/Indicators/BalanceOfPower.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Indicators
     /// The Balance Of Power is calculated with the following formula:
     /// BOP = (Close - Open) / (High - Low)
     /// </summary>
-    public class BalanceOfPower : TradeBarIndicator
+    public class BalanceOfPower : BarIndicator
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BalanceOfPower"/> class using the specified name.
@@ -46,7 +46,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             var range = input.High - input.Low;
             return range > 0 ? (input.Close - input.Open) / range : 0m;

--- a/Indicators/BarIndicator.cs
+++ b/Indicators/BarIndicator.cs
@@ -13,28 +13,24 @@
  * limitations under the License.
 */
 
-using NUnit.Framework;
 using QuantConnect.Data.Market;
-using QuantConnect.Indicators;
 
-namespace QuantConnect.Tests.Indicators
+namespace QuantConnect.Indicators
 {
-    [TestFixture]
-    public class MidPriceTests : CommonIndicatorTests<IBaseDataBar>
+    /// <summary>
+    /// The BarIndicator is an indicator that accepts IBaseDataBar data as its input.
+    /// 
+    /// This type is more of a shim/typedef to reduce the need to refer to things as IndicatorBase&lt;IBaseDataBar&gt;
+    /// </summary>
+    public abstract class BarIndicator : IndicatorBase<IBaseDataBar>
     {
-        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
+        /// <summary>
+        /// Creates a new TradeBarIndicator with the specified name
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        protected BarIndicator(string name)
+            : base(name)
         {
-            return new MidPrice(5);
-        }
-
-        protected override string TestFileName
-        {
-            get { return "spy_midprice.txt"; }
-        }
-
-        protected override string TestColumnName
-        {
-            get { return "MIDPRICE_5"; }
         }
     }
 }

--- a/Indicators/CandlestickPatterns/AbandonedBaby.cs
+++ b/Indicators/CandlestickPatterns/AbandonedBaby.cs
@@ -96,7 +96,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/AdvanceBlock.cs
+++ b/Indicators/CandlestickPatterns/AdvanceBlock.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/BeltHold.cs
+++ b/Indicators/CandlestickPatterns/BeltHold.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Breakaway.cs
+++ b/Indicators/CandlestickPatterns/Breakaway.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/CandlestickPattern.cs
+++ b/Indicators/CandlestickPatterns/CandlestickPattern.cs
@@ -21,7 +21,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
     /// <summary>
     /// Abstract base class for a candlestick pattern indicator
     /// </summary>
-    public abstract class CandlestickPattern : WindowIndicator<TradeBar>
+    public abstract class CandlestickPattern : WindowIndicator<IBaseDataBar>
     {
         /// <summary>
         /// Creates a new <see cref="CandlestickPattern"/> with the specified name
@@ -37,7 +37,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// Returns the candle color of a candle
         /// </summary>
         /// <param name="tradeBar">The input candle</param>
-        protected static CandleColor GetCandleColor(TradeBar tradeBar)
+        protected static CandleColor GetCandleColor(IBaseDataBar tradeBar)
         {
             return tradeBar.Close >= tradeBar.Open ? CandleColor.White : CandleColor.Black;
         }
@@ -46,7 +46,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// Returns the distance between the close and the open of a candle
         /// </summary>
         /// <param name="tradeBar">The input candle</param>
-        protected static decimal GetRealBody(TradeBar tradeBar)
+        protected static decimal GetRealBody(IBaseDataBar tradeBar)
         {
             return Math.Abs(tradeBar.Close - tradeBar.Open);
         }
@@ -55,7 +55,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// Returns the full range of the candle
         /// </summary>
         /// <param name="tradeBar">The input candle</param>
-        protected static decimal GetHighLowRange(TradeBar tradeBar)
+        protected static decimal GetHighLowRange(IBaseDataBar tradeBar)
         {
             return tradeBar.High - tradeBar.Low;
         }
@@ -65,7 +65,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// </summary>
         /// <param name="type">The type of setting to use</param>
         /// <param name="tradeBar">The input candle</param>
-        protected static decimal GetCandleRange(CandleSettingType type, TradeBar tradeBar)
+        protected static decimal GetCandleRange(CandleSettingType type, IBaseDataBar tradeBar)
         {
             switch (CandleSettings.Get(type).RangeType)
             {
@@ -86,7 +86,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <summary>
         /// Returns true if the candle is higher than the previous one
         /// </summary>
-        protected static bool GetCandleGapUp(TradeBar tradeBar, TradeBar previousBar)
+        protected static bool GetCandleGapUp(IBaseDataBar tradeBar, IBaseDataBar previousBar)
         {
             return tradeBar.Low > previousBar.High;
         }
@@ -94,7 +94,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <summary>
         /// Returns true if the candle is lower than the previous one
         /// </summary>
-        protected static bool GetCandleGapDown(TradeBar tradeBar, TradeBar previousBar)
+        protected static bool GetCandleGapDown(IBaseDataBar tradeBar, IBaseDataBar previousBar)
         {
             return tradeBar.High < previousBar.Low;
         }
@@ -102,7 +102,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <summary>
         /// Returns true if the candle is higher than the previous one (with no body overlap)
         /// </summary>
-        protected static bool GetRealBodyGapUp(TradeBar tradeBar, TradeBar previousBar)
+        protected static bool GetRealBodyGapUp(IBaseDataBar tradeBar, IBaseDataBar previousBar)
         {
             return Math.Min(tradeBar.Open, tradeBar.Close) > Math.Max(previousBar.Open, previousBar.Close);
         }
@@ -110,7 +110,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <summary>
         /// Returns true if the candle is lower than the previous one (with no body overlap)
         /// </summary>
-        protected static bool GetRealBodyGapDown(TradeBar tradeBar, TradeBar previousBar)
+        protected static bool GetRealBodyGapDown(IBaseDataBar tradeBar, IBaseDataBar previousBar)
         {
             return Math.Max(tradeBar.Open, tradeBar.Close) < Math.Min(previousBar.Open, previousBar.Close);
         }
@@ -119,7 +119,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// Returns the range of the candle's lower shadow
         /// </summary>
         /// <param name="tradeBar">The input candle</param>
-        protected static decimal GetLowerShadow(TradeBar tradeBar)
+        protected static decimal GetLowerShadow(IBaseDataBar tradeBar)
         {
             return (tradeBar.Close >= tradeBar.Open ? tradeBar.Open : tradeBar.Close) - tradeBar.Low;
         }
@@ -128,7 +128,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// Returns the range of the candle's upper shadow
         /// </summary>
         /// <param name="tradeBar">The input candle</param>
-        protected static decimal GetUpperShadow(TradeBar tradeBar)
+        protected static decimal GetUpperShadow(IBaseDataBar tradeBar)
         {
             return tradeBar.High - (tradeBar.Close >= tradeBar.Open ? tradeBar.Close : tradeBar.Open);
         }
@@ -139,7 +139,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="type">The type of setting to use</param>
         /// <param name="sum">The sum of the previous candles ranges</param>
         /// <param name="tradeBar">The input candle</param>
-        protected static decimal GetCandleAverage(CandleSettingType type, decimal sum, TradeBar tradeBar)
+        protected static decimal GetCandleAverage(CandleSettingType type, decimal sum, IBaseDataBar tradeBar)
         {
             var defaultSetting = CandleSettings.Get(type);
 

--- a/Indicators/CandlestickPatterns/ClosingMarubozu.cs
+++ b/Indicators/CandlestickPatterns/ClosingMarubozu.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/ConcealedBabySwallow.cs
+++ b/Indicators/CandlestickPatterns/ConcealedBabySwallow.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Counterattack.cs
+++ b/Indicators/CandlestickPatterns/Counterattack.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/DarkCloudCover.cs
+++ b/Indicators/CandlestickPatterns/DarkCloudCover.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Doji.cs
+++ b/Indicators/CandlestickPatterns/Doji.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/DojiStar.cs
+++ b/Indicators/CandlestickPatterns/DojiStar.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/DragonflyDoji.cs
+++ b/Indicators/CandlestickPatterns/DragonflyDoji.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Engulfing.cs
+++ b/Indicators/CandlestickPatterns/Engulfing.cs
@@ -62,7 +62,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/EveningDojiStar.cs
+++ b/Indicators/CandlestickPatterns/EveningDojiStar.cs
@@ -94,7 +94,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/EveningStar.cs
+++ b/Indicators/CandlestickPatterns/EveningStar.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/GapSideBySideWhite.cs
+++ b/Indicators/CandlestickPatterns/GapSideBySideWhite.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/GravestoneDoji.cs
+++ b/Indicators/CandlestickPatterns/GravestoneDoji.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Hammer.cs
+++ b/Indicators/CandlestickPatterns/Hammer.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/HangingMan.cs
+++ b/Indicators/CandlestickPatterns/HangingMan.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Harami.cs
+++ b/Indicators/CandlestickPatterns/Harami.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/HaramiCross.cs
+++ b/Indicators/CandlestickPatterns/HaramiCross.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/HighWaveCandle.cs
+++ b/Indicators/CandlestickPatterns/HighWaveCandle.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Hikkake.cs
+++ b/Indicators/CandlestickPatterns/Hikkake.cs
@@ -68,7 +68,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/HikkakeModified.cs
+++ b/Indicators/CandlestickPatterns/HikkakeModified.cs
@@ -78,7 +78,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/HomingPigeon.cs
+++ b/Indicators/CandlestickPatterns/HomingPigeon.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/IdenticalThreeCrows.cs
+++ b/Indicators/CandlestickPatterns/IdenticalThreeCrows.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/InNeck.cs
+++ b/Indicators/CandlestickPatterns/InNeck.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/InvertedHammer.cs
+++ b/Indicators/CandlestickPatterns/InvertedHammer.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Kicking.cs
+++ b/Indicators/CandlestickPatterns/Kicking.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/KickingByLength.cs
+++ b/Indicators/CandlestickPatterns/KickingByLength.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/LadderBottom.cs
+++ b/Indicators/CandlestickPatterns/LadderBottom.cs
@@ -68,7 +68,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/LongLeggedDoji.cs
+++ b/Indicators/CandlestickPatterns/LongLeggedDoji.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/LongLineCandle.cs
+++ b/Indicators/CandlestickPatterns/LongLineCandle.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Marubozu.cs
+++ b/Indicators/CandlestickPatterns/Marubozu.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/MatHold.cs
+++ b/Indicators/CandlestickPatterns/MatHold.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/MatchingLow.cs
+++ b/Indicators/CandlestickPatterns/MatchingLow.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/MorningDojiStar.cs
+++ b/Indicators/CandlestickPatterns/MorningDojiStar.cs
@@ -94,7 +94,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/MorningStar.cs
+++ b/Indicators/CandlestickPatterns/MorningStar.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/OnNeck.cs
+++ b/Indicators/CandlestickPatterns/OnNeck.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Piercing.cs
+++ b/Indicators/CandlestickPatterns/Piercing.cs
@@ -68,7 +68,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/RickshawMan.cs
+++ b/Indicators/CandlestickPatterns/RickshawMan.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/RiseFallThreeMethods.cs
+++ b/Indicators/CandlestickPatterns/RiseFallThreeMethods.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/SeparatingLines.cs
+++ b/Indicators/CandlestickPatterns/SeparatingLines.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/ShootingStar.cs
+++ b/Indicators/CandlestickPatterns/ShootingStar.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/ShortLineCandle.cs
+++ b/Indicators/CandlestickPatterns/ShortLineCandle.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/SpinningTop.cs
+++ b/Indicators/CandlestickPatterns/SpinningTop.cs
@@ -66,7 +66,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/StalledPattern.cs
+++ b/Indicators/CandlestickPatterns/StalledPattern.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/StickSandwich.cs
+++ b/Indicators/CandlestickPatterns/StickSandwich.cs
@@ -68,7 +68,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Takuri.cs
+++ b/Indicators/CandlestickPatterns/Takuri.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/TasukiGap.cs
+++ b/Indicators/CandlestickPatterns/TasukiGap.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/ThreeBlackCrows.cs
+++ b/Indicators/CandlestickPatterns/ThreeBlackCrows.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/ThreeInside.cs
+++ b/Indicators/CandlestickPatterns/ThreeInside.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/ThreeLineStrike.cs
+++ b/Indicators/CandlestickPatterns/ThreeLineStrike.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/ThreeOutside.cs
+++ b/Indicators/CandlestickPatterns/ThreeOutside.cs
@@ -63,7 +63,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/ThreeStarsInSouth.cs
+++ b/Indicators/CandlestickPatterns/ThreeStarsInSouth.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/ThreeWhiteSoldiers.cs
+++ b/Indicators/CandlestickPatterns/ThreeWhiteSoldiers.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Thrusting.cs
+++ b/Indicators/CandlestickPatterns/Thrusting.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/Tristar.cs
+++ b/Indicators/CandlestickPatterns/Tristar.cs
@@ -66,7 +66,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/TwoCrows.cs
+++ b/Indicators/CandlestickPatterns/TwoCrows.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/UniqueThreeRiver.cs
+++ b/Indicators/CandlestickPatterns/UniqueThreeRiver.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/UpDownGapThreeMethods.cs
+++ b/Indicators/CandlestickPatterns/UpDownGapThreeMethods.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CandlestickPatterns/UpsideGapTwoCrows.cs
+++ b/Indicators/CandlestickPatterns/UpsideGapTwoCrows.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<TradeBar> window, TradeBar input)
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IBaseDataBar> window, IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/CommodityChannelIndex.cs
+++ b/Indicators/CommodityChannelIndex.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Indicators
     ///     typical price. Second, take the absolute values of these numbers. Third,
     ///     sum the absolute values. Fourth, divide by the total number of periods (20).
     /// </summary>
-    public class CommodityChannelIndex : TradeBarIndicator
+    public class CommodityChannelIndex : BarIndicator
     {
         /// <summary>This constant is used to ensure that CCI values fall between +100 and -100, 70% to 80% of the time</summary>
         private const decimal _k = 0.015m;
@@ -86,7 +86,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             decimal typicalPrice = (input.High + input.Low + input.Close)/3.0m;
 

--- a/Indicators/ConstantIndicator.cs
+++ b/Indicators/ConstantIndicator.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     /// </summary>
     /// <typeparam name="T">The type of input this indicator takes</typeparam>
     public sealed class ConstantIndicator<T> : IndicatorBase<T>
-        where T : BaseData
+        where T : IBaseData
     {
         private readonly decimal _value;
 

--- a/Indicators/DonchianChannel.cs
+++ b/Indicators/DonchianChannel.cs
@@ -24,9 +24,9 @@ namespace QuantConnect.Indicators
     /// The primary output value of the indicator is the mean of the upper and lower band for 
     /// the given timeframe.
     /// </summary>
-    public class DonchianChannel : TradeBarIndicator
+    public class DonchianChannel : BarIndicator
     {
-        private TradeBar _previousInput;
+        private IBaseDataBar _previousInput;
         /// <summary>
         /// Gets the upper band of the Donchian Channel.
         /// </summary>
@@ -73,7 +73,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator, which by convention is the mean value of the upper band and lower band.</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             if (_previousInput != null)
             {

--- a/Indicators/FisherTransform.cs
+++ b/Indicators/FisherTransform.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Indicators
     /// http://www.mesasoftware.com/papers/UsingTheFisherTransform.pdf
     /// 
     /// </summary>
-    public class FisherTransform : TradeBarIndicator
+    public class FisherTransform : BarIndicator
     {
         private double _alpha;
         private double _previous;
@@ -86,7 +86,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">IndicatorDataPoint - the time and value of the next price</param>
         /// <returns></returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             var x = 0.0;
             var y = 0.0;

--- a/Indicators/FractalAdaptiveMovingAverage.cs
+++ b/Indicators/FractalAdaptiveMovingAverage.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     /// <summary>
     /// The Fractal Adaptive Moving Average (FRAMA) by John Ehlers
     /// </summary>
-    public class FractalAdaptiveMovingAverage : TradeBarIndicator
+    public class FractalAdaptiveMovingAverage : BarIndicator
     {
 
         double _filt;
@@ -67,7 +67,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The data for the calculation</param>
         /// <returns>The average value</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             var price = (double)(input.High + input.Low) / 2;
             _high.Add((double)input.High);

--- a/Indicators/FunctionalIndicator.cs
+++ b/Indicators/FunctionalIndicator.cs
@@ -24,7 +24,7 @@ namespace QuantConnect.Indicators
     /// </summary>
     /// <typeparam name="T">The input type for this indicator</typeparam>
     public class FunctionalIndicator<T> : IndicatorBase<T>
-        where T : BaseData
+        where T : IBaseData
     {
         /// <summary>function implementation of the IndicatorBase.IsReady property</summary>
         private readonly Func<IndicatorBase<T>, bool> _isReady;

--- a/Indicators/HeikinAshi.cs
+++ b/Indicators/HeikinAshi.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Indicators
     /// HA_High[0] = MAX(High[0], HA_Open[0], HA_Close[0])
     /// HA_Low[0] = MIN(Low[0], HA_Open[0], HA_Close[0])
     /// </summary>
-    public class HeikinAshi : TradeBarIndicator
+    public class HeikinAshi : BarIndicator
     {
         /// <summary>
         /// Gets the Heikin-Ashi Open
@@ -90,7 +90,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns> A new value for this indicator </returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/IchimokuKinkoHyo.cs
+++ b/Indicators/IchimokuKinkoHyo.cs
@@ -24,27 +24,27 @@ namespace QuantConnect.Indicators
     /// Senkou A Span: (Tenkan-sen + Kijun-sen )/ 2 from a specific number of periods ago (normally 26)
     /// Senkou B Span: (Highest High + Lowest Low) / 2 for the specific period (normally 52), from a specific number of periods ago (normally 26)
     /// </summary>
-    public class IchimokuKinkoHyo : TradeBarIndicator
+    public class IchimokuKinkoHyo : BarIndicator
     {
         /// <summary>
         /// The Tenkan-sen component of the Ichimoku indicator
         /// </summary>
-        public IndicatorBase<TradeBar> Tenkan { get; private set; }
+        public IndicatorBase<IBaseDataBar> Tenkan { get; private set; }
 
         /// <summary>
         /// The Kijun-sen component of the Ichimoku indicator
         /// </summary>
-        public IndicatorBase<TradeBar> Kijun { get; private set; }
+        public IndicatorBase<IBaseDataBar> Kijun { get; private set; }
 
         /// <summary>
         /// The Senkou A Span component of the Ichimoku indicator
         /// </summary>
-        public IndicatorBase<TradeBar> SenkouA { get; private set; }
+        public IndicatorBase<IBaseDataBar> SenkouA { get; private set; }
 
         /// <summary>
         /// The Senkou B Span component of the Ichimoku indicator
         /// </summary>
-        public IndicatorBase<TradeBar> SenkouB { get; private set; }
+        public IndicatorBase<IBaseDataBar> SenkouB { get; private set; }
 
         /// <summary>
         /// The Tenkan-sen Maximum component of the Ichimoku indicator
@@ -112,7 +112,7 @@ namespace QuantConnect.Indicators
             DelayedMinimumSenkouB = new Delay(name + "DelayedMin", senkouBDelayPeriod);
 
 
-            SenkouA = new FunctionalIndicator<TradeBar>(
+            SenkouA = new FunctionalIndicator<IBaseDataBar>(
                 name + "_SenkouA",
                 input => computeSenkouA(senkouAPeriod, input),
                 senkouA => DelayedTenkanSenkouA.IsReady && DelayedKijunSenkouA.IsReady,
@@ -122,7 +122,7 @@ namespace QuantConnect.Indicators
                     Kijun.Reset();
                 });
 
-            SenkouB = new FunctionalIndicator<TradeBar>(
+            SenkouB = new FunctionalIndicator<IBaseDataBar>(
                 name + "_SenkouB",
                 input => computeSenkouB(senkouBPeriod, input),
                 senkouA => DelayedMaximumSenkouB.IsReady && DelayedMinimumSenkouB.IsReady,
@@ -133,7 +133,7 @@ namespace QuantConnect.Indicators
                 });
 
 
-            Tenkan = new FunctionalIndicator<TradeBar>(
+            Tenkan = new FunctionalIndicator<IBaseDataBar>(
                 name + "_Tenkan",
                 input => ComputeTenkan(tenkanPeriod, input),
                 tenkan => TenkanMaximum.IsReady && TenkanMinimum.IsReady,
@@ -143,7 +143,7 @@ namespace QuantConnect.Indicators
                     TenkanMinimum.Reset();
                 });
 
-            Kijun = new FunctionalIndicator<TradeBar>(
+            Kijun = new FunctionalIndicator<IBaseDataBar>(
                 name + "_Kijun",
                 input => ComputeKijun(kijunPeriod, input),
                 kijun => KijunMaximum.IsReady && KijunMinimum.IsReady,
@@ -154,26 +154,26 @@ namespace QuantConnect.Indicators
                 });
         }
 
-        private decimal computeSenkouB(int period, TradeBar input)
+        private decimal computeSenkouB(int period, IBaseDataBar input)
         {
             var senkouB = DelayedMaximumSenkouB.Samples >= period ? (DelayedMaximumSenkouB + DelayedMinimumSenkouB) / 2 : new decimal(0.0);
             return senkouB;
         }
 
-        private decimal computeSenkouA(int period, TradeBar input)
+        private decimal computeSenkouA(int period, IBaseDataBar input)
         {
             var senkouA = DelayedKijunSenkouA.Samples >= period ? (DelayedTenkanSenkouA + DelayedKijunSenkouA) / 2 : new decimal(0.0);
             return senkouA;
         }
 
-        private decimal ComputeTenkan(int period, TradeBar input)
+        private decimal ComputeTenkan(int period, IBaseDataBar input)
         {
             var tenkan = TenkanMaximum.Samples >= period ? (TenkanMaximum.Current.Value + TenkanMinimum.Current.Value) / 2 : new decimal(0.0);
 
             return tenkan;
         }
 
-        private decimal ComputeKijun(int period, TradeBar input)
+        private decimal ComputeKijun(int period, IBaseDataBar input)
         {
             var kijun = KijunMaximum.Samples >= period ? (KijunMaximum + KijunMinimum) / 2 : new decimal(0.0);
             return kijun;
@@ -192,7 +192,7 @@ namespace QuantConnect.Indicators
         /// Computes the next value of this indicator from the given state
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
 
 

--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -25,7 +25,7 @@ namespace QuantConnect.Indicators
     /// <typeparam name="T">The type of data input into this indicator</typeparam>
     [DebuggerDisplay("{ToDetailedString()}")]
     public abstract partial class IndicatorBase<T> : IIndicator<T>
-        where T : BaseData
+        where T : IBaseData
     {
         /// <summary>the most recent input that was given to this indicator</summary>
         private T _previousInput;
@@ -103,7 +103,7 @@ namespace QuantConnect.Indicators
         public virtual void Reset()
         {
             Samples = 0;
-            _previousInput = null;
+            _previousInput = default(T);
             Current = new IndicatorDataPoint(DateTime.MinValue, default(decimal));
         }
 

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Indicators
         /// <param name="waitForFirstToReady">True to only send updates to the second if first.IsReady returns true, false to alway send updates to second</param>
         /// <returns>The reference to the second indicator to allow for method chaining</returns>
         public static TSecond Of<T, TSecond>(this TSecond second, IndicatorBase<T> first, bool waitForFirstToReady = true)
-            where T : BaseData
+            where T : IBaseData
             where TSecond : IndicatorBase<IndicatorDataPoint>
         {
             first.Updated += (sender, consolidated) =>
@@ -71,7 +71,7 @@ namespace QuantConnect.Indicators
         /// <param name="period">Average period</param>
         /// <returns>Indicator that results of the average of first by weights given by second</returns>
         public static CompositeIndicator<IndicatorDataPoint> WeightedBy<T, TWeight>(this IndicatorBase<T> value, TWeight weight, int period)
-            where T : BaseData
+            where T : IBaseData
             where TWeight : IndicatorBase<IndicatorDataPoint>
         {
             var x = new WindowIdentity(period);
@@ -285,7 +285,7 @@ namespace QuantConnect.Indicators
         /// <param name="waitForFirstToReady">True to only send updates to the second if left.IsReady returns true, false to alway send updates</param>
         /// <returns>A reference to the ExponentialMovingAverage indicator to allow for method chaining</returns>
         public static ExponentialMovingAverage EMA<T>(this IndicatorBase<T> left, int period, decimal? smoothingFactor = null, bool waitForFirstToReady = true)
-            where T : BaseData
+            where T : IBaseData
         {
             decimal k = smoothingFactor.HasValue ? k = smoothingFactor.Value : ExponentialMovingAverage.SmoothingFactorDefault(period);
             ExponentialMovingAverage emaOfLeft = new ExponentialMovingAverage(string.Format("EMA{0}_Of_{1}", period, left.Name), period, k).Of(left, waitForFirstToReady);
@@ -299,7 +299,7 @@ namespace QuantConnect.Indicators
         /// <param name="waitForFirstToReady">True to only send updates to the second if left.IsReady returns true, false to alway send updates</param>
         /// <returns>A reference to the Maximum indicator to allow for method chaining</returns>
         public static Maximum MAX<T>(this IndicatorBase<T> left, int period, bool waitForFirstToReady = true)
-            where T : BaseData
+            where T : IBaseData
         {
             Maximum maxOfLeft = new Maximum(string.Format("MAX{0}_Of_{1}", period, left.Name), period).Of(left, waitForFirstToReady);
             return maxOfLeft;
@@ -312,7 +312,7 @@ namespace QuantConnect.Indicators
         /// <param name="waitForFirstToReady">True to only send updates to the second if left.IsReady returns true, false to alway send updates</param>
         /// <returns>A reference to the Minimum indicator to allow for method chaining</returns>
         public static Minimum MIN<T>(this IndicatorBase<T> left, int period, bool waitForFirstToReady = true)
-            where T : BaseData
+            where T : IBaseData
         {
             Minimum minOfLeft = new Minimum(string.Format("MIN{0}_Of_{1}", period, left.Name), period).Of(left, waitForFirstToReady);
             return minOfLeft;
@@ -325,7 +325,7 @@ namespace QuantConnect.Indicators
         /// <param name="waitForFirstToReady">True to only send updates to the second if first.IsReady returns true, false to alway send updates to second</param>
         /// <returns>The reference to the SimpleMovingAverage indicator to allow for method chaining</returns>
         public static SimpleMovingAverage SMA<T>(this IndicatorBase<T> left, int period, bool waitForFirstToReady = true)
-            where T : BaseData
+            where T : IBaseData
         {
             SimpleMovingAverage smaOfLeft = new SimpleMovingAverage(string.Format("SMA{0}_Of_{1}", period, left.Name), period).Of(left, waitForFirstToReady);
             return smaOfLeft;

--- a/Indicators/KeltnerChannels.cs
+++ b/Indicators/KeltnerChannels.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Indicators
     /// This indicator creates a moving average (middle band) with an upper band and lower band
     /// fixed at k average true range multiples away from the middle band.  
     /// </summary>
-    public class KeltnerChannels : TradeBarIndicator
+    public class KeltnerChannels : BarIndicator
     {
         private readonly decimal _k;
 
@@ -37,7 +37,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets the upper band of the channel
         /// </summary>
-        public IndicatorBase<TradeBar> UpperBand
+        public IndicatorBase<IBaseDataBar> UpperBand
         {
             get; private set;
         }
@@ -45,7 +45,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets the lower band of the channel
         /// </summary>
-        public IndicatorBase<TradeBar> LowerBand
+        public IndicatorBase<IBaseDataBar> LowerBand
         {
             get; private set;
         }
@@ -53,7 +53,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets the average true range
         /// </summary>
-        public IndicatorBase<TradeBar> AverageTrueRange
+        public IndicatorBase<IBaseDataBar> AverageTrueRange
         {
             get; private set;
         }
@@ -87,14 +87,14 @@ namespace QuantConnect.Indicators
             MiddleBand = movingAverageType.AsIndicator(name + "_MiddleBand", period);
 
             //Compute Lower Band
-            LowerBand = new FunctionalIndicator<TradeBar>(name + "_LowerBand",
+            LowerBand = new FunctionalIndicator<IBaseDataBar>(name + "_LowerBand",
                 input => ComputeLowerBand(),
                 lowerBand => MiddleBand.IsReady,
                 () => MiddleBand.Reset()
                 );
 
             //Compute Upper Band
-            UpperBand = new FunctionalIndicator<TradeBar>(name + "_UpperBand",
+            UpperBand = new FunctionalIndicator<IBaseDataBar>(name + "_UpperBand",
                 input => ComputeUpperBand(),
                 upperBand => MiddleBand.IsReady,
                 () => MiddleBand.Reset()
@@ -126,7 +126,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The TradeBar to this indicator on this time step</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             AverageTrueRange.Update(input);
 

--- a/Indicators/MidPrice.cs
+++ b/Indicators/MidPrice.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Indicators
     /// The MidPrice is calculated using the following formula:
     /// MIDPRICE = (Highest High + Lowest Low) / 2
     /// </summary>
-    public class MidPrice : TradeBarIndicator
+    public class MidPrice : BarIndicator
     {
         private readonly decimal _period;
         private readonly Maximum _maximum;
@@ -63,7 +63,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             _maximum.Update(new IndicatorDataPoint { Value = input.High });
             _minimum.Update(new IndicatorDataPoint { Value = input.Low });

--- a/Indicators/NormalizedAverageTrueRange.cs
+++ b/Indicators/NormalizedAverageTrueRange.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Indicators
     /// The Normalized Average True Range is calculated with the following formula:
     /// NATR = (ATR(period) / Close) * 100
     /// </summary>
-    public class NormalizedAverageTrueRange : TradeBarIndicator
+    public class NormalizedAverageTrueRange : BarIndicator
     {
         private readonly int _period;
         private readonly TrueRange _tr;
@@ -64,7 +64,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             _tr.Update(input);
 

--- a/Indicators/ParabolicStopAndReverse.cs
+++ b/Indicators/ParabolicStopAndReverse.cs
@@ -22,10 +22,10 @@ namespace QuantConnect.Indicators
     /// Parabolic SAR Indicator 
     /// Based on TA-Lib implementation
     /// </summary>
-    public class ParabolicStopAndReverse : TradeBarIndicator
+    public class ParabolicStopAndReverse : BarIndicator
     {
         private bool _isLong;
-        private TradeBar _previousBar;
+        private IBaseDataBar _previousBar;
         private decimal _sar;
         private decimal _ep;
         private decimal _outputSar;
@@ -83,7 +83,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The trade bar input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             // On first iteration we can’t produce an SAR value so we save the current bar and return zero
             if (Samples == 1)
@@ -119,7 +119,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Initialize the indicator values 
         /// </summary>
-        private void Init(TradeBar currentBar)
+        private void Init(IBaseDataBar currentBar)
         {
             // init position
             _isLong = currentBar.Close >= _previousBar.Close;
@@ -141,7 +141,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Calculate indicator value when the position is long
         /// </summary>
-        private void HandleLongPosition(TradeBar currentBar)
+        private void HandleLongPosition(IBaseDataBar currentBar)
         {
             // Switch to short if the low penetrates the SAR value.
             if (currentBar.Low <= _sar)
@@ -203,7 +203,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Calculate indicator value when the position is short
         /// </summary>
-        private void HandleShortPosition(TradeBar currentBar)
+        private void HandleShortPosition(IBaseDataBar currentBar)
         {
             // Switch to long if the high penetrates the SAR value.
             if (currentBar.High >= _sar)

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -122,6 +122,7 @@
     <Compile Include="FractalAdaptiveMovingAverage.cs" />
     <Compile Include="RegressionChannel.cs" />
     <Compile Include="SwissArmyKnife.cs" />
+    <Compile Include="TradeBarIndicator.cs" />
     <Compile Include="VolumeWeightedAveragePriceIndicator.cs" />
     <Compile Include="FisherTransform.cs" />
     <Compile Include="HeikinAshi.cs" />
@@ -181,7 +182,7 @@
     <Compile Include="SimpleMovingAverage.cs" />
     <Compile Include="MovingAverageTypeExtensions.cs" />
     <Compile Include="Maximum.cs" />
-    <Compile Include="TradeBarIndicator.cs" />
+    <Compile Include="BarIndicator.cs" />
     <Compile Include="WindowIndicator.cs" />
     <Compile Include="StandardDeviation.cs" />
     <Compile Include="BollingerBands.cs" />

--- a/Indicators/Stochastics.cs
+++ b/Indicators/Stochastics.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     /// multiplied by 100. Once the Fast Stochastics %K is calculated the Slow Stochastic %K is calculated by the average/smoothed price of
     /// of the Fast %K with the given period. The Slow Stochastics %D is then derived from the Slow Stochastics %K with the given period.
     /// </summary>
-    public class Stochastic : TradeBarIndicator
+    public class Stochastic : BarIndicator
     {
         private readonly IndicatorBase<IndicatorDataPoint> _maximum;
         private readonly IndicatorBase<IndicatorDataPoint> _mininum;
@@ -33,17 +33,17 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets the value of the Fast Stochastics %K given Period.
         /// </summary>
-        public IndicatorBase<TradeBar> FastStoch { get; private set; }
+        public IndicatorBase<IBaseDataBar> FastStoch { get; private set; }
 
         /// <summary>
         /// Gets the value of the Slow Stochastics given Period K.
         /// </summary>
-        public IndicatorBase<TradeBar> StochK { get; private set; }
+        public IndicatorBase<IBaseDataBar> StochK { get; private set; }
 
         /// <summary>
         /// Gets the value of the Slow Stochastics given Period D.
         /// </summary>
-        public IndicatorBase<TradeBar> StochD { get; private set; }
+        public IndicatorBase<IBaseDataBar> StochD { get; private set; }
 
         /// <summary>
         /// Creates a new Stochastics Indicator from the specified periods.
@@ -60,19 +60,19 @@ namespace QuantConnect.Indicators
             _sumFastK = new Sum(name + "_SumFastK", kPeriod);
             _sumSlowK = new Sum(name + "_SumD", dPeriod);
 
-            FastStoch = new FunctionalIndicator<TradeBar>(name + "_FastStoch",
+            FastStoch = new FunctionalIndicator<IBaseDataBar>(name + "_FastStoch",
                 input => ComputeFastStoch(period, input),
                 fastStoch => _maximum.IsReady,
                 () => _maximum.Reset()
                 );
 
-            StochK = new FunctionalIndicator<TradeBar>(name + "_StochK",
+            StochK = new FunctionalIndicator<IBaseDataBar>(name + "_StochK",
                 input => ComputeStochK(period, kPeriod, input),
                 stochK => _maximum.IsReady,
                 () => _maximum.Reset()
                 );
 
-            StochD = new FunctionalIndicator<TradeBar>(name + "_StochD",
+            StochD = new FunctionalIndicator<IBaseDataBar>(name + "_StochD",
                 input => ComputeStochD(period, kPeriod, dPeriod),
                 stochD => _maximum.IsReady,
                 () => _maximum.Reset()
@@ -101,7 +101,7 @@ namespace QuantConnect.Indicators
         /// Computes the next value of this indicator from the given state
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             _maximum.Update(input.Time, input.High);
             _mininum.Update(input.Time, input.Low);
@@ -117,7 +117,7 @@ namespace QuantConnect.Indicators
         /// <param name="period">The period.</param>
         /// <param name="input">The input.</param>
         /// <returns>The Fast Stochastics %K value.</returns>
-        private decimal ComputeFastStoch(int period, TradeBar input)
+        private decimal ComputeFastStoch(int period, IBaseDataBar input)
         {
             var denominator = (_maximum - _mininum);
             var numerator = (input.Close - _mininum);
@@ -142,7 +142,7 @@ namespace QuantConnect.Indicators
         /// <param name="constantK">The constant k.</param>
         /// <param name="input">The input.</param>
         /// <returns>The Slow Stochastics %K value.</returns>
-        private decimal ComputeStochK(int period, int constantK, TradeBar input)
+        private decimal ComputeStochK(int period, int constantK, IBaseDataBar input)
         {
             var stochK = _maximum.Samples >= (period + constantK - 1) ? _sumFastK / constantK : new decimal(0.0);
             _sumSlowK.Update(input.Time, stochK);

--- a/Indicators/TrueRange.cs
+++ b/Indicators/TrueRange.cs
@@ -25,9 +25,9 @@ namespace QuantConnect.Indicators
     /// value2 = distance from yesterday's close to today's high.
     /// value3 = distance from yesterday's close to today's low.    
     /// </summary>
-    public class TrueRange : TradeBarIndicator
+    public class TrueRange : BarIndicator
     {
-        private TradeBar _previousInput;
+        private IBaseDataBar _previousInput;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TrueRange"/> class using the specified name.
@@ -51,7 +51,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             if (!IsReady)
             {

--- a/Indicators/UltimateOscillator.cs
+++ b/Indicators/UltimateOscillator.cs
@@ -23,10 +23,10 @@ namespace QuantConnect.Indicators
     /// The Ultimate Oscillator is calculated as explained here:
     /// http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:ultimate_oscillator
     /// </summary>
-    public class UltimateOscillator : TradeBarIndicator
+    public class UltimateOscillator : BarIndicator
     {
         private readonly int _period;
-        private TradeBar _previousInput;
+        private IBaseDataBar _previousInput;
         private readonly TrueRange _trueRange;
         private readonly Sum _sumBuyingPressure1;
         private readonly Sum _sumBuyingPressure2;
@@ -79,7 +79,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             _trueRange.Update(input);
 

--- a/Indicators/WilliamsPercentR.cs
+++ b/Indicators/WilliamsPercentR.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     /// The symbol is said to be oversold when the oscillator is below -80%,
     /// and overbought when the oscillator is above -20%. 
     /// </summary>
-    public class WilliamsPercentR : TradeBarIndicator
+    public class WilliamsPercentR : BarIndicator
     {
         /// <summary>
         /// Gets the Maximum indicator
@@ -79,7 +79,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             Minimum.Update(input.Time, input.Low);
             Maximum.Update(input.Time, input.High);

--- a/Indicators/WindowIndicator.cs
+++ b/Indicators/WindowIndicator.cs
@@ -21,7 +21,7 @@ namespace QuantConnect.Indicators
     ///     Represents an indicator that acts on a rolling window of data
     /// </summary>
     public abstract class WindowIndicator<T> : IndicatorBase<T>
-        where T : BaseData
+        where T : IBaseData
     {
         // a window of data over a certain look back period
         private readonly RollingWindow<T> _window;

--- a/Tests/Common/Data/SequentialConsolidatorTests.cs
+++ b/Tests/Common/Data/SequentialConsolidatorTests.cs
@@ -26,8 +26,8 @@ namespace QuantConnect.Tests.Common.Data
         [Test]
         public void SequentialConsolidatorsFiresAllEvents()
         {
-            var first = new IdentityDataConsolidator<BaseData>();
-            var second = new IdentityDataConsolidator<BaseData>();
+            var first = new IdentityDataConsolidator<IBaseData>();
+            var second = new IdentityDataConsolidator<IBaseData>();
             var sequential = new SequentialConsolidator(first, second);
 
             bool firstFired = false;
@@ -60,7 +60,7 @@ namespace QuantConnect.Tests.Common.Data
         public void SequentialConsolidatorAcceptsSubTypesForSecondInputType()
         {
             var first = new IdentityDataConsolidator<TradeBar>();
-            var second = new IdentityDataConsolidator<BaseData>();
+            var second = new IdentityDataConsolidator<IBaseData>();
             var sequential = new SequentialConsolidator(first, second);
 
 

--- a/Tests/Indicators/AverageDirectionalMovementIndexRatingTests.cs
+++ b/Tests/Indicators/AverageDirectionalMovementIndexRatingTests.cs
@@ -21,9 +21,9 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class AverageDirectionalMovementIndexRatingTests : CommonIndicatorTests<TradeBar>
+    public class AverageDirectionalMovementIndexRatingTests : CommonIndicatorTests<IBaseDataBar>
     {
-        protected override IndicatorBase<TradeBar> CreateIndicator()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
             return new AverageDirectionalMovementIndexRating(14);
         }
@@ -38,7 +38,7 @@ namespace QuantConnect.Tests.Indicators
             get { return "ADXR_14"; }
         }
 
-        protected override Action<IndicatorBase<TradeBar>, double> Assertion
+        protected override Action<IndicatorBase<IBaseDataBar>, double> Assertion
         {
             get { return (indicator, expected) => Assert.AreEqual(expected, (double)indicator.Current.Value, 1.0); }
         }

--- a/Tests/Indicators/BalanceOfPowerTests.cs
+++ b/Tests/Indicators/BalanceOfPowerTests.cs
@@ -20,9 +20,9 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class BalanceOfPowerTests : CommonIndicatorTests<TradeBar>
+    public class BalanceOfPowerTests : CommonIndicatorTests<IBaseDataBar>
     {
-        protected override IndicatorBase<TradeBar> CreateIndicator()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
             return new BalanceOfPower("BOP");
         }

--- a/Tests/Indicators/CandlestickPatterns/CandlestickPatternTests.cs
+++ b/Tests/Indicators/CandlestickPatterns/CandlestickPatternTests.cs
@@ -134,7 +134,7 @@ namespace QuantConnect.Tests.Indicators.CandlestickPatterns
         }
 
         [Test, TestCaseSource("PatternTestParameters")]
-        public void ComparesAgainstExternalData(IndicatorBase<TradeBar> indicator, string columnName, string testFileName)
+        public void ComparesAgainstExternalData(IndicatorBase<IBaseDataBar> indicator, string columnName, string testFileName)
         {
             TestHelper.TestIndicator(indicator, testFileName, columnName, Assertion);
         }
@@ -153,7 +153,7 @@ namespace QuantConnect.Tests.Indicators.CandlestickPatterns
             TestHelper.TestIndicatorReset(indicator, testFileName);
         }
 
-        private static Action<IndicatorBase<TradeBar>, double> Assertion
+        private static Action<IndicatorBase<IBaseDataBar>, double> Assertion
         {
             get
             {

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -22,7 +22,7 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     public abstract class CommonIndicatorTests<T> 
-        where T : BaseData, new()
+        where T : IBaseData
     {
         [Test]
         public virtual void ComparesAgainstExternalData()
@@ -46,6 +46,8 @@ namespace QuantConnect.Tests.Indicators
             var indicator = CreateIndicator();
             if (indicator is IndicatorBase<IndicatorDataPoint>)
                 TestHelper.TestIndicatorReset(indicator as IndicatorBase<IndicatorDataPoint>, TestFileName);
+            else if (indicator is IndicatorBase<IBaseDataBar>)
+                TestHelper.TestIndicatorReset(indicator as IndicatorBase<IBaseDataBar>, TestFileName);
             else if (indicator is IndicatorBase<TradeBar>)
                 TestHelper.TestIndicatorReset(indicator as IndicatorBase<TradeBar>, TestFileName);
             else
@@ -59,6 +61,8 @@ namespace QuantConnect.Tests.Indicators
         {
             if (indicator is IndicatorBase<IndicatorDataPoint>)
                 TestHelper.TestIndicator(indicator as IndicatorBase<IndicatorDataPoint>, TestFileName, TestColumnName, Assertion as Action<IndicatorBase<IndicatorDataPoint>, double>);
+            else if (indicator is IndicatorBase<IBaseDataBar>)
+                TestHelper.TestIndicator(indicator as IndicatorBase<IBaseDataBar>, TestFileName, TestColumnName, Assertion as Action<IndicatorBase<IBaseDataBar>, double>);
             else if (indicator is IndicatorBase<TradeBar>)
                 TestHelper.TestIndicator(indicator as IndicatorBase<TradeBar>, TestFileName, TestColumnName, Assertion as Action<IndicatorBase<TradeBar>, double>);
             else

--- a/Tests/Indicators/FractalAdaptiveMovingAverageTests.cs
+++ b/Tests/Indicators/FractalAdaptiveMovingAverageTests.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Tests.Indicators
             RunTestIndicator(indicator);
         }
 
-        private static void RunTestIndicator(TradeBarIndicator indicator)
+        private static void RunTestIndicator(BarIndicator indicator)
         {
             TestHelper.TestIndicator(indicator, "frama.txt", "Filt", (actual, expected) => {AssertResult(expected, actual.Current.Value);});
         }

--- a/Tests/Indicators/HeikinAshiTests.cs
+++ b/Tests/Indicators/HeikinAshiTests.cs
@@ -20,9 +20,9 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class HeikinAshiTests : CommonIndicatorTests<TradeBar>
+    public class HeikinAshiTests : CommonIndicatorTests<IBaseDataBar>
     {
-        protected override IndicatorBase<TradeBar> CreateIndicator()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
             return new HeikinAshi();
         }

--- a/Tests/Indicators/NormalizedAverageTrueRangeTests.cs
+++ b/Tests/Indicators/NormalizedAverageTrueRangeTests.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Tests.Indicators
             TestHelper.TestIndicatorReset(indicator, "spy_natr.txt");
         }
 
-        private static void RunTestIndicator(TradeBarIndicator indicator)
+        private static void RunTestIndicator(BarIndicator indicator)
         {
             TestHelper.TestIndicator(indicator, "spy_natr.txt", "NATR_5", (ind, expected) => Assert.AreEqual(expected, (double)ind.Current.Value, 1e-3));
         }

--- a/Tests/Indicators/TrueRangeTests.cs
+++ b/Tests/Indicators/TrueRangeTests.cs
@@ -20,9 +20,9 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class TrueRangeTests : CommonIndicatorTests<TradeBar>
+    public class TrueRangeTests : CommonIndicatorTests<IBaseDataBar>
     {
-        protected override IndicatorBase<TradeBar> CreateIndicator()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
             return new TrueRange("TR");
         }

--- a/Tests/Indicators/UltimateOscillatorTests.cs
+++ b/Tests/Indicators/UltimateOscillatorTests.cs
@@ -20,9 +20,9 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class UltimateOscillatorTests : CommonIndicatorTests<TradeBar>
+    public class UltimateOscillatorTests : CommonIndicatorTests<IBaseDataBar>
     {
-        protected override IndicatorBase<TradeBar> CreateIndicator()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
             return new UltimateOscillator(7, 14, 28);
         }

--- a/ToolBox/ConsolidatorDataProcessor.cs
+++ b/ToolBox/ConsolidatorDataProcessor.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.ToolBox
     {
         private DateTime _frontier;
         private readonly IDataProcessor _destination;
-        private readonly Func<BaseData, IDataConsolidator> _createConsolidator;
+        private readonly Func<IBaseData, IDataConsolidator> _createConsolidator;
         private readonly Dictionary<Symbol, IDataConsolidator> _consolidators;
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace QuantConnect.ToolBox
         /// </summary>
         /// <param name="destination">The receiver of the consolidated data</param>
         /// <param name="createConsolidator">Function used to create consolidators</param>
-        public ConsolidatorDataProcessor(IDataProcessor destination, Func<BaseData, IDataConsolidator> createConsolidator)
+        public ConsolidatorDataProcessor(IDataProcessor destination, Func<IBaseData, IDataConsolidator> createConsolidator)
         {
             _destination = destination;
             _createConsolidator = createConsolidator;
@@ -47,7 +47,7 @@ namespace QuantConnect.ToolBox
         /// Invoked for each piece of data from the source file
         /// </summary>
         /// <param name="data">The data to be processed</param>
-        public void Process(BaseData data)
+        public void Process(IBaseData data)
         {
             // grab the correct consolidator for this symbol
             IDataConsolidator consolidator;
@@ -81,7 +81,7 @@ namespace QuantConnect.ToolBox
         /// <summary>
         /// Handles the <see cref="IDataConsolidator.DataConsolidated"/> event
         /// </summary>
-        private void OnDataConsolidated(object sender, BaseData args)
+        private void OnDataConsolidated(object sender, IBaseData args)
         {
             _destination.Process(args);
 

--- a/ToolBox/CsvDataProcessor.cs
+++ b/ToolBox/CsvDataProcessor.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.ToolBox
         /// Invoked for each piece of data from the source file
         /// </summary>
         /// <param name="data">The data to be processed</param>
-        public void Process(BaseData data)
+        public void Process(IBaseData data)
         {
             Writer writer;
             if (!_writers.TryGetValue(data.Symbol, out writer))
@@ -87,7 +87,7 @@ namespace QuantConnect.ToolBox
         /// <summary>
         /// Creates the <see cref="TextWriter"/> that writes data to csv files
         /// </summary>
-        private Writer CreateTextWriter(BaseData data)
+        private Writer CreateTextWriter(IBaseData data)
         {
             var entry = LeanData.GenerateZipEntryName(data.Symbol, data.Time.Date, _resolution, _tickType);
             var relativePath = LeanData.GenerateRelativeZipFilePath(data.Symbol, data.Time.Date, _resolution, _tickType)

--- a/ToolBox/FilteredDataProcessor.cs
+++ b/ToolBox/FilteredDataProcessor.cs
@@ -24,7 +24,7 @@ namespace QuantConnect.ToolBox
     /// </summary>
     public class FilteredDataProcessor : IDataProcessor
     {
-        private readonly Func<BaseData, bool> _predicate;
+        private readonly Func<IBaseData, bool> _predicate;
         private readonly IDataProcessor _processor;
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace QuantConnect.ToolBox
         /// </summary>
         /// <param name="processor">The processor to filter data for</param>
         /// <param name="predicate">The filtering predicate to be applied</param>
-        public FilteredDataProcessor(IDataProcessor processor, Func<BaseData, bool> predicate)
+        public FilteredDataProcessor(IDataProcessor processor, Func<IBaseData, bool> predicate)
         {
             _predicate = predicate;
             _processor = processor;
@@ -42,7 +42,7 @@ namespace QuantConnect.ToolBox
         /// Invoked for each piece of data from the source file
         /// </summary>
         /// <param name="data">The data to be processed</param>
-        public void Process(BaseData data)
+        public void Process(IBaseData data)
         {
             if (_predicate(data))
             {

--- a/ToolBox/IDataProcessor.cs
+++ b/ToolBox/IDataProcessor.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.ToolBox
         /// Invoked for each piece of data from the source file
         /// </summary>
         /// <param name="data">The data to be processed</param>
-        void Process(BaseData data);
+        void Process(IBaseData data);
     }
 
     /// <summary>
@@ -42,7 +42,7 @@ namespace QuantConnect.ToolBox
         /// <summary>
         /// Creates a new data processor that will filter in input data before piping it into the specified processor
         /// </summary>
-        public static IDataProcessor FilteredBy(this IDataProcessor processor, Func<BaseData, bool> predicate)
+        public static IDataProcessor FilteredBy(this IDataProcessor processor, Func<IBaseData, bool> predicate)
         {
             return new FilteredDataProcessor(processor, predicate);
         }
@@ -97,7 +97,7 @@ namespace QuantConnect.ToolBox
             return secondRoot;
         }
 
-        private static IDataConsolidator CreateConsolidator(Resolution resolution, TickType tickType, BaseData data, bool sourceIsTick)
+        private static IDataConsolidator CreateConsolidator(Resolution resolution, TickType tickType, IBaseData data, bool sourceIsTick)
         {
             var securityType = data.Symbol.ID.SecurityType;
             switch (securityType)

--- a/ToolBox/PipeDataProcessor.cs
+++ b/ToolBox/PipeDataProcessor.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.ToolBox
         /// Invoked for each piece of data from the source file
         /// </summary>
         /// <param name="data">The data to be processed</param>
-        public void Process(BaseData data)
+        public void Process(IBaseData data)
         {
             foreach (var processor in _processors)
             {


### PR DESCRIPTION
Refactors existing consolidators, indicators, and helper methods to depend on
IBaseData instead of BaseData. These updates also defines an IBaseDataBar to
act as an abstraction point between TradeBar and QuoteBar.

Tried to think of a way of making this in smaller commits but it really is a
systemic change. Most of the changes involve changing `TradeBar` references
to the new `IBaseDataBar` (open to suggestions on naming). Some other
changes were to the indicator selectors, now `Func<IBaseData, decimal>` and
`Func<IBaseData, IBaseDataBar>`