### PR TITLE
Update Tick quantity fields from integer to decimal

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -20,7 +20,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using QuantConnect.Configuration;
@@ -36,7 +35,6 @@ using Order = QuantConnect.Orders.Order;
 using IB = QuantConnect.Brokerages.InteractiveBrokers.Client;
 using IBApi;
 using NodaTime;
-using QuantConnect.Securities.Option;
 using Bar = QuantConnect.Data.Market.Bar;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
@@ -2177,13 +2175,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 securityType != SecurityType.Option)
                 return;
 
+            int quantity;
             switch (e.Field)
             {
                 case IBApi.TickType.BID:
 
                     tick.TickType = TickType.Quote;
                     tick.BidPrice = price;
-                    _lastBidSizes.TryGetValue(symbol, out tick.Quantity);
+                    _lastBidSizes.TryGetValue(symbol, out quantity);
+                    tick.Quantity = quantity;
                     _lastBidPrices[symbol] = price;
                     break;
 
@@ -2191,7 +2191,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                     tick.TickType = TickType.Quote;
                     tick.AskPrice = price;
-                    _lastAskSizes.TryGetValue(symbol, out tick.Quantity);
+                    _lastAskSizes.TryGetValue(symbol, out quantity);
+                    tick.Quantity = quantity;
                     _lastAskPrices[symbol] = price;
                     break;
 
@@ -2247,7 +2248,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     tick.TickType = TickType.Quote;
 
                     _lastBidPrices.TryGetValue(symbol, out tick.BidPrice);
-                    _lastBidSizes[symbol] = tick.Quantity;
+                    _lastBidSizes[symbol] = (int)tick.Quantity;
 
                     tick.Value = tick.BidPrice;
                     tick.BidSize = tick.Quantity;
@@ -2258,7 +2259,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     tick.TickType = TickType.Quote;
 
                     _lastAskPrices.TryGetValue(symbol, out tick.AskPrice);
-                    _lastAskSizes[symbol] = tick.Quantity;
+                    _lastAskSizes[symbol] = (int)tick.Quantity;
 
                     tick.Value = tick.AskPrice;
                     tick.AskSize = tick.Quantity;
@@ -2270,7 +2271,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                     decimal lastPrice;
                     _lastPrices.TryGetValue(symbol, out lastPrice);
-                    _lastVolumes[symbol] = tick.Quantity;
+                    _lastVolumes[symbol] = (int)tick.Quantity;
 
                     tick.Value = lastPrice;
                         

--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// Quantity exchanged in a trade.
         /// </summary>
-        public int Quantity = 0;
+        public decimal Quantity = 0;
 
         /// <summary>
         /// Exchange we are executing on. String short code expanded in the MarketCodes.US global dictionary
@@ -77,12 +77,12 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// Size of bid quote.
         /// </summary>
-        public long BidSize = 0;
+        public decimal BidSize = 0;
 
         /// <summary>
         /// Size of ask quote.
         /// </summary>
-        public long AskSize = 0;
+        public decimal AskSize = 0;
 
         //In Base Class: Alias of Closing:
         //public decimal Price;
@@ -201,7 +201,7 @@ namespace QuantConnect.Data.Market
             Time = baseDate.Date.AddMilliseconds(csv[0].ToInt32());
             Value = csv[1].ToDecimal() / GetScaleFactor(symbol.SecurityType);
             TickType = TickType.Trade;
-            Quantity = csv[2].ToInt32();
+            Quantity = csv[2].ToDecimal();
             Exchange = csv[3].Trim();
             SaleCondition = csv[4];
             Suspicious = csv[5].ToInt32() == 1;
@@ -231,7 +231,7 @@ namespace QuantConnect.Data.Market
                         Time = date.Date.AddMilliseconds(csv[0].ToInt64()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
                         Value = config.GetNormalizedPrice(csv[1].ToDecimal() / scaleFactor);
                         TickType = TickType.Trade;
-                        Quantity = csv[2].ToInt32();
+                        Quantity = csv[2].ToDecimal();
                         if (csv.Count > 3)
                         {
                             Exchange = csv[3];
@@ -265,7 +265,7 @@ namespace QuantConnect.Data.Market
                         if (TickType == TickType.Trade)
                         {
                             Value = config.GetNormalizedPrice(csv[1].ToDecimal()/scaleFactor);
-                            Quantity = csv[2].ToInt32();
+                            Quantity = csv[2].ToDecimal();
                             Exchange = csv[3];
                             SaleCondition = csv[4];
                             Suspicious = csv[5] == "1";
@@ -279,12 +279,12 @@ namespace QuantConnect.Data.Market
                             if (csv[1].Length != 0)
                             {
                                 BidPrice = config.GetNormalizedPrice(csv[1].ToDecimal()/scaleFactor);
-                                BidSize = csv[2].ToInt32();
+                                BidSize = csv[2].ToDecimal();
                             }
                             if (csv[3].Length != 0)
                             {
                                 AskPrice = config.GetNormalizedPrice(csv[3].ToDecimal()/scaleFactor);
-                                AskSize = csv[4].ToInt32();
+                                AskSize = csv[4].ToDecimal();
                             }
                             Exchange = csv[5];
                             Suspicious = csv[6] == "1";
@@ -373,9 +373,9 @@ namespace QuantConnect.Data.Market
             Value = lastTrade;
             BidPrice = bidPrice;
             AskPrice = askPrice;
-            BidSize = (long) bidSize;
-            AskSize = (long) askSize;
-            Quantity = Convert.ToInt32(volume);
+            BidSize = bidSize;
+            AskSize = askSize;
+            Quantity = Convert.ToDecimal(volume);
         }
 
         /// <summary>

--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -484,12 +484,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 if (tick.AskPrice != 0m)
                 {
                     contract.AskPrice = tick.AskPrice;
-                    contract.AskSize = tick.AskSize;
+                    contract.AskSize = (long)tick.AskSize;
                 }
                 if (tick.BidPrice != 0m)
                 {
                     contract.BidPrice = tick.BidPrice;
-                    contract.BidSize = tick.BidSize;
+                    contract.BidSize = (long)tick.BidSize;
                 }
             }
             else if (tick.TickType == TickType.OpenInterest)
@@ -526,12 +526,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 if (tick.AskPrice != 0m)
                 {
                     contract.AskPrice = tick.AskPrice;
-                    contract.AskSize = tick.AskSize;
+                    contract.AskSize = (long)tick.AskSize;
                 }
                 if (tick.BidPrice != 0m)
                 {
                     contract.BidPrice = tick.BidPrice;
-                    contract.BidSize = tick.BidSize;
+                    contract.BidSize = (long)tick.BidSize;
                 }
             }
             else if (tick.TickType == TickType.OpenInterest)


### PR DESCRIPTION
`Tick.Quantity`: `int` -> `decimal`
`Tick.BidSize`: `long` -> `decimal`
`Tick.AskSize`: `long` -> `decimal`

These changes were missing in the decimalization support PR: #982 