### PR TITLE
Remove redundant properties in HistoryRequest class

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -448,7 +448,7 @@ namespace QuantConnect.Algorithm
             // Get the config with the largest resolution
             var subscriptionDataConfig = GetMatchingSubscription(security, typeof(BaseData));
 
-            var request = new HistoryRequest()
+            var request = new HistoryRequest
             {
                 StartTimeUtc = startTime.ConvertToUtc(_localTimeKeeper.TimeZone),
                 EndTimeUtc = endTime.ConvertToUtc(_localTimeKeeper.TimeZone),
@@ -456,9 +456,7 @@ namespace QuantConnect.Algorithm
                 Resolution = resolution,
                 FillForwardResolution = resolution,
                 Symbol = security.Symbol,
-                Market = security.Symbol.ID.Market,
-                ExchangeHours = security.Exchange.Hours,
-                SecurityType = security.Type
+                ExchangeHours = security.Exchange.Hours
             };
 
             var history = History(new List<HistoryRequest> { request });

--- a/Brokerages/Fxcm/FxcmBrokerage.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.cs
@@ -626,7 +626,7 @@ namespace QuantConnect.Brokerages.Fxcm
             DateTimeZone exchangeTimeZone;
             if (!_symbolExchangeTimeZones.TryGetValue(request.Symbol, out exchangeTimeZone))
             {
-                exchangeTimeZone = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.FXCM, request.Symbol, request.SecurityType).TimeZone;
+                exchangeTimeZone = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.FXCM, request.Symbol, request.Symbol.SecurityType).TimeZone;
                 _symbolExchangeTimeZones.Add(request.Symbol, exchangeTimeZone);
             }
 

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -30,50 +30,52 @@ namespace QuantConnect.Data
         /// Gets the start time of the request.
         /// </summary>
         public DateTime StartTimeUtc { get; set; }
+
         /// <summary>
         /// Gets the end time of the request. 
         /// </summary>
         public DateTime EndTimeUtc { get; set; }
+
         /// <summary>
         /// Gets the symbol to request data for
         /// </summary>
         public Symbol Symbol { get; set; }
+
         /// <summary>
         /// Gets the exchange hours used for processing fill forward requests
         /// </summary>
         public SecurityExchangeHours ExchangeHours { get; set; }
+
         /// <summary>
         /// Gets the requested data resolution
         /// </summary>
         public Resolution Resolution { get; set; }
+
         /// <summary>
         /// Gets the requested fill forward resolution, set to null for no fill forward behavior
         /// </summary>
         public Resolution? FillForwardResolution { get; set; }
+
         /// <summary>
         /// Gets whether or not to include extended market hours data, set to false for only normal market hours
         /// </summary>
         public bool IncludeExtendedMarketHours { get; set; }
+
         /// <summary>
         /// Gets the data type used to process the subscription request, this type must derive from BaseData
         /// </summary>
         public Type DataType { get; set; }
-        /// <summary>
-        /// Gets the security type of the subscription
-        /// </summary>
-        public SecurityType SecurityType { get; set; }
+
         /// <summary>
         /// Gets the time zone of the time stamps on the raw input data
         /// </summary>
         public DateTimeZone TimeZone { get; set; }
-        /// <summary>
-        /// Gets the market for this subscription
-        /// </summary>
-        public string Market { get; set; }
+
         /// <summary>
         /// Gets true if this is a custom data request, false for normal QC data
         /// </summary>
         public bool IsCustomData { get; set; }
+
         /// <summary>
         /// Gets the normalization mode used for this subscription
         /// </summary>
@@ -91,9 +93,7 @@ namespace QuantConnect.Data
             FillForwardResolution = Resolution.Minute;
             IncludeExtendedMarketHours = false;
             DataType = typeof (TradeBar);
-            SecurityType = SecurityType.Equity;
             TimeZone = TimeZones.NewYork;
-            Market = QuantConnect.Market.USA;
             IsCustomData = false;
             DataNormalizationMode = DataNormalizationMode.Adjusted;
         }
@@ -105,9 +105,7 @@ namespace QuantConnect.Data
         /// <param name="endTimeUtc">The start time for this request</param>
         /// <param name="dataType">The data type of the output data</param>
         /// <param name="symbol">The symbol to request data for</param>
-        /// <param name="securityType">The security type of the symbol</param>
         /// <param name="resolution">The requested data resolution</param>
-        /// <param name="market">The market this data belongs to</param>
         /// <param name="exchangeHours">The exchange hours used in fill forward processing</param>
         /// <param name="fillForwardResolution">The requested fill forward resolution for this request</param>
         /// <param name="includeExtendedMarketHours">True to include data from pre/post market hours</param>
@@ -117,9 +115,7 @@ namespace QuantConnect.Data
             DateTime endTimeUtc,
             Type dataType,
             Symbol symbol,
-            SecurityType securityType,
             Resolution resolution,
-            string market,
             SecurityExchangeHours exchangeHours,
             Resolution? fillForwardResolution,
             bool includeExtendedMarketHours,
@@ -135,8 +131,6 @@ namespace QuantConnect.Data
             FillForwardResolution = fillForwardResolution;
             IncludeExtendedMarketHours = includeExtendedMarketHours;
             DataType = dataType;
-            SecurityType = securityType;
-            Market = market;
             IsCustomData = isCustomData;
             DataNormalizationMode = dataNormalizationMode;
             TimeZone = exchangeHours.TimeZone;
@@ -159,8 +153,6 @@ namespace QuantConnect.Data
             FillForwardResolution = config.FillDataForward ? config.Resolution : (Resolution?) null;
             IncludeExtendedMarketHours = config.ExtendedMarketHours;
             DataType = config.Type;
-            SecurityType = config.SecurityType;
-            Market = config.Market;
             IsCustomData = config.IsCustomData;
             DataNormalizationMode = config.DataNormalizationMode;
             TimeZone = config.DataTimeZone;

--- a/Common/Packets/HistoryPacket.cs
+++ b/Common/Packets/HistoryPacket.cs
@@ -1,9 +1,21 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace QuantConnect.Packets
 {
@@ -54,19 +66,9 @@ namespace QuantConnect.Packets
         public Symbol Symbol;
 
         /// <summary>
-        /// The symbol's security type
-        /// </summary>
-        public SecurityType SecurityType;
-
-        /// <summary>
         /// The requested resolution
         /// </summary>
         public Resolution Resolution;
-
-        /// <summary>
-        /// The market the symbol belongs to
-        /// </summary>
-        public string Market;
     }
 
     /// <summary>

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -625,7 +625,7 @@ namespace QuantConnect.ToolBox.IQFeed
                     end = null;
                 }
 
-                Log.Trace(string.Format("HistoryPort.ProcessHistoryJob(): Submitting request: {0}-{1}: {2} {3}->{4}", request.SecurityType, ticker, request.Resolution, start, end ?? DateTime.UtcNow.AddMinutes(-1)));
+                Log.Trace(string.Format("HistoryPort.ProcessHistoryJob(): Submitting request: {0}-{1}: {2} {3}->{4}", request.Symbol.SecurityType, ticker, request.Resolution, start, end ?? DateTime.UtcNow.AddMinutes(-1)));
 
                 int id;
                 var reqid = string.Empty;
@@ -737,7 +737,7 @@ namespace QuantConnect.ToolBox.IQFeed
             /// <returns>BaseData object</returns>
             private BaseData GetData(LookupEventArgs e, HistoryRequest requestData)
             {
-                var isEquity = requestData.SecurityType == SecurityType.Equity;
+                var isEquity = requestData.Symbol.SecurityType == SecurityType.Equity;
                 try
                 {
                     switch (e.Type)


### PR DESCRIPTION
`SecurityType` and `Market` properties are already implicitly included in the `Symbol` property.

With this change we avoid forgetting to set these properties when creating `HistoryRequest` objects (issue #863)