### PR TITLE
Refactored option assignment/exercise

### DIFF
--- a/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
@@ -1,0 +1,107 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This regression algorithm tests option exercise and assignment functionality
+    /// We open two positions and go with them into expiration. We expect to see our long position exercised and short position assigned.
+    /// </summary>
+    public class OptionExerciseAssignRegressionAlgorithm : QCAlgorithm
+    {
+        private const string UnderlyingTicker = "GOOG"; 
+        public readonly Symbol Underlying = QuantConnect.Symbol.Create(UnderlyingTicker, SecurityType.Equity, Market.USA);
+        public readonly Symbol OptionSymbol = QuantConnect.Symbol.Create(UnderlyingTicker, SecurityType.Option, Market.USA);
+        private bool _assignedOption = false;
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 12, 24);
+            SetEndDate(2015, 12, 24);
+            SetCash(100000);
+
+            var equity = AddEquity(UnderlyingTicker);
+            var option = AddOption(UnderlyingTicker);
+
+            // set our strike/expiry filter for this option chain
+            option.SetFilter(u => u.IncludeWeeklys()
+                                   .Strikes(-2, +2)
+                                   .Expiration(TimeSpan.Zero, TimeSpan.FromDays(10)));
+
+            // use the underlying equity as the benchmark
+            SetBenchmark(equity.Symbol);
+        }
+
+        ~OptionExerciseAssignRegressionAlgorithm()
+        {
+            if (!_assignedOption)
+            {
+                throw new Exception("In the end, short ITM option position was not assigned.");
+            }
+        }
+
+        /// <summary>
+        /// Event - v3.0 DATA EVENT HANDLER: (Pattern) Basic template for user to override for receiving all subscription data in a single event
+        /// </summary>
+        /// <param name="slice">The current slice of data keyed by symbol string</param>
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                OptionChain chain;
+                if (slice.OptionChains.TryGetValue(OptionSymbol, out chain))
+                {
+                    // find the second call strike under market price expiring today
+                    var contracts = (
+                        from optionContract in chain.OrderByDescending(x => x.Strike)
+                        where optionContract.Right == OptionRight.Call
+                        where optionContract.Expiry == Time.Date
+                        where optionContract.Strike < chain.Underlying.Price
+                        select optionContract
+                        ).Take(2);
+
+                    if (contracts.Any())
+                    {
+                        MarketOrder(contracts.FirstOrDefault().Symbol, 1);
+                        MarketOrder(contracts.Skip(1).FirstOrDefault().Symbol, -1);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Order fill event handler. On an order fill update the resulting information is passed to this method.
+        /// </summary>
+        /// <param name="orderEvent">Order event details containing details of the evemts</param>
+        /// <remarks>This method can be called asynchronously and so should only be used by seasoned C# experts. Ensure you use proper locks on thread-unsafe objects</remarks>
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Log(orderEvent.ToString());
+        }
+        public override void OnAssignmentOrderEvent(OrderEvent assignmentEvent)
+        {
+            Log(assignmentEvent.ToString());
+            _assignedOption = true;
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -78,6 +78,7 @@
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
     <Compile Include="BasicTemplateFuturesHistoryAlgorithm.cs" />
     <Compile Include="BasicTemplateMultiAssetAlgorithm.cs" />
+    <Compile Include="OptionExerciseAssignRegressionAlgorithm.cs" />
     <Compile Include="BasicTemplateOptionsFilterUniverseAlgorithm.cs" />
     <Compile Include="BasicTemplateOptionsHistoryAlgorithm.cs" />
     <Compile Include="BasicTemplateOptionTradesAlgorithm.cs" />

--- a/Common/Orders/OptionExercise/DefaultExerciseModel.cs
+++ b/Common/Orders/OptionExercise/DefaultExerciseModel.cs
@@ -73,6 +73,11 @@ namespace QuantConnect.Orders.OptionExercise
                             orderFee,
                             "Adjusting(or removing) the exercised/assigned option");
 
+            if (optionRemoveEvent.FillQuantity > 0)
+            {
+                optionRemoveEvent.IsAssignment = true;
+            }
+
             if (option.ExerciseSettlement == SettlementType.PhysicalDelivery &&
                 option.IsAutoExercised(underlying.Close))
             {

--- a/Common/Orders/OptionExercise/DefaultExerciseModel.cs
+++ b/Common/Orders/OptionExercise/DefaultExerciseModel.cs
@@ -34,38 +34,53 @@ namespace QuantConnect.Orders.OptionExercise
         /// </summary>
         /// <param name="option">Option we're trading this order</param>
         /// <param name="order">Order to update</param>
-        public OrderEvent OptionExercise(Option option, OptionExerciseOrder order)
+        public IEnumerable<OrderEvent> OptionExercise(Option option, OptionExerciseOrder order)
         {
-            //Default order event to return
             var utcTime = option.LocalTime.ConvertToUtc(option.Exchange.TimeZone);
-            var deliveryEvent = new OrderEvent(order, utcTime, 0);
 
-            // make sure the exchange is open before filling
-            if (!IsExchangeOpen(option)) return deliveryEvent;
+            var optionQuantity = order.Quantity;
+            var assignment = order.Quantity < 0;
+            var underlying = option.Underlying;
+            var exercisePrice = order.Price;
+            var fillQuantity = option.GetExerciseQuantity(order.Quantity);
+            var exerciseQuantity =
+                    option.Symbol.ID.OptionRight == OptionRight.Call ? fillQuantity : -fillQuantity;
+            var exerciseDirection = assignment? 
+                    (option.Symbol.ID.OptionRight == OptionRight.Call ? OrderDirection.Sell : OrderDirection.Buy):
+                    (option.Symbol.ID.OptionRight == OptionRight.Call ? OrderDirection.Buy : OrderDirection.Sell);
 
-            //Order price for a option exercise order model is the strike price
-            deliveryEvent.FillPrice = order.Price;
-            deliveryEvent.FillQuantity = option.GetExerciseQuantity(order.Quantity);
-            deliveryEvent.OrderFee = option.FeeModel.GetOrderFee(option, order);
-            deliveryEvent.Status = OrderStatus.Filled;
+            var orderFee = option.FeeModel.GetOrderFee(option, order);
 
-            return deliveryEvent;
-        }
-        /// <summary>
-        /// Determines if the exchange is open using the current time of the asset
-        /// </summary>
-        private static bool IsExchangeOpen(Security asset)
-        {
-            if (!asset.Exchange.DateTimeIsOpen(asset.LocalTime))
+            var cashQuote = option.QuoteCurrency;
+
+            var addUnderlyingEvent = new OrderEvent(order.Id,
+                            underlying.Symbol,
+                            utcTime,
+                            OrderStatus.Filled,
+                            exerciseDirection,
+                            exercisePrice,
+                            exerciseQuantity,
+                            0.0m,
+                            "Option Exercise/Assignment");
+
+            var optionRemoveEvent = new OrderEvent(order.Id,
+                            option.Symbol,
+                            utcTime,
+                            OrderStatus.Filled,
+                            assignment ? OrderDirection.Buy : OrderDirection.Sell,
+                            0.0m,
+                            -optionQuantity,
+                            orderFee,
+                            "Adjusting(or removing) the exercised/assigned option");
+
+            if (option.ExerciseSettlement == SettlementType.PhysicalDelivery &&
+                option.IsAutoExercised(underlying.Close))
             {
-                // if we're not open at the current time exactly, check the bar size, this handle large sized bars (hours/days)
-                var currentBar = asset.GetLastData();
-                if (asset.LocalTime.Date != currentBar.EndTime.Date || !asset.Exchange.IsOpenDuringBar(currentBar.Time, currentBar.EndTime, false))
-                {
-                    return false;
-                }
+                return new[] { optionRemoveEvent, addUnderlyingEvent };
             }
-            return true;
+
+            return new[] { optionRemoveEvent };
         }
+        
     }
 }

--- a/Common/Orders/OptionExercise/IOptionExerciseModel.cs
+++ b/Common/Orders/OptionExercise/IOptionExerciseModel.cs
@@ -15,6 +15,7 @@
 
 using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
+using System.Collections.Generic;
 
 namespace QuantConnect.Orders.OptionExercise
 {
@@ -30,7 +31,7 @@ namespace QuantConnect.Orders.OptionExercise
         /// <param name="option">Option we're trading this order</param>
         /// <param name="order">Order to update</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        OrderEvent OptionExercise(Option option, OptionExerciseOrder order);
+        IEnumerable<OrderEvent> OptionExercise(Option option, OptionExerciseOrder order);
 
     }
 }

--- a/Common/Orders/OrderEvent.cs
+++ b/Common/Orders/OrderEvent.cs
@@ -88,6 +88,11 @@ namespace QuantConnect.Orders
         public string Message;
 
         /// <summary>
+        /// True if the order event is an assignment
+        /// </summary>
+        public bool IsAssignment;
+
+        /// <summary>
         /// Order Event Constructor.
         /// </summary>
         /// <param name="orderId">Id of the parent order</param>
@@ -111,6 +116,7 @@ namespace QuantConnect.Orders
             FillQuantity = fillQuantity;
             OrderFee = Math.Abs(orderFee);
             Message = message;
+            IsAssignment = false;
         }
 
         /// <summary>
@@ -135,6 +141,7 @@ namespace QuantConnect.Orders
             UtcTime = utcTime;
             OrderFee = Math.Abs(orderFee);
             Message = message;
+            IsAssignment = false;
         }
 
         /// <summary>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -338,6 +338,7 @@
     <Compile Include="Securities\IDerivativeSecurityFilterUniverse.cs" />
     <Compile Include="Securities\IMarginCallModel.cs" />
     <Compile Include="Securities\ISecuritySeeder.cs" />
+    <Compile Include="Securities\Option\OptionSymbol.cs" />
     <Compile Include="Securities\SecurityPriceVariationModel.cs" />
     <Compile Include="Securities\FuncSecurityDerivativeFilter.cs" />
     <Compile Include="Securities\FuncSecurityInitializer.cs" />

--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -20,6 +20,7 @@ using QuantConnect.Data;
 using System.Linq;
 using System.Collections;
 using QuantConnect.Util;
+using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Securities
 {
@@ -129,7 +130,7 @@ namespace QuantConnect.Securities
 
                 if (memoizedMap.ContainsKey(dt))
                     return memoizedMap[dt];
-                var res = IsStandardType(symbol);
+                var res = OptionSymbol.IsStandardContract(symbol);
                 memoizedMap[dt] = res;
 
                 return res;
@@ -152,26 +153,6 @@ namespace QuantConnect.Securities
 
             _allSymbols = filtered.ToList();
             return this;
-        }
-
-        /// <summary>
-        /// Returns true is the option is a standard contract that expire 3rd Friday of the month
-        /// </summary>
-        /// <param name="symbol"></param>
-        /// <returns></returns>
-        private bool IsStandardType(Symbol symbol)
-        {
-            var date = symbol.ID.Date;
-
-            // first we find out the day of week of the first day in the month
-            var firstDayOfMonth = new DateTime(date.Year, date.Month, 1).DayOfWeek;
-
-            // find out the day of first Friday in this month
-            var firstFriday = firstDayOfMonth == DayOfWeek.Saturday ? 7 : 6 - (int)firstDayOfMonth;
-
-            // check if the expiration date is within the week containing 3rd Friday
-            // we exclude monday, wednesday, and friday weeklys
-            return firstFriday + 7 + 5 /*sat -> wed */ < date.Day && date.Day < firstFriday + 2 * 7 + 2 /* sat, sun*/;
         }
 
         /// <summary>

--- a/Common/Securities/Option/OptionSymbol.cs
+++ b/Common/Securities/Option/OptionSymbol.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuantConnect.Securities.Option
+{
+    /// <summary>
+    /// Static class contains common utility methods specific to symbols representing the option contracts
+    /// </summary>
+    public static class OptionSymbol
+    {
+        /// <summary>
+        /// Returns true is the option is a standard contract that expire 3rd Friday of the month
+        /// </summary>
+        /// <param name="symbol">Option symbol</param>
+        /// <returns></returns>
+        public static bool IsStandardContract(Symbol symbol)
+        {
+            var date = symbol.ID.Date;
+
+            // first we find out the day of week of the first day in the month
+            var firstDayOfMonth = new DateTime(date.Year, date.Month, 1).DayOfWeek;
+
+            // find out the day of first Friday in this month
+            var firstFriday = firstDayOfMonth == DayOfWeek.Saturday ? 7 : 6 - (int)firstDayOfMonth;
+
+            // check if the expiration date is within the week containing 3rd Friday
+            // we exclude monday, wednesday, and friday weeklys
+            return firstFriday + 7 + 5 /*sat -> wed */ < date.Day && date.Day < firstFriday + 2 * 7 + 2 /* sat, sun*/;
+        }
+
+        /// <summary>
+        /// Returns lat trading date for the option contract
+        /// </summary>
+        /// <param name="symbol">Option symbol</param>
+        /// <returns></returns>
+        public static DateTime GetLastDayOfTrading(Symbol symbol)
+        {
+            // The OCC proposed rule change: starting from 1 Feb 2015 standard monthly contracts
+            // expire on 3rd Friday, not Saturday following 3rd Friday as it was before.
+            // More details: https://www.sec.gov/rules/sro/occ/2013/34-69480.pdf
+
+            if (IsStandardContract(symbol) &&
+                symbol.ID.Date.DayOfWeek == DayOfWeek.Saturday &&
+                symbol.ID.Date < new DateTime(2015, 2, 1))
+            {
+                return symbol.ID.Date.Date.AddDays(-1.0);
+            }
+
+            return symbol.ID.Date.Date;
+        }
+    }
+}

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -123,6 +123,11 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 HandleAccountChanged(account);
             };
 
+            _brokerage.OptionPositionAssigned += (sender, fill) =>
+            {
+                HandlePositionAssigned(fill);
+            };
+
             IsActive = true;
 
             _algorithm = algorithm;
@@ -961,6 +966,19 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             {
                 // override the current cash value so we're always guaranteed to be in sync with the brokerage's push updates
                 _algorithm.Portfolio.CashBook[account.CurrencySymbol].SetAmount(account.CashBalance);
+            }
+        }
+
+        /// <summary>
+        /// Option assignment/exercise event is received and propagated to the user algo
+        /// </summary>
+        private void HandlePositionAssigned(OrderEvent fill)
+        {
+            // informing user algorithm that option position has been assigned
+            if (fill.FillPrice > 0 && fill.FillQuantity > 0)
+            {
+                fill.Message = string.Format("Option Assignment: {0}", fill.Symbol.Value);
+                _algorithm.OnAssignmentOrderEvent(fill);
             }
         }
 

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -975,7 +975,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         private void HandlePositionAssigned(OrderEvent fill)
         {
             // informing user algorithm that option position has been assigned
-            if (fill.FillPrice == 0 && fill.FillQuantity > 0)
+            if (fill.IsAssignment)
             {
                 fill.Message = string.Format("Option Assignment: {0}", fill.Symbol.Value);
                 _algorithm.OnAssignmentOrderEvent(fill);

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -975,7 +975,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         private void HandlePositionAssigned(OrderEvent fill)
         {
             // informing user algorithm that option position has been assigned
-            if (fill.FillPrice > 0 && fill.FillQuantity > 0)
+            if (fill.FillPrice == 0 && fill.FillQuantity > 0)
             {
                 fill.Message = string.Format("Option Assignment: {0}", fill.Symbol.Value);
                 _algorithm.OnAssignmentOrderEvent(fill);

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -22,6 +22,7 @@ using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Tests.Common
 {
@@ -363,6 +364,33 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(expectedNotFoundSymbol, notFoundSymbol);
             SymbolCache.Clear();
 #pragma warning restore 0618
+        }
+
+
+        [Test]
+        public void TestIfWeDetectCorrectlyWeekliesAndStandardOptionsBeforeFeb2015()
+        {
+            var symbol = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 200, new DateTime(2012, 09, 22));
+            var weeklySymbol = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 200, new DateTime(2012, 09, 07));
+
+            Assert.True(OptionSymbol.IsStandardContract(symbol));
+            Assert.False(OptionSymbol.IsStandardContract(weeklySymbol));
+
+            Assert.AreEqual(new DateTime(2012, 09, 21)/*Friday*/, OptionSymbol.GetLastDayOfTrading(symbol));
+            Assert.AreEqual(new DateTime(2012, 09, 07)/*Friday*/, OptionSymbol.GetLastDayOfTrading(weeklySymbol));
+        }
+
+        [Test]
+        public void TestIfWeDetectCorrectlyWeekliesAndStandardOptionsAfterFeb2015()
+        {
+            var symbol = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 200, new DateTime(2016, 02, 19));
+            var weeklySymbol = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 200, new DateTime(2016, 02, 05));
+
+            Assert.True(OptionSymbol.IsStandardContract(symbol));
+            Assert.False(OptionSymbol.IsStandardContract(weeklySymbol));
+
+            Assert.AreEqual(new DateTime(2016, 02, 19)/*Friday*/, OptionSymbol.GetLastDayOfTrading(symbol));
+            Assert.AreEqual(new DateTime(2016, 02, 05)/*Friday*/, OptionSymbol.GetLastDayOfTrading(weeklySymbol));
         }
 
         class OldSymbol

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -499,6 +499,28 @@ namespace QuantConnect.Tests
                 {"Treynor Ratio", "0.391"},
                 {"Total Fees", "$23.05"},
             };
+	    var optionExerciseAssignRegressionAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "4"},
+                {"Average Win", "0.30%"},
+                {"Average Loss", "-0.20%"},
+                {"Compounding Annual Return", "-42.722%"},
+                {"Drawdown", "0.400%"},
+                {"Expectancy", "-0.168"},
+                {"Net Profit", "-0.103%"},
+                {"Sharpe Ratio", "0"},
+                {"Loss Rate", "67%"},
+                {"Win Rate", "33%"},
+                {"Profit-Loss Ratio", "1.50"},
+                {"Alpha", "0"},
+                {"Beta", "0"},
+                {"Annual Standard Deviation", "0"},
+                {"Annual Variance", "0"},
+                {"Information Ratio", "0"},
+                {"Tracking Error", "0"},
+                {"Treynor Ratio", "0"},
+                {"Total Fees", "$0.50"},
+            };
 
             return new List<AlgorithmStatisticsTestParameters>
             {
@@ -523,6 +545,8 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("OptionOpenInterestRegressionAlgorithm", optionOpenInterestRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("OptionChainConsistencyRegressionAlgorithm", optionChainConsistencyRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("WeeklyUniverseSelectionRegressionAlgorithm", weeklyUniverseSelectionRegressionAlgorithmStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("OptionExerciseAssignRegressionAlgorithm",optionExerciseAssignRegressionAlgorithmStatistics, Language.CSharp),
+                
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION
Refactored option assignment/exercise:
1. Made sure we treat properly option expiration dates before Feb 2015 and after. Added tests. OCC proposed rule change: starting from 1 Feb 2015 standard monthly contracts expire on 3rd Friday, not Saturday following 3rd Friday as it was before. More details: https://www.sec.gov/rules/sro/occ/2013/34-69480.pdf  
2. Refactored expiration delisting, assignments/option exercise to happen in the end of the date, not MOC orders in the beginning of the day. Regression test.
3. Refactored option exercise model to generate proper fills on assignments/option. Those fills are reflected correctly in margins, in stats and correspond to IB model. Still need to run IB real-life live tests.
4. Refactored option symbol related functions into separate module (OptionSymbol.cs)
5. Made sure OnAssignmentEvent arrived to the user algo in regression test. Do we need OnExercise event? Not sure.
6. Tested end-to-end Ray's current code (covered call strat) to see short option legs expire worthless, and stats updated.