### PR TITLE
Remove call to Environment.Exit in Program.cs

### DIFF
--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -124,15 +124,14 @@ namespace QuantConnect.Lean.Launcher
             }
             finally
             {
-                //Delete the message from the job queue:
+                // Delete the message from the job queue:
                 leanEngineSystemHandlers.JobQueue.AcknowledgeJob(job);
                 Log.Trace("Engine.Main(): Packet removed from queue: " + job.AlgorithmId);
 
-                // clean up resources
+                // Clean up resources
                 leanEngineSystemHandlers.Dispose();
                 leanEngineAlgorithmHandlers.Dispose();
                 Log.LogHandler.Dispose();
-                Environment.Exit(0);
             }
         }
     }


### PR DESCRIPTION
+ Remove call to `Environment.Exit(0)` in `Program.cs`.  This was a hacky fix to a simple threading problem.  The threading problem has fixed.