### PR TITLE
Fix for issue #854

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -115,7 +115,7 @@ namespace QuantConnect.Lean.Engine
 
                 if (_algorithm.Portfolio.TotalPortfolioValue <= 0)
                 {
-                    return "Portfolio value is less or equal to zero";
+                    return "Portfolio value is less than or equal to zero";
                 }
 
                 return null;

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -112,6 +112,12 @@ namespace QuantConnect.Lean.Engine
                 {
                     return "Algorithm took longer than 10 minutes on a single time loop.";
                 }
+
+                if (_algorithm.Portfolio.TotalPortfolioValue <= 0)
+                {
+                    return "Portfolio value is less or equal to zero";
+                }
+
                 return null;
             };
             _liveMode = liveMode;


### PR DESCRIPTION
It was added a new control to avoid going negative in portfolio value, Each second Lean engine will verify the TotalPortfolioValue, if this is less or equal to zero then Lean will stop the execution .
This will resolve #854