### PR TITLE
Fxcm Real Volume same symbol issue fix

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFxcmVolumeAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFxcmVolumeAlgorithm.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);                //Set Strategy Cash
 
             // Find more symbols here: https://www.quantconnect.com/data
-            EURUSD = AddForex("EURUSD", Resolution.Minute, Market.Oanda).Symbol;
+            EURUSD = AddForex("EURUSD", Resolution.Minute).Symbol;
 
             AddData<FxcmVolume>("EURUSD_Vol", Resolution.Minute, DateTimeZone.Utc);
             var _price = Identity(EURUSD);

--- a/Algorithm.CSharp/BasicTemplateFxcmVolumeAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFxcmVolumeAlgorithm.cs
@@ -45,9 +45,9 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);                //Set Strategy Cash
 
             // Find more symbols here: https://www.quantconnect.com/data
-            EURUSD = AddForex("EURUSD", Resolution.Minute, Market.FXCM).Symbol;
+            EURUSD = AddForex("EURUSD", Resolution.Minute, Market.Oanda).Symbol;
 
-            AddData<FxcmVolume>("EURUSD", Resolution.Minute, DateTimeZone.Utc);
+            AddData<FxcmVolume>("EURUSD_Vol", Resolution.Minute, DateTimeZone.Utc);
             var _price = Identity(EURUSD);
             fastVWMA = _price.WeightedBy(volume, period: 15);
             slowVWMA = _price.WeightedBy(volume, period: 300);

--- a/Common/Data/Custom/FxcmVolume.cs
+++ b/Common/Data/Custom/FxcmVolume.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Data.Custom
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
             var interval = GetIntervalFromResolution(config.Resolution);
-            var symbolId = GetFxcmIDFromSymbol(config.Symbol);
+            var symbolId = GetFxcmIDFromSymbol(config.Symbol.Value.Split('_').First());
 
             if (isLiveMode)
             {
@@ -162,14 +162,15 @@ namespace QuantConnect.Data.Custom
             var source = Path.Combine(new[] {Globals.DataFolder, "forex", "fxcm", config.Resolution.ToLower()});
             string filename;
 
+            var symbol = config.Symbol.Value.Split('_').First().ToLower();
             if (config.Resolution == Resolution.Minute)
             {
                 filename = string.Format("{0:yyyyMMdd}_volume.zip", date);
-                source = Path.Combine(source, config.Symbol.Value.ToLower(), filename);
+                source = Path.Combine(source, symbol, filename);
             }
             else
             {
-                filename = string.Format("{0}_volume.zip", config.Symbol.Value.ToLower());
+                filename = string.Format("{0}_volume.zip", symbol);
                 source = Path.Combine(source, filename);
             }
             return source;
@@ -181,12 +182,12 @@ namespace QuantConnect.Data.Custom
         /// <param name="symbol">The pair symbol.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentException">Volume data is not available for the selected symbol. - symbol</exception>
-        private int GetFxcmIDFromSymbol(Symbol symbol)
+        private int GetFxcmIDFromSymbol(string symbol)
         {
             int symbolId;
             try
             {
-                symbolId = (int) Enum.Parse(typeof(FxcmSymbolId), symbol.Value);
+                symbolId = (int) Enum.Parse(typeof(FxcmSymbolId), symbol);
             }
             catch (ArgumentException)
             {

--- a/Common/Data/Custom/FxcmVolume.cs
+++ b/Common/Data/Custom/FxcmVolume.cs
@@ -177,22 +177,22 @@ namespace QuantConnect.Data.Custom
         }
 
         /// <summary>
-        ///     Gets the FXCM identifier from a FOREX pair symbol.
+        ///     Gets the FXCM identifier from a FOREX pair ticker.
         /// </summary>
-        /// <param name="symbol">The pair symbol.</param>
+        /// <param name="ticker">The pair ticker.</param>
         /// <returns></returns>
-        /// <exception cref="System.ArgumentException">Volume data is not available for the selected symbol. - symbol</exception>
-        private int GetFxcmIDFromSymbol(string symbol)
+        /// <exception cref="System.ArgumentException">Volume data is not available for the selected ticker. - ticker</exception>
+        private int GetFxcmIDFromSymbol(string ticker)
         {
             int symbolId;
             try
             {
-                symbolId = (int) Enum.Parse(typeof(FxcmSymbolId), symbol);
+                symbolId = (int) Enum.Parse(typeof(FxcmSymbolId), ticker);
             }
             catch (ArgumentException)
             {
-                throw new ArgumentOutOfRangeException(nameof(symbol), symbol,
-                                                      "Volume data is not available for the selected symbol.");
+                throw new ArgumentOutOfRangeException(nameof(ticker), ticker,
+                                                      "Volume data is not available for the selected ticker.");
             }
             return symbolId;
         }

--- a/Common/Data/Custom/FxcmVolume.cs
+++ b/Common/Data/Custom/FxcmVolume.cs
@@ -119,25 +119,21 @@ namespace QuantConnect.Data.Custom
         /// </returns>
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
+            DateTime time;
+            long volume;
+            int transactions;
             if (isLiveMode)
             {
                 var obs = line.Split('\n')[2].Split(';');
                 var stringDate = obs[0].Substring(startIndex: 3);
-                var obsTime = DateTime.ParseExact(stringDate, "yyyyMMddHHmm",
+                time = DateTime.ParseExact(stringDate, "yyyyMMddHHmm",
                                                   DateTimeFormatInfo.InvariantInfo);
-                var volume = _volumeIdx.Select(x => long.Parse(obs[x])).Sum();
-                var transactions = _transactionsIdx.Select(x => int.Parse(obs[x])).Sum();
-                return new FxcmVolume
-                {
-                    Symbol = config.Symbol,
-                    Time = obsTime,
-                    Value = volume,
-                    Transactions = transactions
-                };
+                volume = _volumeIdx.Select(x => long.Parse(obs[x])).Sum();
+                transactions = _transactionsIdx.Select(x => int.Parse(obs[x])).Sum();
+                
             }
             else
             {
-                DateTime time;
                 var obs = line.Split(',');
                 if (config.Resolution == Resolution.Minute)
                 {
@@ -147,15 +143,18 @@ namespace QuantConnect.Data.Custom
                 {
                     time = DateTime.ParseExact(obs[0], "yyyyMMdd HH:mm", CultureInfo.InvariantCulture);
                 }
-                return new FxcmVolume
-                {
-                    DataType = MarketDataType.Base,
-                    Symbol = config.Symbol,
-                    Time = time,
-                    Value = long.Parse(obs[1]),
-                    Transactions = int.Parse(obs[2])
-                };
+                volume = long.Parse(obs[1]);
+                transactions = int.Parse(obs[2]);
             }
+            return new FxcmVolume
+            {
+                DataType = MarketDataType.Base,
+                Symbol = config.Symbol,
+                Time = time,
+                Value = volume,
+                Transactions = transactions
+            };
+
         }
 
         private static string GenerateZipFilePath(SubscriptionDataConfig config, DateTime date)


### PR DESCRIPTION
It allows to Python users to add FXCM Real Volume data with the pair's ticker followed by an underscore i.e. `EURUSD_Vol` .