### PR TITLE
Fix IB symbol mapper to handle equity tickers with a dot

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
     {
         // we have a special treatment of futures, because IB renamed several exchange tickers (like GBP instead of 6B). We fix this: 
         // We map those tickers back to their original names using the map below
-        private Dictionary<string, string> _ibNameMap = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _ibNameMap = new Dictionary<string, string>();
 
         /// <summary>
         /// Constructs InteractiveBrokersSymbolMapper. Default parameters are used.
@@ -77,13 +77,16 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             if (symbol.ID.SecurityType == SecurityType.Forex && symbol.Value.Length != 6)
                 throw new ArgumentException("Forex symbol length must be equal to 6: " + symbol.Value);
 
-            if (symbol.ID.SecurityType == SecurityType.Option)
+            switch (symbol.ID.SecurityType)
             {
-                return symbol.Underlying.Value;
-            }
-            if (symbol.ID.SecurityType == SecurityType.Future)
-            {
-                return GetBrokerageRootSymbol(symbol.ID.Symbol);
+                case SecurityType.Option:
+                    return symbol.Underlying.Value;
+
+                case SecurityType.Future:
+                    return GetBrokerageRootSymbol(symbol.ID.Symbol);
+
+                case SecurityType.Equity:
+                    return symbol.Value.Replace(".", " ");
             }
 
             return symbol.Value;
@@ -112,20 +115,24 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             try
             {
-                if (securityType == SecurityType.Future)
+                switch (securityType)
                 {
-                    return Symbol.CreateFuture(GetLeanRootSymbol(brokerageSymbol), market, expirationDate);
+                    case SecurityType.Future:
+                        return Symbol.CreateFuture(GetLeanRootSymbol(brokerageSymbol), market, expirationDate);
+
+                    case SecurityType.Option:
+                        return Symbol.CreateOption(brokerageSymbol, market, OptionStyle.American, optionRight, strike, expirationDate);
+
+                    case SecurityType.Equity:
+                        brokerageSymbol = brokerageSymbol.Replace(" ", ".");
+                        break;
                 }
-                else if (securityType == SecurityType.Option)
-                {
-                    return Symbol.CreateOption(brokerageSymbol, market, OptionStyle.American, optionRight, strike, expirationDate);
-                }
-                
+
                 return Symbol.Create(brokerageSymbol, securityType, market);
             }
             catch (Exception)
             {
-                throw new ArgumentException(string.Format("Invalid symbol: {0}, security type: {1}, market: {2}.", brokerageSymbol, securityType, market));
+                throw new ArgumentException($"Invalid symbol: {brokerageSymbol}, security type: {securityType}, market: {market}.");
             }
         }
 

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapperTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapperTests.cs
@@ -20,7 +20,7 @@ using QuantConnect.Brokerages.InteractiveBrokers;
 namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 {
     [TestFixture]
-    class InteractiveBrokersSymbolMapperTests
+    public class InteractiveBrokersSymbolMapperTests
     {
         [Test]
         public void ReturnsCorrectLeanSymbol()
@@ -34,6 +34,11 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 
             symbol = mapper.GetLeanSymbol("AAPL", SecurityType.Equity, Market.USA);
             Assert.AreEqual("AAPL", symbol.Value);
+            Assert.AreEqual(SecurityType.Equity, symbol.ID.SecurityType);
+            Assert.AreEqual(Market.USA, symbol.ID.Market);
+
+            symbol = mapper.GetLeanSymbol("BRK B", SecurityType.Equity, Market.USA);
+            Assert.AreEqual("BRK.B", symbol.Value);
             Assert.AreEqual(SecurityType.Equity, symbol.ID.SecurityType);
             Assert.AreEqual(Market.USA, symbol.ID.Market);
         }
@@ -50,6 +55,10 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             symbol = Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
             brokerageSymbol = mapper.GetBrokerageSymbol(symbol);
             Assert.AreEqual("AAPL", brokerageSymbol);
+
+            symbol = Symbol.Create("BRK.B", SecurityType.Equity, Market.USA);
+            brokerageSymbol = mapper.GetBrokerageSymbol(symbol);
+            Assert.AreEqual("BRK B", brokerageSymbol);
         }
 
         [Test]


### PR DESCRIPTION
Equity symbols with a dot in the ticker (such as `BRK.B`, `TAP.A` and a few others) are not accepted by IB as valid tickers when subscribing: the dot is now replaced with a space in the `InteractiveBrokersSymbolMapper` class.