### PR TITLE
Fix multi resolution consolidator bug

### DIFF
--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -150,7 +150,11 @@ namespace QuantConnect.Data.Consolidators
 
             if (aggregateBeforeFire)
             {
-                AggregateBar(ref _workingBar, data);
+                // prevent starting new bars on fill forward data
+                if (_workingBar != null || !data.IsFillForward)
+                {
+                    AggregateBar(ref _workingBar, data);
+                }
             }
 
             //Fire the event
@@ -178,7 +182,11 @@ namespace QuantConnect.Data.Consolidators
 
             if (!aggregateBeforeFire)
             {
-                AggregateBar(ref _workingBar, data);
+                // prevent starting new bars on fill forward data
+                if (_workingBar != null || !data.IsFillForward)
+                {
+                    AggregateBar(ref _workingBar, data);
+                }
             }
         }
 

--- a/Common/Data/IBaseData.cs
+++ b/Common/Data/IBaseData.cs
@@ -76,6 +76,14 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
+        /// True if this is a fill forward piece of data
+        /// </summary>
+        bool IsFillForward
+        {
+            get;
+        }
+
+        /// <summary>
         /// Reader Method :: using set of arguements we specify read out type. Enumerate
         /// until the end of the data stream or file. E.g. Read CSV file line by line and convert
         /// into data types.


### PR DESCRIPTION
#### The Symptom

There have been errors reported recently pertaining to forward only indicators,
specifically in scenarios with subscriptions of different resolutions and fill
forward activated. The error causes the algorithm to immediately stop.

#### Analysis
Consider an algorithm with two subscriptions, one `Resolution.Minute` and
one `Resolution.Second`. The data feed will fill forward the minute data onto
the second boundaries. The first problem arises on day change, when the first
pieces of `Resolution.Second` data are coming in. The data feed will dutifully
fill forward the previous minute bar (from yesterday) to today. The
`FillForwardEnumerator` will even time stamp it as `09:29:01/09:30:01`. The
data feed will then take this value, and perform an `ExchangeRoundDown`.
This is done to ensure that the bar provided to the algorithm is within the
market hours as defined by the subscription's settings. This will kick the bar's
time back to yesterday.

The second problem arises when a consolidator goes to consolidate this 'new'
data. The consolidator uses the time stamp on the data to create its new
working bar, but the time stamp is in the past, then immediately after, we go
to scan the consolidator and it immediately spits it back out since it's time has
already elapsed.

#### This Solution
The solution in this PR is to prevent the consolidator from creating new bars
off of fill forward data. This addresses the immediately symptom and fixes
the issue. It doesn't, however, address the larger (possibly philosophical)
question as to whether or not consolidators should process fill forward
data at all.

#### Another Solution
Don't send fill forward data into consolidators. I think this is just misleading
and in many cases just flat out incorrect. Consider the `TradeBarConsolidator`
aggregating volume from fill forward bars, oops! We could prevent fill forward
data from making its way to any consolidators by updating `TimeSlice.Create`
to not populate the consolidator update data with fill forward data. In hind
sight, this is also a simple fix.


### Next Steps?
What I have here is basically the solution I thought of and coded up first, but
I think the above warrants some discussion, and as of now, I'm leaning more
towards the *Another Solution* vs the *This Solution*
