### PR TITLE
Remove Prefer32Bit flag from Launcher Release build config

### DIFF
--- a/Launcher/QuantConnect.Lean.Launcher.csproj
+++ b/Launcher/QuantConnect.Lean.Launcher.csproj
@@ -33,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>QuantConnect.Lean.Launcher.Program</StartupObject>


### PR DESCRIPTION
This was causing LEAN to always run as a 32bit process in a Release build