### PR TITLE
Safely dispose of ParallelRunnerWorkers in ParallelRunnerController

### DIFF
--- a/Common/Util/DisposableExtensions.cs
+++ b/Common/Util/DisposableExtensions.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Util
         }
 
         /// <summary>
-        /// Calls <see cref="IDisposable.Dispose"/> within a try/catch and invokes the 
+        /// Calls <see cref="IDisposable.Dispose"/> within a try/catch and invokes the
         /// <paramref name="errorHandler"/> on any errors.
         /// </summary>
         /// <param name="disposable">The <see cref="IDisposable"/> to be disposed</param>
@@ -37,6 +37,11 @@ namespace QuantConnect.Util
             try
             {
                 disposable.Dispose();
+                return true;
+            }
+            catch (ObjectDisposedException)
+            {
+                // we got what we wanted, the object has been diposed
                 return true;
             }
             catch (Exception error)

--- a/Common/Util/ParallelRunner.cs
+++ b/Common/Util/ParallelRunner.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -96,12 +96,14 @@ namespace QuantConnect.Util
             {
                 WaitHandle.WaitAll(waitHandles);
                 _waitHandle.Set();
-
-                foreach (var worker in _workers)
+                lock (_sync)
                 {
-                    worker.Dispose();
+                    for (int i = 0; i < _threadCount; i++)
+                    {
+                        _workers[i].DisposeSafely();
+                        _workers[i] = null;
+                    }
                 }
-
             }, CancellationToken.None);
 
             _processQueueThread = new Thread(() => ProcessHoldQueue(token)) { IsBackground = true };
@@ -160,7 +162,7 @@ namespace QuantConnect.Util
 
                 foreach (var worker in _workers)
                 {
-                    worker.Dispose();
+                    worker.DisposeSafely();
                 }
 
                 if (_waitHandle != null)

--- a/Tests/Common/Util/DisposableExtensionsTests.cs
+++ b/Tests/Common/Util/DisposableExtensionsTests.cs
@@ -35,6 +35,19 @@ namespace QuantConnect.Tests.Common.Util
             Assert.IsTrue(disposable.DisposeWasCalled);
         }
 
+        [Test]
+        public void SwallowsObjectDisposedException()
+        {
+            var errorHandlerWasInvoked = false;
+            var disposable = new Disposable();
+            disposable.Dispose();
+            Assert.IsTrue(disposable.DisposeWasCalled);
+
+            var result = disposable.DisposeSafely(error => errorHandlerWasInvoked = true);
+            Assert.IsTrue(result);
+            Assert.IsFalse(errorHandlerWasInvoked);
+        }
+
         private sealed class Disposable : IDisposable
         {
             private readonly bool _throwException;
@@ -47,7 +60,13 @@ namespace QuantConnect.Tests.Common.Util
 
             public void Dispose()
             {
+                if (DisposeWasCalled)
+                {
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
+
                 DisposeWasCalled = true;
+
                 if (_throwException)
                 {
                     throw new Exception();


### PR DESCRIPTION
The standard implementation of `Dispose` will throw an exception if the object is indeed already disposed. This is usually counter-productive since the goal of calling Dispose is to ensure the object is disposed.

This change makes liberal usage of the null-safe `DisposeSafely` extension method which has the nice quality of being idempotent, that is to say, you can call `DisposeSafely` as many times as you'd like on an object and always get the same net result -> object is disposed.

This was implemented in response to a [comment](https://mail.google.com/mail/u/0/?ui=2&ik=7c33f68406&view=lg&msg=15f7b0d7fa7660d2) from the lean-engine group.