### PR TITLE
Fixes Oanda and FXCM time zone issues in DataQueueHandlers and GetHistory

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.DataQueueHandler.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.DataQueueHandler.cs
@@ -17,10 +17,12 @@ using System.Collections.Generic;
 using System.Linq;
 using com.fxcm.fix;
 using com.fxcm.fix.pretrade;
+using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Logging;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Brokerages.Fxcm
 {
@@ -70,6 +72,15 @@ namespace QuantConnect.Brokerages.Fxcm
                 if (_fxcmInstruments.TryGetValue(_symbolMapper.GetBrokerageSymbol(symbol), out fxcmSecurity))
                 {
                     request.addRelatedSymbol(fxcmSecurity);
+
+                    // cache exchange time zone for symbol
+                    DateTimeZone exchangeTimeZone;
+                    if (!_symbolExchangeTimeZones.TryGetValue(symbol, out exchangeTimeZone))
+                    {
+                        exchangeTimeZone = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.FXCM, symbol, symbol.SecurityType).TimeZone;
+                        _symbolExchangeTimeZones.Add(symbol, exchangeTimeZone);
+                    }
+
                 }
             }
             request.setSubscriptionRequestType(SubscriptionRequestTypeFactory.SUBSCRIBE);

--- a/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
@@ -307,11 +307,23 @@ namespace QuantConnect.Brokerages.Fxcm
                 }
                 else
                 {
-                    var open = Convert.ToDecimal((message.getBidOpen() + message.getAskOpen()) / 2);
-                    var high = Convert.ToDecimal((message.getBidHigh() + message.getAskHigh()) / 2);
-                    var low = Convert.ToDecimal((message.getBidLow() + message.getAskLow()) / 2);
-                    var close = Convert.ToDecimal((message.getBidClose() + message.getAskClose()) / 2);
-                    var bar = new TradeBar(time, symbol, open, high, low, close, 0);
+                    var bar = new QuoteBar(
+                        time,
+                        symbol,
+                        new Bar(
+                            Convert.ToDecimal(message.getBidOpen()),
+                            Convert.ToDecimal(message.getBidHigh()),
+                            Convert.ToDecimal(message.getBidLow()),
+                            Convert.ToDecimal(message.getBidClose())
+                        ),
+                        0,
+                            new Bar(
+                            Convert.ToDecimal(message.getAskOpen()),
+                            Convert.ToDecimal(message.getAskHigh()),
+                            Convert.ToDecimal(message.getAskLow()),
+                            Convert.ToDecimal(message.getAskClose())
+                        ),
+                        0);
 
                     _lastHistoryChunk.Add(bar);
                 }

--- a/Brokerages/Fxcm/FxcmBrokerage.Util.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Util.cs
@@ -22,7 +22,6 @@ using com.sun.rowset;
 using java.util;
 using NodaTime;
 using QuantConnect.Orders;
-using QuantConnect.Securities;
 
 namespace QuantConnect.Brokerages.Fxcm
 {
@@ -31,8 +30,6 @@ namespace QuantConnect.Brokerages.Fxcm
     /// </summary>
     public partial class FxcmBrokerage
     {
-        private static DateTimeZone _configTimeZone;
-
         /// <summary>
         /// Converts an FXCM order to a QuantConnect order.
         /// </summary>
@@ -175,24 +172,17 @@ namespace QuantConnect.Brokerages.Fxcm
         }
 
         /// <summary>
-        /// Converts a Java Date value to a DateTime value
+        /// Converts a Java Date value to a UTC DateTime value
         /// </summary>
         /// <param name="javaDate">The Java date</param>
         /// <returns></returns>
         private static DateTime FromJavaDate(Date javaDate)
         {
-            if (_configTimeZone == null)
-            {
-                // Read time zone from market-hours-config
-                var symbol = Symbol.Create("*", SecurityType.Forex, Market.FXCM);
-                _configTimeZone = MarketHoursDatabase.FromDataFolder().GetDataTimeZone(symbol.ID.Market, symbol, symbol.ID.SecurityType);
-            }
-
             // Convert javaDate to UTC Instant (Epoch)
             var instant = Instant.FromMillisecondsSinceUnixEpoch(javaDate.getTime());
 
-            // Convert to configured TZ then to a .Net DateTime
-            return instant.InZone(_configTimeZone).ToDateTimeUnspecified();
+            // Convert to .Net UTC DateTime
+            return instant.ToDateTimeUtc();
         }
 
         /// <summary>

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2020,7 +2020,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             var contract = CreateContract(request.Symbol);
             var resolution = ConvertResolution(request.Resolution);
             var duration = ConvertResolutionToDuration(request.Resolution);
-            var useRTH = Convert.ToInt32(request.IncludeExtendedMarketHours);
+            var useRegularTradingHours = Convert.ToInt32(!request.IncludeExtendedMarketHours);
             var startTime = request.Resolution == Resolution.Daily ?
                             request.StartTimeUtc.ConvertFromUtc(request.ExchangeHours.TimeZone) :
                             request.StartTimeUtc.ConvertFromUtc(DateTimeZoneProviders.Bcl.GetSystemDefault());
@@ -2078,7 +2078,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 Client.HistoricalDataEnd += clientOnHistoricalDataEnd;
 
                 Client.ClientSocket.reqHistoricalData(historicalTicker, contract, endTime.ToString("yyyyMMdd HH:mm:ss"),
-                    duration, resolution, dataType, useRTH, 1, new List<TagValue>());
+                    duration, resolution, dataType, useRegularTradingHours, 1, new List<TagValue>());
 
                 var waitResult = 0;
                 while (waitResult == 0)

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -146,8 +146,8 @@ namespace QuantConnect.Lean.Engine.RealTime
                 var marketHours = _api.MarketToday(date, security.Symbol);
                 security.Exchange.SetMarketHours(marketHours, date.DayOfWeek);
                 var localMarketHours = security.Exchange.Hours.MarketHours[date.DayOfWeek];
-                Log.Trace(string.Format("LiveTradingRealTimeHandler.SetupEvents({0}): Market hours set: Symbol: {1} {2}",
-                        security.Type, security.Symbol, localMarketHours));
+                Log.Trace(string.Format("LiveTradingRealTimeHandler.RefreshMarketHoursToday({0}): Market hours set: Symbol: {1} {2} ({3})",
+                        security.Type, security.Symbol, localMarketHours, security.Exchange.Hours.TimeZone));
             }
         }
 


### PR DESCRIPTION
Other fixes included:
- FXCM `GetHistory` now returns `QuoteBar`s instead of `TradeBar`s
- RTH/ETH bug fix in InteractiveBrokers `GetHistory` data requests
- Log TimeZone in `LiveTradingRealTimeHandler.RefreshMarketHoursToday`