### PR TITLE
Only process the logs in the BacktesstingResultsHandler once

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -716,8 +716,12 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         public void Exit() 
         {
-            var logLocation = ProcessLogMessages(_job);
-            SystemDebugMessage("Your log was successfully created and can be retrieved from: " + logLocation);
+            // Only process the logs once
+            if (!_exitTriggered)
+            {
+                var logLocation = ProcessLogMessages(_job);
+                SystemDebugMessage("Your log was successfully created and can be retrieved from: " + logLocation);
+            }
 
             //Set exit flag, and wait for the messages to send:
             _exitTriggered = true;


### PR DESCRIPTION
IResultHandler.Exit() is called twice in Engine.cs which causes the logs to be processed twice in BacktestingResultsHandler Exit method. These changes will ensure that the logs are processed only on the first call to BacktestingResultsHandler.Exit()