### PR TITLE
Fix SetBrokerageModel resetting leverage when called after AddSecurity

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -886,8 +886,16 @@ namespace QuantConnect.Algorithm
                 // update models on securities added earlier (before SetBrokerageModel is called)
                 foreach (var security in Securities.Values)
                 {
+                    // save the existing leverage specified in AddSecurity,
+                    // if Leverage needs to be set in a SecurityInitializer,
+                    // SetSecurityInitializer must be called before SetBrokerageModel
+                    var leverage = security.Leverage;
+
                     // no need to seed the security, has already been done in AddSecurity
                     SecurityInitializer.Initialize(security, false);
+
+                    // restore the saved leverage
+                    security.SetLeverage(leverage);
                 }
             }
         }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -184,16 +184,16 @@ namespace QuantConnect.Brokerages
             switch (security.Type)
             {
                 case SecurityType.Base:
+                case SecurityType.Forex:
+                case SecurityType.Cfd:
                     return new ConstantFeeModel(0m);
 
-                case SecurityType.Forex:
                 case SecurityType.Equity:
                 case SecurityType.Option:
                 case SecurityType.Future:
                     return new InteractiveBrokersFeeModel();
 
                 case SecurityType.Commodity:
-                case SecurityType.Cfd:
                 default:
                     return new ConstantFeeModel(0m);
             }

--- a/Tests/Algorithm/AlgorithmInitializeTests.cs
+++ b/Tests/Algorithm/AlgorithmInitializeTests.cs
@@ -1,0 +1,414 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    /// <summary>
+    /// Test mixed call order combinations of SetSecurityInitializer, SetBrokerageModel and AddSecurity
+    /// </summary>
+    [TestFixture]
+    public class AlgorithmInitializeTests
+    {
+        private const string Ticker = "EURUSD";
+        private const Resolution Resolution = QuantConnect.Resolution.Second;
+        private const string Market = QuantConnect.Market.FXCM;
+        private const BrokerageName BrokerageName = QuantConnect.Brokerages.BrokerageName.FxcmBrokerage;
+        private const int RoundingPrecision = 20;
+        private readonly MarketOrder _order = new MarketOrder { Quantity = 1000 }; 
+
+        [Test]
+        public void Validates_SetBrokerageModel_AddForex()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetBrokerageModel(BrokerageName);
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+
+            // Leverage and FeeModel from BrokerageModel
+            Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
+            Assert.AreEqual(0.04, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_AddForex_SetBrokerageModel()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+            algorithm.SetBrokerageModel(BrokerageName);
+
+            // Leverage and FeeModel from BrokerageModel
+            Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
+            Assert.AreEqual(0.04, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetBrokerageModel_AddForexWithLeverage()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetBrokerageModel(BrokerageName);
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+
+            // Leverage passed to AddForex always takes precedence
+            // Leverage from AddForex, FeeModel from BrokerageModel
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
+            Assert.AreEqual(0.04, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_AddForexWithLeverage_SetBrokerageModel()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+            algorithm.SetBrokerageModel(BrokerageName);
+
+            // Leverage passed to AddForex always takes precedence
+            // Leverage from AddForex, FeeModel from BrokerageModel
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
+            Assert.AreEqual(0.04, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetSecurityInitializer_AddForex()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+
+            // Leverage and FeeModel from SecurityInitializer
+            Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
+            Assert.AreEqual(2, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_AddForex_SetSecurityInitializer()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+
+            // SetSecurityInitializer does not apply to securities added before the call
+            // Leverage and FeeModel from DefaultBrokerageModel
+            Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
+            Assert.AreEqual(0, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetSecurityInitializer_AddForexWithLeverage()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+
+            // Leverage passed to AddForex always takes precedence
+            // Leverage from AddForex, FeeModel from SecurityInitializer
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
+            Assert.AreEqual(2, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_AddForexWithLeverage_SetSecurityInitializer()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+
+            // Leverage passed to AddForex always takes precedence
+            // SetSecurityInitializer does not apply to securities added before the call
+            // Leverage from AddForex, FeeModel from DefaultBrokerageModel
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
+            Assert.AreEqual(0, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetSecurityInitializer_AddForex_SetBrokerageModel()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+            algorithm.SetBrokerageModel(BrokerageName);
+
+            // SetSecurityInitializer overrides the brokerage model
+            // Leverage and FeeModel from SecurityInitializer
+            Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
+            Assert.AreEqual(2, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetSecurityInitializer_SetBrokerageModel_AddForex()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            algorithm.SetBrokerageModel(BrokerageName);
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+
+            // SetSecurityInitializer overrides the brokerage model
+            // Leverage and FeeModel from SecurityInitializer
+            Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
+            Assert.AreEqual(2, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetBrokerageModel_SetSecurityInitializer_AddForex()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetBrokerageModel(BrokerageName);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+
+            // SetSecurityInitializer overrides the brokerage model
+            // Leverage and FeeModel from SecurityInitializer
+            Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
+            Assert.AreEqual(2, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetBrokerageModel_AddForex_SetSecurityInitializer()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetBrokerageModel(BrokerageName);
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+
+            // SetSecurityInitializer does not apply to securities added before the call
+            // Leverage and FeeModel from BrokerageModel
+            Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
+            Assert.AreEqual(0.04, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_AddForex_SetSecurityInitializer_SetBrokerageModel()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            algorithm.SetBrokerageModel(BrokerageName);
+
+            // SetSecurityInitializer does not apply to securities added before the call
+            // Leverage and FeeModel from DefaultBrokerageModel
+            Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
+            Assert.AreEqual(0, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_AddForex_SetBrokerageModel_SetSecurityInitializer()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+            algorithm.SetBrokerageModel(BrokerageName);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+
+            // SetSecurityInitializer does not apply to securities added before the call
+            // Leverage and FeeModel from BrokerageModel
+            Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
+            Assert.AreEqual(0.04, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetSecurityInitializer_AddForexWithLeverage_SetBrokerageModel()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+            algorithm.SetBrokerageModel(BrokerageName);
+
+            // Leverage passed to AddForex always takes precedence
+            // Leverage from AddForex, FeeModel from Initializer
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
+            Assert.AreEqual(2, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetSecurityInitializer_SetBrokerageModel_AddForexWithLeverage()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            algorithm.SetBrokerageModel(BrokerageName);
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+
+            // Leverage passed to AddForex always takes precedence
+            // SetSecurityInitializer overrides the brokerage model
+            // Leverage from AddForex, FeeModel from SecurityInitializer
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
+            Assert.AreEqual(2, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetBrokerageModel_SetSecurityInitializer_AddForexWithLeverage()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetBrokerageModel(BrokerageName);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+
+            // Leverage passed to AddForex always takes precedence
+            // SetSecurityInitializer overrides the brokerage model
+            // Leverage from AddForex, FeeModel from SecurityInitializer
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
+            Assert.AreEqual(2, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_SetBrokerageModel_AddForexWithLeverage_SetSecurityInitializer()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetBrokerageModel(BrokerageName);
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+
+            // Leverage passed to AddForex always takes precedence
+            // Leverage from AddForex, FeeModel from BrokerageModel
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
+            Assert.AreEqual(0.04, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_AddForexWithLeverage_SetSecurityInitializer_SetBrokerageModel()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+            algorithm.SetBrokerageModel(BrokerageName);
+
+            // Leverage passed to AddForex always takes precedence
+            // Leverage from AddForex, FeeModel from DefaultBrokerageModel
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
+            Assert.AreEqual(0, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
+        public void Validates_AddForexWithLeverage_SetBrokerageModel_SetSecurityInitializer()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var security = algorithm.AddForex(Ticker, Resolution, Market, true, 25);
+            algorithm.SetBrokerageModel(BrokerageName);
+            algorithm.SetSecurityInitializer(x =>
+            {
+                x.SetLeverage(100);
+                x.FeeModel = new InteractiveBrokersFeeModel();
+            });
+
+            // Leverage passed to AddForex always takes precedence
+            // Leverage from AddForex, FeeModel from BrokerageModel
+            Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
+            Assert.AreEqual(0.04, security.FeeModel.GetOrderFee(security, _order));
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -104,6 +104,7 @@
     </Compile>
     <Compile Include="AlgorithmRunner.cs" />
     <Compile Include="Algorithm\AlgorithmAddDataTests.cs" />
+    <Compile Include="Algorithm\AlgorithmInitializeTests.cs" />
     <Compile Include="Algorithm\AlgorithmResolveConsolidatorTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetBrokerageTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetHoldingsTests.cs" />


### PR DESCRIPTION
Also adds tests for different call sequences of algorithm initialization: `AddSecurity`, `SetBrokerageModel`, `SetSecurityInitializer`.

This is chained to PR #952 