### PR TITLE
Stop sending emails for brokerage warnings

### DIFF
--- a/Common/Brokerages/DefaultBrokerageMessageHandler.cs
+++ b/Common/Brokerages/DefaultBrokerageMessageHandler.cs
@@ -77,7 +77,6 @@ namespace QuantConnect.Brokerages
                 
                 case BrokerageMessageType.Warning:
                     _algorithm.Error("Brokerage Warning: " + message.Message);
-                    _api.SendUserEmail(_job.AlgorithmId, "Brokerage Warning", message.Message);
                     break;
 
                 case BrokerageMessageType.Error:


### PR DESCRIPTION
These warnings will still be displayed in the console.