### PR TITLE
Verify data validity after base data.reader

### DIFF
--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -118,7 +118,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     {
                         foreach (var instance in instances.Data)
                         {
-                            yield return instance;
+                            if (instance != null && instance.EndTime != default(DateTime))
+                            {
+                                yield return instance;
+                            }
                         }
                     }
                 }

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         OnReaderError(line, err);
                     }
 
-                    if (instance != null)
+                    if (instance != null && instance.EndTime != default(DateTime))
                     {
                         yield return instance;
                     }

--- a/Engine/DataFeeds/ZipEntryNameSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/ZipEntryNameSubscriptionDataSourceReader.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -76,7 +76,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             foreach (var entryFileName in zip.EntryFileNames)
             {
-                yield return _factory.Reader(_config, entryFileName, _date, _isLiveMode);
+                var instance = _factory.Reader(_config, entryFileName, _date, _isLiveMode);
+                if (instance != null && instance.EndTime != default(DateTime))
+                {
+                    yield return instance;
+                }
             }
         }
 

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -31,12 +31,6 @@ namespace QuantConnect.Tests
     /// </summary>
     public static class AlgorithmRunner
     {
-        static AlgorithmRunner()
-        {
-            // delete the regression.log file, since we turned debug output on it can grow pretty quickly
-            try { System.IO.File.Delete("regression.log"); } catch { /*NOP*/ }
-        }
-
         public static void RunLocalBacktest(string algorithm, Dictionary<string, string> expectedStatistics, Language language)
         {
             var statistics = new Dictionary<string, string>();


### PR DESCRIPTION
### Filter null or uninitialized data immediately

The convention throughout the documentation and source code is to either
return null or a new, uninitialized object to indicate that the reader method
was unable to produce an instance from the previous content. It appears over
time that these filters were forgotten within the data enumerator stacks.

### Update the FractionalQuantityRegressionAlgorithm statistics
This regression test presents itself occassionaly as a flickering test.
It seems the statistics were changed during such a flicker incorrectly.
By looking at the design of the algorith, one would expect it to trade
on consecutive days, which these statistcs represent. With the recent
filtering changes the flicker rate seems to be waning.

---

#### Original Analysis (might have some truths, left for posterity):
The issue stems from the bitcoin reader returning default instances instead of
null. These default instances get piped all the way through to the algorithm.
While this is happening, the trusty ol' benchmark security, SPY, is keeping
real time. The race is whether or not the SPY subscription can pass the first
real date in the bitcoin data. If this happens, multiple bitcoin dates would
all be dequeued at once since their in the past.

This change solves the race condition by filtering out invalid data points as
early as possible in the pipeline.