### PR TITLE
Fixes OnMarginCall runtime error in python

### DIFF
--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -741,7 +741,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
             catch (PythonException pythonException)
             {
                 // Pythonnet generated error due to List conversion
-                if (pythonException.Message.Equals("TypeError : No method matches given arguments"))
+                if (pythonException.Message.Contains("TypeError : No method matches given arguments"))
                 {
                     _baseAlgorithm.OnMarginCall(requests);
                 }


### PR DESCRIPTION
After we included the method name in the error message, OnMarginCall method was throwing a runtime error when that method was not defined in the script where it sould simply be directed to the method in the base class.