### PR TITLE
Revert PR 1225

### DIFF
--- a/Common/Data/SubscriptionDataConfigList.cs
+++ b/Common/Data/SubscriptionDataConfigList.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ using System.Linq;
 namespace QuantConnect.Data
 {
     /// <summary>
-    /// Provides convenient methods for holding several <see cref="SubscriptionDataConfig"/>
+    /// Provides convenient methods for holding several <see cref="SubscriptionDataConfig"/> 
     /// </summary>
     public class SubscriptionDataConfigList : List<SubscriptionDataConfig>
     {
@@ -34,7 +34,11 @@ namespace QuantConnect.Data
         /// </summary>
         public bool IsInternalFeed
         {
-            get { return Count != 0 && this.All(sdc => sdc.IsInternalFeed); }
+            get
+            {
+                var first = this.FirstOrDefault();
+                return first != null && first.IsInternalFeed;
+            }
         }
 
         /// <summary>

--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -193,7 +193,7 @@ namespace QuantConnect.Data.UniverseSelection
                     isUniverseSubscription: false,
                     universe: this,
                     security: security,
-                    configuration: new SubscriptionDataConfig(config, isInternalFeed: false),
+                    configuration: new SubscriptionDataConfig(config),
                     startTimeUtc: currentTimeUtc,
                     endTimeUtc: maximumEndTimeUtc
                     )


### PR DESCRIPTION
Revert "Merge pull request #1225 from QuantConnect/bugfix/universe-select-benchmark"

This reverts commit 0df445c9a8dafe253d8117892d2f4dc23b9472a4, reversing
changes made to b2095907fde004906755b4d6391a8a8dcd032d67.

Memory instability was reported during live trading. Internal feed defaulting to false
is suspected cause.