### PR TITLE
Fixes three warnings with code CS0168

### DIFF
--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -124,7 +124,7 @@ namespace QuantConnect.Securities.Option
                     {
                         return (decimal)greek();
                     }
-                    catch (Exception err)
+                    catch (Exception)
                     {
                         return optionSecurity.EnableGreekApproximation ? (decimal)reevalFunc() : 0.0m;
                     }

--- a/Configuration/Config.cs
+++ b/Configuration/Config.cs
@@ -192,7 +192,7 @@ namespace QuantConnect.Configuration
             {
                 value = token.Value<string>();
             }
-            catch (Exception err)
+            catch (Exception)
             {
                 value = token.ToString();
             }

--- a/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
+++ b/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                             callback.Invoke(tick);
                         }
                     }
-                    catch (AssertionException ase)
+                    catch (AssertionException)
                     {
                         throw;
                     }


### PR DESCRIPTION
These warnings are caused by not using arguments of the catch block. These warnings can be fixed by removing the variables.