### PR TITLE
Add Dispose() method to IBrokerage

### DIFF
--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -100,6 +100,14 @@ namespace QuantConnect.Brokerages
         public abstract void Disconnect();
 
         /// <summary>
+        /// Dispose of the brokerage instance
+        /// </summary>
+        public virtual void Dispose()
+        {
+            // NOP
+        }
+
+        /// <summary>
         /// Event invocator for the OrderFilled event
         /// </summary>
         /// <param name="e">The OrderEvent</param>

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -667,7 +667,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
-        public void Dispose()
+        public override void Dispose()
         {
             if (_client != null)
             {

--- a/Common/Interfaces/IBrokerage.cs
+++ b/Common/Interfaces/IBrokerage.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Interfaces
     /// Brokerage interface that defines the operations all brokerages must implement. The IBrokerage implementation
     /// must have a matching IBrokerageFactory implementation.
     /// </summary>
-    public interface IBrokerage
+    public interface IBrokerage : IDisposable
     {
         /// <summary>
         /// Event that fires each time an order is filled

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -384,6 +384,7 @@ namespace QuantConnect.Lean.Engine
                 {
                     Log.Trace("Engine.Run(): Disconnecting from brokerage...");
                     brokerage.Disconnect();
+                    brokerage.Dispose();
                 }
                 if (_algorithmHandlers.Setup != null)
                 {


### PR DESCRIPTION
Currently only `InteractiveBrokersBrokerage` has a dispose method with custom logic for cleaning up resources. This PR adds the call to `IBrokerage.Dispose()` at the end of `Engine.Run()`.