### PR TITLE
Hourly and daily crypto filenames

### DIFF
--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -562,7 +562,6 @@ namespace QuantConnect.Util
                 case SecurityType.Equity:
                 case SecurityType.Forex:
                 case SecurityType.Cfd:
-                case SecurityType.Crypto:
                     if (isHourOrDaily)
                     {
                         return string.Format("{0}.zip",
@@ -574,7 +573,19 @@ namespace QuantConnect.Util
                         formattedDate,
                         tickTypeString
                         );
+                case SecurityType.Crypto:
+                    if (isHourOrDaily)
+                    {
+                        return string.Format("{0}_{1}.zip",
+                            symbol.Value.ToLower(),
+                            tickTypeString
+                        );
+                    }
 
+                    return string.Format("{0}_{1}.zip",
+                        formattedDate,
+                        tickTypeString
+                    );
                 case SecurityType.Option:
                     if (isHourOrDaily)
                     {

--- a/Common/Util/LeanDataPathComponents.cs
+++ b/Common/Util/LeanDataPathComponents.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -150,6 +150,12 @@ namespace QuantConnect.Util
                 if (securityType == SecurityType.Future)
                 {
                     // ticker_trade
+                    ticker = ticker.Substring(0, ticker.LastIndexOf("_"));
+                }
+                if (securityType == SecurityType.Crypto &&
+                    (resolution == Resolution.Daily || resolution == Resolution.Hour))
+                {
+                    // ticker_trade or ticker_quote
                     ticker = ticker.Substring(0, ticker.LastIndexOf("_"));
                 }
             }

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -337,15 +337,15 @@ namespace QuantConnect.Tests.Common.Util
                 new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Tick, TickType.Trade, "20160217_trade.zip", "20160217_btcusd_tick_trade.csv", "crypto/gdax/tick/btcusd"),
                 new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Second, TickType.Trade, "20160217_trade.zip", "20160217_btcusd_second_trade.csv", "crypto/gdax/second/btcusd"),
                 new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Minute, TickType.Trade, "20160217_trade.zip", "20160217_btcusd_minute_trade.csv", "crypto/gdax/minute/btcusd"),
-                new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Hour, TickType.Trade, "btcusd.zip", "btcusd_trade.csv", "crypto/gdax/hour"),
-                new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Daily, TickType.Trade, "btcusd.zip", "btcusd_trade.csv", "crypto/gdax/daily"),
+                new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Hour, TickType.Trade, "btcusd_trade.zip", "btcusd_trade.csv", "crypto/gdax/hour"),
+                new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Daily, TickType.Trade, "btcusd_trade.zip", "btcusd_trade.csv", "crypto/gdax/daily"),
 
                 // Crypto -quotes
                 new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Tick, TickType.Quote, "20160217_quote.zip", "20160217_btcusd_tick_quote.csv", "crypto/gdax/tick/btcusd"),
                 new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Second, TickType.Quote, "20160217_quote.zip", "20160217_btcusd_second_quote.csv", "crypto/gdax/second/btcusd"),
                 new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Minute, TickType.Quote, "20160217_quote.zip", "20160217_btcusd_minute_quote.csv", "crypto/gdax/minute/btcusd"),
-                new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Hour, TickType.Quote, "btcusd.zip", "btcusd_quote.csv", "crypto/gdax/hour"),
-                new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Daily, TickType.Quote, "btcusd.zip", "btcusd_quote.csv", "crypto/gdax/daily"),
+                new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Hour, TickType.Quote, "btcusd_quote.zip", "btcusd_quote.csv", "crypto/gdax/hour"),
+                new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Daily, TickType.Quote, "btcusd_quote.zip", "btcusd_quote.csv", "crypto/gdax/daily"),
 
             }.Select(x => new TestCaseData(x).SetName(x.Name)).ToArray();
         }


### PR DESCRIPTION
Hourly and daily crypto files must have their tick type specified in the filename. This is because Lean adds both quote and trade subscriptions to Crypto security types. Lean needs to be able to read both file types for each subscription