### PR TITLE
Fix path comparison in Loader

### DIFF
--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -211,7 +211,8 @@ namespace QuantConnect.AlgorithmFactory
                 
                 // if the assembly is located in the base directory then don't bother loading the pdbs
                 // manually, they'll be loaded automatically by the .NET runtime.
-                if (new FileInfo(assemblyPath).DirectoryName != AppDomain.CurrentDomain.BaseDirectory)
+                var directoryName = new FileInfo(assemblyPath).DirectoryName;
+                if (directoryName != null && directoryName.TrimEnd(Path.DirectorySeparatorChar) != AppDomain.CurrentDomain.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar))
                 {
                     // see if the pdb exists
                     var mdbFilename = assemblyPath + ".mdb";


### PR DESCRIPTION
These two path expressions evaluate to the same physical directory, differing only by the trailing separator char:
- `new FileInfo(assemblyPath).DirectoryName`
- `AppDomain.CurrentDomain.BaseDirectory`