### PR TITLE
Fix time-based consolidator bug with fill-forward data

### DIFF
--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -129,13 +129,13 @@ namespace QuantConnect.Data.Consolidators
             if (!_lastEmit.HasValue)
             {
                 // initialize this value for period computations
-                _lastEmit = data.Time;
+                _lastEmit = IsTimeBased ? DateTime.MinValue : data.Time;
             }
 
             if (_period.HasValue)
             {
                 // we're in time span mode and initialized
-                if (_workingBar != null && data.Time - _workingBar.Time >= _period.Value)
+                if (_workingBar != null && data.Time - _workingBar.Time >= _period.Value && GetRoundedBarTime(data.Time) > _lastEmit)
                 {
                     fireDataConsolidated = true;
                 }
@@ -150,7 +150,10 @@ namespace QuantConnect.Data.Consolidators
 
             if (aggregateBeforeFire)
             {
-                AggregateBar(ref _workingBar, data);
+                if (data.Time >= _lastEmit)
+                {
+                    AggregateBar(ref _workingBar, data);
+                }
             }
 
             //Fire the event
@@ -172,13 +175,16 @@ namespace QuantConnect.Data.Consolidators
                 }
 
                 OnDataConsolidated(_workingBar);
-                _lastEmit = data.Time;
+                _lastEmit = IsTimeBased && _workingBar != null ? _workingBar.Time.Add(Period ?? TimeSpan.Zero) : data.Time;
                 _workingBar = null;
             }
 
             if (!aggregateBeforeFire)
             {
-                AggregateBar(ref _workingBar, data);
+                if (data.Time >= _lastEmit)
+                {
+                    AggregateBar(ref _workingBar, data);
+                }
             }
         }
 
@@ -192,12 +198,9 @@ namespace QuantConnect.Data.Consolidators
             {
                 if (_workingBar != null)
                 {
-                    var fireDataConsolidated = _period.Value == TimeSpan.Zero;
-                    if (!fireDataConsolidated && currentLocalTime - _workingBar.Time >= _period.Value)
-                    {
-                        fireDataConsolidated = true;
-                    }
-                    if (fireDataConsolidated)
+                    currentLocalTime = GetRoundedBarTime(currentLocalTime);
+
+                    if (_period.Value != TimeSpan.Zero && currentLocalTime - _workingBar.Time >= _period.Value && currentLocalTime > _lastEmit)
                     {
                         OnDataConsolidated(_workingBar);
                         _lastEmit = currentLocalTime;
@@ -205,6 +208,22 @@ namespace QuantConnect.Data.Consolidators
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns true if this consolidator is time-based, false otherwise
+        /// </summary>
+        protected bool IsTimeBased
+        {
+            get { return !_maxCount.HasValue; }
+        }
+
+        /// <summary>
+        /// Gets the time period for this consolidator
+        /// </summary>
+        protected TimeSpan? Period
+        {
+            get { return _period; }
         }
 
         /// <summary>

--- a/Common/Data/Consolidators/TradeBarConsolidator.cs
+++ b/Common/Data/Consolidators/TradeBarConsolidator.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.Data.Consolidators
                     Close = data.Close,
                     Volume = data.Volume,
                     DataType = MarketDataType.TradeBar,
-                    Period = data.Period
+                    Period = IsTimeBased && Period.HasValue ? (TimeSpan)Period : data.Period
                 };
             }
             else
@@ -94,7 +94,7 @@ namespace QuantConnect.Data.Consolidators
                 //Aggregate the working bar
                 workingBar.Close = data.Close;
                 workingBar.Volume += data.Volume;
-                workingBar.Period += data.Period;
+                if (!IsTimeBased) workingBar.Period += data.Period;
                 if (data.Low < workingBar.Low) workingBar.Low = data.Low;
                 if (data.High > workingBar.High) workingBar.High = data.High;
             }


### PR DESCRIPTION
This PR solves the consolidator bug reported in issue #642 and possibly some of the problems described in PR #636.

It also fixes a minor bug where the value of the period field in consolidated bars was updated incorrectly in `TradeBarConsolidator`.