### PR TITLE
Sets Equity data to raw in option algorithms

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -530,6 +530,10 @@ namespace QuantConnect.Algorithm
                 // all based on the raw price of the underlying asset instead of the adjusted price. 
                 // In order to select the accurate contracts, we need to set
                 // the data normalization mode of the underlying asset to be raw
+                else if (equity.DataNormalizationMode != DataNormalizationMode.Raw)
+                {
+                    Debug($"Warning: The {underlying.ToString()} equity security was set the raw price normalization mode to work with options.");
+                }
                 equity.SetDataNormalizationMode(DataNormalizationMode.Raw);
 
                 // set the underlying property on the option chain

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -526,6 +526,11 @@ namespace QuantConnect.Algorithm
                     // if it wasn't manually added, add a subscription for underlying updates
                     equity = AddEquity(underlying.Value, option.Resolution, underlying.ID.Market, false);
                 }
+                // In the options trading, the strike price, the options settlement and exercise are
+                // all based on the raw price of the underlying asset instead of the adjusted price. 
+                // In order to select the accurate contracts, we need to set
+                // the data normalization mode of the underlying asset to be raw
+                equity.SetDataNormalizationMode(DataNormalizationMode.Raw);
 
                 // set the underlying property on the option chain
                 option.Underlying = equity;
@@ -537,7 +542,6 @@ namespace QuantConnect.Algorithm
                     equity.VolatilityModel = new StandardDeviationOfReturnsVolatilityModel(periods);
                 }
             }
-
         }
 
         /// <summary>


### PR DESCRIPTION
In the options trading, the strike price, the options settlement and exercise are all based on the raw price of the underlying asset instead of the adjusted price.  In order to select the accurate contracts, we need to set the data normalization mode of the underlying asset to be raw.