### PR TITLE
ALMA sigma parameter default value

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -103,9 +103,8 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The ArnaudLegouxMovingAverage indicator for the requested symbol over the specified period</returns>
-        public ArnaudLegouxMovingAverage ALMA(Symbol symbol, int period, int sigma = 0, decimal offset = 0.85m, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public ArnaudLegouxMovingAverage ALMA(Symbol symbol, int period, int sigma = 6, decimal offset = 0.85m, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
-            sigma = sigma != 0 ? sigma : (int) (period * 1d / 1.5);
             var name = CreateIndicatorName(symbol, string.Format("ALMA_{0}_{1}_{2}", period, sigma, offset), resolution);
             var alma = new ArnaudLegouxMovingAverage(name, period, sigma, offset);
             RegisterIndicator(symbol, alma, resolution, selector);

--- a/Indicators/ArnaudLegouxMovingAverage.cs
+++ b/Indicators/ArnaudLegouxMovingAverage.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Indicators
         /// decimal - This parameter allows regulating the smoothness and high sensitivity of the
         /// Moving Average. The range for this parameter is [0, 1].
         /// </param>
-        public ArnaudLegouxMovingAverage(string name, int period, int sigma, decimal offset = 0.85m)
+        public ArnaudLegouxMovingAverage(string name, int period, int sigma=6, decimal offset = 0.85m)
             : base(name, period)
         {
             if (offset < 0 || offset > 1) throw new ArgumentException("Offset parameter range is [0,1]", "offset");
@@ -54,12 +54,11 @@ namespace QuantConnect.Indicators
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ArnaudLegouxMovingAverage" /> class.
-        ///     In this case, the sigma is estimated to keep the ratio period / sigma approximately 1.5.
         /// </summary>
         /// <param name="name">string - a name for the indicator</param>
         /// <param name="period">int - the number of periods to calculate the ALMA.</param>
         public ArnaudLegouxMovingAverage(string name, int period)
-            : this(name, period, (int)(period * 1d / 1.5))
+            : this(name, period)
         {
         }
 
@@ -79,12 +78,10 @@ namespace QuantConnect.Indicators
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ArnaudLegouxMovingAverage" /> class.
-        ///     In this case, the sigma is estimated to keep the ratio period / sigma approximately 1.5.
         /// </summary>
         /// <param name="period">int - the number of periods to calculate the ALMA.</param>
         public ArnaudLegouxMovingAverage(int period)
-            : this(string.Format("ALMA_{0}_{1}_{2}", period, (int) (period * 1d / 1.5), 0.85m), period,
-                (int) (period * 1d / 1.5))
+            : this(string.Format("ALMA_{0}_{1}_{2}", period, 6, 0.85m), period)
         {
         }
 

--- a/Indicators/ArnaudLegouxMovingAverage.cs
+++ b/Indicators/ArnaudLegouxMovingAverage.cs
@@ -22,6 +22,8 @@ namespace QuantConnect.Indicators
     /// <summary>
     ///     Smooth and high sensitive moving Average. This moving average reduce lag of the informations
     ///     but still being smooth to reduce noises.
+    ///     Is a weighted moving average, which weight have a Normal shape. The parameters Sigma and Offset affect the 
+    ///     kurtosis and skewness of the weights distribution respectively.
     ///     Source: http://www.arnaudlegoux.com/index.html
     /// </summary>
     /// <seealso cref="IndicatorDataPoint" />
@@ -34,11 +36,11 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="name">string - a name for the indicator</param>
         /// <param name="period">int - the number of periods to calculate the ALMA</param>
-        /// <param name="sigma"> int - this parameter is responsible for the shape of the curve coefficients.
+        /// <param name="sigma"> int - this parameter is responsible for the shape of the curve coefficients. It affects the weight vector kurtosis.
         /// </param>
         /// <param name="offset">
         /// decimal - This parameter allows regulating the smoothness and high sensitivity of the
-        /// Moving Average. The range for this parameter is [0, 1].
+        /// Moving Average. The range for this parameter is [0, 1]. It affects the weight vector skewness.
         /// </param>
         public ArnaudLegouxMovingAverage(string name, int period, int sigma=6, decimal offset = 0.85m)
             : base(name, period)
@@ -69,7 +71,7 @@ namespace QuantConnect.Indicators
         /// <param name="sigma">int - this parameter is responsible for the shape of the curve coefficients.</param>
         /// <param name="offset">
         ///     decimal -  This parameter allows regulating the smoothness and high sensitivity of the Moving
-        ///     Average. The range for this parameter is [0, 1].
+        ///     Average. The range for this parameter is [0, 1]. It affects the weight vector skewness.
         /// </param>
         public ArnaudLegouxMovingAverage(int period, int sigma, decimal offset = 0.85m)
             : this(string.Format("ALMA_{0}_{1}_{2}", period, sigma, offset), period, sigma, offset)

--- a/Indicators/ArnaudLegouxMovingAverage.cs
+++ b/Indicators/ArnaudLegouxMovingAverage.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.Indicators
         /// <param name="name">string - a name for the indicator</param>
         /// <param name="period">int - the number of periods to calculate the ALMA.</param>
         public ArnaudLegouxMovingAverage(string name, int period)
-            : this(name, period)
+            : this(name, period, 6)
         {
         }
 

--- a/Indicators/ArnaudLegouxMovingAverage.cs
+++ b/Indicators/ArnaudLegouxMovingAverage.cs
@@ -22,8 +22,8 @@ namespace QuantConnect.Indicators
     /// <summary>
     ///     Smooth and high sensitive moving Average. This moving average reduce lag of the informations
     ///     but still being smooth to reduce noises.
-    ///     Is a weighted moving average, which weight have a Normal shape. The parameters Sigma and Offset affect the 
-    ///     kurtosis and skewness of the weights distribution respectively.
+    ///     Is a weighted moving average, which weights have a Normal shape;
+    ///     the parameters Sigma and Offset affect the kurtosis and skewness of the weights respectively.
     ///     Source: http://www.arnaudlegoux.com/index.html
     /// </summary>
     /// <seealso cref="IndicatorDataPoint" />
@@ -32,17 +32,18 @@ namespace QuantConnect.Indicators
         private readonly decimal[] weightVector;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ArnaudLegouxMovingAverage"/> class.
+        ///     Initializes a new instance of the <see cref="ArnaudLegouxMovingAverage" /> class.
         /// </summary>
         /// <param name="name">string - a name for the indicator</param>
         /// <param name="period">int - the number of periods to calculate the ALMA</param>
-        /// <param name="sigma"> int - this parameter is responsible for the shape of the curve coefficients. It affects the weight vector kurtosis.
+        /// <param name="sigma">
+        ///     int - this parameter is responsible for the shape of the curve coefficients. It affects the weight vector kurtosis.
         /// </param>
         /// <param name="offset">
-        /// decimal - This parameter allows regulating the smoothness and high sensitivity of the
-        /// Moving Average. The range for this parameter is [0, 1]. It affects the weight vector skewness.
+        ///     decimal - This parameter allows regulating the smoothness and high sensitivity of the
+        ///     Moving Average. The range for this parameter is [0, 1]. It affects the weight vector skewness.
         /// </param>
-        public ArnaudLegouxMovingAverage(string name, int period, int sigma=6, decimal offset = 0.85m)
+        public ArnaudLegouxMovingAverage(string name, int period, int sigma = 6, decimal offset = 0.85m)
             : base(name, period)
         {
             if (offset < 0 || offset > 1) throw new ArgumentException("Offset parameter range is [0,1]", "offset");
@@ -68,7 +69,10 @@ namespace QuantConnect.Indicators
         ///     Initializes a new instance of the <see cref="ArnaudLegouxMovingAverage" /> class.
         /// </summary>
         /// <param name="period">int - the number of periods to calculate the ALMA</param>
-        /// <param name="sigma">int - this parameter is responsible for the shape of the curve coefficients.</param>
+        /// <param name="sigma">
+        ///     int - this parameter is responsible for the shape of the curve coefficients. It affects the weight
+        ///     vector kurtosis.
+        /// </param>
         /// <param name="offset">
         ///     decimal -  This parameter allows regulating the smoothness and high sensitivity of the Moving
         ///     Average. The range for this parameter is [0, 1]. It affects the weight vector skewness.


### PR DESCRIPTION
The default sigma value hasn't to do with the period/sigma ratio, instead, is a measure of the weights vector kurtosis and 6 makes a good job making the distribution _more normal_.