### PR TITLE
Brokerage.Connect() called in FXCM and Oanda HistoryProvider.Initialize()

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
@@ -67,6 +67,7 @@ namespace QuantConnect.Brokerages.Fxcm
         /// <param name="statusUpdate">Function used to send status updates</param>
         public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
         {
+            Connect();
         }
 
         /// <summary>

--- a/Brokerages/Fxcm/FxcmBrokerageFactory.cs
+++ b/Brokerages/Fxcm/FxcmBrokerageFactory.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Brokerages.Fxcm
 
             var brokerage = new FxcmBrokerage(algorithm.Transactions, algorithm.Portfolio, server, terminal, userName, password, accountId);
             Composer.Instance.AddPart<IDataQueueHandler>(brokerage);
-
+            Composer.Instance.AddPart<IHistoryProvider>(brokerage);
             return brokerage;
         }
 

--- a/Brokerages/Oanda/OandaBrokerage.HistoryProvider.cs
+++ b/Brokerages/Oanda/OandaBrokerage.HistoryProvider.cs
@@ -52,6 +52,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// <param name="statusUpdate">Function used to send status updates</param>
         public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
         {
+            Connect();
         }
 
         /// <summary>

--- a/Brokerages/Oanda/OandaBrokerageFactory.cs
+++ b/Brokerages/Oanda/OandaBrokerageFactory.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Brokerages.Oanda
 
             var brokerage = new OandaBrokerage(algorithm.Transactions, algorithm.Portfolio, environment, accessToken, accountId);
             Composer.Instance.AddPart<IDataQueueHandler>(brokerage);
-
+            Composer.Instance.AddPart<IHistoryProvider>(brokerage);
             return brokerage;
         }
 

--- a/Brokerages/Tradier/TradierBrokerageFactory.cs
+++ b/Brokerages/Tradier/TradierBrokerageFactory.cs
@@ -176,7 +176,7 @@ namespace QuantConnect.Brokerages.Tradier
 
             //Add the brokerage to the composer to ensure its accessible to the live data feed.
             Composer.Instance.AddPart<IDataQueueHandler>(brokerage);
-
+            Composer.Instance.AddPart<IHistoryProvider>(brokerage);
             return brokerage;
         }
 

--- a/Common/Packets/AlgorithmNodePacket.cs
+++ b/Common/Packets/AlgorithmNodePacket.cs
@@ -132,6 +132,13 @@ namespace QuantConnect.Packets
         /// </summary>
         [JsonProperty(PropertyName = "aParameters")]
         public Dictionary<string, string> Parameters = new Dictionary<string, string>();
+
+        /// <summary>
+        /// String name of the HistoryProvider we're running with
+        /// </summary>
+        [JsonProperty(PropertyName = "sHistoryProvider")]
+        public string HistoryProvider = "";
+
     } // End Node Packet:
 
 } // End of Namespace:

--- a/Common/Packets/LiveNodePacket.cs
+++ b/Common/Packets/LiveNodePacket.cs
@@ -43,10 +43,10 @@ namespace QuantConnect.Packets
         public Dictionary<string, string> BrokerageData = new Dictionary<string, string>();
 
         /// <summary>
-        /// String name of the DataQuoueHandler we're running with
+        /// String name of the DataQueueHandler we're running with
         /// </summary>
-        [JsonProperty(PropertyName = "sDataQuoueHandler")]
-        public string DataQuoueHandler = "";
+        [JsonProperty(PropertyName = "sDataQueueHandler")]
+        public string DataQueueHandler = "";
 
         /// <summary>
         /// Default constructor for JSON of the Live Task Packet

--- a/Common/Packets/LiveNodePacket.cs
+++ b/Common/Packets/LiveNodePacket.cs
@@ -43,6 +43,12 @@ namespace QuantConnect.Packets
         public Dictionary<string, string> BrokerageData = new Dictionary<string, string>();
 
         /// <summary>
+        /// String name of the DataQuoueHandler we're running with
+        /// </summary>
+        [JsonProperty(PropertyName = "sDataQuoueHandler")]
+        public string DataQuoueHandler = "";
+
+        /// <summary>
         /// Default constructor for JSON of the Live Task Packet
         /// </summary>
         public LiveNodePacket() 

--- a/Common/Util/Composer.cs
+++ b/Common/Util/Composer.cs
@@ -185,6 +185,17 @@ namespace QuantConnect.Util
         }
 
         /// <summary>
+        /// Gets all exports of all types registered
+        /// </summary>
+        public IEnumerable<KeyValuePair<Type, IEnumerable>> EnumerateExportedValues()
+        {
+            lock (_exportedValuesLockObject)
+            {
+                return _exportedValues.AsEnumerable();
+            }
+        }
+
+        /// <summary>
         /// Clears the cache of exported values, causing new instances to be created.
         /// </summary>
         public void Reset()

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -366,7 +366,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>The loaded <see cref="IDataQueueHandler"/></returns>
         protected virtual IDataQueueHandler GetDataQueueHandler()
         {
-            return Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(Config.Get("data-queue-handler", "LiveDataQueue"));
+            return Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(_job.DataQuoueHandler);
         }
 
         /// <summary>

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -366,7 +366,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>The loaded <see cref="IDataQueueHandler"/></returns>
         protected virtual IDataQueueHandler GetDataQueueHandler()
         {
-            return Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(_job.DataQuoueHandler);
+            return Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(_job.DataQueueHandler);
         }
 
         /// <summary>

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -397,21 +397,7 @@ namespace QuantConnect.Lean.Engine
         
         private IHistoryProvider GetHistoryProvider(string historyProvider)
         {
-            // we first check if class has already been instantiated 
-            var match = Composer.Instance.EnumerateExportedValues()
-                .SelectMany(x => x.Value.Cast<object>().Where(o => o.GetType().MatchesTypeName(historyProvider)))
-                .OfType<IHistoryProvider>()
-                .DistinctBy(x => x.GetHashCode())
-                .ToList();
-
-            if (match.Any())
-            {
-                return match.First();
-            }
-            else
-            {
-                return Composer.Instance.GetExportedValueByTypeName<IHistoryProvider>(historyProvider);
-            }
+            return Composer.Instance.GetExportedValueByTypeName<IHistoryProvider>(historyProvider);
         }
         private static void SaveListOfTrades(IOrderProvider transactions, string csvFileName)
         {

--- a/Engine/LeanEngineAlgorithmHandlers.cs
+++ b/Engine/LeanEngineAlgorithmHandlers.cs
@@ -37,7 +37,6 @@ namespace QuantConnect.Lean.Engine
         private readonly IResultHandler _results;
         private readonly IRealTimeHandler _realTime;
         private readonly ITransactionHandler _transactions;
-        private readonly IHistoryProvider _historyProvider;
         private readonly ICommandQueueHandler _commandQueue;
         private readonly IMapFileProvider _mapFileProvider;
         private readonly IFactorFileProvider _factorFileProvider;
@@ -84,14 +83,6 @@ namespace QuantConnect.Lean.Engine
         }
 
         /// <summary>
-        /// Gets the history provider used to process historical data requests within the algorithm
-        /// </summary>
-        public IHistoryProvider HistoryProvider
-        {
-            get { return _historyProvider; }
-        }
-
-        /// <summary>
         /// Gets the command queue responsible for receiving external commands for the algorithm
         /// </summary>
         public ICommandQueueHandler CommandQueue
@@ -131,7 +122,6 @@ namespace QuantConnect.Lean.Engine
         /// <param name="dataFeed">The data feed handler used to pump data to the algorithm</param>
         /// <param name="transactions">The transaction handler used to process orders from the algorithm</param>
         /// <param name="realTime">The real time handler used to process real time events</param>
-        /// <param name="historyProvider">The history provider used to process historical data requests</param>
         /// <param name="commandQueue">The command queue handler used to receive external commands for the algorithm</param>
         /// <param name="mapFileProvider">The map file provider used to retrieve map files for the data feed</param>
         /// <param name="factorFileProvider">Map file provider used as a map file source for the data feed</param>
@@ -141,7 +131,6 @@ namespace QuantConnect.Lean.Engine
             IDataFeed dataFeed,
             ITransactionHandler transactions,
             IRealTimeHandler realTime,
-            IHistoryProvider historyProvider,
             ICommandQueueHandler commandQueue,
             IMapFileProvider mapFileProvider,
             IFactorFileProvider factorFileProvider,
@@ -168,10 +157,6 @@ namespace QuantConnect.Lean.Engine
             {
                 throw new ArgumentNullException("realTime");
             }
-            if (historyProvider == null)
-            {
-                throw new ArgumentNullException("realTime");
-            }
             if (commandQueue == null)
             {
                 throw new ArgumentNullException("commandQueue");
@@ -193,7 +178,6 @@ namespace QuantConnect.Lean.Engine
             _dataFeed = dataFeed;
             _transactions = transactions;
             _realTime = realTime;
-            _historyProvider = historyProvider;
             _commandQueue = commandQueue;
             _mapFileProvider = mapFileProvider;
             _factorFileProvider = factorFileProvider;
@@ -213,7 +197,6 @@ namespace QuantConnect.Lean.Engine
             var realTimeHandlerTypeName = Config.Get("real-time-handler", "BacktestingRealTimeHandler");
             var dataFeedHandlerTypeName = Config.Get("data-feed-handler", "FileSystemDataFeed");
             var resultHandlerTypeName = Config.Get("result-handler", "BacktestingResultHandler");
-            var historyProviderTypeName = Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider");
             var commandQueueHandlerTypeName = Config.Get("command-queue-handler", "EmptyCommandQueueHandler");
             var mapFileProviderTypeName = Config.Get("map-file-provider", "LocalDiskMapFileProvider");
             var factorFileProviderTypeName = Config.Get("factor-file-provider", "LocalDiskFactorFileProvider");
@@ -225,7 +208,6 @@ namespace QuantConnect.Lean.Engine
                 composer.GetExportedValueByTypeName<IDataFeed>(dataFeedHandlerTypeName),
                 composer.GetExportedValueByTypeName<ITransactionHandler>(transactionHandlerTypeName),
                 composer.GetExportedValueByTypeName<IRealTimeHandler>(realTimeHandlerTypeName),
-                composer.GetExportedValueByTypeName<IHistoryProvider>(historyProviderTypeName),
                 composer.GetExportedValueByTypeName<ICommandQueueHandler>(commandQueueHandlerTypeName),
                 composer.GetExportedValueByTypeName<IMapFileProvider>(mapFileProviderTypeName),
                 composer.GetExportedValueByTypeName<IFactorFileProvider>(factorFileProviderTypeName),

--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -105,7 +105,6 @@ namespace QuantConnect.Lean.Launcher
             Log.Trace("         RealTime:     " + leanEngineAlgorithmHandlers.RealTime.GetType().FullName);
             Log.Trace("         Results:      " + leanEngineAlgorithmHandlers.Results.GetType().FullName);
             Log.Trace("         Transactions: " + leanEngineAlgorithmHandlers.Transactions.GetType().FullName);
-            Log.Trace("         History:      " + leanEngineAlgorithmHandlers.HistoryProvider.GetType().FullName);
             Log.Trace("         Commands:     " + leanEngineAlgorithmHandlers.CommandQueue.GetType().FullName);
             if (job is LiveNodePacket) Log.Trace("         Brokerage:    " + ((LiveNodePacket)job).Brokerage);
 

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -33,6 +33,8 @@ namespace QuantConnect.Queues
         // The type name of the QuantConnect.Brokerages.Paper.PaperBrokerage
         private static readonly TextWriter Console = System.Console.Out;
         private const string PaperBrokerageTypeName = "PaperBrokerage";
+        private const string DefaultHistoryProvider = "SubscriptionDataReaderHistoryProvider";
+        private const string DefaultDataQuoueHandler = "LiveDataQueue";
         private bool _liveMode = Config.GetBool("live-mode");
         private static readonly string AccessToken = Config.Get("api-access-token");
         private static readonly int UserId = Config.GetInt("job-user-id", 0);
@@ -93,6 +95,8 @@ namespace QuantConnect.Queues
                     Type = PacketType.LiveNode,
                     Algorithm = File.ReadAllBytes(AlgorithmLocation),
                     Brokerage = Config.Get("live-mode-brokerage", PaperBrokerageTypeName),
+                    HistoryProvider = Config.Get("history-provider", DefaultHistoryProvider),
+                    DataQuoueHandler = Config.Get("data-queue-handler", DefaultDataQuoueHandler),
                     Channel = AccessToken,
                     UserId = UserId,
                     ProjectId = ProjectId,
@@ -123,6 +127,7 @@ namespace QuantConnect.Queues
             {
                 Type = PacketType.BacktestNode,
                 Algorithm = File.ReadAllBytes(AlgorithmLocation),
+                HistoryProvider = Config.Get("history-provider", DefaultHistoryProvider),
                 Channel = AccessToken,
                 UserId = UserId,
                 ProjectId = ProjectId,

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Queues
         private static readonly TextWriter Console = System.Console.Out;
         private const string PaperBrokerageTypeName = "PaperBrokerage";
         private const string DefaultHistoryProvider = "SubscriptionDataReaderHistoryProvider";
-        private const string DefaultDataQuoueHandler = "LiveDataQueue";
+        private const string DefaultDataQueueHandler = "LiveDataQueue";
         private bool _liveMode = Config.GetBool("live-mode");
         private static readonly string AccessToken = Config.Get("api-access-token");
         private static readonly int UserId = Config.GetInt("job-user-id", 0);
@@ -96,7 +96,7 @@ namespace QuantConnect.Queues
                     Algorithm = File.ReadAllBytes(AlgorithmLocation),
                     Brokerage = Config.Get("live-mode-brokerage", PaperBrokerageTypeName),
                     HistoryProvider = Config.Get("history-provider", DefaultHistoryProvider),
-                    DataQuoueHandler = Config.Get("data-queue-handler", DefaultDataQuoueHandler),
+                    DataQueueHandler = Config.Get("data-queue-handler", DefaultDataQueueHandler),
                     Channel = AccessToken,
                     UserId = UserId,
                     ProjectId = ProjectId,

--- a/Tests/Common/Util/ComposerTests.cs
+++ b/Tests/Common/Util/ComposerTests.cs
@@ -28,11 +28,12 @@ namespace QuantConnect.Tests.Common.Util
         public void ComposesTypes()
         {
             var instances = Composer.Instance.GetExportedValues<IExport>().ToList();
-            Assert.AreEqual(4, instances.Count);
+            Assert.AreEqual(5, instances.Count);
             Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof (Export1)));
             Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof (Export2)));
             Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof (Export3)));
             Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof (Export4)));
+            Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof(Export5)));
         }
 
         [Test]

--- a/Tests/Common/Util/ComposerTests.cs
+++ b/Tests/Common/Util/ComposerTests.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.ComponentModel.Composition;
 using System.Linq;
 using NUnit.Framework;
@@ -53,10 +54,30 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreNotEqual(export1, export2);
         }
 
+        [Test]
+        public void GetsMultipleInterfacesInstance()
+        {
+            var instance1 = Composer.Instance.Single<IOneMoreExport>(x => x.Export == 5);
+            Assert.IsNotNull(instance1);
+            Assert.IsInstanceOf(typeof(Export5), instance1);
+
+            var instance2 = Composer.Instance.Single<IExport>(x => x.Id == 5);
+            Assert.IsNotNull(instance2);
+            Assert.IsInstanceOf(typeof(Export5), instance2);
+
+            Assert.AreEqual(instance1, instance2);
+        }
+
         [InheritedExport(typeof(IExport))]
         interface IExport
         {
             int Id { get; }
+        }
+
+        [InheritedExport(typeof(IOneMoreExport))]
+        interface IOneMoreExport
+        {
+            decimal Export { get; }
         }
 
         class Export1 : IExport
@@ -74,6 +95,13 @@ namespace QuantConnect.Tests.Common.Util
         class Export4 : IExport
         {
             public int Id { get { return 4; } }
+        }
+
+        class Export5 : IExport, IOneMoreExport
+        {
+            public decimal Export { get { return 5; } }
+
+            public int Id { get { return 5; } }
         }
     }
 }


### PR DESCRIPTION
In the FXCM and Oanda history provider Initialize method, Brokerage.Connect() is called in order to ensure that the brokerage is connected before algorithm.Initialize() is run in BrokerageSetupHandler. 

This will help ensure that the security prices can be seeded correctly using the history provider before the algorithm runs.

Working off of PR #634. @quant1729 