### PR TITLE
Update max run time to check for universes

### DIFF
--- a/Common/Packets/Controls.cs
+++ b/Common/Packets/Controls.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,6 +14,7 @@
  *
 */
 
+using System;
 using Newtonsoft.Json;
 
 namespace QuantConnect.Packets
@@ -28,7 +29,7 @@ namespace QuantConnect.Packets
         /// </summary>
         [JsonProperty(PropertyName = "iMinuteLimit")]
         public int MinuteLimit;
-        
+
         /// <summary>
         /// The maximum number of second symbols
         /// </summary>
@@ -77,6 +78,27 @@ namespace QuantConnect.Packets
             BacktestLogLimit = 10000;
             DailyLogLimit = 3000000;
             RemainingLogAllowance = 10000;
+        }
+
+        /// <summary>
+        /// Gets the maximum number of subscriptions for the specified resolution
+        /// </summary>
+        public int GetLimit(Resolution resolution)
+        {
+            switch (resolution)
+            {
+                case Resolution.Tick:
+                    return TickLimit;
+
+                case Resolution.Second:
+                    return SecondLimit;
+
+                case Resolution.Minute:
+                case Resolution.Hour:
+                case Resolution.Daily:
+                default:
+                    return MinuteLimit;
+            }
         }
     }
 }


### PR DESCRIPTION
The max run time calculation wasn't considering whether or not the user had any universe subscriptions. This was causing some low-end time outs when running coarse/fine for only a couple days.

>NOTE: This does not address the 10 minute per loop timeout.