### PR TITLE
Fixes message about having too may symbols

### DIFF
--- a/Engine/DataFeeds/SubscriptionLimiter.cs
+++ b/Engine/DataFeeds/SubscriptionLimiter.cs
@@ -156,7 +156,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private string GetCountLimitReason(Resolution resolution)
         {
             var limit = GetResolutionLimit(resolution);
-            return string.Format("We currently only support {0} {1} at a time due to physical memory limitations", limit, resolution.ToString().ToLower());
+            return string.Format("We currently only support {0} symbols subscribed with {1} resolution at a time due to physical memory limitations", limit, resolution.ToString().ToLower());
         }
 
         /// <summary>


### PR DESCRIPTION
Previous message was not user-friendly:
We currently only support 50 second at a time due to physical memory limitations
Changed for:
We currently only support 50 symbols subscribed with second resolution at a time due to physical memory limitations