### PR TITLE
Implements indicator operators for python algorithms

### DIFF
--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,8 +16,7 @@
 using System;
 using System.Globalization;
 using QuantConnect.Data;
-using System.Collections.Generic;
-using System.Linq;
+using Python.Runtime;
 
 namespace QuantConnect.Indicators
 {
@@ -329,6 +328,87 @@ namespace QuantConnect.Indicators
         {
             SimpleMovingAverage smaOfLeft = new SimpleMovingAverage(string.Format("SMA{0}_Of_{1}", period, left.Name), period).Of(left, waitForFirstToReady);
             return smaOfLeft;
+        }
+
+        /// <summary>
+        /// Wrapper for <see cref="Of{T, TSecond}(TSecond, IndicatorBase{T}, bool)"/> in python
+        /// </summary>
+        /// <param name="second">The indicator that receives data from the first</param>
+        /// <param name="first">The indicator that sends data via DataConsolidated even to the second</param>
+        /// <param name="waitForFirstToReady">True to only send updates to the second if first.IsReady returns true, false to alway send updates to second</param>
+        /// <returns>The reference to the second indicator to allow for method chaining</returns>
+        public static object Of(PyObject second, PyObject first, bool waitForFirstToReady = true)
+        {
+            dynamic indicator1 = first.AsManagedObject((Type)first.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicator2 = second.AsManagedObject((Type)second.GetPythonType().AsManagedObject(typeof(Type)));
+            return Of(indicator2, indicator1, waitForFirstToReady);
+        }
+
+        /// <summary>
+        /// Wrapper for <see cref="WeightedBy{T, TWeight}(IndicatorBase{T}, TWeight, int)"/> in python
+        /// </summary>
+        /// <param name="value">Indicator that will be averaged</param>
+        /// <param name="weight">Indicator that provides the average weights</param>
+        /// <param name="period">Average period</param>
+        /// <returns>Indicator that results of the average of first by weights given by second</returns>
+        public static CompositeIndicator<IndicatorDataPoint> WeightedBy(PyObject value, PyObject weight, int period)
+        {
+            dynamic indicator1 = value.AsManagedObject((Type)value.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicator2 = weight.AsManagedObject((Type)weight.GetPythonType().AsManagedObject(typeof(Type)));
+            return WeightedBy(indicator1, indicator2, period);
+        }
+
+        /// <summary>
+        /// Wrapper for <see cref="EMA{T}(IndicatorBase{T}, int, decimal?, bool)"/> in python
+        /// </summary>
+        /// <param name="left">The ExponentialMovingAverage indicator will be created using the data from left</param>
+        /// <param name="period">The period of the ExponentialMovingAverage indicators</param>
+        /// <param name="smoothingFactor">The percentage of data from the previous value to be carried into the next value</param>
+        /// <param name="waitForFirstToReady">True to only send updates to the second if left.IsReady returns true, false to alway send updates</param>
+        /// <returns>A reference to the ExponentialMovingAverage indicator to allow for method chaining</returns>
+        public static ExponentialMovingAverage EMA(PyObject left, int period, decimal? smoothingFactor = null, bool waitForFirstToReady = true)
+        {
+            dynamic indicator = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            return EMA(indicator, period, smoothingFactor, waitForFirstToReady);
+        }
+
+        /// <summary>
+        /// Wrapper for <see cref="MAX{T}(IndicatorBase{T}, int, bool)"/> in python
+        /// </summary>
+        /// <param name="left">The Maximum indicator will be created using the data from left</param>
+        /// <param name="period">The period of the Maximum indicator</param>
+        /// <param name="waitForFirstToReady">True to only send updates to the second if left.IsReady returns true, false to alway send updates</param>
+        /// <returns>A reference to the Maximum indicator to allow for method chaining</returns>
+        public static Maximum MAX(PyObject left, int period, bool waitForFirstToReady = true)
+        {
+            dynamic indicator = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            return MAX(indicator, period, waitForFirstToReady);
+        }
+
+        /// <summary>
+        /// Wrapper for <see cref="MIN{T}(IndicatorBase{T}, int, bool)"/> in python
+        /// </summary>
+        /// <param name="left">The Minimum indicator will be created using the data from left</param>
+        /// <param name="period">The period of the Minimum indicator</param>
+        /// <param name="waitForFirstToReady">True to only send updates to the second if left.IsReady returns true, false to alway send updates</param>
+        /// <returns>A reference to the Minimum indicator to allow for method chaining</returns>
+        public static Minimum MIN(PyObject left, int period, bool waitForFirstToReady = true)
+        {
+            dynamic indicator = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            return MIN(indicator, period, waitForFirstToReady);
+        }
+
+        /// <summary>
+        /// Wrapper for <see cref="SMA{T}(IndicatorBase{T}, int, bool)"/> in python
+        /// </summary>
+        /// <param name="left">The SimpleMovingAverage indicator will be created using the data from left</param>
+        /// <param name="period">The period of the SMA</param>
+        /// <param name="waitForFirstToReady">True to only send updates to the second if first.IsReady returns true, false to alway send updates to second</param>
+        /// <returns>The reference to the SimpleMovingAverage indicator to allow for method chaining</returns>
+        public static SimpleMovingAverage SMA(PyObject left, int period, bool waitForFirstToReady = true)
+        {
+            dynamic indicator = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            return SMA(indicator, period, waitForFirstToReady);
         }
     }
 }

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <LangVersion>6</LangVersion>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,6 +39,9 @@
   <ItemGroup>
     <Reference Include="MathNet.Numerics, Version=3.19.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.3.19.0\lib\net40\MathNet.Numerics.dll</HintPath>
+    </Reference>
+    <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.1\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -208,6 +213,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.1\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.1\build\QuantConnect.pythonnet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.1\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.1\build\QuantConnect.pythonnet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Indicators/packages.config
+++ b/Indicators/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MathNet.Numerics" version="3.19.0" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.1" targetFramework="net452" />
 </packages>

--- a/Tests/Python/Indicators/IndicatorExtensionsTests.py
+++ b/Tests/Python/Indicators/IndicatorExtensionsTests.py
@@ -1,0 +1,302 @@
+﻿#
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from clr import AddReference
+AddReference("QuantConnect.Indicators")
+
+from QuantConnect.Indicators import *
+from datetime import datetime
+import decimal as d
+import unittest
+
+class IndicatorExtensionsTests(unittest.TestCase):
+    def test_PipesDataUsingOfFromFirstToSecond(self):
+        first = SimpleMovingAverage(2)
+        second = Delay(1)
+
+        # this is a configuration step, but returns the reference to the second for method chaining
+        third = IndicatorExtensions.Of(second, first)
+
+        data1 = IndicatorDataPoint(datetime.now(), 1)
+        data2 = IndicatorDataPoint(datetime.now(), 2)
+        data3 = IndicatorDataPoint(datetime.now(), 3)
+        data4 = IndicatorDataPoint(datetime.now(), 4)
+
+        # sma has one item
+        first.Update(data1)
+        self.assertFalse(first.IsReady)
+        self.assertEqual(0, second.Current.Value)
+
+        # sma is ready, delay will repeat this value
+        first.Update(data2)
+        self.assertTrue(first.IsReady)
+        self.assertFalse(second.IsReady)
+        self.assertEqual(1.5, second.Current.Value)
+
+        # delay is ready, and repeats its first input
+        first.Update(data3)
+        self.assertTrue(second.IsReady)
+        self.assertEqual(1.5, second.Current.Value)
+
+        # now getting the delayed data
+        first.Update(data4)
+        self.assertEqual(2.5, second.Current.Value)
+
+    def test_PipesDataFirstWeightedBySecond(self):
+        period = 4
+        value = Identity("Value")
+        weight = Identity("Weight")
+
+        third = IndicatorExtensions.WeightedBy(value, weight, period)
+
+        data = range(1, 11)
+        window = list(reversed(data))[:period]
+        current = sum([ 2 * x * x for x in window ]) / float(sum(window))
+
+        for item in data:
+            value.Update(datetime.now(), 2 * item)
+            weight.Update(datetime.now(), item)
+
+        self.assertEqual(current, float(third.Current.Value))
+
+    def test_NewDataPushesToDerivedIndicators(self):
+        identity = Identity("identity")
+        self.sma = SimpleMovingAverage(3)
+
+        identity.Updated += self.identity_updated
+
+        identity.Update(datetime.now(), 1)
+        identity.Update(datetime.now(), 2)
+        self.assertFalse(self.sma.IsReady)
+
+        identity.Update(datetime.now(), 3)
+        self.assertTrue(self.sma.IsReady)
+        self.assertEqual(2, self.sma.Current.Value)
+
+    def identity_updated(self, sender, consolidated):
+        self.sma.Update(consolidated)
+
+    def test_MultiChainSMA(self):
+        identity = Identity("identity")
+        delay = Delay(2)
+
+        # create the SMA of the delay of the identity
+        sma = IndicatorExtensions.SMA(IndicatorExtensions.Of(delay, identity), 2)
+
+        identity.Update(datetime.now(), 1)
+        self.assertTrue(identity.IsReady)
+        self.assertFalse(delay.IsReady)
+        self.assertFalse(sma.IsReady)
+
+        identity.Update(datetime.now(), 2)
+        self.assertTrue(identity.IsReady)
+        self.assertFalse(delay.IsReady)
+        self.assertFalse(sma.IsReady)
+
+        identity.Update(datetime.now(), 3)
+        self.assertTrue(identity.IsReady)
+        self.assertTrue(delay.IsReady)
+        self.assertFalse(sma.IsReady)
+
+        identity.Update(datetime.now(), 4)
+        self.assertTrue(identity.IsReady)
+        self.assertTrue(delay.IsReady)
+        self.assertTrue(sma.IsReady)
+
+        self.assertEqual(1.5, sma.Current.Value)
+
+    def test_MultiChainEMA(self):
+        identity = Identity("identity")
+        delay = Delay(2)
+
+        # create the EMA of chained methods
+        ema = IndicatorExtensions.EMA(IndicatorExtensions.Of(delay, identity), 2, d.Decimal(1))
+            
+        identity.Update(datetime.now(), 1)
+        self.assertTrue(identity.IsReady)
+        self.assertFalse(delay.IsReady)
+        self.assertFalse(ema.IsReady)
+
+        identity.Update(datetime.now(), 2)
+        self.assertTrue(identity.IsReady)
+        self.assertFalse(delay.IsReady)
+        self.assertFalse(ema.IsReady)
+
+        identity.Update(datetime.now(), 3)
+        self.assertTrue(identity.IsReady)
+        self.assertTrue(delay.IsReady)
+        self.assertFalse(ema.IsReady)
+
+        identity.Update(datetime.now(), 4)
+        self.assertTrue(identity.IsReady)
+        self.assertTrue(delay.IsReady)
+        self.assertTrue(ema.IsReady)
+
+        self.assertEqual(2, ema.Current.Value)
+
+    def test_MultiChainMAX(self):
+        identity = Identity("identity")
+        delay = Delay(2)
+
+        # create the MAX of the delay of the identity
+        max = IndicatorExtensions.MAX(IndicatorExtensions.Of(delay, identity), 2)
+
+        identity.Update(datetime.now(), 1)
+        self.assertTrue(identity.IsReady)
+        self.assertFalse(delay.IsReady)
+        self.assertFalse(max.IsReady)
+
+        identity.Update(datetime.now(), 2)
+        self.assertTrue(identity.IsReady)
+        self.assertFalse(delay.IsReady)
+        self.assertFalse(max.IsReady)
+
+        identity.Update(datetime.now(), 3)
+        self.assertTrue(identity.IsReady)
+        self.assertTrue(delay.IsReady)
+        self.assertFalse(max.IsReady)
+
+        identity.Update(datetime.now(), 4)
+        self.assertTrue(identity.IsReady)
+        self.assertTrue(delay.IsReady)
+        self.assertTrue(max.IsReady)
+
+        self.assertEqual(2, max.Current.Value)
+
+    def test_MultiChainMIN(self):
+        identity = Identity("identity")
+        delay = Delay(2)
+
+        # create the MAX of the delay of the identity
+        min = IndicatorExtensions.MIN(IndicatorExtensions.Of(delay, identity), 2)
+
+        identity.Update(datetime.now(), 1)
+        self.assertTrue(identity.IsReady)
+        self.assertFalse(delay.IsReady)
+        self.assertFalse(min.IsReady)
+
+        identity.Update(datetime.now(), 2)
+        self.assertTrue(identity.IsReady)
+        self.assertFalse(delay.IsReady)
+        self.assertFalse(min.IsReady)
+
+        identity.Update(datetime.now(), 3)
+        self.assertTrue(identity.IsReady)
+        self.assertTrue(delay.IsReady)
+        self.assertFalse(min.IsReady)
+
+        identity.Update(datetime.now(), 4)
+        self.assertTrue(identity.IsReady)
+        self.assertTrue(delay.IsReady)
+        self.assertTrue(min.IsReady)
+
+        self.assertEqual(1, min.Current.Value)
+
+    def test_PlusAddsLeftAndRightAfterBothUpdated(self):
+        left = Identity("left")
+        right = Identity("right")
+        composite = IndicatorExtensions.Plus(left, right)
+
+        left.Update(datetime.now(), 1)
+        right.Update(datetime.now(), 1)
+        self.assertEqual(2, composite.Current.Value)
+
+        left.Update(datetime.today(), 2)
+        self.assertEqual(2, composite.Current.Value)
+
+        left.Update(datetime.today(), 3)
+        self.assertEqual(2, composite.Current.Value)
+
+        right.Update(datetime.today(), 4)
+        self.assertEqual(7, composite.Current.Value)
+
+    def test_MinusSubtractsLeftAndRightAfterBothUpdated(self):
+        left = Identity("left")
+        right = Identity("right")
+        composite = IndicatorExtensions.Minus(left, right)
+
+        left.Update(datetime.today(), 1)
+        right.Update(datetime.today(), 1)
+        self.assertEqual(0, composite.Current.Value)
+
+        left.Update(datetime.today(), 2)
+        self.assertEqual(0, composite.Current.Value)
+
+        left.Update(datetime.today(), 3)
+        self.assertEqual(0, composite.Current.Value)
+
+        right.Update(datetime.today(), 4)
+        self.assertEqual(-1, composite.Current.Value)
+
+    def test_OverDivdesLeftAndRightAfterBothUpdated(self):
+        left = Identity("left")
+        right = Identity("right")
+        composite = IndicatorExtensions.Over(left, right)
+
+        left.Update(datetime.today(), 1)
+        right.Update(datetime.today(), 1)
+        self.assertEqual(1, composite.Current.Value)
+
+        left.Update(datetime.today(), 2)
+        self.assertEqual(1, composite.Current.Value)
+
+        left.Update(datetime.today(), 3)
+        self.assertEqual(1, composite.Current.Value)
+
+        right.Update(datetime.today(), 4)
+        self.assertEqual(3.0 / 4.0, composite.Current.Value)
+
+    def test_OverHandlesDivideByZero(self):
+        left = Identity("left")
+        right = Identity("right")
+        composite = IndicatorExtensions.Over(left, right)
+        self.updatedEventFired = False
+        composite.Updated += self.composite_updated
+
+        left.Update(datetime.today(), 1)
+        self.assertFalse(self.updatedEventFired)
+        right.Update(datetime.today(), 0)
+        self.assertFalse(self.updatedEventFired)
+
+        # submitting another update to right won't cause an update without corresponding update to left
+        right.Update(datetime.today(), 1)
+        self.assertFalse(self.updatedEventFired)
+        left.Update(datetime.today(), 1)
+        self.assertTrue(self.updatedEventFired)
+
+    def composite_updated(self, sender, consolidated):
+        self.updatedEventFired = True
+
+    def test_TimesMultipliesLeftAndRightAfterBothUpdated(self):
+        left = Identity("left")
+        right = Identity("right")
+        composite = IndicatorExtensions.Times(left, right)
+
+        left.Update(datetime.today(), 1)
+        right.Update(datetime.today(), 1)
+        self.assertEqual(1, composite.Current.Value)
+
+        left.Update(datetime.today(), 2)
+        self.assertEqual(1, composite.Current.Value)
+
+        left.Update(datetime.today(), 3)
+        self.assertEqual(1, composite.Current.Value)
+
+        right.Update(datetime.today(), 4)
+        self.assertEqual(12, composite.Current.Value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -381,6 +381,7 @@
     <None Include="TestData\CashTestingStrategy.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="Python\Indicators\IndicatorExtensionsTests.py" />
     <Content Include="TestData\FuturesExpiryFunctionsTestData.xml">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Implements indicator operators for python algorithms by wrapping the methods from IndicatorExtensions that python cannot use.
- Adds pythonnet to QuantConnect.Indicators project
- Adds python unit tests for IndicatorExtension