### PR TITLE
Add 5 minute timout to the RestClient in StreamingApi

### DIFF
--- a/Messaging/StreamingApi.cs
+++ b/Messaging/StreamingApi.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,7 +35,10 @@ namespace QuantConnect.Messaging
         public static readonly bool IsEnabled = Config.GetBool("send-via-api");
 
         // Client for sending asynchronous requests.
-        private static readonly RestClient Client = new RestClient("http://streaming.quantconnect.com");
+        private static readonly RestClient Client = new RestClient("http://streaming.quantconnect.com")
+        {
+            Timeout = 300000
+        };
 
         /// <summary>
         /// Send a message to the QuantConnect Chart Streaming API.


### PR DESCRIPTION
Added timeout to StreamingApi of 300000ms (5min) to ensure that requests timeout in an reasonable fashion.