### PR TITLE
Remove call to Environment.Exit(0)

### DIFF
--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -132,7 +132,6 @@ namespace QuantConnect.Lean.Launcher
                 leanEngineSystemHandlers.Dispose();
                 leanEngineAlgorithmHandlers.Dispose();
                 Log.LogHandler.Dispose();
-                Environment.Exit(0);
             }
         }
     }


### PR DESCRIPTION
+ Remove call to Environment.Exit(0) in Program.cs. This was a hacky fix to a simple threading problem. The threading problem has fixed.
+ This has been tested in production.