### PR TITLE
Fixes 18 warnings with code CS1572

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -369,7 +369,6 @@ namespace QuantConnect.Algorithm
         /// <param name="period">The period of the FRAMA</param>
         /// <param name="longPeriod">The long period of the FRAMA</param>
         /// <param name="resolution">The resolution</param>
-        /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The FRAMA for the given parameters</returns>
         public FractalAdaptiveMovingAverage FRAMA(Symbol symbol, int period, int longPeriod = 198, Resolution? resolution = null)
         {

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -369,12 +369,13 @@ namespace QuantConnect.Algorithm
         /// <param name="period">The period of the FRAMA</param>
         /// <param name="longPeriod">The long period of the FRAMA</param>
         /// <param name="resolution">The resolution</param>
+        /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The FRAMA for the given parameters</returns>
-        public FractalAdaptiveMovingAverage FRAMA(Symbol symbol, int period, int longPeriod = 198, Resolution? resolution = null)
+        public FractalAdaptiveMovingAverage FRAMA(Symbol symbol, int period, int longPeriod = 198, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "FRAMA" + period, resolution);
             var frama = new FractalAdaptiveMovingAverage(name, period, longPeriod);
-            RegisterIndicator(symbol, frama, resolution);
+            RegisterIndicator(symbol, frama, resolution, selector);
             return frama;
         }
 

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Algorithm
         /// AddData a new user defined data source, requiring only the minimum config options.
         /// The data is added with a default time zone of NewYork (Eastern Daylight Savings Time)
         /// </summary>
-        /// <param name="typeName">Data source type</param>
+        /// <param name="type">Data source type</param>
         /// <param name="symbol">Key/Symbol for data</param>
         /// <param name="resolution">Resolution of the data</param>
         /// <remarks>Generic type T must implement base data</remarks>
@@ -49,7 +49,7 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// AddData a new user defined data source, requiring only the minimum config options.
         /// </summary>
-        /// <param name="typeName">Data source type</param>
+        /// <param name="type">Data source type</param>
         /// <param name="symbol">Key/Symbol for data</param>
         /// <param name="resolution">Resolution of the Data Required</param>
         /// <param name="timeZone">Specifies the time zone of the raw data</param>

--- a/Common/Data/Consolidators/OpenInterestConsolidator.cs
+++ b/Common/Data/Consolidators/OpenInterestConsolidator.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Data.Consolidators
         /// null following the event firing
         /// </summary>
         /// <param name="workingBar">The bar we're building, null if the event was just fired and we're starting a new OI bar</param>
-        /// <param name="data">The new data</param>
+        /// <param name="tick">The new data</param>
         protected override void AggregateBar(ref OpenInterest workingBar, Tick tick)
         {
             if (workingBar == null)

--- a/Common/Data/Market/QuoteBar.cs
+++ b/Common/Data/Market/QuoteBar.cs
@@ -312,6 +312,8 @@ namespace QuantConnect.Data.Market
             return new QuoteBar { Symbol = config.Symbol, Period = config.Increment };
         }
 
+        private static bool HasShownWarning;
+
         /// <summary>
         /// "Scaffold" code - If the data being read is formatted as a TradeBar, use this method to deserialize it
         /// TODO: Once all Forex data refactored to use QuoteBar formatted data, remove this method
@@ -320,7 +322,6 @@ namespace QuantConnect.Data.Market
         /// <param name="line">Line from the data file requested</param>
         /// <param name="date">Date of this reader request</param>
         /// <returns><see cref="QuoteBar"/> with the bid/ask prices set to same values</returns>
-        private static bool HasShownWarning;
         [Obsolete("All Forex data should use Quotes instead of Trades.")]
         private QuoteBar ParseTradeAsQuoteBar(SubscriptionDataConfig config, DateTime date, string line)
         {

--- a/Common/Securities/Futures/FutureFilterUniverse.cs
+++ b/Common/Securities/Futures/FutureFilterUniverse.cs
@@ -66,7 +66,6 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Returns front month contract
         /// </summary>
-        /// <param name="universe"></param>
         /// <returns></returns>
         public FutureFilterUniverse FrontMonth()
         {
@@ -82,7 +81,6 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Returns a list of back month contracts
         /// </summary>
-        /// <param name="universe"></param>
         /// <returns></returns>
         public FutureFilterUniverse BackMonths()
         {
@@ -97,7 +95,6 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Returns first of back month contracts
         /// </summary>
-        /// <param name="universe"></param>
         /// <returns></returns>
         public FutureFilterUniverse BackMonth()
         {

--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -95,7 +95,6 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Includes universe of weeklys options (if any) into selection
         /// </summary>
-        /// <param name="universe"></param>
         /// <returns></returns>
         public OptionFilterUniverse IncludeWeeklys()
         {
@@ -106,7 +105,6 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Sets universe of weeklys options (if any) as a selection
         /// </summary>
-        /// <param name="universe"></param>
         /// <returns></returns>
         public OptionFilterUniverse WeeklysOnly()
         {
@@ -158,7 +156,6 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Returns front month contract
         /// </summary>
-        /// <param name="universe"></param>
         /// <returns></returns>
         public OptionFilterUniverse FrontMonth()
         {
@@ -174,7 +171,6 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Returns a list of back month contracts
         /// </summary>
-        /// <param name="universe"></param>
         /// <returns></returns>
         public OptionFilterUniverse BackMonths()
         {
@@ -189,7 +185,6 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Returns first of back month contracts
         /// </summary>
-        /// <param name="universe"></param>
         /// <returns></returns>
         public OptionFilterUniverse BackMonth()
         {

--- a/Engine/DataFeeds/BaseDataExchange.cs
+++ b/Engine/DataFeeds/BaseDataExchange.cs
@@ -60,7 +60,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// Initializes a new instance of the <see cref="BaseDataExchange"/>
         /// </summary>
         /// <param name="name">A name for this exchange</param>
-        /// <param name="enumerators">The enumerators to fanout</param>
         public BaseDataExchange(string name)
         {
             _name = name;

--- a/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
@@ -54,9 +54,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// </summary>
         /// <param name="dataCacheProvider">The <see cref="IDataCacheProvider"/> used to retrieve a stream of data</param>
         /// <param name="source">The local file to be read</param>
-        /// <param name="entryName">Specifies the zip entry to be opened. Leave null if not applicable,
-        /// <param name="startingPosition">The starting position in the local file to be read</param>
-        /// or to open the first zip entry found regardless of name</param>
         /// <param name="startingPosition">The position in the stream from which to start reading</param>
         public LocalFileSubscriptionStreamReader(IDataCacheProvider dataCacheProvider, string source, long startingPosition)
         {

--- a/Indicators/FractalAdaptiveMovingAverage.cs
+++ b/Indicators/FractalAdaptiveMovingAverage.cs
@@ -54,7 +54,6 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Initializes a new instance of the average class
         /// </summary>
-        /// <param name="name">The name of the indicator instance</param>
         /// <param name="n">The window period (must be even). Example value: 16</param>
         public FractalAdaptiveMovingAverage(int n)
             : this("FRAMA" + n, n, 198)


### PR DESCRIPTION
In this PRm I fixed the Warnings with code CS1572, there were 5 warnings in
this category. They are of the form:
XML comment has a param tag for ___, but there is no parameter by that name

Solution to these warnings is simple to Remove the tag from the XML
comments. Mostly they are the codes which are not refactored
properly.