### PR TITLE
Fixes unhandled OrderType.OptionExercise in OrderJsonConverter

### DIFF
--- a/Common/Orders/OrderJsonConverter.cs
+++ b/Common/Orders/OrderJsonConverter.cs
@@ -165,6 +165,10 @@ namespace QuantConnect.Orders
                     order = new MarketOnCloseOrder();
                     break;
 
+                case OrderType.OptionExercise:
+                    order = new OptionExerciseOrder();
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Tests/Common/Orders/OrderJsonConverterTests.cs
+++ b/Tests/Common/Orders/OrderJsonConverterTests.cs
@@ -117,6 +117,22 @@ namespace QuantConnect.Tests.Common.Orders
         }
 
         [Test]
+        public void DeserializesOptionExpireOrder()
+        {
+            var expected = new OptionExerciseOrder(Symbols.SPY_P_192_Feb19_2016, 100, new DateTime(2015, 11, 23, 17, 15, 37), "now")
+            {
+                Id = 12345,
+                ContingentId = 123456,
+                BrokerId = new List<string> { "727", "54970" }
+            };
+
+            // Note: Order price equals strike price found in Symbol object
+            // Price = Symbol.ID.StrikePrice
+
+            TestOrderType(expected);
+        }
+
+        [Test]
         public void DeserializesOldSymbol()
         {
             const string json = @"{'Type':0,


### PR DESCRIPTION
Adds the missing switch-case for OrderType.OptionExercise in OrderJsonConverter.CreateOrder