### PR TITLE
Changes SecurityCache.AddData to not save suspicious tick

### DIFF
--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -222,6 +222,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         }
 
                         // this is the data used set market prices
+                        // do not add it if it is a Suspicious tick
+                        var tick = baseData as Tick;
+                        if (tick != null && tick.Suspicious) continue;
+
                         securityUpdate.Add(baseData);
                     }
                     // include checks for various aux types so we don't have to construct the dictionaries in Slice


### PR DESCRIPTION
When Tick data is suspicious, do not save it. It will prevent orders to be filled with suspicious data.
Ref. #1023 