### PR TITLE
Add SubscriptionManager.RemoveConsolidator

### DIFF
--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -196,6 +196,20 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
+        /// Removes the specified consolidator for the symbol
+        /// </summary>
+        /// <param name="symbol">The symbol the consolidator is receiving data from</param>
+        /// <param name="consolidator">The consolidator instance to be removed</param>
+        public void RemoveConsolidator(Symbol symbol, IDataConsolidator consolidator)
+        {
+            // remove consolidator from each subscription
+            foreach (var subscription in Subscriptions.Where(x => x.Symbol == symbol))
+            {
+                subscription.Consolidators.Remove(consolidator);
+            }
+        }
+
+        /// <summary>
         /// Hard code the set of default available data feeds
         /// </summary>
         public Dictionary<SecurityType, List<TickType>> DefaultDataTypes()


### PR DESCRIPTION
This allows algorithms to remove consolidators at run time. This is especially relevant with universe selection where we can add/remove securities at run time and potentially be creating indicators as well. When the security is removed from the universe we'll also want to remove any consolidators/indicators that have been wired up as well.

>Should we be doing this by default when we remove securities from a universe? Basically clearing it out?