### PR TITLE
Fix bug in IB reconnect logic

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1106,6 +1106,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     Log.Trace("InteractiveBrokersBrokerage.TryWaitForReconnect(): Reset time finished and still disconnected. Restarting...");
 
                     _disconnected1100Fired = false;
+
+                    // notify the BrokerageMessageHandler before the restart, so it can stop polling
+                    OnMessage(BrokerageMessageEvent.Reconnected(string.Empty));
+
                     ResetGatewayConnection();
                 }
                 else


### PR DESCRIPTION
This bug was causing algorithms to be terminated with this event sequence:
1. normal disconnect message received during server reset times
2. no reconnect message received during server reset times
3. algorithm terminated 15 minutes after end of server reset times