### PR TITLE
Seed security from history provider

### DIFF
--- a/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
+++ b/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             // set our initializer to our custom type
             SetBrokerageModel(BrokerageName.TradierBrokerage);
-            SetSecurityInitializer(new CustomSecurityInitializer(BrokerageModel, DataNormalizationMode.Raw));
+            SetSecurityInitializer(new CustomSecurityInitializer(BrokerageModel, new FuncSecuritySeeder(GetSingleBarHistory), DataNormalizationMode.Raw));
 
             SetStartDate(2012, 01, 01);
             SetEndDate(2013, 01, 01);
@@ -63,8 +63,8 @@ namespace QuantConnect.Algorithm.CSharp
             /// </summary>
             /// <param name="brokerageModel">The brokerage model used to get fill/fee/slippage/settlement models</param>
             /// <param name="dataNormalizationMode">The desired data normalization mode</param>
-            public CustomSecurityInitializer(IBrokerageModel brokerageModel, DataNormalizationMode dataNormalizationMode)
-                : base(brokerageModel)
+            public CustomSecurityInitializer(IBrokerageModel brokerageModel, ISecuritySeeder securitySeeder, DataNormalizationMode dataNormalizationMode)
+                : base(brokerageModel, securitySeeder)
             {
                 _dataNormalizationMode = dataNormalizationMode;
             }

--- a/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
+++ b/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             // set our initializer to our custom type
             SetBrokerageModel(BrokerageName.TradierBrokerage);
-            SetSecurityInitializer(new CustomSecurityInitializer(BrokerageModel, new FuncSecuritySeeder(GetSingleBarHistory), DataNormalizationMode.Raw));
+            SetSecurityInitializer(new CustomSecurityInitializer(BrokerageModel, new FuncSecuritySeeder(GetLastKnownPrice), DataNormalizationMode.Raw));
 
             SetStartDate(2012, 01, 01);
             SetEndDate(2013, 01, 01);

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -406,6 +406,51 @@ namespace QuantConnect.Algorithm
             return History(requests, TimeZone).Memoize();
         }
 
+        /// <summary>
+        /// Get a single bar of history, useful seeded securities with the correct price
+        /// </summary>
+        /// <param name="security"><see cref="Security"/> object for which to retrieve historical data</param>
+        /// <returns>A single <see cref="BaseData"/> object</returns>
+        public BaseData GetSingleBarHistory(Security security)
+        {
+            var startTime = GetStartTimeAlgoTzForSecurity(security, 1, security.Resolution);
+            var endTime = Time.RoundDown(security.Resolution.ToTimeSpan());
+
+            var request = new HistoryRequest()
+            {
+                StartTimeUtc = startTime.ConvertToUtc(_localTimeKeeper.TimeZone),
+                EndTimeUtc = endTime.ConvertToUtc(_localTimeKeeper.TimeZone),
+                DataType = security.Resolution == Resolution.Tick ? typeof(Tick) : typeof(TradeBar),
+                Resolution = security.Resolution,
+                FillForwardResolution = security.Resolution,
+                Symbol = security.Symbol,
+                Market = security.Symbol.ID.Market,
+                ExchangeHours = security.Exchange.Hours
+            };
+
+            var history = History(new List<HistoryRequest> { request });
+
+            if (history.Any() && history.First().Values.Any())
+            {
+                return history.First().Values.First();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the start time required for the specified bar count for a security in terms of the algorithm's time zone
+        /// Used when the security has not yet been subscribed to
+        /// </summary>
+        private DateTime GetStartTimeAlgoTzForSecurity(Security security, int periods, Resolution? resolution = null)
+        {
+            var timeSpan = (resolution ?? security.Resolution).ToTimeSpan();
+            // make this a minimum of one second
+            timeSpan = timeSpan < QuantConnect.Time.OneSecond ? QuantConnect.Time.OneSecond : timeSpan;
+            var localStartTime = QuantConnect.Time.GetStartTimeForTradeBars(security.Exchange.Hours, UtcTime.ConvertFromUtc(security.Exchange.TimeZone), timeSpan, periods, security.IsExtendedMarketHours);
+            return localStartTime.ConvertTo(security.Exchange.TimeZone, TimeZone);
+        }
+
         private IEnumerable<Slice> History(IEnumerable<HistoryRequest> requests, DateTimeZone timeZone)
         {
             var sentMessage = false;

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -407,14 +407,15 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Get a single bar of history, useful seeded securities with the correct price
+        /// Get the last known price using the history provider.
+        /// Useful for seeding securities with the correct price
         /// </summary>
         /// <param name="security"><see cref="Security"/> object for which to retrieve historical data</param>
-        /// <returns>A single <see cref="BaseData"/> object</returns>
-        public BaseData GetSingleBarHistory(Security security)
+        /// <returns>A single <see cref="BaseData"/> object with the last known price</returns>
+        public BaseData GetLastKnownPrice(Security security)
         {
-            var startTime = GetStartTimeAlgoTzForSecurity(security, 1, security.Resolution);
-            var endTime = Time.RoundDown(security.Resolution.ToTimeSpan());
+            var startTime = GetStartTimeAlgoTzForSecurity(security, 1);
+            var endTime   = Time.RoundDown(security.Resolution.ToTimeSpan());
 
             var request = new HistoryRequest()
             {
@@ -442,11 +443,13 @@ namespace QuantConnect.Algorithm
         /// Gets the start time required for the specified bar count for a security in terms of the algorithm's time zone
         /// Used when the security has not yet been subscribed to
         /// </summary>
-        private DateTime GetStartTimeAlgoTzForSecurity(Security security, int periods, Resolution? resolution = null)
+        private DateTime GetStartTimeAlgoTzForSecurity(Security security, int periods)
         {
-            var timeSpan = (resolution ?? security.Resolution).ToTimeSpan();
+            var timeSpan = security.Resolution.ToTimeSpan();
+
             // make this a minimum of one second
             timeSpan = timeSpan < QuantConnect.Time.OneSecond ? QuantConnect.Time.OneSecond : timeSpan;
+
             var localStartTime = QuantConnect.Time.GetStartTimeForTradeBars(security.Exchange.Hours, UtcTime.ConvertFromUtc(security.Exchange.TimeZone), timeSpan, periods, security.IsExtendedMarketHours);
             return localStartTime.ConvertTo(security.Exchange.TimeZone, TimeZone);
         }

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Algorithm
             TradeBuilder = new TradeBuilder(FillGroupingMethod.FillToFill, FillMatchingMethod.FIFO);
 
             SecurityInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(AccountType.Margin),
-                                                                        new FuncSecuritySeeder(GetSingleBarHistory));
+                                                                        new FuncSecuritySeeder(GetLastKnownPrice));
 
             CandlestickPatterns = new CandlestickPatterns(this);
         }
@@ -836,7 +836,7 @@ namespace QuantConnect.Algorithm
             if (!_userSetSecurityInitializer)
             {
                 // purposefully use the direct setter vs Set method so we don't flip the switch :/
-                SecurityInitializer = new BrokerageModelSecurityInitializer(model, new FuncSecuritySeeder(GetSingleBarHistory));
+                SecurityInitializer = new BrokerageModelSecurityInitializer(model, new FuncSecuritySeeder(GetLastKnownPrice));
             }
         }
 

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -140,7 +140,8 @@ namespace QuantConnect.Algorithm
             // initialize the trade builder
             TradeBuilder = new TradeBuilder(FillGroupingMethod.FillToFill, FillMatchingMethod.FIFO);
 
-            SecurityInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(AccountType.Margin));
+            SecurityInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(AccountType.Margin),
+                                                                        new FuncSecuritySeeder(GetSingleBarHistory));
 
             CandlestickPatterns = new CandlestickPatterns(this);
         }
@@ -835,7 +836,7 @@ namespace QuantConnect.Algorithm
             if (!_userSetSecurityInitializer)
             {
                 // purposefully use the direct setter vs Set method so we don't flip the switch :/
-                SecurityInitializer = new BrokerageModelSecurityInitializer(model);
+                SecurityInitializer = new BrokerageModelSecurityInitializer(model, new FuncSecuritySeeder(GetSingleBarHistory));
             }
         }
 

--- a/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
@@ -67,6 +67,7 @@ namespace QuantConnect.Brokerages.Fxcm
         /// <param name="statusUpdate">Function used to send status updates</param>
         public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
         {
+            Connect();
         }
 
         /// <summary>

--- a/Brokerages/Fxcm/FxcmBrokerageFactory.cs
+++ b/Brokerages/Fxcm/FxcmBrokerageFactory.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Brokerages.Fxcm
 
             var brokerage = new FxcmBrokerage(algorithm.Transactions, algorithm.Portfolio, server, terminal, userName, password, accountId);
             Composer.Instance.AddPart<IDataQueueHandler>(brokerage);
-
+            Composer.Instance.AddPart<IHistoryProvider>(brokerage);
             return brokerage;
         }
 

--- a/Brokerages/Oanda/OandaBrokerage.HistoryProvider.cs
+++ b/Brokerages/Oanda/OandaBrokerage.HistoryProvider.cs
@@ -52,6 +52,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// <param name="statusUpdate">Function used to send status updates</param>
         public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
         {
+            Connect();
         }
 
         /// <summary>

--- a/Brokerages/Oanda/OandaBrokerageFactory.cs
+++ b/Brokerages/Oanda/OandaBrokerageFactory.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Brokerages.Oanda
 
             var brokerage = new OandaBrokerage(algorithm.Transactions, algorithm.Portfolio, environment, accessToken, accountId);
             Composer.Instance.AddPart<IDataQueueHandler>(brokerage);
-
+            Composer.Instance.AddPart<IHistoryProvider>(brokerage);
             return brokerage;
         }
 

--- a/Brokerages/Tradier/TradierBrokerageFactory.cs
+++ b/Brokerages/Tradier/TradierBrokerageFactory.cs
@@ -176,7 +176,7 @@ namespace QuantConnect.Brokerages.Tradier
 
             //Add the brokerage to the composer to ensure its accessible to the live data feed.
             Composer.Instance.AddPart<IDataQueueHandler>(brokerage);
-
+            Composer.Instance.AddPart<IHistoryProvider>(brokerage);
             return brokerage;
         }
 

--- a/Common/Packets/AlgorithmNodePacket.cs
+++ b/Common/Packets/AlgorithmNodePacket.cs
@@ -132,6 +132,13 @@ namespace QuantConnect.Packets
         /// </summary>
         [JsonProperty(PropertyName = "aParameters")]
         public Dictionary<string, string> Parameters = new Dictionary<string, string>();
+
+        /// <summary>
+        /// String name of the HistoryProvider we're running with
+        /// </summary>
+        [JsonProperty(PropertyName = "sHistoryProvider")]
+        public string HistoryProvider = "";
+
     } // End Node Packet:
 
 } // End of Namespace:

--- a/Common/Packets/LiveNodePacket.cs
+++ b/Common/Packets/LiveNodePacket.cs
@@ -43,10 +43,10 @@ namespace QuantConnect.Packets
         public Dictionary<string, string> BrokerageData = new Dictionary<string, string>();
 
         /// <summary>
-        /// String name of the DataQuoueHandler we're running with
+        /// String name of the DataQueueHandler we're running with
         /// </summary>
-        [JsonProperty(PropertyName = "sDataQuoueHandler")]
-        public string DataQuoueHandler = "";
+        [JsonProperty(PropertyName = "sDataQueueHandler")]
+        public string DataQueueHandler = "";
 
         /// <summary>
         /// Default constructor for JSON of the Live Task Packet

--- a/Common/Packets/LiveNodePacket.cs
+++ b/Common/Packets/LiveNodePacket.cs
@@ -43,6 +43,12 @@ namespace QuantConnect.Packets
         public Dictionary<string, string> BrokerageData = new Dictionary<string, string>();
 
         /// <summary>
+        /// String name of the DataQuoueHandler we're running with
+        /// </summary>
+        [JsonProperty(PropertyName = "sDataQuoueHandler")]
+        public string DataQuoueHandler = "";
+
+        /// <summary>
         /// Default constructor for JSON of the Live Task Packet
         /// </summary>
         public LiveNodePacket() 

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -314,6 +314,8 @@
     <Compile Include="Securities\ConstantFeeTransactionModel.cs" />
     <Compile Include="Securities\DelayedSettlementModel.cs" />
     <Compile Include="Securities\AdjustedPriceVariationModel.cs" />
+    <Compile Include="Securities\FuncSecuritySeeder.cs" />
+    <Compile Include="Securities\ISecuritySeeder.cs" />
     <Compile Include="Securities\NoMarginCallMarginModel.cs" />
     <Compile Include="Securities\SecurityPriceVariationModel.cs" />
     <Compile Include="Securities\FuncSecurityDerivativeFilter.cs" />

--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -15,6 +15,7 @@
 */
 
 using QuantConnect.Brokerages;
+using QuantConnect.Data;
 
 namespace QuantConnect.Securities
 {
@@ -26,15 +27,17 @@ namespace QuantConnect.Securities
     public class BrokerageModelSecurityInitializer : ISecurityInitializer
     {
         private readonly IBrokerageModel _brokerageModel;
+        private readonly ISecuritySeeder _securitySeeder;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BrokerageModelSecurityInitializer"/> class
         /// for the specified algorithm
         /// </summary>
         /// <param name="brokerageModel">The brokerage model used to initialize the security models</param>
-        public BrokerageModelSecurityInitializer(IBrokerageModel brokerageModel)
+        public BrokerageModelSecurityInitializer(IBrokerageModel brokerageModel, ISecuritySeeder securitySeeder)
         {
             _brokerageModel = brokerageModel;
+            _securitySeeder = securitySeeder;
         }
 
         /// <summary>
@@ -49,6 +52,12 @@ namespace QuantConnect.Securities
             security.FeeModel = _brokerageModel.GetFeeModel(security);
             security.SlippageModel = _brokerageModel.GetSlippageModel(security);
             security.SettlementModel = _brokerageModel.GetSettlementModel(security, _brokerageModel.AccountType);
+
+            BaseData seedData = _securitySeeder.GetLastData(security);
+            if (seedData != null)
+            {
+                security.SetMarketPrice(seedData);
+            }
         }
     }
 }

--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -34,6 +34,7 @@ namespace QuantConnect.Securities
         /// for the specified algorithm
         /// </summary>
         /// <param name="brokerageModel">The brokerage model used to initialize the security models</param>
+        /// <param name="securitySeeder">An <see cref="ISecuritySeeder"/> used to seed the initial price of the security</param>
         public BrokerageModelSecurityInitializer(IBrokerageModel brokerageModel, ISecuritySeeder securitySeeder)
         {
             _brokerageModel = brokerageModel;
@@ -53,7 +54,7 @@ namespace QuantConnect.Securities
             security.SlippageModel = _brokerageModel.GetSlippageModel(security);
             security.SettlementModel = _brokerageModel.GetSettlementModel(security, _brokerageModel.AccountType);
 
-            BaseData seedData = _securitySeeder.GetLastData(security);
+            BaseData seedData = _securitySeeder.GetSeedData(security);
             if (seedData != null)
             {
                 security.SetMarketPrice(seedData);

--- a/Common/Securities/FuncSecuritySeeder.cs
+++ b/Common/Securities/FuncSecuritySeeder.cs
@@ -4,27 +4,37 @@ using QuantConnect.Logging;
 
 namespace QuantConnect.Securities
 {
+    /// <summary>
+    /// Seed a security price from a history function
+    /// </summary>
     public class FuncSecuritySeeder : ISecuritySeeder
     {
-        private Func<Security, BaseData> _historySeeder;
+        private readonly Func<Security, BaseData> _seedFunction;
 
-        public FuncSecuritySeeder(Func<Security, BaseData> historySeeder)
+        /// <summary>
+        /// Constructor that takes as a parameter the security used to seed the price
+        /// </summary>
+        /// <param name="seedFunction"></param>
+        public FuncSecuritySeeder(Func<Security, BaseData> seedFunction)
         {
-            _historySeeder = historySeeder;
+            _seedFunction = seedFunction;
         }
 
-        public BaseData GetLastData(Security security)
+        /// <summary>
+        /// Get the last data point using the seed function
+        /// </summary>
+        /// <param name="security"><see cref="Security"/> being seeded</param>
+        /// <returns><see cref="BaseData"/> representing the last known data of the security</returns>
+        public BaseData GetSeedData(Security security)
         {
             try
             {
-                return _historySeeder(security);
+                return _seedFunction(security);
             }
             catch (Exception ex)
             {
-                Log.Error("FuncSecuritySeeder.GetSeedPrice(): " + ex.GetBaseException());
+                Log.Error("FuncSecuritySeeder.GetSeedPrice():  Could not seed price for security {0}: {1}", security.Symbol, ex.GetBaseException());
             }
-
-            Log.Trace("FuncSecuritySeeder.GetSeedPrice(): Could not seed price for security {0} from history.", security.Symbol);
 
             return null;
         }

--- a/Common/Securities/FuncSecuritySeeder.cs
+++ b/Common/Securities/FuncSecuritySeeder.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using QuantConnect.Data;
+using QuantConnect.Logging;
+
+namespace QuantConnect.Securities
+{
+    public class FuncSecuritySeeder : ISecuritySeeder
+    {
+        private Func<Security, BaseData> _historySeeder;
+
+        public FuncSecuritySeeder(Func<Security, BaseData> historySeeder)
+        {
+            _historySeeder = historySeeder;
+        }
+
+        public BaseData GetLastData(Security security)
+        {
+            try
+            {
+                return _historySeeder(security);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("FuncSecuritySeeder.GetSeedPrice(): " + ex.GetBaseException());
+            }
+
+            Log.Trace("FuncSecuritySeeder.GetSeedPrice(): Could not seed price for security {0} from history.", security.Symbol);
+
+            return null;
+        }
+    }
+}

--- a/Common/Securities/ISecuritySeeder.cs
+++ b/Common/Securities/ISecuritySeeder.cs
@@ -1,0 +1,12 @@
+﻿using QuantConnect.Data;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Used to seed the security with the correct price
+    /// </summary>
+    public interface ISecuritySeeder
+    {
+        BaseData GetLastData(Security security);
+    }
+}

--- a/Common/Securities/ISecuritySeeder.cs
+++ b/Common/Securities/ISecuritySeeder.cs
@@ -7,6 +7,6 @@ namespace QuantConnect.Securities
     /// </summary>
     public interface ISecuritySeeder
     {
-        BaseData GetLastData(Security security);
+        BaseData GetSeedData(Security security);
     }
 }

--- a/Common/Util/Composer.cs
+++ b/Common/Util/Composer.cs
@@ -185,6 +185,17 @@ namespace QuantConnect.Util
         }
 
         /// <summary>
+        /// Gets all exports of all types registered
+        /// </summary>
+        public IEnumerable<KeyValuePair<Type, IEnumerable>> EnumerateExportedValues()
+        {
+            lock (_exportedValuesLockObject)
+            {
+                return _exportedValues.AsEnumerable();
+            }
+        }
+
+        /// <summary>
         /// Clears the cache of exported values, causing new instances to be created.
         /// </summary>
         public void Reset()

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -366,7 +366,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>The loaded <see cref="IDataQueueHandler"/></returns>
         protected virtual IDataQueueHandler GetDataQueueHandler()
         {
-            return Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(Config.Get("data-queue-handler", "LiveDataQueue"));
+            return Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(_job.DataQuoueHandler);
         }
 
         /// <summary>

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -366,7 +366,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>The loaded <see cref="IDataQueueHandler"/></returns>
         protected virtual IDataQueueHandler GetDataQueueHandler()
         {
-            return Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(_job.DataQuoueHandler);
+            return Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(_job.DataQueueHandler);
         }
 
         /// <summary>

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -397,21 +397,7 @@ namespace QuantConnect.Lean.Engine
         
         private IHistoryProvider GetHistoryProvider(string historyProvider)
         {
-            // we first check if class has already been instantiated 
-            var match = Composer.Instance.EnumerateExportedValues()
-                .SelectMany(x => x.Value.Cast<object>().Where(o => o.GetType().MatchesTypeName(historyProvider)))
-                .OfType<IHistoryProvider>()
-                .DistinctBy(x => x.GetHashCode())
-                .ToList();
-
-            if (match.Any())
-            {
-                return match.First();
-            }
-            else
-            {
-                return Composer.Instance.GetExportedValueByTypeName<IHistoryProvider>(historyProvider);
-            }
+            return Composer.Instance.GetExportedValueByTypeName<IHistoryProvider>(historyProvider);
         }
         private static void SaveListOfTrades(IOrderProvider transactions, string csvFileName)
         {

--- a/Engine/LeanEngineAlgorithmHandlers.cs
+++ b/Engine/LeanEngineAlgorithmHandlers.cs
@@ -37,7 +37,6 @@ namespace QuantConnect.Lean.Engine
         private readonly IResultHandler _results;
         private readonly IRealTimeHandler _realTime;
         private readonly ITransactionHandler _transactions;
-        private readonly IHistoryProvider _historyProvider;
         private readonly ICommandQueueHandler _commandQueue;
         private readonly IMapFileProvider _mapFileProvider;
         private readonly IFactorFileProvider _factorFileProvider;
@@ -84,14 +83,6 @@ namespace QuantConnect.Lean.Engine
         }
 
         /// <summary>
-        /// Gets the history provider used to process historical data requests within the algorithm
-        /// </summary>
-        public IHistoryProvider HistoryProvider
-        {
-            get { return _historyProvider; }
-        }
-
-        /// <summary>
         /// Gets the command queue responsible for receiving external commands for the algorithm
         /// </summary>
         public ICommandQueueHandler CommandQueue
@@ -131,7 +122,6 @@ namespace QuantConnect.Lean.Engine
         /// <param name="dataFeed">The data feed handler used to pump data to the algorithm</param>
         /// <param name="transactions">The transaction handler used to process orders from the algorithm</param>
         /// <param name="realTime">The real time handler used to process real time events</param>
-        /// <param name="historyProvider">The history provider used to process historical data requests</param>
         /// <param name="commandQueue">The command queue handler used to receive external commands for the algorithm</param>
         /// <param name="mapFileProvider">The map file provider used to retrieve map files for the data feed</param>
         /// <param name="factorFileProvider">Map file provider used as a map file source for the data feed</param>
@@ -141,7 +131,6 @@ namespace QuantConnect.Lean.Engine
             IDataFeed dataFeed,
             ITransactionHandler transactions,
             IRealTimeHandler realTime,
-            IHistoryProvider historyProvider,
             ICommandQueueHandler commandQueue,
             IMapFileProvider mapFileProvider,
             IFactorFileProvider factorFileProvider,
@@ -168,10 +157,6 @@ namespace QuantConnect.Lean.Engine
             {
                 throw new ArgumentNullException("realTime");
             }
-            if (historyProvider == null)
-            {
-                throw new ArgumentNullException("realTime");
-            }
             if (commandQueue == null)
             {
                 throw new ArgumentNullException("commandQueue");
@@ -193,7 +178,6 @@ namespace QuantConnect.Lean.Engine
             _dataFeed = dataFeed;
             _transactions = transactions;
             _realTime = realTime;
-            _historyProvider = historyProvider;
             _commandQueue = commandQueue;
             _mapFileProvider = mapFileProvider;
             _factorFileProvider = factorFileProvider;
@@ -213,7 +197,6 @@ namespace QuantConnect.Lean.Engine
             var realTimeHandlerTypeName = Config.Get("real-time-handler", "BacktestingRealTimeHandler");
             var dataFeedHandlerTypeName = Config.Get("data-feed-handler", "FileSystemDataFeed");
             var resultHandlerTypeName = Config.Get("result-handler", "BacktestingResultHandler");
-            var historyProviderTypeName = Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider");
             var commandQueueHandlerTypeName = Config.Get("command-queue-handler", "EmptyCommandQueueHandler");
             var mapFileProviderTypeName = Config.Get("map-file-provider", "LocalDiskMapFileProvider");
             var factorFileProviderTypeName = Config.Get("factor-file-provider", "LocalDiskFactorFileProvider");
@@ -225,7 +208,6 @@ namespace QuantConnect.Lean.Engine
                 composer.GetExportedValueByTypeName<IDataFeed>(dataFeedHandlerTypeName),
                 composer.GetExportedValueByTypeName<ITransactionHandler>(transactionHandlerTypeName),
                 composer.GetExportedValueByTypeName<IRealTimeHandler>(realTimeHandlerTypeName),
-                composer.GetExportedValueByTypeName<IHistoryProvider>(historyProviderTypeName),
                 composer.GetExportedValueByTypeName<ICommandQueueHandler>(commandQueueHandlerTypeName),
                 composer.GetExportedValueByTypeName<IMapFileProvider>(mapFileProviderTypeName),
                 composer.GetExportedValueByTypeName<IFactorFileProvider>(factorFileProviderTypeName),

--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -105,7 +105,6 @@ namespace QuantConnect.Lean.Launcher
             Log.Trace("         RealTime:     " + leanEngineAlgorithmHandlers.RealTime.GetType().FullName);
             Log.Trace("         Results:      " + leanEngineAlgorithmHandlers.Results.GetType().FullName);
             Log.Trace("         Transactions: " + leanEngineAlgorithmHandlers.Transactions.GetType().FullName);
-            Log.Trace("         History:      " + leanEngineAlgorithmHandlers.HistoryProvider.GetType().FullName);
             Log.Trace("         Commands:     " + leanEngineAlgorithmHandlers.CommandQueue.GetType().FullName);
             if (job is LiveNodePacket) Log.Trace("         Brokerage:    " + ((LiveNodePacket)job).Brokerage);
 

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -33,6 +33,8 @@ namespace QuantConnect.Queues
         // The type name of the QuantConnect.Brokerages.Paper.PaperBrokerage
         private static readonly TextWriter Console = System.Console.Out;
         private const string PaperBrokerageTypeName = "PaperBrokerage";
+        private const string DefaultHistoryProvider = "SubscriptionDataReaderHistoryProvider";
+        private const string DefaultDataQuoueHandler = "LiveDataQueue";
         private bool _liveMode = Config.GetBool("live-mode");
         private static readonly string AccessToken = Config.Get("api-access-token");
         private static readonly int UserId = Config.GetInt("job-user-id", 0);
@@ -93,6 +95,8 @@ namespace QuantConnect.Queues
                     Type = PacketType.LiveNode,
                     Algorithm = File.ReadAllBytes(AlgorithmLocation),
                     Brokerage = Config.Get("live-mode-brokerage", PaperBrokerageTypeName),
+                    HistoryProvider = Config.Get("history-provider", DefaultHistoryProvider),
+                    DataQuoueHandler = Config.Get("data-queue-handler", DefaultDataQuoueHandler),
                     Channel = AccessToken,
                     UserId = UserId,
                     ProjectId = ProjectId,
@@ -123,6 +127,7 @@ namespace QuantConnect.Queues
             {
                 Type = PacketType.BacktestNode,
                 Algorithm = File.ReadAllBytes(AlgorithmLocation),
+                HistoryProvider = Config.Get("history-provider", DefaultHistoryProvider),
                 Channel = AccessToken,
                 UserId = UserId,
                 ProjectId = ProjectId,

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Queues
         private static readonly TextWriter Console = System.Console.Out;
         private const string PaperBrokerageTypeName = "PaperBrokerage";
         private const string DefaultHistoryProvider = "SubscriptionDataReaderHistoryProvider";
-        private const string DefaultDataQuoueHandler = "LiveDataQueue";
+        private const string DefaultDataQueueHandler = "LiveDataQueue";
         private bool _liveMode = Config.GetBool("live-mode");
         private static readonly string AccessToken = Config.Get("api-access-token");
         private static readonly int UserId = Config.GetInt("job-user-id", 0);
@@ -96,7 +96,7 @@ namespace QuantConnect.Queues
                     Algorithm = File.ReadAllBytes(AlgorithmLocation),
                     Brokerage = Config.Get("live-mode-brokerage", PaperBrokerageTypeName),
                     HistoryProvider = Config.Get("history-provider", DefaultHistoryProvider),
-                    DataQuoueHandler = Config.Get("data-queue-handler", DefaultDataQuoueHandler),
+                    DataQueueHandler = Config.Get("data-queue-handler", DefaultDataQueueHandler),
                     Channel = AccessToken,
                     UserId = UserId,
                     ProjectId = ProjectId,

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.HistoricalData;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class BrokerageModelSecurityInitializerTests
+    {
+        private QCAlgorithm _algo;
+        private BrokerageModelSecurityInitializer _brokerageInitializer;
+        private Security _security;
+        private readonly SubscriptionDataConfig _config = new SubscriptionDataConfig(typeof(TradeBar),
+                                                                                     Symbols.SPY,
+                                                                                     Resolution.Second,
+                                                                                     TimeZones.NewYork,
+                                                                                     TimeZones.NewYork,
+                                                                                     false,
+                                                                                     false,
+                                                                                     false,
+                                                                                     false,
+                                                                                     TickType.Trade,
+                                                                                     false);
+
+        [SetUp]
+        public void Setup()
+        {
+            _algo =  new QCAlgorithm();
+            var historyProvider = new SubscriptionDataReaderHistoryProvider();
+            historyProvider.Initialize(null,
+                                       new LocalDiskMapFileProvider(),
+                                       new LocalDiskFactorFileProvider(),
+                                       new DefaultDataFileProvider(),
+                                       null);
+
+            _algo.HistoryProvider = historyProvider;
+
+            _security = new Security(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                                        _config,
+                                        new Cash(CashBook.AccountCurrency, 0, 1m),
+                                        SymbolProperties.GetDefault(CashBook.AccountCurrency));
+
+            _brokerageInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(),
+                                                                             new FuncSecuritySeeder(_algo.GetLastKnownPrice));
+        }
+
+        [Test]
+        public void BrokerageModelSecurityInitializer_CanSetLeverageForBacktesting_Successfully()
+        {
+            Assert.AreEqual(_security.Leverage, 1.0);
+
+            _brokerageInitializer.Initialize(_security);
+
+            Assert.AreEqual(_security.Leverage, 2.0);
+        }
+
+        [Test]
+        public void BrokerageModelSecurityInitializer_CanSetPrice_ForExistingHistory()
+        {
+            // Arrange
+            var dateForWhichDataExist = DateTime.Parse("10/10/2013 12:00PM");
+            _algo.SetDateTime(dateForWhichDataExist);
+            
+            // Act
+            _brokerageInitializer.Initialize(_security);
+
+            // Assert
+            Assert.IsFalse(_security.Price == 0);
+        }
+
+        [Test]
+        public void BrokerageModelSecurityInitializer_CannotSetPrice_ForNonExistentHistory()
+        {
+            // Arrange
+            var dateForWhichDataDoesNotExist = DateTime.Parse("10/10/2050 12:00PM");
+            _algo.SetDateTime(dateForWhichDataDoesNotExist);
+
+            // Act
+            _brokerageInitializer.Initialize(_security);
+
+            // Assert
+            Assert.IsTrue(_security.Price == 0);
+        }
+    }
+}

--- a/Tests/Common/Util/ComposerTests.cs
+++ b/Tests/Common/Util/ComposerTests.cs
@@ -28,11 +28,12 @@ namespace QuantConnect.Tests.Common.Util
         public void ComposesTypes()
         {
             var instances = Composer.Instance.GetExportedValues<IExport>().ToList();
-            Assert.AreEqual(4, instances.Count);
+            Assert.AreEqual(5, instances.Count);
             Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof (Export1)));
             Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof (Export2)));
             Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof (Export3)));
             Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof (Export4)));
+            Assert.AreEqual(1, instances.Count(x => x.GetType() == typeof(Export5)));
         }
 
         [Test]

--- a/Tests/Common/Util/ComposerTests.cs
+++ b/Tests/Common/Util/ComposerTests.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.ComponentModel.Composition;
 using System.Linq;
 using NUnit.Framework;
@@ -53,10 +54,30 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreNotEqual(export1, export2);
         }
 
+        [Test]
+        public void GetsMultipleInterfacesInstance()
+        {
+            var instance1 = Composer.Instance.Single<IOneMoreExport>(x => x.Export == 5);
+            Assert.IsNotNull(instance1);
+            Assert.IsInstanceOf(typeof(Export5), instance1);
+
+            var instance2 = Composer.Instance.Single<IExport>(x => x.Id == 5);
+            Assert.IsNotNull(instance2);
+            Assert.IsInstanceOf(typeof(Export5), instance2);
+
+            Assert.AreEqual(instance1, instance2);
+        }
+
         [InheritedExport(typeof(IExport))]
         interface IExport
         {
             int Id { get; }
+        }
+
+        [InheritedExport(typeof(IOneMoreExport))]
+        interface IOneMoreExport
+        {
+            decimal Export { get; }
         }
 
         class Export1 : IExport
@@ -74,6 +95,13 @@ namespace QuantConnect.Tests.Common.Util
         class Export4 : IExport
         {
             public int Id { get { return 4; } }
+        }
+
+        class Export5 : IExport, IOneMoreExport
+        {
+            public decimal Export { get { return 5; } }
+
+            public int Id { get { return 5; } }
         }
     }
 }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Brokerages\Tradier\TradierBrokerageSerializationTests.cs" />
     <Compile Include="Brokerages\Tradier\TradierBrokerageTests.cs" />
     <Compile Include="Common\CurrenciesTests.cs" />
+    <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />
     <Compile Include="Common\Util\FactorFileGeneratorTests.cs" />
     <Compile Include="Common\Data\Auxiliary\LocalDiskFactorFileProviderTests.cs" />
     <Compile Include="Common\Data\Auxiliary\LocalDiskMapFileProviderTests.cs" />


### PR DESCRIPTION
+ Added new interface, ISeedSecurity, which is used by BrokerageModelSecurityInitializer to seed the price when a security is created
+ Added an implementation of ISeedSecurity, FuncSeedSecurity, which takes a Func that is used to retrieve the last known price of the security
+ Added two new methods to QCAlgorithm.History, that help in retrieving the last known price of a security from the history provider
+ Added BrokerageModelSecurityInitializerTests

The security price needs to be seeded when the security is created because if not, the security will be created with a price of 0.  A security price of 0 will cause margin calls for existing securities in a portfolio when Lean is started.

Building off of PR #644