### PR TITLE
ApiDataProvider

### DIFF
--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -14,12 +14,17 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using Fasterflect;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
+using QuantConnect.Logging;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Util
@@ -588,6 +593,89 @@ namespace QuantConnect.Util
             }
 
             return TickType.Trade;
+        }
+
+        /// <summary>
+        /// Parses file name into a <see cref="Security"/> and DateTime
+        /// </summary>
+        /// <param name="fileName">File name to be parsed</param>
+        /// <param name="security">The security as parsed from the fileName</param>
+        /// <param name="date">Date of data in the file path. Only returned if the resolution is lower than Hourly</param>
+        /// <remarks>The security returned from this method ONLY represents the correct symbol, resolution, market and securityType</remarks>
+        public static bool TryParsePath(string fileName, out Security security, out DateTime date)
+        {
+            security = null;
+            date = default(DateTime);
+
+            var pathSeparators = new[] { '/', '\\'};
+            var securityTypes = Enum.GetNames(typeof(SecurityType)).Select(x => x.ToLower()).ToList();
+
+            try
+            {
+                // Removes file extension
+                fileName = fileName.Replace(fileName.GetExtension(), "");
+
+                // remove any relative file path
+                while (fileName.First() == '.' || pathSeparators.Any(x => x == fileName.First()))
+                {
+                    fileName = fileName.Remove(0, 1);
+                }
+
+                // split path into components
+                var info = fileName.Split(pathSeparators, StringSplitOptions.RemoveEmptyEntries).ToList();
+
+                // find where the useful part of the path starts - i.e. the securityType
+                var startIndex = info.FindIndex(x => securityTypes.Contains(x.ToLower()));
+
+                // Gather components useed to create the security
+                var market = info[startIndex + 1];
+                var ticker = info[startIndex + 3];
+                var resolution = (Resolution)Enum.Parse(typeof(Resolution), info[startIndex + 2], true);
+                var securityType = (SecurityType)Enum.Parse(typeof(SecurityType), info[startIndex], true);
+
+                // If resolution is Daily or Hour, we do not need to set the date and tick type
+                if (resolution < Resolution.Hour)
+                {
+                    date = DateTime.ParseExact(info[startIndex + 4].Substring(0, 8), DateFormat.EightCharacter, null);
+                }
+
+                // Create the security identifier that will be used to create the security
+                SecurityIdentifier securityIdentifier;
+                switch (securityType)
+                {
+                    case SecurityType.Equity:
+                        securityIdentifier = SecurityIdentifier.GenerateEquity(date, ticker, market);
+                        break;
+                    case SecurityType.Forex:
+                        securityIdentifier = SecurityIdentifier.GenerateForex(ticker, market);
+                        break;
+                    case SecurityType.Cfd:
+                        securityIdentifier = SecurityIdentifier.GenerateCfd(ticker, market);
+                        break;
+                    case SecurityType.Future:
+                    case SecurityType.Option:
+                    default:
+                        throw new NotImplementedException("LeanData.TryParsePath() has not been implemented for the desired security.");
+                }
+
+                var symbol = new Symbol(securityIdentifier, ticker);
+
+                security = new Security(symbol, 
+                                        SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), 
+                                        new Cash("USD", 0m, 0m), 
+                                        SymbolProperties.GetDefault("USD"));
+
+                var newSubscriptionDataConfig = new SubscriptionDataConfig(typeof(TradeBar), symbol, resolution, TimeZones.Utc, TimeZones.Utc, false, false, false);
+
+                security.AddData(newSubscriptionDataConfig);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("LeanData.TryParsePath(): Error encountered while parsing the path {0}. Error: {1}", fileName, ex.GetBaseException());
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Engine/DataFeeds/ApiDataProvider.cs
+++ b/Engine/DataFeeds/ApiDataProvider.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.IO;
+using QuantConnect.Configuration;
+using QuantConnect.Interfaces;
+using QuantConnect.Logging;
+using QuantConnect.Util;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// An instance of the <see cref="IDataProvider"/> that will attempt to retrieve files not present on the filesystem from the API
+    /// </summary>
+    public class ApiDataProvider : IDataProvider
+    {
+        private readonly int _uid = Config.GetInt("job-user-id", 0);
+        private readonly string _token = Config.Get("api-access-token", "1");
+        private readonly string _dataPath = Config.Get("data-folder", "../../../Data/");
+        private readonly Api.Api _api;
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="ApiDataProvider"/>
+        /// </summary>
+        public ApiDataProvider()
+        {
+            _api = new Api.Api();
+
+            _api.Initialize(_uid, _token, _dataPath);
+        }
+
+        /// <summary>
+        /// Retrieves data to be used in an algorithm
+        /// If file does not exist, an attempt is made to download them from the api
+        /// </summary>
+        /// <param name="key">A string representing where the data is stored</param>
+        /// <returns>A <see cref="Stream"/> of the data requested</returns>
+        public Stream Fetch(string key)
+        {
+            if (File.Exists(key))
+            {
+                return new FileStream(key, FileMode.Open, FileAccess.Read);
+            }
+
+            // If the file cannot be found on disc, attempt to retrieve it from the API
+            Security security;
+            DateTime date;
+
+            if (LeanData.TryParsePath(key, out security, out date))
+            {
+                Log.Trace("ApiDataProvider.Fetch(): Attempting to get data from QuantConnect.com's data library for symbol({0}), resolution({1}) and date({2}).",
+                    security.Symbol.Value, 
+                    security.Resolution, 
+                    date.Date.ToShortDateString());
+
+                var downloadSuccessful = _api.DownloadData(security.Symbol, security.Resolution, date);
+
+                if (downloadSuccessful)
+                {
+                    Log.Trace("ApiDataProvider.Fetch(): Successfully retrieved data for symbol({0}), resolution({1}) and date({2}).",
+                        security.Symbol.Value, 
+                        security.Resolution, 
+                        date.Date.ToShortDateString());
+
+                    return new FileStream(key, FileMode.Open, FileAccess.Read);
+                }
+            }
+
+            Log.Error("ApiDataProvider.Fetch(): Unable to remotely retrieve data for path {0}. " +
+                      "Please make sure you have the necessary data in your online QuantConnect data library.",
+                       key);
+
+            return null;
+        }
+    }
+}

--- a/Engine/DataFeeds/ApiDataProvider.cs
+++ b/Engine/DataFeeds/ApiDataProvider.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        /// Retrieves data to be used in an algorithm
+        /// Retrieves data to be used in an algorithm.
         /// If file does not exist, an attempt is made to download them from the api
         /// </summary>
         /// <param name="key">A string representing where the data is stored</param>

--- a/Engine/DataFeeds/ApiDataProvider.cs
+++ b/Engine/DataFeeds/ApiDataProvider.cs
@@ -42,23 +42,24 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             // If the file cannot be found on disc, attempt to retrieve it from the API
-            Security security;
+            Symbol symbol;
             DateTime date;
+            Resolution resolution;
 
-            if (LeanData.TryParsePath(key, out security, out date))
+            if (LeanData.TryParsePath(key, out symbol, out date, out resolution))
             {
                 Log.Trace("ApiDataProvider.Fetch(): Attempting to get data from QuantConnect.com's data library for symbol({0}), resolution({1}) and date({2}).",
-                    security.Symbol.Value, 
-                    security.Resolution, 
+                    symbol.Value, 
+                    resolution, 
                     date.Date.ToShortDateString());
 
-                var downloadSuccessful = _api.DownloadData(security.Symbol, security.Resolution, date);
+                var downloadSuccessful = _api.DownloadData(symbol, resolution, date);
 
                 if (downloadSuccessful)
                 {
                     Log.Trace("ApiDataProvider.Fetch(): Successfully retrieved data for symbol({0}), resolution({1}) and date({2}).",
-                        security.Symbol.Value, 
-                        security.Resolution, 
+                        symbol.Value, 
+                        resolution, 
                         date.Date.ToShortDateString());
 
                     return new FileStream(key, FileMode.Open, FileAccess.Read);

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -174,6 +174,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AlgorithmManager.cs" />
+    <Compile Include="DataFeeds\ApiDataProvider.cs" />
     <Compile Include="DataFeeds\SingleEntryDataCacheProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\BaseDataCollectionAggregatorEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\EnqueueableEnumerator.cs" />

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -175,93 +175,95 @@ namespace QuantConnect.Tests.Common.Util
         public void IncorrectPaths_CannotBeParsed()
         {
             DateTime date;
-            Security security;
+            Symbol symbol;
+            Resolution resolution;
 
             var invalidPath = "forex/fxcm/eurusd/20160101_quote.zip";
-            Assert.IsFalse(LeanData.TryParsePath(invalidPath, out security, out date));
+            Assert.IsFalse(LeanData.TryParsePath(invalidPath, out symbol, out date, out resolution));
 
             var nonExistantPath = "Data/f/fxcm/eurusd/20160101_quote.zip";
-            Assert.IsFalse(LeanData.TryParsePath(nonExistantPath, out security, out date));
+            Assert.IsFalse(LeanData.TryParsePath(nonExistantPath, out symbol, out date, out resolution));
 
             var notAPath = "ooooooooooooooooooooooooooooooooooooooooooooooooooooooo";
-            Assert.IsFalse(LeanData.TryParsePath(notAPath, out security, out date));
+            Assert.IsFalse(LeanData.TryParsePath(notAPath, out symbol, out date, out resolution));
 
             var  emptyPath = "";
-            Assert.IsFalse(LeanData.TryParsePath(emptyPath, out security, out date));
+            Assert.IsFalse(LeanData.TryParsePath(emptyPath, out symbol, out date, out resolution));
 
             string nullPath = null;
-            Assert.IsFalse(LeanData.TryParsePath(nullPath, out security, out date));
+            Assert.IsFalse(LeanData.TryParsePath(nullPath, out symbol, out date, out resolution));
 
-            var optionsTradePath = "Data/option/usa/minute/aapl/20140606_trade_american.zip";
-            Assert.IsFalse(LeanData.TryParsePath(optionsTradePath, out security, out date));
+            var optionsTradePath = "Data/option/u sa/minute/aapl/20140606_trade_american.zip";
+            Assert.IsFalse(LeanData.TryParsePath(optionsTradePath, out symbol, out date, out resolution));
 
             var optionsOpenInterestPath = "Data/option/usa/minute/aapl/20140609_openinterest_american.zip";
-            Assert.IsFalse(LeanData.TryParsePath(optionsOpenInterestPath, out security, out date));
+            Assert.IsFalse(LeanData.TryParsePath(optionsOpenInterestPath, out symbol, out date, out resolution));
 
             var optionsQuotePath = "Data/option/usa/minute/aapl/20140609_quote_american.zip";
-            Assert.IsFalse(LeanData.TryParsePath(optionsQuotePath, out security, out date));
+            Assert.IsFalse(LeanData.TryParsePath(optionsQuotePath, out symbol, out date, out resolution));
         }
 
         [Test]
         public void CorrectPaths_CanBeParsedCorrectly()
         {
             DateTime date;
-            Security security;
+            Symbol symbol;
+            Resolution resolution;
 
             var customPath = "a/very/custom/path/forex/oanda/tick/eurusd/20170104_quote.zip";
-            Assert.IsTrue(LeanData.TryParsePath(customPath, out security, out date));
-            Assert.AreEqual(security.Symbol.SecurityType, SecurityType.Forex);
-            Assert.AreEqual(security.Symbol.ID.Market, Market.Oanda);
-            Assert.AreEqual(security.Resolution, Resolution.Tick);
-            Assert.AreEqual(security.Symbol.ID.Symbol.ToLower(), "eurusd");
+            Assert.IsTrue(LeanData.TryParsePath(customPath, out symbol, out date, out resolution));
+            Assert.AreEqual(symbol.SecurityType, SecurityType.Forex);
+            Assert.AreEqual(symbol.ID.Market, Market.Oanda);
+            Assert.AreEqual(resolution, Resolution.Tick);
+            Assert.AreEqual(symbol.ID.Symbol.ToLower(), "eurusd");
             Assert.AreEqual(date.Date, DateTime.Parse("01/04/2017").Date);
 
             var mixedPathSeperators = @"Data//forex/fxcm\/minute//eurusd\\20160101_quote.zip";
-            Assert.IsTrue(LeanData.TryParsePath(mixedPathSeperators, out security, out date));
-            Assert.AreEqual(security.Symbol.SecurityType, SecurityType.Forex);
-            Assert.AreEqual(security.Symbol.ID.Market, Market.FXCM);
-            Assert.AreEqual(security.Resolution, Resolution.Minute);
-            Assert.AreEqual(security.Symbol.ID.Symbol.ToLower(), "eurusd");
+            Assert.IsTrue(LeanData.TryParsePath(mixedPathSeperators, out symbol, out date, out resolution));
+            Assert.AreEqual(symbol.SecurityType, SecurityType.Forex);
+            Assert.AreEqual(symbol.ID.Market, Market.FXCM);
+            Assert.AreEqual(resolution, Resolution.Minute);
+            Assert.AreEqual(symbol.ID.Symbol.ToLower(), "eurusd");
             Assert.AreEqual(date.Date, DateTime.Parse("01/01/2016").Date);
 
             var longRelativePath = "../../../../../../../../../Data/forex/fxcm/hour/gbpusd.zip";
-            Assert.IsTrue(LeanData.TryParsePath(longRelativePath, out security, out date));
-            Assert.AreEqual(security.Symbol.SecurityType, SecurityType.Forex);
-            Assert.AreEqual(security.Symbol.ID.Market, Market.FXCM);
-            Assert.AreEqual(security.Resolution, Resolution.Hour);
-            Assert.AreEqual(security.Symbol.ID.Symbol.ToLower(), "gbpusd");
+            Assert.IsTrue(LeanData.TryParsePath(longRelativePath, out symbol, out date, out resolution));
+            Assert.AreEqual(symbol.SecurityType, SecurityType.Forex);
+            Assert.AreEqual(symbol.ID.Market, Market.FXCM);
+            Assert.AreEqual(resolution, Resolution.Hour);
+            Assert.AreEqual(symbol.ID.Symbol.ToLower(), "gbpusd");
             Assert.AreEqual(date.Date, DateTime.MinValue);
 
             var shortRelativePath = "Data/forex/fxcm/minute/eurusd/20160102_quote.zip";
-            Assert.IsTrue(LeanData.TryParsePath(shortRelativePath, out security, out date));
-            Assert.AreEqual(security.Symbol.SecurityType, SecurityType.Forex);
-            Assert.AreEqual(security.Symbol.ID.Market, Market.FXCM);
-            Assert.AreEqual(security.Resolution, Resolution.Minute);
-            Assert.AreEqual(security.Symbol.ID.Symbol.ToLower(), "eurusd");
+            Assert.IsTrue(LeanData.TryParsePath(shortRelativePath, out symbol, out date, out resolution));
+            Assert.AreEqual(symbol.SecurityType, SecurityType.Forex);
+            Assert.AreEqual(symbol.ID.Market, Market.FXCM);
+            Assert.AreEqual(resolution, Resolution.Minute);
+            Assert.AreEqual(symbol.ID.Symbol.ToLower(), "eurusd");
             Assert.AreEqual(date.Date, DateTime.Parse("01/02/2016").Date);
 
             var dailyEquitiesPath = "Data/equity/usa/daily/aapl.zip";
-            Assert.IsTrue(LeanData.TryParsePath(dailyEquitiesPath, out security, out date));
-            Assert.AreEqual(security.Symbol.SecurityType, SecurityType.Equity);
-            Assert.AreEqual(security.Symbol.ID.Market, Market.USA);
-            Assert.AreEqual(security.Resolution, Resolution.Daily);
-            Assert.AreEqual(security.Symbol.ID.Symbol.ToLower(), "aapl");
+            Assert.IsTrue(LeanData.TryParsePath(dailyEquitiesPath, out symbol, out date, out resolution));
+            Assert.AreEqual(symbol.SecurityType, SecurityType.Equity);
+            Assert.AreEqual(symbol.ID.Market, Market.USA);
+            Assert.AreEqual(resolution, Resolution.Daily);
+            Assert.AreEqual(symbol.ID.Symbol.ToLower(), "aapl");
             Assert.AreEqual(date.Date, DateTime.MinValue);
 
             var minuteEquitiesPath = "Data/equity/usa/minute/googl/20070103_trade.zip";
-            Assert.IsTrue(LeanData.TryParsePath(minuteEquitiesPath, out security, out date));
-            Assert.AreEqual(security.Symbol.SecurityType, SecurityType.Equity);
-            Assert.AreEqual(security.Symbol.ID.Market, Market.USA);
-            Assert.AreEqual(security.Resolution, Resolution.Minute);
-            Assert.AreEqual(security.Symbol.ID.Symbol.ToLower(), "googl");
+            Assert.IsTrue(LeanData.TryParsePath(minuteEquitiesPath, out symbol, out date, out resolution));
+            Assert.AreEqual(symbol.SecurityType, SecurityType.Equity);
+            Assert.AreEqual(symbol.ID.Market, Market.USA);
+            Assert.AreEqual(resolution, Resolution.Minute);
+            Assert.AreEqual(symbol.ID.Symbol.ToLower(), "goog");
             Assert.AreEqual(date.Date, DateTime.Parse("01/03/2007").Date);
 
             var cfdPath = "Data/cfd/oanda/minute/bcousd/20160101_trade.zip";
-            Assert.IsTrue(LeanData.TryParsePath(cfdPath, out security, out date));
-            Assert.AreEqual(security.Symbol.SecurityType, SecurityType.Cfd);
-            Assert.AreEqual(security.Symbol.ID.Market, Market.Oanda);
-            Assert.AreEqual(security.Resolution, Resolution.Minute);
-            Assert.AreEqual(security.Symbol.ID.Symbol.ToLower(), "bcousd");
+            Assert.IsTrue(LeanData.TryParsePath(cfdPath, out symbol, out date, out resolution));
+            Assert.AreEqual(symbol.SecurityType, SecurityType.Cfd);
+            Assert.AreEqual(symbol.ID.Market, Market.Oanda);
+            Assert.AreEqual(resolution, Resolution.Minute);
+            Assert.AreEqual(symbol.ID.Symbol.ToLower(), "bcousd");
             Assert.AreEqual(date.Date, DateTime.Parse("01/01/2016").Date);
         }
 


### PR DESCRIPTION
+ Added the ApiDataProvider.cs. The ApiDataProvider is a new instance of the IDataProvider that will check for the data on disc.  If it the data is not present on disc, it will reach out to QuantConnect.com to see if the data is available.
+ Added LeanData.TryParsePath(). This method takes a path and will return a Symbol, DateTime and resolution.  This is useful in the ApiDataProvider that uses the api to retrieve files that are not present on disc.  The IDataProvider only has a path to the file.  Using this method, the ApiDataProvider can extract the useful information from the path to communicate with the api.