### PR TITLE
Add missing DataNormalizationMode in history requests

### DIFF
--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -74,6 +74,10 @@ namespace QuantConnect.Data
         /// Gets true if this is a custom data request, false for normal QC data
         /// </summary>
         public bool IsCustomData { get; set; }
+        /// <summary>
+        /// Gets the normalization mode used for this subscription
+        /// </summary>
+        public DataNormalizationMode DataNormalizationMode { get; set; }
 
         /// <summary>
         /// Initializes a new default instance of the <see cref="HistoryRequest"/> class
@@ -91,6 +95,7 @@ namespace QuantConnect.Data
             TimeZone = TimeZones.NewYork;
             Market = QuantConnect.Market.USA;
             IsCustomData = false;
+            DataNormalizationMode = DataNormalizationMode.Adjusted;
         }
 
         /// <summary>
@@ -107,6 +112,7 @@ namespace QuantConnect.Data
         /// <param name="fillForwardResolution">The requested fill forward resolution for this request</param>
         /// <param name="includeExtendedMarketHours">True to include data from pre/post market hours</param>
         /// <param name="isCustomData">True for custom user data, false for normal QC data</param>
+        /// <param name="dataNormalizationMode">Specifies normalization mode used for this subscription</param>
         public HistoryRequest(DateTime startTimeUtc, 
             DateTime endTimeUtc,
             Type dataType,
@@ -117,7 +123,8 @@ namespace QuantConnect.Data
             SecurityExchangeHours exchangeHours,
             Resolution? fillForwardResolution,
             bool includeExtendedMarketHours,
-            bool isCustomData
+            bool isCustomData,
+            DataNormalizationMode dataNormalizationMode
             )
         {
             StartTimeUtc = startTimeUtc;
@@ -131,6 +138,7 @@ namespace QuantConnect.Data
             SecurityType = securityType;
             Market = market;
             IsCustomData = isCustomData;
+            DataNormalizationMode = dataNormalizationMode;
             TimeZone = exchangeHours.TimeZone;
         }
 
@@ -154,6 +162,7 @@ namespace QuantConnect.Data
             SecurityType = config.SecurityType;
             Market = config.Market;
             IsCustomData = config.IsCustomData;
+            DataNormalizationMode = config.DataNormalizationMode;
             TimeZone = config.DataTimeZone;
         }
     }

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -240,6 +240,7 @@ namespace QuantConnect.Data
         /// <param name="isCustom">True if this is user supplied custom data, false for normal QC data</param>
         /// <param name="tickType">Specifies if trade or quote data is subscribed</param>
         /// <param name="isFilteredSubscription">True if this subscription should have filters applied to it (market hours/user filters from security), false otherwise</param>
+        /// <param name="dataNormalizationMode">Specifies normalization mode used for this subscription</param>
         public SubscriptionDataConfig(SubscriptionDataConfig config,
             Type objectType = null,
             Symbol symbol = null,
@@ -251,7 +252,8 @@ namespace QuantConnect.Data
             bool? isInternalFeed = null,
             bool? isCustom = null,
             TickType? tickType = null,
-            bool? isFilteredSubscription = null)
+            bool? isFilteredSubscription = null,
+            DataNormalizationMode? dataNormalizationMode = null)
             : this(
             objectType ?? config.Type,
             symbol ?? config.Symbol,
@@ -263,7 +265,8 @@ namespace QuantConnect.Data
             isInternalFeed ?? config.IsInternalFeed,
             isCustom ?? config.IsCustomData,
             tickType ?? config.TickType,
-            isFilteredSubscription ?? config.IsFilteredSubscription
+            isFilteredSubscription ?? config.IsFilteredSubscription,
+            dataNormalizationMode ?? config.DataNormalizationMode
             )
         {
         }

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -109,7 +109,10 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 request.FillForwardResolution.HasValue, 
                 request.IncludeExtendedMarketHours, 
                 false, 
-                request.IsCustomData
+                request.IsCustomData,
+                null,
+                true,
+                request.DataNormalizationMode
                 );
 
             var security = new Security(request.ExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));


### PR DESCRIPTION
Previously, `DataNormalizationMode` in history requests was always being set to the `Adjusted` default value, so `SetDataNormalizationMode` calls were not being respected in `SubscriptionDataReaderHistoryProvider.GetHistory` and warmup.