### PR TITLE
Add error handling and disconnect fix in GDAX brokerage

### DIFF
--- a/Brokerages/BaseWebsocketsBrokerage.cs
+++ b/Brokerages/BaseWebsocketsBrokerage.cs
@@ -206,12 +206,22 @@ namespace QuantConnect.Brokerages
                 {
                     Log.Error(exception);
                 }
-            });
+            }) { IsBackground = true };
             _connectionMonitorThread.Start();
             while (!_connectionMonitorThread.IsAlive)
             {
                 Thread.Sleep(1);
             }
+        }
+
+        /// <summary>
+        /// Disconnects the client from the broker's remote servers
+        /// </summary>
+        public override void Disconnect()
+        {
+            // request and wait for thread to stop
+            _cancellationTokenSource?.Cancel();
+            _connectionMonitorThread?.Join();
         }
 
         /// <summary>

--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
 using Newtonsoft.Json;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
@@ -111,7 +112,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// </summary>
         /// <param name="order"></param>
         /// <returns></returns>
-        public override bool UpdateOrder(Orders.Order order)
+        public override bool UpdateOrder(Order order)
         {
             throw new NotSupportedException("GDAXBrokerage.UpdateOrder: Order update not supported. Please cancel and re-create.");
         }
@@ -121,7 +122,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// </summary>
         /// <param name="order"></param>
         /// <returns></returns>
-        public override bool CancelOrder(Orders.Order order)
+        public override bool CancelOrder(Order order)
         {
             var success = new List<bool>();
 
@@ -141,6 +142,8 @@ namespace QuantConnect.Brokerages.GDAX
         /// </summary>
         public override void Disconnect()
         {
+            base.Disconnect();
+
             WebSocket.Close();
         }
 
@@ -148,57 +151,52 @@ namespace QuantConnect.Brokerages.GDAX
         /// Gets all orders not yet closed
         /// </summary>
         /// <returns></returns>
-        public override List<Orders.Order> GetOpenOrders()
+        public override List<Order> GetOpenOrders()
         {
             var list = new List<Order>();
 
-            try
-            {
-                var req = new RestRequest("/orders?status=open&status=pending", Method.GET);
-                GetAuthenticationToken(req);
-                var response = RestClient.Execute(req);
+            var req = new RestRequest("/orders?status=open&status=pending", Method.GET);
+            GetAuthenticationToken(req);
+            var response = RestClient.Execute(req);
 
-                if (response != null)
+            if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                throw new Exception($"GDAXBrokerage.GetOpenOrders: request failed: [{(int) response.StatusCode}] {response.StatusDescription}, Content: {response.Content}, ErrorMessage: {response.ErrorMessage}");
+            }
+
+            var orders = JsonConvert.DeserializeObject<Messages.Order[]>(response.Content);
+            foreach (var item in orders)
+            {
+                Order order = null;
+                if (item.Type == "market")
                 {
-                    var orders = JsonConvert.DeserializeObject<Messages.Order[]>(response.Content);
-                    foreach (var item in orders)
-                    {
-                        Order order = null;
-                        if (item.Type == "market")
-                        {
-                            order = new MarketOrder { Price = item.Price };
-                        }
-                        else if (item.Type == "limit")
-                        {
-                            order = new LimitOrder { LimitPrice = item.Price };
-                        }
-                        else if (item.Type == "stop")
-                        {
-                            order = new StopMarketOrder { StopPrice = item.Price };
-                        }
-                        else
-                        {
-                            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, (int)response.StatusCode,
-                                "GDAXBrokerage.GetOpenOrders: Unsupported order type returned from brokerage: " + item.Type));
-                            continue;
-                        }
-
-                        order.Quantity = item.Side == "sell" ? -item.Size : item.Size;
-                        order.BrokerId = new List<string> { item.Id.ToString() };
-                        order.Symbol = ConvertProductId(item.ProductId);
-                        order.Time = DateTime.UtcNow;
-                        order.Status = ConvertOrderStatus(item);
-                        order.Price = item.Price;
-                        list.Add(order);
-                    }
+                    order = new MarketOrder { Price = item.Price };
                 }
-            }
-            catch (Exception)
-            {
-                throw;
+                else if (item.Type == "limit")
+                {
+                    order = new LimitOrder { LimitPrice = item.Price };
+                }
+                else if (item.Type == "stop")
+                {
+                    order = new StopMarketOrder { StopPrice = item.Price };
+                }
+                else
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, (int)response.StatusCode,
+                        "GDAXBrokerage.GetOpenOrders: Unsupported order type returned from brokerage: " + item.Type));
+                    continue;
+                }
+
+                order.Quantity = item.Side == "sell" ? -item.Size : item.Size;
+                order.BrokerId = new List<string> { item.Id.ToString() };
+                order.Symbol = ConvertProductId(item.ProductId);
+                order.Time = DateTime.UtcNow;
+                order.Status = ConvertOrderStatus(item);
+                order.Price = item.Price;
+                list.Add(order);
             }
 
-            foreach (Order item in list)
+            foreach (var item in list)
             {
                 if (item.Status.IsOpen())
                 {
@@ -234,11 +232,16 @@ namespace QuantConnect.Brokerages.GDAX
         /// <returns></returns>
         public override List<Cash> GetCashBalance()
         {
-            var list = new List<Securities.Cash>();
+            var list = new List<Cash>();
 
-            var req = new RestRequest("/accounts", Method.GET);
-            GetAuthenticationToken(req);
-            var response = RestClient.Execute(req);
+            var request = new RestRequest("/accounts", Method.GET);
+            GetAuthenticationToken(request);
+            var response = RestClient.Execute(request);
+
+            if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                throw new Exception($"GDAXBrokerage.GetCashBalance: request failed: [{(int)response.StatusCode}] {response.StatusDescription}, Content: {response.Content}, ErrorMessage: {response.ErrorMessage}");
+            }
 
             foreach (var item in JsonConvert.DeserializeObject<Messages.Account[]>(response.Content))
             {
@@ -246,21 +249,22 @@ namespace QuantConnect.Brokerages.GDAX
                 {
                     if (item.Currency == "USD")
                     {
-                        list.Add(new Securities.Cash(item.Currency, item.Balance, 1));
+                        list.Add(new Cash(item.Currency, item.Balance, 1));
                     }
-                    else if (new[] {"GBP", "EUR" }.Contains(item.Currency))
+                    else if (new[] {"GBP", "EUR"}.Contains(item.Currency))
                     {
                         var rate = GetConversionRate(item.Currency);
-                        list.Add(new Securities.Cash(item.Currency.ToUpper(), item.Balance, rate));
+                        list.Add(new Cash(item.Currency.ToUpper(), item.Balance, rate));
                     }
                     else
                     {
                         var tick = GetTick(Symbol.Create(item.Currency + "USD", SecurityType.Crypto, Market.GDAX));
 
-                        list.Add(new Securities.Cash(item.Currency.ToUpper(), item.Balance, tick.Price));
+                        list.Add(new Cash(item.Currency.ToUpper(), item.Balance, tick.Price));
                     }
                 }
             }
+
             return list;
         }
 
@@ -280,11 +284,11 @@ namespace QuantConnect.Brokerages.GDAX
         #endregion
 
         /// <summary>
-        /// Retreives the fee for a given order
+        /// Retrieves the fee for a given order
         /// </summary>
         /// <param name="order"></param>
         /// <returns></returns>
-        public decimal GetFee(Orders.Order order)
+        public decimal GetFee(Order order)
         {
             var totalFee = 0m;
 
@@ -293,6 +297,12 @@ namespace QuantConnect.Brokerages.GDAX
                 var req = new RestRequest("/orders/" + item, Method.GET);
                 GetAuthenticationToken(req);
                 var response = RestClient.Execute(req);
+
+                if (response.StatusCode != System.Net.HttpStatusCode.OK)
+                {
+                    throw new Exception($"GDAXBrokerage.GetFee: request failed: [{(int)response.StatusCode}] {response.StatusDescription}, Content: {response.Content}, ErrorMessage: {response.ErrorMessage}");
+                }
+
                 var fill = JsonConvert.DeserializeObject<dynamic>(response.Content);
 
                 totalFee += (decimal)fill.fill_fees;

--- a/Brokerages/WebSocketWrapper.cs
+++ b/Brokerages/WebSocketWrapper.cs
@@ -12,19 +12,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
 using System;
-using System.Threading;
 using WebSocketSharp;
 
 namespace QuantConnect.Brokerages
 {
-
     /// <summary>
     /// Wrapper for WebSocket4Net to enhance testability
     /// </summary>
     public class WebSocketWrapper : IWebSocket
     {
-        private WebSocket wrapped;
+        private WebSocket _wrapped;
         private string _url;
 
         /// <summary>
@@ -33,17 +32,17 @@ namespace QuantConnect.Brokerages
         /// <param name="url"></param>
         public void Initialize(string url)
         {
-            if (wrapped != null)
+            if (_wrapped != null)
             {
                 throw new InvalidOperationException("WebSocketWrapper has already been initialized for: " + _url);
             }
 
             _url = url;
-            wrapped = new WebSocket(url);
+            _wrapped = new WebSocket(url);
 
-            wrapped.OnOpen += (sender, args) => OnOpen();
-            wrapped.OnMessage += (sender, args) => OnMessage(new WebSocketMessage(args.Data));
-            wrapped.OnError += (sender, args) => OnError(new WebSocketError(args.Message, args.Exception));
+            _wrapped.OnOpen += (sender, args) => OnOpen();
+            _wrapped.OnMessage += (sender, args) => OnMessage(new WebSocketMessage(args.Data));
+            _wrapped.OnError += (sender, args) => OnError(new WebSocketError(args.Message, args.Exception));
         }
 
         /// <summary>
@@ -52,7 +51,7 @@ namespace QuantConnect.Brokerages
         /// <param name="data"></param>
         public void Send(string data)
         {
-            wrapped.Send(data);
+            _wrapped.Send(data);
         }
 
         /// <summary>
@@ -62,7 +61,7 @@ namespace QuantConnect.Brokerages
         {
             if (!IsOpen)
             {
-                wrapped.Connect();
+                _wrapped.Connect();
             }
         }
 
@@ -71,16 +70,13 @@ namespace QuantConnect.Brokerages
         /// </summary>
         public void Close()
         {
-            wrapped.Close();
+            _wrapped.Close();
         }
 
         /// <summary>
         /// Wraps IsAlive
         /// </summary>
-        public bool IsOpen
-        {
-            get { return wrapped.IsAlive; }
-        }
+        public bool IsOpen => _wrapped.IsAlive;
 
         /// <summary>
         /// Wraps message event
@@ -121,7 +117,7 @@ namespace QuantConnect.Brokerages
         /// </summary>
         protected virtual void OnOpen()
         {
-            Logging.Log.Trace($"WebSocketWrapper.OnOpen(): Connection opened({IsOpen}: {_url}");
+            Logging.Log.Trace($"WebSocketWrapper.OnOpen(): Connection opened({IsOpen}): {_url}");
             Open?.Invoke(this, EventArgs.Empty);
         }
     }


### PR DESCRIPTION
- Added some extra error handling for edge cases such as connection attempts with invalid credentials
- The connection monitor thread is now a background thread, allowing the process to terminate cleanly and Disconnect now waits for thread termination
- Removed Log.Trace on heartbeats