### PR TITLE
Fix potential ObjectDisposedException in DataFileCacheProvider

### DIFF
--- a/Engine/DataFeeds/DataFileCacheProvider.cs
+++ b/Engine/DataFeeds/DataFileCacheProvider.cs
@@ -70,12 +70,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         // clean all items that that are older than _cachePeriodBars bars than the current date
                         foreach (var zip in _zipFileCache.Where(x => x.Value.Value.Item1 < date.Date.AddDays(-_cachePeriodBars)))
                         {
-                            // disposing zip archive
-                            zip.Value.Value.Item2.Dispose();
-
                             // removing it from the cache
                             Lazy<CacheEntry> removed;
-                            _zipFileCache.TryRemove(zip.Key, out removed);
+                            if (_zipFileCache.TryRemove(zip.Key, out removed))
+                            {
+                                // disposing zip archive
+                                removed.Value.Item2.Dispose();
+                            }
                         }
 
                         lastDate = date.Date;

--- a/Engine/DataFeeds/DataFileCacheProvider.cs
+++ b/Engine/DataFeeds/DataFileCacheProvider.cs
@@ -32,11 +32,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     /// </summary>
     public class DataFileCacheProvider : IDisposable
     {
-        const int _cachePeriodBars = 10;
+        private const int CachePeriodBars = 10;
 
         // ZipArchive cache used by the class
-        private ConcurrentDictionary<string, Lazy<CacheEntry>> _zipFileCache = new ConcurrentDictionary<string, Lazy<CacheEntry>>();
-        private DateTime lastDate = DateTime.MinValue;
+        private readonly ConcurrentDictionary<string, Lazy<CacheEntry>> _zipFileCache = new ConcurrentDictionary<string, Lazy<CacheEntry>>();
+        private DateTime _lastDate = DateTime.MinValue;
 
         /// <summary>
         /// Does not attempt to retrieve any data
@@ -65,10 +65,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 try
                 {
                     // cleaning the outdated cache items
-                    if (lastDate == DateTime.MinValue || lastDate < date.Date)
+                    if (_lastDate == DateTime.MinValue || _lastDate < date.Date)
                     {
                         // clean all items that that are older than _cachePeriodBars bars than the current date
-                        foreach (var zip in _zipFileCache.Where(x => x.Value.Value.Item1 < date.Date.AddDays(-_cachePeriodBars)))
+                        foreach (var zip in _zipFileCache.Where(x => x.Value.Value.Item1 < date.Date.AddDays(-CachePeriodBars)))
                         {
                             // removing it from the cache
                             Lazy<CacheEntry> removed;
@@ -79,7 +79,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             }
                         }
 
-                        lastDate = date.Date;
+                        _lastDate = date.Date;
                     }
 
                     _zipFileCache.AddOrUpdate(filename,


### PR DESCRIPTION
Pretty rare event, but can happen:

```
20170202 13:43:39 ERROR:: R:: DataFileCacheProvider.Fetch(): Inner try/catch System.ObjectDisposedException: Cannot access a disposed object.
20170202 13:43:39 ERROR:: Object name: 'handle'.
20170202 13:43:39 ERROR::   at System.Runtime.InteropServices.SafeHandle.DangerousReleaseInternal (System.Boolean dispose) [0x00040] in <dca3b561b8ad4f9fb10141d81b39ff45>:0
20170202 13:43:39 ERROR::   at System.Runtime.InteropServices.SafeHandle.DangerousRelease () [0x00000] in <dca3b561b8ad4f9fb10141d81b39ff45>:0
20170202 13:43:39 ERROR::   at System.IO.FileStream.Dispose (System.Boolean disposing) [0x00067] in <dca3b561b8ad4f9fb10141d81b39ff45>:0
20170202 13:43:39 ERROR::   at System.IO.Stream.Close () [0x00000] in <dca3b561b8ad4f9fb10141d81b39ff45>:0
20170202 13:43:39 ERROR::   at System.IO.Stream.Dispose () [0x00000] in <dca3b561b8ad4f9fb10141d81b39ff45>:0
20170202 13:43:39 ERROR::   at (wrapper remoting-invoke-with-check) System.IO.Stream:Dispose ()
20170202 13:43:39 ERROR::   at Ionic.Zip.ZipFile.Dispose (System.Boolean disposeManagedResources) [0x0001b] in <d927f24b97454f06a8b33afc17183ddb>:0
20170202 13:43:39 ERROR::   at Ionic.Zip.ZipFile.Dispose () [0x00000] in <d927f24b97454f06a8b33afc17183ddb>:0
20170202 13:43:39 ERROR::   at QuantConnect.Lean.Engine.DataFeeds.DataFileCacheProvider.Fetch (QuantConnect.Symbol symbol, QuantConnect.Data.SubscriptionDataSource source, System.DateTime date, QuantConnect.Resolution resolution, QuantConnect.TickType tickType) [0x0011b] in <5f6ad2ed06d747f1bd039f0159da22dd>:0
```