### PR TITLE
Python: Increase execution speed when not using custom data

### DIFF
--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -35,6 +35,11 @@ namespace QuantConnect.Data
         public List<SubscriptionDataConfig> Subscriptions;
 
         /// <summary>
+        /// Flags the existence of custom data in the subscriptions
+        /// </summary>
+        public bool HasCustomData { get; internal set; }
+
+        /// <summary>
         /// 
         /// </summary>
         public Dictionary<SecurityType, List<TickType>> AvailableDataTypes
@@ -125,6 +130,9 @@ namespace QuantConnect.Data
 
             // add the time zone to our time keeper
             _timeKeeper.AddTimeZone(exchangeTimeZone);
+
+            // if is custom data, sets HasCustomData to true
+            HasCustomData = HasCustomData || isCustomData;
 
             return newConfig;
         }

--- a/Common/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/Common/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -731,7 +731,14 @@ namespace QuantConnect.Python.Wrappers
         {
             using (Py.GIL())
             {
-                _pyAlgorithm.OnPythonData(slice);
+                if (_algorithm.SubscriptionManager.HasCustomData)
+                {
+                    _pyAlgorithm.OnPythonData(slice);
+                }
+                else
+                {
+                    _algorithm.OnData(slice);
+                }
             }
         }
         


### PR DESCRIPTION
When not using custom data, do not wrap slice object.