### PR TITLE
When string cannot be converted into a symbol, log an error message

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -98,6 +98,13 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Message for exception that is thrown when the implicit conversion between symbol and string fails
+        /// </summary>
+        private readonly string _symbolEmptyErrorMessage = "Cannot create history for the given ticker. " +
+                                                           "Either explicitly use a symbol object to make the history request " +
+                                                           "or ensure the symbol has been added using the AddSecurity() method before making the history request.";
+
+        /// <summary>
         /// Gets the history requests required for provide warm up data for the algorithm
         /// </summary>
         /// <returns></returns>
@@ -247,6 +254,7 @@ namespace QuantConnect.Algorithm
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<TradeBar> History(Symbol symbol, int periods, Resolution? resolution = null)
         {
+            if (symbol == QuantConnect.Symbol.Empty) throw new ArgumentException(_symbolEmptyErrorMessage);
             var security = Securities[symbol];
             var start = GetStartTimeAlgoTz(symbol, periods, resolution);
 
@@ -272,6 +280,8 @@ namespace QuantConnect.Algorithm
             where T : IBaseData
         {
             if (resolution == Resolution.Tick) throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
+            if (symbol == QuantConnect.Symbol.Empty) throw new ArgumentException(_symbolEmptyErrorMessage);
+
             var security = Securities[symbol];
             // verify the types match
             var requestedType = typeof(T);
@@ -297,6 +307,7 @@ namespace QuantConnect.Algorithm
         public IEnumerable<T> History<T>(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null)
             where T : IBaseData
         {
+            if (symbol == QuantConnect.Symbol.Empty) throw new ArgumentException(_symbolEmptyErrorMessage);
             var security = Securities[symbol];
             // verify the types match
             var requestedType = typeof(T);

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -93,7 +93,7 @@ namespace QuantConnect
         /// <param name="right">The option right (Put/Call)</param>
         /// <param name="strike">The option strike price</param>
         /// <param name="expiry">The option expiry date</param>
-        /// <param name="alias">An alias to be used for the symbol cache. Required when 
+        /// <param name="alias">An alias to be used for the symbol cache. Required when
         /// adding the same security from diferent markets</param>
         /// <param name="mapSymbol">Specifies if symbol should be mapped using map file provider</param>
         /// <returns>A new Symbol object for the specified option contract</returns>
@@ -114,13 +114,13 @@ namespace QuantConnect
         /// <param name="right">The option right (Put/Call)</param>
         /// <param name="strike">The option strike price</param>
         /// <param name="expiry">The option expiry date</param>
-        /// <param name="alias">An alias to be used for the symbol cache. Required when 
+        /// <param name="alias">An alias to be used for the symbol cache. Required when
         /// adding the same security from diferent markets</param>
         /// <returns>A new Symbol object for the specified option contract</returns>
         public static Symbol CreateOption(Symbol underlyingSymbol, string market, OptionStyle style, OptionRight right, decimal strike, DateTime expiry, string alias = null)
         {
             var sid = SecurityIdentifier.GenerateOption(expiry, underlyingSymbol.ID, market, strike, right, style);
-    
+
             if (expiry == SecurityIdentifier.DefaultDate)
             {
                 alias = alias ?? "?" + underlyingSymbol.Value.ToUpper();
@@ -142,7 +142,7 @@ namespace QuantConnect
         /// <param name="ticker">The ticker</param>
         /// <param name="market">The market the future resides in</param>
         /// <param name="expiry">The future expiry date</param>
-        /// <param name="alias">An alias to be used for the symbol cache. Required when 
+        /// <param name="alias">An alias to be used for the symbol cache. Required when
         /// adding the same security from different markets</param>
         /// <returns>A new Symbol object for the specified future contract</returns>
         public static Symbol CreateFuture(string ticker, string market, DateTime expiry, string alias = null)
@@ -168,7 +168,7 @@ namespace QuantConnect
         /// <returns>true, if symbol is a derivative canonical symbol</returns>
         public bool IsCanonical()
         {
-            return 
+            return
                 (ID.SecurityType == SecurityType.Future ||
                 (ID.SecurityType == SecurityType.Option && HasUnderlying)) &&
                 ID.Date == SecurityIdentifier.DefaultDate;
@@ -231,7 +231,7 @@ namespace QuantConnect
 
         /// <summary>
         /// Creates new symbol with updated mapped symbol. Symbol Mapping: When symbols change over time (e.g. CHASE-> JPM) need to update the symbol requested.
-        /// Method returns newly created symbol 
+        /// Method returns newly created symbol
         /// </summary>
         public Symbol UpdateMappedSymbol(string mappedSymbol)
         {
@@ -298,7 +298,7 @@ namespace QuantConnect
                     return ID.Equals(sid);
                 }
             }
-            
+
             // compare a sid just as you would a symbol object
             if (obj is SecurityIdentifier)
             {
@@ -310,7 +310,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Serves as a hash function for a particular type. 
+        /// Serves as a hash function for a particular type.
         /// </summary>
         /// <returns>
         /// A hash code for the current <see cref="T:System.Object"/>.
@@ -326,7 +326,7 @@ namespace QuantConnect
         /// Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.
         /// </summary>
         /// <returns>
-        /// A value that indicates the relative order of the objects being compared. The return value has these meanings: Value Meaning Less than zero This instance precedes <paramref name="obj"/> in the sort order. Zero This instance occurs in the same position in the sort order as <paramref name="obj"/>. Greater than zero This instance follows <paramref name="obj"/> in the sort order. 
+        /// A value that indicates the relative order of the objects being compared. The return value has these meanings: Value Meaning Less than zero This instance precedes <paramref name="obj"/> in the sort order. Zero This instance occurs in the same position in the sort order as <paramref name="obj"/>. Greater than zero This instance follows <paramref name="obj"/> in the sort order.
         /// </returns>
         /// <param name="obj">An object to compare with this instance. </param><exception cref="T:System.ArgumentException"><paramref name="obj"/> is not the same type as this instance. </exception><filterpriority>2</filterpriority>
         public int CompareTo(object obj)
@@ -377,7 +377,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Equals operator 
+        /// Equals operator
         /// </summary>
         /// <param name="left">The left operand</param>
         /// <param name="right">The right operand</param>
@@ -389,7 +389,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Not equals operator 
+        /// Not equals operator
         /// </summary>
         /// <param name="left">The left operand</param>
         /// <param name="right">The right operand</param>
@@ -434,7 +434,7 @@ namespace QuantConnect
             {
                 return new Symbol(sid, sid.Symbol);
             }
-            
+
             return Empty;
         }
 


### PR DESCRIPTION
Often users will try to use a string in place of a symbol when the Symbol has not been registered using a method like AddSecurity, AddCrypto, AddEquity, etc. When this happens Lean silently fails to implicitly convert the string into a symbol object. This PR adds an error message when Lean is unable to convert the string into a Symbol object. 

This should add more context when users try to, for example, add an EMA using a string instead of `Symbol` which has not been registered in the Algorithm. In such a case, Lean produces a cryptic error message such as:

 ```System.Exception: Please register to receive data for symbol ' ' using the AddSecurity() function```. 

The error message is cryptic precisely because Lean cannot determine what symbol the user meant to use.
