### PR TITLE
ReadZipEntry fix

### DIFF
--- a/Compression/Compression.cs
+++ b/Compression/Compression.cs
@@ -611,13 +611,15 @@ namespace QuantConnect
 
         private static IEnumerable<string> ReadZipEntry(Ionic.Zip.ZipEntry entry)
         {
+            var output = new List<string>();
             using (var entryReader = new StreamReader(entry.OpenReader()))
             {
                 while (!entryReader.EndOfStream)
                 {
-                    yield return entryReader.ReadLine();
+                    output.Add(entryReader.ReadLine());
                 }
             }
+            return output;
         }
 
         /// <summary>


### PR DESCRIPTION
The issue is that after a file using the `Quantconnect.Compression.ReadLines` static method, the file can be modified or deleted.

More in detail, just by using the Quantconnect.Compression.ReadLines, the file can be accessed, but the error arises then one tries to _interact_ with the results. E.g.:
```cs
var lines = QuantConnect.Compression.ReadLines(zipFilePath);
var linesN =lines.Count();
```
Even when the underlying methods disposing the zip handlers correctly, the problem is the use of the `yield` in the `Quantconnect.Compression.ReadZipEntry`.

This PR contains the tests to prove the issue and a fix to the problem.
