### PR TITLE
Send remote files to the DataCacheProvider after downloading

### DIFF
--- a/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,6 +47,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
                 client.DownloadFile(source, destination);
             }
 
+            // Send the file to the dataCacheProvider so it is available when the streamReader asks for it
+            dataCacheProvider.Store(destination, File.ReadAllBytes(destination));
+
             // now we can just use the local file reader
             _streamReader = new LocalFileSubscriptionStreamReader(dataCacheProvider, destination);
         }
@@ -68,7 +71,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         }
 
         /// <summary>
-        /// Gets the next line/batch of content from the stream 
+        /// Gets the next line/batch of content from the stream
         /// </summary>
         public string ReadLine()
         {


### PR DESCRIPTION
The streamReader expects a stream to be provided by the DataCacheProvider. When the file is not available, most `IDataCacheProviders` will look for the file on disc. This works for most Lean data types, but not for remote data. After downloading a remote file, this PR sends the data to the `IDataCacheProvider` via the `Store()` method. This way, when the streamReader asks for the data from the DataCacheProvider - the remote file will already have been cached.