### PR TITLE
Let Lean set it's own start date during backtesting

### DIFF
--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -185,8 +185,6 @@ namespace QuantConnect.Lean.Engine.Setup
                     algorithm.SetParameters(job.Parameters);
                     //Algorithm is backtesting, not live:
                     algorithm.SetLiveMode(false);
-                    //Set the algorithm time before we even initialize:
-                    algorithm.SetDateTime(job.PeriodStart.ConvertToUtc(algorithm.TimeZone));
                     //Set the source impl for the event scheduling
                     algorithm.Schedule.SetEventSchedule(realTimeHandler);
                     //Initialise the algorithm, get the required data:
@@ -201,6 +199,10 @@ namespace QuantConnect.Lean.Engine.Setup
 
             //Before continuing, detect if this is ready:
             if (!initializeComplete) return false;
+
+            //TODO: Refactor the BacktestResultHandler to use algorithm not job to set times
+            job.PeriodStart = algorithm.StartDate;
+            job.PeriodFinish = algorithm.EndDate;
 
             algorithm.PostInitialize();
 

--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -200,7 +200,7 @@ namespace QuantConnect.Lean.Engine.Setup
             //Before continuing, detect if this is ready:
             if (!initializeComplete) return false;
 
-            //TODO: Refactor the BacktestResultHandler to use algorithm not job to set times
+            // TODO: Refactor the BacktestResultHandler to use algorithm not job to set times
             job.PeriodStart = algorithm.StartDate;
             job.PeriodFinish = algorithm.EndDate;
 


### PR DESCRIPTION
`IAlgrithom` sets it's own start and end dates based on the `IAlgorithm.Initialize()` method.

Start and end dates used in the `BacktestingResultHandler` are now set by the `IAlgorithm` instance in `BacktestingSetupHandler.Setup()`