### PR TITLE
Minor string trimming optimization

### DIFF
--- a/Common/Data/Custom/Quandl.cs
+++ b/Common/Data/Custom/Quandl.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Data.Custom
                 _isInitialized = true;
                 foreach (var propertyName in csv)
                 {
-                    var property = propertyName.TrimStart().TrimEnd();
+                    var property = propertyName.Trim();
                     // should we remove property names like Time?
                     // do we need to alias the Time??
                     data.SetProperty(property, 0m);


### PR DESCRIPTION
Using `String.Trim` is more efficient than trimming the start and then the end as you avoid a string allocation between trimming of the head and the tail.

This is something I came across while causally browsing the source code and thought I'd turn it into a PR.