### PR TITLE
Initialize OrderTickets for open orders in BrokerageSetupHandler

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -25,6 +25,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using Newtonsoft.Json;
 using NodaTime;
+using QuantConnect.Orders;
 using QuantConnect.Securities;
 using Timer = System.Timers.Timer;
 
@@ -840,6 +841,26 @@ namespace QuantConnect
         public static string ToLower(this Enum @enum)
         {
             return @enum.ToString().ToLower();
+        }
+
+        /// <summary>
+        /// Turn order into an order ticket
+        /// </summary>
+        /// <param name="order">The <see cref="Order"/> being converted</param>
+        /// <param name="transactionManager">The transaction manager, <see cref="SecurityTransactionManager"/></param>
+        /// <returns></returns>
+        public static OrderTicket ToOrderTicket(this Order order, SecurityTransactionManager transactionManager)
+        {
+            var submitOrderRequest = new SubmitOrderRequest(order.Type,
+                order.SecurityType,
+                order.Symbol,
+                order.Quantity,
+                order.Price,
+                order.Price,
+                order.Time,
+                order.Tag);
+
+            return new OrderTicket(transactionManager, submitOrderRequest);
         }
     }
 }

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -272,17 +272,7 @@ namespace QuantConnect.Lean.Engine.Setup
                 Log.Trace("BrokerageSetupHandler.Setup(): Fetching open orders from brokerage...");
                 try
                 {
-                    // populate the algorithm with the account's outstanding orders
-                    var openOrders = brokerage.GetOpenOrders();
-                    foreach (var order in openOrders)
-                    {
-                        // be sure to assign order IDs such that we increment from the SecurityTransactionManager to avoid ID collisions
-                        Log.Trace("BrokerageSetupHandler.Setup(): Has open order: " + order.Symbol.Value + " - " + order.Quantity);
-                        resultHandler.DebugMessage($"BrokerageSetupHandler.Setup(): Open order detected.  Creating order tickets for open order {order.Symbol.Value} with quantity {order.Quantity}. Beware that this order ticket may not accurately reflect the quantity of the order if the open order is partially filled.");
-                        order.Id = algorithm.Transactions.GetIncrementOrderId();
-                        transactionHandler.Orders.AddOrUpdate(order.Id, order, (i, o) => order);
-                        transactionHandler.OrderTickets.AddOrUpdate(order.Id, order.ToOrderTicket(algorithm.Transactions));
-                    }
+                    GetOpenOrders(algorithm, resultHandler, transactionHandler, brokerage);
                 }
                 catch (Exception err)
                 {
@@ -374,6 +364,28 @@ namespace QuantConnect.Lean.Engine.Setup
             }
 
             return Errors.Count == 0;
+        }
+
+        /// <summary>
+        /// Get the open orders from a brokerage. Adds <see cref="Orders.Order"/> and <see cref="Orders.OrderTicket"/> to the transaction handler
+        /// </summary>
+        /// <param name="algorithm">Algorithm instance</param>
+        /// <param name="resultHandler">The configured result handler</param>
+        /// <param name="transactionHandler">The configurated transaction handler</param>
+        /// <param name="brokerage">Brokerage output instance</param>
+        protected void GetOpenOrders(IAlgorithm algorithm, IResultHandler resultHandler, ITransactionHandler transactionHandler, IBrokerage brokerage)
+        {
+            // populate the algorithm with the account's outstanding orders  resultHandler
+            var openOrders = brokerage.GetOpenOrders();
+            foreach (var order in openOrders)
+            {
+                // be sure to assign order IDs such that we increment from the SecurityTransactionManager to avoid ID collisions
+                Log.Trace("BrokerageSetupHandler.Setup(): Has open order: " + order.Symbol.Value + " - " + order.Quantity);
+                resultHandler.DebugMessage($"BrokerageSetupHandler.Setup(): Open order detected.  Creating order tickets for open order {order.Symbol.Value} with quantity {order.Quantity}. Beware that this order ticket may not accurately reflect the quantity of the order if the open order is partially filled.");
+                order.Id = algorithm.Transactions.GetIncrementOrderId();
+                transactionHandler.Orders.AddOrUpdate(order.Id, order, (i, o) => order);
+                transactionHandler.OrderTickets.AddOrUpdate(order.Id, order.ToOrderTicket(algorithm.Transactions));
+            }
         }
 
         /// <summary>

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -278,6 +278,7 @@ namespace QuantConnect.Lean.Engine.Setup
                     {
                         // be sure to assign order IDs such that we increment from the SecurityTransactionManager to avoid ID collisions
                         Log.Trace("BrokerageSetupHandler.Setup(): Has open order: " + order.Symbol.Value + " - " + order.Quantity);
+                        resultHandler.DebugMessage($"BrokerageSetupHandler.Setup(): Open order detected.  Creating order tickets for open order {order.Symbol.Value} with quantity {order.Quantity}. Beware that this order ticket may not accurately reflect the quantity of the order if the open order is partially filled.");
                         order.Id = algorithm.Transactions.GetIncrementOrderId();
                         transactionHandler.Orders.AddOrUpdate(order.Id, order, (i, o) => order);
                         transactionHandler.OrderTickets.AddOrUpdate(order.Id, order.ToOrderTicket(algorithm.Transactions));

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -280,6 +280,7 @@ namespace QuantConnect.Lean.Engine.Setup
                         Log.Trace("BrokerageSetupHandler.Setup(): Has open order: " + order.Symbol.Value + " - " + order.Quantity);
                         order.Id = algorithm.Transactions.GetIncrementOrderId();
                         transactionHandler.Orders.AddOrUpdate(order.Id, order, (i, o) => order);
+                        transactionHandler.OrderTickets.AddOrUpdate(order.Id, order.ToOrderTicket(algorithm.Transactions));
                     }
                 }
                 catch (Exception err)

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -80,6 +80,14 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         }
 
         /// <summary>
+        /// Gets the permanent storage for all order tickets
+        /// </summary>
+        public ConcurrentDictionary<int, OrderTicket> OrderTickets
+        {
+            get { return _orderTickets; }
+        }
+
+        /// <summary>
         /// Gets the current number of orders that have been processed
         /// </summary>
         public int OrdersCount

--- a/Engine/TransactionHandlers/ITransactionHandler.cs
+++ b/Engine/TransactionHandlers/ITransactionHandler.cs
@@ -48,6 +48,14 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         }
 
         /// <summary>
+        /// Gets the permanent storage for all order tickets
+        /// </summary>
+        ConcurrentDictionary<int, OrderTicket> OrderTickets
+        {
+            get;
+        }
+
+        /// <summary>
         /// Initializes the transaction handler for the specified algorithm using the specified brokerage implementation
         /// </summary>
         void Initialize(IAlgorithm algorithm, IBrokerage brokerage, IResultHandler resultHandler);

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -1,13 +1,23 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
+using QuantConnect.Lean.Engine.Setup;
 using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Logging;
+using QuantConnect.Orders;
+using QuantConnect.Packets;
+using QuantConnect.Securities;
+using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Engine.Setup
 {
@@ -16,21 +26,151 @@ namespace QuantConnect.Tests.Engine.Setup
     {
         private IAlgorithm _algorithm;
         private ITransactionHandler _transactionHandler;
-        private IResultHandler _resultHanlder;
+        private NonDequeingTestResultsHandler _resultHanlder;
         private IBrokerage _brokerage;
+
+        private TestableBrokerageSetupHandler _brokerageSetupHandler;
 
         [TestFixtureSetUp]
         public void Setup()
         {
             _algorithm = new QCAlgorithm();
             _transactionHandler = new BrokerageTransactionHandler();
+            _resultHanlder = new NonDequeingTestResultsHandler();
+            _brokerage = new TestBrokerage();
 
+            _brokerageSetupHandler = new TestableBrokerageSetupHandler();
         }
 
         [Test]
         public void BrokerageSetupHanlder_CanGetOpenOrders()
         {
-            
+            _brokerageSetupHandler.PublicGetOpenOrders(_algorithm, _resultHanlder, _transactionHandler, _brokerage);
+
+            Assert.AreEqual(_transactionHandler.Orders.Count, 4);
+
+            Assert.AreEqual(_transactionHandler.OrderTickets.Count, 4);
+
+            // Warn the user about each open order
+            Assert.AreEqual(_resultHanlder.PersistentMessages.Count, 4);
+
+            // Market order
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.Market).Value.Quantity, 100);
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.Market).Value.SubmitRequest.LimitPrice, 1.2345m);
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.Market).Value.SubmitRequest.StopPrice, 1.2345m);
+
+            // Limit Order
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.Limit).Value.Quantity, -100);
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.Limit).Value.SubmitRequest.LimitPrice, 2.2345m);
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.Limit).Value.SubmitRequest.StopPrice, 0m);
+
+            // Stop market order
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.StopMarket).Value.Quantity, 100);
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.StopMarket).Value.SubmitRequest.LimitPrice, 0m);
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.StopMarket).Value.SubmitRequest.StopPrice, 2.2345m);
+
+            // Stop Limit order
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.StopLimit).Value.Quantity, 100);
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.StopLimit).Value.SubmitRequest.LimitPrice, 0.2345m);
+            Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.StopLimit).Value.SubmitRequest.StopPrice, 2.2345m);
         }
+
+        class NonDequeingTestResultsHandler : TestResultHandler
+        {
+            private AlgorithmNodePacket _job = new BacktestNodePacket();
+            public ConcurrentQueue<Packet> PersistentMessages  = new ConcurrentQueue<Packet>();
+
+            public override void DebugMessage(string message)
+            {
+                PersistentMessages.Enqueue(new DebugPacket(_job.ProjectId, _job.AlgorithmId, _job.CompileId, message));
+            }
+        }
+
+        class TestableBrokerageSetupHandler : BrokerageSetupHandler
+        {
+            public void PublicGetOpenOrders(IAlgorithm algorithm, IResultHandler resultHandler, ITransactionHandler transactionHandler, IBrokerage brokerage)
+            {
+                GetOpenOrders(algorithm, resultHandler, transactionHandler, brokerage);
+            }
+        }
+    }
+
+    class TestBrokerage : IBrokerage
+    {
+        public event EventHandler<OrderEvent> OrderStatusChanged;
+        public event EventHandler<OrderEvent> OptionPositionAssigned;
+        public event EventHandler<AccountEvent> AccountChanged;
+        public event EventHandler<BrokerageMessageEvent> Message;
+        public string Name { get; }
+        public bool IsConnected { get; }
+
+        public List<Order> GetOpenOrders()
+        {
+            const decimal delta = 1m;
+            const decimal price = 1.2345m;
+            const int quantity = 100;
+            const decimal pricePlusDelta = price + delta;
+            const decimal priceMinusDelta = price - delta;
+            var tz = TimeZones.NewYork;
+
+            var time = new DateTime(2016, 2, 4, 16, 0, 0).ConvertToUtc(tz);
+            var marketOrderWithPrice = new MarketOrder(Symbols.SPY, quantity, time);
+            marketOrderWithPrice.Price = price;
+
+            return new List<Order>()
+            {
+                marketOrderWithPrice,
+                new LimitOrder(Symbols.SPY, -quantity, pricePlusDelta, time),
+                new StopMarketOrder(Symbols.SPY, quantity, pricePlusDelta, time),
+                new StopLimitOrder(Symbols.SPY, quantity, pricePlusDelta, priceMinusDelta, time)
+            };
+        }
+
+        #region UnusedMethods
+        public void Dispose()
+        {
+        }
+        public List<Holding> GetAccountHoldings()
+        {
+            throw new NotImplementedException();
+        }
+
+        public List<Cash> GetCashBalance()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool PlaceOrder(Order order)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool UpdateOrder(Order order)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool CancelOrder(Order order)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Connect()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Disconnect()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool AccountInstantlyUpdated { get; }
+        public IEnumerable<BaseData> GetHistory(HistoryRequest request)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
     }
 }

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.Results;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+
+namespace QuantConnect.Tests.Engine.Setup
+{
+    [TestFixture]
+    public class BrokerageSetupHandlerTests
+    {
+        private IAlgorithm _algorithm;
+        private ITransactionHandler _transactionHandler;
+        private IResultHandler _resultHanlder;
+        private IBrokerage _brokerage;
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            _algorithm = new QCAlgorithm();
+            _transactionHandler = new BrokerageTransactionHandler();
+
+        }
+
+        [Test]
+        public void BrokerageSetupHanlder_CanGetOpenOrders()
+        {
+            
+        }
+    }
+}

--- a/Tests/Engine/TestResultHandler.cs
+++ b/Tests/Engine/TestResultHandler.cs
@@ -89,7 +89,7 @@ namespace QuantConnect.Tests.Engine
         {
         }
 
-        public void DebugMessage(string message)
+        public virtual void DebugMessage(string message)
         {
             Messages.Enqueue(new DebugPacket(_job.ProjectId, _job.AlgorithmId, _job.CompileId, message));
         }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -251,6 +251,7 @@
     <Compile Include="Engine\FactorFileTests.cs" />
     <Compile Include="Engine\RealTimePriceUpdateTests.cs" />
     <Compile Include="Engine\RealTime\ScheduledEventTests.cs" />
+    <Compile Include="Engine\Setup\BrokerageSetupHandlerTests.cs" />
     <Compile Include="Engine\TestResultHandler.cs" />
     <Compile Include="Indicators\AbsolutePriceOscillatorTests.cs" />
     <Compile Include="Indicators\AccumulationDistributionOscillatorTests.cs" />


### PR DESCRIPTION
Attempting to address [issue 1044](https://github.com/QuantConnect/Lean/issues/1044)

- Adds extension method to `Order.ToOrderTicket()` that returns an `OrderTicket`.
- Make `ITransactionHandler.OrderTickets` a public property
- Refactored getting open orders to a new method, `BrokerageSetupHadler.GetOpenOrders()`. For every open order, saturate an `OrderTicket` from the existing order and add it to the `ITransactionHandler.OrderTickets` property. Also, add debug message to send back to user regarding the new `OrderTicket` and it's limitations.
- Add `BrokerageSetupHandlerTests.cs`

This PR creates `OrderTickets` that **do not** accurately reflect the fill quantity of partially filled open orders. This is a limitation of the data that can be returned from the brokerage.