### PR TITLE
Do not submit orders during warmup

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -180,6 +180,12 @@ namespace QuantConnect.Algorithm
 
             var request = CreateSubmitOrderRequest(OrderType.Market, security, quantity, tag);
 
+            // If warming up, do not submit
+            if (IsWarmingUp)
+            {
+                return OrderTicket.InvalidWarmingUp(Transactions, request);
+            }
+
             //Initialize the Market order parameters:
             var preOrderCheckResponse = PreOrderChecks(request);
             if (preOrderCheckResponse.IsError)
@@ -316,6 +322,12 @@ namespace QuantConnect.Algorithm
             var option = (Option)Securities[optionSymbol];
 
             var request = CreateSubmitOrderRequest(OrderType.OptionExercise, option, quantity, tag);
+
+            // If warming up, do not submit
+            if (IsWarmingUp)
+            {
+                return OrderTicket.InvalidWarmingUp(Transactions, request);
+            }
 
             //Initialize the exercise order parameters
             var preOrderCheckResponse = PreOrderChecks(request);


### PR DESCRIPTION
This PR solves timeout errors when submitting market orders during Warmup.

Originally reported here: 
https://www.quantconnect.com/forum/discussion/1505/get-an-error-when-run-warm-up-algorithm-in-qc-university/p1