### PR TITLE
Refactor custom live data enumerator stack

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -433,7 +433,7 @@ namespace QuantConnect.Algorithm
         /// <returns>A single <see cref="BaseData"/> object with the last known price</returns>
         public BaseData GetLastKnownPrice(Security security)
         {
-            if (security.Symbol.IsCanonical())
+            if (security.Symbol.IsCanonical() || HistoryProvider == null)
             {
                 return null;
             }

--- a/Common/Data/Custom/DailyFx.cs
+++ b/Common/Data/Custom/DailyFx.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -29,13 +30,15 @@ namespace QuantConnect.Data.Custom
     /// </summary>
     /// <remarks>
     /// Data sourced by Thomson Reuters
-    /// DailyFX provides traders with an easy to use and customizable real-time calendar that updates automatically during 
-    /// announcements.Keep track of significant events that traders care about.As soon as event data is released, the DailyFX 
+    /// DailyFX provides traders with an easy to use and customizable real-time calendar that updates automatically during
+    /// announcements.Keep track of significant events that traders care about.As soon as event data is released, the DailyFX
     /// calendar automatically updates to provide traders with instantaneous information that they can use to formulate their trading decisions.
     /// </remarks>
     public class DailyFx : BaseData
     {
         JsonSerializerSettings _jsonSerializerSettings;
+        private string _previousContent;
+        private readonly Dictionary<string, DailyFx> _previous = new Dictionary<string, DailyFx>();
 
         /// <summary>
         /// Title of the event.
@@ -47,7 +50,7 @@ namespace QuantConnect.Data.Custom
         /// Date the event was displayed on DailyFX
         /// </summary>
         [JsonProperty(PropertyName = "displayDate")]
-        public DateTimeOffset DisplayDate; 
+        public DateTimeOffset DisplayDate;
 
         /// <summary>
         /// Time of the day the event was displayed.
@@ -57,6 +60,14 @@ namespace QuantConnect.Data.Custom
         /// </remarks>
         [JsonProperty(PropertyName = "displayTime")]
         public DateTimeOffset DisplayTime;
+
+        /// <summary>
+        /// Date/time of the event
+        /// </summary>
+        public DateTimeOffset EventDateTime
+        {
+            get { return DisplayDate.Date.Add(DisplayTime.TimeOfDay); }
+        }
 
         /// <summary>
         /// Importance assignment from FxDaily API.
@@ -127,7 +138,7 @@ namespace QuantConnect.Data.Custom
         }
 
         /// <summary>
-        /// Get the source URL for this date. 
+        /// Get the source URL for this date.
         /// </summary>
         /// <remarks>
         ///     FXCM API allows up to 3mo blocks at a time, so we'll return the same URL for each
@@ -147,7 +158,7 @@ namespace QuantConnect.Data.Custom
             {
                 url += GetQuarter(date);
             }
-            
+
             return new SubscriptionDataSource(url, SubscriptionTransportMedium.Rest, FileFormat.Collection);
         }
 
@@ -161,23 +172,58 @@ namespace QuantConnect.Data.Custom
         /// <returns></returns>
         public override BaseData Reader(SubscriptionDataConfig config, string content, DateTime date, bool isLiveMode)
         {
+            if (_previousContent == content)
+            {
+                return null;
+            }
+
+            _previousContent = content;
+
+            // clean old entries from memory
+            var oldEntries = _previous.Where(kvp => kvp.Value.DisplayDate.UtcDateTime < date.Date).ToList();
+            oldEntries.ForEach(oe => _previous.Remove(oe.Key));
+
             var dailyfxList = JsonConvert.DeserializeObject<List<DailyFx>>(content, _jsonSerializerSettings);
 
+            var timestamp = DateTime.UtcNow;
+            var updated = new List<DailyFx>();
             foreach (var dailyfx in dailyfxList)
             {
+                DailyFx previous;
+                var key = MakeKey(dailyfx);
+                if (_previous.TryGetValue(key, out previous))
+                {
+                    // if the event hasn't been updated then don't emit it
+                    if (!dailyfx.HasChangedSince(previous))
+                    {
+                        continue;
+                    }
+                }
+
+                updated.Add(dailyfx);
+                _previous[key] = dailyfx;
+
                 dailyfx.Symbol = config.Symbol;
 
-                // Custom data format without settings in market hours are assumed UTC.
-                dailyfx.Time = dailyfx.DisplayDate.Date.AddHours(dailyfx.DisplayTime.TimeOfDay.TotalHours);
+                if (isLiveMode)
+                {
+                    // Live mode set the time to now, this update just happened
+                    dailyfx.Time = timestamp;
+                }
+                else
+                {
+                    // Custom data format without settings in market hours are assumed UTC.
+                    dailyfx.Time = dailyfx.DisplayDate.Date.AddHours(dailyfx.DisplayTime.TimeOfDay.TotalHours);
+                }
 
-                // Assign a value to this event: 
+                // Assign a value to this event:
                 // Fairly meaningless between unrelated events, but meaningful with the same event over time.
                 dailyfx.Value = 0;
                 try
                 {
-                    if (!string.IsNullOrEmpty(Actual))
+                    if (!string.IsNullOrEmpty(dailyfx.Actual))
                     {
-                        dailyfx.Value = Convert.ToDecimal(RemoveSpecialCharacters(Actual));
+                        dailyfx.Value = Convert.ToDecimal(RemoveSpecialCharacters(dailyfx.Actual));
                     }
                 }
                 catch
@@ -185,7 +231,7 @@ namespace QuantConnect.Data.Custom
                 }
             }
 
-            return new BaseDataCollection(date, config.Symbol, dailyfxList);
+            return new BaseDataCollection(timestamp, config.Symbol, updated);
         }
 
         /// <summary>
@@ -209,7 +255,7 @@ namespace QuantConnect.Data.Custom
             if (date.Month < 4)
             {
                 start += "0101";
-                end += "03312359"; 
+                end += "03312359";
             }
             else if (date.Month < 7)
             {
@@ -235,7 +281,26 @@ namespace QuantConnect.Data.Custom
         /// <returns></returns>
         public override string ToString()
         {
-            return string.Format("DailyFx [{0} {1} {2} {3} {4}]", Time.ToString("u"), Title, Currency, Importance, Meaning);
+            return $"DailyFx: {EndTime} [{EventDateTime.ToString("u")} {Title} {Currency} {Importance} {Meaning} {Actual}]";
+        }
+
+        /// <summary>
+        /// Determines whether or not the values of this event have changed since the previous
+        /// </summary>
+        public bool HasChangedSince(DailyFx previous)
+        {
+            return Importance != previous.Importance
+                || Meaning != previous.Meaning
+                || Actual != previous.Actual
+                || Forecast != previous.Forecast
+                || Previous != previous.Previous
+                || Commentary != previous.Commentary
+                || Value != previous.Value;
+        }
+
+        private static string MakeKey(DailyFx data)
+        {
+            return data.EventDateTime + data.Title;
         }
     }
 

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -510,6 +510,7 @@
     <Compile Include="Util\CircularQueue.cs" />
     <Compile Include="Util\Composer.cs" />
     <Compile Include="Util\DisposableExtensions.cs" />
+    <Compile Include="Util\EnumeratorExtensions.cs" />
     <Compile Include="Util\ExpressionBuilder.cs" />
     <Compile Include="Util\FixedSizeQueue.cs" />
     <Compile Include="Util\FixedSizeHashQueue.cs" />

--- a/Common/Time.cs
+++ b/Common/Time.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ using NodaTime;
 using QuantConnect.Logging;
 using QuantConnect.Securities;
 
-namespace QuantConnect 
+namespace QuantConnect
 {
     /// <summary>
     /// Time helper class collection for working with trading dates
@@ -58,7 +58,7 @@ namespace QuantConnect
         /// One Hour TimeSpan Period Constant
         /// </summary>
         public static readonly TimeSpan OneHour = TimeSpan.FromHours(1);
-        
+
         /// <summary>
         /// One Minute TimeSpan Period Constant
         /// </summary>
@@ -125,10 +125,10 @@ namespace QuantConnect
         /// </summary>
         /// <param name="unixTimeStamp">Double unix timestamp (Time since Midnight Jan 1 1970)</param>
         /// <returns>C# date timeobject</returns>
-        public static DateTime UnixTimeStampToDateTime(double unixTimeStamp) 
+        public static DateTime UnixTimeStampToDateTime(double unixTimeStamp)
         {
             DateTime time;
-            try 
+            try
             {
                 // Unix timestamp is seconds past epoch
                 time = EpochTime.AddSeconds(unixTimeStamp);
@@ -146,14 +146,14 @@ namespace QuantConnect
         /// </summary>
         /// <param name="time">C# datetime object</param>
         /// <returns>Double unix timestamp</returns>
-        public static double DateTimeToUnixTimeStamp(DateTime time) 
+        public static double DateTimeToUnixTimeStamp(DateTime time)
         {
             double timestamp = 0;
-            try 
+            try
             {
                 timestamp = (time - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds;
-            } 
-            catch (Exception err) 
+            }
+            catch (Exception err)
             {
                 Log.Error(err, time.ToString("o"));
             }
@@ -164,11 +164,11 @@ namespace QuantConnect
         /// Get the current time as a unix timestamp
         /// </summary>
         /// <returns>Double value of the unix as UTC timestamp</returns>
-        public static double TimeStamp() 
+        public static double TimeStamp()
         {
             return DateTimeToUnixTimeStamp(DateTime.UtcNow);
         }
-        
+
         /// <summary>
         /// Returns the timespan with the larger value
         /// </summary>
@@ -185,7 +185,23 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Parse a standard YY MM DD date into a DateTime. Attempt common date formats 
+        /// Returns the larger of two date times
+        /// </summary>
+        public static DateTime Max(DateTime one, DateTime two)
+        {
+            return one > two ? one : two;
+        }
+
+        /// <summary>
+        /// Returns the smaller of two date times
+        /// </summary>
+        public static DateTime Min(DateTime one, DateTime two)
+        {
+            return one < two ? one : two;
+        }
+
+        /// <summary>
+        /// Parse a standard YY MM DD date into a DateTime. Attempt common date formats
         /// </summary>
         /// <param name="dateToParse">String date time to parse</param>
         /// <returns>Date time</returns>
@@ -220,7 +236,7 @@ namespace QuantConnect
             {
                 Log.Error(err);
             }
-            
+
             return DateTime.Now;
         }
 
@@ -231,7 +247,7 @@ namespace QuantConnect
         /// <param name="from">DateTime start date</param>
         /// <param name="thru">DateTime end date</param>
         /// <returns>Enumerable date range</returns>
-        public static IEnumerable<DateTime> EachDay(DateTime from, DateTime thru) 
+        public static IEnumerable<DateTime> EachDay(DateTime from, DateTime thru)
         {
             for (var day = from.Date; day.Date <= thru.Date; day = day.AddDays(1))
                 yield return day;
@@ -326,7 +342,7 @@ namespace QuantConnect
 
                 currentExchangeTime = currentInTimeZoneEod.ConvertTo(timeZone, exchange.TimeZone);
             }
-        } 
+        }
 
         /// <summary>
         /// Make sure this date is not a holiday, or weekend for the securities in this algorithm.
@@ -362,17 +378,17 @@ namespace QuantConnect
         {
             var count = 0;
             Log.Trace("Time.TradeableDates(): Security Count: " + securities.Count);
-            try 
+            try
             {
-                foreach (var day in EachDay(start, finish)) 
+                foreach (var day in EachDay(start, finish))
                 {
-                    if (TradableDate(securities, day)) 
+                    if (TradableDate(securities, day))
                     {
                         count++;
                     }
                 }
-            } 
-            catch (Exception err) 
+            }
+            catch (Exception err)
             {
                 Log.Error(err);
             }

--- a/Common/Util/EnumeratorExtensions.cs
+++ b/Common/Util/EnumeratorExtensions.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Util
+{
+    /// <summary>
+    /// Provides convenience of linq extension methods for <see cref="IEnumerator{T}"/> types
+    /// </summary>
+    public static class EnumeratorExtensions
+    {
+        /// <summary>
+        /// Filter the enumerator using the specified predicate
+        /// </summary>
+        public static IEnumerator<T> Where<T>(this IEnumerator<T> enumerator, Func<T, bool> predicate)
+        {
+            using (enumerator)
+            {
+                while (enumerator.MoveNext())
+                {
+                    if (predicate(enumerator.Current))
+                    {
+                        yield return enumerator.Current;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Project the enumerator using the specified selector
+        /// </summary>
+        public static IEnumerator<TResult> Select<T, TResult>(this IEnumerator<T> enumerator, Func<T, TResult> selector)
+        {
+            using (enumerator)
+            {
+                while (enumerator.MoveNext())
+                {
+                    yield return selector(enumerator.Current);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Project the enumerator using the specified selector
+        /// </summary>
+        public static IEnumerator<TResult> SelectMany<T, TResult>(this IEnumerator<T> enumerator, Func<T, IEnumerator<TResult>> selector)
+        {
+            using (enumerator)
+            {
+                while (enumerator.MoveNext())
+                {
+                    using (var inner = selector(enumerator.Current))
+                    {
+                        while (inner.MoveNext())
+                        {
+                            yield return inner.Current;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,7 +28,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     /// </summary>
     public class CollectionSubscriptionDataSourceReader : ISubscriptionDataSourceReader
     {
-        
+
         private readonly DateTime _date;
         private readonly bool _isLiveMode;
         private readonly BaseData _factory;
@@ -58,7 +58,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public event EventHandler<InvalidSourceEventArgs> InvalidSource;
 
         /// <summary>
-        /// Event fired when an exception is thrown during a call to 
+        /// Event fired when an exception is thrown during a call to
         /// <see cref="BaseData.Reader(SubscriptionDataConfig, string, DateTime, bool)"/>
         /// </summary>
         public event EventHandler<ReaderErrorEventArgs> ReaderError;
@@ -73,7 +73,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             SubscriptionDataSourceReader.CheckRemoteFileCache();
 
             IStreamReader reader = null;
-            var instances = new BaseDataCollection();
             try
             {
                 switch (source.TransportMedium)
@@ -91,24 +90,27 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
 
                 var raw = "";
-                try
+                while (!reader.EndOfStream)
                 {
-                    raw = reader.ReadLine();
-                    var result = _factory.Reader(_config, raw, _date, _isLiveMode);
-                    instances = result as BaseDataCollection;
-                    if (instances == null)
+                    BaseDataCollection instances;
+                    try
                     {
-                        OnInvalidSource(source, new Exception("Reader must generate a BaseDataCollection with the FileFormat.Collection"));
+                        raw = reader.ReadLine();
+                        var result = _factory.Reader(_config, raw, _date, _isLiveMode);
+                        instances = result as BaseDataCollection;
+                        if (instances == null)
+                        {
+                            OnInvalidSource(source, new Exception("Reader must generate a BaseDataCollection with the FileFormat.Collection"));
+                            continue;
+                        }
                     }
-                }
-                catch (Exception err)
-                {
-                    OnReaderError(raw, err);
-                }
+                    catch (Exception err)
+                    {
+                        OnReaderError(raw, err);
+                        continue;
+                    }
 
-                foreach (var instance in instances.Data)
-                {
-                    yield return instance;
+                    yield return instances;
                 }
             }
             finally

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -1,0 +1,158 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+using QuantConnect.Util;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="ISubscriptionEnumeratorFactory"/> to handle live custom data.
+    /// </summary>
+    public class LiveCustomDataSubscriptionEnumeratorFactory : ISubscriptionEnumeratorFactory
+    {
+        private readonly ITimeProvider _timeProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiveCustomDataSubscriptionEnumeratorFactory"/> class
+        /// </summary>
+        /// <param name="timeProvider">Time provider from data feed</param>
+        public LiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider)
+        {
+            _timeProvider = timeProvider;
+        }
+
+        /// <summary>
+        /// Creates an enumerator to read the specified request.
+        /// </summary>
+        /// <param name="request">The subscription request to be read</param>
+        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
+        /// <returns>An enumerator reading the subscription request</returns>
+        public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
+        {
+            var config = request.Configuration;
+
+            // frontier value used to prevent emitting duplicate time stamps between refreshed enumerators
+            // also provides some immediate fast-forward to handle spooling through remote files quickly
+            var frontier = Ref.Create(DateTime.MinValue);
+            var lastSourceRefreshTime = DateTime.MinValue;
+            var sourceFactory = (BaseData) ObjectActivator.GetActivator(config.Type).Invoke(new object[] {config.Type});
+
+            // this is refreshing the enumerator stack for each new source
+            var refresher = new RefreshEnumerator<BaseData>(() =>
+            {
+                // rate limit the refresh of this enumerator stack
+                var utcNow = _timeProvider.GetUtcNow();
+                var minimumTimeBetweenCalls = GetMinimumTimeBetweenCalls(config.Increment);
+                if (utcNow - lastSourceRefreshTime < minimumTimeBetweenCalls)
+                {
+                    return Enumerable.Empty<BaseData>().GetEnumerator();
+                }
+
+                lastSourceRefreshTime = utcNow;
+                var localDate = utcNow.ConvertFromUtc(config.ExchangeTimeZone).Date;
+                var source = sourceFactory.GetSource(config, localDate, true);
+
+                // fetch the new source and enumerate the data source reader
+                var enumerator = EnumerateDataSourceReader(config, dataProvider, frontier, source, localDate);
+
+                if (SourceRequiresFastForward(source))
+                {
+                    // apply fast forward logic for file transport mediums
+                    var maximumDataAge = GetMaximumDataAge(config.Increment);
+                    enumerator = new FastForwardEnumerator(enumerator, _timeProvider, config.ExchangeTimeZone, maximumDataAge);
+                }
+                else
+                {
+                    // rate limit calls to this enumerator stack
+                    enumerator = new RateLimitEnumerator<BaseData>(enumerator, _timeProvider, minimumTimeBetweenCalls);
+                }
+
+                if (source.Format == FileFormat.Collection)
+                {
+                    // unroll collections into individual data points after fast forward/rate limiting applied
+                    enumerator = enumerator.SelectMany(data =>
+                    {
+                        var collection = data as BaseDataCollection;
+                        return collection?.Data.GetEnumerator() ?? new List<BaseData> {data}.GetEnumerator();
+                    });
+                }
+
+                return enumerator;
+            });
+
+            // prevent calls to the enumerator stack if current is in the future
+            var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Security.Exchange.TimeZone, request.StartTimeUtc, request.EndTimeUtc);
+            return new FrontierAwareEnumerator(refresher, _timeProvider, timeZoneOffsetProvider);
+        }
+
+        private IEnumerator<BaseData> EnumerateDataSourceReader(SubscriptionDataConfig config, IDataProvider dataProvider, Ref<DateTime> localFrontier, SubscriptionDataSource source, DateTime localDate)
+        {
+            using (var dataCacheProvider = new SingleEntryDataCacheProvider(dataProvider))
+            {
+                var newLocalFrontier = localFrontier.Value;
+                var dataSourceReader = GetSubscriptionDataSourceReader(source, dataCacheProvider, config, localDate);
+                foreach (var datum in dataSourceReader.Read(source))
+                {
+                    // always skip past all times emitted on the previous invocation of this enumerator
+                    // this allows data at the same time from the same refresh of the source while excluding
+                    // data from different refreshes of the source
+                    if (datum.EndTime > localFrontier.Value)
+                    {
+                        yield return datum;
+                    }
+
+                    newLocalFrontier = Time.Max(datum.EndTime, newLocalFrontier);;
+                }
+
+                localFrontier.Value = newLocalFrontier;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ISubscriptionDataSourceReader"/> for the specified source
+        /// </summary>
+        protected virtual ISubscriptionDataSourceReader GetSubscriptionDataSourceReader(SubscriptionDataSource source,
+            IDataCacheProvider dataCacheProvider,
+            SubscriptionDataConfig config,
+            DateTime date
+            )
+        {
+            return SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, true);
+        }
+
+        private bool SourceRequiresFastForward(SubscriptionDataSource source)
+        {
+            return source.TransportMedium == SubscriptionTransportMedium.LocalFile
+                || source.TransportMedium == SubscriptionTransportMedium.RemoteFile;
+        }
+
+        private static TimeSpan GetMinimumTimeBetweenCalls(TimeSpan increment)
+        {
+            return TimeSpan.FromTicks(Math.Min(increment.Ticks, TimeSpan.FromMinutes(30).Ticks));
+        }
+
+        private static TimeSpan GetMaximumDataAge(TimeSpan increment)
+        {
+            return TimeSpan.FromTicks(Math.Max(increment.Ticks, TimeSpan.FromSeconds(5).Ticks));
+        }
+    }
+}

--- a/Engine/DataFeeds/Enumerators/FastForwardEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/FastForwardEnumerator.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,8 +83,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             }
 
             // we've exhausted the underlying enumerator, iterator completed
-            _current = _enumerator.Current;
-            return true;
+            _current = null;
+            return false;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/Enumerators/FrontierAwareEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/FrontierAwareEnumerator.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -94,20 +94,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 
             if (underlyingCurrent != null && underlyingCurrent.EndTime <= localFrontier)
             {
-                // only emit if new data available (skip custom data if same time/value)
-                if (_lastEmittedValue != null && 
-                    _lastEmittedValue.DataType == MarketDataType.Base && 
-                    _lastEmittedValue.EndTime == underlyingCurrent.EndTime &&
-                    _lastEmittedValue.Value == underlyingCurrent.Value)
-                {
-                    _current = null;
-                }
-                else
-                {
-                    _needsMoveNext = true;
-                    _current = underlyingCurrent;
-                    _lastEmittedValue = _current;
-                }
+                _needsMoveNext = true;
+                _current = underlyingCurrent;
+                _lastEmittedValue = _current;
             }
             else
             {

--- a/Engine/DataFeeds/Enumerators/RateLimitEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/RateLimitEnumerator.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using QuantConnect.Data;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 {
@@ -26,22 +25,22 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
     /// an <see cref="ITimeProvider"/> instance and calls to the underlying enumerator are limited
     /// to a minimum time between each call.
     /// </summary>
-    public class RateLimitEnumerator : IEnumerator<BaseData>
+    public class RateLimitEnumerator<T> : IEnumerator<T>
     {
-        private BaseData _current;
+        private T _current;
         private DateTime _lastCallTime;
 
         private readonly ITimeProvider _timeProvider;
-        private readonly IEnumerator<BaseData> _enumerator;
+        private readonly IEnumerator<T> _enumerator;
         private readonly TimeSpan _minimumTimeBetweenCalls;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RateLimitEnumerator"/> class
+        /// Initializes a new instance of the <see cref="RateLimitEnumerator{T}"/> class
         /// </summary>
         /// <param name="enumerator">The underlying enumerator to place rate limits on</param>
         /// <param name="timeProvider">Time provider used for determing the time between calls</param>
         /// <param name="minimumTimeBetweenCalls">The minimum time allowed between calls to the underlying enumerator</param>
-        public RateLimitEnumerator(IEnumerator<BaseData> enumerator, ITimeProvider timeProvider, TimeSpan minimumTimeBetweenCalls)
+        public RateLimitEnumerator(IEnumerator<T> enumerator, ITimeProvider timeProvider, TimeSpan minimumTimeBetweenCalls)
         {
             _enumerator = enumerator;
             _timeProvider = timeProvider;
@@ -68,7 +67,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 if (!_enumerator.MoveNext())
                 {
                     // our underlying is finished
-                    _current = null;
+                    _current = default(T);
                     return false;
                 }
 
@@ -79,7 +78,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             else
             {
                 // we've been rate limitted
-                _current = null;
+                _current = default(T);
             }
 
             return true;
@@ -100,7 +99,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <returns>
         /// The element in the collection at the current position of the enumerator.
         /// </returns>
-        public BaseData Current
+        public T Current
         {
             get { return _current; }
         }

--- a/Engine/DataFeeds/Enumerators/RefreshEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/RefreshEnumerator.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 {
@@ -61,6 +62,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             }
             else
             {
+                _enumerator.DisposeSafely();
+
                 _enumerator = null;
                 _current = default(T);
             }

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -433,7 +433,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // At Second and Minute resolution, it will refresh every second and minute respectively
                     // At Hour and Daily resolutions, it will refresh every 30 minutes
                     var minimumTimeBetweenCalls = Math.Min(request.Configuration.Increment.Ticks, TimeSpan.FromMinutes(30).Ticks);
-                    var rateLimit = new RateLimitEnumerator(refresher, _timeProvider, TimeSpan.FromTicks(minimumTimeBetweenCalls));
+                    var rateLimit = new RateLimitEnumerator<BaseData>(refresher, _timeProvider, TimeSpan.FromTicks(minimumTimeBetweenCalls));
                     _customExchange.AddEnumerator(request.Configuration.Symbol, rateLimit);
 
                     var enqueable = new EnqueueableEnumerator<BaseData>();
@@ -666,7 +666,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                 // rate limit the refreshing of the stack to the requested interval
                 var minimumTimeBetweenCalls = Math.Min(config.Increment.Ticks, TimeSpan.FromMinutes(30).Ticks);
-                var rateLimit = new RateLimitEnumerator(refresher, _timeProvider, TimeSpan.FromTicks(minimumTimeBetweenCalls));
+                var rateLimit = new RateLimitEnumerator<BaseData>(refresher, _timeProvider, TimeSpan.FromTicks(minimumTimeBetweenCalls));
                 var enqueueable = new EnqueueableEnumerator<BaseData>();
                 _customExchange.AddEnumerator(new EnumeratorHandler(config.Symbol, rateLimit, enqueueable));
                 enumerator = enqueueable;

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -145,6 +145,7 @@
     <Compile Include="DataFeeds\ApiDataProvider.cs" />
     <Compile Include="DataFeeds\BacktestingOptionChainProvider.cs" />
     <Compile Include="DataFeeds\CachingOptionChainProvider.cs" />
+    <Compile Include="DataFeeds\Enumerators\Factories\LiveCustomDataSubscriptionEnumeratorFactory.cs" />
     <Compile Include="DataFeeds\Enumerators\QuoteBarFillForwardEnumerator.cs" />
     <Compile Include="DataFeeds\LiveOptionChainProvider.cs" />
     <Compile Include="DataFeeds\SingleEntryDataCacheProvider.cs" />

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -1,0 +1,462 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Equity;
+
+namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
+{
+    public class LiveCustomDataSubscriptionEnumeratorFactoryTests
+    {
+        [TestFixture]
+        public class WhenCreatingEnumeratorForRestData
+        {
+            private readonly DateTime _referenceLocal = new DateTime(2017, 10, 12);
+            private readonly DateTime _referenceUtc = new DateTime(2017, 10, 12).ConvertToUtc(TimeZones.NewYork);
+
+            private ManualTimeProvider _timeProvider;
+            private IEnumerator<BaseData> _enumerator;
+            private Mock<ISubscriptionDataSourceReader> _dataSourceReader;
+
+            [SetUp]
+            public void Given()
+            {
+                _timeProvider = new ManualTimeProvider(_referenceUtc);
+
+                _dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+                _dataSourceReader.Setup(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
+                        sds.Source == "rest.source" &&
+                        sds.TransportMedium == SubscriptionTransportMedium.Rest &&
+                        sds.Format == FileFormat.Csv))
+                    )
+                    .Returns(Enumerable.Range(0, 100)
+                        .Select(i => new RestData
+                        {
+                            EndTime = _referenceLocal.AddSeconds(i)
+                        }))
+                        .Verifiable();
+
+                var quoteCurrency = new Cash(CashBook.AccountCurrency, 0, 1);
+                var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, Symbols.SPY, SecurityType.Equity);
+                var config = new SubscriptionDataConfig(typeof(RestData), Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+                var security = new Equity(Symbols.SPY, exchangeHours, quoteCurrency, SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                var request = new SubscriptionRequest(false, null, security, config, _referenceUtc, _referenceUtc.AddDays(1));
+
+                var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(_timeProvider, _dataSourceReader.Object);
+                _enumerator = factory.CreateEnumerator(request, null);
+            }
+
+            [Test]
+            public void YieldsDataEachSecondAsTimePasses()
+            {
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNotNull(_enumerator.Current);
+                Assert.AreEqual(_referenceLocal, _enumerator.Current.EndTime);
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                _timeProvider.AdvanceSeconds(1);
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNotNull(_enumerator.Current);
+                Assert.AreEqual(_referenceLocal.AddSeconds(1), _enumerator.Current.EndTime);
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                _dataSourceReader.Verify(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
+                        sds.Source == "rest.source" &&
+                        sds.TransportMedium == SubscriptionTransportMedium.Rest &&
+                        sds.Format == FileFormat.Csv))
+                    , Times.Once);
+            }
+        }
+
+        [TestFixture]
+        public class WhenCreatingEnumeratorForRestCollectionData
+        {
+            private const int DataPerTimeStep = 3;
+            private readonly DateTime _referenceLocal = new DateTime(2017, 10, 12);
+            private readonly DateTime _referenceUtc = new DateTime(2017, 10, 12).ConvertToUtc(TimeZones.NewYork);
+
+            private ManualTimeProvider _timeProvider;
+            private IEnumerator<BaseData> _enumerator;
+            private Mock<ISubscriptionDataSourceReader> _dataSourceReader;
+
+            [SetUp]
+            public void Given()
+            {
+                _timeProvider = new ManualTimeProvider(_referenceUtc);
+
+                _dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+                _dataSourceReader.Setup(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
+                        sds.Source == "rest.collection.source" &&
+                        sds.TransportMedium == SubscriptionTransportMedium.Rest &&
+                        sds.Format == FileFormat.Collection))
+                    )
+                    .Returns(Enumerable.Range(0, 100)
+                        .Select(i => new BaseDataCollection(_referenceLocal.AddSeconds(i), Symbols.SPY, Enumerable.Range(0, DataPerTimeStep)
+                            .Select(_ => new RestCollectionData {EndTime = _referenceLocal.AddSeconds(i)})))
+                    )
+                    .Verifiable();
+
+                var quoteCurrency = new Cash(CashBook.AccountCurrency, 0, 1);
+                var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, Symbols.SPY, SecurityType.Equity);
+                var config = new SubscriptionDataConfig(typeof(RestCollectionData), Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+                var security = new Equity(Symbols.SPY, exchangeHours, quoteCurrency, SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                var request = new SubscriptionRequest(false, null, security, config, _referenceUtc, _referenceUtc.AddDays(1));
+
+                var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(_timeProvider, _dataSourceReader.Object);
+                _enumerator = factory.CreateEnumerator(request, null);
+            }
+
+            [Test]
+            public void YieldsGroupOfDataEachSecond()
+            {
+                for (int i = 0; i < DataPerTimeStep; i++)
+                {
+                    Assert.IsTrue(_enumerator.MoveNext());
+                    Assert.IsNotNull(_enumerator.Current, $"Index {i} is null.");
+                    Assert.AreEqual(_referenceLocal, _enumerator.Current.EndTime);
+                }
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                _timeProvider.AdvanceSeconds(1);
+
+                for (int i = 0; i < DataPerTimeStep; i++)
+                {
+                    Assert.IsTrue(_enumerator.MoveNext());
+                    Assert.IsNotNull(_enumerator.Current);
+                    Assert.AreEqual(_referenceLocal.AddSeconds(1), _enumerator.Current.EndTime);
+                }
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                _dataSourceReader.Verify(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
+                        sds.Source == "rest.collection.source" &&
+                        sds.TransportMedium == SubscriptionTransportMedium.Rest &&
+                        sds.Format == FileFormat.Collection))
+                    , Times.Once);
+            }
+        }
+
+        [TestFixture]
+        public class WhenCreatingEnumeratorForSecondRemoteFileData
+        {
+            private readonly DateTime _referenceLocal = new DateTime(2017, 10, 12);
+            private readonly DateTime _referenceUtc = new DateTime(2017, 10, 12).ConvertToUtc(TimeZones.NewYork);
+
+            private ManualTimeProvider _timeProvider;
+            private IEnumerator<BaseData> _enumerator;
+            private Mock<ISubscriptionDataSourceReader> _dataSourceReader;
+
+            [SetUp]
+            public void Given()
+            {
+                _timeProvider = new ManualTimeProvider(_referenceUtc);
+
+                _dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+                _dataSourceReader.Setup(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
+                        sds.Source == "remote.file.source" &&
+                        sds.TransportMedium == SubscriptionTransportMedium.RemoteFile &&
+                        sds.Format == FileFormat.Csv))
+                    )
+                    .Returns(Enumerable.Range(0, 100)
+                        .Select(i => new RemoteFileData
+                        {
+                            // include past data
+                            EndTime = _referenceLocal.AddSeconds(i - 95)
+                        }))
+                    .Verifiable();
+
+                var quoteCurrency = new Cash(CashBook.AccountCurrency, 0, 1);
+                var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, Symbols.SPY, SecurityType.Equity);
+                var config = new SubscriptionDataConfig(typeof(RemoteFileData), Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+                var security = new Equity(Symbols.SPY, exchangeHours, quoteCurrency, SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                var request = new SubscriptionRequest(false, null, security, config, _referenceUtc, _referenceUtc.AddDays(1));
+
+                var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(_timeProvider, _dataSourceReader.Object);
+                _enumerator = factory.CreateEnumerator(request, null);
+            }
+
+            [Test]
+            public void YieldsDataEachSecondAsTimePasses()
+            {
+                // most recent 5 seconds of data
+                for (int i = 5; i >= 0; i--)
+                {
+                    Assert.IsTrue(_enumerator.MoveNext());
+                    Assert.IsNotNull(_enumerator.Current);
+                    Assert.AreEqual(_referenceLocal.AddSeconds(-i), _enumerator.Current.EndTime);
+                }
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                _timeProvider.AdvanceSeconds(1);
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNotNull(_enumerator.Current);
+                Assert.AreEqual(_referenceLocal.AddSeconds(1), _enumerator.Current.EndTime);
+
+                // these are rate limited by the refresh enumerator's func guard clause
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+
+                _dataSourceReader.Verify(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
+                        sds.Source == "remote.file.source" &&
+                        sds.TransportMedium == SubscriptionTransportMedium.RemoteFile &&
+                        sds.Format == FileFormat.Csv))
+                    , Times.Once);
+            }
+        }
+
+        [TestFixture]
+        public class WhenCreatingEnumeratorForDailyRemoteFileData
+        {
+            private int _dataPointsAfterReference = 1;
+            private readonly DateTime _referenceLocal = new DateTime(2017, 10, 12);
+            private readonly DateTime _referenceUtc = new DateTime(2017, 10, 12).ConvertToUtc(TimeZones.NewYork);
+
+            private ManualTimeProvider _timeProvider;
+            private IEnumerator<BaseData> _enumerator;
+            private Mock<ISubscriptionDataSourceReader> _dataSourceReader;
+
+            [SetUp]
+            public void Given()
+            {
+                _timeProvider = new ManualTimeProvider(_referenceUtc);
+
+                _dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+                _dataSourceReader.Setup(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
+                        sds.Source == "remote.file.source" &&
+                        sds.TransportMedium == SubscriptionTransportMedium.RemoteFile &&
+                        sds.Format == FileFormat.Csv))
+                    )
+                    .Returns(() => Enumerable.Range(0, 100)
+                        .Select(i => new RemoteFileData
+                        {
+                            // include past data
+                            EndTime = _referenceLocal.Add(TimeSpan.FromDays(i - (100 - _dataPointsAfterReference - 1)))
+                        }))
+                    .Verifiable();
+
+                var quoteCurrency = new Cash(CashBook.AccountCurrency, 0, 1);
+                var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, Symbols.SPY, SecurityType.Equity);
+                var config = new SubscriptionDataConfig(typeof(RemoteFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+                var security = new Equity(Symbols.SPY, exchangeHours, quoteCurrency, SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                var request = new SubscriptionRequest(false, null, security, config, _referenceUtc, _referenceUtc.AddDays(1));
+
+                var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(_timeProvider, _dataSourceReader.Object);
+                _enumerator = factory.CreateEnumerator(request, null);
+            }
+
+            [Test]
+            public void YieldsDataEachDayAsTimePasses()
+            {
+                // previous point is exactly one resolution step behind, so it emits
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNotNull(_enumerator.Current);
+                Assert.AreEqual(_referenceLocal.AddDays(-1), _enumerator.Current.EndTime);
+                VerifyGetSourceInvocation(1);
+
+                // yields the data for the current time
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNotNull(_enumerator.Current);
+                Assert.AreEqual(_referenceLocal, _enumerator.Current.EndTime);
+                VerifyGetSourceInvocation(0);
+
+                // these are limitted by frontier aware enumerator preventing future data
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(0);
+
+                // still prevented by frontier aware
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(0);
+
+                _timeProvider.Advance(Time.OneDay);
+
+                // now we can yield the next data point as it has passed frontier time
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNotNull(_enumerator.Current);
+                Assert.AreEqual(_referenceLocal.AddDays(1), _enumerator.Current.EndTime);
+                VerifyGetSourceInvocation(0);
+
+                // this call exhaused the enumerator stack and yields a null result
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(0);
+
+                // this call refrshes the enumerator stack but finds no data ahead of the frontier
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(1);
+
+                _timeProvider.Advance(TimeSpan.FromMinutes(30));
+
+                // time advances 30 minutes so we'll try to refresh again
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(1);
+
+                _timeProvider.Advance(Time.OneDay);
+
+                // now to the next day, we'll try again and get data
+                _dataPointsAfterReference++;
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNotNull(_enumerator.Current);
+                Assert.AreEqual(_referenceLocal.AddDays(2), _enumerator.Current.EndTime);
+                VerifyGetSourceInvocation(1);
+
+                _timeProvider.Advance(TimeSpan.FromHours(1));
+
+                // out of data
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(0);
+
+                _timeProvider.Advance(TimeSpan.FromHours(1));
+
+                // time advanced so we'll try to refresh the souce again, but exhaust the stack because no data
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(1);
+
+                // move forward to next whole day, midnight
+                _timeProvider.Advance(Time.OneDay.Subtract(TimeSpan.FromHours(2.5)));
+
+                // the day elapsed but there's still no data available
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(1);
+
+                // this is rate limited by the 30 minute guard for daily data
+                _timeProvider.Advance(TimeSpan.FromMinutes(29));
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(0);
+
+                // another 30 minutes elapsed and now there's data available
+                _dataPointsAfterReference++;
+                _timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNotNull(_enumerator.Current);
+                Assert.AreEqual(_referenceLocal.AddDays(3), _enumerator.Current.EndTime);
+                VerifyGetSourceInvocation(1);
+
+                // exhausted the stack
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(0);
+
+                // rate limited
+                Assert.IsTrue(_enumerator.MoveNext());
+                Assert.IsNull(_enumerator.Current);
+                VerifyGetSourceInvocation(0);
+            }
+
+            private int _runningCount;
+            private void VerifyGetSourceInvocation(int count)
+            {
+                _runningCount += count;
+                _dataSourceReader.Verify(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
+                        sds.Source == "remote.file.source" &&
+                        sds.TransportMedium == SubscriptionTransportMedium.RemoteFile &&
+                        sds.Format == FileFormat.Csv))
+                    , Times.Exactly(_runningCount));
+            }
+        }
+
+        class RestData : BaseData
+        {
+            public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+            {
+                return new SubscriptionDataSource("rest.source", SubscriptionTransportMedium.Rest);
+            }
+        }
+
+        class RestCollectionData : BaseData
+        {
+            public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+            {
+                return new SubscriptionDataSource("rest.collection.source", SubscriptionTransportMedium.Rest, FileFormat.Collection);
+            }
+        }
+
+        class RemoteFileData : BaseData
+        {
+            public override DateTime EndTime
+            {
+                get { return Time + QuantConnect.Time.OneDay; }
+                set { Time = value - QuantConnect.Time.OneDay; }
+            }
+
+            public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+            {
+                return new SubscriptionDataSource("remote.file.source", SubscriptionTransportMedium.RemoteFile);
+            }
+        }
+
+        class TestableLiveCustomDataSubscriptionEnumeratorFactory : LiveCustomDataSubscriptionEnumeratorFactory
+        {
+            private readonly ISubscriptionDataSourceReader _dataSourceReader;
+
+            public TestableLiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, ISubscriptionDataSourceReader dataSourceReader)
+                : base(timeProvider)
+            {
+                _dataSourceReader = dataSourceReader;
+            }
+
+            protected override ISubscriptionDataSourceReader GetSubscriptionDataSourceReader(SubscriptionDataSource source,
+                IDataCacheProvider dataCacheProvider,
+                SubscriptionDataConfig config,
+                DateTime date)
+            {
+                return _dataSourceReader;
+            }
+        }
+    }
+}

--- a/Tests/Engine/DataFeeds/Enumerators/FastForwardEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/FastForwardEnumeratorTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,6 +83,25 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
 
             Assert.IsTrue(fastForward.MoveNext());
             Assert.AreEqual(start.AddSeconds(2), fastForward.Current.Time);
+        }
+
+        [Test]
+        public void CurrentIsNullWhenEnumeratorReturnsFalse()
+        {
+            var start = new DateTime(2015, 10, 10, 13, 0, 0);
+            var data = new List<Tick>
+            {
+                new Tick {Time = start.AddSeconds(0)}
+            };
+
+            var timeProvider = new ManualTimeProvider(start, TimeZones.Utc);
+            var fastForward = new FastForwardEnumerator(data.GetEnumerator(), timeProvider, TimeZones.Utc, TimeSpan.FromSeconds(0.5));
+
+            Assert.IsTrue(fastForward.MoveNext());
+            Assert.IsNotNull(fastForward.Current);
+
+            Assert.IsFalse(fastForward.MoveNext());
+            Assert.IsNull(fastForward.Current);
         }
     }
 }

--- a/Tests/Engine/DataFeeds/Enumerators/RateLimitEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/RateLimitEnumeratorTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,10 +17,10 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
-using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
 {
@@ -33,7 +33,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var currentTime = new DateTime(2015, 10, 10, 13, 6, 0);
             var timeProvider = new ManualTimeProvider(currentTime, TimeZones.Utc);
             var data = Enumerable.Range(0, 100).Select(x => new Tick {Symbol = CreateSymbol(x)}).GetEnumerator();
-            var rateLimit = new RateLimitEnumerator(data, timeProvider, Time.OneSecond);
+            var rateLimit = new RateLimitEnumerator<BaseData>(data, timeProvider, Time.OneSecond);
 
             Assert.IsTrue(rateLimit.MoveNext());
 

--- a/Tests/Engine/DataFeeds/Enumerators/RefreshEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/RefreshEnumeratorTests.cs
@@ -53,6 +53,18 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
         }
 
         [Test]
+        public void UnderlyingEnumeratorDisposed_WhenUnderlyingEnumeratorReturnsFalse()
+        {
+            var fakeEnumerator = new Mock<IEnumerator<int?>>();
+            fakeEnumerator.Setup(e => e.MoveNext()).Returns(false);
+            fakeEnumerator.Setup(e => e.Dispose()).Verifiable();
+            var refresher = new RefreshEnumerator<int?>(() => fakeEnumerator.Object);
+            refresher.MoveNext();
+
+            fakeEnumerator.Verify(enumerator => enumerator.Dispose(), Times.Once);
+        }
+
+        [Test]
         public void DisposeCallsUnderlyingDispose()
         {
             var fakeEnumerator = new Mock<IEnumerator<int?>>();

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Engine\DataFeeds\Enumerators\BaseDataCollectionAggregatorEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\EnqueableEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\Factories\FineFundamentalSubscriptionEnumeratorFactoryTests.cs" />
+    <Compile Include="Engine\DataFeeds\Enumerators\Factories\LiveCustomDataSubscriptionEnumeratorFactoryTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\FastForwardEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\FrontierAwareEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\LiveFillForwardEnumeratorTests.cs" />


### PR DESCRIPTION
>NOTE: Cloud integration testing completed.
- [x] Test bitcoin rest 1 second, 1 minute
- [x] Test bitcoin rest daily
- [x] Test dailyfx in cloud 1 second
- [x] Test quandl daily
- [x] Test TopGainers - refactored selection logic into proper universe
- [x] Test custom data universe, nyse top gainers

This change aims to provide some more guarantees around our live custom data stack.
The big improvement here (besides test and code organization) is that we're now being
smart about applying rate limit and fast forward behaviors. Enumerator stack refreshes
are limited manually while rest rate limits are enforced via `RefreshEnumerator`. We make
this choice based on the `SubscriptionTransportMedium` -- basically, in live it doesn't make
sense to fast forward a rest endpoint. Likewise it doesn't make sense to rate limit access to
a file that's already been downloaded, instead we want to rate limit actual communication
with remote servers which happens every call for rest subscriptions and on each enumerator
stack refresh from file subscriptions.

I added some fairly simple test cases to cover the big 3 cases being addressed here:
1. Normal rest service, data point per invocation
2. Collection rest service, multiple data points per invocation
3. Remote files with historical and/or future data