### PR TITLE
Fix IB client initialization bug

### DIFF
--- a/Brokerages/InteractiveBrokers/Client/InteractiveBrokersClient.cs
+++ b/Brokerages/InteractiveBrokers/Client/InteractiveBrokersClient.cs
@@ -402,9 +402,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="InteractiveBrokersClient"/> class
         /// </summary>
-        public InteractiveBrokersClient()
+        public InteractiveBrokersClient(EReaderSignal signal)
         {
-            ClientSocket = new EClientSocket(this, new EReaderMonitorSignal());
+            ClientSocket = new EClientSocket(this, signal);
         }
 
         /// <summary>


### PR DESCRIPTION
The IB client and reader were incorrectly initialized using two separate `EReaderSignal` objects instead of a single shared one.