### PR TITLE
Scanning consolidators

### DIFF
--- a/Algorithm.CSharp/MACDTrendAlgorithm.cs
+++ b/Algorithm.CSharp/MACDTrendAlgorithm.cs
@@ -33,10 +33,10 @@ namespace QuantConnect.Algorithm.Examples
         /// </summary>
         public override void Initialize()
         {
-            SetStartDate(2009, 01, 01);
+            SetStartDate(2004, 01, 01);
             SetEndDate(2015, 01, 01);
 
-            AddSecurity(SecurityType.Equity, Symbol);
+            AddSecurity(SecurityType.Equity, Symbol, Resolution.Daily);
 
             // define our daily macd(12,26) with a 9 day signal
             macd = MACD(Symbol, 9, 26, 9, MovingAverageType.Exponential, Resolution.Daily);

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1203,12 +1203,10 @@ namespace QuantConnect.Algorithm
         {
             var subscription = GetSubscription(symbol);
 
-            // if the resolution is null or if the requested resolution matches the subscription, return identity
-            if (!resolution.HasValue || subscription.Resolution == resolution.Value)
+            // if not specified, default to the subscription's resolution
+            if (!resolution.HasValue)
             {
-                // since there's a generic type parameter that we don't have access to, we'll just use the activator
-                var identityConsolidatorType = typeof(IdentityDataConsolidator<>).MakeGenericType(subscription.Type);
-                return (IDataConsolidator)Activator.CreateInstance(identityConsolidatorType);
+                resolution = subscription.Resolution;
             }
 
             var timeSpan = resolution.Value.ToTimeSpan();
@@ -1236,12 +1234,10 @@ namespace QuantConnect.Algorithm
         {
             var subscription = GetSubscription(symbol);
 
-            // if the time span is null or if the requested time span matches the subscription, return identity
-            if (!timeSpan.HasValue || subscription.Resolution.ToTimeSpan() == timeSpan.Value)
+            // if not specified, default to the subscription resolution
+            if (!timeSpan.HasValue)
             {
-                // since there's a generic type parameter that we don't have access to, we'll just use the activator
-                var identityConsolidatorType = typeof(IdentityDataConsolidator<>).MakeGenericType(subscription.Type);
-                return (IDataConsolidator)Activator.CreateInstance(identityConsolidatorType);
+                timeSpan = subscription.Resolution.ToTimeSpan();
             }
 
             // verify this consolidator will give reasonable results, if someone asks for second consolidation but we have minute

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -483,12 +483,16 @@ namespace QuantConnect.Lean.Engine
                     foreach (var update in timeSlice.ConsolidatorUpdateData)
                     {
                         var consolidators = update.Target.Consolidators;
-                        foreach (var dataPoint in update.Data)
+                        foreach (var consolidator in consolidators)
                         {
-                            foreach (var consolidator in consolidators)
+                            foreach (var dataPoint in update.Data)
                             {
                                 consolidator.Update(dataPoint);
                             }
+
+                            // scan for time after we've pumped all the data through for this consolidator
+                            var localTime = time.ConvertFromUtc(update.Target.ExchangeTimeZone);
+                            consolidator.Scan(localTime);
                         }
                     }
                 }

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -353,6 +353,29 @@ namespace QuantConnect.Tests
                 {"Total Fees", "$13.91"},
             };
 
+            var macdTrendAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "127"},
+                {"Average Win", "3.65%"},
+                {"Average Loss", "-2.38%"},
+                {"Compounding Annual Return", "2.295%"},
+                {"Drawdown", "31.900%"},
+                {"Expectancy", "0.209"},
+                {"Net Profit", "28.377%"},
+                {"Sharpe Ratio", "0.226"},
+                {"Loss Rate", "52%"},
+                {"Win Rate", "48%"},
+                {"Profit-Loss Ratio", "1.54"},
+                {"Alpha", "-0.006"},
+                {"Beta", "0.394"},
+                {"Annual Standard Deviation", "0.108"},
+                {"Annual Variance", "0.012"},
+                {"Information Ratio", "-0.392"},
+                {"Tracking Error", "0.135"},
+                {"Treynor Ratio", "0.062"},
+                {"Total Fees", "$604.31"},
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -370,6 +393,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("HistoryAlgorithm", historyAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("CoarseFundamentalTop5Algorithm", coarseFundamentalTop5AlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("CoarseFineFundamentalRegressionAlgorithm", coarseFineFundamentalRegressionAlgorithmStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("MACDTrendAlgorithm", macdTrendAlgorithmStatistics, Language.CSharp)
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION
Scan consolidators to emit based on time

Currently, most consolidators rely on receiving a piece of data after
the consolidation period before firing the consolidated event. This
introduces a lag in the results. We've mostly gotten around this  for
the most common case through usage of the IdentityConsolidator.

The issue arises when considering fill forward behavior and subscriptions
with different resolutions.

Consider a Minute subscription a Daily subscription. Default behavior will
fill forward that daily bar on every minute. If your indicator is based on
the IdentityConsolidator, then it will receive the same price update for
each minute the security trades that day.

By scanning the consolidators based on time, the consolidator is able to
determine that it is indeed time for it to emit a new consolidated bar.
This removes the need for the IdentityConsolidator while also fixing the
aforementioned bug.