### PR TITLE
Add start-date parameter to CoarseUniverseGenerator

### DIFF
--- a/ToolBox/CoarseUniverseGenerator/config.json
+++ b/ToolBox/CoarseUniverseGenerator/config.json
@@ -3,7 +3,11 @@
     // Configuration for the Coarse Universe Generator
     //-------------------------------------------
 
-    "data-directory": "C:\\Lean\\Data",
+    // Start date for building coarse data in yyyymmdd format
+    // Continue from the last calculated date if set to null
+    "coarse-universe-generator-start-date": "20000101",
+
+    "data-directory": "../../../Data",
 
     // set to true to keep the process running and each day
     // at the specified update-time-of-day it will wake up
@@ -11,7 +15,7 @@
     "update-mode": false,
     "update-time-of-day": "5:00",
 
-	// QuantQuote data without map files is good filter for non-tradable or test symbols. 
-	// defaults to false here for open source users who have their own data, and no specific map files.
-	"ignore-mapless":"false"
+    // QuantQuote data without map files is good filter for non-tradable or test symbols.
+    // defaults to false here for open source users who have their own data, and no specific map files.
+    "ignore-mapless": "false"
 }


### PR DESCRIPTION
When `CoarseUniverseGenerator` generates fundamental data it starts from the date of the latest file in the fundamental data folder.
This works well if one need to generate newer data but did not work for me when I had to generate data for local backtesting from 1st January 2000.

The PR adds a new parameter `start-date` to the `config.json` in `CoarseUniverseGenerator`. This parameter is optional. If it is omitted the code would work as before.