### PR TITLE
Time-based removal of option contracts from universe in live mode

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1357,7 +1357,7 @@ namespace QuantConnect.Algorithm
             if (!UniverseManager.TryGetValue(canonicalSymbol, out universe))
             {
                 var settings = new UniverseSettings(resolution, leverage, true, false, TimeSpan.Zero);
-                universe = new OptionChainUniverse(canonicalSecurity, settings, SubscriptionManager, SecurityInitializer);
+                universe = new OptionChainUniverse(canonicalSecurity, settings, SecurityInitializer, LiveMode);
                 UniverseManager.Add(canonicalSymbol, universe);
             }
 


### PR DESCRIPTION
Previously, removal of option contracts from the option chain universe was allowed only on date change (in both live and backtesting).

Now, in order to reduce market data subscriptions in live mode, removal is allowed intraday if the contract has been in the universe for at least 15 minutes. When backtesting, behavior is unchanged.