### PR TITLE
Update IB reconnect logic after reset times

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1836,8 +1836,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             else
             {
                 var timeOfDay = time.TimeOfDay;
-                // from 11:45 -> 12:45 is the IB reset times, we'll go from 11:00pm->1:30am for safety margin
-                result = timeOfDay > new TimeSpan(23, 0, 0) || timeOfDay < new TimeSpan(1, 30, 0);
+                // from 11:45 -> 12:45 is the IB reset times, we'll go from 11:30pm->1:00am for safety margin
+                result = timeOfDay > new TimeSpan(23, 30, 0) || timeOfDay < new TimeSpan(1, 0, 0);
             }
 
             Log.Trace("InteractiveBrokersBrokerage.IsWithinScheduledServerResetTimes(): " + result);

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -962,7 +962,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 // begin the try wait logic
                 TryWaitForReconnect();
             }
-            else if (errorCode == 1102)
+            else if (errorCode == 1102 || errorCode == 1101)
             {
                 // we've reconnected
                 _disconnected1100Fired = false;

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersGatewayRunner.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersGatewayRunner.cs
@@ -115,20 +115,42 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 if (OS.IsWindows)
                 {
-                    foreach (var process in Process.GetProcesses())
+                    if (_useTws)
                     {
-                        try
+                        foreach (var process in Process.GetProcessesByName("java"))
                         {
-                            if (process.MainWindowTitle.ToLower().Contains("ibcontroller") ||
-                                process.MainWindowTitle.ToLower().Contains("ib gateway"))
+                            if (process.MainWindowTitle.Contains("Interactive Brokers"))
                             {
                                 process.Kill();
                                 Thread.Sleep(2500);
                             }
                         }
-                        catch (Exception)
+                        foreach (var process in Process.GetProcessesByName("cmd"))
                         {
-                            // ignored
+                            if (process.MainWindowTitle.ToLower().Contains("ibcontroller"))
+                            {
+                                process.Kill();
+                                Thread.Sleep(2500);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        foreach (var process in Process.GetProcesses())
+                        {
+                            try
+                            {
+                                if (process.MainWindowTitle.ToLower().Contains("ibcontroller") ||
+                                    process.MainWindowTitle.ToLower().Contains("ib gateway"))
+                                {
+                                    process.Kill();
+                                    Thread.Sleep(2500);
+                                }
+                            }
+                            catch (Exception)
+                            {
+                                // ignored
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Previously, if no reconnect message was received after the nightly reset, the algorithm was terminated with a runtime error.

With this PR, the IB client will be restarted instead of exiting the algorithm.

Also added handling of error code 1101 (Reconnect with data loss).