### PR TITLE
Limit chart packets for wildcard subscriptions

### DIFF
--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -459,12 +459,14 @@ namespace QuantConnect.Lean.Engine.Results
                 var chart = new Chart(deltaChart.Name);
                 current.Add(deltaChart.Name, chart);
 
-                if (deltaChart.Name == _subscription || _subscription == "*")
+                if (deltaChart.Name == _subscription || (_subscription == "*" && deltaChart.Name == "Strategy Equity"))
                 {
                     chart.Series = deltaChart.Series;
                 }
 
-                if (current.Count >= groupSize)
+                // If there is room left in the group. add the subscription
+                // to the packet unless it is a wildcard subscription
+                if (current.Count >= groupSize && _subscription != "*")
                 {
                     // Add the micro packet to transport.
                     chartPackets.Add(new LiveResultPacket(_job, new LiveResult { Charts = current }));
@@ -473,8 +475,9 @@ namespace QuantConnect.Lean.Engine.Results
                 }
             }
 
-            //Add whatever is left over here too.
-            if (current.Count > 0)
+            // Add whatever is left over here too
+            // unless it is a wildcard subscription
+            if (current.Count > 0 && _subscription != "*")
             {
                 chartPackets.Add(new LiveResultPacket(_job, new LiveResult { Charts = current }));
             }
@@ -492,7 +495,6 @@ namespace QuantConnect.Lean.Engine.Results
                 })
             };
 
-            // combine all the packets to be sent to through pubnub
             return packets.Concat(chartPackets);
         }
 


### PR DESCRIPTION
In the LiveTradeResultHandler it is possible to have wildcard
subscriptions where every chart is added to the packet and is eventually
sent via the message handlers back to the user. This change limits the
packets that are sent via wildcard subscription to only 'Strategy Equity'.
This was done to reduce the number of messages Lean sends the front end
during live trading. This change only affects the live chart packets.