### PR TITLE
Log on live failure

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -668,11 +668,12 @@ namespace QuantConnect.Api
         /// <param name="job">The <see cref="AlgorithmNodePacket"/> used to generate the url to the logs</param>
         /// <param name="permissions">The <see cref="StoragePermissions"/> for the file</param>
         /// <param name="async">Bool indicating whether the method to <see cref="Store"/> should be async</param>
+        /// <param name="isLiveMode">Bool to indicate whether the algorithm is in love mode or not</param>
         /// <returns>The location where the logs can be accessed</returns>
         /// <remarks>Since the logs are stored on disc during local backtest, this method simply returns the location of those logs
         /// TODO: Get the filename of the logs instead of hard coding it.
         ///  </remarks>
-        public virtual string StoreLogs(List<string> logs, AlgorithmNodePacket job, StoragePermissions permissions, bool async = false)
+        public virtual string StoreLogs(List<string> logs, AlgorithmNodePacket job, StoragePermissions permissions, bool isLiveMode = false, bool async = false)
         {
             return Path.Combine(Directory.GetCurrentDirectory(), "log.txt");
         }

--- a/Common/Interfaces/IApi.cs
+++ b/Common/Interfaces/IApi.cs
@@ -297,9 +297,10 @@ namespace QuantConnect.Interfaces
         /// <param name="logs">The list of individual logs to be stored</param>
         /// <param name="job">The <see cref="AlgorithmNodePacket"/> used to generate the url to the logs</param>
         /// <param name="permissions">The <see cref="StoragePermissions"/> for the file</param>
+        /// <param name="isLiveMode">Bool to indicate whether the algorithm is in love mode or not</param>
         /// <param name="async">Bool indicating whether the method to <see cref="Store"/> should be async</param>
         /// <returns>The url where the logs can be accessed</returns>
-        string StoreLogs(List<string> logs, AlgorithmNodePacket job, StoragePermissions permissions, bool async = false);
+        string StoreLogs(List<string> logs, AlgorithmNodePacket job, StoragePermissions permissions, bool isLiveMode = false, bool async = false);
 
         /// <summary>
         /// Store data in the cloud

--- a/Common/Packets/AlgorithmNodePacket.cs
+++ b/Common/Packets/AlgorithmNodePacket.cs
@@ -38,6 +38,10 @@ namespace QuantConnect.Packets
         [JsonProperty(PropertyName = "iUserID")]
         public int UserId = 0;
 
+        /// User API Token
+        [JsonProperty(PropertyName = "sUserToken")]
+        public string UserToken = "";
+
         /// <summary>
         /// Project Id of the request
         /// </summary>

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -935,11 +935,21 @@ namespace QuantConnect.Lean.Engine.Results
         }
 
         /// <summary>
-        /// Terminate the result thread and apply any required exit proceedures.
+        /// Terminate the result thread and apply any required exit procedures.
         /// </summary>
         public void Exit()
         {
+            // If the algorithm was not successfully initialized, be sure to store the logs
+            // Update() will be unable to store the logs if the algorithm never full initialized
+            if (!_exitTriggered && _algorithm != null && !_algorithm.GetLocked())
+            {
+                ProcessSynchronousEvents(true);
+                var logs = _logStore.Select(x => x.Message).ToList();
+                _api.StoreLogs(logs, _job, StoragePermissions.Public, true);
+            }
+
             _exitTriggered = true;
+
             Update();
         }
 


### PR DESCRIPTION
+ Changed the Api StoreLog definition  differentiate between backtest and live logs.
+ Added the UserToken to the AlgorithmNodePacket.
+ Use the Api to upload logs when an algorithm fails during initialization when run in live mode.