### PR TITLE
Fixes example of live custom data

### DIFF
--- a/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
+++ b/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
@@ -44,7 +44,7 @@ namespace QuantConnect
             AddSecurity(SecurityType.Forex, "EURUSD", Resolution.Minute);
 
             //Custom/Bitcoin Live Data: 24/7
-            AddData<Bitcoin>("BTC", Resolution.Second);
+            AddData<Bitcoin>("BTC", Resolution.Second, TimeZones.Utc);
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace QuantConnect
                 try
                 {
                     coin = JsonConvert.DeserializeObject<Bitcoin>(line);
-                    coin.EndTime = DateTime.UtcNow.ConvertFromUtc(config.DataTimeZone);
+                    coin.EndTime = DateTime.UtcNow;
                     coin.Time = coin.EndTime - config.Increment;
                     coin.Value = coin.Close;
                 }

--- a/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
+++ b/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
@@ -91,42 +91,26 @@ namespace QuantConnect
     /// </summary>
     public class Bitcoin : BaseData
     {
-        //Set the defaults:
-        /// <summary>
-        /// Open Price
-        /// </summary>
+        [JsonProperty("timestamp")]
+        public int Timestamp = 0;
+        [JsonProperty("open")]
         public decimal Open = 0;
-        
-        /// <summary>
-        /// High Price
-        /// </summary>
+        [JsonProperty("high")]
         public decimal High = 0;
-        
-        /// <summary>
-        /// Low Price
-        /// </summary>
+        [JsonProperty("low")]
         public decimal Low = 0;
-
-        /// <summary>
-        /// Closing Price
-        /// </summary>
+        [JsonProperty("last")]
         public decimal Close = 0;
-
-        /// <summary>
-        /// Volume in BTC
-        /// </summary>
+        [JsonProperty("bid")]
+        public decimal Bid = 0;
+        [JsonProperty("ask")]
+        public decimal Ask = 0;
+        [JsonProperty("vwap")]
+        public decimal WeightedPrice = 0;
+        [JsonProperty("volume")]
         public decimal VolumeBTC = 0;
-
-        /// <summary>
-        /// Volume in USD
-        /// </summary>
         public decimal VolumeUSD = 0;
         
-        /// <summary>
-        /// Volume in USD:
-        /// </summary>
-        public decimal WeightedPrice = 0;
-
         /// <summary>
         /// 1. DEFAULT CONSTRUCTOR: Custom data types need a default constructor.
         /// We search for a default constructor so please provide one here. It won't be used for data, just to generate the "Factory".
@@ -176,15 +160,9 @@ namespace QuantConnect
                 //{"high": "441.00", "last": "421.86", "timestamp": "1411606877", "bid": "421.96", "vwap": "428.58", "volume": "14120.40683975", "low": "418.83", "ask": "421.99"}
                 try
                 {
-                    var liveBTC = JsonConvert.DeserializeObject<LiveBitcoin>(line);
-                    coin.Time = DateTime.Now;
-                    coin.Open = liveBTC.Last;
-                    coin.High = liveBTC.High;
-                    coin.Low = liveBTC.Low;
-                    coin.Close = liveBTC.Last;
-                    coin.VolumeBTC = liveBTC.Volume;
-                    coin.WeightedPrice = liveBTC.VWAP;
-                    coin.Symbol = "BTC";
+                    coin = JsonConvert.DeserializeObject<Bitcoin>(line);
+                    coin.EndTime = DateTime.UtcNow.ConvertFromUtc(config.DataTimeZone);
+                    coin.Time = coin.EndTime - config.Increment;
                     coin.Value = coin.Close;
                 }
                 catch { /* Do nothing, possible error in json decoding */ }
@@ -205,35 +183,11 @@ namespace QuantConnect
                 coin.VolumeBTC = Convert.ToDecimal(data[5], CultureInfo.InvariantCulture);
                 coin.VolumeUSD = Convert.ToDecimal(data[6], CultureInfo.InvariantCulture);
                 coin.WeightedPrice = Convert.ToDecimal(data[7], CultureInfo.InvariantCulture);
-                coin.Symbol = "BTC";
                 coin.Value = coin.Close;
             }
             catch { /* Do nothing, skip first title row */ }
 
             return coin;
         }
-    }
-
-    /// <summary>
-    /// Live data structure
-    /// </summary>
-    public class LiveBitcoin
-    {
-        [JsonProperty("timestamp")]
-        public int Timestamp = 0;
-        [JsonProperty("last")]
-        public decimal Last = 0;
-        [JsonProperty("high")]
-        public decimal High = 0;
-        [JsonProperty("low")]
-        public decimal Low = 0;
-        [JsonProperty("bid")]
-        public decimal Bid = 0;
-        [JsonProperty("ask")]
-        public decimal Ask = 0;
-        [JsonProperty("vwap")]
-        public decimal VWAP = 0;
-        [JsonProperty("volume")]
-        public decimal Volume = 0;
     }
 }


### PR DESCRIPTION
In this example, the custom data Time was set to Datetime.Now and it was not passing the FrontierAwareEnumerator. Now, EndTime is set to the current time of the default exchange.