### PR TITLE
Add GDAX post-only option for Limit orders + bug fixes

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -490,10 +490,13 @@ namespace QuantConnect.Brokerages.GDAX
         /// </summary>
         public override void Subscribe(IEnumerable<Symbol> symbols)
         {
-
             foreach (var item in symbols)
             {
-                if (item.Value.Contains("UNIVERSE")) continue;
+                if (item.Value.Contains("UNIVERSE") ||
+                    item.SecurityType != SecurityType.Forex && item.SecurityType != SecurityType.Crypto)
+                {
+                    continue;
+                }
 
                 if (!IsSubscribeAvailable(item))
                 {

--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -73,6 +73,13 @@ namespace QuantConnect.Brokerages.GDAX
                     return false;
                 }
 
+                if (raw.Status == "rejected")
+                {
+                    OnOrderEvent(new OrderEvent(order, DateTime.UtcNow, 0, "GDAX Order Event") { Status = OrderStatus.Invalid, Message = "Reject reason: " + raw.RejectReason });
+                    UnlockStream();
+                    return false;
+                }
+
                 var brokerId = raw.Id;
                 if (CachedOrderIDs.ContainsKey(order.Id))
                 {

--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -57,6 +57,15 @@ namespace QuantConnect.Brokerages.GDAX
                 payload.overdraft_enabled = true;
             }
 
+            var orderProperties = order.Properties as GDAXOrderProperties;
+            if (orderProperties != null)
+            {
+                if (order.Type == OrderType.Limit)
+                {
+                    payload.post_only = orderProperties.PostOnly;
+                }
+            }
+
             req.AddJsonBody(payload);
 
             GetAuthenticationToken(req);

--- a/Brokerages/GDAX/Messages.cs
+++ b/Brokerages/GDAX/Messages.cs
@@ -114,6 +114,12 @@ namespace QuantConnect.Brokerages.GDAX.Messages
         public string Side { get; set; }
         public string Stp { get; set; }
         public string Type { get; set; }
+        [JsonProperty("time_in_force")]
+        public string TimeInForce { get; set; }
+        [JsonProperty("post_only")]
+        public bool PostOnly { get; set; }
+        [JsonProperty("reject_reason")]
+        public string RejectReason { get; set; }
         [JsonProperty("fill_fees")]
         public decimal FillFees { get; set; }
         [JsonProperty("filled_size")]

--- a/Common/Orders/GDAXOrderProperties.cs
+++ b/Common/Orders/GDAXOrderProperties.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Orders
+{
+    /// <summary>
+    /// Contains additional properties and settings for an order submitted to GDAX brokerage
+    /// </summary>
+    public class GDAXOrderProperties : IOrderProperties
+    {
+        /// <summary>
+        /// This flag will ensure the order executes only as a maker (no fee) order.
+        /// If part of the order results in taking liquidity rather than providing,
+        /// it will be rejected and no part of the order will execute.
+        /// Note: this flag is only applied to Limit orders.
+        /// </summary>
+        public bool PostOnly { get; set; }
+
+        /// <summary>
+        /// Returns a new instance clone of this object
+        /// </summary>
+        public IOrderProperties Clone()
+        {
+            return (GDAXOrderProperties)MemberwiseClone();
+        }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -150,7 +150,8 @@
     <Compile Include="Brokerages\DefaultBrokerageModel.cs" />
     <Compile Include="Brokerages\FxcmBrokerageModel.cs" />
     <Compile Include="Brokerages\GDAXBrokerageModel.cs" />
-	<Compile Include="Orders\InteractiveBrokersOrderProperties.cs" />
+    <Compile Include="Orders\GDAXOrderProperties.cs" />
+    <Compile Include="Orders\InteractiveBrokersOrderProperties.cs" />
     <Compile Include="Interfaces\IOrderProperties.cs" />
     <Compile Include="Python\BrokerageModelPythonWrapper.cs" />
     <Compile Include="Python\SecurityInitializerPythonWrapper.cs" />


### PR DESCRIPTION
The `PostOnly` flag for Limit orders has been added as a property in `GDAXOrderProperties` class.
It can be set as default for all limit orders in Initialize:
```
DefaultOrderProperties = new GDAXOrderProperties { PostOnly = true };
```

A couple of bugs have also been fixed:
- In GDAX subscribe, the SPY benchmark was being passed to `PollTick`
- Rejected orders were not being marked as Invalid