### PR TITLE
Allow trading of benchmark security when selected by universe selection

### DIFF
--- a/Common/Data/SubscriptionDataConfigList.cs
+++ b/Common/Data/SubscriptionDataConfigList.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ using System.Linq;
 namespace QuantConnect.Data
 {
     /// <summary>
-    /// Provides convenient methods for holding several <see cref="SubscriptionDataConfig"/> 
+    /// Provides convenient methods for holding several <see cref="SubscriptionDataConfig"/>
     /// </summary>
     public class SubscriptionDataConfigList : List<SubscriptionDataConfig>
     {
@@ -34,11 +34,7 @@ namespace QuantConnect.Data
         /// </summary>
         public bool IsInternalFeed
         {
-            get
-            {
-                var first = this.FirstOrDefault();
-                return first != null && first.IsInternalFeed;
-            }
+            get { return Count != 0 && this.All(sdc => sdc.IsInternalFeed); }
         }
 
         /// <summary>

--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -193,7 +193,7 @@ namespace QuantConnect.Data.UniverseSelection
                     isUniverseSubscription: false,
                     universe: this,
                     security: security,
-                    configuration: new SubscriptionDataConfig(config),
+                    configuration: new SubscriptionDataConfig(config, isInternalFeed: false),
                     startTimeUtc: currentTimeUtc,
                     endTimeUtc: maximumEndTimeUtc
                     )


### PR DESCRIPTION
This change forces subscriptions added via universe selection to not be internal feeds. The internal feed flag, when set, prevents data from being piped into the algorithm which prevents a user from trading that security.