### PR TITLE
Fix consolidator not firing in live mode

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -493,7 +493,7 @@ namespace QuantConnect.Lean.Engine
                                 // This is needed to avoid feeding in higher resolution data, typically fill-forward bars.
                                 // It also prevents volume-based indicators or consolidators summing up volume to generate
                                 // invalid values.
-                                if (algorithm.UtcTime == dataPoint.EndTime.RoundUp(resolutionTimeSpan).ConvertToUtc(update.Target.ExchangeTimeZone))
+                                if (algorithm.UtcTime.RoundDown(resolutionTimeSpan) == dataPoint.EndTime.RoundUp(resolutionTimeSpan).ConvertToUtc(update.Target.ExchangeTimeZone))
                                 {
                                     consolidator.Update(dataPoint);
                                 }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -496,7 +496,7 @@ namespace QuantConnect.Lean.Engine
                                 var algorithmTimeSpan = resolutionTimeSpan == TimeSpan.FromTicks(0)
                                     ? TimeSpan.FromTicks(0)
                                     : TimeSpan.FromSeconds(1);
-                                if (algorithm.UtcTime.RoundDown(algorithmTimeSpan) == dataPoint.EndTime.RoundUp(resolutionTimeSpan).ConvertToUtc(update.Target.ExchangeTimeZone))
+                                if (algorithm.UtcTime.RoundDown(algorithmTimeSpan) == dataPoint.EndTime.ConvertToUtc(update.Target.ExchangeTimeZone).RoundUp(resolutionTimeSpan))
                                 {
                                     consolidator.Update(dataPoint);
                                 }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -493,7 +493,10 @@ namespace QuantConnect.Lean.Engine
                                 // This is needed to avoid feeding in higher resolution data, typically fill-forward bars.
                                 // It also prevents volume-based indicators or consolidators summing up volume to generate
                                 // invalid values.
-                                if (algorithm.UtcTime.RoundDown(resolutionTimeSpan) == dataPoint.EndTime.RoundUp(resolutionTimeSpan).ConvertToUtc(update.Target.ExchangeTimeZone))
+                                var algorithmTimeSpan = resolutionTimeSpan == TimeSpan.FromTicks(0)
+                                    ? TimeSpan.FromTicks(0)
+                                    : TimeSpan.FromSeconds(1);
+                                if (algorithm.UtcTime.RoundDown(algorithmTimeSpan) == dataPoint.EndTime.RoundUp(resolutionTimeSpan).ConvertToUtc(update.Target.ExchangeTimeZone))
                                 {
                                     consolidator.Update(dataPoint);
                                 }


### PR DESCRIPTION
Due to the recent filter to data for consolidators, algorithm.UtcTime needs to be rounded down to work in live mode