### PR TITLE
Fixing fill forward resolution race bug in backtesting and live. Test.

### DIFF
--- a/Algorithm.CSharp/HistoryAlgorithm.cs
+++ b/Algorithm.CSharp/HistoryAlgorithm.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Algorithm.CSharp
     public class HistoryAlgorithm : QCAlgorithm
     {
         public SimpleMovingAverage spyDailySma;
-
+        private int _count = 0;
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
         /// </summary>
@@ -195,6 +195,13 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="data">Slice object keyed by symbol containing the stock data</param>
         public override void OnData(Slice data)
         {
+            _count++;
+
+            if (_count > 5)
+            {
+                throw new Exception("Invalid number of bars arrived. Expected exactly 5");
+            }
+
             if (!Portfolio.Invested)
             {
                 SetHoldings("SPY", 1);


### PR DESCRIPTION
Fill forward resolution was initialized too late from time to time. HistoryAlgo test failed due to this under CPU stress. In this test fillforward enumerator produced bars with 1 day data resolution, but 1 minute fill forward resolution. As a result of this, around 200 unexpected bars arrived to the algo while only 5 were expected. Algo statistics produced incorrect numbers. Now test is updated to scream if unexpected bars have arrived.