### PR TITLE
Fixed bug in fine fundamental universe selection

### DIFF
--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -77,7 +77,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 {
                     var factory = new FineFundamentalSubscriptionEnumeratorFactory(_algorithm.LiveMode, x => new[] { dateTimeUtc });
                     var config = FineFundamentalUniverse.CreateConfiguration(symbol);
-                    var security = universe.CreateSecurity(symbol, _algorithm, _marketHoursDatabase, _symbolPropertiesDatabase);
+
+                    Security security;
+                    if (!_algorithm.Securities.TryGetValue(symbol, out security))
+                    {
+                        security = universe.CreateSecurity(symbol, _algorithm, _marketHoursDatabase, _symbolPropertiesDatabase);
+                        _algorithm.Securities.Add(security);
+                    }
+
                     var request = new SubscriptionRequest(true, universe, security, config, dateTimeUtc, dateTimeUtc);
                     var enumerator = factory.CreateEnumerator(request, dataFileProvider);
                     if (enumerator.MoveNext())


### PR DESCRIPTION
Securities selected by the coarse selection function were created even if already existing and were never added to the algorithm. For this reason, consolidators added in OnSecuritiesChanged were not working correctly.