### PR TITLE
RollingWindow(N) now becomes ready after N additions

### DIFF
--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -150,9 +150,9 @@ namespace QuantConnect.Indicators
                 {
                     _listLock.EnterReadLock();
 
-                    if (i >= Count)
+                    if (i < 0 || i > Count - 1)
                     {
-                        throw new ArgumentOutOfRangeException("i", i, string.Format("Must be between 0 and Count {0}", Count));
+                        throw new ArgumentOutOfRangeException("i", i, string.Format("Must be between 0 and {0}", Count - 1));
                     }
                     return _list[(Count + _tail - i - 1) % Count];
                 }
@@ -167,9 +167,9 @@ namespace QuantConnect.Indicators
                 {
                     _listLock.EnterWriteLock();
 
-                    if (i >= Count)
+                    if (i < 0 || i > Count - 1)
                     {
-                        throw new ArgumentOutOfRangeException("i", i, string.Format("Must be between 0 and Count {0}", Count));
+                        throw new ArgumentOutOfRangeException("i", i, string.Format("Must be between 0 and {0}", Count - 1));
                     }
                     _list[(Count + _tail - i - 1) % Count] = value;
                 }
@@ -182,7 +182,7 @@ namespace QuantConnect.Indicators
 
         /// <summary>
         ///     Gets a value indicating whether or not this window is ready, i.e,
-        ///     it has been filled to its capacity and one has fallen off the back
+        ///     it has been filled to its capacity
         /// </summary>
         public bool IsReady
         {
@@ -191,7 +191,7 @@ namespace QuantConnect.Indicators
                 try
                 {
                     _listLock.EnterReadLock();
-                    return Samples > Size;
+                    return Samples >= Size;
                 }
                 finally
                 {

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -122,7 +122,7 @@ namespace QuantConnect.Indicators
                 {
                     _listLock.EnterReadLock();
 
-                    if (!IsReady)
+                    if (Samples <= Size)
                     {
                         throw new InvalidOperationException("No items have been removed yet!");
                     }

--- a/Indicators/Delay.cs
+++ b/Indicators/Delay.cs
@@ -41,6 +41,14 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
+        ///     Gets a flag indicating when this indicator is ready and fully initialized
+        /// </summary>
+        public override bool IsReady
+        {
+            get { return Samples > Period; }
+        }
+
+        /// <summary>
         ///     Computes the next value for this indicator from the given state.
         /// </summary>
         /// <param name="window">The window of data held in this indicator</param>
@@ -48,7 +56,7 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
-            if (!window.IsReady)
+            if (!IsReady)
             {
                 // grab the initial value until we're ready
                 return window[window.Count - 1];

--- a/Indicators/FractalAdaptiveMovingAverage.cs
+++ b/Indicators/FractalAdaptiveMovingAverage.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Indicators
             _low.Add((double)input.Low);
 
             // our first data point just return identity
-            if (!_high.IsReady)
+            if (_high.Samples <= _high.Size)
             {
                 _filt = price;
             }

--- a/Indicators/LeastSquaresMovingAverage.cs
+++ b/Indicators/LeastSquaresMovingAverage.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Indicators
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
             // Until the window is ready, the indicator returns the input value.
-            if (!IsReady) return input;
+            if (window.Samples <= window.Size) return input;
 
             // Sort the window by time, convert the observations to double and transform it to an array
             var series = window

--- a/Indicators/LogReturn.cs
+++ b/Indicators/LogReturn.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Indicators
         {
             decimal valuef = input;
 
-            decimal value0 = !window.IsReady
+            decimal value0 = window.Samples <= window.Size
                 ? window[window.Count - 1]
                 : window.MostRecentlyRemoved;
 

--- a/Indicators/Momentum.cs
+++ b/Indicators/Momentum.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
-            if (!window.IsReady)
+            if (window.Samples <= window.Size)
             {
                 // keep returning the delta from the first item put in there to init
                 return input - window[window.Count - 1];

--- a/Indicators/Momersion.cs
+++ b/Indicators/Momersion.cs
@@ -95,7 +95,7 @@ namespace QuantConnect.Indicators
                 }
                 else
                 {
-                    return _multipliedDiffWindow.IsReady;
+                    return _multipliedDiffWindow.Samples > _multipliedDiffWindow.Size;
                 }
             }
         }

--- a/Indicators/RateOfChange.cs
+++ b/Indicators/RateOfChange.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Indicators
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
             // if we're not ready just grab the first input point in the window
-            decimal denominator = !window.IsReady ? window[window.Count - 1] : window.MostRecentlyRemoved;
+            decimal denominator = window.Samples <= window.Size ? window[window.Count - 1] : window.MostRecentlyRemoved;
 
             if (denominator == 0)
             {

--- a/Indicators/RateOfChangePercent.cs
+++ b/Indicators/RateOfChangePercent.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Indicators
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
             // if we're not ready just grab the first input point in the window
-            decimal denominator = !window.IsReady ? window[window.Count - 1] : window.MostRecentlyRemoved;
+            decimal denominator = window.Samples <= window.Size ? window[window.Count - 1] : window.MostRecentlyRemoved;
 
             if (denominator == 0)
             {

--- a/Indicators/RateOfChangeRatio.cs
+++ b/Indicators/RateOfChangeRatio.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
-            var denominator = IsReady ? window.MostRecentlyRemoved : window[window.Count - 1];
+            var denominator = window.Samples > window.Size ? window.MostRecentlyRemoved : window[window.Count - 1];
 
             return denominator != 0 ? input / denominator : 0m;
         }

--- a/Indicators/Sum.cs
+++ b/Indicators/Sum.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Indicators {
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input) {
             _sum += input.Value;
-            if (window.IsReady) {
+            if (window.Samples > window.Size) {
                 _sum -= window.MostRecentlyRemoved.Value;
             }
             return _sum;

--- a/Tests/Indicators/DelayTests.cs
+++ b/Tests/Indicators/DelayTests.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public void DelayTakesPeriodPlus2UpdaesToEmitNonInitialPoint()
+        public void DelayTakesPeriodPlus2UpdatesToEmitNonInitialPoint()
         {
             int start = 1;
             int count = 10;

--- a/Tests/Indicators/LeastSquaresMovingAverageTest.cs
+++ b/Tests/Indicators/LeastSquaresMovingAverageTest.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Tests.Indicators
             for (int i = 0; i < LSMAPeriod + 1; i++)
             {
                 LSMA.Update(new IndicatorDataPoint(time, 1m));
-                time.AddMinutes(1);
+                time = time.AddMinutes(1);
             }
             Assert.IsTrue(LSMA.IsReady, "LSMA ready");
             LSMA.Reset();

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -62,9 +62,16 @@ namespace QuantConnect.Tests.Indicators
             var window = new RollingWindow<int>(1);
             Assert.IsFalse(window.IsReady);
 
-            // add one and the window is ready
+            // add one and the window is ready, but MostRecentlyRemoved throws
 
             window.Add(0);
+            Assert.Throws<InvalidOperationException>(() => { var x = window.MostRecentlyRemoved; });
+            Assert.AreEqual(1, window.Count);
+            Assert.IsTrue(window.IsReady);
+
+            // add another one and MostRecentlyRemoved is available
+
+            window.Add(1);
             Assert.AreEqual(0, window.MostRecentlyRemoved);
             Assert.AreEqual(1, window.Count);
             Assert.IsTrue(window.IsReady);

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Indicators;
@@ -35,18 +36,23 @@ namespace QuantConnect.Tests.Indicators
         [Test]
         public void AddsData()
         {
-            var window = new RollingWindow<int>(1);
+            var window = new RollingWindow<int>(2);
+            Assert.AreEqual(0, window.Count);
+            Assert.AreEqual(0, window.Samples);
+            Assert.AreEqual(2, window.Size);
+            Assert.IsFalse(window.IsReady);
+
             window.Add(1);
             Assert.AreEqual(1, window.Count);
             Assert.AreEqual(1, window.Samples);
-            Assert.AreEqual(1, window.Size);
+            Assert.AreEqual(2, window.Size);
             Assert.IsFalse(window.IsReady);
 
             // add one more and the window is ready
             window.Add(2);
-            Assert.AreEqual(1, window.Count);
+            Assert.AreEqual(2, window.Count);
             Assert.AreEqual(2, window.Samples);
-            Assert.AreEqual(1, window.Size);
+            Assert.AreEqual(2, window.Size);
             Assert.IsTrue(window.IsReady);
         }
 
@@ -54,12 +60,11 @@ namespace QuantConnect.Tests.Indicators
         public void OldDataFallsOffBackOfWindow()
         {
             var window = new RollingWindow<int>(1);
-            window.Add(0);
             Assert.IsFalse(window.IsReady);
 
-            // add one more and the window is ready
+            // add one and the window is ready
 
-            window.Add(1);
+            window.Add(0);
             Assert.AreEqual(0, window.MostRecentlyRemoved);
             Assert.AreEqual(1, window.Count);
             Assert.IsTrue(window.IsReady);
@@ -110,8 +115,9 @@ namespace QuantConnect.Tests.Indicators
             window.Reset();
             Assert.AreEqual(0, window.Samples);
         }
+
         [Test]
-        public void RetievesNonZeroIndexProperlyAfterReset()
+        public void RetrievesNonZeroIndexProperlyAfterReset()
         {
             var window = new RollingWindow<int>(3);
             window.Add(0);
@@ -156,6 +162,22 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(1, window[2]);
             Assert.AreEqual(2, window[1]);
             Assert.AreEqual(3, window[0]);
+        }
+
+        [Test]
+        public void ThrowsWhenIndexingOutOfRange()
+        {
+            var window = new RollingWindow<int>(1);
+            Assert.IsFalse(window.IsReady);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[0]; });
+
+            window.Add(0);
+            Assert.AreEqual(1, window.Count);
+            Assert.AreEqual(0, window[0]);
+            Assert.IsTrue(window.IsReady);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[1]; });
         }
     }
 }


### PR DESCRIPTION
Previously it became ready only after N+1 additions.
Also updated all indicators dependent on this behavior of RollingWindow.

Fixes this issue:
https://www.quantconnect.com/forum/discussion/1680/why-rolling-window-did-not-work-as-expected