### PR TITLE
Support headers in SubscriptionDataSource

### DIFF
--- a/Common/Data/SubscriptionDataSource.cs
+++ b/Common/Data/SubscriptionDataSource.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,6 +14,8 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantConnect.Data
 {
@@ -38,15 +40,18 @@ namespace QuantConnect.Data
         public readonly SubscriptionTransportMedium TransportMedium;
 
         /// <summary>
+        /// Gets the header values to be used in the web request.
+        /// </summary>
+        public readonly IReadOnlyList<KeyValuePair<string, string>> Headers;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SubscriptionDataSource"/> class.
         /// </summary>
         /// <param name="source">The subscription's data source location</param>
         /// <param name="transportMedium">The transport medium to be used to retrieve the subscription's data from the source</param>
         public SubscriptionDataSource(string source, SubscriptionTransportMedium transportMedium)
+            : this(source, transportMedium, FileFormat.Csv)
         {
-            Source = source;
-            Format = FileFormat.Csv;
-            TransportMedium = transportMedium;
         }
 
         /// <summary>
@@ -56,10 +61,24 @@ namespace QuantConnect.Data
         /// <param name="format">The format of the data within the source</param>
         /// <param name="transportMedium">The transport medium to be used to retrieve the subscription's data from the source</param>
         public SubscriptionDataSource(string source, SubscriptionTransportMedium transportMedium, FileFormat format)
+            : this(source, transportMedium, format, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubscriptionDataSource"/> class with <see cref="SubscriptionTransportMedium.Rest"/>
+        /// including the specified header values
+        /// </summary>
+        /// <param name="source">The subscription's data source location</param>
+        /// <param name="transportMedium">The transport medium to be used to retrieve the subscription's data from the source</param>
+        /// <param name="format">The format of the data within the source</param>
+        /// <param name="headers">The headers to be used for this source</param>
+        public SubscriptionDataSource(string source, SubscriptionTransportMedium transportMedium, FileFormat format, IEnumerable<KeyValuePair<string, string>> headers)
         {
             Source = source;
             Format = format;
             TransportMedium = transportMedium;
+            Headers = (headers?.ToList() ?? new List<KeyValuePair<string, string>>()).AsReadOnly();
         }
 
         /// <summary>
@@ -73,7 +92,9 @@ namespace QuantConnect.Data
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return string.Equals(Source, other.Source) && TransportMedium == other.TransportMedium;
+            return string.Equals(Source, other.Source)
+                && TransportMedium == other.TransportMedium
+                && Headers.SequenceEqual(other.Headers);
         }
 
         /// <summary>
@@ -92,7 +113,7 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// Serves as a hash function for a particular type. 
+        /// Serves as a hash function for a particular type.
         /// </summary>
         /// <returns>
         /// A hash code for the current <see cref="T:System.Object"/>.

--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -79,13 +79,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 {
                     default:
                     case SubscriptionTransportMedium.Rest:
-                        reader = new RestSubscriptionStreamReader(source.Source);
+                        reader = new RestSubscriptionStreamReader(source.Source, source.Headers);
                         break;
                     case SubscriptionTransportMedium.LocalFile:
                         reader = new LocalFileSubscriptionStreamReader(_dataCacheProvider, source.Source);
                         break;
                     case SubscriptionTransportMedium.RemoteFile:
-                        reader = new RemoteFileSubscriptionStreamReader(_dataCacheProvider, source.Source, Globals.Cache);
+                        reader = new RemoteFileSubscriptionStreamReader(_dataCacheProvider, source.Source, Globals.Cache, source.Headers);
                         break;
                 }
 

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ using QuantConnect.Util;
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
     /// <summary>
-    /// Provides an implementations of <see cref="ISubscriptionDataSourceReader"/> that uses the 
+    /// Provides an implementations of <see cref="ISubscriptionDataSourceReader"/> that uses the
     /// <see cref="BaseData.Reader(QuantConnect.Data.SubscriptionDataConfig,string,System.DateTime,bool)"/>
     /// method to read lines of text from a <see cref="SubscriptionDataSource"/>
     /// </summary>
@@ -43,7 +43,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public event EventHandler<InvalidSourceEventArgs> InvalidSource;
 
         /// <summary>
-        /// Event fired when an exception is thrown during a call to 
+        /// Event fired when an exception is thrown during a call to
         /// <see cref="BaseData.Reader(QuantConnect.Data.SubscriptionDataConfig,string,System.DateTime,bool)"/>
         /// </summary>
         public event EventHandler<ReaderErrorEventArgs> ReaderError;
@@ -129,7 +129,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     break;
 
                 case SubscriptionTransportMedium.Rest:
-                    reader = new RestSubscriptionStreamReader(subscriptionDataSource.Source);
+                    reader = new RestSubscriptionStreamReader(subscriptionDataSource.Source, subscriptionDataSource.Headers);
                     break;
 
                 default:
@@ -190,7 +190,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             try
             {
                 // this will fire up a web client in order to download the 'source' file to the cache
-                return new RemoteFileSubscriptionStreamReader(_dataCacheProvider, source.Source, Globals.Cache);
+                return new RemoteFileSubscriptionStreamReader(_dataCacheProvider, source.Source, Globals.Cache, source.Headers);
             }
             catch (Exception err)
             {

--- a/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using QuantConnect.Interfaces;
@@ -35,7 +36,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// <param name="dataCacheProvider">The <see cref="IDataCacheProvider"/> used to retrieve a stream of data</param>
         /// <param name="source">The remote url to be downloaded via web client</param>
         /// <param name="downloadDirectory">The local directory and destination of the download</param>
-        public RemoteFileSubscriptionStreamReader(IDataCacheProvider dataCacheProvider, string source, string downloadDirectory)
+        /// <param name="headers">Defines header values to add to the request</param>
+        public RemoteFileSubscriptionStreamReader(IDataCacheProvider dataCacheProvider, string source, string downloadDirectory, IEnumerable<KeyValuePair<string, string>> headers)
         {
             // create a hash for a new filename
             var filename = Guid.NewGuid() + source.GetExtension();
@@ -44,6 +46,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
             using (var client = new WebClient())
             {
                 client.Proxy = WebRequest.GetSystemWebProxy();
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        client.Headers.Add(header.Key, header.Value);
+                    }
+                }
+
                 client.DownloadFile(source, destination);
             }
 

--- a/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using RestSharp;
@@ -33,10 +34,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// Initializes a new instance of the <see cref="RestSubscriptionStreamReader"/> class.
         /// </summary>
         /// <param name="source">The source url to poll with a GET</param>
-        public RestSubscriptionStreamReader(string source)
+        /// <param name="headers">Defines header values to add to the request</param>
+        public RestSubscriptionStreamReader(string source, IEnumerable<KeyValuePair<string, string>> headers)
         {
             _client = new RestClient(source);
             _request = new RestRequest(Method.GET);
+
+            if (headers != null)
+            {
+                foreach (var header in headers)
+                {
+                    _request.AddHeader(header.Key, header.Value);
+                }
+            }
         }
 
         /// <summary>
@@ -56,7 +66,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         }
 
         /// <summary>
-        /// Gets the next line/batch of content from the stream 
+        /// Gets the next line/batch of content from the stream
         /// </summary>
         public string ReadLine()
         {


### PR DESCRIPTION
It is not uncommon that a web service would require some form of authentication headers to be provided. This change aims to enable this by adding the header information to the source. This design
allows a user's custom data type to return the source properly hydrated with the required header values before being sent back through the rest of the LEAN infrastructure.