### PR TITLE
Add QCAlgorithm.AddSeries method

### DIFF
--- a/Algorithm/QCAlgorithm.Plotting.cs
+++ b/Algorithm/QCAlgorithm.Plotting.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -149,7 +149,7 @@ namespace QuantConnect.Algorithm
         /// <param name="chart">Chart name</param>
         /// <param name="series">Series name</param>
         /// <param name="value">Value of the point</param>
-        public void Plot(string chart, string series, decimal value) 
+        public void Plot(string chart, string series, decimal value)
         {
             //Ignore the reserved chart names:
             if ((chart == "Strategy Equity" && series == "Equity") || (chart == "Daily Performance") || (chart == "Meta"))
@@ -160,11 +160,11 @@ namespace QuantConnect.Algorithm
             // If we don't have the chart, create it:
             if (!_charts.ContainsKey(chart))
             {
-                _charts.Add(chart, new Chart(chart)); 
+                _charts.Add(chart, new Chart(chart));
             }
 
             var thisChart = _charts[chart];
-            if (!thisChart.Series.ContainsKey(series)) 
+            if (!thisChart.Series.ContainsKey(series))
             {
                 //Number of series in total.
                 var seriesCount = (from x in _charts.Values select x.Series.Count).Sum();
@@ -184,10 +184,30 @@ namespace QuantConnect.Algorithm
             {
                 thisSeries.AddPoint(UtcTime, value, _liveMode);
             }
-            else 
+            else
             {
                 Debug("Exceeded maximum points per chart, data skipped.");
             }
+        }
+
+        /// <summary>
+        /// Add a series object for charting. This is useful when initializing charts with
+        /// series other than type = line. If a series exists in the chart with the same name,
+        /// then it is replaced.
+        /// </summary>
+        /// <param name="chart">The chart name</param>
+        /// <param name="series">The series name</param>
+        /// <param name="seriesType">The type of series, i.e, Scatter</param>
+        /// <param name="unit">The unit of the y axis, usually $</param>
+        public void AddSeries(string chart, string series, SeriesType seriesType, string unit = "$")
+        {
+            Chart c;
+            if (!_charts.TryGetValue(chart, out c))
+            {
+                _charts[chart] = c = new Chart(chart);
+            }
+
+            c.Series[series] = new Series(series, seriesType, unit);
         }
 
         /// <summary>


### PR DESCRIPTION
Adding a scatter plot is an involved process because there's not direct and easy way to just define a series object. This change allows an algorithm to simply define the series without pumping any data into it. This allows the user to set the series type and the unit for the series.