### PR TITLE
ImmediateFillModel fills asset prices only if subscription is available

### DIFF
--- a/Common/Orders/Fills/ImmediateFillModel.cs
+++ b/Common/Orders/Fills/ImmediateFillModel.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Linq;
 using QuantConnect.Data.Market;
+using QuantConnect.Logging;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Orders.Fills
@@ -388,8 +389,12 @@ namespace QuantConnect.Orders.Fills
                 return new Prices(current, open, high, low, close);
             }
 
+            // Only fill with data types we are subscribed to
+            var subscriptionTypes = asset.Subscriptions.Select(x => x.Type).ToList();
+
+            // Tick
             var tick = asset.Cache.GetData<Tick>();
-            if (tick != null && asset.Subscriptions.FirstOrDefault(x => x.Resolution == Resolution.Tick) != null)
+            if (subscriptionTypes.Contains(typeof(Tick)) && tick != null)
             {
                 var price = direction == OrderDirection.Sell ? tick.BidPrice : tick.AskPrice;
                 if (price != 0m)
@@ -405,8 +410,9 @@ namespace QuantConnect.Orders.Fills
                 }
             }
 
+            // Quote
             var quoteBar = asset.Cache.GetData<QuoteBar>();
-            if (quoteBar != null)
+            if (subscriptionTypes.Contains(typeof(QuoteBar)) && quoteBar != null)
             {
                 var bar = direction == OrderDirection.Sell ? quoteBar.Bid : quoteBar.Ask;
                 if (bar != null)
@@ -415,26 +421,11 @@ namespace QuantConnect.Orders.Fills
                 }
             }
 
-            if (direction == OrderDirection.Sell && asset.Cache.BidPrice != 0m)
-            {
-                return new Prices(asset.Cache.BidPrice, 0, 0, 0, 0);
-            }
-            if (direction == OrderDirection.Buy && asset.Cache.AskPrice != 0m)
-            {
-                return new Prices(asset.Cache.AskPrice, 0, 0, 0, 0);
-            }
-
+            // Trade
             var tradeBar = asset.Cache.GetData<TradeBar>();
-            if (tradeBar != null)
+            if (subscriptionTypes.Contains(typeof(TradeBar)) && tradeBar != null)
             {
                 return new Prices(tradeBar);
-            }
-
-            var lastData = asset.GetLastData();
-            var lastBar = lastData as IBar;
-            if (lastBar != null)
-            {
-                return new Prices(lastBar);
             }
 
             return new Prices(current, open, high, low, close);

--- a/Common/Orders/Fills/ImmediateFillModel.cs
+++ b/Common/Orders/Fills/ImmediateFillModel.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Linq;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
 
@@ -388,7 +389,7 @@ namespace QuantConnect.Orders.Fills
             }
 
             var tick = asset.Cache.GetData<Tick>();
-            if (tick != null)
+            if (tick != null && asset.Subscriptions.FirstOrDefault(x => x.Resolution == Resolution.Tick) != null)
             {
                 var price = direction == OrderDirection.Sell ? tick.BidPrice : tick.AskPrice;
                 if (price != 0m)

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -38,13 +38,14 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var exchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork);
             var quoteCash = new Cash("USD", 1000, 1);
             var symbolProperties = SymbolProperties.GetDefault("USD");
-            var security = new Forex(symbol, exchangeHours, quoteCash, symbolProperties);
+            var config = new SubscriptionDataConfig(typeof(Tick), symbol, Resolution.Tick, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
+            var security = new Forex(exchangeHours, quoteCash, config, symbolProperties);
 
             var reference = DateTime.Now;
             var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
             var timeKeeper = new TimeKeeper(referenceUtc);
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
-
+            
             var brokerageModel = new FxcmBrokerageModel();
             var fillModel = brokerageModel.GetFillModel(security);
 
@@ -67,7 +68,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var noon = new DateTime(2014, 6, 24, 12, 0, 0);
             var timeKeeper = new TimeKeeper(noon.ConvertToUtc(TimeZones.NewYork), new[] { TimeZones.NewYork });
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
-            var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Tick, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
+            var config = new SubscriptionDataConfig(typeof(Tick), Symbols.SPY, Resolution.Tick, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
             var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, noon, 101.123m));


### PR DESCRIPTION
When the `ImmediateFillModel` fills the trade, it retrieves the price from the securities `SecurityCache`. It is currently possible to add data types to the `SecurityCache` for which there is no corresponding subscription in the the `Security.Subscriptions`.

This PR makes ensures the `ImmediateFillModel` check for a subscription before filling the trade with an price of a certain type from the `Security.Cache`