### PR TITLE
Update GdaxBrokerage.CanSubmitOrder() to check for valid quantities, symbol types and order types.

### DIFF
--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,14 +40,14 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="GDAXBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to 
+        /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="QuantConnect.AccountType.Margin"/></param>
         public GDAXBrokerageModel(AccountType accountType = AccountType.Margin)
             : base(accountType)
         {
             if (accountType == AccountType.Margin)
             {
-                new BrokerageMessageEvent(BrokerageMessageType.Warning, 0, 
+                new BrokerageMessageEvent(BrokerageMessageType.Warning, 0,
                     "It is recommend to use a cash account. Margin trading is currently in pre-Alpha. Use at your own risk and please report any issues encountered.");
             }
         }
@@ -94,10 +94,18 @@ namespace QuantConnect.Brokerages
         /// <param name="message"></param>
         /// <returns></returns>
         public override bool CanSubmitOrder(Security security, Order order, out BrokerageMessageEvent message)
-        {           
+        {
             if (order.BrokerId != null && order.BrokerId.Any())
             {
                 message = _message;
+                return false;
+            }
+
+            if (order.Quantity < 0.01m)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    "The minimum order quantity is 0.01"
+                );
                 return false;
             }
 

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -109,6 +109,24 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
+            if (security.Type != SecurityType.Crypto)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    "This model does not support " + security.Type + " security type."
+                );
+
+                return false;
+            }
+
+            if (order.Type != OrderType.Limit && order.Type != OrderType.Market && order.Type != OrderType.StopMarket)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    "This model does not support " + order.Type + " order type."
+                );
+
+                return false;
+            }
+
             return base.CanSubmitOrder(security, order, out message);
         }
 

--- a/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
+++ b/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
@@ -11,17 +11,19 @@ namespace QuantConnect.Tests.Brokerages.GDAX
     public class GDAXTestsHelpers
     {
 
-        public static Security GetSecurity(decimal price = 1m)
+        public static Security GetSecurity(decimal price = 1m, SecurityType securityType = SecurityType.Crypto)
         {
-            return new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), CreateConfig(), new Cash(CashBook.AccountCurrency, 1000, price), 
+            return new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), CreateConfig(securityType), new Cash(CashBook.AccountCurrency, 1000, price),
                 new SymbolProperties("BTCUSD", CashBook.AccountCurrency, 1, 1, 0.01m));
         }
 
-        private static SubscriptionDataConfig CreateConfig()
+        private static SubscriptionDataConfig CreateConfig(SecurityType securityType = SecurityType.Crypto)
         {
-            return new SubscriptionDataConfig(typeof(TradeBar), Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX), Resolution.Minute, TimeZones.Utc, TimeZones.Utc, 
+            return new SubscriptionDataConfig(typeof(TradeBar), Symbol.Create("BTCUSD", securityType, Market.GDAX), Resolution.Minute, TimeZones.Utc, TimeZones.Utc,
                 false, true, false);
         }
+
+
 
         public static void AddOrder(GDAXBrokerage unit, int id, string brokerId, decimal quantity)
         {

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -34,22 +34,38 @@ namespace QuantConnect.Tests.Common.Brokerages
         public void CanUpdateOrderTest()
         {
             BrokerageMessageEvent message;
-            Assert.AreEqual(false, _unit.CanUpdateOrder(GDAXTestsHelpers.GetSecurity(), Mock.Of<QuantConnect.Orders.Order>(), 
+            Assert.AreEqual(false, _unit.CanUpdateOrder(GDAXTestsHelpers.GetSecurity(), Mock.Of<QuantConnect.Orders.Order>(),
                 new QuantConnect.Orders.UpdateOrderRequest(DateTime.UtcNow, 1, new QuantConnect.Orders.UpdateOrderFields()), out message));
         }
 
         [TestCase(true)]
         [TestCase(false)]
-        public void CanSubmitOrderTest(bool isUpdate)
+        public void CanSubmitOrder_WhenBrokerageIdIsCorrect(bool isUpdate)
         {
             BrokerageMessageEvent message;
             var order = new Mock<QuantConnect.Orders.Order>();
+            // Order quantity must be greater than 0.01
+            // Order brokerageId is under test
+            order.Object.Quantity = 0.01m;
+
             if (isUpdate)
             {
-                order.Object.BrokerId = new List<string>() { "abc123" };
+                order.Object.BrokerId = new List<string>() {"abc123"};
             }
 
             Assert.AreEqual(!isUpdate, _unit.CanSubmitOrder(GDAXTestsHelpers.GetSecurity(), order.Object, out message));
+        }
+
+        [TestCase(0.01, true)]
+        [TestCase(0.009, false)]
+        public void CanSubmitOrder_WhenQuantityIsLargeEnough(decimal orderQuantity, bool isValidOrderQuantity)
+        {
+            BrokerageMessageEvent message;
+            var order = new Mock<QuantConnect.Orders.Order>();
+
+            order.Object.Quantity = orderQuantity;
+
+            Assert.AreEqual(isValidOrderQuantity, _unit.CanSubmitOrder(GDAXTestsHelpers.GetSecurity(), order.Object, out message));
         }
     }
 }


### PR DESCRIPTION
GDAX has a minimum order quantity of 0.01. This PR adds a check in GDAXBrokerage.CanSubmitOrder for the minimum order quantity as well as updates the GDAXBrokerageModel tests