### PR TITLE
ToDecimal extension method allows negative numbers

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -242,7 +242,6 @@ namespace QuantConnect
         /// </summary>
         /// <param name="str">String to be converted to positive decimal value</param>
         /// <remarks>
-        /// Method makes some assuptions - always numbers, no "signs" +,- etc.
         /// Leading and trailing whitespace chars are ignored
         /// </remarks>
         /// <returns>Decimal value of the string</returns>
@@ -255,6 +254,12 @@ namespace QuantConnect
             var length = str.Length;
 
             while (index < length && char.IsWhiteSpace(str[index]))
+            {
+                index++;
+            }
+
+            var isNegative = index < length && str[index] == '-';
+            if (isNegative)
             {
                 index++;
             }
@@ -280,7 +285,7 @@ namespace QuantConnect
 
             var lo = (int)value;
             var mid = (int)(value >> 32);
-            return new decimal(lo, mid, 0, false, (byte)(hasDecimals ? decimalPlaces : 0));
+            return new decimal(lo, mid, 0, isNegative, (byte)(hasDecimals ? decimalPlaces : 0));
         }
 
         /// <summary>

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -154,6 +154,54 @@ namespace QuantConnect.Tests.Common.Util
         }
 
         [Test]
+        public void ConvertsNegativeDecimalFromString()
+        {
+            const string input = "-123.45678";
+            var value = input.ToDecimal();
+            Assert.AreEqual(-123.45678m, value);
+        }
+
+        [Test]
+        public void ConvertsNegativeDecimalFromStringWithExtraWhiteSpace()
+        {
+            const string input = " -123.45678 ";
+            var value = input.ToDecimal();
+            Assert.AreEqual(-123.45678m, value);
+        }
+
+        [Test]
+        public void ConvertsNegativeDecimalFromIntStringWithExtraWhiteSpace()
+        {
+            const string input = " -12345678 ";
+            var value = input.ToDecimal();
+            Assert.AreEqual(-12345678m, value);
+        }
+
+        [Test]
+        public void ConvertsNegativeZeroDecimalFromString()
+        {
+            const string input = "-0.45678";
+            var value = input.ToDecimal();
+            Assert.AreEqual(-0.45678m, value);
+        }
+
+        [Test]
+        public void ConvertsNegavtiveOneNumberDecimalFromString()
+        {
+            const string input = "-1.45678";
+            var value = input.ToDecimal();
+            Assert.AreEqual(-1.45678m, value);
+        }
+
+        [Test]
+        public void ConvertsNegativeZeroDecimalValueFromString()
+        {
+            const string input = "-0";
+            var value = input.ToDecimal();
+            Assert.AreEqual(-0m, value);
+        }
+        
+        [Test]
         public void ConvertsTimeSpanFromString()
         {
             const string input = "16:00";


### PR DESCRIPTION
When a string that represents a negative decimal was parsed with ToDecimal extension method, it returned a wrong number.