### PR TITLE
fixes caching issue causing IB error No security definition has been …

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -613,7 +613,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private string GetPrimaryExchange(Contract contract)
         {
             ContractDetails details;
-            if (_contractDetails.TryGetValue(contract.Symbol, out details))
+            if (_contractDetails.TryGetValue(contract.ToString(), out details))
             {
                 return details.Summary.PrimaryExch;
             }
@@ -631,7 +631,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private string GetTradingClass(Contract contract)
         {
             ContractDetails details;
-            if (_contractDetails.TryGetValue(contract.Symbol, out details))
+            if (_contractDetails.TryGetValue(contract.ToString(), out details))
             {
                 return details.Summary.TradingClass;
             }
@@ -649,7 +649,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private decimal GetMinTick(Contract contract)
         {
             ContractDetails details;
-            if (_contractDetails.TryGetValue(contract.Symbol, out details))
+            if (_contractDetails.TryGetValue(contract.ToString(), out details))
             {
                 return (decimal) details.MinTick;
             }
@@ -679,7 +679,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 // ignore other requests
                 if (args.RequestId != requestId) return;
                 details = args.ContractDetails;
-                _contractDetails.TryAdd(contract.Symbol, details);
+                _contractDetails.TryAdd(contract.ToString(), details);
                 manualResetEvent.Set();
                 Log.Trace("InteractiveBrokersBrokerage.GetContractDetails(): clientOnContractDetails event: " + contract.Symbol);
             };

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -610,10 +610,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
         }
 
+        private string GetUniqueKey(Contract contract)
+        {
+            return string.Format("{0} {1} {2} {3}", contract.ToString(), contract.LastTradeDateOrContractMonth, contract.Strike, contract.Right);
+        }
+
         private string GetPrimaryExchange(Contract contract)
         {
             ContractDetails details;
-            if (_contractDetails.TryGetValue(contract.ToString(), out details))
+            if (_contractDetails.TryGetValue(GetUniqueKey(contract), out details))
             {
                 return details.Summary.PrimaryExch;
             }
@@ -631,7 +636,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private string GetTradingClass(Contract contract)
         {
             ContractDetails details;
-            if (_contractDetails.TryGetValue(contract.ToString(), out details))
+            if (_contractDetails.TryGetValue(GetUniqueKey(contract), out details))
             {
                 return details.Summary.TradingClass;
             }
@@ -649,7 +654,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private decimal GetMinTick(Contract contract)
         {
             ContractDetails details;
-            if (_contractDetails.TryGetValue(contract.ToString(), out details))
+            if (_contractDetails.TryGetValue(GetUniqueKey(contract), out details))
             {
                 return (decimal) details.MinTick;
             }
@@ -679,7 +684,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 // ignore other requests
                 if (args.RequestId != requestId) return;
                 details = args.ContractDetails;
-                _contractDetails.TryAdd(contract.ToString(), details);
+                _contractDetails.TryAdd(GetUniqueKey(contract), details);
                 manualResetEvent.Set();
                 Log.Trace("InteractiveBrokersBrokerage.GetContractDetails(): clientOnContractDetails event: " + contract.Symbol);
             };


### PR DESCRIPTION
…found for the request

Cause: Caching is set up in the InteractiveBrokersBroker.cs for symbon contract details. When the caching was queried it was only using the IB Symbol String eg "AAPL" rather than an identifier that considers if the contract that is being looked up is an equity, option etc. PR uses contract.ToString() rather than contract.Symbol. contract.ToString() has additional data such as "OPT AAPL USD Smart"

Fixes issue in https://trello.com/c/P8ef0zoD/2016-live-ib-paper-no-security-definition-has-been-found-for-the-request