### PR TITLE
Add IB connection state check in GetAccountHoldings and GetCashBalance

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -386,6 +386,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             CheckIbGateway();
 
+            if (!IsConnected)
+            {
+                Log.Trace("InteractiveBrokersBrokerage.GetAccountHoldings(): not connected, connecting now");
+                Connect();
+            }
+
             var holdings = _accountData.AccountHoldings.Select(x => ObjectActivator.Clone(x.Value)).Where(x => x.Quantity != 0).ToList();
 
             // fire up tasks to resolve the conversion rates so we can do them in parallel
@@ -422,6 +428,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         public override List<Cash> GetCashBalance()
         {
             CheckIbGateway();
+
+            if (!IsConnected)
+            {
+                Log.Trace("InteractiveBrokersBrokerage.GetCashBalance(): not connected, connecting now");
+                Connect();
+            }
 
             return _accountData.CashBalances.Select(x => new Cash(x.Key, x.Value, GetUsdConversion(x.Key))).ToList();
         }

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
     [Ignore("These tests require the IBController and IB TraderWorkstation to be installed.")]
     public class InteractiveBrokersBrokerageTests
     {
-        private readonly List<Order> _orders = new List<Order>(); 
+        private readonly List<Order> _orders = new List<Order>();
         private InteractiveBrokersBrokerage _interactiveBrokersBrokerage;
         private const int buyQuantity = 100;
         private const SecurityType Type = SecurityType.Forex;
@@ -42,9 +42,9 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         [SetUp]
         public void InitializeBrokerage()
         {
-            InteractiveBrokersGatewayRunner.Start(Config.Get("ib-controller-dir"), 
-                Config.Get("ib-tws-dir"), 
-                Config.Get("ib-user-name"), 
+            InteractiveBrokersGatewayRunner.Start(Config.Get("ib-controller-dir"),
+                Config.Get("ib-tws-dir"),
+                Config.Get("ib-user-name"),
                 Config.Get("ib-password"),
                 Config.Get("ib-trading-mode"),
                 Config.GetBool("ib-use-tws")
@@ -642,7 +642,7 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             Assert.IsTrue(ib.IsConnected);
 
             var tenMinutes = TimeSpan.FromMinutes(10);
-            
+
             Console.WriteLine("------");
             Console.WriteLine("Waiting for internet disconnection ");
             Console.WriteLine("------");
@@ -653,7 +653,7 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 Thread.Sleep(2500);
                 Console.Write(".");
             }
-            
+
             var stopwatch = Stopwatch.StartNew();
 
             Console.WriteLine("------");
@@ -667,6 +667,32 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 Console.Write(".");
             }
 
+            Assert.IsTrue(ib.IsConnected);
+        }
+
+        [Test]
+        public void GetCashBalanceConnectsIfDisconnected()
+        {
+            var ib = _interactiveBrokersBrokerage;
+            Assert.IsTrue(ib.IsConnected);
+
+            ib.Disconnect();
+            Assert.IsFalse(ib.IsConnected);
+
+            ib.GetCashBalance();
+            Assert.IsTrue(ib.IsConnected);
+        }
+
+        [Test]
+        public void GetAccountHoldingsConnectsIfDisconnected()
+        {
+            var ib = _interactiveBrokersBrokerage;
+            Assert.IsTrue(ib.IsConnected);
+
+            ib.Disconnect();
+            Assert.IsFalse(ib.IsConnected);
+
+            ib.GetAccountHoldings();
             Assert.IsTrue(ib.IsConnected);
         }
 


### PR DESCRIPTION
If we detect a disconnected state when calling these methods, we now attempt a reconnection, instead of issuing IB API calls while disconnected (which would always report a "504 - Not connected" error).