### PR TITLE
Added helpful LeanData methods for getting common types

### DIFF
--- a/Common/Data/UniverseSelection/FuturesChainUniverse.cs
+++ b/Common/Data/UniverseSelection/FuturesChainUniverse.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Data.UniverseSelection
             // we want to return both quote and trade subscriptions
             return _subscriptionManager.GetDataTypesForSecurity(SecurityType.Future)
                 .Select(tickType => new SubscriptionDataConfig(
-                    objectType: GetDataType(UniverseSettings.Resolution, tickType),
+                    objectType: LeanData.GetDataType(UniverseSettings.Resolution, tickType),
                     symbol: security.Symbol,
                     resolution: UniverseSettings.Resolution,
                     dataTimeZone: Configuration.DataTimeZone,
@@ -180,17 +180,6 @@ namespace QuantConnect.Data.UniverseSelection
                 return true;
             }
             return false;
-        }
-
-        /// <summary>
-        /// Gets the data type required for the specified combination of resolution and tick type
-        /// </summary>
-        private static Type GetDataType(Resolution resolution, TickType tickType)
-        {
-            if (resolution == Resolution.Tick) return typeof(Tick);
-            if (tickType == TickType.OpenInterest) return typeof(OpenInterest);
-            if (tickType == TickType.Quote) return typeof(QuoteBar);
-            return typeof(TradeBar);
         }
     }
 }

--- a/Common/Data/UniverseSelection/OptionChainUniverse.cs
+++ b/Common/Data/UniverseSelection/OptionChainUniverse.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Data.UniverseSelection
             // we want to return both quote and trade subscriptions
             return _subscriptionManager.GetDataTypesForSecurity(SecurityType.Option)
                 .Select(tickType => new SubscriptionDataConfig(
-                    objectType: GetDataType(UniverseSettings.Resolution, tickType),
+                    objectType: LeanData.GetDataType(UniverseSettings.Resolution, tickType),
                     symbol: security.Symbol,
                     resolution: UniverseSettings.Resolution,
                     dataTimeZone: Configuration.DataTimeZone,
@@ -216,17 +216,6 @@ namespace QuantConnect.Data.UniverseSelection
                 return true;
             }
             return false;
-        }
-
-        /// <summary>
-        /// Gets the data type required for the specified combination of resolution and tick type
-        /// </summary>
-        private static Type GetDataType(Resolution resolution, TickType tickType)
-        {
-            if (resolution == Resolution.Tick) return typeof(Tick);
-            if (tickType == TickType.OpenInterest) return typeof(OpenInterest);
-            if (tickType == TickType.Quote) return typeof(QuoteBar);
-            return typeof(TradeBar);
         }
     }
 }

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -181,6 +181,27 @@ namespace QuantConnect.Util
             return typeof(TradeBar);
         }
 
+
+        /// <summary>
+        /// Determines if the Type is a 'common' type used throughout lean
+        /// This method is helpful in creating <see cref="SubscriptionDataConfig"/>
+        /// </summary>
+        /// <param name="baseDataType">The Type to check</param>
+        /// <returns>A bool indicating whether the type is of type <see cref="TradeBar"/>
+        ///  <see cref="QuoteBar"/> or <see cref="OpenInterest"/></returns>
+        public static bool IsCommonLeanDataType(Type baseDataType)
+        {
+            if (baseDataType == typeof(TradeBar) ||
+                baseDataType == typeof(QuoteBar) ||
+                baseDataType == typeof(OpenInterest))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+
         /// <summary>
         /// Generates the full zip file path rooted in the <paramref name="dataDirectory"/>
         /// </summary>

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -168,6 +168,20 @@ namespace QuantConnect.Util
         }
 
         /// <summary>
+        /// Gets the data type required for the specified combination of resolution and tick type
+        /// </summary>
+        /// <param name="resolution">The resolution, if Tick, the Type returned is always Tick</param>
+        /// <param name="tickType">The <see cref="TickType"/> that primarily dictates the type returned</param>
+        /// <returns>The Type used to create a subscription</returns>
+        public static Type GetDataType(Resolution resolution, TickType tickType)
+        {
+            if (resolution == Resolution.Tick) return typeof(Tick);
+            if (tickType == TickType.OpenInterest) return typeof(OpenInterest);
+            if (tickType == TickType.Quote) return typeof(QuoteBar);
+            return typeof(TradeBar);
+        }
+
+        /// <summary>
         /// Generates the full zip file path rooted in the <paramref name="dataDirectory"/>
         /// </summary>
         public static string GenerateZipFilePath(string dataDirectory, Symbol symbol, DateTime date, Resolution resolution, TickType tickType)

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -133,6 +133,27 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(expected, source.Source);
         }
 
+        [Test]
+        public void GetDataType_ReturnsCorrectType()
+        {
+            var tickType = typeof(Tick);
+            var openInterestType = typeof(OpenInterest);
+            var quoteBarType = typeof(QuoteBar);
+            var tradeBarType = typeof(TradeBar);
+
+            Assert.AreEqual(LeanData.GetDataType(Resolution.Tick, TickType.OpenInterest), tickType);
+            Assert.AreNotEqual(LeanData.GetDataType(Resolution.Daily, TickType.OpenInterest), tickType);
+
+            Assert.AreEqual(LeanData.GetDataType(Resolution.Second, TickType.OpenInterest), openInterestType);
+            Assert.AreNotEqual(LeanData.GetDataType(Resolution.Tick, TickType.OpenInterest), openInterestType);
+
+            Assert.AreEqual(LeanData.GetDataType(Resolution.Minute, TickType.Quote), quoteBarType);
+            Assert.AreNotEqual(LeanData.GetDataType(Resolution.Second, TickType.Trade), quoteBarType);
+
+            Assert.AreEqual(LeanData.GetDataType(Resolution.Hour, TickType.Trade), tradeBarType);
+            Assert.AreNotEqual(LeanData.GetDataType(Resolution.Tick, TickType.OpenInterest), tradeBarType);
+        }
+
         private static void AssertBarsAreEqual(IBar expected, IBar actual)
         {
             if (expected == null && actual == null)

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -154,6 +154,15 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreNotEqual(LeanData.GetDataType(Resolution.Tick, TickType.OpenInterest), tradeBarType);
         }
 
+        [Test]
+        public void LeanData_CanDetermineTheCorrectCommonDataTypes()
+        {
+            Assert.IsTrue(LeanData.IsCommonLeanDataType(typeof(OpenInterest)));
+            Assert.IsTrue(LeanData.IsCommonLeanDataType(typeof(TradeBar)));
+            Assert.IsTrue(LeanData.IsCommonLeanDataType(typeof(QuoteBar)));
+            Assert.IsFalse(LeanData.IsCommonLeanDataType(typeof(Bitcoin)));
+        }
+
         private static void AssertBarsAreEqual(IBar expected, IBar actual)
         {
             if (expected == null && actual == null)


### PR DESCRIPTION
+ Added method to LeanData, `GetDataType`, to return the Type for a particular Resolution and and TickType
+ Added method to LeanData, `IsCommonLeanDataType`, to determine if a type is a common data type (TradeBar, QuoteBar, OpenInterest)
+ Refactored FuturesChainUniverse and OptionsChainUniverse to use `GetDataType`.
+ Refactored SecurityManager to use both `GetDataType` and `IsCommonLeanDataType`

These new methods are useful when creating subscriptions.