### PR TITLE
Changes quantity calculation in algorithm examples

### DIFF
--- a/Algorithm.CSharp/CustomChartingAlgorithm.cs
+++ b/Algorithm.CSharp/CustomChartingAlgorithm.cs
@@ -116,7 +116,7 @@ namespace QuantConnect.Algorithm.Examples
             //On the 5th days when not invested buy:
             if (!Portfolio.Invested && Time.Day % 13 == 0)
             {
-                Order("SPY", (int)(Portfolio.Cash / data["SPY"].Close));
+                Order("SPY", (int)(Portfolio.MarginRemaining / data["SPY"].Close));
                 Plot("Trade Plot", "Buy", lastPrice);
             }
             else if (Time.Day % 21 == 0 && Portfolio.Invested)

--- a/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Algorithm.Examples
                 //Weather used as a tradable asset, like stocks, futures etc. 
                 if (data.Close != 0)
                 {
-                    Order("BTC", (Portfolio.Cash / Math.Abs(data.Close + 1)));
+                    Order("BTC", (Portfolio.MarginRemaining / Math.Abs(data.Close + 1)));
                 }
                 Console.WriteLine("Buying BTC 'Shares': BTC: " + data.Close);
             }

--- a/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
@@ -51,7 +51,7 @@ namespace QuantConnect.Algorithm.CSharp
                 //Bitcoin used as a tradable asset, like stocks, futures etc. 
                 if (data.Close != 0)
                 {
-                    Order("BTC", (Portfolio.Cash / Math.Abs(data.Close + 1)));
+                    Order("BTC", (Portfolio.MarginRemaining / Math.Abs(data.Close + 1)));
                 }
             }
         }

--- a/Algorithm.CSharp/ETFGlobalRotationAlgorithm.cs
+++ b/Algorithm.CSharp/ETFGlobalRotationAlgorithm.cs
@@ -115,7 +115,7 @@ namespace QuantConnect.Algorithm.Examples
                             Liquidate();
                         }
                         Log(">>BUY>>" + bestGrowth.Symbol + "@" + (100 * bestGrowth.OneMonthPerformance).ToString("00.00"));
-                        decimal qty = Portfolio.Cash / Securities[bestGrowth.Symbol].Close;
+                        decimal qty = Portfolio.MarginRemaining / Securities[bestGrowth.Symbol].Close;
                         MarketOrder(bestGrowth.Symbol, (int) qty);
                     }
                     else

--- a/Algorithm.CSharp/FuzzyInferenceAlgorithm.cs
+++ b/Algorithm.CSharp/FuzzyInferenceAlgorithm.cs
@@ -26,8 +26,8 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void Initialize()
         {
-            SetStartDate(2016, 01, 01);  //Set Start Date
-            SetEndDate(2016, 06, 30);    //Set End Date
+            SetStartDate(2015, 01, 01);  //Set Start Date
+            SetEndDate(2015, 06, 30);    //Set End Date
             SetCash(100000);             //Set Strategy Cash
             AddEquity(symbol, Resolution.Daily);
 
@@ -49,7 +49,7 @@ namespace QuantConnect.Algorithm.CSharp
                     {
                         if (signal > 30)
                         {
-                            int quantity = Decimal.ToInt32(Portfolio.Cash / data[symbol].Price);
+                            int quantity = Decimal.ToInt32(Portfolio.MarginRemaining / data[symbol].Price);
                             Buy(symbol, quantity);
                             Debug("Purchased Stock: " + quantity + " shares");
                         }

--- a/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
@@ -52,7 +52,7 @@ namespace QuantConnect
             SetCash(25000);
 
             //Add as many securities as you like. All the data will be passed into the event handler:
-            AddSecurity(SecurityType.Equity, _symbol, Resolution.Minute);
+            AddSecurity(SecurityType.Equity, _symbol, Resolution.Daily);
 
             //Add the Custom Data:
             AddData<Bitcoin>("BTC");

--- a/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
+++ b/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
@@ -33,12 +33,12 @@ namespace QuantConnect
         /// </summary>
         public override void Initialize()
         {
-            SetStartDate(2013, 1, 1);
-            SetEndDate(DateTime.Now.Date.AddDays(-1));
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 11);
             SetCash(25000);
 
             //Equity Data for US Markets:
-            AddSecurity(SecurityType.Equity, "AAPL", Resolution.Second);
+            AddSecurity(SecurityType.Equity, "IBM", Resolution.Second);
 
             //FOREX Data for Weekends: 24/6
             AddSecurity(SecurityType.Forex, "EURUSD", Resolution.Minute);
@@ -76,11 +76,11 @@ namespace QuantConnect
         /// <param name="data">Data.</param>
         public void OnData(TradeBars data)
         {
-            if (!Portfolio.HoldStock && data.ContainsKey("AAPL"))
+            if (!Portfolio["IBM"].HoldStock && data.ContainsKey("IBM"))
             {
-                int quantity = (int)Math.Floor(Portfolio.Cash / data["AAPL"].Close);
-                Order("AAPL", quantity);
-                Debug("Purchased SPY on " + Time.ToShortDateString());
+                int quantity = (int)Math.Floor(Portfolio.MarginRemaining / data["IBM"].Close);
+                Order("IBM", quantity);
+                Debug("Purchased IBM on " + Time.ToShortDateString());
                 Notify.Email("myemail@gmail.com", "Test", "Test Body", "test attachment");
             }
         }


### PR DESCRIPTION
In some examples, we have been using Portfolio.Cash to calculate the quantity of shares in orders. This is a bad advice for users, since Portfolio.Cash does not account loses in other positions and its use can lead to invalid orders due to insufficient capital. Instead, users should use Portfolio.MarginRemaining.

FuzzyInferenceAlgorithm and LiveFeaturesAlgorithm had minor changes to perform backtests with available data