### PR TITLE
Fix InteractiveBrokersBrokerageModel fee model with Forex

### DIFF
--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Forex;
 
@@ -34,6 +35,16 @@ namespace QuantConnect.Brokerages
         public InteractiveBrokersBrokerageModel(AccountType accountType = AccountType.Margin)
             : base(accountType)
         {
+        }
+
+        /// <summary>
+        /// Gets a new fee model that represents this brokerage's fee structure
+        /// </summary>
+        /// <param name="security">The security to get a fee model for</param>
+        /// <returns>The new fee model for this brokerage</returns>
+        public override IFeeModel GetFeeModel(Security security)
+        {
+            return new InteractiveBrokersFeeModel();
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmInitializeTests.cs
+++ b/Tests/Algorithm/AlgorithmInitializeTests.cs
@@ -50,6 +50,20 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
+        public void Validates_SetBrokerageModel_IB_AddForex()
+        {
+            var algorithm = new QCAlgorithm();
+
+            algorithm.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage);
+            var security = algorithm.AddForex(Ticker, Resolution, Market);
+
+            // Leverage and FeeModel from BrokerageModel
+            Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
+            Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
+            Assert.AreEqual(2, security.FeeModel.GetOrderFee(security, _order));
+        }
+
+        [Test]
         public void Validates_AddForex_SetBrokerageModel()
         {
             var algorithm = new QCAlgorithm();


### PR DESCRIPTION
When calling `SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage)` fees were reported as zero for `Forex` orders.