### PR TITLE
Fix Options and Futures subscriptions at Tick resolution

### DIFF
--- a/Algorithm/DollarVolumeUniverseDefinitions.cs
+++ b/Algorithm/DollarVolumeUniverseDefinitions.cs
@@ -50,7 +50,8 @@ namespace QuantConnect.Algorithm
         {
             universeSettings = universeSettings ?? _algorithm.UniverseSettings;
             var symbol = Symbol.Create("us-equity-dollar-volume-top-" + count, SecurityType.Equity, Market.USA);
-            var config = new SubscriptionDataConfig(typeof(CoarseFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
+            var subscriptionDataType = new SubscriptionDataType(typeof(CoarseFundamental), TickType.Trade);
+            var config = new SubscriptionDataConfig(subscriptionDataType, symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
             return new FuncUniverse(config, universeSettings, _algorithm.SecurityInitializer, selectionData => (
                 from c in selectionData.OfType<CoarseFundamental>()
                 orderby c.DollarVolume descending 
@@ -70,7 +71,8 @@ namespace QuantConnect.Algorithm
         {
             universeSettings = universeSettings ?? _algorithm.UniverseSettings;
             var symbol = Symbol.Create("us-equity-dollar-volume-bottom-" + count, SecurityType.Equity, Market.USA);
-            var config = new SubscriptionDataConfig(typeof(CoarseFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
+            var subscriptionDataType = new SubscriptionDataType(typeof(CoarseFundamental), TickType.Trade);
+            var config = new SubscriptionDataConfig(subscriptionDataType, symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
             return new FuncUniverse(config, universeSettings, _algorithm.SecurityInitializer, selectionData => (
                 from c in selectionData.OfType<CoarseFundamental>()
                 orderby c.DollarVolume descending 
@@ -90,7 +92,8 @@ namespace QuantConnect.Algorithm
         {
             universeSettings = universeSettings ?? _algorithm.UniverseSettings;
             var symbol = Symbol.Create("us-equity-dollar-volume-percentile-" + percentile, SecurityType.Equity, Market.USA);
-            var config = new SubscriptionDataConfig(typeof(CoarseFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
+            var subscriptionDataType = new SubscriptionDataType(typeof(CoarseFundamental), TickType.Trade);
+            var config = new SubscriptionDataConfig(subscriptionDataType, symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
             return new FuncUniverse(config, universeSettings, _algorithm.SecurityInitializer, selectionData =>
             {
                 var list = selectionData as IReadOnlyList<CoarseFundamental> ?? selectionData.OfType<CoarseFundamental>().ToList();
@@ -119,7 +122,8 @@ namespace QuantConnect.Algorithm
         {
             universeSettings = universeSettings ?? _algorithm.UniverseSettings;
             var symbol = Symbol.Create("us-equity-dollar-volume-percentile-" + lowerPercentile + "-" + upperPercentile, SecurityType.Equity, Market.USA);
-            var config = new SubscriptionDataConfig(typeof(CoarseFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
+            var subscriptionDataType = new SubscriptionDataType(typeof(CoarseFundamental), TickType.Trade);
+            var config = new SubscriptionDataConfig(subscriptionDataType, symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
             return new FuncUniverse(config, universeSettings, _algorithm.SecurityInitializer, selectionData =>
             {
                 var list = selectionData as IReadOnlyList<CoarseFundamental> ?? selectionData.OfType<CoarseFundamental>().ToList();

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -451,14 +451,16 @@ namespace QuantConnect.Algorithm
             if (subscriptionDataConfig != null && subscriptionDataConfig.Resolution == Resolution.Tick)
             {
                 var dataType = LeanData.GetDataType(resolution, subscriptionDataConfig.TickType);
-                subscriptionDataConfig = new SubscriptionDataConfig(subscriptionDataConfig, dataType, resolution: resolution);
+                subscriptionDataConfig = new SubscriptionDataConfig(subscriptionDataConfig, 
+                    new SubscriptionDataType(dataType, subscriptionDataConfig.TickType),
+                    resolution: resolution);
             }
 
             var request = new HistoryRequest
             {
                 StartTimeUtc = startTime.ConvertToUtc(_localTimeKeeper.TimeZone),
                 EndTimeUtc = endTime.ConvertToUtc(_localTimeKeeper.TimeZone),
-                DataType = subscriptionDataConfig != null ? subscriptionDataConfig.Type : typeof(TradeBar),
+                SubscriptionDataType = subscriptionDataConfig != null ? subscriptionDataConfig.SubscriptionDataType : new SubscriptionDataType(typeof(TradeBar), TickType.Trade),
                 Resolution = resolution,
                 FillForwardResolution = resolution,
                 Symbol = security.Symbol,
@@ -555,11 +557,13 @@ namespace QuantConnect.Algorithm
             resolution = resolution ?? security.Resolution;
 
             // find the correct data type for the history request
-            var dataType = subscription.IsCustomData ? subscription.Type : LeanData.GetDataType(resolution.Value, subscription.TickType);
+            var dataType = subscription.IsCustomData ? 
+                subscription.SubscriptionDataType : 
+                new SubscriptionDataType(LeanData.GetDataType(resolution.Value, subscription.TickType), subscription.TickType);
 
             var request = new HistoryRequest(subscription, security.Exchange.Hours, startAlgoTz.ConvertToUtc(TimeZone), endAlgoTz.ConvertToUtc(TimeZone))
             {
-                DataType = dataType,
+                SubscriptionDataType = dataType,
                 Resolution = resolution.Value,
                 FillForwardResolution = subscription.FillDataForward ? resolution : null
             };

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -97,9 +97,10 @@ namespace QuantConnect.Algorithm
             //Add this to the data-feed subscriptions
             var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA), symbol);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(Market.USA, symbol, SecurityType.Base, CashBook.AccountCurrency);
+            var types = new List<SubscriptionDataType> { new SubscriptionDataType(T, TickType.Trade) };
 
             //Add this new generic data as a tradeable security: 
-            var security = SecurityManager.CreateSecurity(new List<Type>() { T }, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone,
+            var security = SecurityManager.CreateSecurity(types, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone,
                 symbolProperties, SecurityInitializer, symbolObject, resolution, fillDataForward, leverage, true, false, true, LiveMode);
 
             AddToUserDefinedUniverse(security);

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -220,7 +220,8 @@ namespace QuantConnect.Algorithm
             var dataTimeZone = marketHoursDbEntry.DataTimeZone;
             var exchangeTimeZone = marketHoursDbEntry.ExchangeHours.TimeZone;
             var symbol = QuantConnect.Symbol.Create(name, securityType, market);
-            var config = new SubscriptionDataConfig(typeof(T), symbol, resolution, dataTimeZone, exchangeTimeZone, false, false, true, true, isFilteredSubscription: false);
+            var subscriptionDataType = new SubscriptionDataType(typeof(T), TickType.Trade);
+            var config = new SubscriptionDataConfig(subscriptionDataType, symbol, resolution, dataTimeZone, exchangeTimeZone, false, false, true, true, isFilteredSubscription: false);
             AddUniverse(new FuncUniverse(config, universeSettings, SecurityInitializer, d => selector(d.OfType<T>())));
         }
 
@@ -240,7 +241,8 @@ namespace QuantConnect.Algorithm
             var dataTimeZone = marketHoursDbEntry.DataTimeZone;
             var exchangeTimeZone = marketHoursDbEntry.ExchangeHours.TimeZone;
             var symbol = QuantConnect.Symbol.Create(name, securityType, market);
-            var config = new SubscriptionDataConfig(typeof(T), symbol, resolution, dataTimeZone, exchangeTimeZone, false, false, true, true, isFilteredSubscription: false);
+            var subscriptionDataType = new SubscriptionDataType(typeof(T), TickType.Trade);
+            var config = new SubscriptionDataConfig(subscriptionDataType, symbol, resolution, dataTimeZone, exchangeTimeZone, false, false, true, true, isFilteredSubscription: false);
             AddUniverse(new FuncUniverse(config, universeSettings, SecurityInitializer, d => selector(d.OfType<T>()).Select(x => QuantConnect.Symbol.Create(x, securityType, market))));
         }
 
@@ -316,7 +318,8 @@ namespace QuantConnect.Algorithm
             var dataTimeZone = marketHoursDbEntry.DataTimeZone;
             var exchangeTimeZone = marketHoursDbEntry.ExchangeHours.TimeZone;
             var symbol = QuantConnect.Symbol.Create(name, securityType, market);
-            var config = new SubscriptionDataConfig(typeof(CoarseFundamental), symbol, resolution, dataTimeZone, exchangeTimeZone, false, false, true, isFilteredSubscription: false);
+            var subscriptionDataType = new SubscriptionDataType(typeof(CoarseFundamental), TickType.Trade);
+            var config = new SubscriptionDataConfig(subscriptionDataType, symbol, resolution, dataTimeZone, exchangeTimeZone, false, false, true, isFilteredSubscription: false);
             AddUniverse(new UserDefinedUniverse(config, universeSettings, SecurityInitializer, resolution.ToTimeSpan(), selector));
         }
 

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1370,7 +1370,9 @@ namespace QuantConnect.Algorithm
 
             var marketHoursEntry = _marketHoursDatabase.GetEntry(market, underlying, SecurityType.Option);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, underlying, SecurityType.Option, CashBook.AccountCurrency);
-            var canonicalSecurity = (Option) SecurityManager.CreateSecurity(new List<Type>() { typeof(ZipEntryName) }, Portfolio, SubscriptionManager,
+            var types = new List<SubscriptionDataType> { new SubscriptionDataType(typeof(ZipEntryName), TickType.Quote) };
+
+            var canonicalSecurity = (Option) SecurityManager.CreateSecurity(types, Portfolio, SubscriptionManager,
                 marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties, SecurityInitializer, canonicalSymbol, resolution,
                 fillDataForward, leverage, false, false, false, LiveMode, true, false);
             canonicalSecurity.IsTradable = false;
@@ -1416,7 +1418,7 @@ namespace QuantConnect.Algorithm
 
             var marketHoursEntry = _marketHoursDatabase.GetEntry(market, symbol, SecurityType.Future);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, symbol, SecurityType.Future, CashBook.AccountCurrency);
-            var types = SubscriptionManager.LookupSubscriptionConfigDataTypes(SecurityType.Future, resolution, canonicalSymbol.IsCanonical());
+            var types = new List<SubscriptionDataType> { new SubscriptionDataType(typeof(ZipEntryName), TickType.Quote) };
 
             var canonicalSecurity = (Future)SecurityManager.CreateSecurity(types, Portfolio, SubscriptionManager,
                 marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties, SecurityInitializer, canonicalSymbol, resolution,
@@ -1590,9 +1592,10 @@ namespace QuantConnect.Algorithm
             //Add this to the data-feed subscriptions
             var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA), symbol);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(Market.USA, symbol, SecurityType.Base, CashBook.AccountCurrency);
+            var types = new List<SubscriptionDataType> { new SubscriptionDataType(typeof(T), TickType.Trade) };
 
             //Add this new generic data as a tradeable security: 
-            var security = SecurityManager.CreateSecurity(new List<Type>() { typeof(T) }, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone, 
+            var security = SecurityManager.CreateSecurity(types, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone, 
                 symbolProperties, SecurityInitializer, symbolObject, resolution, fillDataForward, leverage, true, false, true, LiveMode);
 
             AddToUserDefinedUniverse(security);

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Data
         /// <summary>
         /// Gets the data type used to process the subscription request, this type must derive from BaseData
         /// </summary>
-        public Type DataType { get; set; }
+        public SubscriptionDataType SubscriptionDataType { get; set; }
 
         /// <summary>
         /// Gets the time zone of the time stamps on the raw input data
@@ -92,7 +92,7 @@ namespace QuantConnect.Data
             Resolution = Resolution.Minute;
             FillForwardResolution = Resolution.Minute;
             IncludeExtendedMarketHours = false;
-            DataType = typeof (TradeBar);
+            SubscriptionDataType = new SubscriptionDataType(typeof (TradeBar), TickType.Trade);
             TimeZone = TimeZones.NewYork;
             IsCustomData = false;
             DataNormalizationMode = DataNormalizationMode.Adjusted;
@@ -103,7 +103,7 @@ namespace QuantConnect.Data
         /// </summary>
         /// <param name="startTimeUtc">The start time for this request,</param>
         /// <param name="endTimeUtc">The start time for this request</param>
-        /// <param name="dataType">The data type of the output data</param>
+        /// <param name="subscriptionDataType">The data type + tick type of the output data</param>
         /// <param name="symbol">The symbol to request data for</param>
         /// <param name="resolution">The requested data resolution</param>
         /// <param name="exchangeHours">The exchange hours used in fill forward processing</param>
@@ -113,7 +113,7 @@ namespace QuantConnect.Data
         /// <param name="dataNormalizationMode">Specifies normalization mode used for this subscription</param>
         public HistoryRequest(DateTime startTimeUtc, 
             DateTime endTimeUtc,
-            Type dataType,
+            SubscriptionDataType subscriptionDataType,
             Symbol symbol,
             Resolution resolution,
             SecurityExchangeHours exchangeHours,
@@ -130,7 +130,7 @@ namespace QuantConnect.Data
             Resolution = resolution;
             FillForwardResolution = fillForwardResolution;
             IncludeExtendedMarketHours = includeExtendedMarketHours;
-            DataType = dataType;
+            SubscriptionDataType = subscriptionDataType;
             IsCustomData = isCustomData;
             DataNormalizationMode = dataNormalizationMode;
             TimeZone = exchangeHours.TimeZone;
@@ -152,7 +152,7 @@ namespace QuantConnect.Data
             Resolution = config.Resolution;
             FillForwardResolution = config.FillDataForward ? config.Resolution : (Resolution?) null;
             IncludeExtendedMarketHours = config.ExtendedMarketHours;
-            DataType = config.Type;
+            SubscriptionDataType = config.SubscriptionDataType;
             IsCustomData = config.IsCustomData;
             DataNormalizationMode = config.DataNormalizationMode;
             TimeZone = config.DataTimeZone;

--- a/Common/Data/SubscriptionDataType.cs
+++ b/Common/Data/SubscriptionDataType.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+
+namespace QuantConnect.Data
+{
+    /// <summary>
+    /// Represents the data type and tick type for a subscription
+    /// </summary>
+    public class SubscriptionDataType
+    {
+        /// <summary>
+        /// Gets the data type used to process the subscription request, this type must derive from BaseData
+        /// </summary>
+        public Type DataType { get; }
+
+        /// <summary>
+        /// Gets the tick type for the subscription request, currently can be Trade, Quote or OpenInterest
+        /// </summary>
+        public TickType TickType { get; }
+
+        /// <summary>
+        /// Initializes a new default instance of the <see cref="SubscriptionDataType"/> class
+        /// </summary>
+        public SubscriptionDataType(Type dataType, TickType tickType)
+        {
+            DataType = dataType;
+            TickType = tickType;
+        }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        public override string ToString()
+        {
+            return $"{DataType.Name}/{TickType}";
+        }
+    }
+}

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -97,13 +97,15 @@ namespace QuantConnect.Data
             {
                 dataType = typeof(Tick);
             }
-            return Add(dataType, symbol, resolution, timeZone, exchangeTimeZone, isCustomData, fillDataForward, extendedMarketHours);
+            var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType);
+            var subscriptionDataType = new SubscriptionDataType(dataType, tickType);
+            return Add(subscriptionDataType, symbol, resolution, timeZone, exchangeTimeZone, isCustomData, fillDataForward, extendedMarketHours);
         }
 
         /// <summary>
         /// Add Market Data Required - generic data typing support as long as Type implements BaseData.
         /// </summary>
-        /// <param name="dataType">Set the type of the data we're subscribing to.</param>
+        /// <param name="subscriptionDataType">Data type and tick type for the subscription.</param>
         /// <param name="symbol">Symbol of the asset we're like</param>
         /// <param name="resolution">Resolution of Asset Required</param>
         /// <param name="dataTimeZone">The time zone the subscription's data is time stamped in</param>
@@ -115,7 +117,7 @@ namespace QuantConnect.Data
         /// <param name="isInternalFeed">Set to true to prevent data from this subscription from being sent into the algorithm's OnData events</param>
         /// <param name="isFilteredSubscription">True if this subscription should have filters applied to it (market hours/user filters from security), false otherwise</param>
         /// <returns>The newly created <see cref="SubscriptionDataConfig"/></returns>
-        public SubscriptionDataConfig Add(Type dataType, Symbol symbol, Resolution resolution, DateTimeZone dataTimeZone, DateTimeZone exchangeTimeZone, bool isCustomData, bool fillDataForward = true, bool extendedMarketHours = false, bool isInternalFeed = false, bool isFilteredSubscription = true)
+        public SubscriptionDataConfig Add(SubscriptionDataType subscriptionDataType, Symbol symbol, Resolution resolution, DateTimeZone dataTimeZone, DateTimeZone exchangeTimeZone, bool isCustomData, bool fillDataForward = true, bool extendedMarketHours = false, bool isInternalFeed = false, bool isFilteredSubscription = true)
         {
             if (dataTimeZone == null)
             {
@@ -127,7 +129,7 @@ namespace QuantConnect.Data
             }
 
             //Create:
-            var newConfig = new SubscriptionDataConfig(dataType, symbol, resolution, dataTimeZone, exchangeTimeZone, fillDataForward, extendedMarketHours, isInternalFeed, isCustomData, isFilteredSubscription: isFilteredSubscription);
+            var newConfig = new SubscriptionDataConfig(subscriptionDataType, symbol, resolution, dataTimeZone, exchangeTimeZone, fillDataForward, extendedMarketHours, isInternalFeed, isCustomData, isFilteredSubscription: isFilteredSubscription);
 
             //Add to subscription list: make sure we don't have this symbol:
             if (Subscriptions.Contains(newConfig))
@@ -225,19 +227,14 @@ namespace QuantConnect.Data
         /// <param name="resolution">The resolution of the data requested</param>
         /// <param name="isCanonical">Indicates whether the security is Canonical (future and options)</param>
         /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig"/></returns>
-        public List<Type> LookupSubscriptionConfigDataTypes(SecurityType symbolSecurityType, Resolution resolution, bool isCanonical)
+        public List<SubscriptionDataType> LookupSubscriptionConfigDataTypes(SecurityType symbolSecurityType, Resolution resolution, bool isCanonical)
         {
             if (isCanonical)
             {
-                return new List<Type>() { typeof(ZipEntryName) };
+                return new List<SubscriptionDataType> { new SubscriptionDataType(typeof(ZipEntryName), TickType.Quote) };
             }
 
-            if (resolution == Resolution.Tick)
-            {
-                return new List<Type>() { typeof(Tick) };
-            }
-
-            return AvailableDataTypes[symbolSecurityType].Select(tickType => LeanData.GetDataType(resolution, tickType)).ToList();
+            return AvailableDataTypes[symbolSecurityType].Select(tickType => new SubscriptionDataType(LeanData.GetDataType(resolution, tickType), tickType)).ToList();
         }
 
     } // End Algorithm MetaData Manager Class

--- a/Common/Data/UniverseSelection/CoarseFundamentalUniverse.cs
+++ b/Common/Data/UniverseSelection/CoarseFundamentalUniverse.cs
@@ -81,7 +81,8 @@ namespace QuantConnect.Data.UniverseSelection
         /// <returns>A coarse fundamental subscription configuration with the specified symbol</returns>
         public static SubscriptionDataConfig CreateConfiguration(Symbol symbol)
         {
-            return new SubscriptionDataConfig(typeof (CoarseFundamental),
+            return new SubscriptionDataConfig(
+                new SubscriptionDataType(typeof (CoarseFundamental), TickType.Trade),
                 symbol: symbol,
                 resolution: Resolution.Daily,
                 dataTimeZone: TimeZones.NewYork,
@@ -90,7 +91,6 @@ namespace QuantConnect.Data.UniverseSelection
                 extendedHours: false,
                 isInternalFeed: true,
                 isCustom: false,
-                tickType: null,
                 isFilteredSubscription: false
                 );
         }

--- a/Common/Data/UniverseSelection/FineFundamentalUniverse.cs
+++ b/Common/Data/UniverseSelection/FineFundamentalUniverse.cs
@@ -82,7 +82,8 @@ namespace QuantConnect.Data.UniverseSelection
         /// <returns>A fine fundamental subscription configuration with the specified symbol</returns>
         public static SubscriptionDataConfig CreateConfiguration(Symbol symbol)
         {
-            return new SubscriptionDataConfig(typeof (FineFundamental),
+            return new SubscriptionDataConfig(
+                new SubscriptionDataType(typeof(FineFundamental), TickType.Trade),
                 symbol: symbol,
                 resolution: Resolution.Daily,
                 dataTimeZone: TimeZones.NewYork,
@@ -91,7 +92,6 @@ namespace QuantConnect.Data.UniverseSelection
                 extendedHours: false,
                 isInternalFeed: true,
                 isCustom: false,
-                tickType: null,
                 isFilteredSubscription: false
                 );
         }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Brokerages\DefaultBrokerageMessageHandler.cs" />
     <Compile Include="Brokerages\DefaultBrokerageModel.cs" />
     <Compile Include="Brokerages\FxcmBrokerageModel.cs" />
+    <Compile Include="Data\SubscriptionDataType.cs" />
     <Compile Include="Securities\Option\EmptyOptionChainProvider.cs" />
     <Compile Include="Interfaces\IOptionChainProvider.cs" />
     <Compile Include="Brokerages\OandaTransactionModel.cs" />

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -204,7 +204,8 @@ namespace QuantConnect.Securities
                     var marketHoursDbEntry = marketHoursDatabase.GetEntry(symbol.ID.Market, symbol.Value, symbol.ID.SecurityType);
                     var exchangeHours = marketHoursDbEntry.ExchangeHours;
                     // set this as an internal feed so that the data doesn't get sent into the algorithm's OnData events
-                    var config = subscriptions.Add(objectType, symbol, minimumResolution, marketHoursDbEntry.DataTimeZone, exchangeHours.TimeZone, false, true, false, true);
+                    var subscriptionDataType = new SubscriptionDataType(objectType, TickType.Quote);
+                    var config = subscriptions.Add(subscriptionDataType, symbol, minimumResolution, marketHoursDbEntry.DataTimeZone, exchangeHours.TimeZone, false, true, false, true);
                     SecuritySymbol = config.Symbol;
 
                     Security security;

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -21,8 +21,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using NodaTime;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
-using QuantConnect.Util;
 
 namespace QuantConnect.Securities
 {
@@ -307,7 +305,7 @@ namespace QuantConnect.Securities
         /// leverage is less than or equal to zero.
         /// This method also add the new symbol mapping to the <see cref="SymbolCache"/>
         /// </summary>
-        public static Security CreateSecurity(List<Type> factoryTypes,
+        public static Security CreateSecurity(List<SubscriptionDataType> subscriptionDataTypes,
             SecurityPortfolioManager securityPortfolioManager,
             SubscriptionManager subscriptionManager,
             SecurityExchangeHours exchangeHours,
@@ -325,20 +323,20 @@ namespace QuantConnect.Securities
             bool addToSymbolCache = true,
             bool isFilteredSubscription = true)
         {
-            if (!factoryTypes.Any())
+            if (!subscriptionDataTypes.Any())
             {
-                throw new ArgumentNullException("factoryTypes", "At least one type needed to create security");
+                throw new ArgumentNullException(nameof(subscriptionDataTypes), "At least one type needed to create security");
             }
 
             // add the symbol to our cache
             if (addToSymbolCache) SymbolCache.Set(symbol.Value, symbol);
 
             // Add the symbol to Data Manager -- generate unified data streams for algorithm events
-            SubscriptionDataConfigList configList = new SubscriptionDataConfigList(symbol);
+            var configList = new SubscriptionDataConfigList(symbol);
 
-            foreach (var dataFeedType in factoryTypes)
+            foreach (var subscriptionDataType in subscriptionDataTypes)
             {
-                configList.Add(subscriptionManager.Add(dataFeedType, symbol, resolution, dataTimeZone, exchangeHours.TimeZone, isCustomData, fillDataForward,
+                configList.Add(subscriptionManager.Add(subscriptionDataType, symbol, resolution, dataTimeZone, exchangeHours.TimeZone, isCustomData, fillDataForward,
                                                         extendedMarketHours, isInternalFeed, isFilteredSubscription));
             }
 
@@ -458,7 +456,7 @@ namespace QuantConnect.Securities
             var symbolProperties = symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
 
             var types = subscriptionManager.LookupSubscriptionConfigDataTypes(symbol.SecurityType, resolution, symbol.IsCanonical());
-            
+
             return CreateSecurity(types, securityPortfolioManager, subscriptionManager, exchangeHours, marketHoursDbEntry.DataTimeZone, symbolProperties, securityInitializer, symbol, resolution,
                 fillDataForward, leverage, extendedMarketHours, isInternalFeed, isCustomData, isLiveMode, addToSymbolCache);
         }

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -124,7 +124,7 @@ namespace QuantConnect.Securities
                     FillForwardResolution = security.Resolution,
                     IncludeExtendedMarketHours = true,
                     Symbol = security.Symbol,
-                    DataType = typeof(TradeBar),
+                    SubscriptionDataType = new SubscriptionDataType(typeof(TradeBar), TickType.Trade),
                     TimeZone = security.Exchange.TimeZone
                 }
             };

--- a/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
+++ b/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Securities
                     FillForwardResolution = Resolution.Daily,
                     IncludeExtendedMarketHours = true,
                     Symbol = security.Symbol,
-                    DataType = typeof(TradeBar),
+                    SubscriptionDataType = new SubscriptionDataType(typeof(TradeBar), TickType.Trade),
                     TimeZone = security.Exchange.TimeZone
                 }
             };

--- a/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactory.cs
@@ -64,7 +64,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             var tradableDays = _tradableDaysProvider(request);
 
             var fineFundamental = new FineFundamental();
-            var fineFundamentalConfiguration = new SubscriptionDataConfig(request.Configuration, typeof(FineFundamental), request.Security.Symbol);
+            var subscriptionDataType = new SubscriptionDataType(typeof(FineFundamental), TickType.Trade);
+            var fineFundamentalConfiguration = new SubscriptionDataConfig(request.Configuration, subscriptionDataType, request.Security.Symbol);
 
             return (
                 from date in tradableDays

--- a/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactory.cs
@@ -121,7 +121,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             var configurations = new List<SubscriptionDataConfig>
             {
                 // add underlying trade data
-                new SubscriptionDataConfig(config, resolution: resolution, fillForward: true, symbol: underlying, objectType: typeof (TradeBar), tickType: TickType.Trade),
+                new SubscriptionDataConfig(config, 
+                    resolution: resolution, 
+                    fillForward: true, 
+                    symbol: underlying, 
+                    subscriptionDataType: new SubscriptionDataType(typeof (TradeBar), TickType.Trade))
             };
 
             if (!_isLiveMode)

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             var start = request.StartTimeUtc.ConvertFromUtc(request.ExchangeHours.TimeZone);
             var end = request.EndTimeUtc.ConvertFromUtc(request.ExchangeHours.TimeZone);
 
-            var config = new SubscriptionDataConfig(request.DataType,
+            var config = new SubscriptionDataConfig(request.SubscriptionDataType,
                 request.Symbol,
                 request.Resolution,
                 request.TimeZone,
@@ -99,7 +99,6 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 request.IncludeExtendedMarketHours,
                 false,
                 request.IsCustomData,
-                null,
                 true,
                 request.DataNormalizationMode
                 );
@@ -112,7 +111,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             if (request.FillForwardResolution.HasValue)
             {
                 // copy forward Bid/Ask bars for QuoteBars
-                if (request.DataType == typeof(QuoteBar))
+                if (request.SubscriptionDataType.DataType == typeof(QuoteBar))
                 {
                     reader = new QuoteBarFillForwardEnumerator(reader);
                 }

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -94,7 +94,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             start = start.ConvertFromUtc(request.ExchangeHours.TimeZone);
             end = end.ConvertFromUtc(request.ExchangeHours.TimeZone);
 
-            var config = new SubscriptionDataConfig(request.DataType, 
+            var config = new SubscriptionDataConfig(request.SubscriptionDataType, 
                 request.Symbol, 
                 request.Resolution, 
                 request.TimeZone, 
@@ -103,7 +103,6 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 request.IncludeExtendedMarketHours, 
                 false, 
                 request.IsCustomData,
-                null,
                 true,
                 request.DataNormalizationMode
                 );
@@ -127,7 +126,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             if (request.FillForwardResolution.HasValue)
             {
                 // copy forward Bid/Ask bars for QuoteBars
-                if (request.DataType == typeof(QuoteBar))
+                if (request.SubscriptionDataType.DataType == typeof(QuoteBar))
                 {
                     reader = new QuoteBarFillForwardEnumerator(reader);
                 }

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -212,7 +212,9 @@ namespace QuantConnect.Jupyter
                     FillForwardResolution = null,
                     DataNormalizationMode = dataNormalizationMode,
                     IncludeExtendedMarketHours = extendedMarket,
-                    DataType = symbol.ID.SecurityType == SecurityType.Equity ? typeof(TradeBar) : typeof(QuoteBar)
+                    SubscriptionDataType = symbol.ID.SecurityType == SecurityType.Equity ? 
+                        new SubscriptionDataType(typeof(TradeBar), TickType.Trade) :
+                        new SubscriptionDataType(typeof(QuoteBar), TickType.Quote)
                 };
             });
 
@@ -247,7 +249,9 @@ namespace QuantConnect.Jupyter
                 var dir = new DirectoryInfo(Path.Combine(Globals.DataFolder, "equity", symbol.ID.Market, "fundamental", "fine", symbol.Value.ToLower()));
                 if (!dir.Exists) continue;
 
-                var config = new SubscriptionDataConfig(typeof(FineFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+                var subscriptionDataType = new SubscriptionDataType(typeof(FineFundamental), TickType.Trade);
+
+                var config = new SubscriptionDataConfig(subscriptionDataType, symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
 
                 foreach (var fileName in dir.EnumerateFiles())
                 {
@@ -335,7 +339,7 @@ namespace QuantConnect.Jupyter
                     var list = history.Get(symbol, selector).Select(x => (double)x).ToList();
                     if (list.Count == 0) continue;
 
-                    var index = request.DataType.Equals(typeof(QuoteBar))
+                    var index = request.SubscriptionDataType.DataType == typeof(QuoteBar)
                         ? history.Get<QuoteBar>(symbol).Select(x => x.Time)
                         : history.Get<TradeBar>(symbol).Select(x => x.Time);
 
@@ -365,7 +369,7 @@ namespace QuantConnect.Jupyter
                     var symbol = request.Symbol;
                     var dict = new Dictionary<string, List<double>>();
 
-                    if (request.DataType.Equals(typeof(QuoteBar)))
+                    if (request.SubscriptionDataType.DataType == typeof(QuoteBar))
                     {
                         var bars = history.Get<QuoteBar>(symbol).ToList();
                         if (bars.Count == 0) continue;

--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -175,8 +175,9 @@ namespace QuantConnect.Tests.Brokerages
 
         internal static Security CreateSecurity(Symbol symbol)
         {
+            var subscriptionDataType = new SubscriptionDataType(typeof(TradeBar), TickType.Trade);
             return new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                new SubscriptionDataConfig(typeof (TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
+                new SubscriptionDataConfig(subscriptionDataType, symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
                 new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
         }
 

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
@@ -51,9 +51,10 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 );
 
             // grabs account info from configuration
+            var subscriptionDataType = new SubscriptionDataType(typeof(TradeBar), TickType.Trade);
             var securityProvider = new SecurityProvider();
             securityProvider[Symbols.USDJPY] = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.USDJPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
+                new SubscriptionDataConfig(subscriptionDataType, Symbols.USDJPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
                 new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
 
             _interactiveBrokersBrokerage = new InteractiveBrokersBrokerage(new QCAlgorithm(), new OrderProvider(_orders), securityProvider);

--- a/Tests/Common/Data/SubscriptionManagerTests.cs
+++ b/Tests/Common/Data/SubscriptionManagerTests.cs
@@ -1,0 +1,99 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Tests.Common.Data
+{
+    [TestFixture]
+    public class SubscriptionManagerTests
+    {
+        [Test]
+        [TestCase(SecurityType.Base, Resolution.Minute, typeof(TradeBar), TickType.Trade)]
+        [TestCase(SecurityType.Base, Resolution.Tick, typeof(Tick), TickType.Trade)]
+        [TestCase(SecurityType.Equity, Resolution.Minute, typeof(TradeBar), TickType.Trade)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Trade)]
+        [TestCase(SecurityType.Forex, Resolution.Minute, typeof(QuoteBar), TickType.Quote)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Quote)]
+        [TestCase(SecurityType.Cfd, Resolution.Minute, typeof(QuoteBar), TickType.Quote)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Quote)]
+        public void GetsSubscriptionDataTypesSingle(SecurityType securityType, Resolution resolution, Type expectedDataType, TickType expectedTickType)
+        {
+            var types = GetSubscriptionDataTypes(securityType, resolution);
+
+            Assert.AreEqual(1, types.Count);
+            Assert.AreEqual(expectedDataType, types[0].DataType);
+            Assert.AreEqual(expectedTickType, types[0].TickType);
+        }
+
+        [Test]
+        [TestCase(SecurityType.Future, Resolution.Minute, typeof(ZipEntryName), TickType.Quote)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(ZipEntryName), TickType.Quote)]
+        [TestCase(SecurityType.Option, Resolution.Minute, typeof(ZipEntryName), TickType.Quote)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(ZipEntryName), TickType.Quote)]
+        public void GetsSubscriptionDataTypesCanonical(SecurityType securityType, Resolution resolution, Type expectedDataType, TickType expectedTickType)
+        {
+            var types = GetSubscriptionDataTypes(securityType, resolution, true);
+
+            Assert.AreEqual(1, types.Count);
+            Assert.AreEqual(expectedDataType, types[0].DataType);
+            Assert.AreEqual(expectedTickType, types[0].TickType);
+        }
+
+        [Test]
+        [TestCase(SecurityType.Future, Resolution.Minute)]
+        [TestCase(SecurityType.Option, Resolution.Minute)]
+        public void GetsSubscriptionDataTypesFuturesOptionsMinute(SecurityType securityType, Resolution resolution)
+        {
+            var types = GetSubscriptionDataTypes(securityType, resolution);
+
+            Assert.AreEqual(3, types.Count);
+            Assert.AreEqual(typeof(QuoteBar), types[0].DataType);
+            Assert.AreEqual(TickType.Quote, types[0].TickType);
+            Assert.AreEqual(typeof(TradeBar), types[1].DataType);
+            Assert.AreEqual(TickType.Trade, types[1].TickType);
+            Assert.AreEqual(typeof(OpenInterest), types[2].DataType);
+            Assert.AreEqual(TickType.OpenInterest, types[2].TickType);
+        }
+
+        [Test]
+        [TestCase(SecurityType.Future, Resolution.Tick)]
+        [TestCase(SecurityType.Option, Resolution.Tick)]
+        public void GetsSubscriptionDataTypesFuturesOptionsTick(SecurityType securityType, Resolution resolution)
+        {
+            var types = GetSubscriptionDataTypes(securityType, resolution);
+
+            Assert.AreEqual(3, types.Count);
+            Assert.AreEqual(typeof(Tick), types[0].DataType);
+            Assert.AreEqual(TickType.Quote, types[0].TickType);
+            Assert.AreEqual(typeof(Tick), types[1].DataType);
+            Assert.AreEqual(TickType.Trade, types[1].TickType);
+            Assert.AreEqual(typeof(Tick), types[2].DataType);
+            Assert.AreEqual(TickType.OpenInterest, types[2].TickType);
+        }
+
+        private static List<SubscriptionDataType> GetSubscriptionDataTypes(SecurityType securityType, Resolution resolution, bool isCanonical = false)
+        {
+            var timeKeeper = new TimeKeeper(DateTime.UtcNow);
+            var subscriptionManager = new SubscriptionManager(new AlgorithmSettings(), timeKeeper);
+            return subscriptionManager.LookupSubscriptionConfigDataTypes(securityType, resolution, isCanonical);
+        }
+    }
+}

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -17,13 +17,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
-using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -129,7 +127,7 @@ namespace QuantConnect.Tests.Common.Securities
             var forexDefaultQuoteCurrency = forexSymbol.Value.Substring(3);
 
             var forexSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(forexSymbol.ID.Market, forexSymbol, forexSymbol.ID.SecurityType, forexDefaultQuoteCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(QuoteBar) };
+            var subscriptionTypes = new List<SubscriptionDataType> { new SubscriptionDataType(typeof(QuoteBar), TickType.Quote) };
 
             var forex = SecurityManager.CreateSecurity(subscriptionTypes,
                 _securityPortfolioManager,
@@ -158,7 +156,7 @@ namespace QuantConnect.Tests.Common.Securities
             var optionMarketHoursDbEntry = _marketHoursDatabase.GetEntry(optionSymbol.ID.Market, optionSymbol, SecurityType.Option);
             var optionDefaultQuoteCurrency = CashBook.AccountCurrency;
             var optionSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(optionSymbol.ID.Market, optionSymbol, optionSymbol.ID.SecurityType, optionDefaultQuoteCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(ZipEntryName) };
+            var subscriptionTypes = new List<SubscriptionDataType> { new SubscriptionDataType(typeof(ZipEntryName), TickType.Quote) };
 
             var option = SecurityManager.CreateSecurity(subscriptionTypes,
                 _securityPortfolioManager,
@@ -189,7 +187,7 @@ namespace QuantConnect.Tests.Common.Securities
             var equityMarketHoursDbEntry = _marketHoursDatabase.GetEntry(equitySymbol.ID.Market, equitySymbol, SecurityType.Equity);
             var equityDefaultQuoteCurrency = CashBook.AccountCurrency;
             var equitySymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(equitySymbol.ID.Market, equitySymbol, equitySymbol.ID.SecurityType, equityDefaultQuoteCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(TradeBar) };
+            var subscriptionTypes = new List<SubscriptionDataType> { new SubscriptionDataType(typeof(TradeBar), TickType.Trade) };
 
             var equity = SecurityManager.CreateSecurity(subscriptionTypes,
                 _securityPortfolioManager,
@@ -219,7 +217,7 @@ namespace QuantConnect.Tests.Common.Securities
             var marketHoursDbEntry = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, SecurityType.Equity);
             var defaultQuoteCurrency = CashBook.AccountCurrency;
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(TradeBar) };
+            var subscriptionTypes = new List<SubscriptionDataType> { new SubscriptionDataType(typeof(QuoteBar), TickType.Quote) };
 
             var subscriptions = SecurityManager.CreateSecurity(subscriptionTypes,
                 _securityPortfolioManager,
@@ -238,8 +236,8 @@ namespace QuantConnect.Tests.Common.Securities
                 false);
 
             Assert.AreEqual(subscriptions.Subscriptions.Count(), 1);
-            Assert.AreEqual(subscriptions.Subscriptions.First().Type, typeof(TradeBar));
-            Assert.AreEqual(subscriptions.Subscriptions.First().TickType, TickType.Trade);
+            Assert.AreEqual(subscriptions.Subscriptions.First().Type, typeof(QuoteBar));
+            Assert.AreEqual(subscriptions.Subscriptions.First().TickType, TickType.Quote);
         }
 
         [Test]
@@ -248,7 +246,7 @@ namespace QuantConnect.Tests.Common.Securities
             var equitySymbol = new Symbol(SecurityIdentifier.GenerateBase("BTC", Market.USA), "BTC");
             var equityMarketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "BTC", SecurityType.Base, TimeZones.NewYork);
             var equitySymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(equitySymbol.ID.Market, equitySymbol, equitySymbol.ID.SecurityType, CashBook.AccountCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(Bitcoin) };
+            var subscriptionTypes = new List<SubscriptionDataType> { new SubscriptionDataType(typeof(Bitcoin), TickType.Trade) };
 
             var equity = SecurityManager.CreateSecurity(subscriptionTypes,
                 _securityPortfolioManager,
@@ -280,7 +278,12 @@ namespace QuantConnect.Tests.Common.Securities
             var optionMarketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "SPY", SecurityType.Equity, TimeZones.NewYork);
             var optionSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(optionSymbol.ID.Market, "SPY", optionSymbol.ID.SecurityType, CashBook.AccountCurrency);
 
-            var subscriptionTypes = new List<Type>() { typeof(TradeBar), typeof(QuoteBar), typeof(OpenInterest) };
+            var subscriptionTypes = new List<SubscriptionDataType>()
+            {
+                new SubscriptionDataType(typeof(TradeBar), TickType.Trade),
+                new SubscriptionDataType(typeof(QuoteBar), TickType.Quote),
+                new SubscriptionDataType(typeof(OpenInterest), TickType.OpenInterest)
+            };
 
             var optionSubscriptions = SecurityManager.CreateSecurity(subscriptionTypes,
                 _securityPortfolioManager,
@@ -314,7 +317,12 @@ namespace QuantConnect.Tests.Common.Securities
             var marketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "ED", SecurityType.Equity, TimeZones.NewYork);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, "ED", symbol.ID.SecurityType, CashBook.AccountCurrency);
 
-            var subscriptionTypes = new List<Type>() { typeof(TradeBar), typeof(QuoteBar), typeof(OpenInterest) };
+            var subscriptionTypes = new List<SubscriptionDataType>()
+            {
+                new SubscriptionDataType(typeof(TradeBar), TickType.Trade),
+                new SubscriptionDataType(typeof(QuoteBar), TickType.Quote),
+                new SubscriptionDataType(typeof(OpenInterest), TickType.OpenInterest)
+            };
 
             var subscriptions = SecurityManager.CreateSecurity(subscriptionTypes,
                 _securityPortfolioManager,

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -416,7 +416,8 @@ namespace QuantConnect.Tests.Common.Util
                 {
                     BaseDataType = typeof(QuoteBar);
                 }
-                Config = new SubscriptionDataConfig(BaseDataType, symbol, resolution, TimeZones.NewYork, TimeZones.NewYork, true, false, false, false, tickType);
+                var subscriptionDataType = new SubscriptionDataType(BaseDataType, tickType);
+                Config = new SubscriptionDataConfig(subscriptionDataType, symbol, resolution, TimeZones.NewYork, TimeZones.NewYork, true, false, false, false);
             }
         }
 
@@ -460,7 +461,8 @@ namespace QuantConnect.Tests.Common.Util
                     TickType = TickType.Quote;
                 }
 
-                Config = new SubscriptionDataConfig(Data.GetType(), Data.Symbol, Resolution, TimeZones.Utc, TimeZones.Utc, false, true, false, false, TickType);
+                var subscriptionDataType = new SubscriptionDataType(Data.GetType(), TickType);
+                Config = new SubscriptionDataConfig(subscriptionDataType, Data.Symbol, Resolution, TimeZones.Utc, TimeZones.Utc, false, true, false, false);
 
                 Name = SecurityType + "_" + data.GetType().Name;
 

--- a/Tests/Engine/DataFeeds/TimeSliceTests.cs
+++ b/Tests/Engine/DataFeeds/TimeSliceTests.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void HandlesTicks_ExpectInOrderWithNoDuplicates()
         {
             var subscriptionDataConfig = new SubscriptionDataConfig(
-                typeof(Tick), 
+                new SubscriptionDataType(typeof(Tick), TickType.Quote), 
                 Symbols.EURUSD, 
                 Resolution.Tick, 
                 TimeZones.Utc, 

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Common\BrokerageNameTests.cs" />
     <Compile Include="Common\CurrenciesTests.cs" />
     <Compile Include="Common\Data\Market\QuoteBarTests.cs" />
+    <Compile Include="Common\Data\SubscriptionManagerTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />
     <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />
     <Compile Include="Common\Securities\FutureFilterTests.cs" />

--- a/ToolBox/LeanParser.cs
+++ b/ToolBox/LeanParser.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.IO;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.ToolBox.AlgoSeekOptionsConverter;
 using QuantConnect.Util;
 
 namespace QuantConnect.ToolBox
@@ -43,9 +42,10 @@ namespace QuantConnect.ToolBox
 
             var dataType = GetDataType(pathComponents.SecurityType, pathComponents.Resolution, tickType);
             var factory = (BaseData) Activator.CreateInstance(dataType);
-            
+            var subscriptionDataType = new SubscriptionDataType(dataType, tickType);
+
             // ignore time zones here, i.e, we're going to emit data in the data time zone
-            var config = new SubscriptionDataConfig(dataType, pathComponents.Symbol, pathComponents.Resolution, TimeZones.Utc, TimeZones.Utc, false, true, false);
+            var config = new SubscriptionDataConfig(subscriptionDataType, pathComponents.Symbol, pathComponents.Resolution, TimeZones.Utc, TimeZones.Utc, false, true, false);
             using (var reader = new StreamReader(stream))
             {
                 string line;


### PR DESCRIPTION
Previously `Tick` resolution subscriptions only received ticks with `TickType.Trade`, now `TickType.Quote` and `TickType.OpenInterest` are received as well.