### PR TITLE
Remove multiple enumerations of enumerable

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -469,7 +469,7 @@ namespace QuantConnect.Algorithm
                 subscriptionDataConfig == null ? LeanData.GetCommonTickTypeForCommonDataTypes(typeof(TradeBar), security.Type) : subscriptionDataConfig.TickType
             );
 
-            var history = History(new List<HistoryRequest> { request });
+            var history = History(new List<HistoryRequest> { request }).ToList();
 
             if (history.Any() && history.First().Values.Any())
             {


### PR DESCRIPTION
Depending on the IHistoryProvider implementation, this could result in
multiple history requests being sent per GetLastKnownPrice function call.