### PR TITLE
Fix bug in OandaSymbolMapper.IsKnownBrokerageSymbol

### DIFF
--- a/Brokerages/Oanda/OandaSymbolMapper.cs
+++ b/Brokerages/Oanda/OandaSymbolMapper.cs
@@ -483,7 +483,10 @@ namespace QuantConnect.Brokerages.Oanda
             "ZAR_JPY"
         };
 
-        public static List<string> DelistedSymbols = new List<string>()
+        /// <summary>
+        /// The list of delisted/invalid Oanda symbols.
+        /// </summary>
+        public static HashSet<string> DelistedSymbols = new HashSet<string>
         {
             "AUD_CNY",
             "AUD_CZK",
@@ -906,7 +909,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// <returns>True if Oanda supports the symbol</returns>
         public bool IsKnownBrokerageSymbol(string brokerageSymbol)
         {
-            return KnownSymbols.Contains(brokerageSymbol);
+            return KnownSymbols.Contains(brokerageSymbol) && !DelistedSymbols.Contains(brokerageSymbol);
         }
 
         /// <summary>
@@ -921,7 +924,7 @@ namespace QuantConnect.Brokerages.Oanda
 
             var oandaSymbol = ConvertLeanSymbolToOandaSymbol(symbol.Value);
 
-            return KnownSymbols.Contains(oandaSymbol) && GetBrokerageSecurityType(oandaSymbol) == symbol.ID.SecurityType;
+            return IsKnownBrokerageSymbol(oandaSymbol) && GetBrokerageSecurityType(oandaSymbol) == symbol.ID.SecurityType;
         }
 
         /// <summary>

--- a/Tests/Brokerages/Oanda/OandaSymbolMapperTests.cs
+++ b/Tests/Brokerages/Oanda/OandaSymbolMapperTests.cs
@@ -113,6 +113,17 @@ namespace QuantConnect.Tests.Brokerages.Oanda
             Assert.IsFalse(mapper.IsKnownLeanSymbol(Symbol.Create("ABCUSD", SecurityType.Forex, Market.Oanda)));
             Assert.IsFalse(mapper.IsKnownLeanSymbol(Symbol.Create("EURUSD", SecurityType.Cfd, Market.Oanda)));
             Assert.IsFalse(mapper.IsKnownLeanSymbol(Symbol.Create("DE30EUR", SecurityType.Forex, Market.Oanda)));
+
+            Assert.IsTrue(mapper.IsKnownBrokerageSymbol("GBP_USD"));
+            Assert.IsFalse(mapper.IsKnownBrokerageSymbol("USD_GBP"));
+            Assert.IsTrue(mapper.IsKnownLeanSymbol(Symbol.Create("GBPUSD", SecurityType.Forex, Market.Oanda)));
+            Assert.IsFalse(mapper.IsKnownLeanSymbol(Symbol.Create("USDGBP", SecurityType.Forex, Market.Oanda)));
+
+            Assert.IsTrue(mapper.IsKnownBrokerageSymbol("USD_JPY"));
+            Assert.IsFalse(mapper.IsKnownBrokerageSymbol("JPY_USD"));
+            Assert.IsTrue(mapper.IsKnownLeanSymbol(Symbol.Create("USDJPY", SecurityType.Forex, Market.Oanda)));
+            Assert.IsFalse(mapper.IsKnownLeanSymbol(Symbol.Create("JPYUSD", SecurityType.Forex, Market.Oanda)));
+
 #pragma warning restore 0618
         }
 


### PR DESCRIPTION
Many invalid inverted symbols such as `USD_GBP` were returned as valid known symbols.

This was causing Oanda `GetUsdConversion` to use the wrong symbol to find the exchange rate.

Ref. issue #862 