### PR TITLE
Updated InvalidSymbolCharacter collection initialization 

### DIFF
--- a/Common/SecurityIdentifier.cs
+++ b/Common/SecurityIdentifier.cs
@@ -53,7 +53,7 @@ namespace QuantConnect
         /// <summary>
         /// Gets the set of invalids symbol characters
         /// </summary>
-        public static readonly IReadOnlyCollection<char> InvalidSymbolCharacters = (IReadOnlyCollection<char>)new HashSet<char>(InvalidCharacters);
+        public static readonly HashSet<char> InvalidSymbolCharacters = new HashSet<char>(InvalidCharacters);
 
         #endregion
 


### PR DESCRIPTION
Updated InvalidSymbolCharacter collection initialization in SecurityIdentifier class to be compatible with C# <4.5. Tests are running OK.