### PR TITLE
Emit GDAX quote ticks when best bid/ask prices or sizes changed

### DIFF
--- a/Brokerages/GDAX/BestBidAskUpdatedEventArgs.cs
+++ b/Brokerages/GDAX/BestBidAskUpdatedEventArgs.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Brokerages.GDAX
+{
+    /// <summary>
+    /// Event arguments class for the <see cref="OrderBook.BestBidAskUpdated"/> event
+    /// </summary>
+    public sealed class BestBidAskUpdatedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the new best bid price
+        /// </summary>
+        public readonly Symbol Symbol;
+
+        /// <summary>
+        /// Gets the new best bid price
+        /// </summary>
+        public readonly decimal BestBidPrice;
+
+        /// <summary>
+        /// Gets the new best ask price
+        /// </summary>
+        public readonly decimal BestAskPrice;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BestBidAskUpdatedEventArgs"/> class
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="bestBidPrice">The newly updated best bid price</param>
+        /// <param name="bestAskPrice">The newly updated best ask price</param>
+        public BestBidAskUpdatedEventArgs(Symbol symbol, decimal bestBidPrice, decimal bestAskPrice)
+        {
+            Symbol = symbol;
+            BestBidPrice = bestBidPrice;
+            BestAskPrice = bestAskPrice;
+        }
+    }
+}

--- a/Brokerages/GDAX/BestBidAskUpdatedEventArgs.cs
+++ b/Brokerages/GDAX/BestBidAskUpdatedEventArgs.cs
@@ -33,21 +33,35 @@ namespace QuantConnect.Brokerages.GDAX
         public readonly decimal BestBidPrice;
 
         /// <summary>
+        /// Gets the new best bid size
+        /// </summary>
+        public readonly decimal BestBidSize;
+
+        /// <summary>
         /// Gets the new best ask price
         /// </summary>
         public readonly decimal BestAskPrice;
+
+        /// <summary>
+        /// Gets the new best ask size
+        /// </summary>
+        public readonly decimal BestAskSize;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BestBidAskUpdatedEventArgs"/> class
         /// </summary>
         /// <param name="symbol">The symbol</param>
         /// <param name="bestBidPrice">The newly updated best bid price</param>
+        /// <param name="bestBidSize">>The newly updated best bid size</param>
         /// <param name="bestAskPrice">The newly updated best ask price</param>
-        public BestBidAskUpdatedEventArgs(Symbol symbol, decimal bestBidPrice, decimal bestAskPrice)
+        /// <param name="bestAskSize">The newly updated best ask size</param>
+        public BestBidAskUpdatedEventArgs(Symbol symbol, decimal bestBidPrice, decimal bestBidSize, decimal bestAskPrice, decimal bestAskSize)
         {
             Symbol = symbol;
             BestBidPrice = bestBidPrice;
+            BestBidSize = bestBidSize;
             BestAskPrice = bestAskPrice;
+            BestAskSize = bestAskSize;
         }
     }
 }

--- a/Brokerages/GDAX/BestBidAskUpdatedEventArgs.cs
+++ b/Brokerages/GDAX/BestBidAskUpdatedEventArgs.cs
@@ -25,27 +25,27 @@ namespace QuantConnect.Brokerages.GDAX
         /// <summary>
         /// Gets the new best bid price
         /// </summary>
-        public readonly Symbol Symbol;
+        public Symbol Symbol { get; }
 
         /// <summary>
         /// Gets the new best bid price
         /// </summary>
-        public readonly decimal BestBidPrice;
+        public decimal BestBidPrice { get; }
 
         /// <summary>
         /// Gets the new best bid size
         /// </summary>
-        public readonly decimal BestBidSize;
+        public decimal BestBidSize { get; }
 
         /// <summary>
         /// Gets the new best ask price
         /// </summary>
-        public readonly decimal BestAskPrice;
+        public decimal BestAskPrice { get; }
 
         /// <summary>
         /// Gets the new best ask size
         /// </summary>
-        public readonly decimal BestAskSize;
+        public decimal BestAskSize { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BestBidAskUpdatedEventArgs"/> class

--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -492,25 +492,6 @@ namespace QuantConnect.Brokerages.GDAX
                 else
                 {
                     this.ChannelList[item.Value] = new Channel { Name = item.Value, Symbol = item.Value };
-
-                    //emit baseline tick
-                    var message = GetTick(item);
-
-                    lock (_tickLocker)
-                    {
-                        Tick updating = new Tick
-                        {
-                            AskPrice = message.AskPrice,
-                            BidPrice = message.BidPrice,
-                            Value = (message.AskPrice + message.BidPrice) / 2m,
-                            Time = DateTime.UtcNow,
-                            Symbol = item,
-                            TickType = TickType.Quote
-                            //todo: tick volume
-                        };
-
-                        this.Ticks.Add(updating);
-                    }
                 }
             }
 

--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -21,6 +21,7 @@ using QuantConnect.Orders;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using QuantConnect.Packets;
@@ -33,7 +34,6 @@ namespace QuantConnect.Brokerages.GDAX
 {
     public partial class GDAXBrokerage : BaseWebsocketsBrokerage, IDataQueueHandler
     {
-
         #region Declarations
         private object _tickLocker = new object();
         /// <summary>
@@ -43,11 +43,12 @@ namespace QuantConnect.Brokerages.GDAX
         private string _passPhrase;
         private const string _symbolMatching = "ETH|LTC|BTC";
         private IAlgorithm _algorithm;
-        private static string[] _channelNames = new string[] { "heartbeat", "ticker", "user", "matches" };
+        private static string[] _channelNames = new string[] { "heartbeat", "level2", "user", "matches" };
         private CancellationTokenSource _canceller = new CancellationTokenSource();
         private ConcurrentQueue<WebSocketMessage> _messageBuffer = new ConcurrentQueue<WebSocketMessage>();
         private volatile bool _streamLocked;
         private readonly ConcurrentDictionary<int, decimal> _orderFees = new ConcurrentDictionary<int, decimal>();
+        private readonly ConcurrentDictionary<Symbol, OrderBook> _orderBooks = new ConcurrentDictionary<Symbol, OrderBook>();
 
         /// <summary>
         /// Rest client used to call missing conversion rates
@@ -148,9 +149,14 @@ namespace QuantConnect.Brokerages.GDAX
                 {
                     return;
                 }
-                else if (raw.Type == "ticker")
+                else if (raw.Type == "snapshot")
                 {
-                    EmitQuoteTick(e.Message);
+                    OnSnapshot(e.Message);
+                    return;
+                }
+                else if (raw.Type == "l2update")
+                {
+                    OnL2Update(e.Message);
                     return;
                 }
                 else if (raw.Type == "error")
@@ -181,6 +187,102 @@ namespace QuantConnect.Brokerages.GDAX
             catch (Exception exception)
             {
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, -1, $"Parsing wss message failed. Data: {e.Message} Exception: {exception}"));
+                throw;
+            }
+        }
+
+        private void OnSnapshot(string data)
+        {
+            try
+            {
+                var message = JsonConvert.DeserializeObject<Messages.Snapshot>(data);
+
+                var symbol = ConvertProductId(message.ProductId);
+
+                OrderBook orderBook;
+                if (!_orderBooks.TryGetValue(symbol, out orderBook))
+                {
+                    orderBook = new OrderBook(symbol);
+                    _orderBooks[symbol] = orderBook;
+                }
+                else
+                {
+                    orderBook.BestBidAskUpdated -= OnBestBidAskUpdated;
+                    orderBook.Clear();
+                }
+
+                foreach (var row in message.Bids)
+                {
+                    var price = decimal.Parse(row[0], NumberStyles.Float, CultureInfo.InvariantCulture);
+                    var size = decimal.Parse(row[1], NumberStyles.Float, CultureInfo.InvariantCulture);
+                    orderBook.UpdateBidRow(price, size);
+                }
+                foreach (var row in message.Asks)
+                {
+                    var price = decimal.Parse(row[0], NumberStyles.Float, CultureInfo.InvariantCulture);
+                    var size = decimal.Parse(row[1], NumberStyles.Float, CultureInfo.InvariantCulture);
+                    orderBook.UpdateAskRow(price, size);
+                }
+
+                orderBook.BestBidAskUpdated += OnBestBidAskUpdated;
+
+                EmitQuoteTick(symbol, orderBook.BestBidPrice, orderBook.BestAskPrice);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e);
+                throw;
+            }
+        }
+
+        private void OnBestBidAskUpdated(object sender, BestBidAskUpdatedEventArgs e)
+        {
+            EmitQuoteTick(e.Symbol, e.BestBidPrice, e.BestAskPrice);
+        }
+
+        private void OnL2Update(string data)
+        {
+            try
+            {
+                var message = JsonConvert.DeserializeObject<Messages.L2Update>(data);
+
+                var symbol = ConvertProductId(message.ProductId);
+
+                var orderBook = _orderBooks[symbol];
+
+                foreach (var row in message.Changes)
+                {
+                    var side = row[0];
+                    var price = Convert.ToDecimal(row[1], CultureInfo.InvariantCulture);
+                    var size = decimal.Parse(row[2], NumberStyles.Float, CultureInfo.InvariantCulture);
+                    if (side == "buy")
+                    {
+                        if (size == 0)
+                        {
+                            orderBook.RemoveBidRow(price);
+                        }
+                        else
+                        {
+                            orderBook.UpdateBidRow(price, size);
+                        }
+                    }
+                    else if (side == "sell")
+                    {
+                        if (size == 0)
+                        {
+                            orderBook.RemoveAskRow(price);
+                        }
+                        else
+                        {
+                            orderBook.UpdateAskRow(price, size);
+                        }
+                    }
+
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Data: " + data);
                 throw;
             }
         }
@@ -323,22 +425,20 @@ namespace QuantConnect.Brokerages.GDAX
         }
 
         /// <summary>
-        /// Converts a ticker message and emits data as a new quote tick
+        /// Emits a new quote tick
         /// </summary>
-        /// <param name="data"></param>
-        private void EmitQuoteTick(string data)
+        /// <param name="symbol">The symbol</param>
+        /// <param name="bidPrice">The bid price</param>
+        /// <param name="askPrice">The ask price</param>
+        private void EmitQuoteTick(Symbol symbol, decimal bidPrice, decimal askPrice)
         {
-            var message = JsonConvert.DeserializeObject<Messages.Ticker>(data, JsonSettings);
-
-            var symbol = ConvertProductId(message.ProductId);
-
             lock (_tickLocker)
             {
                 Ticks.Add(new Tick
                 {
-                    AskPrice = message.BestAsk,
-                    BidPrice = message.BestBid,
-                    Value = (message.BestAsk + message.BestBid) / 2m,
+                    AskPrice = askPrice,
+                    BidPrice = bidPrice,
+                    Value = (askPrice + bidPrice) / 2m,
                     Time = DateTime.UtcNow,
                     Symbol = symbol,
                     TickType = TickType.Quote

--- a/Brokerages/GDAX/Messages.cs
+++ b/Brokerages/GDAX/Messages.cs
@@ -1,9 +1,21 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace QuantConnect.Brokerages.GDAX.Messages
 {
@@ -149,6 +161,17 @@ namespace QuantConnect.Brokerages.GDAX.Messages
         public decimal BestAsk { get; set; }
         public decimal Price { get; set; }
         public string Side { get; set; }
+    }
+
+    public class Snapshot : BaseMessage
+    {
+        public List<string[]> Bids { get; set; }
+        public List<string[]> Asks { get; set; }
+    }
+
+    public class L2Update : BaseMessage
+    {
+        public List<string[]> Changes { get; set; }
     }
 
 #pragma warning restore 1591

--- a/Brokerages/GDAX/OrderBook.cs
+++ b/Brokerages/GDAX/OrderBook.cs
@@ -42,9 +42,19 @@ namespace QuantConnect.Brokerages.GDAX
         public decimal BestBidPrice { get; private set; }
 
         /// <summary>
+        /// The best bid size
+        /// </summary>
+        public decimal BestBidSize { get; private set; }
+
+        /// <summary>
         /// The best ask price
         /// </summary>
         public decimal BestAskPrice { get; private set; }
+
+        /// <summary>
+        /// The best ask size
+        /// </summary>
+        public decimal BestAskSize { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OrderBook"/> class
@@ -67,7 +77,9 @@ namespace QuantConnect.Brokerages.GDAX
             }
 
             BestBidPrice = 0;
+            BestBidSize = 0;
             BestAskPrice = 0;
+            BestAskSize = 0;
         }
 
         /// <summary>
@@ -82,11 +94,12 @@ namespace QuantConnect.Brokerages.GDAX
                 _bids[price] = size;
             }
 
-            if (BestBidPrice == 0 || price > BestBidPrice)
+            if (BestBidPrice == 0 || price >= BestBidPrice)
             {
                 BestBidPrice = price;
+                BestBidSize = size;
 
-                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestAskPrice));
+                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestBidSize, BestAskPrice, BestAskSize));
             }
         }
 
@@ -102,11 +115,12 @@ namespace QuantConnect.Brokerages.GDAX
                 _asks[price] = size;
             }
 
-            if (BestAskPrice == 0 || price < BestAskPrice)
+            if (BestAskPrice == 0 || price <= BestAskPrice)
             {
                 BestAskPrice = price;
+                BestAskSize = size;
 
-                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestAskPrice));
+                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestBidSize, BestAskPrice, BestAskSize));
             }
         }
 
@@ -126,9 +140,10 @@ namespace QuantConnect.Brokerages.GDAX
                 lock(_locker)
                 {
                     BestBidPrice = _bids.Keys.LastOrDefault();
+                    BestBidSize = BestBidPrice > 0 ? _bids[BestBidPrice] : 0;
                 }
 
-                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestAskPrice));
+                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestBidSize, BestAskPrice, BestAskSize));
             }
         }
 
@@ -148,9 +163,10 @@ namespace QuantConnect.Brokerages.GDAX
                 lock(_locker)
                 {
                     BestAskPrice = _asks.Keys.FirstOrDefault();
+                    BestAskSize = BestAskPrice > 0 ? _asks[BestAskPrice] : 0;
                 }
 
-                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestAskPrice));
+                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestBidSize, BestAskPrice, BestAskSize));
             }
         }
     }

--- a/Brokerages/GDAX/OrderBook.cs
+++ b/Brokerages/GDAX/OrderBook.cs
@@ -1,0 +1,157 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Brokerages.GDAX
+{
+    /// <summary>
+    /// Represents a full order book for a security.
+    /// It contains prices and order sizes for each bid and ask level.
+    /// The best bid and ask prices are also kept up to date.
+    /// </summary>
+    public class OrderBook
+    {
+        private readonly object _locker = new object();
+        private readonly Symbol _symbol;
+        private readonly SortedDictionary<decimal, decimal> _bids = new SortedDictionary<decimal, decimal>();
+        private readonly SortedDictionary<decimal, decimal> _asks = new SortedDictionary<decimal, decimal>();
+
+        /// <summary>
+        /// Event fired each time <see cref="BestBidPrice"/> or <see cref="BestAskPrice"/> are changed
+        /// </summary>
+        public event EventHandler<BestBidAskUpdatedEventArgs> BestBidAskUpdated;
+
+        /// <summary>
+        /// The best bid price
+        /// </summary>
+        public decimal BestBidPrice { get; private set; }
+
+        /// <summary>
+        /// The best ask price
+        /// </summary>
+        public decimal BestAskPrice { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderBook"/> class
+        /// </summary>
+        /// <param name="symbol">The symbol for the order book</param>
+        public OrderBook(Symbol symbol)
+        {
+            _symbol = symbol;
+        }
+
+        /// <summary>
+        /// Clears all bid/ask levels and prices.
+        /// </summary>
+        public void Clear()
+        {
+            lock (_locker)
+            {
+                _bids.Clear();
+                _asks.Clear();
+            }
+
+            BestBidPrice = 0;
+            BestAskPrice = 0;
+        }
+
+        /// <summary>
+        /// Updates or inserts a bid price level in the order book
+        /// </summary>
+        /// <param name="price">The bid price level to be inserted or updated</param>
+        /// <param name="size">The new size at the bid price level</param>
+        public void UpdateBidRow(decimal price, decimal size)
+        {
+            lock(_locker)
+            {
+                _bids[price] = size;
+            }
+
+            if (BestBidPrice == 0 || price > BestBidPrice)
+            {
+                BestBidPrice = price;
+
+                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestAskPrice));
+            }
+        }
+
+        /// <summary>
+        /// Updates or inserts an ask price level in the order book
+        /// </summary>
+        /// <param name="price">The ask price level to be inserted or updated</param>
+        /// <param name="size">The new size at the ask price level</param>
+        public void UpdateAskRow(decimal price, decimal size)
+        {
+            lock(_locker)
+            {
+                _asks[price] = size;
+            }
+
+            if (BestAskPrice == 0 || price < BestAskPrice)
+            {
+                BestAskPrice = price;
+
+                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestAskPrice));
+            }
+        }
+
+        /// <summary>
+        /// Removes a bid price level from the order book
+        /// </summary>
+        /// <param name="price">The bid price level to be removed</param>
+        public void RemoveBidRow(decimal price)
+        {
+            lock(_locker)
+            {
+                _bids.Remove(price);
+            }
+
+            if (price == BestBidPrice)
+            {
+                lock(_locker)
+                {
+                    BestBidPrice = _bids.Keys.LastOrDefault();
+                }
+
+                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestAskPrice));
+            }
+        }
+
+        /// <summary>
+        /// Removes an ask price level from the order book
+        /// </summary>
+        /// <param name="price">The ask price level to be removed</param>
+        public void RemoveAskRow(decimal price)
+        {
+            lock(_locker)
+            {
+                _asks.Remove(price);
+            }
+
+            if (price == BestAskPrice)
+            {
+                lock(_locker)
+                {
+                    BestAskPrice = _asks.Keys.FirstOrDefault();
+                }
+
+                BestBidAskUpdated?.Invoke(this, new BestBidAskUpdatedEventArgs(_symbol, BestBidPrice, BestAskPrice));
+            }
+        }
+    }
+}

--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -181,11 +181,13 @@
     <Compile Include="Fxcm\FxcmBrokerageFactory.cs" />
     <Compile Include="Fxcm\FxcmSymbolMapper.cs" />
     <Compile Include="GDAX\AuthenticationToken.cs" />
+    <Compile Include="GDAX\BestBidAskUpdatedEventArgs.cs" />
     <Compile Include="GDAX\GDAXBrokerage.Utility.cs" />
     <Compile Include="GDAX\GDAXBrokerage.cs" />
     <Compile Include="GDAX\GDAXBrokerageFactory.cs" />
     <Compile Include="GDAX\GDAXFill.cs" />
     <Compile Include="GDAX\GDAXBrokerage.Messaging.cs" />
+    <Compile Include="GDAX\OrderBook.cs" />
     <Compile Include="IWebSocket.cs" />
     <Compile Include="GDAX\Messages.cs" />
     <Compile Include="WebSocketError.cs" />


### PR DESCRIPTION
Previously quote ticks were only emitted when a trade was received.

A new preliminary implementation of the `OrderBook` class was added to the GDAX brokerage, so we can track the best bid/ask prices and sizes and emit a quote `Tick` when one of them has changed.

Also, quote ticks now include values for the `BidSize` and `AskSize` properties.