### PR TITLE
Add missing enumerator disposal when symbol removed from universe

### DIFF
--- a/Engine/DataFeeds/Enumerators/EnqueueableEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/EnqueueableEnumerator.cs
@@ -19,7 +19,6 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
-using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 {
@@ -61,6 +60,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         public T LastEnqueued
         {
             get { return _lastEnqueued; }
+        }
+
+        /// <summary>
+        /// Returns true if the enumerator has finished and will not accept any more data
+        /// </summary>
+        public bool HasFinished
+        {
+            get { return _end || _disposed; }
         }
 
         /// <summary>

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -21,7 +21,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
 using QuantConnect.Data;
-using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
@@ -162,6 +161,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 var count = 0;
                 while (enumerator.MoveNext())
                 {
+                    // subscription has been removed, no need to continue enumerating
+                    if (enqueueable.HasFinished)
+                    {
+                        enumerator.Dispose();
+                        return;
+                    }
+
                     // drop the data into the back of the enqueueable
                     enqueueable.Enqueue(enumerator.Current);
 


### PR DESCRIPTION
This was causing unnecessary data processing with algorithms using universe selection, so we should expect some improvements in speed and memory usage.

Another less common issue fixed in this PR is unexpected price spikes on symbols with splits.

This fix only affects backtesting, no change in live trading.