### PR TITLE
Copy consolidator reference so added ones receive data

### DIFF
--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -264,11 +264,7 @@ namespace QuantConnect.Data
         {
             PriceScaleFactor = config.PriceScaleFactor;
             SumOfDividends = config.SumOfDividends;
-
-            foreach (var consolidator in config.Consolidators)
-            {
-                Consolidators.Add(consolidator);
-            }
+            Consolidators = config.Consolidators;
         }
 
         /// <summary>


### PR DESCRIPTION
Since we're creating a new instance of the `SubscriptionDataConfig`, any new consolidators added afterwards (includes incdicators) won't receive pricing updates because they'll be on the wrong config. They would be attached to the config that live in `SubscriptionManager.Subscriptions`