### PR TITLE
Fixes FF daily data with different data/exchange tz

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -485,6 +485,21 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Rounds the specified date time in the specified time zone
+        /// </summary>
+        /// <param name="dateTime">Date time to be rounded</param>
+        /// <param name="roundingInterval">Timespan rounding period</param>
+        /// <param name="sourceTimeZone">Time zone of the date time</param>
+        /// <param name="roundingTimeZone">Time zone in which the rounding is performed</param>
+        /// <returns>The rounded date time in the source time zone</returns>
+        public static DateTime RoundDownInTimeZone(this DateTime dateTime, TimeSpan roundingInterval, DateTimeZone sourceTimeZone, DateTimeZone roundingTimeZone)
+        {
+            var dateTimeInRoundingTimeZone = dateTime.ConvertTo(sourceTimeZone, roundingTimeZone);
+            var roundedDateTimeInRoundingTimeZone = dateTimeInRoundingTimeZone.RoundDown(roundingInterval);
+            return roundedDateTimeInRoundingTimeZone.ConvertTo(roundingTimeZone, sourceTimeZone);
+        }
+
+        /// <summary>
         /// Extension method to round a datetime down by a timespan interval until it's
         /// within the specified exchange's open hours. This works by first rounding down
         /// the specified time using the interval, then producing a bar between that
@@ -513,7 +528,7 @@ namespace QuantConnect
         /// Extension method to round a datetime to the nearest unit timespan.
         /// </summary>
         /// <param name="datetime">Datetime object we're rounding.</param>
-        /// <param name="roundingInterval">Timespan rounding period.s</param>
+        /// <param name="roundingInterval">Timespan rounding period.</param>
         /// <returns>Rounded datetime</returns>
         public static DateTime Round(this DateTime datetime, TimeSpan roundingInterval)
         {

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,12 +29,12 @@ using QuantConnect.Orders;
 using QuantConnect.Securities;
 using Timer = System.Timers.Timer;
 
-namespace QuantConnect 
+namespace QuantConnect
 {
     /// <summary>
     /// Extensions function collections - group all static extensions functions here.
     /// </summary>
-    public static class Extensions 
+    public static class Extensions
     {
         /// <summary>
         /// Extension to move one element from list from A to position B.
@@ -56,7 +56,7 @@ namespace QuantConnect
         /// </summary>
         /// <param name="str">String to convert to bytes.</param>
         /// <returns>Byte array</returns>
-        public static byte[] GetBytes(this string str) 
+        public static byte[] GetBytes(this string str)
         {
             var bytes = new byte[str.Length * sizeof(char)];
             Buffer.BlockCopy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
@@ -69,7 +69,7 @@ namespace QuantConnect
         /// <remarks>Small risk of race condition if a producer is adding to the list.</remarks>
         /// <typeparam name="T">Queue type</typeparam>
         /// <param name="queue">queue object</param>
-        public static void Clear<T>(this ConcurrentQueue<T> queue) 
+        public static void Clear<T>(this ConcurrentQueue<T> queue)
         {
             T item;
             while (queue.TryDequeue(out item)) {
@@ -95,7 +95,7 @@ namespace QuantConnect
         /// </summary>
         /// <param name="str">String we want to MD5 encode.</param>
         /// <returns>MD5 hash of a string</returns>
-        public static string ToMD5(this string str) 
+        public static string ToMD5(this string str)
         {
             var builder = new StringBuilder();
             using (var md5Hash = MD5.Create())
@@ -124,7 +124,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Extension method to automatically set the update value to same as "add" value for TryAddUpdate. 
+        /// Extension method to automatically set the update value to same as "add" value for TryAddUpdate.
         /// This makes the API similar for traditional and concurrent dictionaries.
         /// </summary>
         /// <typeparam name="K">Key type for dictionary</typeparam>
@@ -138,7 +138,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Extension method to automatically add/update lazy values in concurrent dictionary. 
+        /// Extension method to automatically add/update lazy values in concurrent dictionary.
         /// </summary>
         /// <typeparam name="TKey">Key type for dictionary</typeparam>
         /// <typeparam name="TValue">Value type for dictonary</typeparam>
@@ -239,7 +239,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Extension method for faster string to decimal conversion. 
+        /// Extension method for faster string to decimal conversion.
         /// </summary>
         /// <param name="str">String to be converted to positive decimal value</param>
         /// <remarks>
@@ -290,7 +290,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Extension method for faster string to Int32 conversion. 
+        /// Extension method for faster string to Int32 conversion.
         /// </summary>
         /// <param name="str">String to be converted to positive Int32 value</param>
         /// <remarks>Method makes some assuptions - always numbers, no "signs" +,- etc.</remarks>
@@ -306,7 +306,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Extension method for faster string to Int64 conversion. 
+        /// Extension method for faster string to Int64 conversion.
         /// </summary>
         /// <param name="str">String to be converted to positive Int64 value</param>
         /// <remarks>Method makes some assuptions - always numbers, no "signs" +,- etc.</remarks>
@@ -346,7 +346,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Breaks the specified string into csv components, works correctly with commas in data fields 
+        /// Breaks the specified string into csv components, works correctly with commas in data fields
         /// </summary>
         /// <param name="str">The string to be broken into csv</param>
         /// <param name="size">The expected size of the output list</param>
@@ -423,7 +423,7 @@ namespace QuantConnect
         /// </summary>
         /// <param name="str">String to convert to stream</param>
         /// <returns>Stream instance</returns>
-        public static Stream ToStream(this string str) 
+        public static Stream ToStream(this string str)
         {
             var stream = new MemoryStream();
             var writer = new StreamWriter(stream);
@@ -440,7 +440,7 @@ namespace QuantConnect
         /// <param name="roundingInterval">Rounding Unit</param>
         /// <param name="roundingType">Rounding method</param>
         /// <returns>Rounded timespan</returns>
-        public static TimeSpan Round(this TimeSpan time, TimeSpan roundingInterval, MidpointRounding roundingType) 
+        public static TimeSpan Round(this TimeSpan time, TimeSpan roundingInterval, MidpointRounding roundingType)
         {
             if (roundingInterval == TimeSpan.Zero)
             {
@@ -456,7 +456,7 @@ namespace QuantConnect
             );
         }
 
-        
+
         /// <summary>
         /// Extension method to round timespan to nearest timespan period.
         /// </summary>
@@ -515,7 +515,7 @@ namespace QuantConnect
         /// <param name="datetime">Datetime object we're rounding.</param>
         /// <param name="roundingInterval">Timespan rounding period.s</param>
         /// <returns>Rounded datetime</returns>
-        public static DateTime Round(this DateTime datetime, TimeSpan roundingInterval) 
+        public static DateTime Round(this DateTime datetime, TimeSpan roundingInterval)
         {
             return new DateTime((datetime - DateTime.MinValue).Round(roundingInterval).Ticks);
         }
@@ -552,7 +552,7 @@ namespace QuantConnect
             {
                 return from.AtStrictly(LocalDateTime.FromDateTime(time)).WithZone(to).ToDateTimeUnspecified();
             }
-            
+
             return from.AtLeniently(LocalDateTime.FromDateTime(time)).WithZone(to).ToDateTimeUnspecified();
         }
 
@@ -757,7 +757,7 @@ namespace QuantConnect
         /// <summary>
         /// Blocks the current thread until the current <see cref="T:System.Threading.WaitHandle"/> is set, using a <see cref="T:System.TimeSpan"/> to measure the time interval, while observing a <see cref="T:System.Threading.CancellationToken"/>.
         /// </summary>
-        /// 
+        ///
         /// <returns>
         /// true if the <see cref="T:System.Threading.WaitHandle"/> was set; otherwise, false.
         /// </returns>
@@ -775,7 +775,7 @@ namespace QuantConnect
         /// <summary>
         /// Blocks the current thread until the current <see cref="T:System.Threading.WaitHandle"/> is set, using a 32-bit signed integer to measure the time interval, while observing a <see cref="T:System.Threading.CancellationToken"/>.
         /// </summary>
-        /// 
+        ///
         /// <returns>
         /// true if the <see cref="T:System.Threading.WaitHandle"/> was set; otherwise, false.
         /// </returns>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -525,6 +525,30 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Extension method to round a datetime down by a timespan interval until it's
+        /// within the specified exchange's open hours. The rounding is performed in the
+        /// specified time zone
+        /// </summary>
+        /// <param name="dateTime">Time to be rounded down</param>
+        /// <param name="interval">Timespan interval to round to.</param>
+        /// <param name="exchangeHours">The exchange hours to determine open times</param>
+        /// <param name="roundingTimeZone">The time zone to perform the rounding in</param>
+        /// <param name="extendedMarket">True for extended market hours, otherwise false</param>
+        /// <returns>Rounded datetime</returns>
+        public static DateTime ExchangeRoundDownInTimeZone(this DateTime dateTime, TimeSpan interval, SecurityExchangeHours exchangeHours, DateTimeZone roundingTimeZone, bool extendedMarket)
+        {
+            // can't round against a zero interval
+            if (interval == TimeSpan.Zero) return dateTime;
+
+            var rounded = dateTime.RoundDownInTimeZone(interval, exchangeHours.TimeZone, roundingTimeZone);
+            while (!exchangeHours.IsOpen(rounded, rounded + interval, extendedMarket))
+            {
+                rounded = (rounded - interval).RoundDownInTimeZone(interval, exchangeHours.TimeZone, roundingTimeZone);
+            }
+            return rounded;
+        }
+
+        /// <summary>
         /// Extension method to round a datetime to the nearest unit timespan.
         /// </summary>
         /// <param name="datetime">Datetime object we're rounding.</param>

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -113,7 +113,7 @@ namespace QuantConnect.Lean.Engine
                 {
                     return "Algorithm took longer than 10 minutes on a single time loop.";
                 }
-                
+
                 return null;
             };
             _liveMode = liveMode;
@@ -133,7 +133,7 @@ namespace QuantConnect.Lean.Engine
         /// <param name="leanManager">ILeanManager implementation that is updated periodically with the IAlgorithm instance</param>
         /// <param name="token">Cancellation token</param>
         /// <remarks>Modify with caution</remarks>
-        public void Run(AlgorithmNodePacket job, IAlgorithm algorithm, IDataFeed feed, ITransactionHandler transactions, IResultHandler results, IRealTimeHandler realtime, ILeanManager leanManager, CancellationToken token) 
+        public void Run(AlgorithmNodePacket job, IAlgorithm algorithm, IDataFeed feed, ITransactionHandler transactions, IResultHandler results, IRealTimeHandler realtime, ILeanManager leanManager, CancellationToken token)
         {
             //Initialize:
             _dataPointCount = 0;
@@ -173,10 +173,10 @@ namespace QuantConnect.Lean.Engine
                 .FirstOrDefault(x => x.DeclaringType == algorithm.GetType()) != null;
 
             //Go through the subscription types and create invokers to trigger the event handlers for each custom type:
-            foreach (var config in algorithm.SubscriptionManager.Subscriptions) 
+            foreach (var config in algorithm.SubscriptionManager.Subscriptions)
             {
                 //If type is a custom feed, check for a dedicated event handler
-                if (config.IsCustomData) 
+                if (config.IsCustomData)
                 {
                     //Get the matching method for this event handler - e.g. public void OnData(Quandl data) { .. }
                     var genericMethod = (algorithm.GetType()).GetMethod("OnData", new[] { config.Type });
@@ -219,7 +219,7 @@ namespace QuantConnect.Lean.Engine
                     return;
                 }
 
-                // Update the ILeanManager 
+                // Update the ILeanManager
                 leanManager.Update();
 
                 var time = timeSlice.Time;
@@ -266,7 +266,7 @@ namespace QuantConnect.Lean.Engine
 
                 //Update algorithm state after capturing performance from previous day
 
-                // If backtesting, we need to check if there are realtime events in the past 
+                // If backtesting, we need to check if there are realtime events in the past
                 // which didn't fire because at the scheduled times there was no data (i.e. markets closed)
                 // and fire them with the correct date/time.
                 if (backtestMode)
@@ -555,7 +555,7 @@ namespace QuantConnect.Lean.Engine
                 {
 
                     // TODO: For backwards compatibility only. Remove in 2017
-                    // For compatibility with Forex Trade data, moving 
+                    // For compatibility with Forex Trade data, moving
                     if (timeSlice.Slice.QuoteBars.Count > 0)
                     {
                         foreach (var tradeBar in timeSlice.Slice.QuoteBars.Where(x => x.Key.ID.SecurityType == SecurityType.Forex))
@@ -655,7 +655,7 @@ namespace QuantConnect.Lean.Engine
             results.SampleRange(algorithm.GetChartUpdates());
             results.SampleEquity(_previousTime, Math.Round(algorithm.Portfolio.TotalPortfolioValue, 4));
             SampleBenchmark(algorithm, results, backtestMode ? _previousTime.Date : _previousTime);
-            
+
             //Check for divide by zero
             if (portfolioValue == 0m)
             {
@@ -663,7 +663,7 @@ namespace QuantConnect.Lean.Engine
             }
             else
             {
-                results.SamplePerformance(backtestMode ? _previousTime.Date : _previousTime, 
+                results.SamplePerformance(backtestMode ? _previousTime.Date : _previousTime,
                     Math.Round((algorithm.Portfolio.TotalPortfolioValue - portfolioValue) * 100 / portfolioValue, 10));
             }
         } // End of Run();
@@ -675,7 +675,7 @@ namespace QuantConnect.Lean.Engine
         {
             lock (_lock)
             {
-                //We don't want anyone elseto set our internal state to "Running". 
+                //We don't want anyone elseto set our internal state to "Running".
                 //This is controlled by the algorithm private variable only.
                 if (state != AlgorithmStatus.Running)
                 {
@@ -789,7 +789,7 @@ namespace QuantConnect.Lean.Engine
                         }
                         yield return timeSlice;
                         lastHistoryTimeUtc = timeSlice.Time;
-                    } 
+                    }
                 }
             }
 
@@ -832,7 +832,7 @@ namespace QuantConnect.Lean.Engine
                         {
                             continue;
                         }
-                        
+
                         // prevent us from doing these checks every loop
                         lastHistoryTimeUtc = null;
                     }
@@ -851,7 +851,7 @@ namespace QuantConnect.Lean.Engine
                         // catching up to real time data
                         nextStatusTime = DateTime.UtcNow.AddSeconds(1);
                         var percent = (int) (100*(timeSlice.Time.Ticks - start)/(double) (DateTime.UtcNow.Ticks - start));
-                        results.SendStatusUpdate(AlgorithmStatus.History, string.Format("Catching up to realtime {0}%...", percent));   
+                        results.SendStatusUpdate(AlgorithmStatus.History, string.Format("Catching up to realtime {0}%...", percent));
                     }
                 }
                 yield return timeSlice;
@@ -905,7 +905,7 @@ namespace QuantConnect.Lean.Engine
 
 
         /// <summary>
-        /// Performs delisting logic for the securities specified in <paramref name="newDelistings"/> that are marked as <see cref="DelistingType.Delisted"/>. 
+        /// Performs delisting logic for the securities specified in <paramref name="newDelistings"/> that are marked as <see cref="DelistingType.Delisted"/>.
         /// </summary>
         private static void HandleDelistedSymbols(IAlgorithm algorithm, Delistings newDelistings, List<Delisting> delistings)
         {

--- a/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Logging;
@@ -36,6 +37,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         private bool _isFillingForward;
 
         private readonly TimeSpan _dataResolution;
+        private readonly DateTimeZone _dataTimeZone;
         private readonly bool _isExtendedMarketHours;
         private readonly DateTime _subscriptionEndTime;
         private readonly IEnumerator<BaseData> _enumerator;
@@ -57,18 +59,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <param name="isExtendedMarketHours">True to use the exchange's extended market hours, false to use the regular market hours</param>
         /// <param name="subscriptionEndTime">The end time of the subscrition, once passing this date the enumerator will stop</param>
         /// <param name="dataResolution">The source enumerator's data resolution</param>
-        public FillForwardEnumerator(IEnumerator<BaseData> enumerator,
-            SecurityExchange exchange,
-            IReadOnlyRef<TimeSpan> fillForwardResolution,
-            bool isExtendedMarketHours,
-            DateTime subscriptionEndTime,
-            TimeSpan dataResolution
-            )
+        /// <param name="dataTimeZone">The time zone of the underying source data</param>
+        public FillForwardEnumerator(IEnumerator<BaseData> enumerator, SecurityExchange exchange, IReadOnlyRef<TimeSpan> fillForwardResolution, bool isExtendedMarketHours, DateTime subscriptionEndTime, TimeSpan dataResolution, DateTimeZone dataTimeZone)
         {
             _subscriptionEndTime = subscriptionEndTime;
             Exchange = exchange;
             _enumerator = enumerator;
             _dataResolution = dataResolution;
+            _dataTimeZone = dataTimeZone;
             _fillForwardResolution = fillForwardResolution;
             _isExtendedMarketHours = isExtendedMarketHours;
         }

--- a/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         private DateTime? _delistedTime;
         private BaseData _previous;
         private bool _isFillingForward;
-        
+
         private readonly TimeSpan _dataResolution;
         private readonly bool _isExtendedMarketHours;
         private readonly DateTime _subscriptionEndTime;
@@ -159,7 +159,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     {
                         return false;
                     }
-                    
+
                     Current = endOfSubscription;
                     return true;
                 }
@@ -183,7 +183,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 }
                 return true;
             }
-            
+
             if (RequiresFillForwardData(_fillForwardResolution.Value, _previous, underlyingCurrent, out fillForward))
             {
                 // we require fill forward data because the _enumerator.Current is too far in future

--- a/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -59,8 +60,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <param name="isExtendedMarketHours">True to use the exchange's extended market hours, false to use the regular market hours</param>
         /// <param name="subscriptionEndTime">The end time of the subscrition, once passing this date the enumerator will stop</param>
         /// <param name="dataResolution">The source enumerator's data resolution</param>
-        /// <param name="dataTimeZone">The time zone of the underying source data</param>
-        public FillForwardEnumerator(IEnumerator<BaseData> enumerator, SecurityExchange exchange, IReadOnlyRef<TimeSpan> fillForwardResolution, bool isExtendedMarketHours, DateTime subscriptionEndTime, TimeSpan dataResolution, DateTimeZone dataTimeZone)
+        /// <param name="dataTimeZone">The time zone of the underlying source data. This is used for rounding calculations and
+        /// is NOT the time zone on the BaseData instances (unless of course data time zone equals the exchange time zone)</param>
+        public FillForwardEnumerator(IEnumerator<BaseData> enumerator,
+            SecurityExchange exchange,
+            IReadOnlyRef<TimeSpan> fillForwardResolution,
+            bool isExtendedMarketHours,
+            DateTime subscriptionEndTime,
+            TimeSpan dataResolution,
+            DateTimeZone dataTimeZone
+            )
         {
             _subscriptionEndTime = subscriptionEndTime;
             Exchange = exchange;
@@ -142,7 +151,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 
                     // we can fill forward the rest of this subscription if required
                     var endOfSubscription = (Current ?? _previous).Clone(true);
-                    endOfSubscription.Time = _subscriptionEndTime.RoundDown(_dataResolution);
+                    endOfSubscription.Time = _subscriptionEndTime.RoundDownInTimeZone(_dataResolution, Exchange.TimeZone, _dataTimeZone);
                     endOfSubscription.EndTime = endOfSubscription.Time + _dataResolution;
                     if (RequiresFillForwardData(_fillForwardResolution.Value, _previous, endOfSubscription, out fillForward))
                     {
@@ -231,44 +240,42 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             }
 
             // check to see if the gap between previous and next warrants fill forward behavior
-            if (next.Time - previous.Time <= fillForwardResolution)
+            var nextPreviousTimeDelta = next.Time - previous.Time;
+            if (nextPreviousTimeDelta <= fillForwardResolution && nextPreviousTimeDelta <= _dataResolution)
             {
                 fillForward = null;
                 return false;
             }
 
-            // is the bar after previous in market hours?
-            var barAfterPreviousEndTime = previous.EndTime + fillForwardResolution;
-            if (Exchange.IsOpenDuringBar(previous.EndTime, barAfterPreviousEndTime, _isExtendedMarketHours))
-            {
-                // this is the normal case where we had a hole in the middle of the day
-                fillForward = previous.Clone(true);
-                fillForward.Time = (previous.Time + fillForwardResolution).RoundDown(fillForwardResolution);
-                fillForward.EndTime = fillForward.Time + _dataResolution;
-                return true;
-            }
+            // every bar emitted MUST be of the data resolution.
 
-            // find the next fill forward time after the next market open
-            var nextFillForwardTime = Exchange.Hours.GetNextMarketOpen(previous.EndTime, _isExtendedMarketHours) + fillForwardResolution;
+            // compute end times of the four potential fill forward scenarios
+            // 1. the next fill forward bar. 09:00-10:00 followed by 10:00-11:00 where 01:00 is the fill forward resolution
+            // 2. the next data resolution bar, same as above but with the data resolution instead
+            // 3. the next fill forward bar following the next market open, 15:00-16:00 followed by 09:00-10:00 the following open market day
+            // 4. the next data resolution bar following thenext market open, same as above but with the data resolution instead
 
-            if (_dataResolution == Time.OneDay)
+            // the precedence for validation is based on the order of the end times, obviously if a potential match
+            // is before a later match, the earliest match should win.
+
+            foreach (var item in GetSortedReferenceDateIntervals(previous, fillForwardResolution, _dataResolution))
             {
-                // special case for daily, we need to emit a midnight bar even though markets are closed
-                var dailyBarEnd = GetNextOpenDateAfter(previous.Time.Date) + Time.OneDay;
-                if (dailyBarEnd < nextFillForwardTime)
+                var potentialBarEndTime = RoundDown(item.ReferenceDateTime + item.Interval, item.Interval);
+                if (potentialBarEndTime < next.EndTime)
                 {
-                    // only emit the midnight bar if it's the next bar to be emitted
-                    nextFillForwardTime = dailyBarEnd;
+                    var nextFillForwardBarStartTime = potentialBarEndTime - item.Interval;
+                    if (Exchange.IsOpenDuringBar(nextFillForwardBarStartTime, potentialBarEndTime, _isExtendedMarketHours))
+                    {
+                        fillForward = previous.Clone(true);
+                        fillForward.Time = potentialBarEndTime - _dataResolution; // bar are ALWAYS of the data resolution
+                        fillForward.EndTime = potentialBarEndTime;
+                        return true;
+                    }
                 }
-            }
-
-            if (nextFillForwardTime < next.EndTime)
-            {
-                // if next is still in the future then we need to emit a fill forward for market open
-                fillForward = previous.Clone(true);
-                fillForward.Time = (nextFillForwardTime - _dataResolution).RoundDown(fillForwardResolution);
-                fillForward.EndTime = fillForward.Time + _dataResolution;
-                return true;
+                else
+                {
+                    break;
+                }
             }
 
             // the next is before the next fill forward time, so do nothing
@@ -276,17 +283,74 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             return false;
         }
 
-        /// <summary>
-        /// Finds the next open date that follows the specified date, this functions expects a date, not a date time
-        /// </summary>
-        private DateTime GetNextOpenDateAfter(DateTime date)
+        private IEnumerable<ReferenceDateInterval> GetSortedReferenceDateIntervals(BaseData previous, TimeSpan fillForwardResolution, TimeSpan dataResolution)
         {
-            do
+            if (fillForwardResolution < dataResolution)
             {
-                date = date + Time.OneDay;
+                return GetReferenceDateIntervals(previous.EndTime, fillForwardResolution, dataResolution);
             }
-            while (!Exchange.DateIsOpen(date));
-            return date;
+
+            if (fillForwardResolution > dataResolution)
+            {
+                return GetReferenceDateIntervals(previous.EndTime, dataResolution, fillForwardResolution);
+            }
+
+            return GetReferenceDateIntervals(previous.EndTime, fillForwardResolution);
+        }
+
+        private IEnumerable<ReferenceDateInterval> GetReferenceDateIntervals(DateTime previousEndTime, TimeSpan resolution)
+        {
+            // special case where the fill forward resolution and data resolution are equal
+            if (Exchange.IsOpenDuringBar(previousEndTime - resolution, previousEndTime, _isExtendedMarketHours))
+            {
+                // if we were previous in market, then try another in market
+                yield return new ReferenceDateInterval(previousEndTime, resolution);
+            }
+
+            // now we can try the bar after next market open
+            var marketOpen = Exchange.Hours.GetNextMarketOpen(previousEndTime, _isExtendedMarketHours);
+            yield return new ReferenceDateInterval(marketOpen, resolution);
+        }
+
+        private IEnumerable<ReferenceDateInterval> GetReferenceDateIntervals(DateTime previousEndTime, TimeSpan smallerResolution, TimeSpan largerResolution)
+        {
+            if (Exchange.IsOpenDuringBar(previousEndTime - smallerResolution, previousEndTime, _isExtendedMarketHours))
+            {
+                // if the previous small resolution bar was inside market hours, then continue with the
+                // intuitive progresson of next in market bars and then next bars after market open
+                yield return new ReferenceDateInterval(previousEndTime, smallerResolution);
+                yield return new ReferenceDateInterval(previousEndTime, largerResolution);
+
+                var marketOpen = Exchange.Hours.GetNextMarketOpen(previousEndTime, _isExtendedMarketHours);
+                yield return new ReferenceDateInterval(marketOpen, smallerResolution);
+                yield return new ReferenceDateInterval(marketOpen, largerResolution);
+            }
+            else
+            {
+                // this is typically daily data being filled forward on a higher resolution
+                // since the previous bar was not in market hours then we can just fast forward
+                // to the next market open
+                var marketOpen = Exchange.Hours.GetNextMarketOpen(previousEndTime, _isExtendedMarketHours);
+                yield return new ReferenceDateInterval(marketOpen, smallerResolution);
+                yield return new ReferenceDateInterval(marketOpen, largerResolution);
+            }
+        }
+
+        private DateTime RoundDown(DateTime value, TimeSpan interval)
+        {
+            return value.RoundDownInTimeZone(interval, Exchange.TimeZone, _dataTimeZone);
+        }
+
+        private class ReferenceDateInterval
+        {
+            public readonly DateTime ReferenceDateTime;
+            public readonly TimeSpan Interval;
+
+            public ReferenceDateInterval(DateTime referenceDateTime, TimeSpan interval)
+            {
+                ReferenceDateTime = referenceDateTime;
+                Interval = interval;
+            }
         }
     }
 }

--- a/Engine/DataFeeds/Enumerators/LiveFillForwardEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/LiveFillForwardEnumerator.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/Engine/DataFeeds/Enumerators/LiveFillForwardEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/LiveFillForwardEnumerator.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Securities;
 using QuantConnect.Util;
@@ -43,8 +44,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <param name="isExtendedMarketHours">True to use the exchange's extended market hours, false to use the regular market hours</param>
         /// <param name="subscriptionEndTime">The end time of the subscrition, once passing this date the enumerator will stop</param>
         /// <param name="dataResolution">The source enumerator's data resolution</param>
-        public LiveFillForwardEnumerator(ITimeProvider timeProvider, IEnumerator<BaseData> enumerator, SecurityExchange exchange, IReadOnlyRef<TimeSpan> fillForwardResolution, bool isExtendedMarketHours, DateTime subscriptionEndTime, TimeSpan dataResolution)
-            : base(enumerator, exchange, fillForwardResolution, isExtendedMarketHours, subscriptionEndTime, dataResolution)
+        /// <param name="dataTimeZone">Time zone of the underlying source data</param>
+        public LiveFillForwardEnumerator(ITimeProvider timeProvider, IEnumerator<BaseData> enumerator, SecurityExchange exchange, IReadOnlyRef<TimeSpan> fillForwardResolution, bool isExtendedMarketHours, DateTime subscriptionEndTime, TimeSpan dataResolution, DateTimeZone dataTimeZone)
+            : base(enumerator, exchange, fillForwardResolution, isExtendedMarketHours, subscriptionEndTime, dataResolution, dataTimeZone)
         {
             _timeProvider = timeProvider;
         }

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -212,8 +212,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 return false;
             }
 
-            var subscription = request.IsUniverseSubscription 
-                ? CreateUniverseSubscription(request) 
+            var subscription = request.IsUniverseSubscription
+                ? CreateUniverseSubscription(request)
                 : CreateSubscription(request);
 
             if (subscription == null)
@@ -272,7 +272,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
             catch (Exception err)
             {
-                Log.Error("FileSystemDataFeed.Run(): Encountered an error: " + err.Message); 
+                Log.Error("FileSystemDataFeed.Run(): Encountered an error: " + err.Message);
                 if (!_cancellationTokenSource.IsCancellationRequested)
                 {
                     _cancellationTokenSource.Cancel();
@@ -385,7 +385,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
                 if (request.Universe is OptionChainUniverse)
                 {
-                    return new OptionChainUniverseSubscriptionEnumeratorFactory((req, e) => ConfigureEnumerator(req, true, e), 
+                    return new OptionChainUniverseSubscriptionEnumeratorFactory((req, e) => ConfigureEnumerator(req, true, e),
                         _mapFileProvider.Get(request.Security.Symbol.ID.Market), _factorFileProvider);
                 }
                 if (request.Universe is FuturesChainUniverse)
@@ -479,7 +479,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     break;
                 }
-                
+
                 // syncer returns MaxValue on failure/end of data
                 if (timeSlice.Time != DateTime.MaxValue)
                 {
@@ -488,7 +488,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // end of data signal
                     if (nextFrontier == DateTime.MaxValue) break;
 
-                    _frontierUtc = nextFrontier;    
+                    _frontierUtc = nextFrontier;
                 }
                 else if (timeSlice.SecurityChanges == SecurityChanges.None)
                 {

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -545,7 +545,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 UpdateFillForwardResolution(subscriptionConfigs);
 
                 enumerator = new FillForwardEnumerator(enumerator, request.Security.Exchange, _fillForwardResolution,
-                    request.Security.IsExtendedMarketHours, request.EndTimeLocal, request.Configuration.Resolution.ToTimeSpan());
+                    request.Security.IsExtendedMarketHours, request.EndTimeLocal, request.Configuration.Resolution.ToTimeSpan(), request.Configuration.DataTimeZone);
             }
 
             // optionally apply exchange/user filters

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -512,7 +512,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     UpdateFillForwardResolution(subscriptionConfigs);
 
-                    enumerator = new LiveFillForwardEnumerator(_frontierTimeProvider, enumerator, request.Security.Exchange, _fillForwardResolution, request.Configuration.ExtendedMarketHours, localEndTime, request.Configuration.Increment);
+                    enumerator = new LiveFillForwardEnumerator(_frontierTimeProvider, enumerator, request.Security.Exchange, _fillForwardResolution, request.Configuration.ExtendedMarketHours, localEndTime, request.Configuration.Increment, request.Configuration.DataTimeZone);
                 }
 
                 // define market hours and user filters to incoming data
@@ -617,7 +617,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     UpdateFillForwardResolution(subscriptionConfigs);
 
-                    return new LiveFillForwardEnumerator(_frontierTimeProvider, input, request.Security.Exchange, _fillForwardResolution, request.Configuration.ExtendedMarketHours, localEndTime, request.Configuration.Increment);
+                    return new LiveFillForwardEnumerator(_frontierTimeProvider, input, request.Security.Exchange, _fillForwardResolution, request.Configuration.ExtendedMarketHours, localEndTime, request.Configuration.Increment, request.Configuration.DataTimeZone);
                 };
 
                 var symbolUniverse = _dataQueueHandler as IDataQueueUniverseProvider;

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -61,7 +61,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var earlyBirdTicks = nextFrontier.Ticks;
             var data = new List<DataFeedPacket>();
             var universeData = new Dictionary<Universe, BaseDataCollection>();
-            
+
             SecurityChanges newChanges;
             do
             {

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -97,7 +97,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         // we want bars rounded using their subscription times, we make a clone
                         // so we don't interfere with the enumerator's internal logic
                         var clone = subscription.Current.Clone(subscription.Current.IsFillForward);
-                        clone.Time = clone.Time.ExchangeRoundDown(configuration.Increment, subscription.Security.Exchange.Hours, configuration.ExtendedMarketHours);
+                        clone.Time = clone.Time.ExchangeRoundDownInTimeZone(configuration.Increment, subscription.Security.Exchange.Hours, configuration.DataTimeZone, configuration.ExtendedMarketHours);
 
                         packet.Add(clone);
 

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -118,7 +118,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 }
 
                 var readOnlyRef = Ref.CreateReadOnly(() => request.FillForwardResolution.Value.ToTimeSpan());
-                reader = new FillForwardEnumerator(reader, security.Exchange, readOnlyRef, security.IsExtendedMarketHours, end, config.Increment);
+                reader = new FillForwardEnumerator(reader, security.Exchange, readOnlyRef, security.IsExtendedMarketHours, end, config.Increment, config.DataTimeZone);
             }
 
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(security.Exchange.TimeZone, start, end);

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -94,14 +94,14 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             start = start.ConvertFromUtc(request.ExchangeHours.TimeZone);
             end = end.ConvertFromUtc(request.ExchangeHours.TimeZone);
 
-            var config = new SubscriptionDataConfig(request.DataType, 
-                request.Symbol, 
-                request.Resolution, 
-                request.DataTimeZone, 
-                request.ExchangeHours.TimeZone, 
-                request.FillForwardResolution.HasValue, 
-                request.IncludeExtendedMarketHours, 
-                false, 
+            var config = new SubscriptionDataConfig(request.DataType,
+                request.Symbol,
+                request.Resolution,
+                request.DataTimeZone,
+                request.ExchangeHours.TimeZone,
+                request.FillForwardResolution.HasValue,
+                request.IncludeExtendedMarketHours,
+                false,
                 request.IsCustomData,
                 request.TickType,
                 true,
@@ -110,14 +110,14 @@ namespace QuantConnect.Lean.Engine.HistoricalData
 
             var security = new Security(request.ExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
 
-            IEnumerator<BaseData> reader = new SubscriptionDataReader(config, 
-                start, 
-                end, 
+            IEnumerator<BaseData> reader = new SubscriptionDataReader(config,
+                start,
+                end,
                 ResultHandlerStub.Instance,
-                config.SecurityType == SecurityType.Equity ? _mapFileProvider.Get(config.Market) : MapFileResolver.Empty, 
+                config.SecurityType == SecurityType.Equity ? _mapFileProvider.Get(config.Market) : MapFileResolver.Empty,
                 _factorFileProvider,
                 _dataProvider,
-                Time.EachTradeableDay(request.ExchangeHours, start, end), 
+                Time.EachTradeableDay(request.ExchangeHours, start, end),
                 false,
                 _dataCacheProvider,
                 false

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -133,7 +133,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 }
 
                 var readOnlyRef = Ref.CreateReadOnly(() => request.FillForwardResolution.Value.ToTimeSpan());
-                reader = new FillForwardEnumerator(reader, security.Exchange, readOnlyRef, security.IsExtendedMarketHours, end, config.Increment);
+                reader = new FillForwardEnumerator(reader, security.Exchange, readOnlyRef, security.IsExtendedMarketHours, end, config.Increment, config.DataTimeZone);
             }
 
             // since the SubscriptionDataReader performs an any overlap condition on the trade bar's entire

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -111,6 +111,7 @@
       "result-handler": "QuantConnect.Lean.Engine.Results.BacktestingResultHandler",
       "data-feed-handler": "QuantConnect.Lean.Engine.DataFeeds.FileSystemDataFeed",
       "real-time-handler": "QuantConnect.Lean.Engine.RealTime.BacktestingRealTimeHandler",
+      "history-provider": "QuantConnect.Lean.Engine.HistoricalData.SubscriptionDataReaderHistoryProvider",
       "transaction-handler": "QuantConnect.Lean.Engine.TransactionHandlers.BacktestingTransactionHandler"
     },
 

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -200,7 +200,7 @@ namespace QuantConnect.Tests.Common.Util
             var value = input.ToDecimal();
             Assert.AreEqual(-0m, value);
         }
-        
+
         [Test]
         public void ConvertsTimeSpanFromString()
         {

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -275,6 +275,16 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(expectedOutput, output.ToString(CultureInfo.InvariantCulture));
         }
 
+        [Test]
+        public void RoundsDownInTimeZone()
+        {
+            var dataTimeZone = TimeZones.Utc;
+            var exchangeTimeZone = TimeZones.EasternStandard;
+            var time = new DateTime(2000, 01, 01).ConvertTo(dataTimeZone, exchangeTimeZone);
+            var roundedTime = time.RoundDownInTimeZone(Time.OneDay, exchangeTimeZone, dataTimeZone);
+            Assert.AreEqual(time, roundedTime);
+        }
+
         private class Super<T>
         {
         }

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -79,6 +79,18 @@ namespace QuantConnect.Tests.Common.Util
             var expected = time.Date;
             var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, null, SecurityType.Equity);
             var exchangeRounded = time.ExchangeRoundDown(Time.OneDay, hours, false);
+            Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        public void ExchangeRoundDownInTimeZoneSkipsWeekends()
+        {
+            // moment before EST market open in UTC (time + one day)
+            var time = new DateTime(2017, 10, 01, 9, 29, 59).ConvertToUtc(TimeZones.NewYork);
+            var expected = new DateTime(2017, 09, 29).ConvertFromUtc(TimeZones.NewYork);
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, null, SecurityType.Equity);
+            var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneDay, hours, TimeZones.Utc, false);
+            Assert.AreEqual(expected, exchangeRounded);
         }
 
         [Test]

--- a/Tests/Engine/DataFeeds/Enumerators/LiveFillForwardEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveFillForwardEnumeratorTests.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/Tests/Engine/DataFeeds/Enumerators/LiveFillForwardEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveFillForwardEnumeratorTests.cs
@@ -51,7 +51,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var timeProvider = new ManualTimeProvider(TimeZones.NewYork);
             timeProvider.SetCurrentTime(reference);
             var exchange = new SecurityExchange(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork));
-            var fillForward = new LiveFillForwardEnumerator(timeProvider, underlying.GetEnumerator(), exchange, Ref.Create(Time.OneSecond), false, Time.EndOfTime, Time.OneSecond);
+            var fillForward = new LiveFillForwardEnumerator(timeProvider, underlying.GetEnumerator(), exchange, Ref.Create(Time.OneSecond), false, Time.EndOfTime, Time.OneSecond, exchange.TimeZone);
 
             // first point is always emitted
             Assert.IsTrue(fillForward.MoveNext());

--- a/Tests/Engine/DataFeeds/FillForwardEnumeratorTest.cs
+++ b/Tests/Engine/DataFeeds/FillForwardEnumeratorTest.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var exchange = new EquityExchange();
             var isExtendedMarketHours = false;
             var fillForwardResolution = TimeSpan.FromMinutes(1);
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(fillForwardResolution), isExtendedMarketHours, data.Last().EndTime, dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(fillForwardResolution), isExtendedMarketHours, data.Last().EndTime, dataResolution, exchange.TimeZone);
 
             // 9:31
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -95,7 +95,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var exchange = new EquityExchange();
             var isExtendedMarketHours = false;
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromMinutes(1)), isExtendedMarketHours, data.Last().EndTime, dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromMinutes(1)), isExtendedMarketHours, data.Last().EndTime, dataResolution, exchange.TimeZone);
 
             // 9:29
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -152,7 +152,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var exchange = new EquityExchange();
             const bool isExtendedMarketHours = false;
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromSeconds(1)), isExtendedMarketHours, data.Last().EndTime, dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromSeconds(1)), isExtendedMarketHours, data.Last().EndTime, dataResolution, exchange.TimeZone);
 
             // 8:40:00
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -196,7 +196,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var exchange = new EquityExchange();
             var isExtendedMarketHours = false;
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromMinutes(1)), isExtendedMarketHours, reference.AddMinutes(3), dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromMinutes(1)), isExtendedMarketHours, reference.AddMinutes(3), dataResolution, exchange.TimeZone);
 
             // 3:58
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -241,7 +241,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var exchange = new EquityExchange();
             var isExtendedMarketHours = false;
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromMinutes(1)), isExtendedMarketHours, reference.AddMinutes(3), dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromMinutes(1)), isExtendedMarketHours, reference.AddMinutes(3), dataResolution, exchange.TimeZone);
 
             // 3:58
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -285,7 +285,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var exchange = new EquityExchange();
             var isExtendedMarketHours = false;
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromMinutes(1)), isExtendedMarketHours, reference.Date.AddHours(16), dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromMinutes(1)), isExtendedMarketHours, reference.Date.AddHours(16), dataResolution, exchange.TimeZone);
 
             // 3:58
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -336,7 +336,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var exchange = new EquityExchange();
             bool isExtendedMarketHours = false;
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromHours(1)), isExtendedMarketHours, end, dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromHours(1)), isExtendedMarketHours, end, dataResolution, exchange.TimeZone);
 
             // 3:00
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -393,7 +393,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var exchange = new EquityExchange();
             bool isExtendedMarketHours = false;
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromHours(1)), isExtendedMarketHours, end, dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromHours(1)), isExtendedMarketHours, end, dataResolution, exchange.TimeZone);
 
             // 3:00
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -442,7 +442,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var exchange = new EquityExchange();
             bool isExtendedMarketHours = false;
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromHours(1)), isExtendedMarketHours, data.Last().EndTime, dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromHours(1)), isExtendedMarketHours, data.Last().EndTime, dataResolution, exchange.TimeZone);
 
             // 12:00am
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -526,7 +526,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var exchange = new EquityExchange();
             bool isExtendedMarketHours = false;
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromDays(1)), isExtendedMarketHours, data.Last().EndTime.AddDays(1), dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromDays(1)), isExtendedMarketHours, data.Last().EndTime.AddDays(1), dataResolution, exchange.TimeZone);
 
             // 6/25
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -583,7 +583,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var exchange = new EquityExchange();
             bool isExtendedMarketHours = false;
             var ffResolution = TimeSpan.FromMinutes(30);
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(ffResolution), isExtendedMarketHours, data.Last().EndTime, dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(ffResolution), isExtendedMarketHours, data.Last().EndTime, dataResolution, exchange.TimeZone);
 
             // 3:00
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -629,7 +629,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var exchange = new EquityExchange();
             bool isExtendedMarketHours = false;
             var ffResolution = TimeSpan.FromMinutes(15);
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(ffResolution), isExtendedMarketHours, data.Last().EndTime, dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(ffResolution), isExtendedMarketHours, data.Last().EndTime, dataResolution, exchange.TimeZone);
 
             // 12:00
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
@@ -669,7 +669,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var exchange = new EquityExchange();
             bool isExtendedMarketHours = false;
             var ffResolution = TimeSpan.FromHours(1);
-            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(ffResolution), isExtendedMarketHours, data.Last().EndTime, dataResolution);
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(ffResolution), isExtendedMarketHours, data.Last().EndTime, dataResolution, exchange.TimeZone);
 
             int dailyBars = 0;
             int hourlyBars = 0;

--- a/Tests/Engine/DataFeeds/FillForwardEnumeratorTest.cs
+++ b/Tests/Engine/DataFeeds/FillForwardEnumeratorTest.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,7 +33,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void FillsForwardMidDay()
         {
             var dataResolution = Time.OneMinute;
-            
+
             var reference = new DateTime(2015, 6, 25, 9, 30, 0);
             var data = Enumerable.Range(0, 2).Select(x => new TradeBar
             {
@@ -67,7 +67,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.AreEqual(reference.AddMinutes(3), fillForwardEnumerator.Current.EndTime);
             Assert.AreEqual(1, fillForwardEnumerator.Current.Value);
             Assert.AreEqual(dataResolution, fillForwardEnumerator.Current.EndTime - fillForwardEnumerator.Current.Time);
-            
+
             Assert.IsFalse(fillForwardEnumerator.MoveNext());
         }
 
@@ -375,7 +375,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     Time = reference,
                     Value = 0,
                     Period = dataResolution
-                }, 
+                },
                 new TradeBar
                 {
                     Time = reference.AddHours(3),
@@ -506,7 +506,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.AreEqual(1, fillForwardEnumerator.Current.Value);
             Assert.IsFalse(fillForwardEnumerator.Current.IsFillForward);
             Assert.AreEqual(dataResolution, fillForwardEnumerator.Current.EndTime - fillForwardEnumerator.Current.Time);
-            
+
             Assert.IsFalse(fillForwardEnumerator.MoveNext());
         }
 

--- a/Tests/Engine/DataFeeds/FillForwardEnumeratorTest.cs
+++ b/Tests/Engine/DataFeeds/FillForwardEnumeratorTest.cs
@@ -15,13 +15,15 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+using QuantConnect.Securities;
 using QuantConnect.Securities.Equity;
+using QuantConnect.Securities.Forex;
 using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
@@ -691,6 +693,53 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             // we expect 6 days worth of ff hourly bars at 7 bars a day
             Assert.AreEqual(42, hourlyBars);
+        }
+
+        [Test]
+        public void OandaFillsForwardDailyForexOnWeekends()
+        {
+            var dailyBarsEmitted = 0;
+            var fillForwardBars = new List<BaseData>();
+
+            // 3 QuoteBars as they would be read from the EURUSD oanda daily file by QuoteBar.Reader()
+            // The conversion from dataTimeZone to exchangeTimeZone has been done by hand
+            // dataTimeZone == UTC
+            /*
+                20120719 00:00,1.22769,1.2324,1.22286,1.22759,0,1.22781,1.23253,1.22298,1.22771,0
+                20120720 00:00,1.22757,1.22823,1.21435,1.21542,0,1.22769,1.22835,1.21449,1.21592,0
+                20120722 00:00,1.21542,1.21542,1.21037,1.21271,0,1.21592,1.21592,1.21087,1.21283,0
+                20120723 00:00,1.21273,1.21444,1.20669,1.21238,0,1.21285,1.21454,1.20685,1.21249,0
+             */
+            var data = new BaseData[]
+            {
+                // fri 7/20
+                new QuoteBar{Value = 0, Time =  new DateTime(2012, 7, 19, 20, 0, 0), Period = Time.OneDay},
+                // sunday 7/22
+                new QuoteBar{Value = 1, Time = new DateTime(2012, 7, 21, 20, 0, 0), Period = Time.OneDay},
+                // monday 7/23
+                new QuoteBar{Value = 2, Time = new DateTime(2012, 7, 22, 20, 0, 0), Period = Time.OneDay},
+            }.ToList();
+            var enumerator = data.GetEnumerator();
+
+            var market = Market.Oanda;
+            var symbol = Symbol.Create("EURUSD", SecurityType.Forex, market);
+
+            var marketHours = MarketHoursDatabase.FromDataFolder();
+            var exchange = new ForexExchange(marketHours.GetExchangeHours(market, symbol, SecurityType.Forex));
+
+            var fillForwardEnumerator = new FillForwardEnumerator(enumerator, exchange, Ref.Create(TimeSpan.FromDays(1)), false, data.Last().EndTime, Time.OneDay, TimeZones.Utc);
+
+            while (fillForwardEnumerator.MoveNext())
+            {
+                fillForwardBars.Add(fillForwardEnumerator.Current);
+                Console.WriteLine(fillForwardEnumerator.Current.Time.DayOfWeek + " " + fillForwardEnumerator.Current.Time + " - " + fillForwardEnumerator.Current.EndTime.DayOfWeek + " " + fillForwardEnumerator.Current.EndTime);
+                dailyBarsEmitted++;
+            }
+
+            Assert.AreEqual(3, dailyBarsEmitted);
+            Assert.AreEqual(new DateTime(2012, 7, 19, 20, 0, 0), fillForwardBars[0].Time);
+            Assert.AreEqual(new DateTime(2012, 7, 21, 20, 0, 0), fillForwardBars[1].Time);
+            Assert.AreEqual(new DateTime(2012, 7, 22, 20, 0, 0), fillForwardBars[2].Time);
         }
     }
 }


### PR DESCRIPTION
The issue with having a different data and exchange time zone is that
daily data no longer follows a common assumption of beginning and ending
at midnight each day. This assumption was baked into the existing impl
to its own detriment. Specifically, the get next market open date calc
was being improperly executed. In most case (data resolution < one day)
we would use the start time of the bar, but since daily data spans a day,
we need to use the end time of the bar to properly calculate this value.

Fixes #1073