### PR TITLE
Call ProcessSynchronousEvents() in BacktestingResultsHandler.Exit()

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -87,13 +87,13 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Packeting message queue to temporarily store packets and then pull for processing.
         /// </summary>
-        public ConcurrentQueue<Packet> Messages 
+        public ConcurrentQueue<Packet> Messages
         {
             get
             {
                 return _messages;
             }
-            set 
+            set
             {
                 _messages = value;
             }
@@ -102,7 +102,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Local object access to the algorithm for the underlying Debug and Error messaging.
         /// </summary>
-        public IAlgorithm Algorithm 
+        public IAlgorithm Algorithm
         {
             get
             {
@@ -117,7 +117,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Charts collection for storing the master copy of user charting data.
         /// </summary>
-        public ConcurrentDictionary<string, Chart> Charts 
+        public ConcurrentDictionary<string, Chart> Charts
         {
             get
             {
@@ -132,8 +132,8 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Boolean flag indicating the result hander thread is completely finished and ready to dispose.
         /// </summary>
-        public bool IsActive 
-        { 
+        public bool IsActive
+        {
             get
             {
                 return _isActive;
@@ -148,7 +148,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <remarks>Specifically critical for backtesting since with such long timeframes the sampled data can get extreme.</remarks>
         public TimeSpan ResamplePeriod
         {
-            get 
+            get
             {
                 return _resamplePeriod;
             }
@@ -160,7 +160,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <remarks>Update frequency of notification packets</remarks>
         public TimeSpan NotificationPeriod
         {
-            get 
+            get
             {
                 return _notificationPeriod;
             }
@@ -172,7 +172,7 @@ namespace QuantConnect.Lean.Engine.Results
         public Dictionary<string, string> FinalStatistics { get; private set; }
 
         /// <summary>
-        /// Default initializer for 
+        /// Default initializer for
         /// </summary>
         public BacktestingResultHandler()
         {
@@ -214,11 +214,11 @@ namespace QuantConnect.Lean.Engine.Results
             _compileId = _job.CompileId;
             _backtestId = _job.BacktestId;
         }
-        
+
         /// <summary>
         /// The main processing method steps through the messaging queue and processes the messages one by one.
         /// </summary>
-        public void Run() 
+        public void Run()
         {
             //Initialize:
             var lastMessage = "";
@@ -267,7 +267,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Send a backtest update to the browser taking a latest snapshot of the charting data.
         /// </summary>
-        public void Update() 
+        public void Update()
         {
             try
             {
@@ -312,7 +312,7 @@ namespace QuantConnect.Lean.Engine.Results
                 lock (_chartLock)
                 {
                     //Get the updates since the last chart
-                    foreach (var chart in Charts.Values) 
+                    foreach (var chart in Charts.Values)
                     {
                         deltaCharts.Add(chart.Name, chart.GetUpdates());
                     }
@@ -414,7 +414,7 @@ namespace QuantConnect.Lean.Engine.Results
                         //4. Save results
                         SaveResults(key, result.Results);
                     }
-                    else 
+                    else
                     {
                         Log.Error("BacktestingResultHandler.StoreResult(): Result Null.");
                     }
@@ -436,7 +436,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="statisticsResults">Statistics information for the algorithm (empty if not finished)</param>
         /// <param name="banner">Runtime statistics banner information</param>
         public void SendFinalResult(AlgorithmNodePacket job, Dictionary<int, Order> orders, Dictionary<DateTime, decimal> profitLoss, Dictionary<string, Holding> holdings, StatisticsResults statisticsResults, Dictionary<string, string> banner)
-        { 
+        {
             try
             {
                 FinalStatistics = statisticsResults.Summary;
@@ -467,8 +467,8 @@ namespace QuantConnect.Lean.Engine.Results
                 //Second, send the truncated packet:
                 _messagingHandler.Send(result);
 
-                Log.Trace("BacktestingResultHandler.SendAnalysisResult(): Processed final packet"); 
-            } 
+                Log.Trace("BacktestingResultHandler.SendAnalysisResult(): Processed final packet");
+            }
             catch (Exception err)
             {
                 Log.Error(err);
@@ -486,10 +486,10 @@ namespace QuantConnect.Lean.Engine.Results
 
             //Get the resample period:
             var totalMinutes = (_job.PeriodFinish - _job.PeriodStart).TotalMinutes;
-            var resampleMinutes = (totalMinutes < (_minimumSamplePeriod * _samples)) ? _minimumSamplePeriod : (totalMinutes / _samples); // Space out the sampling every 
+            var resampleMinutes = (totalMinutes < (_minimumSamplePeriod * _samples)) ? _minimumSamplePeriod : (totalMinutes / _samples); // Space out the sampling every
             _resamplePeriod = TimeSpan.FromMinutes(resampleMinutes);
             Log.Trace("BacktestingResultHandler(): Sample Period Set: " + resampleMinutes.ToString("00.00"));
-            
+
             //Setup the sampling periods:
             _jobDays = Time.TradeableDates(Algorithm.Securities.Values, _job.PeriodStart, _job.PeriodFinish);
 
@@ -522,7 +522,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// Send a debug message back to the browser console.
         /// </summary>
         /// <param name="message">Message we'd like shown in console.</param>
-        public void DebugMessage(string message) 
+        public void DebugMessage(string message)
         {
             Messages.Enqueue(new DebugPacket(_job.ProjectId, _backtestId, _compileId, message));
 
@@ -581,7 +581,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         /// <param name="message">Error message we'd like shown in console.</param>
         /// <param name="stacktrace">Stacktrace information string</param>
-        public void ErrorMessage(string message, string stacktrace = "") 
+        public void ErrorMessage(string message, string stacktrace = "")
         {
             if (message == _errorMessage) return;
             if (Messages.Count > 500) return;
@@ -590,11 +590,11 @@ namespace QuantConnect.Lean.Engine.Results
         }
 
         /// <summary>
-        /// Send a runtime error message back to the browser highlighted with in red 
+        /// Send a runtime error message back to the browser highlighted with in red
         /// </summary>
         /// <param name="message">Error message.</param>
         /// <param name="stacktrace">Stacktrace information string</param>
-        public void RuntimeError(string message, string stacktrace = "") 
+        public void RuntimeError(string message, string stacktrace = "")
         {
             PurgeQueue();
             Messages.Enqueue(new RuntimeErrorPacket(_job.UserId, _backtestId, message, stacktrace));
@@ -611,7 +611,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="time">Time for the sample</param>
         /// <param name="unit">Unit of the sample</param>
         /// <param name="value">Value for the chart sample.</param>
-        public void Sample(string chartName, string seriesName, int seriesIndex, SeriesType seriesType, DateTime time, decimal value, string unit = "$") 
+        public void Sample(string chartName, string seriesName, int seriesIndex, SeriesType seriesType, DateTime time, decimal value, string unit = "$")
         {
             lock (_chartLock)
             {
@@ -644,7 +644,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         /// <param name="time">Current backtest time.</param>
         /// <param name="value">Current equity value.</param>
-        public void SampleEquity(DateTime time, decimal value) 
+        public void SampleEquity(DateTime time, decimal value)
         {
             //Sample the Equity Value:
             Sample("Strategy Equity", "Equity", 0, SeriesType.Candle, time, value, "$");
@@ -658,7 +658,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         /// <param name="time">Current backtest date.</param>
         /// <param name="value">Current daily performance value.</param>
-        public void SamplePerformance(DateTime time, decimal value) 
+        public void SamplePerformance(DateTime time, decimal value)
         {
             //Added a second chart to equity plot - daily perforamnce:
             Sample("Strategy Equity", "Daily Performance", 1, SeriesType.Bar, time, value, "%");
@@ -679,20 +679,20 @@ namespace QuantConnect.Lean.Engine.Results
         /// Add a range of samples from the users algorithms to the end of our current list.
         /// </summary>
         /// <param name="updates">Chart updates since the last request.</param>
-        public void SampleRange(List<Chart> updates) 
+        public void SampleRange(List<Chart> updates)
         {
-            lock (_chartLock) 
+            lock (_chartLock)
             {
-                foreach (var update in updates) 
+                foreach (var update in updates)
                 {
                     //Create the chart if it doesn't exist already:
-                    if (!Charts.ContainsKey(update.Name)) 
+                    if (!Charts.ContainsKey(update.Name))
                     {
                         Charts.AddOrUpdate(update.Name, new Chart(update.Name));
                     }
 
                     //Add these samples to this chart.
-                    foreach (var series in update.Series.Values) 
+                    foreach (var series in update.Series.Values)
                     {
                         //If we don't already have this record, its the first packet
                         if (!Charts[update.Name].Series.ContainsKey(series.Name))
@@ -713,11 +713,12 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Terminate the result thread and apply any required exit procedures.
         /// </summary>
-        public void Exit() 
+        public void Exit()
         {
             // Only process the logs once
             if (!_exitTriggered)
             {
+                ProcessSynchronousEvents(true);
                 var logLocation = SaveLogs(_job.BacktestId, _log);
                 SystemDebugMessage("Your log was successfully created and can be retrieved from: " + logLocation);
             }
@@ -732,7 +733,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <remarks>In backtesting the order events are not sent because it would generate a high load of messaging.</remarks>
         /// <param name="newEvent">New order event details</param>
         public void OrderEvent(OrderEvent newEvent)
-        { 
+        {
             // NOP. Don't do any order event processing for results in backtest mode.
         }
 
@@ -744,7 +745,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="message">Additional optional status message.</param>
         /// <remarks>In backtesting we do not send the algorithm status updates.</remarks>
         public void SendStatusUpdate(AlgorithmStatus status, string message = "")
-        { 
+        {
             //NOP. Don't send status for backtests
         }
 
@@ -762,13 +763,13 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Purge/clear any outstanding messages in message queue.
         /// </summary>
-        public void PurgeQueue() 
+        public void PurgeQueue()
         {
             Messages.Clear();
         }
 
         /// <summary>
-        /// Set the current runtime statistics of the algorithm. 
+        /// Set the current runtime statistics of the algorithm.
         /// These are banner/title statistics which show at the top of the live trading results.
         /// </summary>
         /// <param name="key">Runtime headline statistic name</param>
@@ -790,7 +791,7 @@ namespace QuantConnect.Lean.Engine.Results
         }
 
         /// <summary>
-        /// Process the synchronous result events, sampling and message reading. 
+        /// Process the synchronous result events, sampling and message reading.
         /// This method is triggered from the algorithm manager thread.
         /// </summary>
         /// <remarks>Prime candidate for putting into a base class. Is identical across all result handlers.</remarks>


### PR DESCRIPTION
Debug messages can be lost if an exception is thrown in the algorithm before IResultsHandler.ProcessSynchronousEvents() is called in AlgorithmManager. Calling ProcessSynchronousEvents() in the Exit method of the BacktestingResultsHandler should help ensure that Debug messages make it back to the user even if there is an exception thrown in the algorithm. This is the pattern used by the LiveTradingResultsHandler

Trailing whitespace was removed by VS plugin. Only one line of code was added on line 721