### PR TITLE
Add More Crypto Markets to Market Class

### DIFF
--- a/Common/Market.cs
+++ b/Common/Market.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,8 +44,17 @@ namespace QuantConnect
             Tuple.Create(ICE, 9),
             Tuple.Create(CBOE, 10),
             Tuple.Create(NSE, 11),
+
             Tuple.Create(GDAX, 12),
-            Tuple.Create(Kraken, 13)
+            Tuple.Create(Kraken, 13),
+            Tuple.Create(Bittrex, 14),
+            Tuple.Create(Bithumb, 15),
+            Tuple.Create(Binance, 16),
+            Tuple.Create(Poloniex, 17),
+            Tuple.Create(Coinone, 18),
+            Tuple.Create(HitBTC, 19),
+            Tuple.Create(OkCoin, 20),
+            Tuple.Create(Bitstamp, 21),
         };
 
         static Market()
@@ -59,7 +68,7 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// USA Market 
+        /// USA Market
         /// </summary>
         public const string USA = "usa";
 
@@ -124,6 +133,46 @@ namespace QuantConnect
         /// Kraken
         /// </summary>
         public const string Kraken = "kraken";
+
+        /// <summary>
+        /// Bitstamp
+        /// </summary>
+        public const string Bitstamp = "bitstamp";
+
+        /// <summary>
+        /// OkCoin
+        /// </summary>
+        public const string OkCoin = "okcoin";
+
+        /// <summary>
+        /// Bithumb
+        /// </summary>
+        public const string Bithumb = "bithumb";
+
+        /// <summary>
+        /// Binance
+        /// </summary>
+        public const string Binance = "binance";
+
+        /// <summary>
+        /// Poloniex
+        /// </summary>
+        public const string Poloniex = "poloniex";
+
+        /// <summary>
+        /// Coinone
+        /// </summary>
+        public const string Coinone = "coinone";
+
+        /// <summary>
+        /// HitBTC
+        /// </summary>
+        public const string HitBTC = "hitbtc";
+
+        /// <summary>
+        /// Bittrex
+        /// </summary>
+        public const string Bittrex = "bittrex";
 
         /// <summary>
         /// Adds the specified market to the map of available markets with the specified identifier.

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -36,7 +36,7 @@
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <StartupObject>QuantConnect.ToolBox.KrakenDownloader.Program</StartupObject>
+    <StartupObject>QuantConnect.ToolBox.KaikoDataConverter.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">


### PR DESCRIPTION
These changes add the 9 more crypto markets to the market enum. This will enable the KaikoDataConverter to process the data from these markets. These changes do not add Brokerage functionality for the additional markets.

In addition, the KaikoDataConverter now checks for scientific notation on all quantity and price fields. If the KaikoDataConverter encounters a poorly formatted row off raw data, it skips that single row and continues with the conversion process.

