### PR TITLE
Remove alpha charts non framework algos and only average finalized alpha scores

### DIFF
--- a/Common/Packets/BacktestResultPacket.cs
+++ b/Common/Packets/BacktestResultPacket.cs
@@ -212,7 +212,7 @@ namespace QuantConnect.Packets
         public AlgorithmPerformance TotalPerformance = null;
 
         /// Determines if the compiled assembly contains a framework algorithm implementation
-        public bool IsFrameworkAlgorthm;
+        public bool IsFrameworkAlgorithm;
 
         /// <summary>
         /// Default Constructor
@@ -225,9 +225,9 @@ namespace QuantConnect.Packets
         /// <summary>
         /// Constructor for the result class using dictionary objects.
         /// </summary>
-        public BacktestResult(bool isFrameworkAlgorthm, IDictionary<string, Chart> charts, IDictionary<int, Order> orders, IDictionary<DateTime, decimal> profitLoss, IDictionary<string, string> statistics, IDictionary<string, string> runtimeStatistics, Dictionary<string, AlgorithmPerformance> rollingWindow, AlgorithmPerformance totalPerformance = null)
+        public BacktestResult(bool isFrameworkAlgorithm, IDictionary<string, Chart> charts, IDictionary<int, Order> orders, IDictionary<DateTime, decimal> profitLoss, IDictionary<string, string> statistics, IDictionary<string, string> runtimeStatistics, Dictionary<string, AlgorithmPerformance> rollingWindow, AlgorithmPerformance totalPerformance = null)
         {
-            IsFrameworkAlgorthm = isFrameworkAlgorthm;
+            IsFrameworkAlgorithm = isFrameworkAlgorithm;
             Charts = charts;
             Orders = orders;
             ProfitLoss = profitLoss;

--- a/Engine/Alphas/DefaultAlphaHandler.cs
+++ b/Engine/Alphas/DefaultAlphaHandler.cs
@@ -332,8 +332,8 @@ namespace QuantConnect.Lean.Engine.Alphas
             var count = 0;
             var runningScoreTotals = ScoreTypes.ToDictionary(type => type, type => 0d);
 
-            // ignore alphas that haven't received scoring updates yet
-            foreach (var alpha in alphas.Where(alpha => alpha.GeneratedTimeUtc != alpha.Score.UpdatedTimeUtc))
+            // only chart averages of final scores
+            foreach (var alpha in alphas.Where(alpha => alpha.Score.IsFinalScore))
             {
                 count++;
                 foreach (var scoreType in ScoreTypes)

--- a/Engine/Alphas/DefaultAlphaHandler.cs
+++ b/Engine/Alphas/DefaultAlphaHandler.cs
@@ -44,6 +44,7 @@ namespace QuantConnect.Lean.Engine.Alphas
         private DateTime _nextChartSampleAlgorithmTimeUtc;
         private DateTime _lastChartSampleAlgorithmTimeUtc;
 
+        private bool _isNotFrameworkAlgorithm;
         private IMessagingHandler _messagingHandler;
         private CancellationTokenSource _cancellationTokenSource;
         private readonly ConcurrentQueue<Packet> _messages = new ConcurrentQueue<Packet>();
@@ -99,11 +100,19 @@ namespace QuantConnect.Lean.Engine.Alphas
         /// <inheritdoc />
         public virtual void Initialize(AlgorithmNodePacket job, IAlgorithm algorithm, IMessagingHandler messagingHandler, IApi api)
         {
+            // initializing these properties just in case, doens't hurt to have them populated
             Job = job;
             Algorithm = algorithm;
             _messagingHandler = messagingHandler;
+            _isNotFrameworkAlgorithm = !algorithm.IsFrameworkAlgorithm;
+            if (_isNotFrameworkAlgorithm)
+            {
+                return;
+            }
+
             AlphaManager = CreateAlphaManager();
             algorithm.AlphasGenerated += (algo, collection) => OnAlphasGenerated(collection);
+
 
             // chart for average scores over sample period
             var scoreChart = new Chart("Alpha");
@@ -126,6 +135,11 @@ namespace QuantConnect.Lean.Engine.Alphas
         /// <inheritdoc />
         public void OnAfterAlgorithmInitialized(IAlgorithm algorithm)
         {
+            if (_isNotFrameworkAlgorithm)
+            {
+                return;
+            }
+
             _lastChartSampleAlgorithmTimeUtc = algorithm.UtcTime;
             if (!LiveMode)
             {
@@ -143,6 +157,11 @@ namespace QuantConnect.Lean.Engine.Alphas
         /// <inheritdoc />
         public virtual void ProcessSynchronousEvents()
         {
+            if (_isNotFrameworkAlgorithm)
+            {
+                return;
+            }
+
             // before updating scores, emit chart points for the previous sample period
             if (Algorithm.UtcTime >= _nextChartSampleAlgorithmTimeUtc)
             {
@@ -207,6 +226,11 @@ namespace QuantConnect.Lean.Engine.Alphas
         /// <inheritdoc />
         public virtual void Run()
         {
+            if (_isNotFrameworkAlgorithm)
+            {
+                return;
+            }
+
             _cancellationTokenSource = new CancellationTokenSource();
 
             // run until cancelled AND we're done processing messages
@@ -232,6 +256,11 @@ namespace QuantConnect.Lean.Engine.Alphas
         /// <inheritdoc />
         public void Exit()
         {
+            if (_isNotFrameworkAlgorithm)
+            {
+                return;
+            }
+
             // send final alpha scoring updates before we exit
             _messages.Enqueue(new AlphaPacket
             {

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -373,7 +373,7 @@ namespace QuantConnect.Lean.Engine.Results
 
                 splitPackets.Add(new BacktestResultPacket(_job, new BacktestResult
                 {
-                    IsFrameworkAlgorthm = _algorithm.IsFrameworkAlgorithm,
+                    IsFrameworkAlgorithm = _algorithm.IsFrameworkAlgorithm,
                     Charts = new Dictionary<string, Chart>()
                     {
                         {chart.Name, chart}
@@ -382,10 +382,10 @@ namespace QuantConnect.Lean.Engine.Results
             }
 
             // Add the orders into the charting packet:
-            splitPackets.Add(new BacktestResultPacket(_job, new BacktestResult { IsFrameworkAlgorthm = _algorithm.IsFrameworkAlgorithm, Orders = deltaOrders }, progress));
+            splitPackets.Add(new BacktestResultPacket(_job, new BacktestResult { IsFrameworkAlgorithm = _algorithm.IsFrameworkAlgorithm, Orders = deltaOrders }, progress));
 
             //Add any user runtime statistics into the backtest.
-            splitPackets.Add(new BacktestResultPacket(_job, new BacktestResult { IsFrameworkAlgorthm = _algorithm.IsFrameworkAlgorithm, RuntimeStatistics = runtimeStatistics }, progress));
+            splitPackets.Add(new BacktestResultPacket(_job, new BacktestResult { IsFrameworkAlgorithm = _algorithm.IsFrameworkAlgorithm, RuntimeStatistics = runtimeStatistics }, progress));
 
             return splitPackets;
         }


### PR DESCRIPTION
We were averaging alpha scores that haven't been finalized yet, artificially deflating the perceived score value.
Also, we were running the alpha handler for non-framework algorithms which is just a waste of resources and also caused alpha charts to be created with non data. This change disables the alpha handler in such event.

but wait there's more!

This also fixes a typo in `BacktestResultIsFrameworkAlgorithm` field name.