### PR TITLE
Fixed a couple bugs in chart sampling

### DIFF
--- a/Algorithm.CSharp/BasicTemplateDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateDailyAlgorithm.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Basic template algorithm simply initializes the date range and cash
+    /// </summary>
+    public class BasicTemplateDailyAlgorithm : QCAlgorithm
+    {
+        private Symbol _spy = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+        
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);  //Set Start Date
+            SetEndDate(2013, 10, 18);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+            // Find more symbols here: http://quantconnect.com/data
+            AddEquity("SPY", Resolution.Daily);
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(_spy, 1);
+                Debug("Purchased Stock");
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -76,6 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
+    <Compile Include="BasicTemplateDailyAlgorithm.cs" />
     <Compile Include="BasicTemplateFuturesConsolidationAlgorithm.cs" />
     <Compile Include="BasicTemplateFuturesHistoryAlgorithm.cs" />
     <Compile Include="BasicTemplateMultiAssetAlgorithm.cs" />

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -659,16 +659,17 @@ namespace QuantConnect.Lean.Engine
             //Take final samples:
             results.SampleRange(algorithm.GetChartUpdates());
             results.SampleEquity(_previousTime, Math.Round(algorithm.Portfolio.TotalPortfolioValue, 4));
-            SampleBenchmark(algorithm, results, _previousTime);
+            SampleBenchmark(algorithm, results, backtestMode ? _previousTime.Date : _previousTime);
             
             //Check for divide by zero
             if (portfolioValue == 0m)
             {
-                results.SamplePerformance(_previousTime, 0m);
+                results.SamplePerformance(backtestMode ? _previousTime.Date : _previousTime, 0m);
             }
             else
             {
-                results.SamplePerformance(_previousTime, Math.Round((algorithm.Portfolio.TotalPortfolioValue - portfolioValue) * 100 / portfolioValue, 10));
+                results.SamplePerformance(backtestMode ? _previousTime.Date : _previousTime, 
+                    Math.Round((algorithm.Portfolio.TotalPortfolioValue - portfolioValue) * 100 / portfolioValue, 10));
             }
         } // End of Run();
 

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -624,19 +624,26 @@ namespace QuantConnect.Lean.Engine.Results
             lock (_chartLock)
             {
                 //Add a copy locally:
-                if (!Charts.ContainsKey(chartName))
+                Chart chart;
+                if (!Charts.TryGetValue(chartName, out chart))
                 {
-                    Charts.AddOrUpdate(chartName, new Chart(chartName));
+                    chart = new Chart(chartName);
+                    Charts.AddOrUpdate(chartName, chart);
                 }
 
                 //Add the sample to our chart:
-                if (!Charts[chartName].Series.ContainsKey(seriesName)) 
+                Series series;
+                if (!chart.Series.TryGetValue(seriesName, out series))
                 {
-                    Charts[chartName].Series.Add(seriesName, new Series(seriesName, seriesType, seriesIndex, unit));
+                    series = new Series(seriesName, seriesType, seriesIndex, unit);
+                    chart.Series.Add(seriesName, series);
                 }
 
                 //Add our value:
-                Charts[chartName].Series[seriesName].Values.Add(new ChartPoint(time, value));
+                if (series.Values.Count == 0 || time > Time.UnixTimeStampToDateTime(series.Values[series.Values.Count - 1].x))
+                {
+                    series.Values.Add(new ChartPoint(time, value));
+                }
             }
         }
 

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -522,6 +522,29 @@ namespace QuantConnect.Tests
                 {"Total Fees", "$0.50"},
             };
 
+            var basicTemplateDailyStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "1"},
+                {"Average Win", "0%"},
+                {"Average Loss", "0%"},
+                {"Compounding Annual Return", "244.780%"},
+                {"Drawdown", "1.100%"},
+                {"Expectancy", "0"},
+                {"Net Profit", "0%"},
+                {"Sharpe Ratio", "6.165"},
+                {"Loss Rate", "0%"},
+                {"Win Rate", "0%"},
+                {"Profit-Loss Ratio", "0"},
+                {"Alpha", "0.254"},
+                {"Beta", "0.898"},
+                {"Annual Standard Deviation", "0.14"},
+                {"Annual Variance", "0.02"},
+                {"Information Ratio", "4.625"},
+                {"Tracking Error", "0.04"},
+                {"Treynor Ratio", "0.963"},
+                {"Total Fees", "$3.09"}
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -546,7 +569,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("OptionChainConsistencyRegressionAlgorithm", optionChainConsistencyRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("WeeklyUniverseSelectionRegressionAlgorithm", weeklyUniverseSelectionRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("OptionExerciseAssignRegressionAlgorithm",optionExerciseAssignRegressionAlgorithmStatistics, Language.CSharp),
-                
+                new AlgorithmStatisticsTestParameters("BasicTemplateDailyAlgorithm", basicTemplateDailyStatistics, Language.CSharp),
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION
These bug fixes only affect backtesting.

1. Benchmark and Daily Performance charts: the timestamp of the last point includes time, the other points only have the date part.

2. Equity chart: There are duplicate samples for the same date, when using daily algorithms. (Ref. #462)

