### PR TITLE
Add IDataCacheFileProvider

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.HistoryProvider.cs
@@ -65,7 +65,8 @@ namespace QuantConnect.Brokerages.Fxcm
         /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
         /// <param name="dataFileProvider">Provider used to get data when it is not present on disk</param>
         /// <param name="statusUpdate">Function used to send status updates</param>
-        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
+        /// <param name="dataFileCacheProvider">Provider used to cache history data files</param>
+        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate, IDataFileCacheProvider dataFileCacheProvider = null)
         {
             Connect();
         }

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1948,7 +1948,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
         /// <param name="dataFileProvider">Provider used to get data when it is not present on disk</param>
         /// <param name="statusUpdate">Function used to send status updates</param>
-        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
+        /// <param name="dataFileCacheProvider">Provider used to cache history data files</param>
+        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate, IDataFileCacheProvider dataFileCacheProvider = null)
         {
             Connect();
         }

--- a/Brokerages/Oanda/OandaBrokerage.HistoryProvider.cs
+++ b/Brokerages/Oanda/OandaBrokerage.HistoryProvider.cs
@@ -50,7 +50,8 @@ namespace QuantConnect.Brokerages.Oanda
         /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
         /// <param name="dataFileProvider">Provider used to get data when it is not present on disk</param>
         /// <param name="statusUpdate">Function used to send status updates</param>
-        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
+        /// <param name="dataFileCacheProvider">Provider used to cache history data files</param>
+        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate, IDataFileCacheProvider dataFileCacheProvider = null)
         {
             Connect();
         }

--- a/Brokerages/Tradier/TradierBrokerage.HistoryProvider.cs
+++ b/Brokerages/Tradier/TradierBrokerage.HistoryProvider.cs
@@ -46,7 +46,8 @@ namespace QuantConnect.Brokerages.Tradier
         /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
         /// <param name="dataFileProvider">Provider used to get data when it is not present on disk</param>
         /// <param name="statusUpdate">Function used to send status updates</param>
-        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
+        /// <param name="dataFileCacheProvider">Provider used to cache history data files</param>
+        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate, IDataFileCacheProvider dataFileCacheProvider = null)
         {
         }
 

--- a/Common/Interfaces/IDataFileCacheProvider.cs
+++ b/Common/Interfaces/IDataFileCacheProvider.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using QuantConnect.Data;
+
+namespace QuantConnect.Interfaces
+{
+    /// <summary>
+    /// Defines a cache for data
+    /// </summary>
+    public interface IDataFileCacheProvider : IDisposable
+    {
+        /// <summary>
+        /// Fetch data from the cache
+        /// </summary>
+        /// <param name="symbol">The Symbol of the requested data</param>
+        /// <param name="source">The <see cref="SubscriptionDataSource"/> of the requested data</param>
+        /// <param name="date"></param>
+        /// <param name="resolution">The resolution of the data requested</param>
+        /// <param name="tickType">The <see cref="TickType"/> of the data requested from the cache</param>
+        /// <returns>An <see cref="IStreamReader"/> that has the data from the cache preloaded</returns>
+        IStreamReader Fetch(Symbol symbol, SubscriptionDataSource source, DateTime date, Resolution resolution, TickType tickType);
+
+        /// <summary>
+        /// Store the data in the cache
+        /// </summary>
+        /// <param name="source">The source of the data, used as a key to retrieve data in the cache</param>
+        /// <param name="data">The data as a byte array</param>
+        void Store(string source, byte[] data);
+    }
+}

--- a/Common/Interfaces/IHistoryProvider.cs
+++ b/Common/Interfaces/IHistoryProvider.cs
@@ -42,7 +42,8 @@ namespace QuantConnect.Interfaces
         /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
         /// <param name="dataFileProvider">Provider used to get data when it is not present on disk</param>
         /// <param name="statusUpdate">Function used to send status updates</param>
-        void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate);
+        /// <param name="dataFileCacheProvider">Provider used to cache history data files</param>
+        void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate, IDataFileCacheProvider dataFileCacheProvider = null);
 
         /// <summary>
         /// Gets the history for the requested securities

--- a/Common/Interfaces/IStreamReader.cs
+++ b/Common/Interfaces/IStreamReader.cs
@@ -16,7 +16,7 @@
 
 using System;
 
-namespace QuantConnect.Lean.Engine.DataFeeds.Transport
+namespace QuantConnect.Interfaces
 {
     /// <summary>
     /// Defines a transport mechanism for data from its source into various reader methods
@@ -32,7 +32,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// Gets whether or not there's more data to be read in the stream
         /// </summary>
         bool EndOfStream { get; }
-        
+
         /// <summary>
         /// Gets the next line/batch of content from the stream 
         /// </summary>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -257,6 +257,7 @@
     <Compile Include="Interfaces\IApi.cs" />
     <Compile Include="Interfaces\IBrokerage.cs" />
     <Compile Include="Interfaces\IBrokerageFactory.cs" />
+    <Compile Include="Interfaces\IDataFileCacheProvider.cs" />
     <Compile Include="Interfaces\IDataQueueUniverseProvider.cs" />
     <Compile Include="Interfaces\ICommandQueueHandler.cs" />
     <Compile Include="Interfaces\IDataQueueHandler.cs" />
@@ -266,6 +267,7 @@
     <Compile Include="Interfaces\IJobQueueHandler.cs" />
     <Compile Include="Interfaces\IMapFileProvider.cs" />
     <Compile Include="Interfaces\IMessagingHandler.cs" />
+    <Compile Include="Interfaces\IStreamReader.cs" />
     <Compile Include="LocalTimeKeeper.cs" />
     <Compile Include="Market.cs" />
     <Compile Include="Notifications\Notification.cs" />

--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds.Transport;
 using QuantConnect.Util;
 

--- a/Engine/DataFeeds/DataFileCacheProvider.cs
+++ b/Engine/DataFeeds/DataFileCacheProvider.cs
@@ -21,6 +21,7 @@ using System.Collections.Concurrent;
 using QuantConnect.Logging;
 using System.Linq;
 using Ionic.Zip;
+using QuantConnect.Interfaces;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -30,7 +31,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     /// <summary>
     /// File provider implements optimized zip archives caching facility. Cache is thread safe.
     /// </summary>
-    public class DataFileCacheProvider : IDisposable
+    public class DataFileCacheProvider : IDataFileCacheProvider
     {
         private const int CachePeriodBars = 10;
 
@@ -109,6 +110,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // handles text files
                 return new LocalFileSubscriptionStreamReader(filename, entryName);
             }
+        }
+
+        /// <summary>
+        /// Store the data in the cache. Not implementated in this instance of the IDataFileCacheProvider
+        /// </summary>
+        /// <param name="source">The source of the data, used as a key to retrieve data in the cache</param>
+        /// <param name="data">The data as a byte array</param>
+        public void Store(string source, byte[] data)
+        {
+            //
         }
 
         /// <summary>

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private bool _emittedAuxilliaryData;
         private BaseData _lastInstanceBeforeAuxilliaryData;
         private readonly IDataFileProvider _dataFileProvider;
-        private readonly DataFileCacheProvider _dataFileCacheProvider;
+        private readonly IDataFileCacheProvider _dataFileCacheProvider;
 
         /// <summary>
         /// Last read BaseData object from this type and source
@@ -135,7 +135,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             IDataFileProvider dataFileProvider,
             IEnumerable<DateTime> tradeableDates,
             bool isLiveMode,
-            DataFileCacheProvider dataFileCacheProvider = null,
+            IDataFileCacheProvider dataFileCacheProvider = null,
             bool includeAuxilliaryData = true)
         {
             //Save configuration of data-subscription:

--- a/Engine/DataFeeds/SubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataSourceReader.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="date">The date to be processed</param>
         /// <param name="isLiveMode">True for live mode, false otherwise</param>
         /// <returns>A new <see cref="ISubscriptionDataSourceReader"/> that can read the specified <paramref name="source"/></returns>
-        public static ISubscriptionDataSourceReader ForSource(SubscriptionDataSource source, IDataFileProvider dataFileProvider, DataFileCacheProvider dataFileCacheProvider, SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+        public static ISubscriptionDataSourceReader ForSource(SubscriptionDataSource source, IDataFileProvider dataFileProvider, IDataFileCacheProvider dataFileCacheProvider, SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
             switch (source.Format)
             {

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private readonly BaseData _factory;
         private readonly DateTime _date;
         private readonly SubscriptionDataConfig _config;
-        private readonly DataFileCacheProvider _dataFileCacheProvider;
+        private readonly IDataFileCacheProvider _dataFileCacheProvider;
         private readonly IDataFileProvider _dataFileProvider;
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="config">The subscription's configuration</param>
         /// <param name="date">The date this factory was produced to read data for</param>
         /// <param name="isLiveMode">True if we're in live mode, false for backtesting</param>
-        public TextSubscriptionDataSourceReader(IDataFileProvider dataFileProvider, DataFileCacheProvider dataFileCacheProvider, SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+        public TextSubscriptionDataSourceReader(IDataFileProvider dataFileProvider, IDataFileCacheProvider dataFileCacheProvider, SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
             _dataFileProvider = dataFileProvider;
             _dataFileCacheProvider = dataFileCacheProvider;

--- a/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
@@ -17,6 +17,7 @@
 using System;
 using System.IO;
 using System.Net;
+using QuantConnect.Interfaces;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Transport
 {

--- a/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using RestSharp;
 

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -65,7 +65,8 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
         /// <param name="dataFileProvider">Provider used to get data when it is not present on disk</param>
         /// <param name="statusUpdate">Function used to send status updates</param>
-        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
+        /// <param name="dataFileCacheProvider">Provider used to cache history data files</param>
+        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate, IDataFileCacheProvider dataFileCacheProvider = null)
         {
             _mapFileProvider = mapFileProvider;
             _factorFileProvider = factorFileProvider;

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -48,6 +48,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         private IMapFileProvider _mapFileProvider;
         private IFactorFileProvider _factorFileProvider;
         private IDataFileProvider _dataFileProvider;
+        private IDataFileCacheProvider _dataFileCacheProvider;
 
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
@@ -71,6 +72,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             _mapFileProvider = mapFileProvider;
             _factorFileProvider = factorFileProvider;
             _dataFileProvider = dataFileProvider;
+            _dataFileCacheProvider = dataFileCacheProvider;
         }
 
         /// <summary>
@@ -127,7 +129,8 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 _dataFileProvider,
                 Time.EachTradeableDay(request.ExchangeHours, start, end), 
                 false,
-                includeAuxilliaryData: false
+                _dataFileCacheProvider,
+                false
                 );
 
             // optionally apply fill forward behavior

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -223,7 +223,6 @@
     <Compile Include="DataFeeds\ReaderErrorEventArgs.cs" />
     <Compile Include="DataFeeds\SubscriptionDataReader.cs" />
     <Compile Include="DataFeeds\TimeSlice.cs" />
-    <Compile Include="DataFeeds\Transport\IStreamReader.cs" />
     <Compile Include="DataFeeds\Transport\LocalFileSubscriptionStreamReader.cs" />
     <Compile Include="DataFeeds\Transport\RemoteFileSubscriptionStreamReader.cs" />
     <Compile Include="DataFeeds\Transport\RestSubscriptionStreamReader.cs" />

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -43,7 +43,8 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
         public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider,
             IFactorFileProvider factorFileProvider,
-            IDataFileProvider dataFileProvider, Action<int> statusUpdate)
+            IDataFileProvider dataFileProvider, Action<int> statusUpdate,
+            IDataFileCacheProvider dataFileCacheProvider = null)
         {
         }
 

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -197,7 +197,8 @@ namespace QuantConnect.ToolBox.IQFeed
         /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
         /// <param name="dataFileProvider">Provider used to get data when it is not present on disk</param>
         /// <param name="statusUpdate">Function used to send status updates</param>
-        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate)
+        /// <param name="dataFileCacheProvider">Provider used to cache history data files</param>
+        public void Initialize(AlgorithmNodePacket job, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, IDataFileProvider dataFileProvider, Action<int> statusUpdate, IDataFileCacheProvider dataFileCacheProvider = null)
         {
             return;
         }


### PR DESCRIPTION
+ Added new interface, `IDataCacheFileProvider`, which defines the ability to cache data files and retrieve the data from cache.
+ Changed the existing `DataFileCacheProvider` class to inherit from the new `IDataCacheFileProvider` interface
+ Added the `IDataCacheFileProvider` to the `IHistoryProvider.Initialize()` method as a parameter with a default value of null
+ Moved the `IStreamReader` from the `QuantConnect.Lean.Engine` project to the `QuantConnect` project so that it can be returned in `IDataCacheFileProvider.Fetch()` method.

These changes, while fairly extensive, should not affect any existing code.