### PR TITLE
Improve IB error messaging for authentication issues (2FA)

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -506,6 +506,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             var attempt = 1;
             const int maxAttempts = 5;
             var existingSessionDetected = false;
+            var securityDialogDetected = false;
             while (true)
             {
                 try
@@ -553,11 +554,20 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                         // no response, disconnect and retry
                         Disconnect();
 
+                        var ibcLogContent = LoadCurrentIbControllerLogFile();
+
                         // if existing session detected from IBController log file, log error and throw exception
-                        if (ExistingSessionDetected())
+                        if (ExistingSessionDetected(ibcLogContent))
                         {
                             existingSessionDetected = true;
                             throw new Exception("InteractiveBrokersBrokerage.Connect(): An existing session was detected and will not be automatically disconnected. Please close the existing session manually.");
+                        }
+
+                        // if security dialog detected from IBController log file, log error and throw exception
+                        if (SecurityDialogDetected(ibcLogContent))
+                        {
+                            securityDialogDetected = true;
+                            throw new Exception("InteractiveBrokersBrokerage.Connect(): A security dialog was detected for Second Factor/Code Card Authentication. Please opt out of the Secure Login System: Manage Account > Security > Secure Login System > SLS Opt Out");
                         }
 
                         // max out at 5 attempts to connect ~1 minute
@@ -616,8 +626,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 }
                 catch (Exception err)
                 {
-                    // if existing session detected from IBController log file, log error and throw exception
-                    if (existingSessionDetected)
+                    // if existing session or security dialog detected from IBController log file, log error and throw exception
+                    if (existingSessionDetected || securityDialogDetected)
                     {
                         Log.Error(err);
                         throw;
@@ -632,15 +642,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                     // we couldn't connect after several attempts, log the error and throw an exception
                     Log.Error(err);
-
-                    // add a blurb about TWS for connection refused errors
-                    if (err.Message.Contains("Connection refused"))
-                    {
-                        throw new Exception(err.Message + ". Be sure to logout of Trader Workstation. " +
-                            "IB only allows one active log in at a time. " +
-                            "This can also be caused by requiring two-factor authentication. " +
-                            "Be sure to disable this in IB Account Management > Security > SLS Opt out.", err);
-                    }
 
                     throw;
                 }
@@ -2740,7 +2741,25 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// For this method to work, the following setting is required in the IBController.ini file:
         /// ExistingSessionDetectedAction=secondary
         /// </remarks>
-        private static bool ExistingSessionDetected()
+        private static bool ExistingSessionDetected(List<string> ibcLogLines)
+        {
+            return IbControllerLogContainsMessage(ibcLogLines, "End this session and let the other session proceed");
+        }
+
+        /// <summary>
+        /// Returns true if an IB security dialog (2FA/code card) was detected by IBController
+        /// </summary>
+        private static bool SecurityDialogDetected(List<string> ibcLogLines)
+        {
+            return IbControllerLogContainsMessage(ibcLogLines, "Second Factor Authentication") ||
+                   IbControllerLogContainsMessage(ibcLogLines, "Security Code Card Authentication");
+        }
+
+        /// <summary>
+        /// Reads the current IBController log file
+        /// </summary>
+        /// <returns>A list containing the lines of the file</returns>
+        private static List<string> LoadCurrentIbControllerLogFile()
         {
             // find the current IBController log file name
             var ibControllerLogPath = Path.Combine(Config.Get("ib-controller-dir"), "Logs");
@@ -2757,17 +2776,24 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 }
             }
 
-            if (ibControllerLogFileName.IsNullOrEmpty())
-            {
-                return false;
-            }
+            return ibControllerLogFileName.IsNullOrEmpty()
+                ? new List<string>()
+                : File.ReadAllLines(ibControllerLogFileName).ToList();
+        }
 
-            // read the lines and find the message indicating the choice to leave the existing session running
-            var lines = File.ReadAllLines(ibControllerLogFileName).ToList();
+        /// <summary>
+        /// Searches for a message in the IBController log file
+        /// </summary>
+        /// <param name="lines">The lines of text of the IBController log file</param>
+        /// <param name="message">The message text to find</param>
+        /// <returns>true if the message was found</returns>
+        private static bool IbControllerLogContainsMessage(List<string> lines, string message)
+        {
+            // read the lines and find the message
             var separatorLine = new string('-', 60);
             var index = lines.FindLastIndex(x => x.Contains(separatorLine));
 
-            return index >= 0 && lines.Skip(index + 1).Any(line => line.Contains("End this session and let the other session proceed"));
+            return index >= 0 && lines.Skip(index + 1).Any(line => line.Contains(message));
         }
 
         /// <summary>


### PR DESCRIPTION
Previously a connection error due to invalid SLS configuration was reporting a generic message such as:

> "Operation took longer than 15 seconds. This may be caused by incorrect login credentials or an unsupported account type."


Now we are detecting security dialogs by reading the IBController log files and are able to display a better message:

> "A security dialog was detected for Second Factor/Code Card Authentication. Please opt out of the Secure Login System: Manage Account > Security > Secure Login System > SLS Opt Out"