### PR TITLE
Add check for exit around BusyBlockingCollection in LTDF

### DIFF
--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -331,9 +331,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // so the algorithm manager has a chance to detect the runtime error
                 // and exit showing the correct error instead of a timeout
                 nextEmit = _frontierUtc.RoundDown(Time.OneSecond).Add(Time.OneSecond);
-                _bridge.Add(
-                    TimeSlice.Create(nextEmit, _algorithm.TimeZone, _algorithm.Portfolio.CashBook, new List<DataFeedPacket>(), SecurityChanges.None),
-                    _cancellationTokenSource.Token);
+
+                if (!_cancellationTokenSource.IsCancellationRequested)
+                {
+                    _bridge.Add(
+                        TimeSlice.Create(nextEmit, _algorithm.TimeZone, _algorithm.Portfolio.CashBook, new List<DataFeedPacket>(), SecurityChanges.None),
+                        _cancellationTokenSource.Token);
+                }
             }
 
             Log.Trace("LiveTradingDataFeed.Run(): Exited thread.");

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -398,6 +398,49 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         }
 
 
+        [Test]
+        public void FastExitsDoNotThrowUnhandledExceptions()
+        {
+            var algorithm = new AlgorithmStub(Resolution.Tick, Enumerable.Range(0, 20).Select(x => x.ToString()).ToList());
+            var getNextTicksFunction = Enumerable.Range(0, 20).Select(x => new Tick { Symbol = SymbolCache.GetSymbol(x.ToString()) }).ToList();
+
+            // job is used to send into DataQueueHandler
+            var job = new LiveNodePacket();
+            
+            // result handler is used due to dependency in SubscriptionDataReader
+            var resultHandler = new BacktestingResultHandler();
+
+            var dataQueueHandler = new FuncDataQueueHandler(handler => getNextTicksFunction);
+
+            var feed = new TestableLiveTradingDataFeed(dataQueueHandler, null);
+            var mapFileProvider = new LocalDiskMapFileProvider();
+            var fileProvider = new DefaultDataProvider();
+            feed.Initialize(algorithm, job, resultHandler, mapFileProvider, new LocalDiskFactorFileProvider(mapFileProvider), fileProvider);
+
+            var feedThreadStarted = new ManualResetEvent(false);
+
+            var unhandledExceptionWasThrown = false;
+            Task.Run(() =>
+            {
+                try
+                {
+                    feedThreadStarted.Set();
+                    feed.Run();
+                }
+                catch(Exception ex)
+                {
+                    QuantConnect.Logging.Log.Error(ex.ToString());
+                    unhandledExceptionWasThrown = true;
+                }
+            });
+
+            feedThreadStarted.WaitOne();
+            feed.Exit();
+
+            Thread.Sleep(1000);
+
+            Assert.IsFalse(unhandledExceptionWasThrown);
+        }
 
         private IDataFeed RunDataFeed(IAlgorithm algorithm, Func<FuncDataQueueHandler, IEnumerable<BaseData>> getNextTicksFunction = null)
         {


### PR DESCRIPTION
In live trading, the following unhandled exception was seen:

```
20170810 16:31:40 ERROR:: [ERROR] FATAL UNHANDLED EXCEPTION: System.ObjectDisposedException: Cannot access a disposed object.
20170810 16:31:40 ERROR:: Object name: 'The event has been disposed.'.
20170810 16:31:40 ERROR:: at System.Threading.ManualResetEventSlim.ThrowIfDisposed () [0x0001d] in <dca3b561b8ad4f9fb10141d81b39ff45>:0
20170810 16:31:40 ERROR:: at System.Threading.ManualResetEventSlim.Reset () [0x00000] in <dca3b561b8ad4f9fb10141d81b39ff45>:0
20170810 16:31:40 ERROR:: at QuantConnect.Util.BusyBlockingCollection`1[T].Add (T item, System.Threading.CancellationToken cancellationToken) [0x00014] in <eb1d4f7b51ea426a9ac41a2170a2312e>:0
20170810 16:31:40 ERROR:: at QuantConnect.Lean.Engine.DataFeeds.LiveTradingDataFeed.Run () [0x002c0] in <ea9ae71ff33643cd8d90eb9c46801030>:0
```

I was able to reproduce this exception in the test included with this PR. I determined that the exception was being thrown when `LiveTradingDataFeed.Exit()` had been called after which the `LiveTradingDataFeed.Run()` method was then trying to access the disposed `_bridge` variable (The `BusyBlockingCollection` referenced in the stack trace above) . Adding a check to see if the cancellation token had been cancelled before access the `_bridge` variable in the Catch() method seems to fix the issue and allows the test included in this PR to pass.