### PR TITLE
Require specification of DataTimeZone on history requests

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -457,7 +457,7 @@ namespace QuantConnect.Algorithm
             var request = new HistoryRequest(
                 startTime.ConvertToUtc(_localTimeKeeper.TimeZone),
                 endTime.ConvertToUtc(_localTimeKeeper.TimeZone),
-                subscriptionDataConfig != null ? subscriptionDataConfig.Type : typeof(TradeBar),
+                subscriptionDataConfig == null ? typeof(TradeBar) : subscriptionDataConfig.Type,
                 security.Symbol,
                 resolution,
                 security.Exchange.Hours,
@@ -465,7 +465,8 @@ namespace QuantConnect.Algorithm
                 resolution,
                 security.IsExtendedMarketHours,
                 security.IsCustomData(),
-                security.DataNormalizationMode
+                security.DataNormalizationMode,
+                subscriptionDataConfig == null ? TickType.Trade: subscriptionDataConfig.TickType
             );
 
             var history = History(new List<HistoryRequest> { request });

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -466,7 +466,7 @@ namespace QuantConnect.Algorithm
                 security.IsExtendedMarketHours,
                 security.IsCustomData(),
                 security.DataNormalizationMode,
-                subscriptionDataConfig == null ? TickType.Trade: subscriptionDataConfig.TickType
+                subscriptionDataConfig == null ? LeanData.GetCommonTickTypeForCommonDataTypes(typeof(TradeBar), security.Type) : subscriptionDataConfig.TickType
             );
 
             var history = History(new List<HistoryRequest> { request });

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -454,16 +454,19 @@ namespace QuantConnect.Algorithm
                 subscriptionDataConfig = new SubscriptionDataConfig(subscriptionDataConfig, dataType, resolution: resolution);
             }
 
-            var request = new HistoryRequest
-            {
-                StartTimeUtc = startTime.ConvertToUtc(_localTimeKeeper.TimeZone),
-                EndTimeUtc = endTime.ConvertToUtc(_localTimeKeeper.TimeZone),
-                DataType = subscriptionDataConfig != null ? subscriptionDataConfig.Type : typeof(TradeBar),
-                Resolution = resolution,
-                FillForwardResolution = resolution,
-                Symbol = security.Symbol,
-                ExchangeHours = security.Exchange.Hours
-            };
+            var request = new HistoryRequest(
+                startTime.ConvertToUtc(_localTimeKeeper.TimeZone),
+                endTime.ConvertToUtc(_localTimeKeeper.TimeZone),
+                subscriptionDataConfig != null ? subscriptionDataConfig.Type : typeof(TradeBar),
+                security.Symbol,
+                resolution,
+                security.Exchange.Hours,
+                MarketHoursDatabase.FromDataFolder().GetDataTimeZone(security.Symbol.ID.Market, security.Symbol, security.Symbol.SecurityType),
+                resolution,
+                false,
+                false,
+                DataNormalizationMode.Adjusted
+            );
 
             var history = History(new List<HistoryRequest> { request });
 

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -463,9 +463,9 @@ namespace QuantConnect.Algorithm
                 security.Exchange.Hours,
                 MarketHoursDatabase.FromDataFolder().GetDataTimeZone(security.Symbol.ID.Market, security.Symbol, security.Symbol.SecurityType),
                 resolution,
-                false,
-                false,
-                DataNormalizationMode.Adjusted
+                security.IsExtendedMarketHours,
+                security.IsCustomData(),
+                security.DataNormalizationMode
             );
 
             var history = History(new List<HistoryRequest> { request });

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1585,32 +1585,14 @@ namespace QuantConnect.Algorithm
         public void AddData<T>(string symbol, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
-            // Assume that the exchange time zone and the data time zone are the same
-            AddData<T>(symbol, resolution, timeZone, timeZone, fillDataForward, leverage);
-        }
-
-        /// <summary>
-        /// AddData<typeparam name="T"/> a new user defined data source.
-        /// Allows the specification of different data and exchange timezones
-        /// </summary>
-        /// <param name="symbol">Key/Symbol for data</param>
-        /// <param name="resolution">Resolution of the Data Required</param>
-        /// <param name="exchangeTimeZone">Specifies the time zone of the exchange</param>
-        /// <param name="dataTimeZone">Specifies the data timezone of the raw data</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
-        /// <param name="leverage">Custom leverage per security</param>
-        /// <remarks>Generic type T must implement base data</remarks>
-        public void AddData<T>(string symbol, Resolution resolution, DateTimeZone exchangeTimeZone, DateTimeZone dataTimeZone, bool fillDataForward = false, decimal leverage = 1.0m)
-            where T : IBaseData, new()
-        {
-            var marketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, symbol, SecurityType.Base, exchangeTimeZone);
+            var marketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, symbol, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
             var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA), symbol);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(Market.USA, symbol, SecurityType.Base, CashBook.AccountCurrency);
 
             //Add this new generic data as a tradeable security: 
-            var security = SecurityManager.CreateSecurity(new List<Type>() { typeof(T) }, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, dataTimeZone,
+            var security = SecurityManager.CreateSecurity(new List<Type>() { typeof(T) }, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone, 
                 symbolProperties, SecurityInitializer, symbolObject, resolution, fillDataForward, leverage, true, false, true, LiveMode);
 
             AddToUserDefinedUniverse(security);

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Data
         /// <summary>
         /// Gets the time zone of the time stamps on the raw input data
         /// </summary>
-        public DateTimeZone TimeZone { get; set; }
+        public DateTimeZone DataTimeZone { get; set; }
 
         /// <summary>
         /// Gets true if this is a custom data request, false for normal QC data
@@ -113,7 +113,7 @@ namespace QuantConnect.Data
             EndTimeUtc = endTimeUtc;
             Symbol = symbol;
             ExchangeHours = exchangeHours;
-            TimeZone = dataTimeZone;
+            DataTimeZone = dataTimeZone;
             Resolution = resolution;
             FillForwardResolution = fillForwardResolution;
             IncludeExtendedMarketHours = includeExtendedMarketHours;
@@ -141,7 +141,7 @@ namespace QuantConnect.Data
             DataType = config.Type;
             IsCustomData = config.IsCustomData;
             DataNormalizationMode = config.DataNormalizationMode;
-            TimeZone = config.DataTimeZone;
+            DataTimeZone = config.DataTimeZone;
         }
     }
 }

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -81,22 +81,6 @@ namespace QuantConnect.Data
         /// </summary>
         public DataNormalizationMode DataNormalizationMode { get; set; }
 
-        /// <summary>
-        /// Initializes a new default instance of the <see cref="HistoryRequest"/> class
-        /// </summary>
-        public HistoryRequest()
-        {
-            StartTimeUtc = EndTimeUtc = DateTime.UtcNow;
-            Symbol = Symbol.Empty;
-            ExchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork);
-            Resolution = Resolution.Minute;
-            FillForwardResolution = Resolution.Minute;
-            IncludeExtendedMarketHours = false;
-            DataType = typeof (TradeBar);
-            TimeZone = TimeZones.NewYork;
-            IsCustomData = false;
-            DataNormalizationMode = DataNormalizationMode.Adjusted;
-        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HistoryRequest"/> class from the specified parameters
@@ -107,6 +91,7 @@ namespace QuantConnect.Data
         /// <param name="symbol">The symbol to request data for</param>
         /// <param name="resolution">The requested data resolution</param>
         /// <param name="exchangeHours">The exchange hours used in fill forward processing</param>
+        /// <param name="dataTimeZone">The time zone of the data</param>
         /// <param name="fillForwardResolution">The requested fill forward resolution for this request</param>
         /// <param name="includeExtendedMarketHours">True to include data from pre/post market hours</param>
         /// <param name="isCustomData">True for custom user data, false for normal QC data</param>
@@ -117,6 +102,7 @@ namespace QuantConnect.Data
             Symbol symbol,
             Resolution resolution,
             SecurityExchangeHours exchangeHours,
+            DateTimeZone dataTimeZone,
             Resolution? fillForwardResolution,
             bool includeExtendedMarketHours,
             bool isCustomData,
@@ -127,13 +113,13 @@ namespace QuantConnect.Data
             EndTimeUtc = endTimeUtc;
             Symbol = symbol;
             ExchangeHours = exchangeHours;
+            TimeZone = dataTimeZone;
             Resolution = resolution;
             FillForwardResolution = fillForwardResolution;
             IncludeExtendedMarketHours = includeExtendedMarketHours;
             DataType = dataType;
             IsCustomData = isCustomData;
             DataNormalizationMode = dataNormalizationMode;
-            TimeZone = exchangeHours.TimeZone;
         }
 
         /// <summary>

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -18,6 +18,7 @@ using System;
 using NodaTime;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
+using QuantConnect.Util;
 
 namespace QuantConnect.Data
 {
@@ -72,6 +73,11 @@ namespace QuantConnect.Data
         public DateTimeZone DataTimeZone { get; set; }
 
         /// <summary>
+        /// Gets the time zone of the time stamps on the raw input data
+        /// </summary>
+        public TickType TickType { get; set; }
+
+        /// <summary>
         /// Gets true if this is a custom data request, false for normal QC data
         /// </summary>
         public bool IsCustomData { get; set; }
@@ -96,6 +102,7 @@ namespace QuantConnect.Data
         /// <param name="includeExtendedMarketHours">True to include data from pre/post market hours</param>
         /// <param name="isCustomData">True for custom user data, false for normal QC data</param>
         /// <param name="dataNormalizationMode">Specifies normalization mode used for this subscription</param>
+        /// <param name="tickType">The tick type used to created the <see cref="SubscriptionDataConfig"/> for the retrieval of history data</param>
         public HistoryRequest(DateTime startTimeUtc, 
             DateTime endTimeUtc,
             Type dataType,
@@ -106,8 +113,8 @@ namespace QuantConnect.Data
             Resolution? fillForwardResolution,
             bool includeExtendedMarketHours,
             bool isCustomData,
-            DataNormalizationMode dataNormalizationMode
-            )
+            DataNormalizationMode dataNormalizationMode,
+            TickType tickType)
         {
             StartTimeUtc = startTimeUtc;
             EndTimeUtc = endTimeUtc;
@@ -120,6 +127,7 @@ namespace QuantConnect.Data
             DataType = dataType;
             IsCustomData = isCustomData;
             DataNormalizationMode = dataNormalizationMode;
+            TickType = tickType;
         }
 
         /// <summary>
@@ -142,6 +150,7 @@ namespace QuantConnect.Data
             IsCustomData = config.IsCustomData;
             DataNormalizationMode = config.DataNormalizationMode;
             DataTimeZone = config.DataTimeZone;
+            TickType = config.TickType;
         }
     }
 }

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -632,7 +632,20 @@ namespace QuantConnect.Securities
             if (data is OpenInterest || data.Price == 0m) return;
             Holdings.UpdateMarketPrice(Price);
         }
- 
+
+        /// <summary>
+        /// Returns true if the security contains at least one subscription that represents custom data
+        /// </summary>
+        public bool IsCustomData()
+        {
+            if (Subscriptions == null || !Subscriptions.Any())
+            {
+                return false;
+            }
+
+            return Subscriptions.Any(x => x.IsCustomData);
+        }
+
         /// <summary>
         /// Set the leverage parameter for this security
         /// </summary>

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -116,17 +116,17 @@ namespace QuantConnect.Securities
 
             return new[] 
             {
-                new HistoryRequest()
-                {
-                    StartTimeUtc = utcStartTime,
-                    EndTimeUtc = utcTime,
-                    Resolution = security.Resolution,
-                    FillForwardResolution = security.Resolution,
-                    IncludeExtendedMarketHours = true,
-                    Symbol = security.Symbol,
-                    DataType = typeof(TradeBar),
-                    TimeZone = security.Exchange.TimeZone
-                }
+                new HistoryRequest(utcStartTime, 
+                                   utcTime,
+                                   typeof(TradeBar),
+                                   security.Symbol,
+                                   security.Resolution,
+                                   security.Exchange.Hours,
+                                   MarketHoursDatabase.FromDataFolder().GetDataTimeZone(security.Symbol.ID.Market, security.Symbol, security.Type),
+                                   Resolution.Minute,
+                                   true,
+                                   false,
+                                   DataNormalizationMode.Adjusted)
             };
         }
     }

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -20,6 +20,7 @@ using QuantConnect.Data;
 using QuantConnect.Indicators;
 using QuantConnect.Data.Market;
 using System.Collections.Generic;
+using QuantConnect.Util;
 
 namespace QuantConnect.Securities
 {
@@ -127,7 +128,7 @@ namespace QuantConnect.Securities
                                    security.IsExtendedMarketHours,
                                    security.IsCustomData(),
                                    security.DataNormalizationMode,
-                                   TickType.Trade)
+                                   LeanData.GetCommonTickTypeForCommonDataTypes(typeof(TradeBar), security.Type))
             };
         }
     }

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -123,10 +123,10 @@ namespace QuantConnect.Securities
                                    security.Resolution,
                                    security.Exchange.Hours,
                                    MarketHoursDatabase.FromDataFolder().GetDataTimeZone(security.Symbol.ID.Market, security.Symbol, security.Type),
-                                   Resolution.Minute,
-                                   true,
-                                   false,
-                                   DataNormalizationMode.Adjusted)
+                                   security.Resolution,
+                                   security.IsExtendedMarketHours,
+                                   security.IsCustomData(),
+                                   security.DataNormalizationMode)
             };
         }
     }

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -126,7 +126,8 @@ namespace QuantConnect.Securities
                                    security.Resolution,
                                    security.IsExtendedMarketHours,
                                    security.IsCustomData(),
-                                   security.DataNormalizationMode)
+                                   security.DataNormalizationMode,
+                                   TickType.Trade)
             };
         }
     }

--- a/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
+++ b/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
@@ -19,6 +19,7 @@ using QuantConnect.Data;
 using QuantConnect.Indicators;
 using QuantConnect.Data.Market;
 using System.Collections.Generic;
+using QuantConnect.Util;
 
 namespace QuantConnect.Securities
 {
@@ -120,7 +121,7 @@ namespace QuantConnect.Securities
                                    security.IsExtendedMarketHours, 
                                    security.IsCustomData(), 
                                    security.DataNormalizationMode,
-                                   TickType.Trade)
+                                   LeanData.GetCommonTickTypeForCommonDataTypes(typeof(TradeBar), security.Type))
             };
         }
     }

--- a/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
+++ b/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
@@ -109,17 +109,17 @@ namespace QuantConnect.Securities
 
             return new[]
             {
-                new HistoryRequest()
-                {
-                    StartTimeUtc = utcStartTime,
-                    EndTimeUtc = utcTime,
-                    Resolution = Resolution.Daily,
-                    FillForwardResolution = Resolution.Daily,
-                    IncludeExtendedMarketHours = true,
-                    Symbol = security.Symbol,
-                    DataType = typeof(TradeBar),
-                    TimeZone = security.Exchange.TimeZone
-                }
+                new HistoryRequest(utcStartTime, 
+                                   utcTime, 
+                                   typeof(TradeBar), 
+                                   security.Symbol, 
+                                   Resolution.Daily, 
+                                   security.Exchange.Hours, 
+                                   MarketHoursDatabase.FromDataFolder().GetDataTimeZone(security.Symbol.ID.Market, security.Symbol, security.Type), 
+                                   Resolution.Daily, 
+                                   true, 
+                                   false, 
+                                   DataNormalizationMode.Adjusted)
             };
         }
     }

--- a/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
+++ b/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
@@ -119,7 +119,8 @@ namespace QuantConnect.Securities
                                    Resolution.Daily, 
                                    security.IsExtendedMarketHours, 
                                    security.IsCustomData(), 
-                                   security.DataNormalizationMode)
+                                   security.DataNormalizationMode,
+                                   TickType.Trade)
             };
         }
     }

--- a/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
+++ b/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
@@ -117,9 +117,9 @@ namespace QuantConnect.Securities
                                    security.Exchange.Hours, 
                                    MarketHoursDatabase.FromDataFolder().GetDataTimeZone(security.Symbol.ID.Market, security.Symbol, security.Type), 
                                    Resolution.Daily, 
-                                   true, 
-                                   false, 
-                                   DataNormalizationMode.Adjusted)
+                                   security.IsExtendedMarketHours, 
+                                   security.IsCustomData(), 
+                                   security.DataNormalizationMode)
             };
         }
     }

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 request.IncludeExtendedMarketHours,
                 false,
                 request.IsCustomData,
-                null,
+                request.TickType,
                 true,
                 request.DataNormalizationMode
                 );

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             var config = new SubscriptionDataConfig(request.DataType,
                 request.Symbol,
                 request.Resolution,
-                request.TimeZone,
+                request.DataTimeZone,
                 request.ExchangeHours.TimeZone,
                 request.FillForwardResolution.HasValue,
                 request.IncludeExtendedMarketHours,

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -97,7 +97,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             var config = new SubscriptionDataConfig(request.DataType, 
                 request.Symbol, 
                 request.Resolution, 
-                request.TimeZone, 
+                request.DataTimeZone, 
                 request.ExchangeHours.TimeZone, 
                 request.FillForwardResolution.HasValue, 
                 request.IncludeExtendedMarketHours, 

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -103,7 +103,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 request.IncludeExtendedMarketHours, 
                 false, 
                 request.IsCustomData,
-                null,
+                request.TickType,
                 true,
                 request.DataNormalizationMode
                 );

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -343,7 +343,8 @@ namespace QuantConnect.Jupyter
                                         Resolution.Minute, 
                                         underlying.IsExtendedMarketHours, 
                                         underlying.IsCustomData(), 
-                                        DataNormalizationMode.Raw)
+                                        DataNormalizationMode.Raw,
+                                        TickType.Quote)
                     );
 
             requests = requests.Union(new[] { new HistoryRequest(underlying.Subscriptions.FirstOrDefault(), underlying.Exchange.Hours, date.AddDays(-1), date) });

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -334,7 +334,8 @@ namespace QuantConnect.Jupyter
                 .Distinct()
                 .Select(x =>
                      new HistoryRequest(date.AddDays(-1), 
-                                        date, typeof(QuoteBar), 
+                                        date, 
+                                        typeof(QuoteBar), 
                                         x, 
                                         resolution ?? option.Resolution, 
                                         underlying.Exchange.Hours, 

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -344,7 +344,7 @@ namespace QuantConnect.Jupyter
                                         underlying.IsExtendedMarketHours, 
                                         underlying.IsCustomData(), 
                                         DataNormalizationMode.Raw,
-                                        TickType.Quote)
+                                        LeanData.GetCommonTickTypeForCommonDataTypes(typeof(QuoteBar), underlying.Type))
                     );
 
             requests = requests.Union(new[] { new HistoryRequest(underlying.Subscriptions.FirstOrDefault(), underlying.Exchange.Hours, date.AddDays(-1), date) });

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -333,14 +333,16 @@ namespace QuantConnect.Jupyter
                 .SelectMany(x => option.ContractFilter.Filter(new OptionFilterUniverse(allSymbols, x)))
                 .Distinct()
                 .Select(x =>
-                     new HistoryRequest()
-                        {
-                            Symbol = x,
-                            StartTimeUtc = date.AddDays(-1),
-                            EndTimeUtc = date,
-                            Resolution = resolution ?? option.Resolution,
-                            DataType = typeof(QuoteBar)
-                        }
+                     new HistoryRequest(date.AddDays(-1), 
+                                        date, typeof(QuoteBar), 
+                                        x, 
+                                        resolution ?? option.Resolution, 
+                                        underlying.Exchange.Hours, 
+                                        _algorithm.TimeZone,  // QuantBook should follow the algorithms assumptions
+                                        Resolution.Minute, 
+                                        false, 
+                                        false, 
+                                        DataNormalizationMode.Adjusted)
                     );
 
             requests = requests.Union(new[] { new HistoryRequest(underlying.Subscriptions.FirstOrDefault(), underlying.Exchange.Hours, date.AddDays(-1), date) });

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -338,12 +338,12 @@ namespace QuantConnect.Jupyter
                                         typeof(QuoteBar), 
                                         x, 
                                         resolution ?? option.Resolution, 
-                                        underlying.Exchange.Hours, 
-                                        _algorithm.TimeZone,  // QuantBook should follow the algorithms assumptions
+                                        underlying.Exchange.Hours,
+                                        MarketHoursDatabase.FromDataFolder().GetDataTimeZone(underlying.Symbol.ID.Market, underlying.Symbol, underlying.Type),
                                         Resolution.Minute, 
-                                        false, 
-                                        false, 
-                                        DataNormalizationMode.Adjusted)
+                                        underlying.IsExtendedMarketHours, 
+                                        underlying.IsCustomData(), 
+                                        DataNormalizationMode.Raw)
                     );
 
             requests = requests.Union(new[] { new HistoryRequest(underlying.Subscriptions.FirstOrDefault(), underlying.Exchange.Hours, date.AddDays(-1), date) });

--- a/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
@@ -16,12 +16,15 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Brokerages;
 using QuantConnect.Brokerages.Fxcm;
 using QuantConnect.Data;
+using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Logging;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Brokerages.Fxcm
 {
@@ -68,13 +71,17 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
 
                 var requests = new[]
                 {
-                    new HistoryRequest
-                    {
-                        Symbol = symbol,
-                        Resolution = resolution,
-                        StartTimeUtc = now.Add(-period),
-                        EndTimeUtc = now
-                    }
+                    new HistoryRequest(now.Add(-period), 
+                                       now, 
+                                       typeof(QuoteBar), 
+                                       symbol, 
+                                       resolution, 
+                                       SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), 
+                                       DateTimeZone.Utc, 
+                                       Resolution.Minute, 
+                                       false, 
+                                       false, 
+                                       DataNormalizationMode.Adjusted)
                 };
 
                 var history = historyProvider.GetHistory(requests, TimeZones.Utc);
@@ -128,13 +135,17 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
 
             var requests = new[]
             {
-                new HistoryRequest
-                {
-                    Symbol = symbol,
-                    Resolution = resolution,
-                    StartTimeUtc = startDate,
-                    EndTimeUtc = endDate
-                }
+                new HistoryRequest(startDate,
+                    endDate,
+                    typeof(QuoteBar),
+                    symbol,
+                    resolution,
+                    SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                    DateTimeZone.Utc,
+                    Resolution.Minute,
+                    false,
+                    false,
+                    DataNormalizationMode.Adjusted)
             };
 
             var history = historyProvider.GetHistory(requests, TimeZones.Utc);

--- a/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
@@ -81,7 +81,8 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
                                        Resolution.Minute, 
                                        false, 
                                        false, 
-                                       DataNormalizationMode.Adjusted)
+                                       DataNormalizationMode.Adjusted,
+                                       TickType.Quote)
                 };
 
                 var history = historyProvider.GetHistory(requests, TimeZones.Utc);
@@ -145,7 +146,8 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
                     Resolution.Minute,
                     false,
                     false,
-                    DataNormalizationMode.Adjusted)
+                    DataNormalizationMode.Adjusted,
+                    TickType.Quote)
             };
 
             var history = historyProvider.GetHistory(requests, TimeZones.Utc);

--- a/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
@@ -14,12 +14,15 @@
 */
 
 using System;
+using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Brokerages.Oanda;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
+using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Logging;
+using QuantConnect.Securities;
 using Environment = QuantConnect.Brokerages.Oanda.Environment;
 
 namespace QuantConnect.Tests.Brokerages.Oanda
@@ -75,13 +78,17 @@ namespace QuantConnect.Tests.Brokerages.Oanda
 
                 var requests = new[]
                 {
-                    new HistoryRequest
-                    {
-                        Symbol = symbol,
-                        Resolution = resolution,
-                        StartTimeUtc = now.Add(-period),
-                        EndTimeUtc = now
-                    }
+                    new HistoryRequest(now.Add(-period),
+                        now,
+                        typeof(QuoteBar),
+                        symbol,
+                        resolution,
+                        SecurityExchangeHours.AlwaysOpen(TimeZones.EasternStandard),
+                        DateTimeZone.Utc,
+                        Resolution.Minute,
+                        false,
+                        false,
+                        DataNormalizationMode.Adjusted)
                 };
 
                 var history = historyProvider.GetHistory(requests, TimeZones.Utc);

--- a/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
@@ -88,7 +88,8 @@ namespace QuantConnect.Tests.Brokerages.Oanda
                         Resolution.Minute,
                         false,
                         false,
-                        DataNormalizationMode.Adjusted)
+                        DataNormalizationMode.Adjusted,
+                        TickType.Quote)
                 };
 
                 var history = historyProvider.GetHistory(requests, TimeZones.Utc);

--- a/Tests/Brokerages/Tradier/TradierBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Tradier/TradierBrokerageHistoryProviderTests.cs
@@ -74,7 +74,8 @@ namespace QuantConnect.Tests.Brokerages.Tradier
                         Resolution.Minute,
                         false,
                         false,
-                        DataNormalizationMode.Adjusted)
+                        DataNormalizationMode.Adjusted,
+                        TickType.Quote)
                 };
 
                 var history = brokerage.GetHistory(requests, TimeZones.Utc);

--- a/Tests/Brokerages/Tradier/TradierBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Tradier/TradierBrokerageHistoryProviderTests.cs
@@ -14,11 +14,14 @@
 */
 
 using System;
+using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Brokerages.Tradier;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
+using QuantConnect.Data.Market;
 using QuantConnect.Logging;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Brokerages.Tradier
 {
@@ -61,13 +64,17 @@ namespace QuantConnect.Tests.Brokerages.Tradier
 
                 var requests = new[]
                 {
-                    new HistoryRequest
-                    {
-                        Symbol = symbol,
-                        Resolution = resolution,
-                        StartTimeUtc = now.Add(-period),
-                        EndTimeUtc = now
-                    }
+                    new HistoryRequest(now.Add(-period),
+                        now,
+                        typeof(QuoteBar),
+                        symbol,
+                        resolution,
+                        SecurityExchangeHours.AlwaysOpen(TimeZones.EasternStandard),
+                        TimeZones.EasternStandard,
+                        Resolution.Minute,
+                        false,
+                        false,
+                        DataNormalizationMode.Adjusted)
                 };
 
                 var history = brokerage.GetHistory(requests, TimeZones.Utc);


### PR DESCRIPTION
- Renamed `HistoryRequest.TimeZone` to `HistoryRequest.DataTimeZone` using resharper in order to be clearer on what this timezone is used for.
- Removed the parameterless `HistoryRequest` constructor. Defaults are not assumed by the `HistoryRequest` and must be specified.
- Added new `AddData` method that allows users to specify separate exchange time zones and the data time zones.
- Added new method, `Security.IsCustomData` that determines if the security contains at least one subscription that represents custom data 
- Added `HistoryRequest.TickType` to avoid ambiguity between Options/Futures history request with Tick resolution 