### PR TITLE
Implement IEX IDataQueueHandler

### DIFF
--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -627,7 +627,8 @@ namespace QuantConnect
             {"W", "Chicago Board Options Exchange"},
             {"X", "Philadelphia Stock Exchange"},
             {"Y", "BATS Y-Exchange, Inc"},
-            {"Z", "BATS Exchange, Inc"}
+            {"Z", "BATS Exchange, Inc"},
+            {"IEX", "Investors Exchange"},
         };
 
         /// Canada Market Short Codes:

--- a/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
+++ b/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
@@ -1,0 +1,215 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.ToolBox.IEX;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture, Ignore("Tests are dependent on network and are long")]
+    public class IEXDataQueueHandlerTests
+    {
+        private void ProcessFeed(IEXDataQueueHandler iex, Action<BaseData> callback = null)
+        {
+            Task.Run(() =>
+            {
+                foreach (var tick in iex.GetNextTicks())
+                {
+                    try
+                    {
+                        if (callback != null)
+                        {
+                            callback.Invoke(tick);
+                        }
+                    }
+                    catch (AssertionException ase)
+                    {
+                        throw;
+                    }
+                    catch (Exception err)
+                    {
+                        Console.WriteLine(err.Message);
+                    }
+                }
+            });
+        }
+
+        [Test]
+        public void IEXCouldConnect()
+        {
+            var iex = new IEXDataQueueHandler();
+            Thread.Sleep(5000);
+            Assert.IsTrue(iex.IsConnected);
+            iex = null;
+            GC.Collect(2, GCCollectionMode.Forced, true);
+            Thread.Sleep(1000);
+            // finalizer should print disconnected message
+        }
+
+        /// <summary>
+        /// Firehose is a special symbol that subscribes to all IEX symbols
+        /// </summary>
+        [Test]
+        public void IEXCouldSubscribeToAll()
+        {
+            var iex = new IEXDataQueueHandler();
+
+            ProcessFeed(iex, tick => Console.WriteLine(tick.ToString()));
+
+            iex.Subscribe(null, new[]
+            {
+                Symbol.Create("firehose", SecurityType.Equity, Market.USA)
+            });
+
+            Thread.Sleep(30000);
+            iex.Dispose();
+        }
+
+        /// <summary>
+        /// Subscribe to multiple symbols in a single call
+        /// </summary>
+        [Test]
+        public void IEXCouldSubscribe()
+        {
+            var iex = new IEXDataQueueHandler();
+
+            ProcessFeed(iex, tick => Console.WriteLine(tick.ToString()));
+
+            iex.Subscribe(null, new[]
+            {
+                Symbol.Create("FB", SecurityType.Equity, Market.USA),
+                Symbol.Create("AAPL", SecurityType.Equity, Market.USA),
+                Symbol.Create("XIV", SecurityType.Equity, Market.USA),
+                Symbol.Create("PTN", SecurityType.Equity, Market.USA),
+                Symbol.Create("USO", SecurityType.Equity, Market.USA),
+            });
+
+            Thread.Sleep(10000);
+            iex.Dispose();
+        }
+
+        /// <summary>
+        /// Subscribe to multiple symbols in a series of calls
+        /// </summary>
+        [Test]
+        public void IEXCouldSubscribeManyTimes()
+        {
+            var iex = new IEXDataQueueHandler();
+
+            ProcessFeed(iex, tick => Console.WriteLine(tick.ToString()));
+
+            iex.Subscribe(null, new[]
+            {
+                Symbol.Create("MBLY", SecurityType.Equity, Market.USA),
+            });
+
+            iex.Subscribe(null, new[]
+            {
+                Symbol.Create("FB", SecurityType.Equity, Market.USA),
+            });
+
+            iex.Subscribe(null, new[]
+            {
+                Symbol.Create("AAPL", SecurityType.Equity, Market.USA),
+            });
+
+            iex.Subscribe(null, new[]
+            {
+                Symbol.Create("USO", SecurityType.Equity, Market.USA),
+            });
+
+            Thread.Sleep(10000);
+
+            Console.WriteLine("Unsubscribing from all except MBLY");
+
+            iex.Unsubscribe(null, new[]
+            {
+                Symbol.Create("FB", SecurityType.Equity, Market.USA),
+            });
+
+            iex.Unsubscribe(null, new[]
+            {
+                Symbol.Create("AAPL", SecurityType.Equity, Market.USA),
+            });
+
+            iex.Unsubscribe(null, new[]
+            {
+                Symbol.Create("USO", SecurityType.Equity, Market.USA),
+            });
+
+            Thread.Sleep(10000);
+
+            iex.Dispose();
+        }
+
+        [Test]
+        public void IEXCouldSubscribeAndUnsubscribe()
+        {
+            // MBLY is the most liquid IEX instrument
+            var iex = new IEXDataQueueHandler();
+            var unsubscribed = false;
+            ProcessFeed(iex, tick =>
+            {
+                Console.WriteLine(tick.ToString());
+                if (unsubscribed && tick.Symbol.Value == "MBLY")
+                {
+                    Assert.Fail("Should not receive data for unsubscribed symbol");
+                }
+            });
+
+            iex.Subscribe(null, new[] {
+                Symbol.Create("MBLY", SecurityType.Equity, Market.USA),
+                Symbol.Create("USO", SecurityType.Equity, Market.USA)
+            });
+
+            Thread.Sleep(20000);
+
+            iex.Unsubscribe(null, new[]
+            {
+                Symbol.Create("MBLY", SecurityType.Equity, Market.USA)
+            });
+            Console.WriteLine("Unsubscribing");
+            Thread.Sleep(2000);
+            // some messages could be inflight, but after a pause all MBLY messages must have beed consumed by ProcessFeed
+            unsubscribed = true;
+
+            Thread.Sleep(20000);
+            iex.Dispose();
+        }
+
+        [Test]
+        public void IEXCouldReconnect()
+        {
+            var iex = new IEXDataQueueHandler();
+            var realEndpoint = iex.Endpoint;
+            Thread.Sleep(1000);
+            iex.Dispose();
+            iex.Endpoint = "https://badd.address";
+            iex.Reconnect();
+            Thread.Sleep(1000);
+            iex.Dispose();
+            iex.Endpoint = realEndpoint;
+            iex.Reconnect();
+            Thread.Sleep(1000);
+            Assert.IsTrue(iex.IsConnected);
+            iex.Dispose();
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Engine\DataFeeds\Enumerators\TradeBarBuilderEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\FileSystemDataFeedTests.cs" />
     <Compile Include="Engine\DataFeeds\FillForwardEnumeratorTest.cs" />
+    <Compile Include="Engine\DataFeeds\IEXDataQueueHandlerTests.cs" />
     <Compile Include="Engine\DataFeeds\IQFeedRealtimeDataFeedTests.cs" />
     <Compile Include="Engine\DataFeeds\RemoteFileBaseData.cs" />
     <Compile Include="Engine\DataFeeds\RestApiBaseData.cs" />

--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -1,0 +1,295 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Lean.Engine.DataFeeds.Queues;
+using QuantConnect.Packets;
+using Quobject.SocketIoClientDotNet.Client;
+using QuantConnect.Logging;
+using Newtonsoft.Json.Linq;
+using QuantConnect.Data.Market;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text;
+
+namespace QuantConnect.ToolBox.IEX
+{
+    /// <summary>
+    /// IEX live data handler
+    /// </summary>
+    public class IEXDataQueueHandler : LiveDataQueue, IDisposable
+    {
+        // using SocketIoClientDotNet is a temp solution until IEX implements standard WebSockets protocol
+        private Socket _socket;
+
+        private ConcurrentDictionary<string, Symbol> _symbols = new ConcurrentDictionary<string, Symbol>(StringComparer.InvariantCultureIgnoreCase);
+        private Manager _manager;
+        private CancellationTokenSource _cts = new CancellationTokenSource();
+        private static DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Unspecified);
+        private TaskCompletionSource<bool> _connected = new TaskCompletionSource<bool>();
+        private Task _lastEmitTask;
+        private bool _subscribedToAll;
+
+        private BlockingCollection<BaseData> _outputCollection = new BlockingCollection<BaseData>();
+
+        public string Endpoint { get; internal set; }
+
+        public bool IsConnected
+        {
+            get { return _manager.ReadyState == Manager.ReadyStateEnum.OPEN; }
+        }
+
+        public IEXDataQueueHandler()
+        {
+            Endpoint = "https://ws-api.iextrading.com/1.0/tops";
+            Reconnect();
+        }
+
+        internal void Reconnect()
+        {
+            try
+            {
+                _socket = IO.Socket(Endpoint,
+                    new IO.Options()
+                    {
+                        // default is 1000, default attempts is int.MaxValue
+                        ReconnectionDelay = 250
+                    });
+                _socket.On(Socket.EVENT_CONNECT, () =>
+                {
+                    _connected.TrySetResult(true);
+                    Log.Trace("IEXDataQueueHandler: Connected to IEX live data");
+                });
+
+                _socket.On("message", message => ProcessJsonObject((JObject)message));
+                _manager = _socket.Io();
+            }
+            catch (Exception err)
+            {
+                Log.Error("IEXDataQueueHandler.ProcessJsonObject(): " + err.Message);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void ProcessJsonObject(JObject message)
+        {
+            try
+            {
+                // https://iextrading.com/developer/#tops-tops-response
+                var symbolString = message["symbol"].Value<string>();
+                Symbol symbol;
+                if (!_symbols.TryGetValue(symbolString, out symbol))
+                {
+                    if (_subscribedToAll)
+                    {
+                        symbol = Symbol.Create(symbolString, SecurityType.Equity, Market.USA);
+                    }
+                    else
+                    {
+                        Log.Trace("IEXDataQueueHandler.ProcessJsonObject(): Recieved unexpected symbol '" + symbolString + "' from IEX in IEXDataQueueHandler");
+                        return;
+                    }
+                }
+                var bidSize = message["bidSize"].Value<long>();
+                var bidPrice = message["bidPrice"].Value<decimal>();
+                var askSize = message["askSize"].Value<long>();
+                var askPrice = message["askPrice"].Value<decimal>();
+                var volume = message["volume"].Value<int>();
+                var lastSalePrice = message["lastSalePrice"].Value<decimal>();
+                var lastSaleSize = message["lastSaleSize"].Value<int>();
+                var lastSaleTime = message["lastSaleTime"].Value<long>();
+                var lastSaleDateTime = UnixEpoch.AddMilliseconds(lastSaleTime);
+                var lastUpdated = message["lastUpdated"].Value<long>();
+                if (lastUpdated == -1)
+                {
+                    // there were no trades on this day
+                    return;
+                }
+                var lastUpdatedDatetime = UnixEpoch.AddMilliseconds(lastUpdated);
+
+                var tick = new Tick()
+                {
+                    Symbol = symbol,
+                    TickType = TickType.Quote,
+                    Exchange = "IEX",
+                    BidSize = bidSize,
+                    BidPrice = bidPrice,
+                    AskSize = askSize,
+                    AskPrice = askPrice,
+                    Value = lastSalePrice,
+                    Quantity = lastSaleSize
+                };
+                _outputCollection.TryAdd(tick);
+            }
+            catch (Exception err)
+            {
+                // this method should never fail
+                Log.Error("IEXDataQueueHandler.ProcessJsonObject(): " + err.Message);
+            }
+        }
+
+        /// <summary>
+        /// Desktop/Local doesn't support live data from this handler
+        /// </summary>
+        /// <returns>Tick</returns>
+        public sealed override IEnumerable<BaseData> GetNextTicks()
+        {
+            return _outputCollection.GetConsumingEnumerable();
+        }
+
+        /// <summary>
+        /// Subscribe to symbols
+        /// </summary>
+        public sealed override void Subscribe(LiveNodePacket job, IEnumerable<Symbol> symbols)
+        {
+            try
+            {
+                var sb = new StringBuilder();
+                foreach (var symbol in symbols)
+                {
+                    // IEX only supports equities
+                    if (symbol.SecurityType != SecurityType.Equity) continue;
+                    if (symbol.Value.Equals("firehose", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        _subscribedToAll = true;
+                    }
+                    if (_symbols.TryAdd(symbol.Value, symbol))
+                    {
+                        // added new symbol
+                        sb.Append(symbol.Value);
+                        sb.Append(",");
+                    }
+                }
+                var symbolsList = sb.ToString().TrimEnd(',');
+                if (!String.IsNullOrEmpty(symbolsList))
+                {
+                    SocketSafeAsyncEmit("subscribe", symbolsList);
+                }
+            }
+            catch (Exception err)
+            {
+                Log.Error("IEXDataQueueHandler.Subscribe(): " + err.Message);
+            }
+        }
+
+
+        /// <summary>
+        /// Unsubscribe from symbols
+        /// </summary>
+        public sealed override void Unsubscribe(LiveNodePacket job, IEnumerable<Symbol> symbols)
+        {
+            try
+            {
+                var sb = new StringBuilder();
+                foreach (var symbol in symbols)
+                {
+                    // IEX only supports equities
+                    if (symbol.SecurityType != SecurityType.Equity) continue;
+                    Symbol tmp;
+                    if (_symbols.TryRemove(symbol.Value, out tmp))
+                    {
+                        // removed existing
+                        Trace.Assert(symbol.Value == tmp.Value);
+                        sb.Append(symbol.Value);
+                        sb.Append(",");
+                    }
+                }
+                var symbolsList = sb.ToString().TrimEnd(',');
+                if (!String.IsNullOrEmpty(symbolsList))
+                {
+                    SocketSafeAsyncEmit("unsubscribe", symbolsList);
+                }
+            }
+            catch (Exception err)
+            {
+                Log.Error("IEXDataQueueHandler.Unsubscribe(): " + err.Message);
+            }
+        }
+
+        /// <summary>
+        /// This method is used to schedule _socket.Emit request until the connection state is OPEN
+        /// </summary>
+        /// <param name="symbol"></param>
+        private void SocketSafeAsyncEmit(string command, string value)
+        {
+            Task.Run(async () =>
+            {
+                await _connected.Task;
+                const int retriesLimit = 100;
+                var retriesCount = 0;
+                while (true)
+                {
+                    try
+                    {
+                        if (_manager.ReadyState == Manager.ReadyStateEnum.OPEN)
+                        {
+                            // there is an ACK functionality in socket.io, but IEX will be moving to standard WebSockets
+                            // and this retry logic is just for rare cases of connection interrupts
+                            _socket.Emit(command, value);
+                            break;
+                        }
+                    }
+                    catch (Exception err)
+                    {
+                        Log.Error("IEXDataQueueHandler.SocketSafeAsyncEmit(): " + err.Message);
+                    }
+                    await Task.Delay(100);
+                    retriesCount++;
+                    if (retriesCount >= retriesLimit)
+                    {
+                        Log.Error("IEXDataQueueHandler.SocketSafeAsyncEmit(): " +
+                                  (new TimeoutException("Cannot subscribe to symbol :" + value)));
+                        break;
+                    }
+                }
+            }, _cts.Token)
+            .ContinueWith((t) =>
+            {
+                Log.Error("IEXDataQueueHandler.SocketSafeAsyncEmit(): " + t.Exception.Message);
+                return t;
+
+            }, TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        /// <summary>
+        /// Dispose connection to IEX
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            _outputCollection.CompleteAdding();
+            _cts.Cancel();
+            _socket.Disconnect();
+            _socket.Close();
+
+            Log.Trace("IEXDataQueueHandler: Disconnected from IEX live data");
+        }
+
+        ~IEXDataQueueHandler()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/ToolBox/Properties/AssemblyInfo.cs
+++ b/ToolBox/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("QuantConnect.Tests")]

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -36,6 +36,9 @@
     <StartupObject>QuantConnect.ToolBox.AlgoSeekFuturesConverter.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EngineIoClientDotNet, Version=0.9.22.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EngineIoClientDotNet.0.9.22\lib\net45\EngineIoClientDotNet.dll</HintPath>
+    </Reference>
     <Reference Include="IKVM.AWT.WinForms">
       <HintPath>..\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.AWT.WinForms.dll</HintPath>
     </Reference>
@@ -120,20 +123,20 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
-      <HintPath>..\packages\NodaTime.1.3.1\lib\net35-Client\NodaTime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="QuantConnect.Fxcm">
       <HintPath>..\Brokerages\Fxcm\QuantConnect.Fxcm.dll</HintPath>
     </Reference>
     <Reference Include="SevenZipSharp">
       <HintPath>..\packages\SevenZipSharp.0.64\lib\SevenZipSharp.dll</HintPath>
     </Reference>
+    <Reference Include="SocketIoClientDotNet, Version=0.9.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SocketIoClientDotNet.0.9.13\lib\net45\SocketIoClientDotNet.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -142,6 +145,9 @@
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.1\lib\net35-Client\NodaTime.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="WebSocket4Net, Version=0.14.1.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocket4Net.0.14.1\lib\net45\WebSocket4Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -170,6 +176,7 @@
     <Compile Include="GoogleDownloader\GoogleDataDownloader.cs" />
     <Compile Include="GoogleDownloader\Program.cs" />
     <Compile Include="IDataProcessor.cs" />
+    <Compile Include="IEX\IEXDataQueueHandler.cs" />
     <Compile Include="IQFeed\IQFeedDataQueueHandler.cs" />
     <Compile Include="IQFeed\IQFeedDataQueueUniverseProvider.cs" />
     <Compile Include="IQFeed\IQ\DataStructures.cs" />
@@ -203,6 +210,9 @@
   <ItemGroup>
     <None Include="AlgoSeekFuturesConverter\AlgoSeek.US.Futures.PriceMultipliers.1.1.csv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
     </None>
     <None Include="CoarseUniverseGenerator\config.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/ToolBox/packages.config
+++ b/ToolBox/packages.config
@@ -2,6 +2,9 @@
 <packages>
   <package id="DotNetZip" version="1.9.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="EngineIoClientDotNet" version="0.9.22" targetFramework="net45" />
   <package id="NodaTime" version="1.3.1" targetFramework="net45" />
   <package id="SevenZipSharp" version="0.64" targetFramework="net45" />
+  <package id="SocketIoClientDotNet" version="0.9.13" targetFramework="net45" />
+  <package id="WebSocket4Net" version="0.14.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR implements IEX IDataQueueHandler from #773.

The first commit has all code related to the handler. 

In the second commit I had to update Json.Net, because Socket.IO client has the 8.0.1 version as a dependency. Also the current dependency 7.0.1 is almost two years old, while 9.0.1 works on any platform (even .NET 2.0), has no dependencies and has improved performance since 7.0. However, if for some reason that package update is undesirable, I could revert the last commit and will use assembly redirect to an older version in the Toolbox project.

I was able to test basic functionality today before market close.