### PR TITLE
Fixes current holdings value computation in CalculateOrderQuantity

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -776,8 +776,7 @@ namespace QuantConnect.Algorithm
 
             // this is the value in dollars that we want our holdings to have
             var targetPortfolioValue = target*Portfolio.TotalPortfolioValue;
-            var quantity = security.Holdings.Quantity;
-            var currentHoldingsValue = price*quantity;
+            var currentHoldingsValue = security.Holdings.HoldingsValue;
 
             // remove directionality, we'll work in the land of absolutes
             var targetOrderValue = Math.Abs(targetPortfolioValue - currentHoldingsValue);


### PR DESCRIPTION
The variable currentHoldingsValue didn't take into account the quote currency conversion rate.