### PR TITLE
Added LookupSubscriptionConfigDataTypes to lookup Subscription Type

### DIFF
--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -15,9 +15,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NodaTime;
+using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
+using QuantConnect.Util;
 
 namespace QuantConnect.Data
 {
@@ -180,7 +183,27 @@ namespace QuantConnect.Data
             return AvailableDataTypes[securityType];
         }
 
+        /// <summary>
+        /// Get the data feed types for a given <see cref="SecurityType"/> <see cref="Resolution"/> 
+        /// </summary>
+        /// <param name="symbolSecurityType">The <see cref="SecurityType"/> used to determine the types</param>
+        /// <param name="resolution">The resolution of the data requested</param>
+        /// <param name="isCanonical">Indicates whether the security is Canonical (future and options)</param>
+        /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig"/></returns>
+        public IEnumerable<Type> LookupSubscriptionConfigDataTypes(SecurityType symbolSecurityType, Resolution resolution, bool isCanonical)
+        {
+            if (isCanonical)
+            {
+                return new List<Type>() {typeof(ZipEntryName)};
+            }
 
+            if (resolution == Resolution.Tick)
+            {
+                return new List<Type>() { typeof(Tick) };
+            }
+
+            return AvailableDataTypes[symbolSecurityType].Select(tickType => LeanData.GetDataType(resolution, tickType)).ToList();
+        }
     } // End Algorithm MetaData Manager Class
 
 } // End QC Namespace

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -333,11 +333,15 @@ namespace QuantConnect.Securities
 
             // Get the type that will be used in the data feed
             // Could be more than one for a given security - i.e. More than one subscription needed
-
-            var dataFeedTypes = subscriptionManager.AvailableDataTypes[symbol.ID.SecurityType]
-                .Select(dataFeed => GetDataFeedType(factoryType, dataFeed, resolution))
-                .Distinct()
-                .ToList();
+            IEnumerable<Type> dataFeedTypes;
+            if (LeanData.IsCommonLeanDataType(factoryType))
+            {
+                dataFeedTypes = subscriptionManager.LookupSubscriptionConfigDataTypes(symbol.SecurityType, resolution, symbol.IsCanonical());
+            }
+            else
+            {
+                dataFeedTypes = new List<Type>() {factoryType};
+            }
 
             foreach (var dataFeedType in dataFeedTypes)
             {
@@ -430,21 +434,6 @@ namespace QuantConnect.Securities
             }
 
             return security;
-        }
-
-        /// <summary>
-        /// Get the data feed type for the given security. If it is a common data type, LeanData Methods can be used 
-        /// to retrieve the returned type. If not, the type passed in is returned.
-        /// </summary>
-        /// <param name="factoryType"><see cref="BaseData"/> type of the security</param>
-        /// <param name="tickType">The <see cref="TickType"/> of the security</param>
-        /// <param name="resolution"></param>
-        /// <returns>Type that should be added as a subscription</returns>
-        private static Type GetDataFeedType(Type factoryType, TickType tickType, Resolution resolution)
-        {
-            return LeanData.IsCommonLeanDataType(factoryType) ?
-                            LeanData.GetDataType(resolution, tickType) :
-                            factoryType;
         }
 
         /// <summary>


### PR DESCRIPTION
+ Fixes a bug in the SecurityManager.CreateSecurity that would not generate the appropriate SubscriptionDataConfigs for Canonical Options and Futures
+ New method added, LookupSubscriptionConfigDataTypes, to SubscriptionManager that uses the SecurityType, Resolution and whether the symbol is canonical, to determine the subscription Types.