### PR TITLE
Bugfix/live btc

### DIFF
--- a/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
+++ b/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
@@ -165,8 +165,7 @@ namespace QuantConnect.Algorithm.CSharp
                 try
                 {
                     coin = JsonConvert.DeserializeObject<Bitcoin>(line);
-                    coin.EndTime = DateTime.UtcNow;
-                    coin.Time = coin.EndTime - config.Increment;
+                    coin.EndTime = DateTime.UtcNow.ConvertFromUtc(config.ExchangeTimeZone);
                     coin.Value = coin.Close;
                 }
                 catch { /* Do nothing, possible error in json decoding */ }

--- a/Engine/DataFeeds/Enumerators/RefreshEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/RefreshEnumerator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <exception cref="T:System.InvalidOperationException">The collection was modified after the enumerator was created. </exception><filterpriority>2</filterpriority>
         public bool MoveNext()
         {
-            _enumerator = _enumeratorFactory.Invoke();
+            if (_enumerator == null)
+            {
+                _enumerator = _enumeratorFactory.Invoke();
+            }
 
             var moveNext = _enumerator.MoveNext();
             if (moveNext)
@@ -71,7 +74,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <exception cref="T:System.InvalidOperationException">The collection was modified after the enumerator was created. </exception><filterpriority>2</filterpriority>
         public void Reset()
         {
-            _enumerator.Reset();
+            if (_enumerator != null)
+            {
+                _enumerator.Reset();
+            }
         }
 
         /// <summary>
@@ -103,7 +109,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <filterpriority>2</filterpriority>
         public void Dispose()
         {
-            _enumerator.Dispose();
+            if (_enumerator != null)
+            {
+                _enumerator.Dispose();
+            }
         }
     }
 }

--- a/Tests/Engine/DataFeeds/Enumerators/RefreshEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/RefreshEnumeratorTests.cs
@@ -1,0 +1,113 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+
+namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
+{
+    [TestFixture]
+    public class RefreshEnumeratorTests
+    {
+        [Test]
+        public void RefreshesEnumeratorOnFirstMoveNext()
+        {
+            var refreshed = false;
+            var refresher = new RefreshEnumerator<int?>(() =>
+            {
+                refreshed = true;
+                return new List<int?>().GetEnumerator();
+            });
+
+            refresher.MoveNext();
+            Assert.IsTrue(refreshed);
+        }
+
+        [Test]
+        public void MoveNextReturnsTrueWhenUnderlyingEnumeratorReturnsFalse()
+        {
+            var refresher = new RefreshEnumerator<int?>(() => new List<int?>().GetEnumerator());
+            Assert.IsTrue(refresher.MoveNext());
+        }
+
+        [Test]
+        public void CurrentIsDefault_T_WhenUnderlyingEnumeratorReturnsFalse()
+        {
+            var refresher = new RefreshEnumerator<int?>(() => new List<int?>().GetEnumerator());
+            refresher.MoveNext();
+            Assert.AreEqual(default(int?), refresher.Current);
+        }
+
+        [Test]
+        public void DisposeCallsUnderlyingDispose()
+        {
+            var fakeEnumerator = new Mock<IEnumerator<int?>>();
+            fakeEnumerator.Setup(e => e.MoveNext()).Returns(true);
+            fakeEnumerator.Setup(e => e.Dispose()).Verifiable();
+            var refresher = new RefreshEnumerator<int?>(() => fakeEnumerator.Object);
+            refresher.MoveNext();
+            refresher.Dispose();
+
+            fakeEnumerator.Verify(enumerator => enumerator.Dispose(), Times.Once);
+        }
+
+        [Test]
+        public void ResetCallsUnderlyingReset()
+        {
+            var fakeEnumerator = new Mock<IEnumerator<int?>>();
+            fakeEnumerator.Setup(e => e.MoveNext()).Returns(true);
+            fakeEnumerator.Setup(e => e.Reset()).Verifiable();
+            var refresher = new RefreshEnumerator<int?>(() => fakeEnumerator.Object);
+            refresher.MoveNext();
+            refresher.Reset();
+
+            fakeEnumerator.Verify(enumerator => enumerator.Reset(), Times.Once);
+        }
+
+        [Test]
+        public void RefreshesAfterMoveNextReturnsFalse()
+        {
+            var refreshCount = 0;
+            var list = new List<int?> {1, 2};
+            var refresher = new RefreshEnumerator<int?>(() =>
+            {
+                refreshCount++;
+                return list.GetEnumerator();
+            });
+
+            Assert.IsTrue(refresher.MoveNext());
+            Assert.AreEqual(1, refreshCount);
+            Assert.AreEqual(1, refresher.Current);
+
+            Assert.IsTrue(refresher.MoveNext());
+            Assert.AreEqual(1, refreshCount);
+            Assert.AreEqual(2, refresher.Current);
+
+            Assert.IsTrue(refresher.MoveNext());
+            Assert.AreEqual(1, refreshCount);
+            Assert.AreEqual(default(int?), refresher.Current);
+
+            Assert.IsTrue(refresher.MoveNext());
+            Assert.AreEqual(2, refreshCount);
+            Assert.AreEqual(1, refresher.Current);
+
+            Assert.IsTrue(refresher.MoveNext());
+            Assert.AreEqual(2, refreshCount);
+            Assert.AreEqual(2, refresher.Current);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Engine\DataFeeds\Enumerators\OptionChainUniverseDataCollectionAggregatorEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\QuoteBarFillForwardEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\RateLimitEnumeratorTests.cs" />
+    <Compile Include="Engine\DataFeeds\Enumerators\RefreshEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\SynchronizingEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\TradeBarBuilderEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\FileSystemDataFeedTests.cs" />


### PR DESCRIPTION
This example custom data implementation was setting both the `Time` and `EndTime`
properties of `BaseData`. The issue with this is that `BaseData` uses the same storage
for each property. So the `coin.Time = coin.EndTime - config.Increment` call was always
pushing the end time far enough in the past that we would try to fast forward.

A thought here is that perhaps we should never try to fast forward rest subscription
sources. The fast forward was implemented to support remote files which may have
data into the future that we don't want to yield until the correct time.