### PR TITLE
Handle corrupt zip files in data cache providers

### DIFF
--- a/Engine/DataFeeds/SingleEntryDataCacheProvider.cs
+++ b/Engine/DataFeeds/SingleEntryDataCacheProvider.cs
@@ -1,7 +1,23 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 using System.IO;
 using Ionic.Zip;
 using QuantConnect.Interfaces;
+using QuantConnect.Logging;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -34,7 +50,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             if (key.EndsWith(".zip") && stream != null)
             {
                 // get the first entry from the zip file
-                return Compression.UnzipStream(stream, out _zipFile);
+                try
+                {
+                    return Compression.UnzipStream(stream, out _zipFile);
+                }
+                catch (ZipException exception)
+                {
+                    Log.Error("SingleEntryDataCacheProvider.Fetch(): Corrupt file: " + key + " Error: " + exception);
+                    stream.Dispose();
+                    return null;
+                }
             }
 
             return stream;
@@ -50,6 +75,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             //
         }
 
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
         public void Dispose()
         {
             if (_zipFile != null)


### PR DESCRIPTION
Instead of leaving zip exceptions to the data feed enumerator stack, we now log file names of corrupt zip files, return null and continue.

The file system data feed should now handle corrupt files like missing files.