### PR TITLE
Update zip entry path of equity Tick files

### DIFF
--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -373,6 +373,16 @@ namespace QuantConnect.Util
                 case SecurityType.Equity:
                 case SecurityType.Forex:
                 case SecurityType.Cfd:
+                    if (resolution == Resolution.Tick && symbol.SecurityType == SecurityType.Equity)
+                    {
+                        return string.Format("{0}_{1}_{2}_{3}.csv",
+                            formattedDate,
+                            symbol.Value.ToLower(),
+                            tickType,
+                            resolution
+                        );
+                    }
+
                     if (isHourOrDaily)
                     {
                         return string.Format("{0}.csv", 

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -300,7 +300,7 @@ namespace QuantConnect.Tests.Common.Util
             return new List<LeanDataTestParameters>
             {
                 // equity
-                new LeanDataTestParameters(Symbols.SPY, date, Resolution.Tick, TickType.Trade, "20160217_trade.zip", "20160217_spy_tick_trade.csv", "equity/usa/tick/spy"),
+                new LeanDataTestParameters(Symbols.SPY, date, Resolution.Tick, TickType.Trade, "20160217_trade.zip", "20160217_spy_Trade_Tick.csv", "equity/usa/tick/spy"),
                 new LeanDataTestParameters(Symbols.SPY, date, Resolution.Second, TickType.Trade, "20160217_trade.zip", "20160217_spy_second_trade.csv", "equity/usa/second/spy"),
                 new LeanDataTestParameters(Symbols.SPY, date, Resolution.Minute, TickType.Trade, "20160217_trade.zip", "20160217_spy_minute_trade.csv", "equity/usa/minute/spy"),
                 new LeanDataTestParameters(Symbols.SPY, date, Resolution.Hour, TickType.Trade, "spy.zip", "spy.csv", "equity/usa/hour"),


### PR DESCRIPTION
Fixed bug where zip entry path created by `LeanData.GenerateZipEntryName()` is incorrect for equity tick files.

Was created like, "20160217_spy_tick_trade.csv"
Should be created like, "20160217_spy_Trade_Tick.csv"