### PR TITLE
Disable FxcmBrokerage auto-reconnect with EnableOnlyHistoryRequests

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
@@ -115,10 +115,18 @@ namespace QuantConnect.Brokerages.Fxcm
                     if (!autoResetEvent.WaitOne(HistoryResponseTimeout))
                     {
                         // no response
+                        if (EnableOnlyHistoryRequests)
+                        {
+                            throw new TimeoutException(string.Format("FxcmBrokerage.GetHistory(): Operation took longer than {0} seconds.", (decimal) HistoryResponseTimeout/1000));
+                        }
+
                         if (++attempt > MaximumHistoryRetryAttempts)
                         {
+                            Log.Trace("FxcmBrokerage.GetHistory(): Maximum attempts reached for: " + request.Symbol.Value);
                             break;
                         }
+
+                        Log.Trace("FxcmBrokerage.GetHistory(): Attempt " + attempt + " for: " + request.Symbol.Value);
                         continue;
                     }
 


### PR DESCRIPTION
This update only affects client applications using the EnableOnlyHistoryRequests flag (such as parallel server downloaders) and has no impact on live trading.
The changes for this mode are:
- Threads for order event handling and connection monitor are not created
- On historical request timeout, throws exception instead of retrying