### PR TITLE
Changed time rules to explicitly require a user to specify only posit…

### DIFF
--- a/Common/Scheduling/TimeRules.cs
+++ b/Common/Scheduling/TimeRules.cs
@@ -137,6 +137,11 @@ namespace QuantConnect.Scheduling
         /// <returns>A time rule that fires the specified number of minutes after the symbol's market open</returns>
         public ITimeRule AfterMarketOpen(Symbol symbol, double minutesAfterOpen = 0, bool extendedMarketOpen = false)
         {
+            if (minutesAfterOpen < 0)
+            {
+                throw new ArgumentException("The time after market open is negative. Please make sure it is a non-negative value", "minutesAfterOpen");
+            }
+
             var security = GetSecurity(symbol);
 
             var type = extendedMarketOpen ? "ExtendedMarketOpen" : "MarketOpen";
@@ -163,6 +168,11 @@ namespace QuantConnect.Scheduling
         /// <returns>A time rule that fires the specified number of minutes before the symbol's market close</returns>
         public ITimeRule BeforeMarketClose(Symbol symbol, double minutesBeforeClose = 0, bool extendedMarketClose = false)
         {
+            if (minutesBeforeClose < 0)
+            {
+                throw new ArgumentException("The time before market close is negative. Please make sure it is a non-negative value", "minutesBeforeClose");
+            }
+
             var security = GetSecurity(symbol);
 
             var type = extendedMarketClose ? "ExtendedMarketClose" : "MarketClose";

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -125,6 +125,13 @@ namespace QuantConnect.Tests.Common.Scheduling
         }
 
         [Test]
+        public void RegularMarketOpenWithNegativeDelta()
+        {
+            var rules = GetTimeRules(TimeZones.Utc);
+            Assert.Throws<ArgumentException>(() => rules.AfterMarketOpen(Symbols.SPY, -30));
+        }
+
+        [Test]
         public void RegularMarketCloseNoDelta()
         {
             var rules = GetTimeRules(TimeZones.Utc);
@@ -154,6 +161,13 @@ namespace QuantConnect.Tests.Common.Scheduling
                 Assert.AreEqual(TimeSpan.FromHours(16 + 5 - .5), time.TimeOfDay);
             }
             Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void RegularMarketCloseWithNegativeDelta()
+        {
+            var rules = GetTimeRules(TimeZones.Utc);
+            Assert.Throws<ArgumentException>(() => rules.BeforeMarketClose(Symbols.SPY, -30));
         }
 
         [Test]


### PR DESCRIPTION
…ive numbers in offsets for both live and backtest modes. Tests.

This commit refers to trello ticket #1770. In backtests this negative offset is ignored and event is fired at the moment when markets are open. In live mode, we don't ignore negative offset and attempt to fire event N minutes before markets are open. I propose to fix this issue by explicitly requiring user to specify only positive numbers in offsets for both live and backtest modes. 