### PR TITLE
Optimize conversion of Python lists to CLR generic Lists

### DIFF
--- a/Algorithm.Python/CoarseFineFundamentalComboAlgorithm.py
+++ b/Algorithm.Python/CoarseFineFundamentalComboAlgorithm.py
@@ -54,7 +54,7 @@ class CoarseFineFundamentalComboAlgorithm(QCAlgorithm):
         top5 = sortedByDollarVolume[:self.__numberOfSymbols]
 
         # we need to return only the symbol objects
-        list = List[Symbol]()
+        list = List[Symbol](len(top5))
         for x in top5:
             list.Add(x.Symbol)
 
@@ -68,7 +68,7 @@ class CoarseFineFundamentalComboAlgorithm(QCAlgorithm):
         # take the top entries from our sorted collection
         topFine = sortedByPeRatio[:self.__numberOfSymbolsFine]
 
-        list = List[Symbol]()
+        list = List[Symbol](len(topFine))
         for x in topFine:
             list.Add(x.Symbol)
 


### PR DESCRIPTION
Since we're copying from a Python list to a CLR List, and we already know the size of the Python list, we should pre-allocate the CLR list with the size.