### PR TITLE
Fix open interest bug setting value to zero for contracts added intraday

### DIFF
--- a/Common/Data/Market/OpenInterest.cs
+++ b/Common/Data/Market/OpenInterest.cs
@@ -1,10 +1,21 @@
-﻿using QuantConnect.Logging;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 using QuantConnect.Util;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace QuantConnect.Data.Market
 {

--- a/Common/Data/UniverseSelection/SubscriptionRequest.cs
+++ b/Common/Data/UniverseSelection/SubscriptionRequest.cs
@@ -103,7 +103,13 @@ namespace QuantConnect.Data.UniverseSelection
             Universe = universe;
             Security = security;
             Configuration = configuration;
-            StartTimeUtc = startTimeUtc;
+
+            // open interest data comes in once a day before market open,
+            // make the subscription start from midnight
+            StartTimeUtc = configuration.TickType == TickType.OpenInterest ?
+                startTimeUtc.ConvertFromUtc(Configuration.ExchangeTimeZone).Date.ConvertToUtc(Configuration.ExchangeTimeZone) :
+                startTimeUtc;
+
             EndTimeUtc = endTimeUtc;
 
             _localStartTime = new Lazy<DateTime>(() => StartTimeUtc.ConvertFromUtc(Configuration.ExchangeTimeZone));


### PR DESCRIPTION
When using a filter function creating a dynamic chain universe, contracts added during the day would have the value of open interest set to zero.