### PR TITLE
Tick resolution SubscriptionDataConfigs for Forex and Cfds

### DIFF
--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -192,7 +192,7 @@ namespace QuantConnect.Data
 
             if (!tickType.HasValue)
             {
-                TickType = LeanData.GetCommonTickTypeForCommonDataTypes(objectType);
+                TickType = LeanData.GetCommonTickTypeForCommonDataTypes(objectType, SecurityType);
             }
             else
             {

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -559,8 +559,9 @@ namespace QuantConnect.Util
         /// If not a Lean common data type, return a TickType of Trade.
         /// </summary>
         /// <param name="type">A Type used to determine the TickType</param>
+        /// <param name="securityType">The SecurityType used to determine the TickType</param>
         /// <returns>A TickType corresponding to the type</returns>
-        public static TickType GetCommonTickTypeForCommonDataTypes(Type type)
+        public static TickType GetCommonTickTypeForCommonDataTypes(Type type, SecurityType securityType)
         {
             if (type == typeof(TradeBar))
             {
@@ -577,6 +578,13 @@ namespace QuantConnect.Util
             if (type == typeof(ZipEntryName))
             {
                 return TickType.Trade;
+            }
+            if (type == typeof(Tick))
+            {
+                if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
+                {
+                    return TickType.Quote;
+                }
             }
 
             return TickType.Trade;

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -163,6 +163,12 @@ namespace QuantConnect.Tests.Common.Util
             Assert.IsFalse(LeanData.IsCommonLeanDataType(typeof(Bitcoin)));
         }
 
+        [Test]
+        public void LeanData_GetCommonTickTypeForCommonDataTypes_ReturnsCorrectDataForTickResolution()
+        {
+            Assert.AreEqual(LeanData.GetCommonTickTypeForCommonDataTypes(typeof(Tick), SecurityType.Cfd), TickType.Quote);
+            Assert.AreEqual(LeanData.GetCommonTickTypeForCommonDataTypes(typeof(Tick), SecurityType.Forex), TickType.Quote);
+        }
         private static void AssertBarsAreEqual(IBar expected, IBar actual)
         {
             if (expected == null && actual == null)


### PR DESCRIPTION
This PR fixes the bug whereby Tick resolution Forex and Cfds were created with SubscriptionDataConfigs that had a TickType of Trade instead of Quote.