### PR TITLE
Set leverage to 1 for cash accounts

### DIFF
--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -59,6 +59,11 @@ namespace QuantConnect.Brokerages
         /// <returns></returns>
         public override decimal GetLeverage(Security security)
         {
+            if (AccountType == AccountType.Cash)
+            {
+                return 1m;
+            }
+
             return 3m;
         }
 


### PR DESCRIPTION
Cash accounts were implemented to explicitly prevent leverage. This change updates the `GDAXBrokerageModel` to respect the cash account setting.