### PR TITLE
QuoteBar.Reader will process Cfd data

### DIFF
--- a/Common/Data/Market/QuoteBar.cs
+++ b/Common/Data/Market/QuoteBar.cs
@@ -278,7 +278,7 @@ namespace QuantConnect.Data.Market
             {
                 // "Scaffold" code - simple check to see how the data is formatted and decide how to parse appropriately
                 // TODO: Once all FX is reprocessed to QuoteBars, remove this check
-                if (csvLength > 5)
+                if (csvLength > 6)
                 {
                     // Parse as quote
                     return ParseQuoteAsQuoteBar(config, date, line);


### PR DESCRIPTION
Currently, Cfd's are configured to use `QuoteBars`. The `QuoteBar.Reader` method will not work with Cfd data because of a trailing 0 in the Cfd data.  This change should be temporary until the Cfd data can be reprocessed into full QuoteBars or the trailing zero can be removed.