### PR TITLE
Add ITradeBuilder interface and QCAlgorithm.SetTradeBuilder

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -238,7 +238,7 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// Gets the Trade Builder to generate trades from executions
         /// </summary>
-        public TradeBuilder TradeBuilder
+        public ITradeBuilder TradeBuilder
         {
             get;
             private set;
@@ -1187,6 +1187,15 @@ namespace QuantConnect.Algorithm
                     _endDate = QuantConnect.Time.EndOfTime;
                 }
             }
+        }
+
+        /// <summary>
+        /// Set the <see cref="ITradeBuilder"/> implementation to generate trades from executions and market price updates
+        /// </summary>
+        public void SetTradeBuilder(ITradeBuilder tradeBuilder)
+        {
+            TradeBuilder = tradeBuilder;
+            TradeBuilder.SetLiveMode(LiveMode);
         }
 
         /// <summary>

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -275,7 +275,7 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Gets the Trade Builder to generate trades from executions
         /// </summary>
-        TradeBuilder TradeBuilder
+        ITradeBuilder TradeBuilder
         {
             get;
         }

--- a/Common/Interfaces/ITradeBuilder.cs
+++ b/Common/Interfaces/ITradeBuilder.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Orders;
+using QuantConnect.Statistics;
+
+namespace QuantConnect.Interfaces
+{
+    /// <summary>
+    /// Generates trades from executions and market price updates
+    /// </summary>
+    public interface ITradeBuilder
+    {
+        /// <summary>
+        /// Sets the live mode flag
+        /// </summary>
+        /// <param name="live">The live mode flag</param>
+        void SetLiveMode(bool live);
+
+        /// <summary>
+        /// The list of closed trades
+        /// </summary>
+        List<Trade> ClosedTrades { get; }
+
+        /// <summary>
+        /// Returns true if there is an open position for the symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <returns>true if there is an open position for the symbol</returns>
+        bool HasOpenPosition(Symbol symbol);
+
+        /// <summary>
+        /// Sets the current market price for the symbol
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <param name="price"></param>
+        void SetMarketPrice(Symbol symbol, decimal price);
+
+        /// <summary>
+        /// Processes a new fill, eventually creating new trades
+        /// </summary>
+        /// <param name="fill">The new fill order event</param>
+        /// <param name="conversionRate">The current market conversion rate into the account currency</param>
+        /// <param name="multiplier">The contract multiplier</param>
+        void ProcessFill(OrderEvent fill, decimal conversionRate, decimal multiplier);
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -267,6 +267,7 @@
     <Compile Include="Interfaces\IMapFileProvider.cs" />
     <Compile Include="Interfaces\IMessagingHandler.cs" />
     <Compile Include="Interfaces\IStreamReader.cs" />
+    <Compile Include="Interfaces\ITradeBuilder.cs" />
     <Compile Include="LocalTimeKeeper.cs" />
     <Compile Include="Market.cs" />
     <Compile Include="Notifications\Notification.cs" />

--- a/Common/Statistics/TradeBuilder.cs
+++ b/Common/Statistics/TradeBuilder.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Util;
 
@@ -24,7 +25,7 @@ namespace QuantConnect.Statistics
     /// <summary>
     /// The <see cref="TradeBuilder"/> class generates trades from executions and market price updates
     /// </summary>
-    public class TradeBuilder
+    public class TradeBuilder : ITradeBuilder
     {
         /// <summary>
         /// Helper class to manage pending trades and market price updates for a symbol


### PR DESCRIPTION
The `TradeBuilder` (used for `TradeStatistics`) is instantiated in the `QCAlgorithm` constructor with fixed settings (`FillGroupingMethod.FillToFill` and `FillMatchingMethod.FIFO`) and there was no way to change them.

This PR enables users to set a `TradeBuilder` instance initialized with different grouping and matching settings or even a custom `ITradeBuilder` implementation.

Ref. https://www.quantconnect.com/forum/discussion/1794/tradebuilder-to-fill-flattoflat/p1