### PR TITLE
Trim all trailing 0s when generating Lean formatted lines

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -231,7 +231,7 @@ namespace QuantConnect
             return (decimal) input;
         }
 
-        private static decimal Normalize(decimal input)
+        public static decimal Normalize(this decimal input)
         {
             // http://stackoverflow.com/a/7983330/1582922
             return input / 1.000000000000000000000000000000000m;

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -544,7 +544,7 @@ namespace QuantConnect.Util
                 var value = args[i];
                 if (value is decimal)
                 {
-                    args[i] = ((decimal) value).ToString(CultureInfo.InvariantCulture).TrimEnd('0');
+                    args[i] = ((decimal) value).Normalize().ToString(CultureInfo.InvariantCulture);
                 }
             }
 

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -544,7 +544,7 @@ namespace QuantConnect.Util
                 var value = args[i];
                 if (value is decimal)
                 {
-                    args[i] = ((decimal) value).ToString(CultureInfo.InvariantCulture);
+                    args[i] = ((decimal) value).ToString(CultureInfo.InvariantCulture).TrimEnd('0');
                 }
             }
 

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Securities;
@@ -214,6 +215,16 @@ namespace QuantConnect.Tests.Common.Util
             var input = (double) decimal.MinValue;
             var output = input.SafeDecimalCast();
             Assert.AreEqual(decimal.MinValue, output);
+        }
+
+        [Test]
+        [TestCase(1.200, "1.2")]
+        [TestCase(1200, "1200")]
+        [TestCase(123.456, "123.456")]
+        public void NormalizeDecimalReturnsNoTrailingZeros(decimal input, string expectedOutput)
+        {
+            var output = input.Normalize();
+            Assert.AreEqual(expectedOutput, output.ToString(CultureInfo.InvariantCulture));
         }
 
         private class Super<T>


### PR DESCRIPTION
Remove all trailing 0s in LeanData.GenerateLine(). This creates smaller data files and prevents large numbers of trailing zeros on data points.  This change will apply to all data written with LeanData.GenerateLine.