### PR TITLE
Fixes ParallelRunner bug

### DIFF
--- a/Common/Util/ParallelRunner.cs
+++ b/Common/Util/ParallelRunner.cs
@@ -152,6 +152,10 @@ namespace QuantConnect.Util
             {
                 if (_holdQueue != null) _holdQueue.Dispose();
                 if (_processQueue != null) _processQueue.Dispose();
+
+                // Wait for _holdQueue disposal be completed
+                Thread.Sleep(10000);
+
                 if (_processQueueThread != null && _processQueueThread.IsAlive) _processQueueThread.Abort();
 
                 foreach (var worker in _workers)


### PR DESCRIPTION
The Lean engine backtesting desktop configuration, compiled in debug mode, raised an exception that appears to be the result of an intermittent race condition occurring between the disposal of a .net blocking collection instance and the abort of the thread the collection runs on. In order to fix it, we added a delay between them.