### PR TITLE
Extends Option.SetFilter to accept complex filtering expressions for python algorithms

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -519,6 +519,7 @@
     <Compile Include="Util\ParallelRunner.cs" />
     <Compile Include="Util\ParallelRunnerWorker.cs" />
     <Compile Include="Util\ColorJsonConverter.cs" />
+    <Compile Include="Util\PythonUtil.cs" />
     <Compile Include="Util\RateGate.cs" />
     <Compile Include="Util\SecurityExtensions.cs" />
     <Compile Include="Util\SecurityIdentifierJsonConverter.cs" />

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -19,6 +19,8 @@ using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Slippage;
 using QuantConnect.Orders.OptionExercise;
+using Python.Runtime;
+using QuantConnect.Util;
 
 namespace QuantConnect.Securities.Option
 {
@@ -330,6 +332,16 @@ namespace QuantConnect.Securities.Option
                 var result = universeFunc(optionUniverse);
                 return result.ApplyOptionTypesFilter();
             });
+        }
+
+        /// <summary>
+        /// Sets the <see cref="ContractFilter"/> to a new universe selection function
+        /// </summary>
+        /// <param name="universeFunc">new universe selection function</param>
+        public void SetFilter(PyObject universeFunc)
+        {
+            var pyUniverseFunc = PythonUtil.ToFunc<OptionFilterUniverse, OptionFilterUniverse>(universeFunc);
+            SetFilter(pyUniverseFunc);
         }
 
         /// <summary>

--- a/Common/Util/PythonUtil.cs
+++ b/Common/Util/PythonUtil.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using Python.Runtime;
+using System;
+
+namespace QuantConnect.Util
+{
+    /// <summary>
+    /// Collection of utils for python objects processing
+    /// </summary>
+    public class PythonUtil
+    {
+        /// <summary>
+        /// Encapsulates a python method with a <see cref="System.Func{T, TResult}"/>
+        /// </summary>
+        /// <typeparam name="T">The data type</typeparam>
+        /// <typeparam name="TSecond">The output type</typeparam>
+        /// <param name="pyObject">The python method</param>
+        /// <returns>A <see cref="System.Func{T, TResult}"/> that encapsulates the python method</returns>
+        public static Func<T, TSecond> ToFunc<T, TSecond>(PyObject pyObject)
+        {
+            var testMod =
+               "from clr import AddReference\n" +
+               "AddReference(\"System\")\n" +
+               "from System import Func\n" +
+               "def to_func(pyobject, in_type, out_type):\n" +
+               "    return Func[in_type, out_type](pyobject)";
+
+            using (Py.GIL())
+            {
+                if (!pyObject.IsCallable()) return null;
+                dynamic toFunc = PythonEngine.ModuleFromString("x", testMod).GetAttr("to_func");
+                return toFunc(pyObject, typeof(T), typeof(TSecond)).AsManagedObject(typeof(Func<T, TSecond>));
+            }
+        }
+    }
+}

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -690,7 +690,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("OptionOpenInterestRegressionAlgorithm", optionOpenInterestRegressionAlgorithmStatistics, Language.Python),
                 //new AlgorithmStatisticsTestParameters("OptionChainConsistencyRegressionAlgorithm", optionChainConsistencyRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("WeeklyUniverseSelectionRegressionAlgorithm", weeklyUniverseSelectionRegressionAlgorithmStatistics, Language.Python),
-                //new AlgorithmStatisticsTestParameters("OptionExerciseAssignRegressionAlgorithm",optionExerciseAssignRegressionAlgorithmStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("OptionExerciseAssignRegressionAlgorithm",optionExerciseAssignRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("BasicTemplateDailyAlgorithm", basicTemplateDailyStatistics, Language.Python),
                 //new AlgorithmStatisticsTestParameters("HourSplitRegressionAlgorithm", hourSplitStatistics, Language.Python),
                 //new AlgorithmStatisticsTestParameters("HourReverseSplitRegressionAlgorithm", hourReverseSplitStatistics, Language.Python),


### PR DESCRIPTION
- Moves ToFunc method from QCAlgorithm to Util/PythonUtil
- Extends Option.SetFilter with an overload that accepts PyObject 