### PR TITLE
FXCM Real Volume live implementation.

### DIFF
--- a/Common/Data/Custom/FxcmVolume.cs
+++ b/Common/Data/Custom/FxcmVolume.cs
@@ -96,7 +96,7 @@ namespace QuantConnect.Data.Custom
             {
                 var source = string.Format("{0}&ver={1}&sid={2}&interval={3}&offerID={4}", _baseUrl, _ver, _sid,
                                            interval, symbolId);
-                return new SubscriptionDataSource(source, SubscriptionTransportMedium.Rest, FileFormat.Collection);
+                return new SubscriptionDataSource(source, SubscriptionTransportMedium.Rest, FileFormat.Csv);
             }
             else
             {

--- a/Common/Data/Custom/FxcmVolume.cs
+++ b/Common/Data/Custom/FxcmVolume.cs
@@ -1,8 +1,9 @@
-﻿using QuantConnect.Util;
+using QuantConnect.Util;
 using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using QuantConnect.Logging;
 
 namespace QuantConnect.Data.Custom
 {
@@ -17,11 +18,48 @@ namespace QuantConnect.Data.Custom
     /// <seealso cref="QuantConnect.Data.BaseData" />
     public class FxcmVolume : BaseData
     {
-        private string[] _availableSymbols =
+        private enum FxcmSymbolId
         {
-            "EURUSD", "USDJPY", "GBPUSD", "USDCHF", "EURCHF", "AUDUSD", "USDCAD", "NZDUSD", "EURGBP", "EURJPY",
-            "GBPJPY", "EURAUD", "EURCAD", "AUDJPY"
-        };
+            EURUSD = 1,
+            USDJPY = 2,
+            GBPUSD = 3,
+            USDCHF = 4,
+            EURCHF = 5,
+            AUDUSD = 6,
+            USDCAD = 7,
+            NZDUSD = 8,
+            EURGBP = 9,
+            EURJPY = 10,
+            GBPJPY = 11,
+            EURAUD = 14,
+            EURCAD = 15,
+            AUDJPY = 17
+        }
+
+        /// <summary>
+        ///     The request base URL.
+        /// </summary>
+        private readonly string _baseUrl = " http://marketsummary2.fxcorporate.com/ssisa/servlet?RT=SSI";
+
+        /// <summary>
+        ///     FXCM session id.
+        /// </summary>
+        private readonly string _sid = "quantconnect";
+
+        /// <summary>
+        ///     The columns index which should be added to obtain the transactions.
+        /// </summary>
+        private readonly long[] _transactionsIdx = { 27, 29, 31, 33 };
+
+        /// <summary>
+        ///     Integer representing client version.
+        /// </summary>
+        private readonly int _ver = 1;
+
+        /// <summary>
+        ///     The columns index which should be added to obtain the volume.
+        /// </summary>
+        private readonly int[] _volumeIdx = { 26, 28, 30, 32 };
 
         /// <summary>
         ///     Sum of opening and closing Transactions for the entire time interval.
@@ -50,11 +88,19 @@ namespace QuantConnect.Data.Custom
         /// <exception cref="System.NotImplementedException">FOREX Volume data is not available in live mode, yet.</exception>
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
-            if (isLiveMode) throw new NotImplementedException("FOREX Volume data is not available in live mode, yet.");
-            CheckResolution(config.Resolution);
-            CheckForexPair(config.Symbol.Value);
-            var source = GenerateZipFilePath(config, date);
-            return new SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile);
+            var interval = GetIntervalFromResolution(config.Resolution);
+            var symbolId = GetFxcmIDFromSymbol(config.Symbol);
+
+            if (isLiveMode)
+            {
+                var source = string.Format("{0}&ver={1}&sid={2}&interval={3}&offerID={4}", _baseUrl, _ver, _sid, interval, symbolId);
+                return new SubscriptionDataSource(source, SubscriptionTransportMedium.Rest, FileFormat.Collection);
+            }
+            else
+            {
+                var source = GenerateZipFilePath(config, date);
+                return new SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile);
+            }
         }
 
         private static string GenerateZipFilePath(SubscriptionDataConfig config, DateTime date)
@@ -89,42 +135,97 @@ namespace QuantConnect.Data.Custom
         /// </returns>
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
-            DateTime time;
-            var obs = line.Split(',');
-            if (config.Resolution == Resolution.Minute)
+            if (isLiveMode)
             {
-                time = date.Date.AddMilliseconds(int.Parse(obs[0]));
+                var obs = line.Split('\n')[2].Split(';');
+                var stringDate = obs[0].Substring(startIndex: 3);
+                var obsTime = DateTime.ParseExact(stringDate, "yyyyMMddHHmm",
+                                              DateTimeFormatInfo.InvariantInfo);
+                var volume = _volumeIdx.Select(x => long.Parse(obs[x])).Sum();
+                var transactions = _transactionsIdx.Select(x => int.Parse(obs[x])).Sum();
+                return new FxcmVolume
+                {
+                    Symbol = config.Symbol,
+                    Time = obsTime,
+                    Value = volume,
+                    Transactions = transactions
+                };
             }
             else
             {
-                time = DateTime.ParseExact(obs[0], "yyyyMMdd HH:mm", CultureInfo.InvariantCulture);
+                DateTime time;
+                var obs = line.Split(',');
+                if (config.Resolution == Resolution.Minute)
+                {
+                    time = date.Date.AddMilliseconds(int.Parse(obs[0]));
+                }
+                else
+                {
+                    time = DateTime.ParseExact(obs[0], "yyyyMMdd HH:mm", CultureInfo.InvariantCulture);
+                }
+                return new FxcmVolume
+                {
+                    DataType = MarketDataType.Base,
+                    Symbol = config.Symbol,
+                    Time = time,
+                    Value = long.Parse(obs[1]),
+                    Transactions = int.Parse(obs[2]),
+                };
             }
-            return new FxcmVolume
-            {
-                DataType = MarketDataType.Base,
-                Symbol = config.Symbol,
-                Time = time,
-                Value = long.Parse(obs[1]),
-                Transactions = int.Parse(obs[2]),
-            };
         }
 
-        private void CheckForexPair(string symbol)
+        /// <summary>
+        ///     Gets the FXCM identifier from a FOREX pair symbol.
+        /// </summary>
+        /// <param name="symbol">The pair symbol.</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentException">Volume data is not available for the selected symbol. - symbol</exception>
+        private int GetFxcmIDFromSymbol(Symbol symbol)
         {
-            if (!_availableSymbols.Contains(symbol))
+            int symbolId;
+            try
             {
-                throw new ArgumentException("Volume data is not available for the selected symbol.\nAvailable pairs:\n\t" +
-                    string.Join(", ", _availableSymbols), "symbol");
+                symbolId = (int)Enum.Parse(typeof(FxcmSymbolId), symbol.Value);
             }
+            catch (ArgumentException)
+            {
+                throw new ArgumentException("Volume data is not available for the selected symbol.", nameof(symbol));
+            }
+            return symbolId;
         }
 
-        private void CheckResolution(Resolution resolution)
+        /// <summary>
+        ///     Gets the string interval representation from the resolution.
+        /// </summary>
+        /// <param name="resolution">The requested resolution.</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        ///     resolution - tick or second resolution are not supported for Forex
+        ///     Volume.
+        /// </exception>
+        private string GetIntervalFromResolution(Resolution resolution)
         {
-            if (resolution != Resolution.Minute && resolution != Resolution.Hour && resolution != Resolution.Daily)
+            string interval;
+            switch (resolution)
             {
-                throw new ArgumentOutOfRangeException("resolution", resolution,
-                    "Available resolutions for FXCM Forex Volume data are Minute, Hour and Daily.");
+                case Resolution.Minute:
+                    interval = "M1";
+                    break;
+
+                case Resolution.Hour:
+                    interval = "H1";
+                    break;
+
+                case Resolution.Daily:
+                    interval = "D1";
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(resolution), resolution,
+                                                          "tick or second resolution are not supported for Forex Volume.");
             }
+            return interval;
         }
+
     }
 }


### PR DESCRIPTION
Now the FXCM Real Volume data can be used in live mode by making API calls.

For backtesting purposes, the data should be downloaded using the ToolBox downloader.