### PR TITLE
Fix missing tag from Liquidate call

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -803,7 +803,7 @@ namespace QuantConnect.Algorithm
                 if (quantity != 0)
                 {
                     // calculate quantity for closing market order
-                    var ticket = Order(symbol, -quantity - marketOrdersQuantity);
+                    var ticket = Order(symbol, -quantity - marketOrdersQuantity, tag: tag);
                     if (ticket.Status == OrderStatus.Filled)
                     {
                         orderIdList.Add(ticket.OrderId);


### PR DESCRIPTION
Orders that are placed with Liquidate method did not come with the tag.