### PR TITLE
Fix SetOrderProcessor called too late

### DIFF
--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -124,6 +124,9 @@ namespace QuantConnect.Lean.Engine
                     // initialize command queue system
                     _algorithmHandlers.CommandQueue.Initialize(job, algorithm);
 
+                    // set the order processor on the transaction manager (needs to be done before initializing BrokerageHistoryProvider)
+                    algorithm.Transactions.SetOrderProcessor(_algorithmHandlers.Transactions);
+
                     // set the history provider before setting up the algorithm
                     var historyProvider = GetHistoryProvider(job.HistoryProvider);
                     if (historyProvider is BrokerageHistoryProvider)

--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -202,10 +202,8 @@ namespace QuantConnect.Lean.Engine.Setup
             //Before continuing, detect if this is ready:
             if (!initializeComplete) return false;
 
-            algorithm.Transactions.SetOrderProcessor(transactionHandler);
             algorithm.PostInitialize();
 
-            
             //Calculate the max runtime for the strategy
             _maxRuntime = GetMaximumRuntime(job.PeriodStart, job.PeriodFinish, algorithm.SubscriptionManager, baseJob.Controls);
 

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -225,8 +225,6 @@ namespace QuantConnect.Lean.Engine.Setup
 
                 brokerage.Message += brokerageOnMessage;
 
-                algorithm.Transactions.SetOrderProcessor(transactionHandler);
-
                 Log.Trace("BrokerageSetupHandler.Setup(): Connecting to brokerage...");
                 try
                 {

--- a/Engine/Setup/ConsoleSetupHandler.cs
+++ b/Engine/Setup/ConsoleSetupHandler.cs
@@ -172,7 +172,6 @@ namespace QuantConnect.Lean.Engine.Setup
                 initializeComplete = true;
             }
 
-            algorithm.Transactions.SetOrderProcessor(transactionHandler);
             algorithm.PostInitialize();
 
             return initializeComplete;


### PR DESCRIPTION
When using `BrokerageHistoryProvider` with InteractiveBrokers, `GetOrderByBrokerageId` calls on open orders were logging `NullReferenceException`s because `SetOrderProcessor` is called later, in `BrokerageSetupHandler.Setup`.