### PR TITLE
Add Volume property to HeikinAshi indicator

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -854,7 +854,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Heikin-Ashi indicator for the requested symbol over the specified period</returns>
-        public HeikinAshi HeikinAshi(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public HeikinAshi HeikinAshi(Symbol symbol, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "HA", resolution);
             var ha = new HeikinAshi(name);

--- a/Indicators/HeikinAshi.cs
+++ b/Indicators/HeikinAshi.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Indicators
     /// HA_High[0] = MAX(High[0], HA_Open[0], HA_Close[0])
     /// HA_Low[0] = MIN(Low[0], HA_Open[0], HA_Close[0])
     /// </summary>
-    public class HeikinAshi : BarIndicator
+    public class HeikinAshi : TradeBarIndicator
     {
         /// <summary>
         /// Gets the Heikin-Ashi Open
@@ -49,11 +49,16 @@ namespace QuantConnect.Indicators
         public IndicatorBase<IndicatorDataPoint> Close { get; private set; }
 
         /// <summary>
+        /// Gets the Heikin-Ashi Volume
+        /// </summary>
+        public IndicatorBase<IndicatorDataPoint> Volume { get; private set; }
+
+        /// <summary>
         /// Gets the Heikin-Ashi current TradeBar
         /// </summary>
         public TradeBar CurrentBar
         {
-            get {  return new TradeBar(Open.Current.Time, Symbol.Empty, Open, High, Low, Close, 0);}
+            get { return new TradeBar(Open.Current.Time, Symbol.Empty, Open, High, Low, Close, Convert.ToInt64(Volume.Current.Value)); }
         }
 
         /// <summary>
@@ -67,6 +72,7 @@ namespace QuantConnect.Indicators
             High = new Identity(name + "_High");
             Low = new Identity(name + "_Low");
             Close = new Identity(name + "_Close");
+            Volume = new Identity(name + "_Volume");
         }
 
         /// <summary>
@@ -90,7 +96,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns> A new value for this indicator </returns>
-        protected override decimal ComputeNextValue(IBaseDataBar input)
+        protected override decimal ComputeNextValue(TradeBar input)
         {
             if (!IsReady)
             {
@@ -107,6 +113,8 @@ namespace QuantConnect.Indicators
                 Low.Update(new IndicatorDataPoint(input.Time, Math.Min(input.Low, Math.Min(Open, Close))));
             }
 
+            Volume.Update(new IndicatorDataPoint(input.Time, input.Volume));
+
             return Close;
         }
 
@@ -119,6 +127,7 @@ namespace QuantConnect.Indicators
             High.Reset();
             Low.Reset();
             Close.Reset();
+            Volume.Reset();
             base.Reset();
         }
     }

--- a/Tests/Indicators/HeikinAshiTests.cs
+++ b/Tests/Indicators/HeikinAshiTests.cs
@@ -20,9 +20,9 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class HeikinAshiTests : CommonIndicatorTests<IBaseDataBar>
+    public class HeikinAshiTests : CommonIndicatorTests<TradeBar>
     {
-        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
+        protected override IndicatorBase<TradeBar> CreateIndicator()
         {
             return new HeikinAshi();
         }
@@ -44,6 +44,7 @@ namespace QuantConnect.Tests.Indicators
             TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "HA_High", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).High.Current.Value, 1e-3));
             TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "HA_Low", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Low.Current.Value, 1e-3));
             TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "HA_Close", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Close.Current.Value, 1e-3));
+            TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "Volume", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Volume.Current.Value, 1e-3));
         }
 
         [Test]
@@ -59,6 +60,8 @@ namespace QuantConnect.Tests.Indicators
                 TestHelper.TestIndicator(indicator, TestFileName, "HA_Low", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Low.Current.Value, 1e-3));
                 indicator.Reset();
                 TestHelper.TestIndicator(indicator, TestFileName, "HA_Close", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Close.Current.Value, 1e-3));
+                indicator.Reset();
+                TestHelper.TestIndicator(indicator, TestFileName, "Volume", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Volume.Current.Value, 1e-3));
                 indicator.Reset();
             }
         }


### PR DESCRIPTION
This makes volume available to indicators chained to HeikinAshi, as requested here:
https://www.quantconnect.com/forum/discussion/1566/getting-volume-in-a-heikin-ashi-tradebar