### PR TITLE
Fixes CalculateOrderQuantity to handle decimal quantities

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -957,48 +957,40 @@ namespace QuantConnect.Algorithm
             decimal marginRequired;
             decimal orderValue;
             decimal orderFees;
-            var feeToPriceRatio = 0;
+            var feeToPriceRatio = 0m;
 
             // compute the initial order quantity
-            decimal orderQuantity = targetOrderValue / unitPrice;
+            var orderQuantity = targetOrderValue / unitPrice;
 
-            if (orderQuantity % security.SymbolProperties.LotSize != 0)
-            {
-                orderQuantity = orderQuantity - (orderQuantity % security.SymbolProperties.LotSize);
-            }
-
-            var iterations = 0;
+            // rounding off Order Quantity to the nearest multiple of Lot Size
+            orderQuantity -= orderQuantity % security.SymbolProperties.LotSize;
 
             do
             {
-                // decrease the order quantity
-                if (iterations > 0)
-                {
-                    // if fees are high relative to price, we reduce the order quantity faster
-                    if (feeToPriceRatio > 0)
-                        orderQuantity -= feeToPriceRatio;
-                    else
-                        orderQuantity--;
-                }
+                // reduce order quantity by feeToPriceRatio, since it is faster than by lot size
+                // if it becomes nonpositive, return zero
+                orderQuantity -= feeToPriceRatio;
+                if (orderQuantity <= 0) return 0;
 
                 // generate the order
                 var order = new MarketOrder(security.Symbol, orderQuantity, UtcTime);
                 orderValue = order.GetValue(security);
                 orderFees = security.FeeModel.GetOrderFee(security, order);
-                feeToPriceRatio = (int)(orderFees / unitPrice);
+
+                // calculate feeToPriceRatio, if lower than lot size, use lot size instead
+                feeToPriceRatio = orderFees / unitPrice;
+                if (feeToPriceRatio < security.SymbolProperties.LotSize)
+                {
+                    feeToPriceRatio = security.SymbolProperties.LotSize;
+                }
 
                 // calculate the margin required for the order
                 marginRequired = security.MarginModel.GetInitialMarginRequiredForOrder(security, order);
 
-                iterations++;
+            } while (marginRequired > marginRemaining || orderValue + orderFees > targetOrderValue);
 
-            } while (orderQuantity > 0 && (marginRequired > marginRemaining || orderValue + orderFees > targetOrderValue));
-
-            //Rounding off Order Quantity to the nearest multiple of Lot Size
-            if (orderQuantity % security.SymbolProperties.LotSize != 0)
-            {
-                orderQuantity = orderQuantity - (orderQuantity % security.SymbolProperties.LotSize);
-            }
+            var remainder = orderQuantity % security.SymbolProperties.LotSize;
+            if (remainder > 0) orderQuantity -= remainder;
 
             // add directionality back in
             return (direction == OrderDirection.Sell ? -1 : 1) * orderQuantity;

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -977,8 +977,9 @@ namespace QuantConnect.Algorithm
                 orderValue = order.GetValue(security);
                 orderFees = security.FeeModel.GetOrderFee(security, order);
 
-                // calculate feeToPriceRatio, if lower than lot size, use lot size instead
+                // find an incremental delta value for the next iteration step
                 feeToPriceRatio = orderFees / unitPrice;
+                feeToPriceRatio -= feeToPriceRatio % security.SymbolProperties.LotSize;
                 if (feeToPriceRatio < security.SymbolProperties.LotSize)
                 {
                     feeToPriceRatio = security.SymbolProperties.LotSize;
@@ -988,9 +989,6 @@ namespace QuantConnect.Algorithm
                 marginRequired = security.MarginModel.GetInitialMarginRequiredForOrder(security, order);
 
             } while (marginRequired > marginRemaining || orderValue + orderFees > targetOrderValue);
-
-            var remainder = orderQuantity % security.SymbolProperties.LotSize;
-            if (remainder > 0) orderQuantity -= remainder;
 
             // add directionality back in
             return (direction == OrderDirection.Sell ? -1 : 1) * orderQuantity;

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -956,6 +956,13 @@ namespace QuantConnect.Tests.Algorithm
             var actual = algo.CalculateOrderQuantity(Symbols.EURUSD, 1m);
             Assert.AreEqual(3000m, actual);
 
+            var btcusd = algo.AddCrypto("BTCUSD", market: Market.GDAX);
+            btcusd.TransactionModel = new ConstantFeeTransactionModel(0);
+            // Set Price to $26
+            Update(btcusd, 26);
+            // So 100000/26 = 3846.153846153846, After Rounding off becomes 3846.15384615, since lot size is 0.00000001
+            actual = algo.CalculateOrderQuantity(Symbols.BTCUSD, 1m);
+            Assert.AreEqual(3846.15384615m, actual);
         }
 
         [Test]
@@ -972,6 +979,14 @@ namespace QuantConnect.Tests.Algorithm
             // So -100000/26 = -3846, After Rounding off becomes -3000
             var actual = algo.CalculateOrderQuantity(Symbols.EURUSD, -1m);
             Assert.AreEqual(-3000m, actual);
+
+            var btcusd = algo.AddCrypto("BTCUSD", market: Market.GDAX);
+            btcusd.TransactionModel = new ConstantFeeTransactionModel(0);
+            // Set Price to $26
+            Update(btcusd, 26);
+            // So -100000/26 = 3846.153846153846, After Rounding off becomes -3846.15384615, since lot size is 0.00000001
+            actual = algo.CalculateOrderQuantity(Symbols.BTCUSD, -1m);
+            Assert.AreEqual(-3846.15384615m, actual);
         }
 
         [Test]


### PR DESCRIPTION
In quantity calculation, we didn't reduce the order quantity by decimal numbers, leading to a big step when dealing with crypto-currencies. For example, from 2.3456 it would drop to 1.3456 where values in between should've been tested.
- Updates RegressionTests statitics to reflect changes in CalculateOrderQuantity