### PR TITLE
Fix error generating statistics packet

### DIFF
--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -307,7 +307,10 @@ namespace QuantConnect.Lean.Engine
                             // make sure we've taken samples for these series before just blindly requesting them
                             if (charts.ContainsKey(strategyEquityKey) &&
                                 charts[strategyEquityKey].Series.ContainsKey(equityKey) &&
-                                charts[strategyEquityKey].Series.ContainsKey(dailyPerformanceKey))
+                                charts[strategyEquityKey].Series.ContainsKey(dailyPerformanceKey) &&
+                                charts.ContainsKey(benchmarkKey) &&
+                                charts[benchmarkKey].Series.ContainsKey(benchmarkKey)
+                            )
                             {
                                 var equity = charts[strategyEquityKey].Series[equityKey].Values;
                                 var performance = charts[strategyEquityKey].Series[dailyPerformanceKey].Values;


### PR DESCRIPTION
If an algorithm throws an exception immediately from `OnData`, another error is thrown:

```
Error generating statistics packet
System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
```