### PR TITLE
Use provided types in SecurityManager.CreateSecurity

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1312,7 +1312,7 @@ namespace QuantConnect.Algorithm
 
             var marketHoursEntry = _marketHoursDatabase.GetEntry(market, underlying, SecurityType.Option);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, underlying, SecurityType.Option, CashBook.AccountCurrency);
-            var canonicalSecurity = (Option) SecurityManager.CreateSecurity(typeof (ZipEntryName), Portfolio, SubscriptionManager,
+            var canonicalSecurity = (Option) SecurityManager.CreateSecurity(new List<Type>() { typeof(ZipEntryName) }, Portfolio, SubscriptionManager,
                 marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties, SecurityInitializer, canonicalSymbol, resolution,
                 fillDataForward, leverage, false, false, false, LiveMode, true, false);
             canonicalSecurity.IsTradable = false;
@@ -1358,7 +1358,7 @@ namespace QuantConnect.Algorithm
 
             var marketHoursEntry = _marketHoursDatabase.GetEntry(market, symbol, SecurityType.Future);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, symbol, SecurityType.Future, CashBook.AccountCurrency);
-            var canonicalSecurity = (Future)SecurityManager.CreateSecurity(typeof(ZipEntryName), Portfolio, SubscriptionManager,
+            var canonicalSecurity = (Future)SecurityManager.CreateSecurity(new List<Type>() { typeof(ZipEntryName) }, Portfolio, SubscriptionManager,
                 marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties, SecurityInitializer, canonicalSymbol, resolution,
                 fillDataForward, leverage, false, false, false, LiveMode, true, false);
             canonicalSecurity.IsTradable = false;
@@ -1497,7 +1497,7 @@ namespace QuantConnect.Algorithm
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(Market.USA, symbol, SecurityType.Base, CashBook.AccountCurrency);
 
             //Add this new generic data as a tradeable security: 
-            var security = SecurityManager.CreateSecurity(typeof(T), Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone, 
+            var security = SecurityManager.CreateSecurity(new List<Type>() { typeof(T) }, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone, 
                 symbolProperties, SecurityInitializer, symbolObject, resolution, fillDataForward, leverage, true, false, true, LiveMode);
 
             AddToUserDefinedUniverse(security);

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -15,9 +15,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NodaTime;
+using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
+using QuantConnect.Util;
 
 namespace QuantConnect.Data
 {
@@ -180,6 +183,27 @@ namespace QuantConnect.Data
             return AvailableDataTypes[securityType];
         }
 
+        /// <summary>
+        /// Get the data feed types for a given <see cref="SecurityType"/> <see cref="Resolution"/> 
+        /// </summary>
+        /// <param name="symbolSecurityType">The <see cref="SecurityType"/> used to determine the types</param>
+        /// <param name="resolution">The resolution of the data requested</param>
+        /// <param name="isCanonical">Indicates whether the security is Canonical (future and options)</param>
+        /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig"/></returns>
+        public List<Type> LookupSubscriptionConfigDataTypes(SecurityType symbolSecurityType, Resolution resolution, bool isCanonical)
+        {
+            if (isCanonical)
+            {
+                return new List<Type>() { typeof(ZipEntryName) };
+            }
+
+            if (resolution == Resolution.Tick)
+            {
+                return new List<Type>() { typeof(Tick) };
+            }
+
+            return AvailableDataTypes[symbolSecurityType].Select(tickType => LeanData.GetDataType(resolution, tickType)).ToList();
+        }
 
     } // End Algorithm MetaData Manager Class
 

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -430,21 +430,6 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Get the data feed type for the given security. If it is a common data type, LeanData Methods can be used 
-        /// to retrieve the returned type. If not, the type passed in is returned.
-        /// </summary>
-        /// <param name="factoryType"><see cref="BaseData"/> type of the security</param>
-        /// <param name="tickType">The <see cref="TickType"/> of the security</param>
-        /// <param name="resolution"></param>
-        /// <returns>Type that should be added as a subscription</returns>
-        private static Type GetDataFeedType(Type factoryType, TickType tickType, Resolution resolution)
-        {
-            return LeanData.IsCommonLeanDataType(factoryType) ?
-                            LeanData.GetDataType(resolution, tickType) :
-                            factoryType;
-        }
-
-        /// <summary>
         /// Creates a security and matching configuration. This applies the default leverage if
         /// leverage is less than or equal to zero.
         /// This method also add the new symbol mapping to the <see cref="SymbolCache"/>

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -468,7 +468,7 @@ namespace QuantConnect.Securities
             var symbolProperties = symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
 
             var type = resolution == Resolution.Tick ? typeof(Tick) : typeof(TradeBar);
-            if (symbol.ID.SecurityType == SecurityType.Option && resolution != Resolution.Tick)
+            if (symbol.ID.SecurityType == SecurityType.Forex && resolution != Resolution.Tick)
             {
                 type = typeof(QuoteBar);
             }

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -325,6 +325,11 @@ namespace QuantConnect.Securities
             bool addToSymbolCache = true,
             bool isFilteredSubscription = true)
         {
+            if (!factoryTypes.Any())
+            {
+                throw new ArgumentNullException("factoryTypes", "At least one type needed to create security");
+            }
+
             // add the symbol to our cache
             if (addToSymbolCache) SymbolCache.Set(symbol.Value, symbol);
 
@@ -467,12 +472,9 @@ namespace QuantConnect.Securities
             if (symbol.ID.SecurityType == SecurityType.Forex) defaultQuoteCurrency = symbol.Value.Substring(3);
             var symbolProperties = symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
 
-            var type = resolution == Resolution.Tick ? typeof(Tick) : typeof(TradeBar);
-            if (symbol.ID.SecurityType == SecurityType.Forex && resolution != Resolution.Tick)
-            {
-                type = typeof(QuoteBar);
-            }
-            return CreateSecurity(new List<Type>() { type }, securityPortfolioManager, subscriptionManager, exchangeHours, marketHoursDbEntry.DataTimeZone, symbolProperties, securityInitializer, symbol, resolution,
+            var types = subscriptionManager.LookupSubscriptionConfigDataTypes(symbol.SecurityType, resolution, symbol.IsCanonical());
+            
+            return CreateSecurity(types, securityPortfolioManager, subscriptionManager, exchangeHours, marketHoursDbEntry.DataTimeZone, symbolProperties, securityInitializer, symbol, resolution,
                 fillDataForward, leverage, extendedMarketHours, isInternalFeed, isCustomData, isLiveMode, addToSymbolCache);
         }
     }

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -307,7 +307,7 @@ namespace QuantConnect.Securities
         /// leverage is less than or equal to zero.
         /// This method also add the new symbol mapping to the <see cref="SymbolCache"/>
         /// </summary>
-        public static Security CreateSecurity(Type factoryType,
+        public static Security CreateSecurity(List<Type> factoryTypes,
             SecurityPortfolioManager securityPortfolioManager,
             SubscriptionManager subscriptionManager,
             SecurityExchangeHours exchangeHours,
@@ -331,15 +331,7 @@ namespace QuantConnect.Securities
             // Add the symbol to Data Manager -- generate unified data streams for algorithm events
             SubscriptionDataConfigList configList = new SubscriptionDataConfigList(symbol);
 
-            // Get the type that will be used in the data feed
-            // Could be more than one for a given security - i.e. More than one subscription needed
-
-            var dataFeedTypes = subscriptionManager.AvailableDataTypes[symbol.ID.SecurityType]
-                .Select(dataFeed => GetDataFeedType(factoryType, dataFeed, resolution))
-                .Distinct()
-                .ToList();
-
-            foreach (var dataFeedType in dataFeedTypes)
+            foreach (var dataFeedType in factoryTypes)
             {
                 configList.Add(subscriptionManager.Add(dataFeedType, symbol, resolution, dataTimeZone, exchangeHours.TimeZone, isCustomData, fillDataForward,
                                                         extendedMarketHours, isInternalFeed, isFilteredSubscription));
@@ -480,7 +472,7 @@ namespace QuantConnect.Securities
             {
                 type = typeof(QuoteBar);
             }
-            return CreateSecurity(type, securityPortfolioManager, subscriptionManager, exchangeHours, marketHoursDbEntry.DataTimeZone, symbolProperties, securityInitializer, symbol, resolution,
+            return CreateSecurity(new List<Type>() { type }, securityPortfolioManager, subscriptionManager, exchangeHours, marketHoursDbEntry.DataTimeZone, symbolProperties, securityInitializer, symbol, resolution,
                 fillDataForward, leverage, extendedMarketHours, isInternalFeed, isCustomData, isLiveMode, addToSymbolCache);
         }
     }

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -14,18 +14,42 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Tests.Common.Securities
 {
     [TestFixture]
     public class SecurityManagerTests
     {
+        private SecurityManager _securityManager;
+        private SecurityTransactionManager _securityTransactionManager;
+        private SecurityPortfolioManager _securityPortfolioManager;
+        private SubscriptionManager _subscriptionManager;
+        private MarketHoursDatabase _marketHoursDatabase;
+        private SymbolPropertiesDatabase _symbolPropertiesDatabase;
+        private ISecurityInitializer _securityInitializer;
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            var timeKeeper = new TimeKeeper(new DateTime(2015, 12, 07));
+            _securityManager = new SecurityManager(timeKeeper);
+            _securityTransactionManager = new SecurityTransactionManager(_securityManager);
+            _securityPortfolioManager = new SecurityPortfolioManager(_securityManager, _securityTransactionManager);
+            _subscriptionManager = new SubscriptionManager(timeKeeper);
+            _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
+            _securityInitializer = SecurityInitializer.Null;
+        }
+
         [Test]
         public void NotifiesWhenSecurityAdded()
         {
@@ -96,9 +120,125 @@ namespace QuantConnect.Tests.Common.Securities
             manager.Remove(security.Symbol);
         }
 
+        [Test]
+        public void SecurityManagerCanCreate_Forex_WithCorrectSubscriptions()
+        {
+            var forexSymbol = Symbol.Create("EURUSD", SecurityType.Forex, Market.FXCM);
+            var forexMarketHoursDbEntry = _marketHoursDatabase.GetEntry(forexSymbol.ID.Market, forexSymbol, SecurityType.Forex);
+            var forexDefaultQuoteCurrency = forexSymbol.Value.Substring(3);
+
+            var forexSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(forexSymbol.ID.Market, forexSymbol, forexSymbol.ID.SecurityType, forexDefaultQuoteCurrency);
+            var subscriptionTypes = new List<Type>() { typeof(QuoteBar) };
+
+            var forex = SecurityManager.CreateSecurity(subscriptionTypes,
+                _securityPortfolioManager,
+                _subscriptionManager,
+                forexMarketHoursDbEntry.ExchangeHours,
+                forexMarketHoursDbEntry.DataTimeZone,
+                forexSymbolProperties,
+                _securityInitializer,
+                forexSymbol,
+                Resolution.Second,
+                false,
+                1.0m,
+                false,
+                false,
+                false,
+                false);
+            Assert.AreEqual(forex.Subscriptions.Count(), 1);
+            Assert.AreEqual(forex.Subscriptions.First().Type, typeof(QuoteBar));
+        }
+
+        [Test]
+        public void SecurityManagerCanCreate_CanonicalOption_WithCorrectSubscriptions()
+        {
+            var optionSymbol = Symbol.Create("GOOG", SecurityType.Option, Market.USA);
+            var optionMarketHoursDbEntry = _marketHoursDatabase.GetEntry(optionSymbol.ID.Market, optionSymbol, SecurityType.Option);
+            var optionDefaultQuoteCurrency = CashBook.AccountCurrency;
+            var optionSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(optionSymbol.ID.Market, optionSymbol, optionSymbol.ID.SecurityType, optionDefaultQuoteCurrency);
+            var subscriptionTypes = new List<Type>() { typeof(ZipEntryName) };
+
+            var option = SecurityManager.CreateSecurity(subscriptionTypes,
+                _securityPortfolioManager,
+                _subscriptionManager,
+                optionMarketHoursDbEntry.ExchangeHours,
+                optionMarketHoursDbEntry.DataTimeZone,
+                optionSymbolProperties,
+                _securityInitializer,
+                optionSymbol,
+                Resolution.Second,
+                false,
+                1.0m,
+                false,
+                false,
+                false,
+                false);
+
+            Assert.AreEqual(option.Subscriptions.Count(), 1);
+            Assert.AreEqual(option.Subscriptions.First().Type, typeof(ZipEntryName));
+        }
+
+
+        [Test]
+        public void SecurityManagerCanCreate_Equity_WithCorrectSubscriptions()
+        {
+            var equitySymbol = Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
+            var equityMarketHoursDbEntry = _marketHoursDatabase.GetEntry(equitySymbol.ID.Market, equitySymbol, SecurityType.Equity);
+            var equityDefaultQuoteCurrency = CashBook.AccountCurrency;
+            var equitySymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(equitySymbol.ID.Market, equitySymbol, equitySymbol.ID.SecurityType, equityDefaultQuoteCurrency);
+            var subscriptionTypes = new List<Type>() { typeof(TradeBar) };
+
+            var equity = SecurityManager.CreateSecurity(subscriptionTypes,
+                _securityPortfolioManager,
+                _subscriptionManager,
+                equityMarketHoursDbEntry.ExchangeHours,
+                equityMarketHoursDbEntry.DataTimeZone,
+                equitySymbolProperties,
+                _securityInitializer,
+                equitySymbol,
+                Resolution.Second,
+                false,
+                1.0m,
+                false,
+                false,
+                false,
+                false);
+
+            Assert.AreEqual(equity.Subscriptions.Count(), 1);
+            Assert.AreEqual(equity.Subscriptions.First().Type, typeof(TradeBar));
+        }
+
+        [Test]
+        public void SecurityManagerCanCreate_Custom_WithCorrectSubscriptions()
+        {
+            var equitySymbol = new Symbol(SecurityIdentifier.GenerateBase("BTC", Market.USA), "BTC");
+            var equityMarketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "BTC", SecurityType.Base, TimeZones.NewYork);
+            var equitySymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(equitySymbol.ID.Market, equitySymbol, equitySymbol.ID.SecurityType, CashBook.AccountCurrency);
+            var subscriptionTypes = new List<Type>() { typeof(Bitcoin) };
+
+            var equity = SecurityManager.CreateSecurity(subscriptionTypes,
+                _securityPortfolioManager,
+                _subscriptionManager,
+                equityMarketHoursDbEntry.ExchangeHours,
+                equityMarketHoursDbEntry.DataTimeZone,
+                equitySymbolProperties,
+                _securityInitializer,
+                equitySymbol,
+                Resolution.Second,
+                false,
+                1.0m,
+                false,
+                false,
+                false,
+                false);
+
+            Assert.AreEqual(equity.Subscriptions.Count(), 1);
+            Assert.AreEqual(equity.Subscriptions.First().Type, typeof(Bitcoin));
+        }
+
         private SubscriptionDataConfig CreateTradeBarConfig()
         {
-            return new SubscriptionDataConfig(typeof (TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
+            return new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
         }
     }
 }


### PR DESCRIPTION
+ Allow SecurityManager.CreateSecurity() to accept a list of types.  If types are provided, create subscriptions with those types.
+ If no types are provided to SecurityManager.CreateSecurity(), look them up via the SubscriptionManager.
+ Added tests to SecurityManagerTests specifically for CreateSecurity()
