### PR TITLE
Fixes default Equity leverage for Cash accounts

### DIFF
--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -146,13 +146,14 @@ namespace QuantConnect.Brokerages
         /// <returns>The leverage for the specified security</returns>
         public decimal GetLeverage(Security security)
         {
+            if (AccountType == AccountType.Cash)
+            {
+                return 1m;
+            }
+                    
             switch (security.Type)
             {
                 case SecurityType.Equity:
-                    if (AccountType == AccountType.Cash)
-                    {
-                        return 1m;
-                    }
                     return 2m;
 
                 case SecurityType.Forex:

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -149,6 +149,10 @@ namespace QuantConnect.Brokerages
             switch (security.Type)
             {
                 case SecurityType.Equity:
+                    if (AccountType == AccountType.Cash)
+                    {
+                        return 1m;
+                    }
                     return 2m;
 
                 case SecurityType.Forex:


### PR DESCRIPTION
When trading in a cash only account, the maximum leverage for the account should be 1.0. This change is a step in the right direction but we still need a good way to cap leverage for the whole account such that multiple positions can not total up to be more than 1.0.
I'm new to this code base so if anyone knows a good place where such a rule may be set, please let me know.
I also do not know anything about Forex and Cfd trading, if those need to consider a "cash only" type account please let me know and I'll add that in.