### PR TITLE
Remove arbitrary precision from order/order event decimal properties

### DIFF
--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ namespace QuantConnect.Orders
     /// <summary>
     /// Order struct for placing new trade
     /// </summary>
-    public abstract class Order 
+    public abstract class Order
     {
         /// <summary>
         /// Order ID.
@@ -48,7 +48,11 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Price of the Order.
         /// </summary>
-        public decimal Price { get; internal set; }
+        public decimal Price
+        {
+            get { return price; }
+            internal set { price = value.Normalize(); }
+        }
 
         /// <summary>
         /// Currency for the order price
@@ -63,7 +67,11 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Number of shares to execute.
         /// </summary>
-        public decimal Quantity { get; internal set; }
+        public decimal Quantity
+        {
+            get { return quantity; }
+            internal set { quantity = value.Normalize(); }
+        }
 
         /// <summary>
         /// Order Type
@@ -93,15 +101,15 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Order Direction Property based off Quantity.
         /// </summary>
-        public OrderDirection Direction 
+        public OrderDirection Direction
         {
-            get 
+            get
             {
-                if (Quantity > 0) 
+                if (Quantity > 0)
                 {
                     return OrderDirection.Buy;
-                } 
-                if (Quantity < 0) 
+                }
+                if (Quantity < 0)
                 {
                     return OrderDirection.Sell;
                 }
@@ -290,5 +298,8 @@ namespace QuantConnect.Orders
         /// Order Expiry on a specific UTC time.
         /// </summary>
         public DateTime DurationValue;
+
+        private decimal quantity;
+        private decimal price;
     }
 }

--- a/Common/Orders/OrderEvent.cs
+++ b/Common/Orders/OrderEvent.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,78 +19,69 @@ using QuantConnect.Securities;
 namespace QuantConnect.Orders
 {
     /// <summary>
-    /// Order Event - Messaging class signifying a change in an order state and record the change in the user's algorithm portfolio 
+    /// Order Event - Messaging class signifying a change in an order state and record the change in the user's algorithm portfolio
     /// </summary>
     public class OrderEvent
     {
         /// <summary>
         /// Id of the order this event comes from.
         /// </summary>
-        public int OrderId;
+        public int OrderId { get; set; }
 
         /// <summary>
         /// Easy access to the order symbol associated with this event.
         /// </summary>
-        public Symbol Symbol;
+        public Symbol Symbol { get; set; }
 
         /// <summary>
         /// The date and time of this event (UTC).
         /// </summary>
-        public DateTime UtcTime;
+        public DateTime UtcTime { get; set; }
 
         /// <summary>
         /// Status message of the order.
         /// </summary>
-        public OrderStatus Status;
+        public OrderStatus Status { get; set; }
 
         /// <summary>
         /// The fee associated with the order (always positive value).
         /// </summary>
-        public decimal OrderFee;
+        public decimal OrderFee { get; set; }
 
         /// <summary>
         /// Fill price information about the order
         /// </summary>
-        public decimal FillPrice;
+        public decimal FillPrice { get; set; }
 
         /// <summary>
         /// Currency for the fill price
         /// </summary>
-        public string FillPriceCurrency;
+        public string FillPriceCurrency { get; set; }
 
         /// <summary>
         /// Number of shares of the order that was filled in this event.
         /// </summary>
-        public decimal FillQuantity;
+        public decimal FillQuantity { get; set; }
 
         /// <summary>
         /// Public Property Absolute Getter of Quantity -Filled
         /// </summary>
-        public decimal AbsoluteFillQuantity 
-        {
-            get 
-            {
-                return Math.Abs(FillQuantity);
-            }
-        }
+        public decimal AbsoluteFillQuantity => Math.Abs(FillQuantity);
 
         /// <summary>
         /// Order direction.
         /// </summary>
-        public OrderDirection Direction
-        {
-            get; private set;
-        }
+        public OrderDirection Direction { get; set; }
 
         /// <summary>
         /// Any message from the exchange.
         /// </summary>
-        public string Message;
+        public string Message { get; set; }
 
         /// <summary>
         /// True if the order event is an assignment
         /// </summary>
-        public bool IsAssignment;
+        public bool IsAssignment { get; set; }
 
         /// <summary>
         /// Order Event Constructor.
@@ -104,7 +95,16 @@ namespace QuantConnect.Orders
         /// <param name="fillQuantity">Fill quantity</param>
         /// <param name="orderFee">The order fee</param>
         /// <param name="message">Message from the exchange</param>
-        public OrderEvent(int orderId, Symbol symbol, DateTime utcTime, OrderStatus status, OrderDirection direction, decimal fillPrice, decimal fillQuantity, decimal orderFee, string message = "")
+        public OrderEvent(int orderId,
+            Symbol symbol,
+            DateTime utcTime,
+            OrderStatus status,
+            OrderDirection direction,
+            decimal fillPrice,
+            decimal fillQuantity,
+            decimal orderFee,
+            string message = ""
+            )
         {
             OrderId = orderId;
             Symbol = symbol;
@@ -126,7 +126,7 @@ namespace QuantConnect.Orders
         /// <param name="utcTime">Date/time of this event</param>
         /// <param name="orderFee">The order fee</param>
         /// <param name="message">Message from exchange or QC.</param>
-        public OrderEvent(Order order, DateTime utcTime, decimal orderFee, string message = "") 
+        public OrderEvent(Order order, DateTime utcTime, decimal orderFee, string message = "")
         {
             OrderId = order.Id;
             Symbol = order.Symbol;
@@ -153,8 +153,8 @@ namespace QuantConnect.Orders
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            var message = FillQuantity == 0 
-                ? string.Format("Time: {0} OrderID: {1} Symbol: {2} Status: {3}", UtcTime, OrderId, Symbol.Value, Status) 
+            var message = FillQuantity == 0
+                ? string.Format("Time: {0} OrderID: {1} Symbol: {2} Status: {3}", UtcTime, OrderId, Symbol.Value, Status)
                 : string.Format("Time: {0} OrderID: {1} Symbol: {2} Status: {3} Quantity: {4} FillPrice: {5} {6}", UtcTime, OrderId, Symbol.Value, Status, FillQuantity, FillPrice, FillPriceCurrency);
 
             // attach the order fee so it ends up in logs properly
@@ -164,7 +164,7 @@ namespace QuantConnect.Orders
             if (!string.IsNullOrEmpty(Message))
             {
                 message += string.Format(" Message: {0}", Message);
-            } 
+            }
 
             return message;
         }
@@ -175,8 +175,7 @@ namespace QuantConnect.Orders
         /// <returns>The new clone object</returns>
         public OrderEvent Clone()
         {
-            return (OrderEvent)MemberwiseClone();
+            return (OrderEvent) MemberwiseClone();
         }
     }
-
-} // End QC Namespace:
+}

--- a/Common/Orders/OrderEvent.cs
+++ b/Common/Orders/OrderEvent.cs
@@ -23,6 +23,10 @@ namespace QuantConnect.Orders
     /// </summary>
     public class OrderEvent
     {
+        private decimal orderFee;
+        private decimal fillPrice;
+        private decimal fillQuantity;
+
         /// <summary>
         /// Id of the order this event comes from.
         /// </summary>
@@ -46,12 +50,20 @@ namespace QuantConnect.Orders
         /// <summary>
         /// The fee associated with the order (always positive value).
         /// </summary>
-        public decimal OrderFee { get; set; }
+        public decimal OrderFee
+        {
+            get { return orderFee; }
+            set { orderFee = value.Normalize(); }
+        }
 
         /// <summary>
         /// Fill price information about the order
         /// </summary>
-        public decimal FillPrice { get; set; }
+        public decimal FillPrice
+        {
+            get { return fillPrice; }
+            set { fillPrice = value.Normalize(); }
+        }
 
         /// <summary>
         /// Currency for the fill price
@@ -61,7 +73,11 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Number of shares of the order that was filled in this event.
         /// </summary>
-        public decimal FillQuantity { get; set; }
+        public decimal FillQuantity
+        {
+            get { return fillQuantity; }
+            set { fillQuantity = value.Normalize(); }
+        }
 
         /// <summary>
         /// Public Property Absolute Getter of Quantity -Filled
@@ -155,7 +171,7 @@ namespace QuantConnect.Orders
         {
             var message = FillQuantity == 0
                 ? string.Format("Time: {0} OrderID: {1} Symbol: {2} Status: {3}", UtcTime, OrderId, Symbol.Value, Status)
-                : string.Format("Time: {0} OrderID: {1} Symbol: {2} Status: {3} Quantity: {4} FillPrice: {5} {6}", UtcTime, OrderId, Symbol.Value, Status, FillQuantity, FillPrice, FillPriceCurrency);
+                : string.Format("Time: {0} OrderID: {1} Symbol: {2} Status: {3} Quantity: {4} FillPrice: {5} {6}", UtcTime, OrderId, Symbol.Value, Status, FillQuantity, FillPrice.SmartRounding(), FillPriceCurrency);
 
             // attach the order fee so it ends up in logs properly
             if (OrderFee != 0m) message += string.Format(" OrderFee: {0} {1}", OrderFee, CashBook.AccountCurrency);


### PR DESCRIPTION
Since decimalization of order quantity, all logs and serialized values have many trailing zeros. You might get something that looks like this: `FillQuantity = 100.000000000`. This is due to conversion from integer (infinite precision) to decimal (fixed precision). So the conversion is exactly correct, but we don't need all of this precision -- especially in our outputs (logs/result json/ect) as it just takes up space and doesn't add any real value.

This change normalized the values to the `OrderEvent` class as their set. In addition it normalizes the decimal values on the `Order` class. This `Normalize` extension [method](https://github.com/QuantConnect/Lean/blob/bugfix-order-event-quantity-fillprice-arbitrary-precision/Common/Extensions.cs#L238) doesn't remove data, but only removes trailing zeros from the in-memory representation of the decimal value.