### PR TITLE
Fix open interest bug in IB brokerage

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2474,7 +2474,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private readonly ConcurrentDictionary<Symbol, int> _lastBidSizes = new ConcurrentDictionary<Symbol, int>();
         private readonly ConcurrentDictionary<Symbol, decimal> _lastAskPrices = new ConcurrentDictionary<Symbol, decimal>();
         private readonly ConcurrentDictionary<Symbol, int> _lastAskSizes = new ConcurrentDictionary<Symbol, int>();
-        private readonly ConcurrentDictionary<string, int> _openInterests = new ConcurrentDictionary<string, int>();
+        private readonly ConcurrentDictionary<Symbol, int> _openInterests = new ConcurrentDictionary<Symbol, int>();
         private readonly List<Tick> _ticks = new List<Tick>();
 
 


### PR DESCRIPTION
The dictionary for open interest data was keyed by `string` instead of `Symbol`