### PR TITLE
Fixes 5 warnings with code CS1574

### DIFF
--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.Policy;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
@@ -384,7 +385,7 @@ namespace QuantConnect.AlgorithmFactory
         /// Unload this factory's appDomain.
         /// </summary>
         /// <remarks>Not used in lean engine. Running the library in an app domain is 10x slower.</remarks>
-        /// <seealso cref="CreateAppDomain"/>
+        /// <seealso cref="AppDomain.CreateDomain(string, Evidence, string, string, bool, AppDomainInitializer, string[])"/>
         public void Unload() {
             if (appDomain != null) 
             {

--- a/Common/Data/Market/FuturesChain.cs
+++ b/Common/Data/Market/FuturesChain.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Securities.Future;
 using QuantConnect.Util;
 
 namespace QuantConnect.Data.Market

--- a/Common/Data/Market/OptionChain.cs
+++ b/Common/Data/Market/OptionChain.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Securities.Option;
 using QuantConnect.Util;
 
 namespace QuantConnect.Data.Market

--- a/Common/Data/Market/RenkoBar.cs
+++ b/Common/Data/Market/RenkoBar.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Data.Market
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="WickoBar"/> class with the specified values
+        /// Initializes a new instance of the <see cref="RenkoBar"/> class with the specified values
         /// </summary>
         /// <param name="symbol">The symbol of this data</param>
         /// <param name="start">The start time of the bar</param>

--- a/Common/Securities/Option/CurrentPriceOptionPriceModel.cs
+++ b/Common/Securities/Option/CurrentPriceOptionPriceModel.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Securities.Option
     {
         /// <summary>
         /// Creates a new <see cref="OptionPriceModelResult"/> containing the current <see cref="Security.Price"/>
-        /// and a default, empty instance of <see cref="FirstOrderGreeks"/>
+        /// and a default, empty instance of first Order <see cref="Greeks"/>
         /// </summary>
         /// <param name="security">The option security object</param>
         /// <param name="slice">The current data slice. This can be used to access other information


### PR DESCRIPTION
CS1574 is caused by wrong or ambiguous crefs in XML comments. I have fixed the warnings but writing the correct crefs in the corresponding XML comments.