### PR TITLE
Fix inverted conversion rate in GDAX brokerage

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -459,9 +459,14 @@ namespace QuantConnect.Brokerages.GDAX
             }
 
             var raw = JsonConvert.DeserializeObject<JObject>(response.Content);
-            var parsing = raw.SelectToken("rates." + currency);
+            var rate = raw.SelectToken("rates." + currency).Value<decimal>();
+            if (rate == 0)
+            {
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, (int)response.StatusCode, "GetConversionRate: zero value returned from conversion rate service."));
+                return 0;
+            }
 
-            return parsing.Value<decimal>();
+            return 1m / rate;
         }
 
         private bool IsSubscribeAvailable(Symbol symbol)


### PR DESCRIPTION
The conversion service is returning the inverted conversion rate, we need to return the reciprocal of the returned value.