### PR TITLE
Tick consolidator minor fix

### DIFF
--- a/Common/Data/Consolidators/TickConsolidator.cs
+++ b/Common/Data/Consolidators/TickConsolidator.cs
@@ -74,6 +74,8 @@ namespace QuantConnect.Data.Consolidators
                     Value = data.Value,
                     Volume = data.Quantity
                 };
+
+                if (Period.HasValue) workingBar.Period = Period.Value;
             }
             else
             {

--- a/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
@@ -79,6 +79,8 @@ namespace QuantConnect.Data.Consolidators
                     Bid = null,
                     Ask = null
                 };
+
+                if (Period.HasValue) workingBar.Period = Period.Value;
             }
 
             // update the bid and ask


### PR DESCRIPTION
WorkingBar resolution was not set explicitly and that made it incoherent with the Consolidator, since the default is minute. It causes IDataConsolidator.Scan to emit a bar that was already emited