### PR TITLE
Alpha score range bounding

### DIFF
--- a/Common/Algorithm/Framework/Alphas/AlphaScore.cs
+++ b/Common/Algorithm/Framework/Alphas/AlphaScore.cs
@@ -76,11 +76,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             switch (type)
             {
                 case AlphaScoreType.Direction:
-                    Direction = value;
+                    Direction = Math.Max(0, Math.Min(1, value));
                     break;
 
                 case AlphaScoreType.Magnitude:
-                    Magnitude = value;
+                    Magnitude = Math.Max(0, Math.Min(1, value));
                     break;
 
                 default:

--- a/Engine/Alphas/DefaultAlphaHandler.cs
+++ b/Engine/Alphas/DefaultAlphaHandler.cs
@@ -339,7 +339,14 @@ namespace QuantConnect.Lean.Engine.Alphas
                 var runningTotal = kvp.Value;
                 var average = runningTotal / count;
                 // scale the value from [0,1] to [0,100] for charting
-                _seriesByScoreType[scoreType].AddPoint(end, 100m * (decimal) average, LiveMode);
+                var scoreToPlot = 100 * average;
+
+                // ensure we're not violating the decimal type's range before plotting
+                if (Math.Abs(scoreToPlot) > (double) Extensions.GetDecimalEpsilon() &&
+                    Math.Abs(scoreToPlot) < (double) decimal.MaxValue)
+                {
+                    _seriesByScoreType[scoreType].AddPoint(end, (decimal) scoreToPlot, LiveMode);
+                }
             }
         }
     }


### PR DESCRIPTION
Forces alpha scores within the range of [0, 1]
Provides double->decimal bounds checking to avoid cast errors