### PR TITLE
Add check for zero unitprice in SetHoldings

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -611,6 +611,7 @@ namespace QuantConnect.Algorithm
 
             // determine the unit price in terms of the account currency
             var unitPrice = new MarketOrder(symbol, 1, UtcTime).GetValue(security);
+            if (unitPrice == 0) return 0;
 
             // calculate the total margin available
             var marginRemaining = Portfolio.GetMarginRemaining(symbol, direction);


### PR DESCRIPTION
Prevents possible DivideByZeroException with non-USD Forex pairs at Tick resolution.

Example algorithm:

```
public class BasicTemplateAlgorithm : QCAlgorithm
{
    private const string Symbol = "EURJPY";

    public override void Initialize()
    {
        SetStartDate(2016, 1, 1);
        SetEndDate(2016, 1, 5);
        SetCash(10000);

        AddForex(Symbol, Resolution.Tick, Market.FXCM);
    }
    
    public override void OnData(Slice data) {
    	if (!Portfolio[Symbol].Invested) {
    		SetHoldings(Symbol, 0.4);
    	}
    }
}
```