### PR TITLE
Synchronize results from IB history provider

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -503,6 +503,7 @@
     <Compile Include="Util\ColorJsonConverter.cs" />
     <Compile Include="Util\SecurityExtensions.cs" />
     <Compile Include="Util\SecurityIdentifierJsonConverter.cs" />
+    <Compile Include="Util\SynchronizingEnumerator.cs" />
     <Compile Include="Util\TypeChangeJsonConverter.cs" />
     <Compile Include="Util\LinqExtensions.cs" />
     <Compile Include="Util\MemoizingEnumerable.cs" />

--- a/Common/Util/LinqExtensions.cs
+++ b/Common/Util/LinqExtensions.cs
@@ -269,7 +269,7 @@ namespace QuantConnect.Util
         }
 
         /// <summary>
-        /// Groups adjacent elements of the enumerale using the specified grouper function
+        /// Groups adjacent elements of the enumerable using the specified grouper function
         /// </summary>
         /// <typeparam name="T">The enumerable item type</typeparam>
         /// <param name="enumerable">The source enumerable to be grouped</param>
@@ -277,26 +277,40 @@ namespace QuantConnect.Util
         /// true if the next value belongs in the same group as the previous value, otherwise returns false</param>
         /// <returns>A new enumerable of the groups defined by grouper. These groups don't have a key
         /// and are only grouped by being emitted separately from this enumerable</returns>
-        public static IEnumerable<IEnumerable<T>> GroupAdjacentBy<T>(this IEnumerable<T> enumerable, Func<T, T, bool> grouper)
+        public static IEnumerable<IList<T>> GroupAdjacentBy<T>(this IEnumerable<T> enumerable, Func<T, T, bool> grouper)
         {
-            using (var e = enumerable.GetEnumerator())
+            return enumerable.GetEnumerator().GroupAdjacentBy(grouper);
+        }
+
+        /// <summary>
+        /// Groups adjacent elements of the enumerator using the specified grouper function
+        /// </summary>
+        /// <typeparam name="T">The enumerator item type</typeparam>
+        /// <param name="enumerator">The source enumerator to be grouped</param>
+        /// <param name="grouper">A function that accepts the previous value and the next value and returns
+        /// true if the next value belongs in the same group as the previous value, otherwise returns false</param>
+        /// <returns>A new enumerable of the groups defined by grouper. These groups don't have a key
+        /// and are only grouped by being emitted separately from this enumerator</returns>
+        public static IEnumerable<IList<T>> GroupAdjacentBy<T>(this IEnumerator<T> enumerator, Func<T, T, bool> grouper)
+        {
+            using (enumerator)
             {
-                if (e.MoveNext())
+                if (enumerator.MoveNext())
                 {
-                    var list = new List<T> {e.Current};
-                    var pred = e.Current;
-                    while (e.MoveNext())
+                    var list = new List<T> { enumerator.Current };
+                    var pred = enumerator.Current;
+                    while (enumerator.MoveNext())
                     {
-                        if (grouper(pred, e.Current))
+                        if (grouper(pred, enumerator.Current))
                         {
-                            list.Add(e.Current);
+                            list.Add(enumerator.Current);
                         }
                         else
                         {
                             yield return list;
-                            list = new List<T> {e.Current};
+                            list = new List<T> { enumerator.Current };
                         }
-                        pred = e.Current;
+                        pred = enumerator.Current;
                     }
                     yield return list;
                 }

--- a/Common/Util/SynchronizingEnumerator.cs
+++ b/Common/Util/SynchronizingEnumerator.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
 
-namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
+namespace QuantConnect.Util
 {
     /// <summary>
     /// Represents an enumerator capable of synchronizing other base data enumerators in time.

--- a/Engine/DataFeeds/Enumerators/Factories/FuturesChainUniverseSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/FuturesChainUniverseSubscriptionEnumeratorFactory.cs
@@ -23,6 +23,7 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using System.Threading;
 using QuantConnect.Data.Auxiliary;
+using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
 {

--- a/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactory.cs
@@ -23,6 +23,7 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using System.Threading;
 using QuantConnect.Data.Auxiliary;
+using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
 {

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -197,7 +197,6 @@
     <Compile Include="DataFeeds\Enumerators\RateLimitEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\RefreshEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\SubscriptionFilterEnumerator.cs" />
-    <Compile Include="DataFeeds\Enumerators\SynchronizingEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\QuoteBarBuilderEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\TradeBarBuilderEnumerator.cs" />
     <Compile Include="DataFeeds\DefaultDataProvider.cs" />

--- a/Tests/Common/Util/SynchronizingEnumeratorTests.cs
+++ b/Tests/Common/Util/SynchronizingEnumeratorTests.cs
@@ -18,9 +18,9 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data.Market;
-using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+using QuantConnect.Util;
 
-namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
+namespace QuantConnect.Tests.Common.Util
 {
     [TestFixture]
     public class SynchronizingEnumeratorTests

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Common\Util\ObjectActivatorTests.cs" />
     <Compile Include="Common\Util\ObjectToListJsonConverterTests.cs" />
     <Compile Include="Common\Util\ReaderWriterLockSlimExtensionsTests.cs" />
+    <Compile Include="Common\Util\SynchronizingEnumeratorTests.cs" />
     <Compile Include="Common\Util\VersionHelperTests.cs" />
     <Compile Include="Common\Util\WhoCalledMeTests.cs" />
     <Compile Include="Compression\CompressionTests.cs" />
@@ -222,7 +223,6 @@
     <Compile Include="Engine\DataFeeds\Enumerators\LiveFillForwardEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\OptionChainUniverseDataCollectionAggregatorEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\RateLimitEnumeratorTests.cs" />
-    <Compile Include="Engine\DataFeeds\Enumerators\SynchronizingEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\TradeBarBuilderEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\FileSystemDataFeedTests.cs" />
     <Compile Include="Engine\DataFeeds\FillForwardEnumeratorTest.cs" />


### PR DESCRIPTION
Posting for some early feedback regarding the approach.

The current IB history implementation sychronously executes each `HistoryRequest`
and forms slices and emits them. This causes issues with multiple requests since
the individual requests never get synced. This PR aims to synchronize the results
from each history request.

This PR *also* fixes a would-be latent bug in the time zoning of the resultant trade
bars. It was returning the trade bars time stamped in the slice's time zone instead of
the security's configured time zone.

### This code has not been tested yet!

#### Move SynchronizingEnumerator to Common\Util
>This is a pretty generic utility class that is capable of accepting multiple
IEnumerator<BaseData> instances and synchronizing them into a single
IEnumerator<BaseData> instance. This can be handy for many things. This move is
to enable usage in the QuantConnect.Brokerages projects where the IB history
provider impl needs to synchronize multiple trader bar streams into Slices.

#### Refactor GroupByAdjacent into overload
>This new overload accepts just the enumerator instead of the full enumerable.
This enables easy usages with the enumerator stack, specifically the
SynchronizingEnumerator.

>In addition, the method was updated to return an IList<T> to represent the inner
grouped collection. The current implementation of this method is such that it
emits only full groupings, so this return type change codifies that implementation
detail into the type signature, allowing consumers to depend on it.

#### WIP: Initial implementation of syncing IB GetHistory
>I threw this together this evening as a proof of concept of what I'm going for
here. Each request results in a BaseDataCollection time stamped in the slice time
zone. The separate collections are then synchronized by the SynchronizingEnumerator
and formed into Slice instances.

>I've modified the time zone handling of the raw data. It appears as though we're
modifying the time zone of the data to match the requested sliceTimeZone, but
really the data should get fed to the algorithm in the configured exchange time
zone.
