### PR TITLE
Filter consolidator inputs on data resolution

### DIFF
--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -99,11 +99,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         var clone = subscription.Current.Clone(subscription.Current.IsFillForward);
                         clone.Time = clone.Time.ExchangeRoundDown(configuration.Increment, subscription.Security.Exchange.Hours, configuration.ExtendedMarketHours);
 
-                        // do not add fill-forward data if rounded down to the previous day
-                        if (!clone.IsFillForward || clone.Time.Date == subscription.Current.Time.Date)
-                        {
-                            packet.Add(clone);
-                        }
+                        packet.Add(clone);
 
                         if (!subscription.MoveNext())
                         {


### PR DESCRIPTION
This update reverts PR #664 and includes an improved filtering solution.

It prevents consolidators and indicators from receiving inputs at a resolution higher than the data subscription resolution, typically fill-forward bars.
Volume-based indicators and consolidators will now be calculated correctly with fill-forward data.

It also fixes the RegressionAlgorithm failing test.