### PR TITLE
Prevent duplicate security creation

### DIFF
--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,6 +40,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private readonly MarketHoursDatabase _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
         private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
         private readonly HashSet<Security> _pendingRemovals = new HashSet<Security>();
+        private readonly Dictionary<DateTime, Dictionary<Symbol, Security>> _pendingSecurityAdditions = new Dictionary<DateTime, Dictionary<Symbol, Security>>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UniverseSelection"/> class
@@ -156,14 +157,30 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
             }
 
+            var keys = _pendingSecurityAdditions.Keys;
+            if (keys.Any() && keys.Single() != dateTimeUtc)
+            {
+                // if the frontier moved forward then we've added these securities to the algorithm
+                _pendingSecurityAdditions.Clear();
+            }
+
+            Dictionary<Symbol, Security> pendingAdditions;
+            if (!_pendingSecurityAdditions.TryGetValue(dateTimeUtc, out pendingAdditions))
+            {
+                // keep track of created securities so we don't create the same security twice, leads to bad things :)
+                pendingAdditions = new Dictionary<Symbol, Security>();
+                _pendingSecurityAdditions[dateTimeUtc] = pendingAdditions;
+            }
+
             // find new selections and add them to the algorithm
             foreach (var symbol in selections)
             {
                 // create the new security, the algorithm thread will add this at the appropriate time
                 Security security;
-                if (!_algorithm.Securities.TryGetValue(symbol, out security))
+                if (!pendingAdditions.TryGetValue(symbol, out security) || !_algorithm.Securities.TryGetValue(symbol, out security))
                 {
                     security = universe.CreateSecurity(symbol, _algorithm, _marketHoursDatabase, _symbolPropertiesDatabase);
+                    pendingAdditions.Add(symbol, security);
                 }
 
                 var addedSubscription = false;


### PR DESCRIPTION
Since securities are created AND THEN added to the algorithm, it was possible for two different universes to create the SAME security at the same time step. This led to two different Security instances and only one of them being added. Ironically, it appears that it was a last in wins situation.

This change aims to track securities that are created by a universe in a given time step and re-use the already created security. A more holistic solution here may be to encapsulate the creation/fetching of securities into a new type and then ensure we use that abstraction everywhere, but this would have led to many more changes.