### PR TITLE
Fix AlgorithmPerformance property setters for JSON deserialization

### DIFF
--- a/Common/Statistics/AlgorithmPerformance.cs
+++ b/Common/Statistics/AlgorithmPerformance.cs
@@ -26,17 +26,17 @@ namespace QuantConnect.Statistics
         /// <summary>
         /// The algorithm statistics on closed trades
         /// </summary>
-        public TradeStatistics TradeStatistics { get; private set; }
+        public TradeStatistics TradeStatistics { get; set; }
 
         /// <summary>
         /// The algorithm statistics on portfolio
         /// </summary>
-        public PortfolioStatistics PortfolioStatistics { get; private set; }
+        public PortfolioStatistics PortfolioStatistics { get; set; }
 
         /// <summary>
         /// The list of closed trades
         /// </summary>
-        public List<Trade> ClosedTrades { get; private set; }
+        public List<Trade> ClosedTrades { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AlgorithmPerformance"/> class

--- a/Common/Statistics/PortfolioStatistics.cs
+++ b/Common/Statistics/PortfolioStatistics.cs
@@ -30,94 +30,94 @@ namespace QuantConnect.Statistics
         /// <summary>
         /// The average rate of return for winning trades
         /// </summary>
-        public decimal AverageWinRate { get; private set; }
+        public decimal AverageWinRate { get; set; }
 
         /// <summary>
         /// The average rate of return for losing trades
         /// </summary>
-        public decimal AverageLossRate { get; private set; }
+        public decimal AverageLossRate { get; set; }
 
         /// <summary>
         /// The ratio of the average win rate to the average loss rate
         /// </summary>
         /// <remarks>If the average loss rate is zero, ProfitLossRatio is set to 0</remarks>
-        public decimal ProfitLossRatio { get; private set; }
+        public decimal ProfitLossRatio { get; set; }
 
         /// <summary>
         /// The ratio of the number of winning trades to the total number of trades
         /// </summary>
         /// <remarks>If the total number of trades is zero, WinRate is set to zero</remarks>
-        public decimal WinRate { get; private set; }
+        public decimal WinRate { get; set; }
 
         /// <summary>
         /// The ratio of the number of losing trades to the total number of trades
         /// </summary>
         /// <remarks>If the total number of trades is zero, LossRate is set to zero</remarks>
-        public decimal LossRate { get; private set; }
+        public decimal LossRate { get; set; }
 
         /// <summary>
         /// The expected value of the rate of return
         /// </summary>
-        public decimal Expectancy { get; private set; }
+        public decimal Expectancy { get; set; }
 
         /// <summary>
         /// Annual compounded returns statistic based on the final-starting capital and years.
         /// </summary>
         /// <remarks>Also known as Compound Annual Growth Rate (CAGR)</remarks>
-        public decimal CompoundingAnnualReturn { get; private set; }
+        public decimal CompoundingAnnualReturn { get; set; }
 
         /// <summary>
         /// Drawdown maximum percentage.
         /// </summary>
-        public decimal Drawdown { get; private set; }
+        public decimal Drawdown { get; set; }
 
         /// <summary>
         /// The total net profit percentage.
         /// </summary>
-        public decimal TotalNetProfit { get; private set; }
+        public decimal TotalNetProfit { get; set; }
 
         /// <summary>
         /// Sharpe ratio with respect to risk free rate: measures excess of return per unit of risk.
         /// </summary>
         /// <remarks>With risk defined as the algorithm's volatility</remarks>
-        public decimal SharpeRatio { get; private set; }
+        public decimal SharpeRatio { get; set; }
 
         /// <summary>
         /// Algorithm "Alpha" statistic - abnormal returns over the risk free rate and the relationshio (beta) with the benchmark returns.
         /// </summary>
-        public decimal Alpha { get; private set; }
+        public decimal Alpha { get; set; }
 
         /// <summary>
         /// Algorithm "beta" statistic - the covariance between the algorithm and benchmark performance, divided by benchmark's variance
         /// </summary>
-        public decimal Beta { get; private set; }
+        public decimal Beta { get; set; }
 
         /// <summary>
         /// Annualized standard deviation
         /// </summary>
-        public decimal AnnualStandardDeviation { get; private set; }
+        public decimal AnnualStandardDeviation { get; set; }
 
         /// <summary>
         /// Annualized variance statistic calculation using the daily performance variance and trading days per year.
         /// </summary>
-        public decimal AnnualVariance { get; private set; }
+        public decimal AnnualVariance { get; set; }
 
         /// <summary>
         /// Information ratio - risk adjusted return
         /// </summary>
         /// <remarks>(risk = tracking error volatility, a volatility measures that considers the volatility of both algo and benchmark)</remarks>
-        public decimal InformationRatio { get; private set; }
+        public decimal InformationRatio { get; set; }
 
         /// <summary>
         /// Tracking error volatility (TEV) statistic - a measure of how closely a portfolio follows the index to which it is benchmarked
         /// </summary>
         /// <remarks>If algo = benchmark, TEV = 0</remarks>
-        public decimal TrackingError { get; private set; }
+        public decimal TrackingError { get; set; }
 
         /// <summary>
         /// Treynor ratio statistic is a measurement of the returns earned in excess of that which could have been earned on an investment that has no diversifiable risk
         /// </summary>
-        public decimal TreynorRatio { get; private set; }
+        public decimal TreynorRatio { get; set; }
 
 
         /// <summary>

--- a/Common/Statistics/TradeStatistics.cs
+++ b/Common/Statistics/TradeStatistics.cs
@@ -26,204 +26,204 @@ namespace QuantConnect.Statistics
         /// <summary>
         /// The entry date/time of the first trade
         /// </summary>
-        public DateTime? StartDateTime { get; private set; }
+        public DateTime? StartDateTime { get; set; }
 
         /// <summary>
         /// The exit date/time of the last trade
         /// </summary>
-        public DateTime? EndDateTime { get; private set; }
+        public DateTime? EndDateTime { get; set; }
 
         /// <summary>
         /// The total number of trades
         /// </summary>
-        public int TotalNumberOfTrades { get; private set; }
+        public int TotalNumberOfTrades { get; set; }
 
         /// <summary>
         /// The total number of winning trades
         /// </summary>
-        public int NumberOfWinningTrades { get; private set; }
+        public int NumberOfWinningTrades { get; set; }
 
         /// <summary>
         /// The total number of losing trades
         /// </summary>
-        public int NumberOfLosingTrades { get; private set; }
+        public int NumberOfLosingTrades { get; set; }
 
         /// <summary>
         /// The total profit/loss for all trades (as symbol currency)
         /// </summary>
-        public decimal TotalProfitLoss { get; private set; }
+        public decimal TotalProfitLoss { get; set; }
 
         /// <summary>
         /// The total profit for all winning trades (as symbol currency)
         /// </summary>
-        public decimal TotalProfit { get; private set; }
+        public decimal TotalProfit { get; set; }
 
         /// <summary>
         /// The total loss for all losing trades (as symbol currency)
         /// </summary>
-        public decimal TotalLoss { get; private set; }
+        public decimal TotalLoss { get; set; }
 
         /// <summary>
         /// The largest profit in a single trade (as symbol currency)
         /// </summary>
-        public decimal LargestProfit { get; private set; }
+        public decimal LargestProfit { get; set; }
 
         /// <summary>
         /// The largest loss in a single trade (as symbol currency)
         /// </summary>
-        public decimal LargestLoss { get; private set; }
+        public decimal LargestLoss { get; set; }
 
         /// <summary>
         /// The average profit/loss (a.k.a. Expectancy or Average Trade) for all trades (as symbol currency)
         /// </summary>
-        public decimal AverageProfitLoss { get; private set; }
+        public decimal AverageProfitLoss { get; set; }
 
         /// <summary>
         /// The average profit for all winning trades (as symbol currency)
         /// </summary>
-        public decimal AverageProfit { get; private set; }
+        public decimal AverageProfit { get; set; }
 
         /// <summary>
         /// The average loss for all winning trades (as symbol currency)
         /// </summary>
-        public decimal AverageLoss { get; private set; }
+        public decimal AverageLoss { get; set; }
 
         /// <summary>
         /// The average duration for all trades
         /// </summary>
-        public TimeSpan AverageTradeDuration { get; private set; }
+        public TimeSpan AverageTradeDuration { get; set; }
 
         /// <summary>
         /// The average duration for all winning trades
         /// </summary>
-        public TimeSpan AverageWinningTradeDuration { get; private set; }
+        public TimeSpan AverageWinningTradeDuration { get; set; }
 
         /// <summary>
         /// The average duration for all losing trades
         /// </summary>
-        public TimeSpan AverageLosingTradeDuration { get; private set; }
+        public TimeSpan AverageLosingTradeDuration { get; set; }
 
         /// <summary>
         /// The maximum number of consecutive winning trades
         /// </summary>
-        public int MaxConsecutiveWinningTrades { get; private set; }
+        public int MaxConsecutiveWinningTrades { get; set; }
 
         /// <summary>
         /// The maximum number of consecutive losing trades
         /// </summary>
-        public int MaxConsecutiveLosingTrades { get; private set; }
+        public int MaxConsecutiveLosingTrades { get; set; }
 
         /// <summary>
         /// The ratio of the average profit per trade to the average loss per trade
         /// </summary>
         /// <remarks>If the average loss is zero, ProfitLossRatio is set to 0</remarks>
-        public decimal ProfitLossRatio { get; private set; }
+        public decimal ProfitLossRatio { get; set; }
 
         /// <summary>
         /// The ratio of the number of winning trades to the number of losing trades
         /// </summary>
         /// <remarks>If the total number of trades is zero, WinLossRatio is set to zero</remarks>
         /// <remarks>If the number of losing trades is zero and the number of winning trades is nonzero, WinLossRatio is set to 10</remarks>
-        public decimal WinLossRatio { get; private set; }
+        public decimal WinLossRatio { get; set; }
 
         /// <summary>
         /// The ratio of the number of winning trades to the total number of trades
         /// </summary>
         /// <remarks>If the total number of trades is zero, WinRate is set to zero</remarks>
-        public decimal WinRate { get; private set; }
+        public decimal WinRate { get; set; }
 
         /// <summary>
         /// The ratio of the number of losing trades to the total number of trades
         /// </summary>
         /// <remarks>If the total number of trades is zero, LossRate is set to zero</remarks>
-        public decimal LossRate { get; private set; }
+        public decimal LossRate { get; set; }
 
         /// <summary>
         /// The average Maximum Adverse Excursion for all trades
         /// </summary>
-        public decimal AverageMAE { get; private set; }
+        public decimal AverageMAE { get; set; }
 
         /// <summary>
         /// The average Maximum Favorable Excursion for all trades
         /// </summary>
-        public decimal AverageMFE { get; private set; }
+        public decimal AverageMFE { get; set; }
 
         /// <summary>
         /// The largest Maximum Adverse Excursion in a single trade (as symbol currency)
         /// </summary>
-        public decimal LargestMAE { get; private set; }
+        public decimal LargestMAE { get; set; }
 
         /// <summary>
         /// The largest Maximum Favorable Excursion in a single trade (as symbol currency)
         /// </summary>
-        public decimal LargestMFE { get; private set; }
+        public decimal LargestMFE { get; set; }
 
         /// <summary>
         /// The maximum closed-trade drawdown for all trades (as symbol currency)
         /// </summary>
         /// <remarks>The calculation only takes into account the profit/loss of each trade</remarks>
-        public decimal MaximumClosedTradeDrawdown { get; private set; }
+        public decimal MaximumClosedTradeDrawdown { get; set; }
 
         /// <summary>
         /// The maximum intra-trade drawdown for all trades (as symbol currency)
         /// </summary>
         /// <remarks>The calculation takes into account MAE and MFE of each trade</remarks>
-        public decimal MaximumIntraTradeDrawdown { get; private set; }
+        public decimal MaximumIntraTradeDrawdown { get; set; }
 
         /// <summary>
         /// The standard deviation of the profits/losses for all trades (as symbol currency)
         /// </summary>
-        public decimal ProfitLossStandardDeviation { get; private set; }
+        public decimal ProfitLossStandardDeviation { get; set; }
 
         /// <summary>
         /// The downside deviation of the profits/losses for all trades (as symbol currency)
         /// </summary>
         /// <remarks>This metric only considers deviations of losing trades</remarks>
-        public decimal ProfitLossDownsideDeviation { get; private set; }
+        public decimal ProfitLossDownsideDeviation { get; set; }
 
         /// <summary>
         /// The ratio of the total profit to the total loss
         /// </summary>
         /// <remarks>If the total profit is zero, ProfitFactor is set to zero</remarks>
         /// <remarks>if the total loss is zero and the total profit is nonzero, ProfitFactor is set to 10</remarks>
-        public decimal ProfitFactor { get; private set; }
+        public decimal ProfitFactor { get; set; }
 
         /// <summary>
         /// The ratio of the average profit/loss to the standard deviation
         /// </summary>
-        public decimal SharpeRatio { get; private set; }
+        public decimal SharpeRatio { get; set; }
 
         /// <summary>
         /// The ratio of the average profit/loss to the downside deviation
         /// </summary>
-        public decimal SortinoRatio { get; private set; }
+        public decimal SortinoRatio { get; set; }
 
         /// <summary>
         /// The ratio of the total profit/loss to the maximum closed trade drawdown
         /// </summary>
         /// <remarks>If the total profit/loss is zero, ProfitToMaxDrawdownRatio is set to zero</remarks>
         /// <remarks>if the drawdown is zero and the total profit is nonzero, ProfitToMaxDrawdownRatio is set to 10</remarks>
-        public decimal ProfitToMaxDrawdownRatio { get; private set; }
+        public decimal ProfitToMaxDrawdownRatio { get; set; }
 
         /// <summary>
         /// The maximum amount of profit given back by a single trade before exit (as symbol currency)
         /// </summary>
-        public decimal MaximumEndTradeDrawdown { get; private set; }
+        public decimal MaximumEndTradeDrawdown { get; set; }
 
         /// <summary>
         /// The average amount of profit given back by all trades before exit (as symbol currency)
         /// </summary>
-        public decimal AverageEndTradeDrawdown { get; private set; }
+        public decimal AverageEndTradeDrawdown { get; set; }
 
         /// <summary>
         /// The maximum amount of time to recover from a drawdown (longest time between new equity highs or peaks)
         /// </summary>
-        public TimeSpan MaximumDrawdownDuration { get; private set; }
+        public TimeSpan MaximumDrawdownDuration { get; set; }
 
         /// <summary>
         /// The sum of fees for all trades
         /// </summary>
-        public decimal TotalFees { get; private set; }
+        public decimal TotalFees { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TradeStatistics"/> class


### PR DESCRIPTION
`AlgorithmPerformance`, `PortfolioStatistics` and `TradeStatistics` had private setters, so JSON deserialization could not populate their properties.