### PR TITLE
Properly deserialize decimalized quantity values

### DIFF
--- a/Common/Orders/OrderJsonConverter.cs
+++ b/Common/Orders/OrderJsonConverter.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -98,8 +98,7 @@ namespace QuantConnect.Orders
             order.Time = jObject["Time"].Value<DateTime>();
             order.Tag = jObject["Tag"].Value<string>();
 
-            try { order.Quantity = jObject["Quantity"].Value<int>(); }
-            catch { order.Quantity = jObject["Quantity"].Value<decimal>(); }
+            order.Quantity = jObject["Quantity"].Value<decimal>();
 
             order.Price = jObject["Price"].Value<decimal>();
             var securityType = (SecurityType) jObject["SecurityType"].Value<int>();
@@ -116,7 +115,7 @@ namespace QuantConnect.Orders
             }
             else
             {
-                //no data, use default                
+                //no data, use default
                 new DefaultBrokerageModel().DefaultMarkets.TryGetValue(securityType, out market);
             }
 

--- a/Tests/Common/Orders/OrderJsonConverterTests.cs
+++ b/Tests/Common/Orders/OrderJsonConverterTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -202,6 +202,13 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.IsInstanceOf<MarketOrder>(order);
             Assert.AreEqual(Market.USA, order.Symbol.ID.Market);
 
+        }
+
+        [Test]
+        public void DeserializesDecimalizedQuantity()
+        {
+            var expected = new MarketOrder(Symbols.BTCUSD, 0.123m, DateTime.Today);
+            TestOrderType(expected);
         }
 
         private static T TestOrderType<T>(T expected)


### PR DESCRIPTION
The try/catch is unnecessary and even causes errors. The json.net serializer is very forgiving with types, so it would convert a value of 0.123 into 0 when doing `Value<int>()`. Instead we should always just parse to a decimal which includes all int values anyway.