### PR TITLE
Update BasicTemplateFrameworkAlgorithm To match CSharp Twin

### DIFF
--- a/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
@@ -25,7 +25,7 @@ from QuantConnect.Algorithm.Framework.Execution import *
 from QuantConnect.Algorithm.Framework.Portfolio import *
 from QuantConnect.Algorithm.Framework.Risk import *
 from QuantConnect.Algorithm.Framework.Selection import *
-from QuantConnect.Algorithm.Framework.Signals import *
+from QuantConnect.Algorithm.Framework.Alphas import *
 import numpy as np
 
 ### <summary>
@@ -55,12 +55,13 @@ class BasicTemplateFrameworkAlgorithm(QCAlgorithmFramework):
 
         # set algorithm framework models
         self.PortfolioSelection = ManualPortfolioSelectionModel(symbols)
-        self.Signal = ConstantSignalModel(SignalType.Price, Direction.Up)
+        self.Alpha = ConstantAlphaModel(AlphaType.Price, AlphaDirection.Up, TimeSpan.FromMinutes(20), 0.025, None)
         self.PortfolioConstruction = SimplePortfolioConstructionModel()
 
         # these are the default values for Execution and RiskManagement models
         #self.Execution = ImmediateExecutionModel()
         #self.RiskManagement = NullRiskManagementModel()
+        
         self.Debug("numpy test >>> print numpy.pi: " + str(np.pi))
 
     def OnOrderEvent(self, orderEvent):


### PR DESCRIPTION
Updated BasicTemplateFrameworkAlgorithm.py example to match it's c# equivalent.

Signals -> Alphas namespace update.

QC example backtest:
https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_e7812b395b8746770ec99d7b482e21a8.html