### PR TITLE
Fix scheduled event scheduling

### DIFF
--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             Add(ScheduledEventFactory.EveryAlgorithmEndOfDay(_algorithm, _resultHandler, _algorithm.StartDate, _algorithm.EndDate, ScheduledEvent.AlgorithmEndOfDayDelta));
 
             // set up the events for each security to fire every tradeable date before market close
-            foreach (var security in _algorithm.Securities.Values.Where(x => x.IsInternalFeed()))
+            foreach (var security in _algorithm.Securities.Values.Where(x => !x.IsInternalFeed()))
             {
                 Add(ScheduledEventFactory.EverySecurityEndOfDay(_algorithm, _resultHandler, security, algorithm.StartDate, _algorithm.EndDate, ScheduledEvent.SecurityEndOfDayDelta));
             }

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -82,7 +82,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             Add(ScheduledEventFactory.EveryAlgorithmEndOfDay(_algorithm, _resultHandler, todayInAlgorithmTimeZone, Time.EndOfTime, ScheduledEvent.AlgorithmEndOfDayDelta, DateTime.UtcNow));
 
             // add end of trading day events for each security
-            foreach (var security in _algorithm.Securities.Values.Where(x => x.IsInternalFeed()))
+            foreach (var security in _algorithm.Securities.Values.Where(x => !x.IsInternalFeed()))
             {
                 // assumes security.Exchange has been updated with today's hours via RefreshMarketHoursToday
                 Add(ScheduledEventFactory.EverySecurityEndOfDay(_algorithm, _resultHandler, security, todayInAlgorithmTimeZone, Time.EndOfTime, ScheduledEvent.SecurityEndOfDayDelta, DateTime.UtcNow));


### PR DESCRIPTION
Scheduled events were seemingly only being submitted for internal feed securities -- the opposite of what we're looking for.

I've confirmed in the backtesting cloud that events were *not* firing and that this change permits events to fire.