### PR TITLE
Oanda v2 API

### DIFF
--- a/Brokerages/Oanda/OandaBrokerage.Rest.cs
+++ b/Brokerages/Oanda/OandaBrokerage.Rest.cs
@@ -246,7 +246,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// <param name="instruments">list of instruments to stream rates for</param>
         /// <param name="accountId">the account ID you want to stream on</param>
         /// <returns>the WebResponse object that can be used to retrieve the rates as they stream</returns>
-        public WebResponse StartRatesSession(List<Instrument> instruments, int accountId)
+        public WebResponse StartRatesSession(List<Instrument> instruments, string accountId)
         {
             var instrumentList = string.Join(",", instruments.Select(x => x.instrument));
 
@@ -278,7 +278,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// </summary>
         /// <param name="accountId">the account IDs you want to stream on</param>
         /// <returns>the WebResponse object that can be used to retrieve the events as they stream</returns>
-        public WebResponse StartEventsSession(List<int> accountId = null)
+        public WebResponse StartEventsSession(List<string> accountId = null)
         {
             var requestString = EndpointResolver.ResolveEndpoint(_environment, Server.StreamingEvents) + "events";
 
@@ -403,7 +403,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// </summary>
         /// <param name="accountId">positions will be retrieved for this account id</param>
         /// <returns>List of Position objects with the details for each position (or empty list iff no positions)</returns>
-        private List<Position> GetPositions(int accountId)
+        private List<Position> GetPositions(string accountId)
         {
             var requestString = EndpointResolver.ResolveEndpoint(_environment, Server.Account) + "accounts/" + accountId + "/positions";
             var positionResponse = MakeRequest<PositionsResponse>(requestString);

--- a/Brokerages/Oanda/OandaBrokerage.cs
+++ b/Brokerages/Oanda/OandaBrokerage.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Brokerages.Oanda
         private readonly ISecurityProvider _securityProvider;
         private readonly Environment _environment;
         private readonly string _accessToken;
-        private readonly int _accountId;
+        private readonly string _accountId;
 
         private EventsSession _eventsSession;
         private Dictionary<string, Instrument> _oandaInstruments; 
@@ -59,7 +59,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// <param name="environment">The Oanda environment (Trade or Practice)</param>
         /// <param name="accessToken">The Oanda access token (can be the user's personal access token or the access token obtained with OAuth by QC on behalf of the user)</param>
         /// <param name="accountId">The account identifier.</param>
-        public OandaBrokerage(IOrderProvider orderProvider, ISecurityProvider securityProvider, Environment environment, string accessToken, int accountId)
+        public OandaBrokerage(IOrderProvider orderProvider, ISecurityProvider securityProvider, Environment environment, string accessToken, string accountId)
             : base("Oanda Brokerage")
         {
             _orderProvider = orderProvider;

--- a/Brokerages/Oanda/OandaBrokerageFactory.cs
+++ b/Brokerages/Oanda/OandaBrokerageFactory.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Brokerages.Oanda
             // read values from the brokerage data
             var environment = Read<Environment>(job.BrokerageData, "oanda-environment", errors);
             var accessToken = Read<string>(job.BrokerageData, "oanda-access-token", errors);
-            var accountId = Read<int>(job.BrokerageData, "oanda-account-id", errors);
+            var accountId = Read<string>(job.BrokerageData, "oanda-account-id", errors);
 
             if (errors.Count != 0)
             {

--- a/Brokerages/Oanda/Session/EventsSession.cs
+++ b/Brokerages/Oanda/Session/EventsSession.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Brokerages.Oanda.Session
     {
         private readonly OandaBrokerage _brokerage;
 
-        public EventsSession(OandaBrokerage brokerage, int accountId)
+        public EventsSession(OandaBrokerage brokerage, string accountId)
             : base(accountId)
         {
             _brokerage = brokerage;
@@ -39,7 +39,7 @@ namespace QuantConnect.Brokerages.Oanda.Session
 
         protected override WebResponse GetSession()
         {
-            return _brokerage.StartEventsSession(new List<int> {_accountId});
+            return _brokerage.StartEventsSession(new List<string> {_accountId});
         }
     }
 #pragma warning restore 1591

--- a/Brokerages/Oanda/Session/RatesSession.cs
+++ b/Brokerages/Oanda/Session/RatesSession.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Brokerages.Oanda.Session
         private readonly OandaBrokerage _brokerage;
         private readonly List<Instrument> _instruments;
 
-        public RatesSession(OandaBrokerage brokerage, int accountId, List<Instrument> instruments)
+        public RatesSession(OandaBrokerage brokerage, string accountId, List<Instrument> instruments)
             : base(accountId)
         {
             _brokerage = brokerage;

--- a/Brokerages/Oanda/Session/StreamSession.cs
+++ b/Brokerages/Oanda/Session/StreamSession.cs
@@ -36,12 +36,12 @@ namespace QuantConnect.Brokerages.Oanda.Session
     {
         public delegate void DataHandler(T data);
 
-        protected readonly int _accountId;
+        protected readonly string _accountId;
         private WebResponse _response;
         private bool _shutdown;
         private Task _runningTask;
 
-        protected StreamSession(int accountId)
+        protected StreamSession(string accountId)
         {
             _accountId = accountId;
         }

--- a/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.Tests.Brokerages.Oanda
             {
                 var environment = Config.Get("oanda-environment").ConvertTo<Environment>();
                 var accessToken = Config.Get("oanda-access-token");
-                var accountId = Config.Get("oanda-account-id").ConvertTo<int>();
+                var accountId = Config.Get("oanda-account-id");
 
                 var brokerage = new OandaBrokerage(null, null, environment, accessToken, accountId);
         

--- a/Tests/Brokerages/Oanda/OandaBrokerageTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageTests.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Tests.Brokerages.Oanda
         {
             var environment = Config.Get("oanda-environment").ConvertTo<Environment>();
             var accessToken = Config.Get("oanda-access-token");
-            var accountId = Config.Get("oanda-account-id").ConvertTo<int>();
+            var accountId = Config.Get("oanda-account-id");
 
             return new OandaBrokerage(orderProvider, securityProvider, environment, accessToken, accountId);
         }

--- a/ToolBox/OandaDownloader/OandaDataDownloader.cs
+++ b/ToolBox/OandaDownloader/OandaDataDownloader.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.ToolBox.OandaDownloader
         /// <summary>
         /// Initializes a new instance of the <see cref="OandaDataDownloader"/> class
         /// </summary>
-        public OandaDataDownloader(string accessToken, int accountId)
+        public OandaDataDownloader(string accessToken, string accountId)
         {
             // Set Oanda account credentials
             _brokerage = new OandaBrokerage(null, null, Environment.Practice, accessToken, accountId);

--- a/ToolBox/OandaDownloader/Program.cs
+++ b/ToolBox/OandaDownloader/Program.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.ToolBox.OandaDownloader
                 // Load settings from config.json
                 var dataDirectory = Config.Get("data-directory", "../../../Data");
                 var accessToken = Config.Get("access-token", "73eba38ad5b44778f9a0c0fec1a66ed1-44f47f052c897b3e1e7f24196bbc071f");
-                var accountId = Convert.ToInt32(Config.Get("account-id", "621396"));
+                var accountId = Config.Get("account-id", "001-011-5838423-001");
 
                 // Create an instance of the downloader
                 const string market = Market.Oanda;


### PR DESCRIPTION
This request updates the Oanda Brokerage and Downloader code to support string type when passing in AccountID (as per documentation on http://developer.oanda.com/rest-live-v20/account-df/).

This request provides the ability to connect using the new v2 AccountID (“-“-delimited string with format “{siteID}-{divisionID}-{userID}-{accountNumber}”) and doesn't impact on passing of legacy "AccountNumber" only.