### PR TITLE
Refactors indicator Update(DateTime, decimal) method

### DIFF
--- a/Algorithm.Python/EmaCrossUniverseSelectionAlgorithm.py
+++ b/Algorithm.Python/EmaCrossUniverseSelectionAlgorithm.py
@@ -99,9 +99,7 @@ class SymbolData(object):
         self.scale = 0
 
     def update(self, time, value):
-        datapoint = IndicatorDataPoint(time, value)
-
-        if self.fast.Update(datapoint) and self.slow.Update(datapoint):
+        if self.fast.Update(time, value) and self.slow.Update(time, value):
             fast = self.fast.Current.Value
             slow = self.slow.Current.Value
             self.is_uptrend = fast > slow * self.tolerance

--- a/Algorithm.Python/WarmupHistoryAlgorithm.py
+++ b/Algorithm.Python/WarmupHistoryAlgorithm.py
@@ -57,9 +57,8 @@ class WarmupHistoryAlgorithm(QCAlgorithm):
         self.Log(str(history.loc["NZDUSD"].tail()))
 
         for index, row in history.loc["EURUSD"].iterrows():
-            datapoint = IndicatorDataPoint(index, row["close"])
-            self.fast.Update(datapoint)
-            self.slow.Update(datapoint)
+            self.fast.Update(index, row["close"])
+            self.slow.Update(index, row["close"])
 
         self.Log("FAST {0} READY. Samples: {1}".format("IS" if self.fast.IsReady else "IS NOT", self.fast.Samples))
         self.Log("SLOW {0} READY. Samples: {1}".format("IS" if self.slow.IsReady else "IS NOT", self.slow.Samples))

--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -98,6 +98,25 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
+        /// Updates the state of this indicator with the given value and returns true
+        /// if this indicator is ready, false otherwise
+        /// </summary>
+        /// <param name="time">The time associated with the value</param>
+        /// <param name="value">The value to use to update this indicator</param>
+        /// <returns>True if this indicator is ready, false otherwise</returns>
+        public bool Update(DateTime time, decimal value)
+        {
+            if (typeof(T) == typeof(IndicatorDataPoint))
+            {
+                return Update((T)Activator.CreateInstance(typeof(T), new object[] { time, value }));
+            }
+            else
+            {
+                throw new NotSupportedException(string.Format("{0} does not support Update(DateTime, decimal) method overload. Use Update({1}) instead.", GetType().Name, typeof(T).Name));
+            }
+        }
+
+        /// <summary>
         /// Resets this indicator to its initial state
         /// </summary>
         public virtual void Reset()

--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -108,7 +108,7 @@ namespace QuantConnect.Indicators
         {
             if (typeof(T) == typeof(IndicatorDataPoint))
             {
-                return Update((T)Activator.CreateInstance(typeof(T), new object[] { time, value }));
+                return Update((T)(object)new IndicatorDataPoint(time, value));
             }
             else
             {

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -27,19 +27,6 @@ namespace QuantConnect.Indicators
     public static class IndicatorExtensions
     {
         /// <summary>
-        /// Updates the state of this indicator with the given value and returns true
-        /// if this indicator is ready, false otherwise
-        /// </summary>
-        /// <param name="indicator">The indicator to be updated</param>
-        /// <param name="time">The time associated with the value</param>
-        /// <param name="value">The value to use to update this indicator</param>
-        /// <returns>True if this indicator is ready, false otherwise</returns>
-        public static bool Update(this IndicatorBase<IndicatorDataPoint> indicator, DateTime time, decimal value)
-        {
-            return indicator.Update(new IndicatorDataPoint(time, value));
-        }
-
-        /// <summary>
         /// Configures the second indicator to receive automatic updates from the first by attaching an event handler
         /// to first.DataConsolidated
         /// </summary>

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -27,6 +27,19 @@ namespace QuantConnect.Indicators
     public static class IndicatorExtensions
     {
         /// <summary>
+        /// Updates the state of this indicator with the given value and returns true
+        /// if this indicator is ready, false otherwise
+        /// </summary>
+        /// <param name="indicator">The indicator to be updated</param>
+        /// <param name="time">The time associated with the value</param>
+        /// <param name="value">The value to use to update this indicator</param>
+        /// <returns>True if this indicator is ready, false otherwise</returns>
+        public static bool Update(this IndicatorBase<IndicatorDataPoint> indicator, DateTime time, decimal value)
+        {
+            return indicator.Update(new IndicatorDataPoint(time, value));
+        }
+
+        /// <summary>
         /// Configures the second indicator to receive automatic updates from the first by attaching an event handler
         /// to first.DataConsolidated
         /// </summary>


### PR DESCRIPTION
- Moves indicator Update(DateTime, decimal) method overload from the extension class to the base class.
With this change, python algorithms can access this overload since pythonnet doesn't support extension methods.
- Changes python algorithms to use Update(DateTime, decimal) method