### PR TITLE
Compress futures and options files using System.IO.Compression

### DIFF
--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
@@ -148,11 +148,11 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
                             if (!processors.TryGetValue(tick.Symbol, out symbolProcessors))
                             {
                                 symbolProcessors = new List<List<AlgoSeekFuturesProcessor>>(3)
-                                {
-                                    { _resolutions.Select(x => new AlgoSeekFuturesProcessor(tick.Symbol, _referenceDate, TickType.Trade, x, _destination)).ToList() },
-                                    { _resolutions.Select(x => new AlgoSeekFuturesProcessor(tick.Symbol, _referenceDate, TickType.Quote, x, _destination)).ToList() },
-                                    { _resolutions.Select(x => new AlgoSeekFuturesProcessor(tick.Symbol, _referenceDate, TickType.OpenInterest, x, _destination)).ToList() }
-                                };
+                                        {
+                                            { _resolutions.Select(x => new AlgoSeekFuturesProcessor(tick.Symbol, _referenceDate, TickType.Trade, x, _destination)).ToList() },
+                                            { _resolutions.Select(x => new AlgoSeekFuturesProcessor(tick.Symbol, _referenceDate, TickType.Quote, x, _destination)).ToList() },
+                                            { _resolutions.Select(x => new AlgoSeekFuturesProcessor(tick.Symbol, _referenceDate, TickType.OpenInterest, x, _destination)).ToList() }
+                                        };
 
                                 processors[tick.Symbol] = symbolProcessors;
                             }
@@ -184,7 +184,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
                     Log.Trace("AlgoSeekFuturesConverter.Convert(): Finished processing file: " + file);
                     Interlocked.Increment(ref totalFilesProcessed);
                 }
-                catch (Exception err)
+                catch(Exception err)
                 {
                     Log.Error("Exception caught! File: {0} Err: {1} Source {2} Stack {3}", file, err.Message, err.Source, err.StackTrace);
                 }
@@ -207,14 +207,14 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
             const int columnInfo = 3;
 
             return File.ReadAllLines("AlgoSeekFuturesConverter/AlgoSeek.US.Futures.PriceMultipliers.1.1.csv")
-                .Select(line => line.ToCsvData())
-                // skipping empty fields
-                .Where(line => !string.IsNullOrEmpty(line[columnUnderlying]) &&
-                               !string.IsNullOrEmpty(line[columnMultipleFactor]))
-                // skipping header
-                .Skip(1)
-                .ToDictionary(line => line[columnUnderlying],
-                    line => System.Convert.ToDecimal(line[columnMultipleFactor]));
+                    .Select(line => line.ToCsvData())
+                    // skipping empty fields
+                    .Where(line => !string.IsNullOrEmpty(line[columnUnderlying]) &&
+                                   !string.IsNullOrEmpty(line[columnMultipleFactor]))
+                    // skipping header
+                    .Skip(1)
+                    .ToDictionary(line => line[columnUnderlying],
+                                  line => System.Convert.ToDecimal(line[columnMultipleFactor]));
         }
 
         private void Flush(Processors processors, DateTime time, bool final)
@@ -240,8 +240,8 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
 
             var files =
                 Directory.EnumerateFiles(destination, dateMask + "*.csv", SearchOption.AllDirectories)
-                    .GroupBy(x => Directory.GetParent(x).FullName)
-                    .ToList();
+                .GroupBy(x => Directory.GetParent(x).FullName)
+                .ToList();
 
             // Zip each file massively in parallel
             Parallel.ForEach(files, file =>

--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesProcessor.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesProcessor.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
         private Symbol _symbol;
         private TickType _tickType;
         private Resolution _resolution;
-        private FuturesStreamWriter _streamWriter;
+        private LazyStreamWriter _streamWriter;
         private string _dataDirectory;
         private IDataConsolidator _consolidator;
         private DateTime _referenceDate;
@@ -155,7 +155,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
 
             try
             {
-                _streamWriter = new FuturesStreamWriter(file);
+                _streamWriter = new LazyStreamWriter(file);
             }
             catch (Exception err)
             {
@@ -165,7 +165,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
 
                 // we store the information under different (randomized) name
                 Log.Trace("Changing name from {0} to {1}", file, newRandomizedName);
-                _streamWriter = new FuturesStreamWriter(newRandomizedName);
+                _streamWriter = new LazyStreamWriter(newRandomizedName);
             }
 
             // On consolidating the bars put the bar into a queue in memory to be written to disk later.

--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesProcessor.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesProcessor.cs
@@ -14,15 +14,13 @@
 */
 
 using System;
-using QuantConnect.Data;
-using System.Collections.Generic;
 using System.IO;
-using QuantConnect.Data.Consolidators;
-using QuantConnect.Data.Market;
-using QuantConnect.Util;
 using System.Linq;
 using System.Threading;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
 using QuantConnect.Logging;
+using QuantConnect.Util;
 
 namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
 {
@@ -38,7 +36,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
         private Symbol _symbol;
         private TickType _tickType;
         private Resolution _resolution;
-        private StreamWriter _streamWriter;
+        private FuturesStreamWriter _streamWriter;
         private string _dataDirectory;
         private IDataConsolidator _consolidator;
         private DateTime _referenceDate;
@@ -106,6 +104,14 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
         }
 
         /// <summary>
+        /// If no data has been consolidated, do not write to disk
+        /// </summary>
+        public bool ShouldWriteToDisk()
+        {
+            return _consolidator.Consolidated != null;
+        }
+
+        /// <summary>
         /// Create a new AlgoSeekFuturesProcessor for enquing consolidated bars and flushing them to disk
         /// </summary>
         /// <param name="symbol">Symbol for the processor</param>
@@ -149,7 +155,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
 
             try
             {
-                _streamWriter = new StreamWriter(file);
+                _streamWriter = new FuturesStreamWriter(file);
             }
             catch (Exception err)
             {
@@ -159,7 +165,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
 
                 // we store the information under different (randomized) name
                 Log.Trace("Changing name from {0} to {1}", file, newRandomizedName);
-                _streamWriter = new StreamWriter(newRandomizedName);
+                _streamWriter = new FuturesStreamWriter(newRandomizedName);
             }
 
             // On consolidating the bars put the bar into a queue in memory to be written to disk later.
@@ -241,7 +247,10 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
             {
                 foreach (var name in _windowsRestrictedNames)
                 {
-                    fileName = fileName.Replace(name, "_" + name);
+                    // The 'con' restricted filename will corrupt the 'seCONed' filepath
+                    var restrictedFilePath = Path.DirectorySeparatorChar + name;
+                    var safeFilePath = Path.DirectorySeparatorChar + "_" + name;
+                    fileName = fileName.Replace(restrictedFilePath, safeFilePath);
                 }
             }
             return fileName;

--- a/ToolBox/AlgoSeekFuturesConverter/FuturesSteamWriter.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/FuturesSteamWriter.cs
@@ -1,0 +1,70 @@
+﻿using System.IO;
+
+namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
+{
+    /// <summary>
+    /// This class wraps a <see cref="StreamWriter"/> so that the StreamWriter is only
+    /// instantiated until WriteLine() is called.  This ensures that the file the StreamWriter is
+    /// writing to is only created if something is written to it. A StreamWriter will create a empty file
+    /// as soon as it is instantiated.
+    /// </summary>
+    public class FuturesStreamWriter
+    {
+        private StreamWriter _streamWriter;
+        private readonly string _path;
+
+        /// <summary>
+        /// Constructor for the <see cref="FuturesStreamWriter"/>
+        /// </summary>
+        /// <param name="path">Path to the file that should be created</param>
+        public FuturesStreamWriter(string path)
+        {
+            _path = path;
+        }
+
+        /// <summary>
+        /// Wraps the WriteLine method of the StreamWriter.
+        /// </summary>
+        /// <param name="line">The line to write</param>
+        /// <remarks>Will instantiate the StreamWriter if this is the first time this method is called</remarks>
+        public void WriteLine(string line)
+        {
+            PrepareStreamWriter();
+
+            _streamWriter.WriteLine(line);
+        }
+
+        /// <summary>
+        /// Wraps the <see cref="StreamWriter.Flush()"/> method
+        /// </summary>
+        public void Flush()
+        {
+            if (_streamWriter != null)
+            {
+                _streamWriter.Flush();
+            }
+        }
+
+        /// <summary>
+        /// Wraps the <see cref="StreamWriter.Close()"/> method
+        /// </summary>
+        public void Close()
+        {
+            if (_streamWriter != null)
+            {
+                _streamWriter.Close();
+            }
+        }
+
+        /// <summary>
+        /// Checks if the StreamWriter is instantiated. If not, it will instantiate the StreamWriter
+        /// </summary>
+        private void PrepareStreamWriter()
+        {
+            if (_streamWriter == null)
+            {
+                _streamWriter = new StreamWriter(_path);
+            }
+        }
+    }
+}

--- a/ToolBox/AlgoSeekOptionsConverter/AlgoSeekOptionsConverter.cs
+++ b/ToolBox/AlgoSeekOptionsConverter/AlgoSeekOptionsConverter.cs
@@ -138,11 +138,11 @@ namespace QuantConnect.ToolBox.AlgoSeekOptionsConverter
                             if (!processors.TryGetValue(tick.Symbol, out symbolProcessors))
                             {
                                 symbolProcessors = new List<AlgoSeekOptionsProcessor>(3)
-                                {
-                                    new AlgoSeekOptionsProcessor(tick.Symbol, _referenceDate, TickType.Trade, _resolution, _destination),
-                                    new AlgoSeekOptionsProcessor(tick.Symbol, _referenceDate, TickType.Quote, _resolution, _destination),
-                                    new AlgoSeekOptionsProcessor(tick.Symbol, _referenceDate, TickType.OpenInterest, _resolution, _destination)
-                                };
+                                            {
+                                                new AlgoSeekOptionsProcessor(tick.Symbol, _referenceDate, TickType.Trade, _resolution, _destination),
+                                                new AlgoSeekOptionsProcessor(tick.Symbol, _referenceDate, TickType.Quote, _resolution, _destination),
+                                                new AlgoSeekOptionsProcessor(tick.Symbol, _referenceDate, TickType.OpenInterest, _resolution, _destination)
+                                            };
 
                                 processors[tick.Symbol] = symbolProcessors;
                             }
@@ -272,7 +272,7 @@ namespace QuantConnect.ToolBox.AlgoSeekOptionsConverter
 
             var files =
                 Directory.EnumerateFiles(destination, dateMask + "*.csv", SearchOption.AllDirectories)
-                    .GroupBy(x => Directory.GetParent(x).FullName);
+                .GroupBy(x => Directory.GetParent(x).FullName);
 
             //Zip each file massively in parallel.
             Parallel.ForEach(files, parallelOptionsZipping, file =>
@@ -325,8 +325,8 @@ namespace QuantConnect.ToolBox.AlgoSeekOptionsConverter
 
             var files =
                 Directory.EnumerateFiles(destination, dateMask + "_" + "*.*", SearchOption.AllDirectories)
-                    .Where(x => extensions.Contains(Path.GetExtension(x)))
-                    .ToList();
+                .Where(x => extensions.Contains(Path.GetExtension(x)))
+                .ToList();
 
             Log.Trace("AlgoSeekOptionsConverter.Clean(): found {0} files..", files.Count);
 
@@ -395,7 +395,7 @@ namespace QuantConnect.ToolBox.AlgoSeekOptionsConverter
                     }
                 }
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 if (!timedOut)
                 {

--- a/ToolBox/LazyStreamWriter.cs
+++ b/ToolBox/LazyStreamWriter.cs
@@ -1,6 +1,20 @@
-﻿using System.IO;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+using System.IO;
 
-namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
+namespace QuantConnect.ToolBox
 {
     /// <summary>
     /// This class wraps a <see cref="StreamWriter"/> so that the StreamWriter is only
@@ -8,16 +22,16 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
     /// writing to is only created if something is written to it. A StreamWriter will create a empty file
     /// as soon as it is instantiated.
     /// </summary>
-    public class FuturesStreamWriter
+    public class LazyStreamWriter
     {
         private StreamWriter _streamWriter;
         private readonly string _path;
 
         /// <summary>
-        /// Constructor for the <see cref="FuturesStreamWriter"/>
+        /// Constructor for the <see cref="LazyStreamWriter"/>
         /// </summary>
         /// <param name="path">Path to the file that should be created</param>
-        public FuturesStreamWriter(string path)
+        public LazyStreamWriter(string path)
         {
             _path = path;
         }

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -154,6 +154,7 @@
     <Compile Include="AlgoSeekFuturesConverter\AlgoSeekFuturesConverter.cs" />
     <Compile Include="AlgoSeekFuturesConverter\AlgoSeekFuturesProcessor.cs" />
     <Compile Include="AlgoSeekFuturesConverter\AlgoSeekFuturesReader.cs" />
+    <Compile Include="AlgoSeekFuturesConverter\FuturesSteamWriter.cs" />
     <Compile Include="AlgoSeekFuturesConverter\Program.cs" />
     <Compile Include="AlgoSeekOptionsConverter\AlgoSeekOptionsConverter.cs" />
     <Compile Include="AlgoSeekOptionsConverter\AlgoSeekOptionsProcessor.cs" />

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -154,7 +154,6 @@
     <Compile Include="AlgoSeekFuturesConverter\AlgoSeekFuturesConverter.cs" />
     <Compile Include="AlgoSeekFuturesConverter\AlgoSeekFuturesProcessor.cs" />
     <Compile Include="AlgoSeekFuturesConverter\AlgoSeekFuturesReader.cs" />
-    <Compile Include="AlgoSeekFuturesConverter\FuturesSteamWriter.cs" />
     <Compile Include="AlgoSeekFuturesConverter\Program.cs" />
     <Compile Include="AlgoSeekOptionsConverter\AlgoSeekOptionsConverter.cs" />
     <Compile Include="AlgoSeekOptionsConverter\AlgoSeekOptionsProcessor.cs" />
@@ -191,6 +190,7 @@
     <Compile Include="IQFeed\IQ\SocketClient.cs" />
     <Compile Include="IStreamParser.cs" />
     <Compile Include="IStreamProvider.cs" />
+    <Compile Include="LazyStreamWriter.cs" />
     <Compile Include="LeanDataWriter.cs" />
     <Compile Include="LeanInstrument.cs" />
     <Compile Include="LeanParser.cs" />


### PR DESCRIPTION
+ Instead of using 7z to zip potentially thousands of small files in parallel, use System.IO.Compression to zip the processed Lean futures and options files.  This results in better performance and improved overall reliability
+ Fixed bug where all empty csv files were created in the futures and options data.  This bug was present in the data because the `StreamWriter`, when instantiated, creates an empty file.  Many times, the `StreamWriter` would not be used - resulting in empty files.  Created class called `LazyStreamWriter`, which only creates a file if the `WriteLine()` method is called.