### PR TITLE
Implements Quandl support for Python

### DIFF
--- a/Algorithm.Python/CustomDataNIFTYAlgorithm.py
+++ b/Algorithm.Python/CustomDataNIFTYAlgorithm.py
@@ -66,7 +66,7 @@ class CustomDataNIFTYAlgorithm(QCAlgorithm):
         if self.Time.weekday() != 2: return
 
         cur_qnty = self.Portfolio["NIFTY"].Quantity
-        quantity = math.floor(self.Portfolio.MarginRemaining * decimal.Decimal(0.9) / data["NIFTY"].Close)
+        quantity = decimal.Decimal(math.floor(self.Portfolio.MarginRemaining * decimal.Decimal(0.9) / data["NIFTY"].Close))
         hi_nifty = max(price.NiftyPrice for price in self.prices)
         lo_nifty = min(price.NiftyPrice for price in self.prices)
 

--- a/Algorithm.Python/QCUWeatherBasedRebalancing.py
+++ b/Algorithm.Python/QCUWeatherBasedRebalancing.py
@@ -83,8 +83,9 @@ class Weather(PythonData):
         weather = Weather()
         weather.Symbol = config.Symbol
         weather.Time = datetime.strptime(data[0], '%Y-%m-%d') + timedelta(hours=20) # Make sure we only get this data AFTER trading day - don't want forward bias.
+        if not data[2]: return None
         weather.Value = decimal.Decimal(data[2])
-        weather["MaxC"] = float(data[1])
-        weather["MinC"] = float(data[3])
+        weather["Max.C"] = float(data[1])   # Using a dot in the propety name, it will capitalize the first letter of each word:
+        weather["Min.C"] = float(data[3])   # Max.C -> MaxC and Min.C -> MinC
 
         return weather

--- a/Algorithm.Python/QCUWeatherBasedRebalancing.py
+++ b/Algorithm.Python/QCUWeatherBasedRebalancing.py
@@ -83,6 +83,7 @@ class Weather(PythonData):
         weather = Weather()
         weather.Symbol = config.Symbol
         weather.Time = datetime.strptime(data[0], '%Y-%m-%d') + timedelta(hours=20) # Make sure we only get this data AFTER trading day - don't want forward bias.
+        # If the second column is an invalid value (empty string), return None. The algorithm will discard it.
         if not data[2]: return None
         weather.Value = decimal.Decimal(data[2])
         weather["Max.C"] = float(data[1])   # Using a dot in the propety name, it will capitalize the first letter of each word:

--- a/Algorithm.Python/QuandlFuturesDataAlgorithm.py
+++ b/Algorithm.Python/QuandlFuturesDataAlgorithm.py
@@ -35,6 +35,7 @@ class QCUQuandlFutures(QCAlgorithm):
         self.SetEndDate(datetime.now().date() - timedelta(1))
         self.SetCash(25000);
 
+        # Symbol corresponding to the quandl code
         self.crude = "SCF/CME_CL1_ON"
         self.AddData(QuandlFuture, self.crude, Resolution.Daily)
 
@@ -50,4 +51,7 @@ class QCUQuandlFutures(QCAlgorithm):
 class QuandlFuture(PythonQuandl):
     '''Custom quandl data type for setting customized value column name. Value column is used for the primary trading calculations and charting.'''
     def __init__(self):
+        # Define ValueColumnName: cannot be None, Empty or non-existant column name
+        # If ValueColumnName is "Close", do not use PythonQuandl, use Quandl:
+        # self.AddData[QuandlFuture](self.crude, Resolution.Daily)
         self.ValueColumnName = "Settle"

--- a/Algorithm.Python/QuandlFuturesDataAlgorithm.py
+++ b/Algorithm.Python/QuandlFuturesDataAlgorithm.py
@@ -1,0 +1,53 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Python import PythonQuandl
+from datetime import datetime, timedelta
+
+class QCUQuandlFutures(QCAlgorithm):
+    '''QuantConnect University: Futures Example 
+    QuantConnect allows importing generic data sources! This example demonstrates 
+    importing a futures data from the popular open data source Quandl.
+    QuantConnect has a special deal with Quandl giving you access to Stevens Continuous Futurs (SCF) for free.
+    If you'd like to download SCF for local backtesting, you can download it through Quandl.com.'''
+
+    def Initialize(self):
+        ''' Initialize the data and resolution you require for your strategy '''
+        self.SetStartDate(2000, 1, 1)
+        self.SetEndDate(datetime.now().date() - timedelta(1))
+        self.SetCash(25000);
+
+        self.crude = "SCF/CME_CL1_ON"
+        self.AddData(QuandlFuture, self.crude, Resolution.Daily)
+
+
+    def OnData(self, data):
+        '''Data Event Handler: New data arrives here. "TradeBars" type is a dictionary of strings so you can access it by symbol.'''
+        if self.Portfolio.HoldStock: return
+     
+        self.SetHoldings(self.crude, 1);
+        self.Debug(str(self.Time) + str(" Purchased Crude Oil: ") + self.crude)
+
+
+class QuandlFuture(PythonQuandl):
+    '''Custom quandl data type for setting customized value column name. Value column is used for the primary trading calculations and charting.'''
+    def __init__(self):
+        self.ValueColumnName = "Settle"

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -34,6 +34,9 @@
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="QuandlFuturesDataAlgorithm.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="CustomChartingAlgorithm.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -898,7 +898,6 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
                 "from clr import AddReference\n" +
                 "AddReference(\"System\")\n" +
                 "AddReference(\"QuantConnect.Common\")\n" +
-                "from QuantConnect.Python import PythonData\n" +
                 "import decimal\n" +
 
                 // OnPythonData call OnData after converting the Slice object
@@ -919,11 +918,12 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
                 "        for member in members:\n" +
                 "            setattr(self, member, getattr(data, member))\n" +
 
-                "        if not isinstance(data, PythonData): return\n" +
+                "        if not hasattr(data, 'GetStorageDictionary'): return\n" +
 
-                "        for member in data.DynamicMembers:\n" +
-                "            val = data[member]\n" +
-                "            setattr(self, member, decimal.Decimal(val) if isinstance(val, float) else val)";
+                "        for kvp in data.GetStorageDictionary():\n" +
+                "           name = kvp.Key.replace('-',' ').replace('.',' ').title().replace(' ', '')\n" +
+                "           value = decimal.Decimal(kvp.Value) if isinstance(kvp.Value, float) else kvp.Value\n" +
+                "           setattr(self, name, value)";
 
             using (Py.GIL())
             {

--- a/Common/Data/DynamicData.cs
+++ b/Common/Data/DynamicData.cs
@@ -125,6 +125,16 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
+        /// Gets the storage dictionary
+        /// Python algorithms need this information since DynamicMetaObject does not work
+        /// </summary>
+        /// <returns>Dictionary that stores the paramenters names and values</returns>
+        public IDictionary<string, object> GetStorageDictionary()
+        {
+            return _storage;
+        }
+
+        /// <summary>
         /// Return a new instance clone of this object, used in fill forward
         /// </summary>
         /// <remarks>

--- a/Common/Python/PythonData.cs
+++ b/Common/Python/PythonData.cs
@@ -16,7 +16,6 @@
 using Python.Runtime;
 using QuantConnect.Data;
 using System;
-using System.Collections.Generic;
 
 namespace QuantConnect.Python
 {
@@ -27,12 +26,7 @@ namespace QuantConnect.Python
     public class PythonData : DynamicData
     {
         private readonly dynamic _pythonData;
-
-        /// <summary>
-        /// List of Dynamic Members
-        /// </summary>
-        public List<string> DynamicMembers = new List<string>();
-
+        
         /// <summary>
         /// Constructor for initialising the PythonData class
         /// </summary>
@@ -80,8 +74,7 @@ namespace QuantConnect.Python
                 return _pythonData.Reader(config, line, date, isLiveMode);
             }
         }
-
-
+        
         /// <summary>
         /// Indexes into this PythonData, where index is key to the dynamic property
         /// </summary>
@@ -96,12 +89,7 @@ namespace QuantConnect.Python
 
             set
             {
-                var val = value is double ? Convert.ToDecimal(value) : value;
-                SetProperty(index, val);
-
-                // Saves the names for future reference
-                if (DynamicMembers.Contains(index)) return;
-                DynamicMembers.Add(index);
+                SetProperty(index, value is double ? Convert.ToDecimal(value) : value);
             }
         }   
     }

--- a/Common/Python/PythonQuandl.cs
+++ b/Common/Python/PythonQuandl.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Data.Custom;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Python
+{
+    /// <summary>
+    /// Dynamic data class for Python algorithms.
+    /// </summary>
+    public class PythonQuandl : Quandl
+    {
+        /// <summary>
+        /// Constructor for initialising the PythonQuandl class
+        /// </summary>
+        public PythonQuandl() : base("Close")
+        {
+            //Empty constructor required for fast-reflection initialization
+        }
+
+        /// <summary>
+        /// Constructor for creating customized quandl instance which doesn't use "Close" as its value item.
+        /// </summary>
+        /// <param name="valueColumnName"></param>
+        public PythonQuandl(string valueColumnName) : base(valueColumnName)
+        {
+            //
+        }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -311,6 +311,7 @@
     <Compile Include="Parameters\ParameterAttribute.cs" />
     <Compile Include="Properties\SharedAssemblyInfo.cs" />
     <Compile Include="Python\PythonData.cs" />
+    <Compile Include="Python\PythonQuandl.cs" />
     <Compile Include="Scheduling\CompositeTimeRule.cs" />
     <Compile Include="Scheduling\DateRules.cs" />
     <Compile Include="Scheduling\FluentScheduledEventBuilder.cs" />


### PR DESCRIPTION
Implements Quandl support for Python.
It was not possible to derive from Quandl in order to select the column. If the data did not have "close", it would thrown an exception since it would look for this word in a dictionary.
It is now possible to select the column.
See example QuandFuturesDataAlgorithm.py