### PR TITLE
Fix SetBrokerageModel when called after AddSecurity and friends

### DIFF
--- a/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
+++ b/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
@@ -62,6 +62,7 @@ namespace QuantConnect.Algorithm.CSharp
             /// with the specified normalization mode
             /// </summary>
             /// <param name="brokerageModel">The brokerage model used to get fill/fee/slippage/settlement models</param>
+            /// <param name="securitySeeder">The security seeder to be used</param>
             /// <param name="dataNormalizationMode">The desired data normalization mode</param>
             public CustomSecurityInitializer(IBrokerageModel brokerageModel, ISecuritySeeder securitySeeder, DataNormalizationMode dataNormalizationMode)
                 : base(brokerageModel, securitySeeder)
@@ -73,10 +74,11 @@ namespace QuantConnect.Algorithm.CSharp
             /// Initializes the specified security by setting up the models
             /// </summary>
             /// <param name="security">The security to be initialized</param>
-            public override void Initialize(Security security)
+            /// <param name="seedSecurity">True to seed the security, false otherwise</param>
+            public override void Initialize(Security security, bool seedSecurity)
             {
                 // first call the default implementation
-                base.Initialize(security);
+                base.Initialize(security, seedSecurity);
 
                 // now apply our data normalization mode
                 security.SetDataNormalizationMode(_dataNormalizationMode);

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -559,9 +559,18 @@ namespace QuantConnect.Algorithm
         /// Sets the security initializer function, used to initialize/configure securities after creation
         /// </summary>
         /// <param name="securityInitializer">The security initializer function</param>
-        public void SetSecurityInitializer(Action<Security> securityInitializer)
+        public void SetSecurityInitializer(Action<Security, bool> securityInitializer)
         {
             SetSecurityInitializer(new FuncSecurityInitializer(securityInitializer));
+        }
+
+        /// <summary>
+        /// Sets the security initializer function, used to initialize/configure securities after creation
+        /// </summary>
+        /// <param name="securityInitializer">The security initializer function</param>
+        public void SetSecurityInitializer(Action<Security> securityInitializer)
+        {
+            SetSecurityInitializer(new FuncSecurityInitializer((security, seedSecurity) => securityInitializer(security)));
         }
 
         /// <summary>
@@ -864,6 +873,13 @@ namespace QuantConnect.Algorithm
             {
                 // purposefully use the direct setter vs Set method so we don't flip the switch :/
                 SecurityInitializer = new BrokerageModelSecurityInitializer(model, new FuncSecuritySeeder(GetLastKnownPrice));
+
+                // update models on securities added earlier (before SetBrokerageModel is called)
+                foreach (var security in Securities.Values)
+                {
+                    // no need to seed the security, has already been done in AddSecurity
+                    SecurityInitializer.Initialize(security, false);
+                }
             }
         }
 

--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -46,7 +46,8 @@ namespace QuantConnect.Securities
         /// Initializes the specified security by setting up the models
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        public virtual void Initialize(Security security)
+        /// <param name="seedSecurity">True to seed the security, false otherwise</param>
+        public virtual void Initialize(Security security, bool seedSecurity)
         {
             // set leverage and models
             security.SetLeverage(_brokerageModel.GetLeverage(security));
@@ -55,18 +56,21 @@ namespace QuantConnect.Securities
             security.SlippageModel = _brokerageModel.GetSlippageModel(security);
             security.SettlementModel = _brokerageModel.GetSettlementModel(security, _brokerageModel.AccountType);
 
-            // Do not seed Options and Futures
-            if (security.Symbol.SecurityType != SecurityType.Option && security.Symbol.SecurityType != SecurityType.Future)
+            if (seedSecurity)
             {
-                BaseData seedData = _securitySeeder.GetSeedData(security);
-                if (seedData != null)
+                // Do not seed Options and Futures
+                if (security.Symbol.SecurityType != SecurityType.Option && security.Symbol.SecurityType != SecurityType.Future)
                 {
-                    security.SetMarketPrice(seedData);
-                    Log.Trace("BrokerageModelSecurityInitializer.Initialize(): Seeded security: " + seedData.Symbol.Value + ": " + seedData.Value);
-                }
-                else
-                {
-                    Log.Trace("BrokerageModelSecurityInitializer.Initialize(): Unable to seed security: " + security.Symbol.Value);
+                    BaseData seedData = _securitySeeder.GetSeedData(security);
+                    if (seedData != null)
+                    {
+                        security.SetMarketPrice(seedData);
+                        Log.Trace("BrokerageModelSecurityInitializer.Initialize(): Seeded security: " + seedData.Symbol.Value + ": " + seedData.Value);
+                    }
+                    else
+                    {
+                        Log.Trace("BrokerageModelSecurityInitializer.Initialize(): Unable to seed security: " + security.Symbol.Value);
+                    }
                 }
             }
         }

--- a/Common/Securities/CompositeSecurityInitializer.cs
+++ b/Common/Securities/CompositeSecurityInitializer.cs
@@ -37,11 +37,12 @@ namespace QuantConnect.Securities
         /// Execute each of the internally held initializers in sequence
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        public void Initialize(Security security)
+        /// <param name="seedSecurity">True to seed the security, false otherwise</param>
+        public void Initialize(Security security, bool seedSecurity)
         {
             foreach (var initializer in _initializers)
             {
-                initializer.Initialize(security);
+                initializer.Initialize(security, seedSecurity);
             }
         }
     }

--- a/Common/Securities/FuncSecurityInitializer.cs
+++ b/Common/Securities/FuncSecurityInitializer.cs
@@ -23,13 +23,13 @@ namespace QuantConnect.Securities
     /// </summary>
     public class FuncSecurityInitializer : ISecurityInitializer
     {
-        private readonly Action<Security> _initializer;
+        private readonly Action<Security, bool> _initializer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FuncSecurityInitializer"/> class
         /// </summary>
         /// <param name="initializer">The functional implementation of <see cref="ISecurityInitializer.Initialize"/></param>
-        public FuncSecurityInitializer(Action<Security> initializer)
+        public FuncSecurityInitializer(Action<Security, bool> initializer)
         {
             _initializer = initializer;
         }
@@ -38,9 +38,10 @@ namespace QuantConnect.Securities
         /// Initializes the specified security
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        public void Initialize(Security security)
+        /// <param name="seedSecurity">True to seed the security, false otherwise</param>
+        public void Initialize(Security security, bool seedSecurity)
         {
-            _initializer(security);
+            _initializer(security, seedSecurity);
         }
     }
 }

--- a/Common/Securities/FuncSecuritySeeder.cs
+++ b/Common/Securities/FuncSecuritySeeder.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
 using QuantConnect.Data;
 using QuantConnect.Logging;
 

--- a/Common/Securities/ISecurityInitializer.cs
+++ b/Common/Securities/ISecurityInitializer.cs
@@ -25,7 +25,8 @@ namespace QuantConnect.Securities
         /// Initializes the specified security
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        void Initialize(Security security);
+        /// <param name="seedSecurity">True to seed the security, false otherwise</param>
+        void Initialize(Security security, bool seedSecurity);
     }
 
     /// <summary>
@@ -40,7 +41,7 @@ namespace QuantConnect.Securities
 
         private sealed class NullSecurityInitializer : ISecurityInitializer
         {
-            public void Initialize(Security security) { }
+            public void Initialize(Security security, bool seedSecurity) { }
         }
     }
 }

--- a/Common/Securities/ISecuritySeeder.cs
+++ b/Common/Securities/ISecuritySeeder.cs
@@ -1,4 +1,20 @@
-﻿using QuantConnect.Data;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Data;
 
 namespace QuantConnect.Securities
 {
@@ -7,6 +23,11 @@ namespace QuantConnect.Securities
     /// </summary>
     public interface ISecuritySeeder
     {
+        /// <summary>
+        /// Get the last data point using the seed function
+        /// </summary>
+        /// <param name="security"><see cref="Security"/> being seeded</param>
+        /// <returns><see cref="BaseData"/> representing the last known data of the security</returns>
         BaseData GetSeedData(Security security);
     }
 }

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -411,7 +411,7 @@ namespace QuantConnect.Securities
             security.AddData(configList);
 
             // invoke the security initializer
-            securityInitializer.Initialize(security);
+            securityInitializer.Initialize(security, true);
             
             // if leverage was specified then apply to security after the initializer has run, parameters of this
             // method take precedence over the intializer

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
 using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
@@ -76,7 +92,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             Assert.AreEqual(_tradeBarSecurity.Leverage, 1.0);
 
-            _brokerageInitializer.Initialize(_tradeBarSecurity);
+            _brokerageInitializer.Initialize(_tradeBarSecurity, true);
 
             Assert.AreEqual(_tradeBarSecurity.Leverage, 2.0);
         }
@@ -89,7 +105,7 @@ namespace QuantConnect.Tests.Common.Securities
             _algo.SetDateTime(dateForWhichDataExist);
             
             // Act
-            _brokerageInitializer.Initialize(_tradeBarSecurity);
+            _brokerageInitializer.Initialize(_tradeBarSecurity, true);
 
             // Assert
             Assert.IsFalse(_tradeBarSecurity.Price == 0);
@@ -103,7 +119,7 @@ namespace QuantConnect.Tests.Common.Securities
             _algo.SetDateTime(dateForWhichDataExist);
 
             // Act
-            _brokerageInitializer.Initialize(_quoteBarSecurity);
+            _brokerageInitializer.Initialize(_quoteBarSecurity, true);
 
             // Assert
             Assert.IsFalse(_quoteBarSecurity.Price == 0);
@@ -117,7 +133,7 @@ namespace QuantConnect.Tests.Common.Securities
             _algo.SetDateTime(dateForWhichDataDoesNotExist);
 
             // Act
-            _brokerageInitializer.Initialize(_tradeBarSecurity);
+            _brokerageInitializer.Initialize(_tradeBarSecurity, true);
 
             // Assert
             Assert.IsTrue(_tradeBarSecurity.Price == 0);


### PR DESCRIPTION
Currently, calling `SetBrokerageModel` after `AddSecurity`, `AddForex`, etc. has no effect, the security initializer has already been initialized and its models have been set to their default implementations.

For example, Forex backtests using `OandaBrokerageModel` will report fees calculated with the default fee model (Oanda fees are spread-based, so they should always be reported as zero).

In this PR, `SetBrokerageModel` now calls `SecurityInitializer.Initialize` on all securities added before SetBrokerageModel is called.

Fees will be calculated using the correct fee models and the order of the calls in algorithm `Initialize` is now irrelevant.