### PR TITLE
Keep old DailyFx entries longer

### DIFF
--- a/Common/Data/Custom/DailyFx.cs
+++ b/Common/Data/Custom/DailyFx.cs
@@ -180,7 +180,8 @@ namespace QuantConnect.Data.Custom
             _previousContent = content;
 
             // clean old entries from memory
-            var oldEntries = _previous.Where(kvp => kvp.Value.DisplayDate.UtcDateTime < date.Date).ToList();
+            var clearingDate = date.Date.AddDays(-2);
+            var oldEntries = _previous.Where(kvp => kvp.Value.DisplayDate.UtcDateTime.Date < clearingDate).ToList();
             oldEntries.ForEach(oe => _previous.Remove(oe.Key));
 
             var dailyfxList = JsonConvert.DeserializeObject<List<DailyFx>>(content, _jsonSerializerSettings);


### PR DESCRIPTION
The issue with removing these entries too quickly is that the server may still return them. In such an event, we would continually emit the data and then remove the data causing it to be emit at every time step.

This keeps the old entries around for a minimum of 2 days to ensure that the server won't return the same events again during live mode. In backtesting mode, we invoke the reader once a quarter, so each invocation should still clear 99% of the events -- all events except those occurring within 2 days of the quarter end/beginning dates.