### PR TITLE
Fix LiveTradingResultHandler calling SetMarketPrice with zero price

### DIFF
--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -1059,7 +1059,10 @@ namespace QuantConnect.Lean.Engine.Results
                             else
                             {
                                 // we haven't gotten data yet so just spoof a tick to push through the system to start with
-                                security.SetMarketPrice(new Tick(time, subscription.Configuration.Symbol, price, price));
+                                if (price > 0)
+                                {
+                                    security.SetMarketPrice(new Tick(time, subscription.Configuration.Symbol, price, price));
+                                }
                             }
 
                             //Sample Asset Pricing:


### PR DESCRIPTION
This bug was causing `MarketOnOpen` order fills to happen immediately after submission (when live trading with `PaperBrokerage`).