### PR TITLE
Fix IB bug causing error "Already Connected"

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -577,8 +577,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// </summary>
         public override void Disconnect()
         {
-            if (!IsConnected) return;
-
             _client.ClientSocket.eDisconnect();
         }
 
@@ -1008,7 +1006,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             else if (errorCode == 1102 || errorCode == 1101)
             {
                 // we've reconnected
-                _disconnected1100Fired = false;
                 OnMessage(BrokerageMessageEvent.Reconnected(errorMsg));
 
                 OnMessage(new BrokerageMessageEvent(brokerageMessageType, errorCode, errorMsg));
@@ -1047,8 +1044,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Restarts the IB Gateway and restores the connection
         /// </summary>
-        private void ResetGatewayConnection()
+        public void ResetGatewayConnection()
         {
+            _disconnected1100Fired = false;
+
             Log.Trace("InteractiveBrokersBrokerage.ResetGatewayConnection(): Disconnecting...");
             Disconnect();
 
@@ -1104,8 +1103,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 {
                     // reset time finished and we're still disconnected, restart IB client
                     Log.Trace("InteractiveBrokersBrokerage.TryWaitForReconnect(): Reset time finished and still disconnected. Restarting...");
-
-                    _disconnected1100Fired = false;
 
                     // notify the BrokerageMessageHandler before the restart, so it can stop polling
                     OnMessage(BrokerageMessageEvent.Reconnected(string.Empty));
@@ -2532,7 +2529,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Check if IB Gateway running, restart if not
         /// </summary>
-        private void CheckIbGateway()
+        public void CheckIbGateway()
         {
             Log.Trace("InteractiveBrokersBrokerage.CheckIbGateway(): start");
             if (!InteractiveBrokersGatewayRunner.IsRunning())

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
@@ -131,6 +131,33 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         }
 
         [Test]
+        public void IsConnectedUpdatesCorrectly()
+        {
+            var ib = _interactiveBrokersBrokerage;
+            Assert.IsTrue(ib.IsConnected);
+
+            ib.Disconnect();
+            Assert.IsFalse(ib.IsConnected);
+
+            ib.Connect();
+            Assert.IsTrue(ib.IsConnected);
+        }
+
+        [Test]
+        public void IsConnectedAfterReset()
+        {
+            var ib = _interactiveBrokersBrokerage;
+            Assert.IsTrue(ib.IsConnected);
+
+            ib.ResetGatewayConnection();
+            Assert.IsTrue(InteractiveBrokersGatewayRunner.IsRunning());
+            Assert.IsTrue(ib.IsConnected);
+
+            ib.CheckIbGateway();
+            Assert.IsTrue(ib.IsConnected);
+        }
+
+        [Test]
         public void PlacedOrderHasNewBrokerageOrderID()
         {
             var ib = _interactiveBrokersBrokerage;


### PR DESCRIPTION
After the previous nightly reset, `CheckIbGateway` wasn't detecting the connection state properly.