### PR TITLE
Fix GDAX order fees with partial fills

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -178,9 +178,9 @@ namespace QuantConnect.Brokerages.GDAX
 
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Information, -1, ("GDAXWebsocketsBrokerage.OnMessage: Unexpected message format: " + e.Message)));
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, -1, $"Parsing wss message failed. Data: {e.Message} Exception: {ex.ToString()}"));
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, -1, $"Parsing wss message failed. Data: {e.Message} Exception: {exception}"));
                 throw;
             }
         }
@@ -188,7 +188,7 @@ namespace QuantConnect.Brokerages.GDAX
         private void OrderMatch(string data)
         {
             var message = JsonConvert.DeserializeObject<Messages.Matched>(data, JsonSettings);
-            
+
             EmitTradeTick(message);
 
             var cached = CachedOrderIDs


### PR DESCRIPTION
Previously each partial fill was being attributed the total order fee, now each partial fill event includes the pro rated partial fee.

Also, the REST request to fetch the total order fee is sent only once, preventing the 5-second timeout in `BrokerageTransactionHandler` when receiving lots of partial fills with market orders.