### PR TITLE
Fixes BasicTemplateForexAlgorithm

### DIFF
--- a/Algorithm.CSharp/BasicTemplateForexAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateForexAlgorithm.cs
@@ -14,7 +14,7 @@
 */
 
 using QuantConnect.Data;
-using System.Linq;
+using System;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -28,21 +28,20 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public override void Initialize()
         {
-            SetStartDate(2013, 10, 07);  //Set Start Date
-            SetEndDate(2013, 10, 11);    //Set End Date
+            SetStartDate(2014, 5, 7);  //Set Start Date
+            SetEndDate(2014, 5, 15);    //Set End Date
             SetCash(100000);             //Set Strategy Cash
             // Find more symbols here: http://quantconnect.com/data
-            AddForex("EURUSD", Resolution.Minute);
-            AddForex("GBPUSD", Resolution.Minute);
-            AddForex("EURGBP", Resolution.Minute);
+            AddForex("EURUSD");
+            AddForex("NZDUSD");
 
-            History(5, Resolution.Daily);
-            History(5, Resolution.Hour);
-            History(5, Resolution.Minute);
+            var dailyHistory = History(5, Resolution.Daily);
+            var hourHistory = History(5, Resolution.Hour);
+            var minuteHistory = History(5, Resolution.Minute);
+            var secondHistory = History(5, Resolution.Second);
 
-            var history = History(System.TimeSpan.FromSeconds(5), Resolution.Second);
-
-            foreach (var data in history.OrderBy(x => x.Time))
+            // Log values from history request of second-resolution data
+            foreach (var data in secondHistory)
             {
                 foreach (var key in data.Keys)
                 {
@@ -57,10 +56,11 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="data">Slice object keyed by symbol containing the stock data</param>
         public override void OnData(Slice data)
         {
-            // Print to console to verify that data is coming in
-            foreach (var key in data.Keys)
+            if (!Portfolio.Invested)
             {
-                Log(key.Value + ": " + data[key].Time + " > " + data[key].Value);
+                SetHoldings("EURUSD", .5);
+                SetHoldings("NZDUSD", .5);
+                Log(string.Join(", ", data.Values));
             }
         }
     }


### PR DESCRIPTION
The previous version has an uneccessary Linq operation to order the results from a Historical Data request.
Also changes the algorithm period to match locally available data.