### PR TITLE
Fix Options and Futures subscriptions at Tick resolution

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -74,13 +74,13 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// AddData a new user defined data source, requiring only the minimum config options.
         /// </summary>
-        /// <param name="T">Data source type</param>
+        /// <param name="dataType">Data source type</param>
         /// <param name="symbol">Key/Symbol for data</param>
         /// <param name="resolution">Resolution of the Data Required</param>
         /// <param name="timeZone">Specifies the time zone of the raw data</param>
         /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
-        public void AddData(Type T, string symbol, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public void AddData(Type dataType, string symbol, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
         {
             var marketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, symbol, SecurityType.Base, timeZone);
 
@@ -89,7 +89,7 @@ namespace QuantConnect.Algorithm
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(Market.USA, symbol, SecurityType.Base, CashBook.AccountCurrency);
 
             //Add this new generic data as a tradeable security: 
-            var security = SecurityManager.CreateSecurity(new List<Type>() { T }, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone,
+            var security = SecurityManager.CreateSecurity(dataType, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone,
                 symbolProperties, SecurityInitializer, symbolObject, resolution, fillDataForward, leverage, true, false, true, LiveMode);
 
             AddToUserDefinedUniverse(security);

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1370,7 +1370,7 @@ namespace QuantConnect.Algorithm
 
             var marketHoursEntry = _marketHoursDatabase.GetEntry(market, underlying, SecurityType.Option);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, underlying, SecurityType.Option, CashBook.AccountCurrency);
-            var canonicalSecurity = (Option) SecurityManager.CreateSecurity(new List<Type>() { typeof(ZipEntryName) }, Portfolio, SubscriptionManager,
+            var canonicalSecurity = (Option) SecurityManager.CreateSecurity(typeof(ZipEntryName), Portfolio, SubscriptionManager,
                 marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties, SecurityInitializer, canonicalSymbol, resolution,
                 fillDataForward, leverage, false, false, false, LiveMode, true, false);
             canonicalSecurity.IsTradable = false;
@@ -1416,9 +1416,7 @@ namespace QuantConnect.Algorithm
 
             var marketHoursEntry = _marketHoursDatabase.GetEntry(market, symbol, SecurityType.Future);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, symbol, SecurityType.Future, CashBook.AccountCurrency);
-            var types = SubscriptionManager.LookupSubscriptionConfigDataTypes(SecurityType.Future, resolution, canonicalSymbol.IsCanonical());
-
-            var canonicalSecurity = (Future)SecurityManager.CreateSecurity(types, Portfolio, SubscriptionManager,
+            var canonicalSecurity = (Future)SecurityManager.CreateSecurity(typeof(ZipEntryName), Portfolio, SubscriptionManager,
                 marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties, SecurityInitializer, canonicalSymbol, resolution,
                 fillDataForward, leverage, false, false, false, LiveMode, true, false);
             canonicalSecurity.IsTradable = false;
@@ -1592,7 +1590,7 @@ namespace QuantConnect.Algorithm
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(Market.USA, symbol, SecurityType.Base, CashBook.AccountCurrency);
 
             //Add this new generic data as a tradeable security: 
-            var security = SecurityManager.CreateSecurity(new List<Type>() { typeof(T) }, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone, 
+            var security = SecurityManager.CreateSecurity(typeof(T), Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone, 
                 symbolProperties, SecurityInitializer, symbolObject, resolution, fillDataForward, leverage, true, false, true, LiveMode);
 
             AddToUserDefinedUniverse(security);

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -29,7 +29,6 @@ namespace QuantConnect.Data
     /// </summary>
     public class SubscriptionDataConfig : IEquatable<SubscriptionDataConfig>
     {
-        private Symbol _symbol;
         private readonly SecurityIdentifier _sid;
 
         /// <summary>
@@ -45,13 +44,10 @@ namespace QuantConnect.Data
         /// <summary>
         /// Symbol of the asset we're requesting: this is really a perm tick!!
         /// </summary>
-        public Symbol Symbol
-        {
-            get { return _symbol; }
-        }
+        public Symbol Symbol { get; private set; }
 
         /// <summary>
-        /// Trade or quote data
+        /// Trade, quote or open interest data
         /// </summary>
         public readonly TickType TickType;
 
@@ -107,13 +103,13 @@ namespace QuantConnect.Data
         {
             get
             {
-                return _symbol.ID.SecurityType == SecurityType.Option ? 
-                    (_symbol.HasUnderlying ? _symbol.Underlying.Value : _symbol.Value) :
-                    _symbol.Value;
+                return Symbol.ID.SecurityType == SecurityType.Option ? 
+                    (Symbol.HasUnderlying ? Symbol.Underlying.Value : Symbol.Value) :
+                    Symbol.Value;
             }
             set
             {
-                _symbol = _symbol.UpdateMappedSymbol(value);
+                Symbol = Symbol.UpdateMappedSymbol(value);
             }
         }
 
@@ -181,7 +177,7 @@ namespace QuantConnect.Data
             SecurityType = symbol.ID.SecurityType;
             Resolution = resolution;
             _sid = symbol.ID;
-            _symbol = symbol;
+            Symbol = symbol;
             FillDataForward = fillForward;
             ExtendedMarketHours = extendedHours;
             PriceScaleFactor = 1;
@@ -194,14 +190,7 @@ namespace QuantConnect.Data
             Consolidators = new HashSet<IDataConsolidator>();
             DataNormalizationMode = dataNormalizationMode;
 
-            if (!tickType.HasValue)
-            {
-                TickType = LeanData.GetCommonTickTypeForCommonDataTypes(objectType, SecurityType);
-            }
-            else
-            {
-                TickType = tickType.Value;
-            }
+            TickType = tickType ?? LeanData.GetCommonTickTypeForCommonDataTypes(objectType, SecurityType);
 
             switch (resolution)
             {
@@ -333,7 +322,7 @@ namespace QuantConnect.Data
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
+            if (obj.GetType() != GetType()) return false;
             return Equals((SubscriptionDataConfig) obj);
         }
 
@@ -387,7 +376,7 @@ namespace QuantConnect.Data
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            return Symbol.Value + "," + MappedSymbol + "," + Resolution + "," + Type.Name;
+            return Symbol.Value + "," + MappedSymbol + "," + Resolution + "," + Type.Name + "," + TickType;
         }
     }
 }

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -97,13 +97,15 @@ namespace QuantConnect.Data
             {
                 dataType = typeof(Tick);
             }
-            return Add(dataType, symbol, resolution, timeZone, exchangeTimeZone, isCustomData, fillDataForward, extendedMarketHours);
+            var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType);
+            return Add(dataType, tickType, symbol, resolution, timeZone, exchangeTimeZone, isCustomData, fillDataForward, extendedMarketHours);
         }
 
         /// <summary>
         /// Add Market Data Required - generic data typing support as long as Type implements BaseData.
         /// </summary>
         /// <param name="dataType">Set the type of the data we're subscribing to.</param>
+        /// <param name="tickType">Tick type for the subscription.</param>
         /// <param name="symbol">Symbol of the asset we're like</param>
         /// <param name="resolution">Resolution of Asset Required</param>
         /// <param name="dataTimeZone">The time zone the subscription's data is time stamped in</param>
@@ -115,7 +117,7 @@ namespace QuantConnect.Data
         /// <param name="isInternalFeed">Set to true to prevent data from this subscription from being sent into the algorithm's OnData events</param>
         /// <param name="isFilteredSubscription">True if this subscription should have filters applied to it (market hours/user filters from security), false otherwise</param>
         /// <returns>The newly created <see cref="SubscriptionDataConfig"/></returns>
-        public SubscriptionDataConfig Add(Type dataType, Symbol symbol, Resolution resolution, DateTimeZone dataTimeZone, DateTimeZone exchangeTimeZone, bool isCustomData, bool fillDataForward = true, bool extendedMarketHours = false, bool isInternalFeed = false, bool isFilteredSubscription = true)
+        public SubscriptionDataConfig Add(Type dataType, TickType tickType, Symbol symbol, Resolution resolution, DateTimeZone dataTimeZone, DateTimeZone exchangeTimeZone, bool isCustomData, bool fillDataForward = true, bool extendedMarketHours = false, bool isInternalFeed = false, bool isFilteredSubscription = true)
         {
             if (dataTimeZone == null)
             {
@@ -127,7 +129,7 @@ namespace QuantConnect.Data
             }
 
             //Create:
-            var newConfig = new SubscriptionDataConfig(dataType, symbol, resolution, dataTimeZone, exchangeTimeZone, fillDataForward, extendedMarketHours, isInternalFeed, isCustomData, isFilteredSubscription: isFilteredSubscription);
+            var newConfig = new SubscriptionDataConfig(dataType, symbol, resolution, dataTimeZone, exchangeTimeZone, fillDataForward, extendedMarketHours, isInternalFeed, isCustomData, isFilteredSubscription: isFilteredSubscription, tickType: tickType);
 
             //Add to subscription list: make sure we don't have this symbol:
             if (Subscriptions.Contains(newConfig))
@@ -225,19 +227,14 @@ namespace QuantConnect.Data
         /// <param name="resolution">The resolution of the data requested</param>
         /// <param name="isCanonical">Indicates whether the security is Canonical (future and options)</param>
         /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig"/></returns>
-        public List<Type> LookupSubscriptionConfigDataTypes(SecurityType symbolSecurityType, Resolution resolution, bool isCanonical)
+        public List<Tuple<Type, TickType>> LookupSubscriptionConfigDataTypes(SecurityType symbolSecurityType, Resolution resolution, bool isCanonical)
         {
             if (isCanonical)
             {
-                return new List<Type>() { typeof(ZipEntryName) };
+                return new List<Tuple<Type, TickType>> { new Tuple<Type, TickType>(typeof(ZipEntryName), TickType.Quote) };
             }
 
-            if (resolution == Resolution.Tick)
-            {
-                return new List<Type>() { typeof(Tick) };
-            }
-
-            return AvailableDataTypes[symbolSecurityType].Select(tickType => LeanData.GetDataType(resolution, tickType)).ToList();
+            return AvailableDataTypes[symbolSecurityType].Select(tickType => new Tuple<Type, TickType>(LeanData.GetDataType(resolution, tickType), tickType)).ToList();
         }
 
     } // End Algorithm MetaData Manager Class

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -204,7 +204,7 @@ namespace QuantConnect.Securities
                     var marketHoursDbEntry = marketHoursDatabase.GetEntry(symbol.ID.Market, symbol.Value, symbol.ID.SecurityType);
                     var exchangeHours = marketHoursDbEntry.ExchangeHours;
                     // set this as an internal feed so that the data doesn't get sent into the algorithm's OnData events
-                    var config = subscriptions.Add(objectType, symbol, minimumResolution, marketHoursDbEntry.DataTimeZone, exchangeHours.TimeZone, false, true, false, true);
+                    var config = subscriptions.Add(objectType, TickType.Quote, symbol, minimumResolution, marketHoursDbEntry.DataTimeZone, exchangeHours.TimeZone, false, true, false, true);
                     SecuritySymbol = config.Symbol;
 
                     Security security;

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -21,7 +21,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using NodaTime;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
 using QuantConnect.Util;
 
 namespace QuantConnect.Securities
@@ -307,7 +306,7 @@ namespace QuantConnect.Securities
         /// leverage is less than or equal to zero.
         /// This method also add the new symbol mapping to the <see cref="SymbolCache"/>
         /// </summary>
-        public static Security CreateSecurity(List<Type> factoryTypes,
+        public static Security CreateSecurity(List<Tuple<Type, TickType>> subscriptionDataTypes,
             SecurityPortfolioManager securityPortfolioManager,
             SubscriptionManager subscriptionManager,
             SecurityExchangeHours exchangeHours,
@@ -325,22 +324,25 @@ namespace QuantConnect.Securities
             bool addToSymbolCache = true,
             bool isFilteredSubscription = true)
         {
-            if (!factoryTypes.Any())
+            if (!subscriptionDataTypes.Any())
             {
-                throw new ArgumentNullException("factoryTypes", "At least one type needed to create security");
+                throw new ArgumentNullException(nameof(subscriptionDataTypes), "At least one type needed to create security");
             }
 
             // add the symbol to our cache
             if (addToSymbolCache) SymbolCache.Set(symbol.Value, symbol);
 
             // Add the symbol to Data Manager -- generate unified data streams for algorithm events
-            SubscriptionDataConfigList configList = new SubscriptionDataConfigList(symbol);
-
-            foreach (var dataFeedType in factoryTypes)
-            {
-                configList.Add(subscriptionManager.Add(dataFeedType, symbol, resolution, dataTimeZone, exchangeHours.TimeZone, isCustomData, fillDataForward,
-                                                        extendedMarketHours, isInternalFeed, isFilteredSubscription));
-            }
+            var configList = new SubscriptionDataConfigList(symbol);
+            configList.AddRange(from subscriptionDataType 
+                                in subscriptionDataTypes
+                                let dataType = subscriptionDataType.Item1
+                                let tickType = subscriptionDataType.Item2
+                                select subscriptionManager.Add(dataType, tickType, 
+                                                               symbol, resolution, dataTimeZone, 
+                                                               exchangeHours.TimeZone, isCustomData, 
+                                                               fillDataForward, extendedMarketHours, 
+                                                               isInternalFeed, isFilteredSubscription));
 
             // verify the cash book is in a ready state
             var quoteCurrency = symbolProperties.QuoteCurrency;
@@ -434,6 +436,52 @@ namespace QuantConnect.Securities
         /// leverage is less than or equal to zero.
         /// This method also add the new symbol mapping to the <see cref="SymbolCache"/>
         /// </summary>
+        public static Security CreateSecurity(Type dataType,
+            SecurityPortfolioManager securityPortfolioManager,
+            SubscriptionManager subscriptionManager,
+            SecurityExchangeHours exchangeHours,
+            DateTimeZone dataTimeZone,
+            SymbolProperties symbolProperties,
+            ISecurityInitializer securityInitializer,
+            Symbol symbol,
+            Resolution resolution,
+            bool fillDataForward,
+            decimal leverage,
+            bool extendedMarketHours,
+            bool isInternalFeed,
+            bool isCustomData,
+            bool isLiveMode,
+            bool addToSymbolCache = true,
+            bool isFilteredSubscription = true)
+        {
+            return CreateSecurity(
+                new List<Tuple<Type, TickType>>
+                {
+                    new Tuple<Type, TickType>(dataType, LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType))
+                },
+                securityPortfolioManager,
+                subscriptionManager,
+                exchangeHours,
+                dataTimeZone,
+                symbolProperties,
+                securityInitializer,
+                symbol,
+                resolution,
+                fillDataForward,
+                leverage,
+                extendedMarketHours,
+                isInternalFeed,
+                isCustomData,
+                isLiveMode,
+                addToSymbolCache,
+                isFilteredSubscription);
+        }
+
+        /// <summary>
+        /// Creates a security and matching configuration. This applies the default leverage if
+        /// leverage is less than or equal to zero.
+        /// This method also add the new symbol mapping to the <see cref="SymbolCache"/>
+        /// </summary>
         public static Security CreateSecurity(SecurityPortfolioManager securityPortfolioManager,
             SubscriptionManager subscriptionManager,
             MarketHoursDatabase marketHoursDatabase,
@@ -458,7 +506,7 @@ namespace QuantConnect.Securities
             var symbolProperties = symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
 
             var types = subscriptionManager.LookupSubscriptionConfigDataTypes(symbol.SecurityType, resolution, symbol.IsCanonical());
-            
+
             return CreateSecurity(types, securityPortfolioManager, subscriptionManager, exchangeHours, marketHoursDbEntry.DataTimeZone, symbolProperties, securityInitializer, symbol, resolution,
                 fillDataForward, leverage, extendedMarketHours, isInternalFeed, isCustomData, isLiveMode, addToSymbolCache);
         }

--- a/Tests/Common/Data/SubscriptionManagerTests.cs
+++ b/Tests/Common/Data/SubscriptionManagerTests.cs
@@ -1,0 +1,99 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Tests.Common.Data
+{
+    [TestFixture]
+    public class SubscriptionManagerTests
+    {
+        [Test]
+        [TestCase(SecurityType.Base, Resolution.Minute, typeof(TradeBar), TickType.Trade)]
+        [TestCase(SecurityType.Base, Resolution.Tick, typeof(Tick), TickType.Trade)]
+        [TestCase(SecurityType.Equity, Resolution.Minute, typeof(TradeBar), TickType.Trade)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Trade)]
+        [TestCase(SecurityType.Forex, Resolution.Minute, typeof(QuoteBar), TickType.Quote)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Quote)]
+        [TestCase(SecurityType.Cfd, Resolution.Minute, typeof(QuoteBar), TickType.Quote)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Quote)]
+        public void GetsSubscriptionDataTypesSingle(SecurityType securityType, Resolution resolution, Type expectedDataType, TickType expectedTickType)
+        {
+            var types = GetSubscriptionDataTypes(securityType, resolution);
+
+            Assert.AreEqual(1, types.Count);
+            Assert.AreEqual(expectedDataType, types[0].Item1);
+            Assert.AreEqual(expectedTickType, types[0].Item2);
+        }
+
+        [Test]
+        [TestCase(SecurityType.Future, Resolution.Minute, typeof(ZipEntryName), TickType.Quote)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(ZipEntryName), TickType.Quote)]
+        [TestCase(SecurityType.Option, Resolution.Minute, typeof(ZipEntryName), TickType.Quote)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(ZipEntryName), TickType.Quote)]
+        public void GetsSubscriptionDataTypesCanonical(SecurityType securityType, Resolution resolution, Type expectedDataType, TickType expectedTickType)
+        {
+            var types = GetSubscriptionDataTypes(securityType, resolution, true);
+
+            Assert.AreEqual(1, types.Count);
+            Assert.AreEqual(expectedDataType, types[0].Item1);
+            Assert.AreEqual(expectedTickType, types[0].Item2);
+        }
+
+        [Test]
+        [TestCase(SecurityType.Future, Resolution.Minute)]
+        [TestCase(SecurityType.Option, Resolution.Minute)]
+        public void GetsSubscriptionDataTypesFuturesOptionsMinute(SecurityType securityType, Resolution resolution)
+        {
+            var types = GetSubscriptionDataTypes(securityType, resolution);
+
+            Assert.AreEqual(3, types.Count);
+            Assert.AreEqual(typeof(QuoteBar), types[0].Item1);
+            Assert.AreEqual(TickType.Quote, types[0].Item2);
+            Assert.AreEqual(typeof(TradeBar), types[1].Item1);
+            Assert.AreEqual(TickType.Trade, types[1].Item2);
+            Assert.AreEqual(typeof(OpenInterest), types[2].Item1);
+            Assert.AreEqual(TickType.OpenInterest, types[2].Item2);
+        }
+
+        [Test]
+        [TestCase(SecurityType.Future, Resolution.Tick)]
+        [TestCase(SecurityType.Option, Resolution.Tick)]
+        public void GetsSubscriptionDataTypesFuturesOptionsTick(SecurityType securityType, Resolution resolution)
+        {
+            var types = GetSubscriptionDataTypes(securityType, resolution);
+
+            Assert.AreEqual(3, types.Count);
+            Assert.AreEqual(typeof(Tick), types[0].Item1);
+            Assert.AreEqual(TickType.Quote, types[0].Item2);
+            Assert.AreEqual(typeof(Tick), types[1].Item1);
+            Assert.AreEqual(TickType.Trade, types[1].Item2);
+            Assert.AreEqual(typeof(Tick), types[2].Item1);
+            Assert.AreEqual(TickType.OpenInterest, types[2].Item2);
+        }
+
+        private static List<Tuple<Type, TickType>> GetSubscriptionDataTypes(SecurityType securityType, Resolution resolution, bool isCanonical = false)
+        {
+            var timeKeeper = new TimeKeeper(DateTime.UtcNow);
+            var subscriptionManager = new SubscriptionManager(new AlgorithmSettings(), timeKeeper);
+            return subscriptionManager.LookupSubscriptionConfigDataTypes(securityType, resolution, isCanonical);
+        }
+    }
+}

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -17,13 +17,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
-using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -129,9 +127,8 @@ namespace QuantConnect.Tests.Common.Securities
             var forexDefaultQuoteCurrency = forexSymbol.Value.Substring(3);
 
             var forexSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(forexSymbol.ID.Market, forexSymbol, forexSymbol.ID.SecurityType, forexDefaultQuoteCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(QuoteBar) };
 
-            var forex = SecurityManager.CreateSecurity(subscriptionTypes,
+            var forex = SecurityManager.CreateSecurity(typeof(QuoteBar),
                 _securityPortfolioManager,
                 _subscriptionManager,
                 forexMarketHoursDbEntry.ExchangeHours,
@@ -158,9 +155,8 @@ namespace QuantConnect.Tests.Common.Securities
             var optionMarketHoursDbEntry = _marketHoursDatabase.GetEntry(optionSymbol.ID.Market, optionSymbol, SecurityType.Option);
             var optionDefaultQuoteCurrency = CashBook.AccountCurrency;
             var optionSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(optionSymbol.ID.Market, optionSymbol, optionSymbol.ID.SecurityType, optionDefaultQuoteCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(ZipEntryName) };
 
-            var option = SecurityManager.CreateSecurity(subscriptionTypes,
+            var option = SecurityManager.CreateSecurity(typeof(ZipEntryName),
                 _securityPortfolioManager,
                 _subscriptionManager,
                 optionMarketHoursDbEntry.ExchangeHours,
@@ -189,9 +185,8 @@ namespace QuantConnect.Tests.Common.Securities
             var equityMarketHoursDbEntry = _marketHoursDatabase.GetEntry(equitySymbol.ID.Market, equitySymbol, SecurityType.Equity);
             var equityDefaultQuoteCurrency = CashBook.AccountCurrency;
             var equitySymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(equitySymbol.ID.Market, equitySymbol, equitySymbol.ID.SecurityType, equityDefaultQuoteCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(TradeBar) };
 
-            var equity = SecurityManager.CreateSecurity(subscriptionTypes,
+            var equity = SecurityManager.CreateSecurity(typeof(TradeBar),
                 _securityPortfolioManager,
                 _subscriptionManager,
                 equityMarketHoursDbEntry.ExchangeHours,
@@ -219,9 +214,8 @@ namespace QuantConnect.Tests.Common.Securities
             var marketHoursDbEntry = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, SecurityType.Equity);
             var defaultQuoteCurrency = CashBook.AccountCurrency;
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(TradeBar) };
 
-            var subscriptions = SecurityManager.CreateSecurity(subscriptionTypes,
+            var subscriptions = SecurityManager.CreateSecurity(typeof(QuoteBar),
                 _securityPortfolioManager,
                 _subscriptionManager,
                 marketHoursDbEntry.ExchangeHours,
@@ -238,8 +232,8 @@ namespace QuantConnect.Tests.Common.Securities
                 false);
 
             Assert.AreEqual(subscriptions.Subscriptions.Count(), 1);
-            Assert.AreEqual(subscriptions.Subscriptions.First().Type, typeof(TradeBar));
-            Assert.AreEqual(subscriptions.Subscriptions.First().TickType, TickType.Trade);
+            Assert.AreEqual(subscriptions.Subscriptions.First().Type, typeof(QuoteBar));
+            Assert.AreEqual(subscriptions.Subscriptions.First().TickType, TickType.Quote);
         }
 
         [Test]
@@ -248,9 +242,8 @@ namespace QuantConnect.Tests.Common.Securities
             var equitySymbol = new Symbol(SecurityIdentifier.GenerateBase("BTC", Market.USA), "BTC");
             var equityMarketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "BTC", SecurityType.Base, TimeZones.NewYork);
             var equitySymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(equitySymbol.ID.Market, equitySymbol, equitySymbol.ID.SecurityType, CashBook.AccountCurrency);
-            var subscriptionTypes = new List<Type>() { typeof(Bitcoin) };
 
-            var equity = SecurityManager.CreateSecurity(subscriptionTypes,
+            var equity = SecurityManager.CreateSecurity(typeof(Bitcoin),
                 _securityPortfolioManager,
                 _subscriptionManager,
                 equityMarketHoursDbEntry.ExchangeHours,
@@ -280,7 +273,12 @@ namespace QuantConnect.Tests.Common.Securities
             var optionMarketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "SPY", SecurityType.Equity, TimeZones.NewYork);
             var optionSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(optionSymbol.ID.Market, "SPY", optionSymbol.ID.SecurityType, CashBook.AccountCurrency);
 
-            var subscriptionTypes = new List<Type>() { typeof(TradeBar), typeof(QuoteBar), typeof(OpenInterest) };
+            var subscriptionTypes = new List<Tuple<Type, TickType>>
+            {
+                new Tuple<Type, TickType>(typeof(TradeBar), TickType.Trade),
+                new Tuple<Type, TickType>(typeof(QuoteBar), TickType.Quote),
+                new Tuple<Type, TickType>(typeof(OpenInterest), TickType.OpenInterest)
+            };
 
             var optionSubscriptions = SecurityManager.CreateSecurity(subscriptionTypes,
                 _securityPortfolioManager,
@@ -314,7 +312,12 @@ namespace QuantConnect.Tests.Common.Securities
             var marketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "ED", SecurityType.Equity, TimeZones.NewYork);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, "ED", symbol.ID.SecurityType, CashBook.AccountCurrency);
 
-            var subscriptionTypes = new List<Type>() { typeof(TradeBar), typeof(QuoteBar), typeof(OpenInterest) };
+            var subscriptionTypes = new List<Tuple<Type, TickType>>
+            {
+                new Tuple<Type, TickType>(typeof(TradeBar), TickType.Trade),
+                new Tuple<Type, TickType>(typeof(QuoteBar), TickType.Quote),
+                new Tuple<Type, TickType>(typeof(OpenInterest), TickType.OpenInterest)
+            };
 
             var subscriptions = SecurityManager.CreateSecurity(subscriptionTypes,
                 _securityPortfolioManager,

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Common\BrokerageNameTests.cs" />
     <Compile Include="Common\CurrenciesTests.cs" />
     <Compile Include="Common\Data\Market\QuoteBarTests.cs" />
+    <Compile Include="Common\Data\SubscriptionManagerTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />
     <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />
     <Compile Include="Common\Securities\FutureFilterTests.cs" />


### PR DESCRIPTION
Previously `Tick` resolution subscriptions only received ticks with `TickType.Trade`, now `TickType.Quote` and `TickType.OpenInterest` are received as well.

This PR replaces PR #1065