### PR TITLE
Fix symbol mapping with futures expiring before contract month

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1746,7 +1746,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 // Otherwise we convert Market.* markets into IB exchanges if we have them in our map
 
                 contract.Symbol = ibSymbol;
-                contract.LastTradeDateOrContractMonth = symbol.ID.Date.ToString(DateFormat.YearMonth);
+                contract.LastTradeDateOrContractMonth = symbol.ID.Date.ToString(DateFormat.EightCharacter);
 
                 if (symbol.ID.Market == Market.USA)
                 {

--- a/Common/Securities/Future/FutureExpirationCycles.cs
+++ b/Common/Securities/Future/FutureExpirationCycles.cs
@@ -1,8 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
 
 namespace QuantConnect.Securities
 {
@@ -14,22 +23,22 @@ namespace QuantConnect.Securities
         /// <summary>
         /// January Cycle: Expirations in January, April, July, October (the first month of each quarter)
         /// </summary>
-        public static readonly int[] January = new int[] { 1, 4, 7, 10 };
+        public static readonly int[] January = { 1, 4, 7, 10 };
 
         /// <summary>
         /// February Cycle: Expirations in February, May, August, November (second month)
         /// </summary>
-        public static readonly int[] February = new int[] { 2, 5, 8, 11 };
+        public static readonly int[] February = { 2, 5, 8, 11 };
 
         /// <summary>
         /// March Cycle: Expirations in March, June, September, December (third month)
         /// </summary>
-        public static readonly int[] March = new int[] { 3, 6, 9, 12 };
+        public static readonly int[] March = { 3, 6, 9, 12 };
 
         /// <summary>
         /// All Year Cycle: Expirations in every month of the year
         /// </summary>
-        public static readonly int[] AllYear = new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        public static readonly int[] AllYear = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
 
         /// <summary>
         /// HMUZ Cycle
@@ -39,28 +48,26 @@ namespace QuantConnect.Securities
         /// <summary>
         /// HKNUZ Cycle
         /// </summary>
-        public static readonly int[] HKNUZ = new int[] { 3, 5, 7, 9, 12 };
+        public static readonly int[] HKNUZ = { 3, 5, 7, 9, 12 };
 
         /// <summary>
         /// HKNUVZ Cycle
         /// </summary>
-        public static readonly int[] HKNUVZ = new int[] { 3, 5, 7, 9, 10, 12 };
+        public static readonly int[] HKNUVZ = { 3, 5, 7, 9, 10, 12 };
 
         /// <summary>
         /// FHKNQUVZ Cycle
         /// </summary>
-        public static readonly int[] FHKNQUVZ = new int[] { 1, 3, 5, 7, 9, 10, 12 };
+        public static readonly int[] FHKNQUVZ = { 1, 3, 5, 7, 9, 10, 12 };
 
         /// <summary>
         /// FHKNQUX Cycle
         /// </summary>
-        public static readonly int[] FHKNQUX = new int[] { 1, 3, 5, 7, 8, 9, 11 };
+        public static readonly int[] FHKNQUX = { 1, 3, 5, 7, 8, 9, 11 };
 
         /// <summary>
         /// FGHJKMNQUVXZ Cycle
         /// </summary>
         public static readonly int[] FGHJKMNQUVXZ = AllYear;
-
-
     }
 }

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -1,10 +1,21 @@
-﻿using System;
-using System.Linq;
-using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
 using NUnit.Framework;
-using QuantConnect.Data;
-using QuantConnect.Data.Market;
 
 namespace QuantConnect.Tests.Common
 {
@@ -35,8 +46,8 @@ namespace QuantConnect.Tests.Common
 
             Assert.AreEqual(result.Underlying, "MSFT");
             Assert.AreEqual(result.OptionRight, OptionRight.Call);
-            Assert.AreEqual(result.OptionStrike, 30m); 
-            Assert.AreEqual(result.ExpirationDate, new DateTime(2016, 4, 15)); 
+            Assert.AreEqual(result.OptionStrike, 30m);
+            Assert.AreEqual(result.ExpirationDate, new DateTime(2016, 4, 15));
         }
 
         [Test]
@@ -84,6 +95,15 @@ namespace QuantConnect.Tests.Common
         {
             var result = SymbolRepresentation.ParseFutureTicker("invalid");
             Assert.AreEqual(result, null);
+        }
+
+        [Test]
+        public void GenerateFutureTickerExpiringInPreviousMonth()
+        {
+            // CL Dec17 expires in Nov17
+            var result = SymbolRepresentation.GenerateFutureTicker("CL", new DateTime(2017, 11, 20));
+
+            Assert.AreEqual("CLZ17", result);
         }
     }
 }


### PR DESCRIPTION
Some Futures (CL, HO, RB, NG) expire during the month before the contract month. Incorrect symbol mapping was causing two issues:
- IB requests were returning an "Ambiguous contract" error
- The ticker generated by `SymbolRepresentation.GenerateFutureTicker` was referring to the previous contract month