### PR TITLE
Fixes IEX missing Time information

### DIFF
--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -129,7 +129,8 @@ namespace QuantConnect.ToolBox.IEX
                 var tick = new Tick()
                 {
                     Symbol = symbol,
-                    TickType = TickType.Quote,
+                    Time = lastUpdatedDatetime.ConvertFromUtc(TimeZones.NewYork),
+                    TickType = lastUpdatedDatetime == lastSaleDateTime ? TickType.Trade : TickType.Quote,
                     Exchange = "IEX",
                     BidSize = bidSize,
                     BidPrice = bidPrice,


### PR DESCRIPTION
Tick.Time was not set with the information from IEX.

Tick.TickTime was defined as TickType.Quote even when it was a TickType.Trade tick. This distinction is helpful when an algorithm filters out quote ticks.