### PR TITLE
Refactor Result Handlers

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -672,30 +672,6 @@ namespace QuantConnect.Api
         }
 
         /// <summary>
-        /// Retrieves the location of the logs
-        /// </summary>
-        /// <param name="logs">The list of individual logs to be stored</param>
-        /// <param name="job">The <see cref="AlgorithmNodePacket"/> used to generate the url to the logs</param>
-        /// <param name="permissions">The <see cref="StoragePermissions"/> for the file</param>
-        /// <param name="async">Bool indicating whether the method to <see cref="Store"/> should be async</param>
-        /// <returns>The location where the logs can be accessed</returns>
-        /// <remarks>Since the logs are stored on disc during local backtest, this method simply returns the location of those logs
-        /// TODO: Get the filename of the logs instead of hard coding it.
-        ///  </remarks>
-        public virtual string StoreLogs(List<string> logs, AlgorithmNodePacket job, StoragePermissions permissions, bool async = false)
-        {
-            return Path.Combine(Directory.GetCurrentDirectory(), "log.txt");
-        }
-
-        /// <summary>
-        /// Store data with these authentication type
-        /// </summary>
-        public virtual void Store(string data, string location, StoragePermissions permissions, bool async = false)
-        {
-            //
-        }
-
-        /// <summary>
         /// Send an email to the user associated with the specified algorithm id
         /// </summary>
         /// <param name="algorithmId">The algorithm id</param>

--- a/Common/Interfaces/IApi.cs
+++ b/Common/Interfaces/IApi.cs
@@ -289,21 +289,6 @@ namespace QuantConnect.Interfaces
         IEnumerable<MarketHoursSegment> MarketToday(DateTime time, Symbol symbol);
 
         /// <summary>
-        /// Store logs in the cloud
-        /// </summary>
-        /// <param name="logs">The list of individual logs to be stored</param>
-        /// <param name="job">The <see cref="AlgorithmNodePacket"/> used to generate the url to the logs</param>
-        /// <param name="permissions">The <see cref="StoragePermissions"/> for the file</param>
-        /// <param name="async">Bool indicating whether the method to <see cref="Store"/> should be async</param>
-        /// <returns>The url where the logs can be accessed</returns>
-        string StoreLogs(List<string> logs, AlgorithmNodePacket job, StoragePermissions permissions, bool async = false);
-
-        /// <summary>
-        /// Store data in the cloud
-        /// </summary>
-        void Store(string data, string location, StoragePermissions permissions, bool async = false);
-
-        /// <summary>
         /// Send an email to the user associated with the specified algorithm id
         /// </summary>
         /// <param name="algorithmId">The algorithm id</param>

--- a/Common/Packets/BacktestResultPacket.cs
+++ b/Common/Packets/BacktestResultPacket.cs
@@ -199,34 +199,8 @@ namespace QuantConnect.Packets
     /// <summary>
     /// Backtest results object class - result specific items from the packet.
     /// </summary>
-    public class BacktestResult
+    public class BacktestResult : Result
     {
-        /// <summary>
-        /// Chart updates in this backtest since the last backtest result packet was sent.
-        /// </summary>
-        public IDictionary<string, Chart> Charts = new Dictionary<string, Chart>();
-        
-        /// <summary>
-        /// Order updates since the last backtest result packet was sent.
-        /// </summary>
-        public IDictionary<int, Order> Orders = new Dictionary<int, Order>();
-        
-        /// <summary>
-        /// Profit and loss results from closed trades.
-        /// </summary>
-        public IDictionary<DateTime, decimal> ProfitLoss = new Dictionary<DateTime, decimal>();
-
-        /// <summary>
-        /// Statistics information for the backtest.
-        /// </summary>
-        /// <remarks>The statistics are only generated on the last result packet of the backtest.</remarks>
-        public IDictionary<string, string> Statistics = new Dictionary<string, string>();
-
-        /// <summary>
-        /// The runtime / dynamic statistics generated while a backtest is running.
-        /// </summary>
-        public IDictionary<string, string> RuntimeStatistics = new Dictionary<string, string>();
-
         /// <summary>
         /// Rolling window detailed statistics.
         /// </summary>

--- a/Common/Packets/LiveResultPacket.cs
+++ b/Common/Packets/LiveResultPacket.cs
@@ -130,43 +130,17 @@ namespace QuantConnect.Packets
     /// <summary>
     /// Live results object class for packaging live result data.
     /// </summary>
-    public class LiveResult
+    public class LiveResult : Result
     {
-        /// <summary>
-        /// Charts updates for the live algorithm since the last result packet
-        /// </summary>
-        public Dictionary<string, Chart> Charts = new Dictionary<string, Chart>();
-
         /// <summary>
         /// Holdings dictionary of algorithm holdings information
         /// </summary>
-        public Dictionary<string, Holding> Holdings = new Dictionary<string, Holding>();
-        
-        /// <summary>
-        /// Order updates since the last result packet
-        /// </summary>
-        public Dictionary<int, Order> Orders = new Dictionary<int, Order>();
-        
-        /// <summary>
-        /// Trade profit and loss information since the last algorithm result packet
-        /// </summary>
-        public Dictionary<DateTime, decimal> ProfitLoss = new Dictionary<DateTime, decimal>();
-
-        /// <summary>
-        /// Statistics information sent during the algorithm operations.
-        /// </summary>
-        /// <remarks>Intended for update mode -- send updates to the existing statistics in the result GUI. If statistic key does not exist in GUI, create it</remarks>
-        public Dictionary<string, string> Statistics = new Dictionary<string, string>();
-
-        /// <summary>
-        /// Runtime banner/updating statistics in the title banner of the live algorithm GUI.
-        /// </summary>
-        public Dictionary<string, string> RuntimeStatistics = new Dictionary<string, string>();
+        public IDictionary<string, Holding> Holdings = new Dictionary<string, Holding>();
 
         /// <summary>
         /// Server status information, including CPU/RAM usage, ect...
         /// </summary>
-        public Dictionary<string, string> ServerStatistics = new Dictionary<string, string>();
+        public IDictionary<string, string> ServerStatistics = new Dictionary<string, string>();
 
         /// <summary>
         /// Default Constructor
@@ -177,7 +151,7 @@ namespace QuantConnect.Packets
         /// <summary>
         /// Constructor for the result class for dictionary objects
         /// </summary>
-        public LiveResult(Dictionary<string, Chart> charts, Dictionary<int, Order> orders, Dictionary<DateTime, decimal> profitLoss, Dictionary<string, Holding> holdings, Dictionary<string, string> statistics, Dictionary<string, string> runtime, Dictionary<string, string> serverStatistics = null)
+        public LiveResult(IDictionary<string, Chart> charts, IDictionary<int, Order> orders, IDictionary<DateTime, decimal> profitLoss, IDictionary<string, Holding> holdings, IDictionary<string, string> statistics, IDictionary<string, string> runtime, IDictionary<string, string> serverStatistics = null)
         {
             Charts = charts;
             Orders = orders;

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -478,6 +478,7 @@
     <Compile Include="Statistics\TradeBuilder.cs" />
     <Compile Include="Statistics\TradeEnums.cs" />
     <Compile Include="SymbolCache.cs" />
+    <Compile Include="Result.cs" />
     <Compile Include="SymbolJsonConverter.cs" />
     <Compile Include="SymbolRepresentation.cs" />
     <Compile Include="SymbolValueJsonConverter.cs" />

--- a/Common/Result.cs
+++ b/Common/Result.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using QuantConnect.Orders;
+using QuantConnect.Packets;
 
 namespace QuantConnect
 {
+    /// <summary>
+    /// Base class for backtesting and live results that packages result data.
+    /// <see cref="LiveResult"/>
+    /// <see cref="BacktestResult"/>
+    /// </summary>
     public class Result
     {
         /// <summary>

--- a/Common/Result.cs
+++ b/Common/Result.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using QuantConnect.Orders;
+
+namespace QuantConnect
+{
+    public class Result
+    {
+        /// <summary>
+        /// Charts updates for the live algorithm since the last result packet
+        /// </summary>
+        public IDictionary<string, Chart> Charts = new Dictionary<string, Chart>();
+
+        /// <summary>
+        /// Order updates since the last result packet
+        /// </summary>
+        public IDictionary<int, Order> Orders = new Dictionary<int, Order>();
+
+        /// <summary>
+        /// Trade profit and loss information since the last algorithm result packet
+        /// </summary>
+        public IDictionary<DateTime, decimal> ProfitLoss = new Dictionary<DateTime, decimal>();
+
+        /// <summary>
+        /// Statistics information sent during the algorithm operations.
+        /// </summary>
+        /// <remarks>Intended for update mode -- send updates to the existing statistics in the result GUI. If statistic key does not exist in GUI, create it</remarks>
+        public IDictionary<string, string> Statistics = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Runtime banner/updating statistics in the title banner of the live algorithm GUI.
+        /// </summary>
+        public IDictionary<string, string> RuntimeStatistics = new Dictionary<string, string>();
+    }
+}

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -151,7 +151,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
 
         // this implementation is provided solely for the data reader's dependency,
         // in the future we can refactor the data reader to not use the result handler
-        private class ResultHandlerStub : IResultHandler
+        private class ResultHandlerStub : BaseResultsHandler, IResultHandler
         {
             public static readonly IResultHandler Instance = new ResultHandlerStub();
 

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -201,6 +201,7 @@
     <Compile Include="DataFeeds\UpdateData.cs" />
     <Compile Include="DataFeeds\ZipDataCacheProvider.cs" />
     <Compile Include="DataFeeds\ZipEntryNameSubscriptionDataSourceReader.cs" />
+    <Compile Include="Results\BaseResultsHandler.cs" />
     <Compile Include="Server\LocalLeanManagement.cs" />
     <Compile Include="HistoricalData\BrokerageHistoryProvider.cs" />
     <Compile Include="HistoricalData\SubscriptionDataReaderHistoryProvider.cs" />

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Lean.Engine.Results
     /// <summary>
     /// Backtesting result handler passes messages back from the Lean to the User.
     /// </summary>
-    public class BacktestingResultHandler : IResultHandler
+    public class BacktestingResultHandler : BaseResultsHandler, IResultHandler
     {
         private bool _exitTriggered = false;
         private BacktestNodePacket _job;

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -32,6 +32,7 @@ using QuantConnect.Packets;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
 using System.Diagnostics;
+using System.IO;
 
 namespace QuantConnect.Lean.Engine.Results
 {
@@ -425,7 +426,8 @@ namespace QuantConnect.Lean.Engine.Results
                     }
 
                     //Upload Results Portion
-                    _api.Store(serialized, key, StoragePermissions.Authenticated, async);
+                    //_api.Store(serialized, key, StoragePermissions.Authenticated, async);
+                    SaveResults(key, result.Results);
                 }
             }
             catch (Exception err)
@@ -726,7 +728,7 @@ namespace QuantConnect.Lean.Engine.Results
             // Only process the logs once
             if (!_exitTriggered)
             {
-                var logLocation = ProcessLogMessages(_job);
+                var logLocation = ProcessLogMessages();
                 SystemDebugMessage("Your log was successfully created and can be retrieved from: " + logLocation);
             }
 
@@ -794,9 +796,9 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         /// <param name="job">Algorithm job/task packet</param>
         /// <returns>String URL of log</returns>
-        private string ProcessLogMessages(AlgorithmNodePacket job)
+        private string ProcessLogMessages()
         {
-            return _api.StoreLogs(_log, job, StoragePermissions.Public, false);
+            return SaveLogs(_log);
         }
 
         /// <summary>

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -204,9 +204,8 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="dataFeed"></param>
         /// <param name="setupHandler"></param>
         /// <param name="transactionHandler"></param>
-        public void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, IDataFeed dataFeed, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
+        public virtual void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, IDataFeed dataFeed, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
         {
-            Log.Trace("BacktestingResultHandler.Initialize(): Initializing BacktestingResultHanlder.");
             _messagingHandler = messagingHandler;
             _transactionHandler = transactionHandler;
             _setupHandler = setupHandler;

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -718,7 +718,7 @@ namespace QuantConnect.Lean.Engine.Results
             // Only process the logs once
             if (!_exitTriggered)
             {
-                var logLocation = ProcessLogMessages();
+                var logLocation = SaveLogs(_job.BacktestId, _log);
                 SystemDebugMessage("Your log was successfully created and can be retrieved from: " + logLocation);
             }
 
@@ -779,16 +779,6 @@ namespace QuantConnect.Lean.Engine.Results
             {
                 _runtimeStatistics[key] = value;
             }
-        }
-
-        /// <summary>
-        /// Process log messages and return a string indicating the location of the logs
-        /// </summary>
-        /// <param name="job">Algorithm job/task packet</param>
-        /// <returns>String URL of log</returns>
-        private string ProcessLogMessages()
-        {
-            return SaveLogs(_log);
         }
 
         /// <summary>

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using QuantConnect.Interfaces;
+using QuantConnect.Logging;
 using QuantConnect.Packets;
 
 namespace QuantConnect.Lean.Engine.Results
 {
     public class BaseResultsHandler
     {
-        public virtual void SaveLogs(string logs)
+        public virtual void SaveLogs(IEnumerable<LogEntry> logs)
         {
-            throw new NotImplementedException();
+            var joined = string.Join("\r\n", logs.Select(x => x.Message));
         }
 
         public virtual void SaveCharts(string chartName, Dictionary<string, Chart> charts)

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace QuantConnect.Lean.Engine.Results
+{
+    public class BaseResultsHandler
+    {
+        public void SaveLogs(string logs)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -10,9 +10,10 @@ namespace QuantConnect.Lean.Engine.Results
 {
     public class BaseResultsHandler
     {
-        public virtual void SaveLogs(IEnumerable<LogEntry> logs)
+        public virtual string SaveLogs(IEnumerable<string> logs)
         {
-            var joined = string.Join("\r\n", logs.Select(x => x.Message));
+            var joined = string.Join("\r\n", logs);
+            return Path.Combine(Directory.GetCurrentDirectory(), "log.txt");
         }
 
         public virtual void SaveCharts(string chartName, Dictionary<string, Chart> charts)

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -1,29 +1,44 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using QuantConnect.Interfaces;
-using QuantConnect.Logging;
-using QuantConnect.Packets;
+using Newtonsoft.Json;
 
 namespace QuantConnect.Lean.Engine.Results
 {
+    /// <summary>
+    /// Provides base functionality to the implementations of <see cref="IResultHandler"/>
+    /// </summary>
     public class BaseResultsHandler
     {
+        /// <summary>
+        /// Returns the location of the logs
+        /// </summary>
+        /// <param name="logs">The logs to save</param>
+        /// <returns>The path to the logs</returns>
         public virtual string SaveLogs(IEnumerable<string> logs)
         {
-            var joined = string.Join("\r\n", logs);
+            // When running lean locally, the logs are written to disk by the LogHandler
+            // Just return the location of this log file
             return Path.Combine(Directory.GetCurrentDirectory(), "log.txt");
         }
 
+        /// <summary>
+        /// Save the charts to disk
+        /// </summary>
+        /// <param name="chartName">The name of the chart</param>
+        /// <param name="charts">The charts to save</param>
         public virtual void SaveCharts(string chartName, Dictionary<string, Chart> charts)
         {
-            File.WriteAllText(chartName, "");
+            File.WriteAllText(chartName, JsonConvert.SerializeObject(charts));
         }
 
+        /// <summary>
+        /// Save the results to disk
+        /// </summary>
+        /// <param name="name">The name of the results</param>
+        /// <param name="result">The results to save</param>
         public virtual void SaveResults(string name, Result result)
         {
-            
+            File.WriteAllText(Path.Combine(Directory.GetCurrentDirectory(), name), JsonConvert.SerializeObject(result));
         }
     }
 }

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -1,12 +1,26 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using QuantConnect.Interfaces;
+using QuantConnect.Packets;
 
 namespace QuantConnect.Lean.Engine.Results
 {
     public class BaseResultsHandler
     {
-        public void SaveLogs(string logs)
+        public virtual void SaveLogs(string logs)
         {
             throw new NotImplementedException();
+        }
+
+        public virtual void SaveCharts(string chartName, Dictionary<string, Chart> charts)
+        {
+            File.WriteAllText(chartName, "");
+        }
+
+        public virtual void SaveResults(string name, Result result)
+        {
+            
         }
     }
 }

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -12,23 +12,14 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Returns the location of the logs
         /// </summary>
+        /// <param name="id">Id that will be incorporated into the algorithm log name</param>
         /// <param name="logs">The logs to save</param>
         /// <returns>The path to the logs</returns>
-        public virtual string SaveLogs(IEnumerable<string> logs)
+        public virtual string SaveLogs(string id, IEnumerable<string> logs)
         {
-            // When running lean locally, the logs are written to disk by the LogHandler
-            // Just return the location of this log file
-            return Path.Combine(Directory.GetCurrentDirectory(), "log.txt");
-        }
-
-        /// <summary>
-        /// Save the charts to disk
-        /// </summary>
-        /// <param name="chartName">The name of the chart</param>
-        /// <param name="charts">The charts to save</param>
-        public virtual void SaveCharts(string chartName, Dictionary<string, Chart> charts)
-        {
-            File.WriteAllText(chartName, JsonConvert.SerializeObject(charts));
+            var path = $"{id}-log.txt";
+            File.WriteAllLines(path, logs);
+            return Path.Combine(Directory.GetCurrentDirectory(), path);
         }
 
         /// <summary>

--- a/Engine/Results/DesktopResultHandler.cs
+++ b/Engine/Results/DesktopResultHandler.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.Lean.Engine.Results
     /// <summary>
     /// Desktop Result Handler - Desktop GUI Result Handler for Piping Results to WinForms:
     /// </summary>
-    public class DesktopResultHandler : IResultHandler
+    public class DesktopResultHandler : BaseResultsHandler, IResultHandler
     {
         private bool _isActive;
         private bool _exitTriggered;

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -258,7 +258,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// 
         /// </summary>
         /// <param name="logs"></param>
-        void SaveLogs(IEnumerable<LogEntry> logs);
+        string SaveLogs(IEnumerable<string> logs);
 
         void SaveCharts(string chartName, Dictionary<string, Chart> charts);
 

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -258,5 +258,9 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         /// <param name="logs"></param>
         void SaveLogs(string logs);
+
+        void SaveCharts(string chartName, Dictionary<string, Chart> charts);
+
+        void SaveResults(string name, Result result);
     }
 }

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -255,13 +255,23 @@ namespace QuantConnect.Lean.Engine.Results
         void ProcessSynchronousEvents(bool forceProcess = false);
 
         /// <summary>
-        /// 
+        /// Save the logs
         /// </summary>
-        /// <param name="logs"></param>
+        /// <param name="logs">The logs to save</param>
         string SaveLogs(IEnumerable<string> logs);
 
+        /// <summary>
+        /// Save the charts
+        /// </summary>
+        /// <param name="chartName">The name of the chart</param>
+        /// <param name="charts">The charts to save</param>
         void SaveCharts(string chartName, Dictionary<string, Chart> charts);
 
+        /// <summary>
+        /// Save the results
+        /// </summary>
+        /// <param name="name">The name of the results</param>
+        /// <param name="result">The results to save</param>
         void SaveResults(string name, Result result);
     }
 }

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -252,5 +252,11 @@ namespace QuantConnect.Lean.Engine.Results
         /// Process any synchronous events in here that are primarily triggered from the algorithm loop
         /// </summary>
         void ProcessSynchronousEvents(bool forceProcess = false);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logs"></param>
+        void SaveLogs(string logs);
     }
 }

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -22,6 +22,7 @@ using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.Setup;
 using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Packets;
 using QuantConnect.Statistics;
@@ -257,7 +258,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// 
         /// </summary>
         /// <param name="logs"></param>
-        void SaveLogs(string logs);
+        void SaveLogs(IEnumerable<LogEntry> logs);
 
         void SaveCharts(string chartName, Dictionary<string, Chart> charts);
 

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -22,7 +22,6 @@ using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.Setup;
 using QuantConnect.Lean.Engine.TransactionHandlers;
-using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Packets;
 using QuantConnect.Statistics;
@@ -257,15 +256,9 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Save the logs
         /// </summary>
+        /// <param name="id">Id that will be incorporated into the algorithm log name</param>
         /// <param name="logs">The logs to save</param>
-        string SaveLogs(IEnumerable<string> logs);
-
-        /// <summary>
-        /// Save the charts
-        /// </summary>
-        /// <param name="chartName">The name of the chart</param>
-        /// <param name="charts">The charts to save</param>
-        void SaveCharts(string chartName, Dictionary<string, Chart> charts);
+        string SaveLogs(string id, IEnumerable<string> logs);
 
         /// <summary>
         /// Save the results

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Lean.Engine.Results
     /// Live trading result handler implementation passes the messages to the QC live trading interface.
     /// </summary>
     /// <remarks>Live trading result handler is quite busy. It sends constant price updates, equity updates and order/holdings updates.</remarks>
-    public class LiveTradingResultHandler : IResultHandler
+    public class LiveTradingResultHandler : BaseResultsHandler, IResultHandler
     {
         private readonly DateTime _launchTimeUtc = DateTime.UtcNow;
 

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -982,7 +982,7 @@ namespace QuantConnect.Lean.Engine.Results
 
         private string CreateKey(string suffix, string dateFormat = "yyyy-MM-dd")
         {
-            return string.Format("live/{0}/{1}/{2}-{3}_{4}.json", _job.UserId, _job.ProjectId, _job.DeployId, DateTime.UtcNow.ToString(dateFormat), suffix);
+            return string.Format("{2}-{3}_{4}.json", _job.DeployId, DateTime.UtcNow.ToString(dateFormat), suffix);
         }
 
 

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -811,7 +811,7 @@ namespace QuantConnect.Lean.Engine.Results
         {
             try
             {
-                SaveLogs(logs);
+                SaveLogs(logs.Select(x => x.Message));
             }
             catch (Exception err)
             {

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -811,11 +811,7 @@ namespace QuantConnect.Lean.Engine.Results
         {
             try
             {
-                //Concatenate and upload the log file:
-                var joined = string.Join("\r\n", logs.Select(x=>x.Message));
-                //var key = "live/" + _job.UserId + "/" + _job.ProjectId + "/" + _job.DeployId + "-" + DateTime.UtcNow.ToString("yyyy-MM-dd-HH") + "-log.txt";
-                //_api.Store(joined, key, StoragePermissions.Authenticated);
-                base.SaveLogs(joined);
+                SaveLogs(logs);
             }
             catch (Exception err)
             {
@@ -834,13 +830,6 @@ namespace QuantConnect.Lean.Engine.Results
         /// </remarks>
         public void StoreResult(Packet packet, bool async = true)
         {
-            // this will hold all the serialized data and the keys to be stored
-            //var data_keys = Enumerable.Range(0, 0).Select(x => new
-            //{
-            //    Key = (string)null,
-            //    Serialized = (string)null
-            //}).ToList();
-
             try
             {
                 Log.Debug("LiveTradingResultHandler.StoreResult(): Begin store result sampling");
@@ -869,11 +858,6 @@ namespace QuantConnect.Lean.Engine.Results
 
                         // swap out our charts with the sampeld data
                         live.Results.Charts = minuteCharts;
-                        //data_keys.Add(new
-                        //{
-                        //    Key = CreateKey("minute"),
-                        //    Serialized = JsonConvert.SerializeObject(live.Results)
-                        //});
                         SaveCharts(CreateKey("minute"), minuteCharts);
 
                         // 10 minute resolution data, save today
@@ -881,11 +865,6 @@ namespace QuantConnect.Lean.Engine.Results
                         var tenminuteCharts = tenminuteSampler.SampleCharts(live.Results.Charts, start, stop);
 
                         live.Results.Charts = tenminuteCharts;
-                        //data_keys.Add(new
-                        //{
-                        //    Key = CreateKey("10minute"),
-                        //    Serialized = JsonConvert.SerializeObject(live.Results)
-                        //});
                         SaveCharts(CreateKey("10minute"), tenminuteCharts);
 
                         // high resolution data, we only want to save an hour
@@ -904,11 +883,6 @@ namespace QuantConnect.Lean.Engine.Results
                             result.Charts.Add(name, live.Results.Charts[name]);
 
                             SaveResults(CreateKey("second_" + Uri.EscapeUriString(name), "yyyy-MM-dd-HH"), result);
-                            //data_keys.Add(new
-                            //{
-                            //    Key = CreateKey("second_" + Uri.EscapeUriString(name), "yyyy-MM-dd-HH"),
-                            //    Serialized = JsonConvert.SerializeObject(newPacket)
-                            //});
                         }
                     }
                     else

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="dataFeed"></param>
         /// <param name="setupHandler"></param>
         /// <param name="transactionHandler"></param>
-        public void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, IDataFeed dataFeed, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
+        public virtual void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, IDataFeed dataFeed, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
         {
             _api = api;
             _dataFeed = dataFeed;
@@ -811,7 +811,7 @@ namespace QuantConnect.Lean.Engine.Results
         {
             try
             {
-                SaveLogs(logs.Select(x => x.Message));
+                SaveLogs(_job.DeployId, logs.Select(x => x.Message));
             }
             catch (Exception err)
             {
@@ -858,14 +858,14 @@ namespace QuantConnect.Lean.Engine.Results
 
                         // swap out our charts with the sampeld data
                         live.Results.Charts = minuteCharts;
-                        SaveCharts(CreateKey("minute"), minuteCharts);
+                        SaveResults(CreateKey("minute"), live.Results);
 
                         // 10 minute resolution data, save today
                         var tenminuteSampler = new SeriesSampler(TimeSpan.FromMinutes(10));
                         var tenminuteCharts = tenminuteSampler.SampleCharts(live.Results.Charts, start, stop);
 
                         live.Results.Charts = tenminuteCharts;
-                        SaveCharts(CreateKey("10minute"), tenminuteCharts);
+                        SaveResults(CreateKey("10minute"), live.Results);
 
                         // high resolution data, we only want to save an hour
                         live.Results.Charts = highResolutionCharts;
@@ -982,7 +982,7 @@ namespace QuantConnect.Lean.Engine.Results
 
         private string CreateKey(string suffix, string dateFormat = "yyyy-MM-dd")
         {
-            return string.Format("{2}-{3}_{4}.json", _job.DeployId, DateTime.UtcNow.ToString(dateFormat), suffix);
+            return string.Format("{0}-{1}_{2}.json", _job.DeployId, DateTime.UtcNow.ToString(dateFormat), suffix);
         }
 
 

--- a/Tests/Engine/TestResultHandler.cs
+++ b/Tests/Engine/TestResultHandler.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Tests.Engine
     /// the Run method to be called at all, a task is launched via ctor to process
     /// the packets
     /// </summary>
-    public class TestResultHandler : IResultHandler
+    public class TestResultHandler : BaseResultsHandler, IResultHandler
     {
         private AlgorithmNodePacket _job = new BacktestNodePacket();
 


### PR DESCRIPTION
+ Refactor many of the BacktestResultHandler and LiveTradingResultHandler methods into a common base class. This base class saves results and logs to disk in a manner that makes it easier for users to retrieve and use later.
+ Refactor many of the properties on the Backtest and Live Result classes into a common base class.
+ Remove unused Api methods

