### PR TITLE
Fixes 6 warnings with code CS0108

### DIFF
--- a/Algorithm.CSharp/MACDTrendAlgorithm.cs
+++ b/Algorithm.CSharp/MACDTrendAlgorithm.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Algorithm.Examples
     {
         private DateTime previous;
         private MovingAverageConvergenceDivergence macd;
-        private string Symbol = "SPY";
+        private string symbol = "SPY";
 
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
@@ -36,10 +36,10 @@ namespace QuantConnect.Algorithm.Examples
             SetStartDate(2004, 01, 01);
             SetEndDate(2015, 01, 01);
 
-            AddSecurity(SecurityType.Equity, Symbol, Resolution.Daily);
+            AddSecurity(SecurityType.Equity, symbol, Resolution.Daily);
 
             // define our daily macd(12,26) with a 9 day signal
-            macd = MACD(Symbol, 9, 26, 9, MovingAverageType.Exponential, Resolution.Daily);
+            macd = MACD(symbol, 9, 26, 9, MovingAverageType.Exponential, Resolution.Daily);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace QuantConnect.Algorithm.Examples
 
             if (!macd.IsReady) return;
 
-            var holding = Portfolio[Symbol];
+            var holding = Portfolio[symbol];
 
             decimal signalDeltaPercent = (macd - macd.Signal)/macd.Fast;
             var tolerance = 0.0025m;
@@ -62,18 +62,18 @@ namespace QuantConnect.Algorithm.Examples
             if (holding.Quantity <= 0 && signalDeltaPercent > tolerance) // 0.01%
             {
                 // longterm says buy as well
-                SetHoldings(Symbol, 1.0);
+                SetHoldings(symbol, 1.0);
             }
             // of our macd is less than our signal, then let's go short
             else if (holding.Quantity >= 0 && signalDeltaPercent < -tolerance)
             {
-                Liquidate(Symbol);
+                Liquidate(symbol);
             }
 
             // plot both lines
             Plot("MACD", macd, macd.Signal);
-            Plot(Symbol, "Open", data[Symbol].Open);
-            Plot(Symbol, macd.Fast, macd.Slow);
+            Plot(symbol, "Open", data[symbol].Open);
+            Plot(symbol, macd.Fast, macd.Slow);
 
             previous = Time;
         }

--- a/Algorithm.CSharp/MovingAverageCrossAlgorithm.cs
+++ b/Algorithm.CSharp/MovingAverageCrossAlgorithm.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Algorithm.Examples
     /// </summary>
     public class MovingAverageCrossAlgorithm : QCAlgorithm
     {
-        private const string Symbol = "SPY";
+        private const string symbol = "SPY";
         private DateTime previous;
         private ExponentialMovingAverage fast;
         private ExponentialMovingAverage slow;
@@ -43,17 +43,17 @@ namespace QuantConnect.Algorithm.Examples
             SetEndDate(2015, 01, 01);
 
             // request SPY data with minute resolution
-            AddSecurity(SecurityType.Equity, Symbol, Resolution.Minute);
+            AddSecurity(SecurityType.Equity, symbol, Resolution.Minute);
 
             // create a 15 day exponential moving average
-            fast = EMA(Symbol, 15, Resolution.Daily);
+            fast = EMA(symbol, 15, Resolution.Daily);
 
             // create a 30 day exponential moving average
-            slow = EMA(Symbol, 30, Resolution.Daily);
+            slow = EMA(symbol, 30, Resolution.Daily);
 
             int ribbonCount = 8;
             int ribbonInterval = 15;
-            ribbon = Enumerable.Range(0, ribbonCount).Select(x => SMA(Symbol, (x + 1)*ribbonInterval, Resolution.Daily)).ToArray();
+            ribbon = Enumerable.Range(0, ribbonCount).Select(x => SMA(symbol, (x + 1)*ribbonInterval, Resolution.Daily)).ToArray();
         }
 
         
@@ -76,7 +76,7 @@ namespace QuantConnect.Algorithm.Examples
 
             // define a small tolerance on our checks to avoid bouncing
             const decimal tolerance = 0.00015m;
-            var holdings = Portfolio[Symbol].Quantity;
+            var holdings = Portfolio[symbol].Quantity;
 
             // we only want to go long if we're currently short or flat
             if (holdings <= 0)
@@ -84,8 +84,8 @@ namespace QuantConnect.Algorithm.Examples
                 // if the fast is greater than the slow, we'll go long
                 if (fast > slow * (1 + tolerance))
                 {
-                    Log("BUY  >> " + Securities[Symbol].Price);
-                    SetHoldings(Symbol, 1.0);
+                    Log("BUY  >> " + Securities[symbol].Price);
+                    SetHoldings(symbol, 1.0);
                 }
             }
 
@@ -93,14 +93,14 @@ namespace QuantConnect.Algorithm.Examples
             // if the fast is less than the slow we'll liquidate our long
             if (holdings > 0 && fast < slow)
             {
-                Log("SELL >> " + Securities[Symbol].Price);
-                Liquidate(Symbol);    
+                Log("SELL >> " + Securities[symbol].Price);
+                Liquidate(symbol);    
             }
 
-            Plot(Symbol, "Price", data[Symbol].Price);
+            Plot(symbol, "Price", data[symbol].Price);
             
             // easily plot indicators, the series name will be the name of the indicator
-            Plot(Symbol, fast, slow);
+            Plot(symbol, fast, slow);
             Plot("Ribbon", ribbon);
 
             previous = Time;

--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// </summary>
     public class OrderTicketDemoAlgorithm : QCAlgorithm
     {
-        private const string Symbol = "SPY";
+        private const string symbol = "SPY";
         private readonly List<OrderTicket> _openMarketOnOpenOrders = new List<OrderTicket>(); 
         private readonly List<OrderTicket> _openMarketOnCloseOrders = new List<OrderTicket>(); 
         private readonly List<OrderTicket> _openLimitOrders = new List<OrderTicket>();
@@ -42,7 +42,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 11);    //Set End Date
             SetCash(100000);             //Set Strategy Cash
             // Find more symbols here: http://quantconnect.com/data
-            AddSecurity(SecurityType.Equity, Symbol, Resolution.Minute);
+            AddSecurity(SecurityType.Equity, symbol, Resolution.Minute);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace QuantConnect.Algorithm.CSharp
 
                 // submit a market order to buy 10 shares, this function returns an OrderTicket object
                 // we submit the order with asynchronous:false, so it block until it is filled
-                var newTicket = MarketOrder(Symbol, 10, asynchronous: false);
+                var newTicket = MarketOrder(symbol, 10, asynchronous: false);
                 if (newTicket.Status != OrderStatus.Filled)
                 {
                     Log("Synchronous market order was not filled synchronously!");
@@ -100,7 +100,7 @@ namespace QuantConnect.Algorithm.CSharp
                 // the fill before the next time events for your algorithm. here we'll submit the order
                 // asynchronously and try to cancel it, sometimes it will, sometimes it will be filled
                 // first.
-                newTicket = MarketOrder(Symbol, 10, asynchronous: true);
+                newTicket = MarketOrder(symbol, 10, asynchronous: true);
                 var response = newTicket.Cancel("Attempt to cancel async order");
                 if (response.IsSuccess)
                 {
@@ -134,12 +134,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Log("Submitting LimitOrder");
 
                 // submit a limit order to buy 10 shares at .1% below the bar's close
-                var close = Securities[Symbol].Close;
-                var newTicket = LimitOrder(Symbol, 10, close * .999m);
+                var close = Securities[symbol].Close;
+                var newTicket = LimitOrder(symbol, 10, close * .999m);
                 _openLimitOrders.Add(newTicket);
 
                 // submit another limit order to sell 10 shares at .1% above the bar's close
-                newTicket = LimitOrder(Symbol, 10, close * 1.001m);
+                newTicket = LimitOrder(symbol, 10, close * 1.001m);
                 _openLimitOrders.Add(newTicket);
             }
 
@@ -201,16 +201,16 @@ namespace QuantConnect.Algorithm.CSharp
                 // a long stop is triggered when the price rises above the value
                 // so we'll set a long stop .25% above the current bar's close
 
-                var close = Securities[Symbol].Close;
+                var close = Securities[symbol].Close;
                 var stopPrice = close * 1.0025m;
-                var newTicket = StopMarketOrder(Symbol, 10, stopPrice);
+                var newTicket = StopMarketOrder(symbol, 10, stopPrice);
                 _openStopMarketOrders.Add(newTicket);
 
                 // a short stop is triggered when the price falls below the value
                 // so we'll set a short stop .25% below the current bar's close
 
                 stopPrice = close * .9975m;
-                newTicket = StopMarketOrder(Symbol, -10, stopPrice);
+                newTicket = StopMarketOrder(symbol, -10, stopPrice);
                 _openStopMarketOrders.Add(newTicket);
             }
 
@@ -276,10 +276,10 @@ namespace QuantConnect.Algorithm.CSharp
                 // to get at least the limit price for our fills, so make the limit
                 // price a little softer than the stop price
 
-                var close = Securities[Symbol].Close;
+                var close = Securities[symbol].Close;
                 var stopPrice = close * 1.001m;
                 var limitPrice = close - 0.03m;
-                var newTicket = StopLimitOrder(Symbol, 10, stopPrice, limitPrice);
+                var newTicket = StopLimitOrder(symbol, 10, stopPrice, limitPrice);
                 _openStopLimitOrders.Add(newTicket);
 
                 // a short stop is triggered when the price falls below the value
@@ -290,7 +290,7 @@ namespace QuantConnect.Algorithm.CSharp
 
                 stopPrice = close * .999m;
                 limitPrice = close + 0.03m;
-                newTicket = StopLimitOrder(Symbol, -10, stopPrice, limitPrice);
+                newTicket = StopLimitOrder(symbol, -10, stopPrice, limitPrice);
                 _openStopLimitOrders.Add(newTicket);
             }
 
@@ -345,10 +345,10 @@ namespace QuantConnect.Algorithm.CSharp
                 Log("Submitting MarketOnCloseOrder");
 
                 // open a new position or triple our existing position
-                var qty = Portfolio[Symbol].Quantity;
+                var qty = Portfolio[symbol].Quantity;
                 qty = qty == 0 ? 100 : 2*qty;
 
-                var newTicket = MarketOnCloseOrder(Symbol, qty);
+                var newTicket = MarketOnCloseOrder(symbol, qty);
                 _openMarketOnCloseOrders.Add(newTicket);
             }
 
@@ -377,7 +377,7 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 Log("Submitting MarketOnCloseOrder to liquidate end of algorithm");
 
-                MarketOnCloseOrder(Symbol, -Portfolio[Symbol].Quantity, "Liquidate end of algorithm");
+                MarketOnCloseOrder(symbol, -Portfolio[symbol].Quantity, "Liquidate end of algorithm");
             }
         }
 
@@ -393,7 +393,7 @@ namespace QuantConnect.Algorithm.CSharp
                 Log("Submitting MarketOnOpenOrder");
 
                 // its EOD, let's submit a market on open order to short even more!
-                var newTicket = MarketOnOpenOrder(Symbol, 50);
+                var newTicket = MarketOnOpenOrder(symbol, 50);
                 _openMarketOnOpenOrders.Add(newTicket);
             }
 

--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Algorithm.CSharp
         private const decimal LimitPercentage = 0.025m;
         private const decimal LimitPercentageDelta = 0.005m;
 
-        private const string Symbol = "SPY";
+        private const string symbol = "SPY";
         private const SecurityType SecType = SecurityType.Equity;
 
         private readonly CircularQueue<OrderType> _orderTypesQueue = new CircularQueue<OrderType>(Enum.GetValues(typeof(OrderType))
@@ -56,8 +56,8 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2015, 01, 01);    //Set End Date
             SetCash(100000);             //Set Strategy Cash
             // Find more symbols here: http://quantconnect.com/data
-            AddSecurity(SecType, Symbol, Resolution.Daily);
-            Security = Securities[Symbol];
+            AddSecurity(SecType, symbol, Resolution.Daily);
+            Security = Securities[symbol];
 
             _orderTypesQueue.CircleCompleted += (sender, args) =>
             {
@@ -72,7 +72,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="data">Slice object keyed by symbol containing the stock data</param>
         public override void OnData(Slice data)
         {
-            if (!data.Bars.ContainsKey(Symbol)) return;
+            if (!data.Bars.ContainsKey(symbol)) return;
 
             // each month make an action
             if (Time.Month != LastMonth)
@@ -85,13 +85,13 @@ namespace QuantConnect.Algorithm.CSharp
                 LastMonth = Time.Month;
                 Log("ORDER TYPE:: " + orderType);
                 var isLong = Quantity > 0;
-                var stopPrice = isLong ? (1 + StopPercentage)*data.Bars[Symbol].High : (1 - StopPercentage)*data.Bars[Symbol].Low;
+                var stopPrice = isLong ? (1 + StopPercentage)*data.Bars[symbol].High : (1 - StopPercentage)*data.Bars[symbol].Low;
                 var limitPrice = isLong ? (1 - LimitPercentage)*stopPrice : (1 + LimitPercentage)*stopPrice;
                 if (orderType == OrderType.Limit)
                 {
-                    limitPrice = !isLong ? (1 + LimitPercentage) * data.Bars[Symbol].High : (1 - LimitPercentage) * data.Bars[Symbol].Low;
+                    limitPrice = !isLong ? (1 + LimitPercentage) * data.Bars[symbol].High : (1 - LimitPercentage) * data.Bars[symbol].Low;
                 }
-                var request = new SubmitOrderRequest(orderType, SecType, Symbol, Quantity, stopPrice, limitPrice, Time, orderType.ToString());
+                var request = new SubmitOrderRequest(orderType, SecType, symbol, Quantity, stopPrice, limitPrice, Time, orderType.ToString());
                 var ticket = Transactions.AddOrder(request);
                 _tickets.Add(ticket);
             }

--- a/Algorithm.CSharp/WarmupAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupAlgorithm.cs
@@ -7,7 +7,7 @@ namespace QuantConnect.Algorithm.CSharp
     public class WarmupAlgorithm : QCAlgorithm
     {
         private bool first = true;
-        private const string Symbol = "SPY";
+        private const string symbol = "SPY";
         private const int FastPeriod = 60;
         private const int SlowPeriod = 3600;
         private ExponentialMovingAverage fast, slow;
@@ -18,10 +18,10 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 11);    //Set End Date
             SetCash(100000);             //Set Strategy Cash
             // Find more symbols here: http://quantconnect.com/data
-            AddSecurity(SecurityType.Equity, Symbol, Resolution.Second);
+            AddSecurity(SecurityType.Equity, symbol, Resolution.Second);
 
-            fast = EMA(Symbol, FastPeriod);
-            slow = EMA(Symbol, SlowPeriod);
+            fast = EMA(symbol, FastPeriod);
+            slow = EMA(symbol, SlowPeriod);
 
             SetWarmup(SlowPeriod);
         }
@@ -39,11 +39,11 @@ namespace QuantConnect.Algorithm.CSharp
             }
             if (fast > slow)
             {
-                SetHoldings(Symbol, 1);
+                SetHoldings(symbol, 1);
             }
             else
             {
-                SetHoldings(Symbol, -1);
+                SetHoldings(symbol, -1);
             }
         }
     }


### PR DESCRIPTION
This PR fixes warnings with code CS0108. There are 6 warnings of
this kind. A variable was declared with the same name as a variable in
a base class. However, the new keyword was not used.

"______ hides inherited member _____. 
Use the new keyword if hiding was intended"

There were two solutions to this warning one using new keyword and second renaming the variables. We choose to rename because we don't want to hide the Symbol method from the base class and using new is a bad practice. Plus the concerned variables were not following good naming conventions.