### PR TITLE
Fix universe selection bug when adding/removing symbols with holdings

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -153,6 +153,7 @@
     <Compile Include="UpdateOrderLiveTestAlgorithm.cs" />
     <Compile Include="UpdateOrderRegressionAlgorithm.cs" />
     <Compile Include="OrderTicketDemoAlgorithm.cs" />
+    <Compile Include="WeeklyUniverseSelectionRegressionAlgorithm.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Algorithm\QuantConnect.Algorithm.csproj">

--- a/Algorithm.CSharp/WeeklyUniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WeeklyUniverseSelectionRegressionAlgorithm.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm to test universe additions and removals with open positions
+    /// </summary>
+    public class WeeklyUniverseSelectionRegressionAlgorithm : QCAlgorithm
+    {
+        private readonly Symbol _ibm = QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA);
+        private SecurityChanges _changes = SecurityChanges.None;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            UniverseSettings.Resolution = Resolution.Hour;
+
+            SetStartDate(2013, 10, 1);  //Set Start Date
+            SetEndDate(2013, 10, 31);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+
+            // select IBM once a week, empty universe the other days
+            AddUniverse(coarse => Time.Day % 7 == 0 ? new List<Symbol> { _ibm } : Enumerable.Empty<Symbol>());
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">TradeBars dictionary object keyed by symbol containing the stock data</param>
+        public void OnData(TradeBars data)
+        {
+            if (_changes == SecurityChanges.None) return;
+
+            // liquidate securities removed from our universe
+            foreach (var security in _changes.RemovedSecurities)
+            {
+                if (security.Invested)
+                {
+                    Log(Time + " Liquidate " + security.Symbol.Value);
+                    Liquidate(security.Symbol);
+                }
+            }
+
+            // we'll simply go long each security we added to the universe
+            foreach (var security in _changes.AddedSecurities)
+            {
+                if (!security.Invested)
+                {
+                    Log(Time + " Buy " + security.Symbol.Value);
+                    SetHoldings(security.Symbol, 1);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed
+        /// </summary>
+        /// <param name="changes">Object containing AddedSecurities and RemovedSecurities</param>
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            _changes = changes;
+            Log(Time + " " + changes);
+        }
+    }
+}

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -477,6 +477,28 @@ namespace QuantConnect.Tests
                 {"Total Fees", "$0.50"},
             };
 
+            var weeklyUniverseSelectionRegressionAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "8"},
+                {"Average Win", "1.68%"},
+                {"Average Loss", "-0.77%"},
+                {"Compounding Annual Return", "23.389%"},
+                {"Drawdown", "1.900%"},
+                {"Expectancy", "0.597"},
+                {"Net Profit", "1.801%"},
+                {"Sharpe Ratio", "1.884"},
+                {"Loss Rate", "50%"},
+                {"Win Rate", "50%"},
+                {"Profit-Loss Ratio", "2.19"},
+                {"Alpha", "-0.003"},
+                {"Beta", "0.421"},
+                {"Annual Standard Deviation", "0.087"},
+                {"Annual Variance", "0.008"},
+                {"Information Ratio", "-2.459"},
+                {"Tracking Error", "0.094"},
+                {"Treynor Ratio", "0.391"},
+                {"Total Fees", "$23.05"},
+            };
 
             return new List<AlgorithmStatisticsTestParameters>
             {
@@ -500,6 +522,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("OptionRenameRegressionAlgorithm", optionRenameRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("OptionOpenInterestRegressionAlgorithm", optionOpenInterestRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("OptionChainConsistencyRegressionAlgorithm", optionChainConsistencyRegressionAlgorithmStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("WeeklyUniverseSelectionRegressionAlgorithm", weeklyUniverseSelectionRegressionAlgorithmStatistics, Language.CSharp),
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION
When a symbol gets selected again, after being unselected while having an open position, it is still subscribed. So when the `SecuritiesChanged` event fires, it does not contain the re-added symbol.

The `WeeklyUniverseSelectionRegressionAlgorithm` is a regression test for the universe selection bug fix.