### PR TITLE
Updated Brokerage ID for paper trading

### DIFF
--- a/Common/API/LiveAlgorithmSettings.cs
+++ b/Common/API/LiveAlgorithmSettings.cs
@@ -169,7 +169,7 @@ namespace QuantConnect.API
                                                 string account)
             : base(user, password, environment, account)
         {
-            Id = BrokerageName.Default.ToString();
+            Id = "QuantConnectBrokerage";
         }
     }
 

--- a/Common/API/LiveAlgorithmSettings.cs
+++ b/Common/API/LiveAlgorithmSettings.cs
@@ -169,7 +169,7 @@ namespace QuantConnect.API
                                                 string account)
             : base(user, password, environment, account)
         {
-            Id = "QuantConnectBrokerage";
+            Id = BrokerageName.QuantConnectBrokerage.ToString();
         }
     }
 

--- a/Common/Brokerages/BrokerageName.cs
+++ b/Common/Brokerages/BrokerageName.cs
@@ -26,6 +26,12 @@ namespace QuantConnect.Brokerages
         Default,
 
         /// <summary>
+        /// Transaction and submit/execution rules will be the default as initialized
+        /// Alternate naming for default brokerage
+        /// </summary>
+        QuantConnectBrokerage = Default,
+
+        /// <summary>
         /// Transaction and submit/execution rules will use interactive brokers models
         /// </summary>
         InteractiveBrokersBrokerage,

--- a/Tests/Common/BrokerageNameTests.cs
+++ b/Tests/Common/BrokerageNameTests.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using QuantConnect.Brokerages;
+
+namespace QuantConnect.Tests.Common
+{
+    [TestFixture]
+    public class BrokerageNameTests
+    {
+        [Test]
+        public void BrokerageNameEnumsAreNumberedCorrectly()
+        {
+            Assert.AreEqual((int) BrokerageName.Default, 0);
+            Assert.AreEqual((int) BrokerageName.QuantConnectBrokerage, 0);
+            Assert.AreEqual((int) BrokerageName.InteractiveBrokersBrokerage, 1);
+            Assert.AreEqual((int) BrokerageName.TradierBrokerage, 2);
+            Assert.AreEqual((int) BrokerageName.OandaBrokerage, 3);
+            Assert.AreEqual((int) BrokerageName.FxcmBrokerage, 4);
+            Assert.AreEqual((int) BrokerageName.Bitfinex, 5);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Brokerages\Tradier\TradierBrokerageHistoryProviderTests.cs" />
     <Compile Include="Brokerages\Tradier\TradierBrokerageSerializationTests.cs" />
     <Compile Include="Brokerages\Tradier\TradierBrokerageTests.cs" />
+    <Compile Include="Common\BrokerageNameTests.cs" />
     <Compile Include="Common\CurrenciesTests.cs" />
     <Compile Include="Common\Data\Market\QuoteBarTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />


### PR DESCRIPTION
When paper trading on QC, the default brokerage name (api parameter "id") is "QuantConnectBrokerage" and not "Default".