### PR TITLE
Fix a couple of bugs in BasicTemplateOptionsAlgorithm

### DIFF
--- a/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
@@ -19,7 +19,6 @@ using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
-using QuantConnect.Securities;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -57,15 +56,16 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="slice">The current slice of data keyed by symbol string</param>
         public override void OnData(Slice slice)
         {
-            if (!Portfolio.Invested)
+            if (!Portfolio.Invested && IsMarketOpen(OptionSymbol))
             {
                 OptionChain chain;
                 if (slice.OptionChains.TryGetValue(OptionSymbol, out chain))
                 {
-                    // we find at the money (ATM) contract with farthest expiration
+                    // we find at the money (ATM) put contract with farthest expiration
                     var atmContract = chain
                         .OrderByDescending(x => x.Expiry)
                         .ThenBy(x => Math.Abs(chain.Underlying.Price - x.Strike))
+                        .ThenByDescending(x => x.Right)
                         .FirstOrDefault();
 
                     if (atmContract != null)

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -1044,6 +1044,22 @@ namespace QuantConnect.Algorithm
             return Order(symbol, (decimal)quantity);
         }
 
+        /// <summary>
+        /// Determines if the exchange for the specified symbol is open at the current time.
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <returns>True if the exchange is considered open at the current time, false otherwise</returns>
+        public bool IsMarketOpen(Symbol symbol)
+        {
+            var exchangeHours = MarketHoursDatabase
+                .FromDataFolder()
+                .GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+
+            var time = UtcTime.ConvertFromUtc(exchangeHours.TimeZone);
+
+            return exchangeHours.IsOpen(time, false);
+        }
+
         private SubmitOrderRequest CreateSubmitOrderRequest(OrderType orderType, Security security, decimal quantity, string tag, decimal stopPrice = 0m, decimal limitPrice = 0m)
         {
             return new SubmitOrderRequest(orderType, security.Type, security.Symbol, quantity, stopPrice, limitPrice, UtcTime, tag);


### PR DESCRIPTION
The algorithm had two issues:
1. the LINQ query for contract selection was not including the option right (Put or Call)
2. the algorithm was submitting two extra orders at the end of the day (when market closed)

A helper method was also added in QCAlgorithm to determine if the market is open for a given symbol at the current time.