### PR TITLE
Update Forex/CFD default fee model to FxcmFeeModel

### DIFF
--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
@@ -187,13 +186,15 @@ namespace QuantConnect.Brokerages
                     return new ConstantFeeModel(0m);
 
                 case SecurityType.Forex:
+                case SecurityType.Cfd:
+                    return new FxcmFeeModel();
+
                 case SecurityType.Equity:
                 case SecurityType.Option:
                 case SecurityType.Future:
                     return new InteractiveBrokersFeeModel();
 
                 case SecurityType.Commodity:
-                case SecurityType.Cfd:
                 default:
                     return new ConstantFeeModel(0m);
             }


### PR DESCRIPTION
Previously, in `DefaultBrokerageModel`, the default fee model used was `InteractiveBrokersFeeModel`.