### PR TITLE
Log location on disc displayed for local backtests

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -25,6 +25,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
+using QuantConnect.Packets;
 using QuantConnect.Securities;
 using RestSharp;
 using RestSharp.Extensions;
@@ -595,35 +596,6 @@ namespace QuantConnect.Api
         }
 
         /// <summary>
-        /// Calculate the remaining bytes of user log allowed based on the user's cap and daily cumulative usage.
-        /// </summary>
-        /// <param name="userId">User ID</param>
-        /// <param name="projectId">Project ID</param>
-        /// <param name="userToken">User API token</param>
-        /// <returns>int[3] iUserBacktestLimit, iUserDailyLimit, remaining</returns>
-        
-        public virtual int[] ReadLogAllowance(int userId, int projectId, string userToken)
-        {
-            return new[] { int.MaxValue, int.MaxValue, int.MaxValue };
-        }
-
-        /// <summary>
-        /// Update the daily log of allowed logging-data
-        /// </summary>
-        /// <param name="userId">Id of the User</param>
-        /// <param name="backtestId">BacktestId</param>
-        /// <param name="url">URL of the log entry</param>
-        /// <param name="length">length of data</param>
-        /// <param name="userToken">User access token</param>
-        /// <param name="hitLimit">Boolean signifying hit log limit</param>
-        /// <returns>Number of bytes remaining</returns>
-        
-        public virtual void UpdateDailyLogUsed(int userId, string backtestId, string url, int length, string userToken, bool hitLimit = false)
-        {
-            //
-        }
-
-        /// <summary>
         /// Get the algorithm status from the user with this algorithm id.
         /// </summary>
         /// <param name="algorithmId">String algorithm id we're searching for.</param>
@@ -687,9 +659,24 @@ namespace QuantConnect.Api
         }
 
         /// <summary>
-        /// Store logs with these authentication type
+        /// Retrieves the location of the logs
         /// </summary>
-        
+        /// <param name="logs">The list of individual logs to be stored</param>
+        /// <param name="job">The <see cref="AlgorithmNodePacket"/> used to generate the url to the logs</param>
+        /// <param name="permissions">The <see cref="StoragePermissions"/> for the file</param>
+        /// <param name="async">Bool indicating whether the method to <see cref="Store"/> should be async</param>
+        /// <returns>The location where the logs can be accessed</returns>
+        /// <remarks>Since the logs are stored on disc during local backtest, this method simply returns the location of those logs
+        /// TODO: Get the filename of the logs instead of hard coding it.
+        ///  </remarks>
+        public virtual string StoreLogs(List<string> logs, AlgorithmNodePacket job, StoragePermissions permissions, bool async = false)
+        {
+            return Path.Combine(Directory.GetCurrentDirectory(), "log.txt");
+        }
+
+        /// <summary>
+        /// Store data with these authentication type
+        /// </summary>
         public virtual void Store(string data, string location, StoragePermissions permissions, bool async = false)
         {
             //

--- a/Common/Interfaces/IApi.cs
+++ b/Common/Interfaces/IApi.cs
@@ -22,6 +22,7 @@ using QuantConnect.API;
 using QuantConnect.Brokerages;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Packets;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Interfaces
@@ -251,18 +252,6 @@ namespace QuantConnect.Interfaces
         //void NotifyOwner(int projectId, string algorithmId, string subject, string body);
         //IEnumerable<MarketHoursSegment> MarketHours(int projectId, DateTime time, Symbol symbol);
 
-
-
-        /// <summary>
-        /// Read the maximum log allowance
-        /// </summary>
-        int[] ReadLogAllowance(int userId, int projectId, string userToken);
-
-        /// <summary>
-        /// Update running total of log usage
-        /// </summary>
-        void UpdateDailyLogUsed(int userId, string backtestId, string url, int length, string userToken, bool hitLimit = false);
-
         /// <summary>
         /// Get the algorithm current status, active or cancelled from the user
         /// </summary>
@@ -303,7 +292,17 @@ namespace QuantConnect.Interfaces
         IEnumerable<MarketHoursSegment> MarketToday(DateTime time, Symbol symbol);
 
         /// <summary>
-        /// Store the algorithm logs.
+        /// Store logs in the cloud
+        /// </summary>
+        /// <param name="logs">The list of individual logs to be stored</param>
+        /// <param name="job">The <see cref="AlgorithmNodePacket"/> used to generate the url to the logs</param>
+        /// <param name="permissions">The <see cref="StoragePermissions"/> for the file</param>
+        /// <param name="async">Bool indicating whether the method to <see cref="Store"/> should be async</param>
+        /// <returns>The url where the logs can be accessed</returns>
+        string StoreLogs(List<string> logs, AlgorithmNodePacket job, StoragePermissions permissions, bool async = false);
+
+        /// <summary>
+        /// Store data in the cloud
         /// </summary>
         void Store(string data, string location, StoragePermissions permissions, bool async = false);
 

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -691,13 +691,12 @@ namespace QuantConnect.Lean.Engine.Results
         }
 
         /// <summary>
-        /// Terminate the result thread and apply any required exit proceedures.
+        /// Terminate the result thread and apply any required exit procedures.
         /// </summary>
         public void Exit() 
         {
-            //Process all the log messages and send them to the S3:
-            var logURL = ProcessLogMessages(_job);
-            if (logURL != "") DebugMessage("Your log was successfully created and can be downloaded from: " + logURL);
+            var logLocation = ProcessLogMessages(_job);
+            DebugMessage("Your log was successfully created and can be retrieved from: " + logLocation);
 
             //Set exit flag, and wait for the messages to send:
             _exitTriggered = true;
@@ -759,76 +758,13 @@ namespace QuantConnect.Lean.Engine.Results
         }
 
         /// <summary>
-        /// Process log messages to ensure the meet the user caps and send them to storage.
+        /// Process log messages and return a string indicating the location of the logs
         /// </summary>
         /// <param name="job">Algorithm job/task packet</param>
         /// <returns>String URL of log</returns>
         private string ProcessLogMessages(AlgorithmNodePacket job)
         {
-            var remoteUrl = @"http://data.quantconnect.com/";
-            var logLength = 0;
-
-            try
-            {
-                //Return nothing if there's no log messages to procesS:
-                if (!_log.Any()) return "";
-
-                //Get the max length allowed for the algorithm:
-                var allowance = _api.ReadLogAllowance(job.UserId, job.ProjectId, job.Channel);
-                var logBacktestMax = allowance[0];
-                var logDailyMax = allowance[1];
-                var logRemaining = Math.Min(logBacktestMax, allowance[2]); //Minimum of maxium backtest or remaining allowance.
-                var hitLimit = false;
-                var serialized = new StringBuilder();
-
-                var key = "backtests/" + job.UserId + "/" + job.ProjectId + "/" + job.AlgorithmId + "-log.txt";
-                remoteUrl += key;
-
-                foreach (var line in _log)
-                {
-                    if ((logLength + line.Length) < logRemaining)
-                    {
-                        serialized.Append(line + "\r\n");
-                        logLength += line.Length;
-                    }
-                    else
-                    {
-                        var btMax = Math.Round((double)logBacktestMax / 1024, 0) + "kb";
-                        var dyMax = Math.Round((double)logDailyMax / 1024, 0) + "kb";
-
-                        //Same cap notice for both free & subscribers
-                        var requestMore = "";
-                        var capNotice = "You currently have a maximum of " + btMax + " of log data per backtest, and " + dyMax + " total max per day.";
-                        DebugMessage("You currently have a maximum of " + btMax + " of log data per backtest remaining, and " + dyMax + " total max per day.");
-                        
-                        //Data providers set max log limits and require email requests for extensions
-                        if (job.UserPlan == UserPlan.Free)
-                        {
-                            requestMore ="Please upgrade your account and contact us to request more allocation here: https://www.quantconnect.com/contact"; 
-                        }
-                        else
-                        {
-                            requestMore = "If you require more please briefly explain request for more allocation here: https://www.quantconnect.com/contact";
-                        }
-                        DebugMessage(requestMore);
-                        serialized.Append(capNotice);
-                        serialized.Append(requestMore);
-                        hitLimit = true;
-                        break;
-                    }
-                }
-
-                //Save the log: Upload this file to S3:
-                _api.Store(serialized.ToString(), key, StoragePermissions.Public);
-                //Record the data usage:
-                _api.UpdateDailyLogUsed(job.UserId, job.AlgorithmId, remoteUrl, logLength, job.Channel, hitLimit);
-            }
-            catch (Exception err)
-            {
-                Log.Error(err);
-            }
-            Log.Trace("BacktestingResultHandler.ProcessLogMessages(): Ready: " + remoteUrl);
-            return remoteUrl;
+            return _api.StoreLogs(_log, job, StoragePermissions.Public, false);
         }
 
         /// <summary>


### PR DESCRIPTION
+ Removes broken "Your logs can be downloaded from ..." message at the end of local backtests
+ Api implements a new method, StoreLogs, that returns the location of logs on disc.  
+ Removed unnecessary log processing from BacktestingResultsHandler ProcessLogMessages method
+ Removed unnecessary log processing methods from Api.cs - ReadLogAllowance and UpdateDailyLogUsed