### PR TITLE
Fixes Cash.EnsureCurrencyDataFeed to enable Oanda and QuoteBar

### DIFF
--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -164,15 +164,31 @@ namespace QuantConnect.Securities
                 }
             }
             // if we've made it here we didn't find a subscription, so we'll need to add one
+
+            // Create a SecurityType to Market mapping with the markets from SecurityManager members
+            var markets = securities.Keys.GroupBy(x => x.SecurityType).ToDictionary(x => x.Key, y => y.FirstOrDefault().ID.Market);
+            if (markets.ContainsKey(SecurityType.Cfd) && !markets.ContainsKey(SecurityType.Forex))
+            {
+                markets.Add(SecurityType.Forex, markets[SecurityType.Cfd]);
+            }
+            if (markets.ContainsKey(SecurityType.Forex) && !markets.ContainsKey(SecurityType.Cfd))
+            {
+                markets.Add(SecurityType.Cfd, markets[SecurityType.Forex]);
+            }
+
             var currencyPairs = Currencies.CurrencyPairs.Select(x =>
             {
                 // allow XAU or XAG to be used as quote currencies, but pairs including them are CFDs
                 var securityType = Symbol.StartsWith("X") ? SecurityType.Cfd : SecurityType.Forex;
-                var market = marketMap[securityType];
+                var market = string.Empty;
+                if (!markets.TryGetValue(securityType, out market))
+                {
+                    market = marketMap[securityType];
+                }
                 return QuantConnect.Symbol.Create(x, securityType, market);
             });
             var minimumResolution = subscriptions.Subscriptions.Select(x => x.Resolution).DefaultIfEmpty(Resolution.Minute).Min();
-            var objectType = minimumResolution == Resolution.Tick ? typeof (Tick) : typeof (TradeBar);
+            var objectType = minimumResolution == Resolution.Tick ? typeof (Tick) : typeof (QuoteBar);
             foreach (var symbol in currencyPairs)
             {
                 if (symbol.Value == normal || symbol.Value == invert)

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -166,7 +166,7 @@ namespace QuantConnect.Securities
             // if we've made it here we didn't find a subscription, so we'll need to add one
 
             // Create a SecurityType to Market mapping with the markets from SecurityManager members
-            var markets = securities.Keys.GroupBy(x => x.SecurityType).ToDictionary(x => x.Key, y => y.FirstOrDefault().ID.Market);
+            var markets = securities.Keys.GroupBy(x => x.SecurityType).ToDictionary(x => x.Key, y => y.First().ID.Market);
             if (markets.ContainsKey(SecurityType.Cfd) && !markets.ContainsKey(SecurityType.Forex))
             {
                 markets.Add(SecurityType.Forex, markets[SecurityType.Cfd]);


### PR DESCRIPTION
Cash.EnsureCurrencyDataFeed was subscribing to currencies with trade bar information while they come in as quote bars.
Since it was using DefaultMarkets to select the market the symbol belongs to, it was subscribing to currencies from the FXCM market despite the fact the algorithm could be using Oanda data. With this fix, when the algorithm is trading CFD or Forex it will subscribe to a quote currency from the same market.