### PR TITLE
Changed config key name to 'data-provider'

### DIFF
--- a/Engine/LeanEngineAlgorithmHandlers.cs
+++ b/Engine/LeanEngineAlgorithmHandlers.cs
@@ -200,7 +200,7 @@ namespace QuantConnect.Lean.Engine
             var commandQueueHandlerTypeName = Config.Get("command-queue-handler", "EmptyCommandQueueHandler");
             var mapFileProviderTypeName = Config.Get("map-file-provider", "LocalDiskMapFileProvider");
             var factorFileProviderTypeName = Config.Get("factor-file-provider", "LocalDiskFactorFileProvider");
-            var fileProviderTypeName = Config.Get("data-file-provider", "DefaultDataProvider");
+            var dataProviderTypeName = Config.Get("data-provider", "DefaultDataProvider");
 
             return new LeanEngineAlgorithmHandlers(
                 composer.GetExportedValueByTypeName<IResultHandler>(resultHandlerTypeName),
@@ -211,7 +211,7 @@ namespace QuantConnect.Lean.Engine
                 composer.GetExportedValueByTypeName<ICommandQueueHandler>(commandQueueHandlerTypeName),
                 composer.GetExportedValueByTypeName<IMapFileProvider>(mapFileProviderTypeName),
                 composer.GetExportedValueByTypeName<IFactorFileProvider>(factorFileProviderTypeName),
-                composer.GetExportedValueByTypeName<IDataProvider>(fileProviderTypeName)
+                composer.GetExportedValueByTypeName<IDataProvider>(dataProviderTypeName)
                 );
         }
 

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -36,7 +36,7 @@
   "command-json-file": "command.json",
   "map-file-provider": "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider",
   "factor-file-provider": "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider",
-  "data-file-provider": "QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider",
+  "data-provider": "QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider",
 
   // limits on number of symbols to allow
   "symbol-minute-limit": 10000, 


### PR DESCRIPTION
Changed config name form "data-file-provider" to "data-provider" to reflect new interface naming changes