### PR TITLE
Make subscription enumeration order deterministic

### DIFF
--- a/Engine/DataFeeds/SubscriptionCollection.cs
+++ b/Engine/DataFeeds/SubscriptionCollection.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using QuantConnect.Data;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
@@ -97,7 +98,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             return dictionary.TryGetValue(configuration, out subscription);
         }
-        
+
         /// <summary>
         /// Attempts to retrieve the subscription with the specified configuration
         /// </summary>
@@ -112,7 +113,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 subscriptions = null;
                 return false;
             }
-            
+
             subscriptions = dictionary.Values;
             return true;
         }
@@ -165,7 +166,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             foreach (var subscriptionsBySymbol in _subscriptions)
             {
                 var subscriptionsByConfig = subscriptionsBySymbol.Value;
-                foreach (var kvp in subscriptionsByConfig)
+                foreach (var kvp in subscriptionsByConfig.OrderBy(x => x.Key.TickType))
                 {
                     var subscription = kvp.Value;
                     yield return subscription;

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -595,24 +595,24 @@ namespace QuantConnect.Tests
             var fractionalQuantityRegressionStatistics = new Dictionary<string, string>
             {
                 {"Total Trades", "6"},
-                {"Average Win", "2.45%"},
-                {"Average Loss", "-2.03%"},
-                {"Compounding Annual Return", "2313.556%"},
-                {"Drawdown", "4.500%"},
-                {"Expectancy", "0.473"},
-                {"Net Profit", "4.458%"},
-                {"Sharpe Ratio", "3.408"},
+                {"Average Win", "0.95%"},
+                {"Average Loss", "-2.01%"},
+                {"Compounding Annual Return", "255.854%"},
+                {"Drawdown", "6.600%"},
+                {"Expectancy", "-0.016"},
+                {"Net Profit", "1.401%"},
+                {"Sharpe Ratio", "1.18"},
                 {"Loss Rate", "33%"},
                 {"Win Rate", "67%"},
-                {"Profit-Loss Ratio", "1.21"},
-                {"Alpha", "-0.4"},
-                {"Beta", "0.831"},
-                {"Annual Standard Deviation", "0.579"},
-                {"Annual Variance", "0.336"},
-                {"Information Ratio", "-5.399"},
-                {"Tracking Error", "0.163"},
-                {"Treynor Ratio", "2.375"},
-                {"Total Fees", "$2092.41"}
+                {"Profit-Loss Ratio", "0.48"},
+                {"Alpha", "-1.135"},
+                {"Beta", "1.08"},
+                {"Annual Standard Deviation", "0.812"},
+                {"Annual Variance", "0.66"},
+                {"Information Ratio", "-8.445"},
+                {"Tracking Error", "0.116"},
+                {"Treynor Ratio", "0.888"},
+                {"Total Fees", "$2039.69"}
             };
 
             var basicTemplateFuturesAlgorithmDailyStatistics = new Dictionary<string, string>


### PR DESCRIPTION
In the `SubscriptionCollection` class, subscriptions are stored in nested dictionaries, keyed by `Symbol` and by `SubscriptionDataConfig`.
According to MSDN when enumerating: _The order in which the items are returned is undefined._
https://msdn.microsoft.com/en-us/library/xfhwa508.aspx

The enumeration ordering for different symbols is not an issue, but the order of configs for the same symbol can cause non-deterministic backtest results (only security types with multiple data types per subscription are affected such as `Crypto`, `Futures`, `Options`). This random behavior was observed with the `FractionalQuantityRegressionAlgorithm`, also described [here](https://github.com/QuantConnect/Lean/pull/1361), so the regression statistics have also been updated.

In this PR we force a fixed priority for data types, which will guarantee that different data points for the same symbol at the same time step will always be emitted in the same order (`TradeBar` before `QuoteBar`).