### PR TITLE
Remove the byte order mark

### DIFF
--- a/Algorithm.Python/build.bat
+++ b/Algorithm.Python/build.bat
@@ -1,4 +1,4 @@
-﻿REM QuantConnect Lean Engine -- Python Build Script.
+REM QuantConnect Lean Engine -- Python Build Script.
 del Python.Runtime.dll
 
 REM Python Compile the Algorithm with all the files in current directory


### PR DESCRIPTION
Used Notepad++ to change the file encoding from UTF-8-BOM to UTF-8 (i.e. removed the byte order mark) which seems to be confusing the Windows shell.  Fixes issue mentioned in #915