### PR TITLE
Fixes DailyFx missing Symbol

### DIFF
--- a/Common/Data/Custom/DailyFx.cs
+++ b/Common/Data/Custom/DailyFx.cs
@@ -165,6 +165,8 @@ namespace QuantConnect.Data.Custom
 
             foreach (var dailyfx in dailyfxList)
             {
+                dailyfx.Symbol = config.Symbol;
+
                 // Custom data format without settings in market hours are assumed UTC.
                 dailyfx.Time = dailyfx.DisplayDate.Date.AddHours(dailyfx.DisplayTime.TimeOfDay.TotalHours);
 


### PR DESCRIPTION
We didn't assign a symbol to DailyFx objects, so we needed to get the bar with Get<T> which was not possible in python.