### PR TITLE
Remove throw statements from alpha handler try/catch

### DIFF
--- a/Engine/Alphas/DefaultAlphaHandler.cs
+++ b/Engine/Alphas/DefaultAlphaHandler.cs
@@ -153,7 +153,6 @@ namespace QuantConnect.Lean.Engine.Alphas
                 catch (Exception err)
                 {
                     Log.Error(err);
-                    throw;
                 }
             }
 
@@ -166,7 +165,6 @@ namespace QuantConnect.Lean.Engine.Alphas
             catch (Exception err)
             {
                 Log.Error(err);
-                throw;
             }
         }
 


### PR DESCRIPTION
These were put in to prevent bubbling exceptions up. So far the experience has been exceptions caused here are due to double->decimal out of bounds.