### PR TITLE
Fix race condition in BacktestingBrokerage order cancellations

### DIFF
--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -126,6 +126,8 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <returns>True if the request for a new order has been placed, false otherwise</returns>
         public override bool PlaceOrder(Order order)
         {
+            Log.Trace("BacktestingBrokerage.PlaceOrder(): Symbol: " + order.Symbol.Value + " Quantity: " + order.Quantity);
+
             if (order.Status == OrderStatus.New)
             {
                 lock (_needsScanLock)
@@ -154,6 +156,8 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <returns>True if the request was made for the order to be updated, false otherwise</returns>
         public override bool UpdateOrder(Order order)
         {
+            Log.Trace("BacktestingBrokerage.UpdateOrder(): Symbol: " + order.Symbol.Value + " Quantity: " + order.Quantity + " Status: " + order.Status);
+
             lock (_needsScanLock)
             {
                 Order pending;
@@ -185,6 +189,8 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <returns>True if the request was made for the order to be canceled, false otherwise</returns>
         public override bool CancelOrder(Order order)
         {
+            Log.Trace("BacktestingBrokerage.CancelOrder(): Symbol: " + order.Symbol.Value + " Quantity: " + order.Quantity);
+
             lock (_needsScanLock)
             {
                 Order pending;

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -105,8 +105,8 @@ namespace QuantConnect.Brokerages.Backtesting
         public override List<Holding> GetAccountHoldings()
         {
             // grab everything from the portfolio with a non-zero absolute quantity
-            return (from security in Algorithm.Portfolio.Securities.Values.OrderBy(x => x.Symbol) 
-                    where security.Holdings.AbsoluteQuantity > 0 
+            return (from security in Algorithm.Portfolio.Securities.Values.OrderBy(x => x.Symbol)
+                    where security.Holdings.AbsoluteQuantity > 0
                     select new Holding(security)).ToList();
         }
 
@@ -154,7 +154,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <returns>True if the request was made for the order to be updated, false otherwise</returns>
         public override bool UpdateOrder(Order order)
         {
-            if (true)
+            lock (_needsScanLock)
             {
                 Order pending;
                 if (!_pending.TryGetValue(order.Id, out pending))
@@ -163,22 +163,19 @@ namespace QuantConnect.Brokerages.Backtesting
                     return false;
                 }
 
-                lock (_needsScanLock)
-                {
-                    _needsScan = true;
-                    SetPendingOrder(order);
-                }
-
-                var orderId = order.Id.ToString();
-                if (!order.BrokerId.Contains(orderId)) order.BrokerId.Add(orderId);
-
-                // fire off the event that says this order has been updated
-                const int orderFee = 0;
-                var updated = new OrderEvent(order, Algorithm.UtcTime, orderFee) { Status = OrderStatus.Submitted };
-                OnOrderEvent(updated);
-
-                return true;
+                _needsScan = true;
+                SetPendingOrder(order);
             }
+
+            var orderId = order.Id.ToString();
+            if (!order.BrokerId.Contains(orderId)) order.BrokerId.Add(orderId);
+
+            // fire off the event that says this order has been updated
+            const int orderFee = 0;
+            var updated = new OrderEvent(order, Algorithm.UtcTime, orderFee) { Status = OrderStatus.Submitted };
+            OnOrderEvent(updated);
+
+            return true;
         }
 
         /// <summary>
@@ -188,11 +185,14 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <returns>True if the request was made for the order to be canceled, false otherwise</returns>
         public override bool CancelOrder(Order order)
         {
-            Order pending;
-            if (!_pending.TryRemove(order.Id, out pending))
+            lock (_needsScanLock)
             {
-                // can't cancel something that isn't there
-                return false;
+                Order pending;
+                if (!_pending.TryRemove(order.Id, out pending))
+                {
+                    // can't cancel something that isn't there
+                    return false;
+                }
             }
 
             var orderId = order.Id.ToString();
@@ -230,6 +230,12 @@ namespace QuantConnect.Brokerages.Backtesting
                 foreach (var kvp in _pending.OrderBy(x => x.Key))
                 {
                     var order = kvp.Value;
+                    if (order == null)
+                    {
+                        Log.Error("BacktestingBrokerage.Scan(): Null pending order found: " + kvp.Key);
+                        _pending.TryRemove(kvp.Key, out order);
+                        continue;
+                    }
 
                     if (order.Status.IsClosed())
                     {
@@ -369,7 +375,7 @@ namespace QuantConnect.Brokerages.Backtesting
         }
 
         /// <summary>
-        /// Runs market simulation 
+        /// Runs market simulation
         /// </summary>
         public void SimulateMarket()
         {

--- a/Common/Orders/OrderTicket.cs
+++ b/Common/Orders/OrderTicket.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@ namespace QuantConnect.Orders
     {
         private readonly object _orderEventsLock = new object();
         private readonly object _updateRequestsLock = new object();
-        private readonly object _setCancelRequestLock = new object();
+        private readonly object _cancelRequestLock = new object();
 
         private Order _order;
         private OrderStatus? _orderStatusOverride;
@@ -39,7 +39,7 @@ namespace QuantConnect.Orders
         private decimal _averageFillPrice;
 
         private readonly int _orderId;
-        private readonly List<OrderEvent> _orderEvents; 
+        private readonly List<OrderEvent> _orderEvents;
         private readonly SubmitOrderRequest _submitRequest;
         private readonly ManualResetEvent _orderStatusClosedEvent;
         private readonly List<UpdateOrderRequest> _updateRequests;
@@ -128,7 +128,7 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Gets the order's current tag
         /// </summary>
-        public string Tag 
+        public string Tag
         {
             get { return _order == null ? _submitRequest.Tag : _order.Tag; }
         }
@@ -162,7 +162,13 @@ namespace QuantConnect.Orders
         /// </summary>
         public CancelOrderRequest CancelRequest
         {
-            get { return _cancelRequest; }
+            get
+            {
+                lock (_cancelRequestLock)
+                {
+                    return _cancelRequest;
+                }
+            }
         }
 
         /// <summary>
@@ -260,7 +266,11 @@ namespace QuantConnect.Orders
         {
             var request = new CancelOrderRequest(_transactionManager.UtcTime, OrderId, tag);
             _transactionManager.ProcessRequest(request);
-            return CancelRequest.Response;
+
+            lock (_cancelRequestLock)
+            {
+                return _cancelRequest.Response;
+            }
         }
 
         /// <summary>
@@ -278,10 +288,14 @@ namespace QuantConnect.Orders
         /// <returns>The most recent <see cref="OrderRequest"/> for this ticket</returns>
         public OrderRequest GetMostRecentOrderRequest()
         {
-            if (CancelRequest != null)
+            lock (_cancelRequestLock)
             {
-                return CancelRequest;
+                if (_cancelRequest != null)
+                {
+                    return _cancelRequest;
+                }
             }
+
             var lastUpdate = _updateRequests.LastOrDefault();
             if (lastUpdate != null)
             {
@@ -361,7 +375,8 @@ namespace QuantConnect.Orders
             {
                 throw new ArgumentException("Received CancelOrderRequest for incorrect order id.");
             }
-            lock (_setCancelRequestLock)
+
+            lock (_cancelRequestLock)
             {
                 if (_cancelRequest != null)
                 {
@@ -369,6 +384,7 @@ namespace QuantConnect.Orders
                 }
                 _cancelRequest = request;
             }
+
             return true;
         }
 
@@ -439,14 +455,27 @@ namespace QuantConnect.Orders
 
         private int ResponseCount()
         {
-            return (_submitRequest.Response == OrderResponse.Unprocessed ? 0 : 1) 
-                 + (_cancelRequest == null || _cancelRequest.Response == OrderResponse.Unprocessed ? 0 : 1)
-                 + _updateRequests.Count(x => x.Response != OrderResponse.Unprocessed);
+            var count = (_submitRequest.Response == OrderResponse.Unprocessed ? 0 : 1) +
+                        _updateRequests.Count(x => x.Response != OrderResponse.Unprocessed);
+
+            lock (_cancelRequestLock)
+            {
+                count += _cancelRequest == null || _cancelRequest.Response == OrderResponse.Unprocessed ? 0 : 1;
+            }
+
+            return count;
         }
 
         private int RequestCount()
         {
-            return 1 + _updateRequests.Count + (_cancelRequest == null ? 0 : 1);
+            var count = 1 + _updateRequests.Count;
+
+            lock (_cancelRequestLock)
+            {
+                count += _cancelRequest == null ? 0 : 1;
+            }
+
+            return count;
         }
 
         /// <summary>

--- a/Common/Orders/OrderTicket.cs
+++ b/Common/Orders/OrderTicket.cs
@@ -269,8 +269,13 @@ namespace QuantConnect.Orders
 
             lock (_cancelRequestLock)
             {
-                return _cancelRequest.Response;
+                if (_cancelRequest != null)
+                {
+                    return _cancelRequest.Response;
+                }
             }
+
+            throw new ArgumentException("CancelRequest is null.");
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes occasional `NullReferenceException`s in `BacktestingBrokerage.Scan` and in `OrderTicket.Cancel`