### PR TITLE
Removed reference to System.IO.Compression zip library 

### DIFF
--- a/Compression/Compression.cs
+++ b/Compression/Compression.cs
@@ -474,7 +474,7 @@ namespace QuantConnect
         /// <param name="filename">Location of the original zip file</param>
         /// <param name="zip">The ZipFile instance to be returned to the caller</param>
         /// <returns>Stream reader of the first file contents in the zip file</returns>
-        public static StreamReader Unzip(string filename, out ZipArchive zip)
+        public static StreamReader Unzip(string filename, out ZipFile zip)
         {
             return Unzip(filename, null, out zip);
         }
@@ -485,9 +485,9 @@ namespace QuantConnect
         /// </summary>
         /// <param name="filename">Location of the original zip file</param>
         /// <param name="zipEntryName">The zip entry name to open a reader for. Specify null to access the first entry</param>
-        /// <param name="zip">The ZipArchive instance to be returned to the caller</param>
+        /// <param name="zip">The ZipFile instance to be returned to the caller</param>
         /// <returns>Stream reader of the first file contents in the zip file</returns>
-        public static StreamReader Unzip(string filename, string zipEntryName, out ZipArchive zip)
+        public static StreamReader Unzip(string filename, string zipEntryName, out ZipFile zip)
         {
             StreamReader reader = null;
             zip = null;
@@ -498,20 +498,15 @@ namespace QuantConnect
                 {
                     try
                     {
-                        var file = File.OpenRead(filename);
-                        // reading up first two bytes 
-                        // http://george.chiramattel.com/blog/2007/09/deflatestream-block-length-does-not-match.html
-                        file.ReadByte(); file.ReadByte();
-
-                        zip = new ZipArchive(file);
-                        var entry = zip.Entries.FirstOrDefault(x => zipEntryName == null || string.Compare(x.FullName, zipEntryName, StringComparison.OrdinalIgnoreCase) == 0);
+                        zip = new ZipFile(filename);
+                        var entry = zip.FirstOrDefault(x => zipEntryName == null || string.Compare(x.FileName, zipEntryName, StringComparison.OrdinalIgnoreCase) == 0);
                         if (entry == null)
                         {
                             // Unable to locate zip entry 
                             return null;
                         }
 
-                        reader = new StreamReader(entry.Open());
+                        reader = new StreamReader(entry.OpenReader());
                     }
                     catch (Exception err)
                     {

--- a/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
     public class LocalFileSubscriptionStreamReader : IStreamReader
     {
         private StreamReader _streamReader;
-        private readonly ZipArchive _zipArchive;
+        private readonly ZipFile _zipFile;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LocalFileSubscriptionStreamReader"/> class.
@@ -42,7 +42,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         {
             // unzip if necessary
             _streamReader = source.GetExtension() == ".zip"
-                ? Compression.Unzip(source, entryName, out _zipArchive)
+                ? Compression.Unzip(source, entryName, out _zipFile)
                 : new StreamReader(source);
         }
 
@@ -57,7 +57,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         {
             // unzip if necessary
             _streamReader = source.GetExtension() == ".zip"
-                ? Compression.Unzip(source, entryName, out _zipArchive)
+                ? Compression.Unzip(source, entryName, out _zipFile)
                 : new StreamReader(source);
 
             if (startingPosition != 0)
@@ -70,17 +70,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// <summary>
         /// Initializes a new instance of the <see cref="LocalFileSubscriptionStreamReader"/> class.
         /// </summary>
-        /// <param name="zipArchive">The local zip archive to be read</param>
+        /// <param name="zipFile">The local zip archive to be read</param>
         /// <param name="entryName">Specifies the zip entry to be opened. Leave null if not applicable,
         /// or to open the first zip entry found regardless of name</param>
-        public LocalFileSubscriptionStreamReader(ZipArchive zipArchive, string entryName = null)
+        public LocalFileSubscriptionStreamReader(ZipFile zipFile, string entryName = null)
         {
-            _zipArchive = zipArchive;
-            var entry = _zipArchive.Entries.FirstOrDefault(x => entryName == null || string.Compare(x.FullName, entryName, StringComparison.OrdinalIgnoreCase) == 0);
+            _zipFile = zipFile;
+            var entry = _zipFile.Entries.FirstOrDefault(x => entryName == null || string.Compare(x.FileName, entryName, StringComparison.OrdinalIgnoreCase) == 0);
             if (entry != null)
             {
                 var stream = new MemoryStream();
-                entry.Open().CopyTo(stream);
+                entry.OpenReader().CopyTo(stream);
                 stream.Position = 0;
                 _streamReader = new StreamReader(stream);
             }
@@ -93,7 +93,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         {
             get
             {
-                return _zipArchive != null ? _zipArchive.Entries.Select(x => x.FullName).ToList() : Enumerable.Empty<string>();
+                return _zipFile != null ? _zipFile.Entries.Select(x => x.FileName).ToList() : Enumerable.Empty<string>();
             }
         }
 

--- a/Tests/Compression/CompressionTests.cs
+++ b/Tests/Compression/CompressionTests.cs
@@ -55,9 +55,9 @@ namespace QuantConnect.Tests.Compression
         public void ExtractsZipEntryByName()
         {
             var zip = Path.Combine("TestData", "multizip.zip");
-            ZipArchive zipArchive;
-            using (var entryStream = QuantConnect.Compression.Unzip(zip, "multizip/two.txt", out zipArchive))
-            using (zipArchive)
+            ZipFile zipFile;
+            using (var entryStream = QuantConnect.Compression.Unzip(zip, "multizip/two.txt", out zipFile))
+            using (zipFile)
             {
                 var text = entryStream.ReadToEnd();
                 Assert.AreEqual("2", text);

--- a/ToolBox/CoarseUniverseGenerator/Program.cs
+++ b/ToolBox/CoarseUniverseGenerator/Program.cs
@@ -24,7 +24,6 @@ using Newtonsoft.Json.Linq;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Util;
 using Log = QuantConnect.Logging.Log;
-using System.IO.Compression;
 
 namespace QuantConnect.ToolBox.CoarseUniverseGenerator
 {
@@ -203,7 +202,7 @@ namespace QuantConnect.ToolBox.CoarseUniverseGenerator
                         }
                     }
 
-                    ZipArchive zip;
+                    ZipFile zip;
                     using (var reader = Compression.Unzip(file, out zip))
                     {
                         // 30 period EMA constant


### PR DESCRIPTION
Removed reference to System.IO.Compression zip library in Compression.Unzip() and DataFileCacheProvider.cs, as in mono this namespace is implemented using SharpCompress. Reverted back to Ionic zip library.

Tests (incl regression) are green.