### PR TITLE
Added logging limits to the AlgorithmNodePacket

### DIFF
--- a/Common/Packets/Controls.cs
+++ b/Common/Packets/Controls.cs
@@ -48,6 +48,24 @@ namespace QuantConnect.Packets
         public int RamAllocation;
 
         /// <summary>
+        /// The user backtesting log limit
+        /// </summary>
+        [JsonProperty(PropertyName = "iBacktestLogLimit")]
+        public int BacktestLogLimit;
+
+        /// <summary>
+        /// The daily log limit of a user
+        /// </summary>
+        [JsonProperty(PropertyName = "iDailyLogLimit")]
+        public int DailyLogLimit;
+
+        /// <summary>
+        /// The remaining log allowance for a user
+        /// </summary>
+        [JsonProperty(PropertyName = "iRemainingLogAllowance")]
+        public int RemainingLogAllowance;
+
+        /// <summary>
         /// Initializes a new default instance of the <see cref="Controls"/> class
         /// </summary>
         public Controls()


### PR DESCRIPTION
+ The properties BacktestLogLimit, DailyLogLimit and RemainingLogAllowance added to the AlgorithmNodePacket.Controls class.
+ The logs limits will now be taken from the AlgorithmNodePacket