### PR TITLE
Handle Errors in ScheduleEvent Callbacks

### DIFF
--- a/Common/Scheduling/ScheduledEvent.cs
+++ b/Common/Scheduling/ScheduledEvent.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -228,15 +228,44 @@ namespace QuantConnect.Scheduling
         /// <param name="triggerTime">The event's time in UTC</param>
         protected void OnEventFired(DateTime triggerTime)
         {
-            // don't fire the event if we're turned off
-            if (!Enabled) return;
-
-            if (_callback != null)
+            try
             {
-                _callback(_name, _orderedEventUtcTimes.Current);
+                // don't fire the event if we're turned off
+                if (!Enabled) return;
+
+                if (_callback != null)
+                {
+                    _callback(_name, _orderedEventUtcTimes.Current);
+                }
+                var handler = EventFired;
+                if (handler != null) handler(_name, triggerTime);
             }
-            var handler = EventFired;
-            if (handler != null) handler(_name, triggerTime);
+            catch (Exception ex)
+            {
+                // This scheduled event failed, so move on to the next one
+                _needsMoveNext = true;
+                throw new ScheduledEventException(ex.ToString());
+            }
+        }
+    }
+
+    /// <summary>
+    /// Throw this if there is an exception in the callback function of the scheduled event
+    /// </summary>
+    public class ScheduledEventException : Exception
+    {
+        /// <summary>
+        /// Exception message
+        /// </summary>
+        public string ScheduledEventExceptionMessage { get; }
+
+        /// <summary>
+        /// ScheduledEventException constructor
+        /// </summary>
+        /// <param name="exceptionMessage">The exception as a string</param>
+        public ScheduledEventException(string exceptionMessage)
+        {
+            ScheduledEventExceptionMessage = exceptionMessage;
         }
     }
 }

--- a/Common/Scheduling/ScheduledEvent.cs
+++ b/Common/Scheduling/ScheduledEvent.cs
@@ -242,7 +242,7 @@ namespace QuantConnect.Scheduling
             }
             catch (Exception ex)
             {
-                // This scheduled event failed, so move on to the next one
+                // This scheduled event failed, so don't repeat the same event
                 _needsMoveNext = true;
                 throw new ScheduledEventException(ex.ToString());
             }

--- a/Common/Scheduling/ScheduledEvent.cs
+++ b/Common/Scheduling/ScheduledEvent.cs
@@ -242,6 +242,8 @@ namespace QuantConnect.Scheduling
             }
             catch (Exception ex)
             {
+                Log.Error($"ScheduledEvent.Scan(): Exception was thrown in OnEventFired: {ex}");
+
                 // This scheduled event failed, so don't repeat the same event
                 _needsMoveNext = true;
                 throw new ScheduledEventException(ex.ToString());
@@ -263,7 +265,7 @@ namespace QuantConnect.Scheduling
         /// ScheduledEventException constructor
         /// </summary>
         /// <param name="exceptionMessage">The exception as a string</param>
-        public ScheduledEventException(string exceptionMessage)
+        public ScheduledEventException(string exceptionMessage) : base(exceptionMessage)
         {
             ScheduledEventExceptionMessage = exceptionMessage;
         }

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ namespace QuantConnect.Lean.Engine.RealTime
         /// <summary>
         /// Intializes the real time handler for the specified algorithm and job
         /// </summary>
-        public void Setup(IAlgorithm algorithm, AlgorithmNodePacket job, IResultHandler resultHandler, IApi api) 
+        public void Setup(IAlgorithm algorithm, AlgorithmNodePacket job, IResultHandler resultHandler, IApi api)
         {
             //Initialize:
             _algorithm = algorithm;
@@ -72,7 +72,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                 scheduledEvent.Value.IsLoggingEnabled = Log.DebuggingEnabled;
             }
         }
-        
+
         /// <summary>
         /// Normally this would run the realtime event monitoring. Backtesting is in fastforward so the realtime is linked to the backtest clock.
         /// This thread does nothing. Wait until the job is over.
@@ -133,7 +133,23 @@ namespace QuantConnect.Lean.Engine.RealTime
                 while (scheduledEvent.Value.NextEventUtcTime < time)
                 {
                     _algorithm.SetDateTime(scheduledEvent.Value.NextEventUtcTime);
-                    scheduledEvent.Value.Scan(scheduledEvent.Value.NextEventUtcTime);
+
+                    try
+                    {
+                        scheduledEvent.Value.Scan(scheduledEvent.Value.NextEventUtcTime);
+                    }
+                    catch (ScheduledEventException scheduledEventException)
+                    {
+                        var errorMessage = $"BacktestingRealTimeHandler.Run(): There was an error in a scheduled event {scheduledEvent.Key}. The error was {scheduledEventException.ScheduledEventExceptionMessage}";
+
+                        Log.Error(errorMessage);
+
+                        _resultHandler.RuntimeError(errorMessage);
+
+                        // Errors in scheduled event should be treated as runtime error
+                        // Runtime errors should end Lean execution
+                        _algorithm.RunTimeError = new Exception(errorMessage);
+                    }
                 }
             }
         }

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -98,7 +98,7 @@ namespace QuantConnect.Lean.Engine.RealTime
         }
 
         /// <summary>
-        /// Execute the live realtime event thread montioring. 
+        /// Execute the live realtime event thread montioring.
         /// It scans every second monitoring for an event trigger.
         /// </summary>
         public void Run()
@@ -122,6 +122,12 @@ namespace QuantConnect.Lean.Engine.RealTime
                     {
                         scheduledEvent.Value.Scan(time);
                     }
+                }
+                catch (ScheduledEventException scheduledEventException)
+                {
+                    var errorMessage = $"LiveTradingRealTimeHandler: There was an error thrown in the scheduled event: {scheduledEventException.ScheduledEventExceptionMessage}";
+                    Log.Error(errorMessage);
+                    _resultHandler.ErrorMessage(errorMessage);
                 }
                 catch (Exception err)
                 {

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -125,7 +125,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                     }
                     catch (ScheduledEventException scheduledEventException)
                     {
-                        var errorMessage = $"LiveTradingRealTimeHandler.Run(): There was an error in a scheduled event {scheduledEvent.Key}. The error was {scheduledEventException}";
+                        var errorMessage = $"LiveTradingRealTimeHandler.Run(): There was an error in a scheduled event {scheduledEvent.Key}. The error was {scheduledEventException.ScheduledEventExceptionMessage}";
 
                         Log.Error(errorMessage);
 


### PR DESCRIPTION
These changes fix a bug where if a exception was thrown in a scheduled event in live mode, the exception did not shut down Lean and the scheduled event was then continuously executed every second. These changes should provide additional information to exception thrown in scheduled event callbacks for both backtesting and live and provide that information to the user.  

+ Added new Exception class, `ScheduledEventException` that is thrown when there is an exception in the callback method of the scheduled event.
+ In both,  `BacktestingRealTimeHandler` and `LiveTradingRealTimeHandler`, catch the `ScheduledEventException`, log the error, add a run time error message to the `IResultHandler` and set the `IAlgorithm.RunTimeException` which should shut Lean down.

