### PR TITLE
Fixed scheduled event firing time in backtesting

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -272,6 +272,14 @@ namespace QuantConnect.Lean.Engine
 
                 //Update algorithm state after capturing performance from previous day
 
+                // If backtesting, we need to check if there are realtime events in the past 
+                // which didn't fire because at the scheduled times there was no data (i.e. markets closed)
+                // and fire them with the correct date/time.
+                if (backtestMode)
+                {
+                    realtime.ScanPastEvents(time);
+                }
+
                 //Set the algorithm and real time handler's time
                 algorithm.SetDateTime(time);
 

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -123,6 +123,22 @@ namespace QuantConnect.Lean.Engine.RealTime
         }
 
         /// <summary>
+        /// Scan for past events that didn't fire because there was no data at the scheduled time.
+        /// </summary>
+        /// <param name="time">Current time.</param>
+        public void ScanPastEvents(DateTime time)
+        {
+            foreach (var scheduledEvent in _scheduledEvents)
+            {
+                while (scheduledEvent.Value.NextEventUtcTime < time)
+                {
+                    _algorithm.SetDateTime(scheduledEvent.Value.NextEventUtcTime);
+                    scheduledEvent.Value.Scan(scheduledEvent.Value.NextEventUtcTime);
+                }
+            }
+        }
+
+        /// <summary>
         /// Stop the real time thread
         /// </summary>
         public void Exit()

--- a/Engine/RealTime/IRealTimeHandler.cs
+++ b/Engine/RealTime/IRealTimeHandler.cs
@@ -54,6 +54,12 @@ namespace QuantConnect.Lean.Engine.RealTime
         void SetTime(DateTime time);
 
         /// <summary>
+        /// Scan for past events that didn't fire because there was no data at the scheduled time.
+        /// </summary>
+        /// <param name="time">Current time.</param>
+        void ScanPastEvents(DateTime time);
+
+        /// <summary>
         /// Trigger and exit signal to terminate real time event scanner.
         /// </summary>
         void Exit();

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using QuantConnect.Interfaces;
@@ -24,7 +23,6 @@ using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Logging;
 using QuantConnect.Packets;
 using QuantConnect.Scheduling;
-using QuantConnect.Securities;
 using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.RealTime
@@ -185,6 +183,16 @@ namespace QuantConnect.Lean.Engine.RealTime
         {
             // in live mode we use current time for our time keeping
             // this method is used by backtesting to set time based on the data
+        }
+
+        /// <summary>
+        /// Scan for past events that didn't fire because there was no data at the scheduled time.
+        /// </summary>
+        /// <param name="time">Current time.</param>
+        public void ScanPastEvents(DateTime time)
+        {
+            // in live mode we use current time for our time keeping
+            // this method is used by backtesting to scan for past events based on the data
         }
 
         /// <summary>


### PR DESCRIPTION
If backtesting, we need to check if there are realtime events in the past which didn't fire because at the scheduled times there was no data (i.e. markets closed) and fire them with the correct date/time.

In live mode, no changes are needed.

Sample algorithm:

```
public class BasicTemplateAlgorithm : QCAlgorithm
{
    public override void Initialize()
    {
        SetStartDate(2013, 10, 07);  //Set Start Date
        SetEndDate(2013, 10, 11);    //Set End Date
        SetCash(100000);             //Set Strategy Cash
        AddEquity("SPY", Resolution.Hour);

        // schedule an event to fire every trading day at 00:15
        Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(0, 15), () =>
        {
            // BUG: fires at 10:00 AM (at Hourly resolution), instead of 12:15 AM
            Log("EveryDay.SPY @ 00:15: Fired at: " + Time);
        });
    }
}
```