### PR TITLE
EnableGreekApproximation is now enabled by default on QuantLib option price models

### DIFF
--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -250,10 +250,29 @@ namespace QuantConnect.Securities.Option
         /// <summary>
         /// When enabled, approximates Greeks if corresponding pricing model didn't calculate exact numbers
         /// </summary>
+        [Obsolete("This property has been deprecated. Please use QLOptionPriceModel.EnableGreekApproximation instead.")]
         public bool EnableGreekApproximation
         {
-            get; set;
+            get
+            {
+                var model = PriceModel as QLOptionPriceModel;
+                if (model != null)
+                {
+                    return model.EnableGreekApproximation;
+                }
+                return false;
+            }
+
+            set
+            {
+                var model = PriceModel as QLOptionPriceModel;
+                if (model != null)
+                {
+                   model.EnableGreekApproximation = value;
+                }
+            }
         }
+
         /// <summary>
         /// Gets or sets the contract filter
         /// </summary>

--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -15,14 +15,9 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QLNet;
-using QuantConnect.Util;
 
 namespace QuantConnect.Securities.Option
 {
@@ -41,13 +36,19 @@ namespace QuantConnect.Securities.Option
         private readonly PricingEngineFuncEx _pricingEngineFunc;
 
         /// <summary>
+        /// When enabled, approximates Greeks if corresponding pricing model didn't calculate exact numbers.
+        /// The default value is true.
+        /// </summary>
+        public bool EnableGreekApproximation { get; set; } = true;
+
+        /// <summary>
         /// Method constructs QuantLib option price model with necessary estimators of underlying volatility, risk free rate, and underlying dividend yield
         /// </summary>
         /// <param name="pricingEngineFunc">Function modeled stochastic process, and returns new pricing engine to run calculations for that option</param>
         /// <param name="underlyingVolEstimator">The underlying volatility estimator</param>
         /// <param name="riskFreeRateEstimator">The risk free rate estimator</param>
         /// <param name="dividendYieldEstimator">The underlying dividend yield estimator</param>
-        public QLOptionPriceModel(PricingEngineFunc pricingEngineFunc, IQLUnderlyingVolatilityEstimator underlyingVolEstimator, IQLRiskFreeRateEstimator riskFreeRateEstimator, IQLDividendYieldEstimator dividendYieldEstimator)
+      public QLOptionPriceModel(PricingEngineFunc pricingEngineFunc, IQLUnderlyingVolatilityEstimator underlyingVolEstimator, IQLRiskFreeRateEstimator riskFreeRateEstimator, IQLDividendYieldEstimator dividendYieldEstimator)
         {
             _pricingEngineFunc = (option, process) => pricingEngineFunc(process);
             _underlyingVolEstimator = underlyingVolEstimator ?? new ConstantQLUnderlyingVolatilityEstimator();
@@ -126,7 +127,7 @@ namespace QuantConnect.Securities.Option
                     }
                     catch (Exception)
                     {
-                        return optionSecurity.EnableGreekApproximation ? (decimal)reevalFunc() : 0.0m;
+                        return EnableGreekApproximation ? (decimal)reevalFunc() : 0.0m;
                     }
                 };
 
@@ -155,7 +156,7 @@ namespace QuantConnect.Securities.Option
                     }
                     catch (Exception)
                     {
-                        if (optionSecurity.EnableGreekApproximation)
+                        if (EnableGreekApproximation)
                         {
                             var step = 0.01;
                             var initial = underlyingQuoteValue.value();

--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Securities.Option
         /// <param name="underlyingVolEstimator">The underlying volatility estimator</param>
         /// <param name="riskFreeRateEstimator">The risk free rate estimator</param>
         /// <param name="dividendYieldEstimator">The underlying dividend yield estimator</param>
-      public QLOptionPriceModel(PricingEngineFunc pricingEngineFunc, IQLUnderlyingVolatilityEstimator underlyingVolEstimator, IQLRiskFreeRateEstimator riskFreeRateEstimator, IQLDividendYieldEstimator dividendYieldEstimator)
+        public QLOptionPriceModel(PricingEngineFunc pricingEngineFunc, IQLUnderlyingVolatilityEstimator underlyingVolEstimator, IQLRiskFreeRateEstimator riskFreeRateEstimator, IQLDividendYieldEstimator dividendYieldEstimator)
         {
             _pricingEngineFunc = (option, process) => pricingEngineFunc(process);
             _underlyingVolEstimator = underlyingVolEstimator ?? new ConstantQLUnderlyingVolatilityEstimator();

--- a/Tests/Common/Securities/OptionPriceModelTests.cs
+++ b/Tests/Common/Securities/OptionPriceModelTests.cs
@@ -18,12 +18,8 @@ using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Indicators;
-using QuantConnect.Orders;
 using QuantConnect.Securities;
-using QuantConnect.Securities.Cfd;
 using QuantConnect.Securities.Equity;
-using QuantConnect.Securities.Forex;
 using QuantConnect.Securities.Option;
 using System.Collections.Generic;
 
@@ -194,9 +190,10 @@ namespace QuantConnect.Tests.Common
             var optionPut = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;
-            optionPut.EnableGreekApproximation = false;
 
-            var priceModel = OptionPriceModels.CrankNicolsonFD();
+            var priceModel = (QLOptionPriceModel)OptionPriceModels.CrankNicolsonFD();
+            priceModel.EnableGreekApproximation = false;
+
             var results = priceModel.Evaluate(optionPut, null, contract);
             var greeks = results.Greeks;
 
@@ -204,9 +201,9 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(greeks.Rho, 0);
             Assert.AreEqual(greeks.Vega, 0);
 
-            optionPut.EnableGreekApproximation = true;
+            priceModel = (QLOptionPriceModel)OptionPriceModels.CrankNicolsonFD();
+            priceModel.EnableGreekApproximation = true;
 
-            priceModel = OptionPriceModels.CrankNicolsonFD();
             results = priceModel.Evaluate(optionPut, null, contract);
             greeks = results.Greeks;
 

--- a/Tests/Common/Securities/OptionPriceModelTests.cs
+++ b/Tests/Common/Securities/OptionPriceModelTests.cs
@@ -191,7 +191,7 @@ namespace QuantConnect.Tests.Common
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
 
             var contract = new OptionContract(Symbols.SPY_P_192_Feb19_2016, Symbols.SPY) { Time = evaluationDate };
-            var optionPut = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_C_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var optionPut = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;
             optionPut.EnableGreekApproximation = false;


### PR DESCRIPTION
This bool property has been moved to the `QLOptionPriceModel` class and
the same property in the `Option` class has been obsoleted.