### PR TITLE
Fixes exception at OnMarginCall in Python

### DIFF
--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -681,9 +681,25 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// <param name="requests"></param>
         public void OnMarginCall(List<SubmitOrderRequest> requests)
         {
-            using (Py.GIL())
+            try
             {
-                _algorithm.OnMarginCall(requests);
+                using (Py.GIL())
+                {
+                    _algorithm.OnMarginCall(requests);
+                }
+            }
+            catch (PythonException pythonException)
+            {
+                // Pythonnet generated error due to List conversion 
+                if (pythonException.Message.Equals("TypeError : No method matches given arguments"))
+                {
+                    _baseAlgorithm.OnMarginCall(requests);
+                }
+                // User code generated error
+                else
+                {
+                    throw pythonException;
+                }
             }
         }
 


### PR DESCRIPTION
When OnMarginCall is not defined at the python script, pythonnet cannot find the method in the base class.
Instead of throwing the exception and exiting, we direct the event to the method in the base class.