### PR TITLE
Fix bug in security seeding when using Tick resolution

### DIFF
--- a/Common/Benchmarks/SecurityBenchmark.cs
+++ b/Common/Benchmarks/SecurityBenchmark.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Benchmarks
         /// <returns>The value of the benchmark at the specified time</returns>
         public decimal Evaluate(DateTime time)
         {
-            return _security.Close;
+            return _security.Price;
         }
     }
 }


### PR DESCRIPTION
With securities added at `Tick` resolution the wrong data type was used for the seeding history request.