### PR TITLE
Add new CancelPending order status

### DIFF
--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -129,6 +129,11 @@ namespace QuantConnect.Orders
         Filled = 3,
 
         /// <summary>
+        /// Order waiting for confirmation of cancellation
+        /// </summary>
+        CancelPending = 4,
+
+        /// <summary>
         /// Order cancelled before it was filled
         /// </summary>
         Canceled = 5,

--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -129,11 +129,6 @@ namespace QuantConnect.Orders
         Filled = 3,
 
         /// <summary>
-        /// Order waiting for confirmation of cancellation
-        /// </summary>
-        CancelPending = 4,
-
-        /// <summary>
         /// Order cancelled before it was filled
         /// </summary>
         Canceled = 5,
@@ -146,7 +141,12 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Order invalidated before it hit the market (e.g. insufficient capital)..
         /// </summary>
-        Invalid = 7
+        Invalid = 7,
+
+        /// <summary>
+        /// Order waiting for confirmation of cancellation
+        /// </summary>
+        CancelPending = 8
     }
 
 } // End QC Namespace:

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -298,6 +298,12 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 }
                 else
                 {
+                    // update the order status
+                    order.Status = OrderStatus.CancelPending;
+
+                    // notify the algorithm with an order event
+                    HandleOrderEvent(new OrderEvent(order, _algorithm.UtcTime, 0m));
+
                     // send the request to be processed
                     request.SetResponse(OrderResponse.Success(request), OrderRequestStatus.Processing);
                     _orderRequestQueue.Add(request);

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -14,19 +14,45 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Moq;
+using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Brokerages;
 using QuantConnect.Brokerages.Backtesting;
+using QuantConnect.Data;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Packets;
+using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 {
+    internal class EmptyHistoryProvider : IHistoryProvider
+    {
+        public int DataPointCount
+        {
+            get { return 0; }
+        }
+
+        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider,
+            IFactorFileProvider factorFileProvider,
+            IDataFileProvider dataFileProvider, Action<int> statusUpdate)
+        {
+        }
+
+        public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+        {
+            return Enumerable.Empty<Slice>();
+        }
+    }
+
     [TestFixture]
     class BrokerageTransactionHandlerTests
     {
@@ -36,7 +62,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         [SetUp]
         public void Initialize()
         {
-            _algorithm = new QCAlgorithm();
+            _algorithm = new QCAlgorithm { HistoryProvider = new EmptyHistoryProvider() };
             _algorithm.SetBrokerageModel(BrokerageName.FxcmBrokerage);
             _algorithm.SetCash(100000);
             _algorithm.AddSecurity(SecurityType.Forex, Ticker);
@@ -193,6 +219,46 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.AreEqual(1000, orderTicket.Quantity);
             // 1.12131212 after round becomes 1.12131
             Assert.AreEqual(1.12131m, orderTicket.Get(OrderField.StopPrice));
+        }
+
+        [Test]
+        public void OrderCancellationTransitionsThroughCancelPendingStatus()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new BrokerageTransactionHandler();
+            transactionHandler.Initialize(_algorithm, new BacktestingBrokerage(_algorithm), new BacktestingResultHandler());
+
+            // Creates a limit order
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Limit, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            // Submit and process a limit order
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.IsTrue(orderRequest.Response.IsProcessed);
+            Assert.IsTrue(orderRequest.Response.IsSuccess);
+            Assert.IsTrue(orderTicket.Status == OrderStatus.Submitted);
+
+            // Cancel the order
+            var cancelRequest = new CancelOrderRequest(DateTime.Now, orderTicket.OrderId, "");
+            transactionHandler.Process(cancelRequest);
+            Assert.IsTrue(cancelRequest.Response.IsProcessed);
+            Assert.IsTrue(cancelRequest.Response.IsSuccess);
+            Assert.IsTrue(cancelRequest.Status == OrderRequestStatus.Processing);
+            Assert.IsTrue(orderTicket.Status == OrderStatus.CancelPending);
+
+            transactionHandler.HandleOrderRequest(cancelRequest);
+            Assert.IsTrue(cancelRequest.Response.IsProcessed);
+            Assert.IsTrue(cancelRequest.Response.IsSuccess);
+            Assert.IsTrue(cancelRequest.Status == OrderRequestStatus.Processed);
+            Assert.IsTrue(orderTicket.Status == OrderStatus.Canceled);
         }
     }
 }


### PR DESCRIPTION
This new status is being added to solve the following problem with order cancellations:

Working orders (limit or stop) are usually cancelled by calling the `OrderTicket.Cancel()` method. This method is asynchronous in both backtesting and live, so reading the `OrderStatus` immediately after the Cancel call, can result in different values seen over different runs.

The solution introduces a new `CancelPending` value to the `OrderStatus` enum and guarantees that the order will have this status (or the `Canceled` status) when the Cancel method returns (unless there was an error earlier, such as invalid order id). This status is meant to be temporary and will be overwritten/replaced by the `Canceled` value after the brokerage has completed the cancel operation.