### PR TITLE
Add Error message when History methods returning IEnumerable<TradeBar> are called on Forex/CFD

### DIFF
--- a/Algorithm.CSharp/HistoryAlgorithm.cs
+++ b/Algorithm.CSharp/HistoryAlgorithm.cs
@@ -51,20 +51,20 @@ namespace QuantConnect.Algorithm.CSharp
             spyDailySma = new SimpleMovingAverage(14);
 
             // get the last calendar year's worth of SPY data at the configured resolution (daily)
-            var tradeBarHistory = History("SPY", TimeSpan.FromDays(365));
-            AssertHistoryCount("History(\"SPY\", TimeSpan.FromDays(365))", tradeBarHistory, 250);
+            var tradeBarHistory = History<TradeBar>("SPY", TimeSpan.FromDays(365));
+            AssertHistoryCount("History<TradeBar>(\"SPY\", TimeSpan.FromDays(365))", tradeBarHistory, 250);
 
             // get the last calendar day's worth of SPY data at the specified resolution
-            tradeBarHistory = History("SPY", TimeSpan.FromDays(1), Resolution.Minute);
-            AssertHistoryCount("History(\"SPY\", TimeSpan.FromDays(1), Resolution.Minute)", tradeBarHistory, 390);
+            tradeBarHistory = History<TradeBar>("SPY", TimeSpan.FromDays(1), Resolution.Minute);
+            AssertHistoryCount("History<TradeBar>(\"SPY\", TimeSpan.FromDays(1), Resolution.Minute)", tradeBarHistory, 390);
 
             // get the last 14 bars of SPY at the configured resolution (daily)
-            tradeBarHistory = History("SPY", 14).ToList();
-            AssertHistoryCount("History(\"SPY\", 14)", tradeBarHistory, 14);
+            tradeBarHistory = History<TradeBar>("SPY", 14).ToList();
+            AssertHistoryCount("History<TradeBar>(\"SPY\", 14)", tradeBarHistory, 14);
 
             // get the last 14 minute bars of SPY
-            tradeBarHistory = History("SPY", 14, Resolution.Minute);
-            AssertHistoryCount("History(\"SPY\", 14, Resolution.Minute)", tradeBarHistory, 14);
+            tradeBarHistory = History<TradeBar>("SPY", 14, Resolution.Minute);
+            AssertHistoryCount("History<TradeBar>(\"SPY\", 14, Resolution.Minute)", tradeBarHistory, 14);
 
             // we can loop over the return value from these functions and we get TradeBars
             // we can use these TradeBars to initialize indicators or perform other math
@@ -174,7 +174,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             // we can access the history for individual symbols from the all history by specifying the symbol
             // the type must be a trade bar!
-            tradeBarHistory = allHistory.Get("SPY");
+            tradeBarHistory = allHistory.Get<TradeBar>("SPY");
             AssertHistoryCount("allHistory.Get(\"SPY\")", tradeBarHistory, 390);
 
             // we can access all the closing prices in chronological order using this get function

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -245,6 +245,7 @@ namespace QuantConnect.Algorithm
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
+        [Obsolete("This History method has been made obsolete, please use the generic version with TradeBar or QuoteBar type arguments instead. Calls to this method for a Forex or CFD security will return an empty result.")]
         public IEnumerable<TradeBar> History(Symbol symbol, int periods, Resolution? resolution = null)
         {
             var security = Securities[symbol];
@@ -311,6 +312,7 @@ namespace QuantConnect.Algorithm
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
+        [Obsolete("This History method has been made obsolete, please use the generic version with TradeBar or QuoteBar type arguments instead. Calls to this method for a Forex or CFD security will return an empty result.")]
         public IEnumerable<TradeBar> History(Symbol symbol, TimeSpan span, Resolution? resolution = null)
         {
             return History(new[] {symbol}, span, resolution).Get(symbol).Memoize();
@@ -324,6 +326,7 @@ namespace QuantConnect.Algorithm
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
+        [Obsolete("This History method has been made obsolete, please use the generic version with TradeBar or QuoteBar type arguments instead. Calls to this method for a Forex or CFD security will return an empty result.")]
         public IEnumerable<TradeBar> History(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null)
         {
             return History(new[] {symbol}, start, end, resolution).Get(symbol).Memoize();

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -245,11 +245,17 @@ namespace QuantConnect.Algorithm
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
-        [Obsolete("This History method has been made obsolete, please use the generic version with TradeBar or QuoteBar type arguments instead. Calls to this method for a Forex or CFD security will return an empty result.")]
         public IEnumerable<TradeBar> History(Symbol symbol, int periods, Resolution? resolution = null)
         {
             var security = Securities[symbol];
             var start = GetStartTimeAlgoTz(symbol, periods, resolution);
+
+            var securityType = symbol.ID.SecurityType;
+            if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
+            {
+                Error("Calling this method on a Forex or CFD security will return an empty result. Please use the generic version with QuoteBar type parameter.");
+            }
+
             return History(new[] {symbol}, start, Time.RoundDown((resolution ?? security.Resolution).ToTimeSpan()), resolution).Get(symbol).Memoize();
         }
 
@@ -312,9 +318,14 @@ namespace QuantConnect.Algorithm
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
-        [Obsolete("This History method has been made obsolete, please use the generic version with TradeBar or QuoteBar type arguments instead. Calls to this method for a Forex or CFD security will return an empty result.")]
         public IEnumerable<TradeBar> History(Symbol symbol, TimeSpan span, Resolution? resolution = null)
         {
+            var securityType = symbol.ID.SecurityType;
+            if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
+            {
+                Error("Calling this method on a Forex or CFD security will return an empty result. Please use the generic version with QuoteBar type parameter.");
+            }
+
             return History(new[] {symbol}, span, resolution).Get(symbol).Memoize();
         }
 
@@ -326,9 +337,14 @@ namespace QuantConnect.Algorithm
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
-        [Obsolete("This History method has been made obsolete, please use the generic version with TradeBar or QuoteBar type arguments instead. Calls to this method for a Forex or CFD security will return an empty result.")]
         public IEnumerable<TradeBar> History(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null)
         {
+            var securityType = symbol.ID.SecurityType;
+            if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
+            {
+                Error("Calling this method on a Forex or CFD security will return an empty result. Please use the generic version with QuoteBar type parameter.");
+            }
+
             return History(new[] {symbol}, start, end, resolution).Get(symbol).Memoize();
         }
 

--- a/Common/Data/SliceExtensions.cs
+++ b/Common/Data/SliceExtensions.cs
@@ -53,6 +53,7 @@ namespace QuantConnect.Data
         /// <param name="slices">The enumerable of slice</param>
         /// <param name="symbol">The symbol to retrieve</param>
         /// <returns>An enumerable of TradeBar for the matching symbol, of no TradeBar found for symbol, empty enumerable is returned</returns>
+        [Obsolete("This method has been made obsolete, please use the generic version with TradeBar or QuoteBar type arguments instead. Calls to this method for a Forex or CFD security will return an empty result.")]
         public static IEnumerable<TradeBar> Get(this IEnumerable<Slice> slices, Symbol symbol)
         {
             return slices.TradeBars().Where(x => x.ContainsKey(symbol)).Select(x => x[symbol]);

--- a/Common/Data/SliceExtensions.cs
+++ b/Common/Data/SliceExtensions.cs
@@ -53,7 +53,6 @@ namespace QuantConnect.Data
         /// <param name="slices">The enumerable of slice</param>
         /// <param name="symbol">The symbol to retrieve</param>
         /// <returns>An enumerable of TradeBar for the matching symbol, of no TradeBar found for symbol, empty enumerable is returned</returns>
-        [Obsolete("This method has been made obsolete, please use the generic version with TradeBar or QuoteBar type arguments instead. Calls to this method for a Forex or CFD security will return an empty result.")]
         public static IEnumerable<TradeBar> Get(this IEnumerable<Slice> slices, Symbol symbol)
         {
             return slices.TradeBars().Where(x => x.ContainsKey(symbol)).Select(x => x[symbol]);


### PR DESCRIPTION
Non-generic history methods returning `IEnumerable<TradeBar>` have been marked as obsolete because they return an empty result when called with Forex and CFD security types.

The recommended replacements are their generic equivalents, using `TradeBar` or `QuoteBar` data type arguments, depending on the security type.