### PR TITLE
Add null check in BRH.ProcessSynchronousEvents()

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -797,6 +797,8 @@ namespace QuantConnect.Lean.Engine.Results
         /// <remarks>Prime candidate for putting into a base class. Is identical across all result handlers.</remarks>
         public void ProcessSynchronousEvents(bool forceProcess = false)
         {
+            if (_algorithm == null) return;
+
             var time = _algorithm.UtcTime;
 
             if (time > _nextSample || forceProcess)


### PR DESCRIPTION
There are cases were creating the instance of the algorithm or setting up the algorithm will throw an error. In those cases, the backtesting result handler - who has already been initiaized - will attempt to call ProcessSynchronousEvents() when it's instance of IAlgorithm is still null. This will then throw a null reference exception when BRH.ProcessSynchronousEvents() attempts to access the properties on IAlgorithm