### PR TITLE
Fix subscription sharing issue with universe selection in backtesting

### DIFF
--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -103,7 +103,7 @@ namespace QuantConnect.Data
         {
             get
             {
-                return Symbol.ID.SecurityType == SecurityType.Option ? 
+                return Symbol.ID.SecurityType == SecurityType.Option ?
                     (Symbol.HasUnderlying ? Symbol.Underlying.Value : Symbol.Value) :
                     Symbol.Value;
             }
@@ -251,7 +251,7 @@ namespace QuantConnect.Data
             objectType ?? config.Type,
             symbol ?? config.Symbol,
             resolution ?? config.Resolution,
-            dataTimeZone ?? config.DataTimeZone, 
+            dataTimeZone ?? config.DataTimeZone,
             exchangeTimeZone ?? config.ExchangeTimeZone,
             fillForward ?? config.FillDataForward,
             extendedHours ?? config.ExtendedMarketHours,
@@ -262,6 +262,13 @@ namespace QuantConnect.Data
             dataNormalizationMode ?? config.DataNormalizationMode
             )
         {
+            PriceScaleFactor = config.PriceScaleFactor;
+            SumOfDividends = config.SumOfDividends;
+
+            foreach (var consolidator in config.Consolidators)
+            {
+                Consolidators.Add(consolidator);
+            }
         }
 
         /// <summary>
@@ -274,15 +281,15 @@ namespace QuantConnect.Data
             {
                 case DataNormalizationMode.Raw:
                     return price;
-                
+
                 // the price scale factor will be set accordingly based on the mode in update scale factors
                 case DataNormalizationMode.Adjusted:
                 case DataNormalizationMode.SplitAdjusted:
                     return price*PriceScaleFactor;
-                
+
                 case DataNormalizationMode.TotalReturn:
                     return (price*PriceScaleFactor) + SumOfDividends;
-                
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -299,14 +306,14 @@ namespace QuantConnect.Data
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return _sid.Equals(other._sid) && Type == other.Type 
-                && TickType == other.TickType 
+            return _sid.Equals(other._sid) && Type == other.Type
+                && TickType == other.TickType
                 && Resolution == other.Resolution
-                && FillDataForward == other.FillDataForward 
-                && ExtendedMarketHours == other.ExtendedMarketHours 
+                && FillDataForward == other.FillDataForward
+                && ExtendedMarketHours == other.ExtendedMarketHours
                 && IsInternalFeed == other.IsInternalFeed
-                && IsCustomData == other.IsCustomData 
-                && DataTimeZone.Equals(other.DataTimeZone) 
+                && IsCustomData == other.IsCustomData
+                && DataTimeZone.Equals(other.DataTimeZone)
                 && ExchangeTimeZone.Equals(other.ExchangeTimeZone)
                 && IsFilteredSubscription == other.IsFilteredSubscription;
         }
@@ -327,7 +334,7 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// Serves as the default hash function. 
+        /// Serves as the default hash function.
         /// </summary>
         /// <returns>
         /// A hash code for the current object.

--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -193,7 +193,7 @@ namespace QuantConnect.Data.UniverseSelection
                     isUniverseSubscription: false,
                     universe: this,
                     security: security,
-                    configuration: config,
+                    configuration: new SubscriptionDataConfig(config),
                     startTimeUtc: currentTimeUtc,
                     endTimeUtc: maximumEndTimeUtc
                     )

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories;
@@ -85,7 +86,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     var security = new Equity(symbol, exchangeHours, quoteCash, symbolProperties);
 
-                    var request = new SubscriptionRequest(true, universe, security, config, dateTimeUtc, dateTimeUtc);
+                    var request = new SubscriptionRequest(true, universe, security, new SubscriptionDataConfig(config), dateTimeUtc, dateTimeUtc);
                     using (var enumerator = factory.CreateEnumerator(request, dataProvider))
                     {
                         if (enumerator.MoveNext())
@@ -207,7 +208,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 foreach (var security in addedSecurities)
                 {
                     // assume currency feeds are always one subscription per, these are typically quote subscriptions
-                    _dataFeed.AddSubscription(new SubscriptionRequest(false, universe, security, security.Subscriptions.First(), dateTimeUtc, algorithmEndDateUtc));
+                    _dataFeed.AddSubscription(new SubscriptionRequest(false, universe, security, new SubscriptionDataConfig(security.Subscriptions.First()), dateTimeUtc, algorithmEndDateUtc));
                 }
             }
 


### PR DESCRIPTION
In backtesting with universe selection, when symbols are be added and removed the next day, we have experienced slightly different backtesting results for the same algorithm. This was caused by invalid factors applied to equities due to the sharing of a `SubscriptionDataConfig` instance between two threads.

The issue was solved by calling the `SubscriptionDataConfig` copy constructor in `Universe.GetSubscriptionRequests`.