### PR TITLE
Fix option assignment simulation in backtesting

### DIFF
--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -415,7 +415,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <param name="e">The OrderEvent</param>
         protected override void OnOrderEvent(OrderEvent e)
         {
-            if (e.Status == OrderStatus.Filled && _pendingOptionAssignments.Contains(e.Symbol))
+            if (e.Status.IsClosed() && _pendingOptionAssignments.Contains(e.Symbol))
             {
                 _pendingOptionAssignments.Remove(e.Symbol);
             }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -955,7 +955,7 @@ namespace QuantConnect.Lean.Engine
                     }
                     else
                     {
-                        var message = option.GetPayOff(option.Underlying.Price) < 0
+                        var message = option.GetPayOff(option.Underlying.Price) > 0
                             ? "Automatic option assignment on expiration"
                             : "Option expiration";
 


### PR DESCRIPTION
The option assignment simulator used in backtesting was firing assignment events multiple times before expiration, but the actual assignment was not being performed until the expiration date.

The order messages for option assignment and expiration were inverted and have also been corrected.