### PR TITLE
Update Crypto.Price to use last Trade price instead of Quote midprice

### DIFF
--- a/Common/Securities/Crypto/Crypto.cs
+++ b/Common/Securities/Crypto/Crypto.cs
@@ -13,8 +13,8 @@
  * limitations under the License.
 */
 
-using System;
 using QuantConnect.Data;
+using QuantConnect.Data.Market;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Slippage;
@@ -101,5 +101,9 @@ namespace QuantConnect.Securities.Crypto
         /// </remarks>
         public string BaseCurrencySymbol { get; protected set; }
 
+        /// <summary>
+        /// Get the current value of the security.
+        /// </summary>
+        public override decimal Price => Cache.GetData<TradeBar>()?.Close ?? Cache.Price;
     }
 }

--- a/Engine/DataFeeds/SubscriptionCollection.cs
+++ b/Engine/DataFeeds/SubscriptionCollection.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using QuantConnect.Data;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
@@ -97,7 +98,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             return dictionary.TryGetValue(configuration, out subscription);
         }
-        
+
         /// <summary>
         /// Attempts to retrieve the subscription with the specified configuration
         /// </summary>
@@ -112,7 +113,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 subscriptions = null;
                 return false;
             }
-            
+
             subscriptions = dictionary.Values;
             return true;
         }
@@ -165,7 +166,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             foreach (var subscriptionsBySymbol in _subscriptions)
             {
                 var subscriptionsByConfig = subscriptionsBySymbol.Value;
-                foreach (var kvp in subscriptionsByConfig)
+                foreach (var kvp in subscriptionsByConfig.OrderBy(x => x.Key.TickType))
                 {
                     var subscription = kvp.Value;
                     yield return subscription;

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -595,24 +595,24 @@ namespace QuantConnect.Tests
             var fractionalQuantityRegressionStatistics = new Dictionary<string, string>
             {
                 {"Total Trades", "6"},
-                {"Average Win", "2.45%"},
-                {"Average Loss", "-2.03%"},
-                {"Compounding Annual Return", "2313.556%"},
-                {"Drawdown", "4.500%"},
-                {"Expectancy", "0.473"},
-                {"Net Profit", "4.458%"},
-                {"Sharpe Ratio", "3.408"},
+                {"Average Win", "0.95%"},
+                {"Average Loss", "-2.01%"},
+                {"Compounding Annual Return", "255.854%"},
+                {"Drawdown", "6.600%"},
+                {"Expectancy", "-0.016"},
+                {"Net Profit", "1.401%"},
+                {"Sharpe Ratio", "1.18"},
                 {"Loss Rate", "33%"},
                 {"Win Rate", "67%"},
-                {"Profit-Loss Ratio", "1.21"},
-                {"Alpha", "-0.4"},
-                {"Beta", "0.831"},
-                {"Annual Standard Deviation", "0.579"},
-                {"Annual Variance", "0.336"},
-                {"Information Ratio", "-5.399"},
-                {"Tracking Error", "0.163"},
-                {"Treynor Ratio", "2.375"},
-                {"Total Fees", "$2092.41"}
+                {"Profit-Loss Ratio", "0.48"},
+                {"Alpha", "-1.135"},
+                {"Beta", "1.08"},
+                {"Annual Standard Deviation", "0.812"},
+                {"Annual Variance", "0.66"},
+                {"Information Ratio", "-8.445"},
+                {"Tracking Error", "0.116"},
+                {"Treynor Ratio", "0.888"},
+                {"Total Fees", "$2039.69"}
             };
 
             var basicTemplateFuturesAlgorithmDailyStatistics = new Dictionary<string, string>

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -597,22 +597,22 @@ namespace QuantConnect.Tests
                 {"Total Trades", "6"},
                 {"Average Win", "0.95%"},
                 {"Average Loss", "-2.01%"},
-                {"Compounding Annual Return", "255.854%"},
+                {"Compounding Annual Return", "255.643%"},
                 {"Drawdown", "6.600%"},
                 {"Expectancy", "-0.016"},
-                {"Net Profit", "1.401%"},
-                {"Sharpe Ratio", "1.18"},
+                {"Net Profit", "1.400%"},
+                {"Sharpe Ratio", "1.179"},
                 {"Loss Rate", "33%"},
                 {"Win Rate", "67%"},
                 {"Profit-Loss Ratio", "0.48"},
-                {"Alpha", "-1.135"},
-                {"Beta", "1.08"},
+                {"Alpha", "-1.178"},
+                {"Beta", "1.249"},
                 {"Annual Standard Deviation", "0.812"},
                 {"Annual Variance", "0.66"},
-                {"Information Ratio", "-8.445"},
-                {"Tracking Error", "0.116"},
-                {"Treynor Ratio", "0.888"},
-                {"Total Fees", "$2039.69"}
+                {"Information Ratio", "-4.236"},
+                {"Tracking Error", "0.177"},
+                {"Treynor Ratio", "0.767"},
+                {"Total Fees", "$2040.34"}
             };
 
             var basicTemplateFuturesAlgorithmDailyStatistics = new Dictionary<string, string>


### PR DESCRIPTION
This PR is chained to PR #1362.

The slight change in regression statistics is caused by the `GDAXFeeModel` using `security.Price` for fee calculation.