### PR TITLE
Fix time zone bug in cash sync

### DIFF
--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -45,7 +45,9 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         private long _lastFillTimeTicks;
         private long _lastSyncTimeTicks;
         private readonly object _performCashSyncReentranceGuard = new object();
-        private static readonly TimeSpan _liveBrokerageCashSyncTime = new TimeSpan(7, 45, 0); // 7:45 am
+
+        // 7:45 AM (New York time zone)
+        private static readonly TimeSpan LiveBrokerageCashSyncTime = new TimeSpan(7, 45, 0);
 
         /// <summary>
         /// OrderQueue holds the newly updated orders from the user algorithm waiting to be processed. Once
@@ -101,7 +103,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             // we don't need to do this today because we just initialized/synced
             _resultHandler = resultHandler;
             _syncedLiveBrokerageCashToday = true;
-            _lastSyncTimeTicks = DateTime.Now.Ticks;
+            _lastSyncTimeTicks = DateTime.UtcNow.Ticks;
 
             _brokerage = brokerage;
             _brokerage.OrderStatusChanged += (sender, fill) =>
@@ -456,13 +458,13 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             Log.Debug("BrokerageTransactionHandler.ProcessSynchronousEvents(): Enter");
 
             // every morning flip this switch back
-            if (_syncedLiveBrokerageCashToday && DateTime.Now.Date != LastSyncDate)
+            if (_syncedLiveBrokerageCashToday && DateTime.UtcNow.Date != LastSyncDate)
             {
                 _syncedLiveBrokerageCashToday = false;
             }
 
             // we want to sync up our cash balance before market open
-            if (_algorithm.LiveMode && !_syncedLiveBrokerageCashToday && DateTime.Now.TimeOfDay >= _liveBrokerageCashSyncTime)
+            if (_algorithm.LiveMode && !_syncedLiveBrokerageCashToday && DateTime.UtcNow.ConvertFromUtc(TimeZones.NewYork).TimeOfDay >= LiveBrokerageCashSyncTime)
             {
                 try
                 {
@@ -584,7 +586,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 }
                 else
                 {
-                    _lastSyncTimeTicks = DateTime.Now.Ticks;
+                    _lastSyncTimeTicks = DateTime.UtcNow.Ticks;
                     Log.Trace("BrokerageTransactionHandler.PerformCashSync(): Verified cash sync.");
                 }
             });
@@ -886,7 +888,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             //Apply the filled order to our portfolio:
             if (fill.Status == OrderStatus.Filled || fill.Status == OrderStatus.PartiallyFilled)
             {
-                Interlocked.Exchange(ref _lastFillTimeTicks, DateTime.Now.Ticks);
+                Interlocked.Exchange(ref _lastFillTimeTicks, DateTime.UtcNow.Ticks);
                 
                 // check if the fill currency and the order currency match the symbol currency
                 var security = _algorithm.Securities[fill.Symbol];
@@ -987,7 +989,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// </summary>
         private TimeSpan TimeSinceLastFill
         {
-            get { return DateTime.Now - new DateTime(Interlocked.Read(ref _lastFillTimeTicks)); }
+            get { return DateTime.UtcNow - new DateTime(Interlocked.Read(ref _lastFillTimeTicks)); }
         }
 
         /// <summary>


### PR DESCRIPTION
With the update in the PR, cash synchronization in `BrokerageTransactionHandler` will now always be performed at `7:45 AM` NewYork time, even if Lean is running in a different time zone.