### PR TITLE
DataNormalizationMode or options must be Raw

### DIFF
--- a/Common/Data/SubscriptionDataConfigList.cs
+++ b/Common/Data/SubscriptionDataConfigList.cs
@@ -12,6 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -54,6 +56,11 @@ namespace QuantConnect.Data
         /// <param name="normalizationMode"></param>
         public void SetDataNormalizationMode(DataNormalizationMode normalizationMode)
         {
+            if (Symbol.SecurityType == SecurityType.Option && normalizationMode != DataNormalizationMode.Raw)
+            {
+                throw new ArgumentException("DataNormalizationMode.Raw must be used with options");
+            }
+
             foreach (var config in this)
             {
                 config.DataNormalizationMode = normalizationMode;

--- a/Common/Securities/Equity/Equity.cs
+++ b/Common/Securities/Equity/Equity.cs
@@ -83,5 +83,22 @@ namespace QuantConnect.Securities.Equity
         {
             Holdings = new EquityHolding(this);
         }
+
+        /// <summary>
+        /// Sets the data normalization mode to be used by this security
+        /// </summary>
+        public override void SetDataNormalizationMode(DataNormalizationMode mode)
+        {
+            base.SetDataNormalizationMode(mode);
+
+            if (mode == DataNormalizationMode.Adjusted)
+            {
+                PriceVariationModel = new AdjustedPriceVariationModel();
+            }
+            else
+            {
+                PriceVariationModel = new EquityPriceVariationModel();
+            }
+        }
     }
 }

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -325,10 +325,7 @@ namespace QuantConnect.Securities.Option
                 throw new ArgumentException("DataNormalizationMode.Raw must be used with options");
             }
 
-            foreach (var subscription in SubscriptionsBag)
-            {
-                subscription.DataNormalizationMode = mode;
-            }
+            base.SetDataNormalizationMode(mode);
         }
     }
 }

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -65,6 +65,7 @@ namespace QuantConnect.Securities.Option
                 )
         {
             ExerciseSettlement = SettlementType.PhysicalDelivery;
+            SetDataNormalizationMode(DataNormalizationMode.Raw);
             OptionExerciseModel = new DefaultExerciseModel();
             PriceModel = new CurrentPriceOptionPriceModel();
             Holdings = new OptionHolding(this);
@@ -97,6 +98,7 @@ namespace QuantConnect.Securities.Option
                )
         {
             ExerciseSettlement = SettlementType.PhysicalDelivery;
+            SetDataNormalizationMode(DataNormalizationMode.Raw);
             OptionExerciseModel = new DefaultExerciseModel();
             PriceModel = new CurrentPriceOptionPriceModel();
             Holdings = new OptionHolding(this);

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -315,5 +315,20 @@ namespace QuantConnect.Securities.Option
             });
         }
 
+        /// <summary>
+        /// Sets the data normalization mode to be used by this security
+        /// </summary>
+        public override void SetDataNormalizationMode(DataNormalizationMode mode)
+        {
+            if (mode != DataNormalizationMode.Raw)
+            {
+                throw new ArgumentException("DataNormalizationMode.Raw must be used with options");
+            }
+
+            foreach (var subscription in SubscriptionsBag)
+            {
+                subscription.DataNormalizationMode = mode;
+            }
+        }
     }
 }

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -649,13 +649,8 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Sets the data normalization mode to be used by this security
         /// </summary>
-        public void SetDataNormalizationMode(DataNormalizationMode mode)
+        public virtual void SetDataNormalizationMode(DataNormalizationMode mode)
         {
-            if (Symbol.SecurityType == SecurityType.Option && mode != DataNormalizationMode.Raw)
-            {
-                throw new ArgumentException("DataNormalizationMode.Raw must be used with options");
-            }
-
             foreach (var subscription in SubscriptionsBag)
             {
                 subscription.DataNormalizationMode = mode;

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -655,18 +655,6 @@ namespace QuantConnect.Securities
             {
                 subscription.DataNormalizationMode = mode;
             }
-
-            if (Type == SecurityType.Equity)
-            {
-                if (mode == DataNormalizationMode.Adjusted)
-                {
-                    PriceVariationModel = new AdjustedPriceVariationModel();
-                }
-                else
-                {
-                    PriceVariationModel = new EquityPriceVariationModel();
-                }
-            }
         }
 
         /// <summary>

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -651,6 +651,11 @@ namespace QuantConnect.Securities
         /// </summary>
         public void SetDataNormalizationMode(DataNormalizationMode mode)
         {
+            if (Symbol.SecurityType == SecurityType.Option && mode != DataNormalizationMode.Raw)
+            {
+                throw new ArgumentException("DataNormalizationMode.Raw must be used with options");
+            }
+
             foreach (var subscription in SubscriptionsBag)
             {
                 subscription.DataNormalizationMode = mode;

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -17,11 +17,13 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -336,6 +338,21 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsTrue(subscriptions.Subscriptions.Any(x => x.TickType == TickType.OpenInterest && x.Type == typeof(OpenInterest)));
             Assert.IsTrue(subscriptions.Subscriptions.Any(x => x.TickType == TickType.Quote && x.Type == typeof(QuoteBar)));
             Assert.IsTrue(subscriptions.Subscriptions.Any(x => x.TickType == TickType.Trade && x.Type == typeof(TradeBar)));
+        }
+
+        [Test]
+        public void Option_SubscriptionDataConfigList_CanOnlyHave_RawDataNormalization()
+        {
+            var option = new Symbol(SecurityIdentifier.GenerateOption(SecurityIdentifier.DefaultDate, Symbols.SPY.ID, Market.USA, 0, default(OptionRight), default(OptionStyle)), "?SPY");
+
+            var subscriptionDataConfigList = new SubscriptionDataConfigList(option);
+
+            Assert.DoesNotThrow(() => { subscriptionDataConfigList.SetDataNormalizationMode(DataNormalizationMode.Raw); });
+
+            Assert.Throws(typeof(ArgumentException), () => { subscriptionDataConfigList.SetDataNormalizationMode(DataNormalizationMode.Adjusted); });
+            Assert.Throws(typeof(ArgumentException), () => { subscriptionDataConfigList.SetDataNormalizationMode(DataNormalizationMode.SplitAdjusted); });
+            Assert.Throws(typeof(ArgumentException), () => { subscriptionDataConfigList.SetDataNormalizationMode(DataNormalizationMode.Adjusted); });
+            Assert.Throws(typeof(ArgumentException), () => { subscriptionDataConfigList.SetDataNormalizationMode(DataNormalizationMode.TotalReturn); });
         }
 
         private SubscriptionDataConfig CreateTradeBarConfig()


### PR DESCRIPTION
This PR ensures that the data normalization for options can only ever be Raw. Options now have a default data normalization of Raw (set in the constructor). Similarly, if the data normalization mode for an option is ever set to anything other than Raw - Lean will throw an error.