### PR TITLE
Fixes bug using collection subscriptions in backtest

### DIFF
--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -110,7 +110,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         continue;
                     }
 
-                    yield return instances;
+                    if (_isLiveMode)
+                    {
+                        yield return instances;
+                    }
+                    else
+                    {
+                        foreach (var instance in instances.Data)
+                        {
+                            yield return instance;
+                        }
+                    }
                 }
             }
             finally


### PR DESCRIPTION
Yielding the entire collection as a single unit is only necessary in live and as such we should unroll the collection in backtest.