### PR TITLE
Use Tick.Price for fill price when bid/ask spread is not available

### DIFF
--- a/Common/Orders/Fills/ImmediateFillModel.cs
+++ b/Common/Orders/Fills/ImmediateFillModel.cs
@@ -395,6 +395,13 @@ namespace QuantConnect.Orders.Fills
                 {
                     return new Prices(price, 0, 0, 0, 0);
                 }
+
+                // If the ask/bid spreads are not available for ticks, try the price
+                price = tick.Price;
+                if (price != 0m)
+                {
+                    return new Prices(price, 0, 0, 0, 0);
+                }
             }
 
             var quoteBar = asset.Cache.GetData<QuoteBar>();

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -16,10 +16,14 @@
 using System;
 using NUnit.Framework;
 using QuantConnect.Brokerages;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
 using QuantConnect.Orders;
+using QuantConnect.Orders.Fills;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Forex;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Orders.Fills
 {
@@ -57,6 +61,28 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(expected, fill.FillPrice);
         }
 
+        [Test]
+        public void ImmediateFillModelUsesPriceForTicksWhenBidAskSpreadsAreNotAvailable()
+        {
+            var noon = new DateTime(2014, 6, 24, 12, 0, 0);
+            var timeKeeper = new TimeKeeper(noon.ConvertToUtc(TimeZones.NewYork), new[] { TimeZones.NewYork });
+            var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+            var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Tick, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
+            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, noon, 101.123m));
 
+            // Add both a tradebar and a tick to the security cache
+            // This is the case when a tick is seeded with minute data in an algorithm
+            security.Cache.AddData(new TradeBar(DateTime.MinValue, symbol, 1.0m, 1.0m, 1.0m, 1.0m, 1.0m));
+            security.Cache.AddData(new Tick(config, "42525000,1000000,100,A,@,0", DateTime.MinValue));
+
+            var fillModel = new ImmediateFillModel();
+            var order = new MarketOrder(symbol, 1000, DateTime.Now);
+            var fill = fillModel.MarketFill(security, order);
+
+            // The fill model should use the tick.Price
+            Assert.AreEqual(fill.FillPrice, 100m);
+        }
     }
 }


### PR DESCRIPTION
When an equity at tick resolution is used in Lean, it is seeded with a price using minute data.  For equities, this adds a TradeBar to the security.SecurityCache. When the `ImmediateFillModel` is then used with this security (and tick Bid/Ask spreads are not available), the ImmediateFillModel uses the tradebar that was used to seed the security to generate the fill price.

This PR uses the tick.Price in the `ImmediateFillModel` when the tick bid/ask spreads are not available.