### PR TITLE
Set mono version equal to docker mono version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono:
-  - latest
+  - 5.2.0
 solution: QuantConnect.Lean.sln
 install:
   - nuget restore QuantConnect.Lean.sln


### PR DESCRIPTION
We should always be running our tests against the same version of mono
that we use in production. This was noticed only after travis C# upgraded
to mono 5.4.0 from 5.2.0 which apparently has a regression.

Forces mono version to ~~4.6.1~~  5.2.0

https://github.com/travis-ci/travis-ci/issues/8594

Unable to set to 4.6.1.5 as in the docker file. It appears that travis doesn't like patch numbers in the version. Looking at the build logs it appears to be selecting 4.6.1.5 -- I'm guessing it will continue to select the highest patch for version 4.6.1.x.

UPDATE: 4.6.1 builds failed due to the following compilation error. Setting to 5.2 (previous default in travis) so we can proceed, but I think this requires a little more investigation.
```
QCAlgorithm.Python.cs(496,13): error CS1502: The best overloaded method match for `QuantConnect.Algorithm.QCAlgorithm.RegisterIndicator(QuantConnect.Symbol, QuantConnect.Indicators.IndicatorBase<QuantConnect.Data.Market.IBaseDataBar>, QuantConnect.Resolution?, System.Func<QuantConnect.Data.IBaseData,QuantConnect.Data.Market.IBaseDataBar>)' has some invalid arguments
QCAlgorithm.Python.cs(496,39): error CS1503: Argument `#2' cannot convert `QuantConnect.Indicators.FilteredIdentity' expression to type `QuantConnect.Indicators.IndicatorBase<QuantConnect.Data.Market.IBaseDataBar>'
QCAlgorithm.Python.cs(516,13): error CS1502: The best overloaded method match for `QuantConnect.Algorithm.QCAlgorithm.RegisterIndicator(QuantConnect.Symbol, QuantConnect.Indicators.IndicatorBase<QuantConnect.Data.Market.IBaseDataBar>, QuantConnect.Resolution?, System.Func<QuantConnect.Data.IBaseData,QuantConnect.Data.Market.IBaseDataBar>)' has some invalid arguments
QCAlgorithm.Python.cs(516,39): error CS1503: Argument `#2' cannot convert `QuantConnect.Indicators.FilteredIdentity' expression to type `QuantConnect.Indicators.IndicatorBase<QuantConnect.Data.Market.IBaseDataBar>'
```
