### PR TITLE
Alpha total asset breakdown pie chart

### DIFF
--- a/Common/Algorithm/Framework/Alphas/AlphaScore.cs
+++ b/Common/Algorithm/Framework/Alphas/AlphaScore.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <summary>
         /// Gets whether or not this is the alpha's final score
         /// </summary>
-        public bool IsFinalScore { get; internal set; }
+        public bool IsFinalScore { get; private set; }
 
         /// <summary>
         /// Initializes a new, default instance of the <see cref="AlphaScore"/> class
@@ -69,9 +69,14 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="type">The score type to be set, Direction/Magnitude</param>
         /// <param name="value">The new value for the score</param>
         /// <param name="algorithmUtcTime">The algorithm's utc time at which time the new score was computed</param>
-        internal void SetScore(AlphaScoreType type, double value, DateTime algorithmUtcTime)
+        /// <param name="analysisPeriodEndTimeUtc">The end utc time for analysis period of these sores, used to set <see cref="IsFinalScore"/></param>
+        internal void SetScore(AlphaScoreType type, double value, DateTime algorithmUtcTime, DateTime analysisPeriodEndTimeUtc)
         {
             UpdatedTimeUtc = algorithmUtcTime;
+            if (algorithmUtcTime >= analysisPeriodEndTimeUtc)
+            {
+                IsFinalScore = true;
+            }
 
             switch (type)
             {

--- a/Common/Algorithm/Framework/Alphas/Analysis/AlphaManager.cs
+++ b/Common/Algorithm/Framework/Alphas/Analysis/AlphaManager.cs
@@ -130,14 +130,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Analysis
                     // resolve and evaluate the scoring function, storing the result in the context
                     var function = _scoreFunctionProvider.GetScoreFunction(context.Alpha.Type, scoreType);
                     var score = function.Evaluate(context, scoreType);
-                    context.Score.SetScore(scoreType, score, context.CurrentValues.TimeUtc);
+                    context.Score.SetScore(scoreType, score, context.CurrentValues.TimeUtc, context.AnalysisEndTimeUtc);
                 }
 
-                // if we've passed the end time then mark it as finalized
-                if (context.CurrentValues.TimeUtc >= context.AnalysisEndTimeUtc)
+                // if this score has been finalized, remove it from the open set
+                if (context.Score.IsFinalScore)
                 {
-                    context.Alpha.Score.IsFinalScore = true;
-
                     var id = context.Alpha.Id;
                     _closedAlphaContexts[id] = context;
 

--- a/Common/Charting.cs
+++ b/Common/Charting.cs
@@ -447,7 +447,9 @@ namespace QuantConnect
         /// Flag indicators
         Flag,
         /// 100% area chart showing relative proportions of series values at each time index
-        StackedArea
+        StackedArea,
+        /// Pie chart
+        Pie
     }
 
     /// <summary>

--- a/Engine/Alphas/DefaultAlphaHandler.cs
+++ b/Engine/Alphas/DefaultAlphaHandler.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Lean.Engine.Alphas
 
         private DateTime _nextMessagingUpdate;
         private DateTime _nextPersistenceUpdate;
-        private DateTime _nextPredictionCountTimeUtc;
+        private DateTime _nextAlphaCountSampleTimeUtc;
         private DateTime _nextChartSampleAlgorithmTimeUtc;
         private DateTime _lastChartSampleAlgorithmTimeUtc;
 
@@ -50,10 +50,13 @@ namespace QuantConnect.Lean.Engine.Alphas
         private CancellationTokenSource _cancellationTokenSource;
         private readonly ConcurrentQueue<Packet> _messages = new ConcurrentQueue<Packet>();
 
-        private readonly Chart _assetBreakdownChart = new Chart("Alpha Asset Breakdown");
-        private readonly Series _predictionCountSeries = new Series("Count", SeriesType.Bar, "#");
-        private readonly ConcurrentDictionary<Symbol, int> _alphaCountPerSymbol = new ConcurrentDictionary<Symbol, int>();
+        private readonly Chart _totalAlphaCountPerSymbolChart = new Chart("Alpha Assets");          // pie chart
+        private readonly Chart _dailyAlphaCountPerSymbolChart = new Chart("Alpha Asset Breakdown"); // stacked area
+        private readonly Series _totalAlphaCountSeries = new Series("Count", SeriesType.Bar, "#");
+
         private readonly Dictionary<AlphaScoreType, Series> _seriesByScoreType = new Dictionary<AlphaScoreType, Series>();
+        private readonly ConcurrentDictionary<Symbol, int> _dailyAlphaCountPerSymbol = new ConcurrentDictionary<Symbol, int>();
+        private readonly ConcurrentDictionary<Symbol, int> _alphaCountPerSymbol = new ConcurrentDictionary<Symbol, int>();
 
         /// <inheritdoc />
         public bool IsActive => !_cancellationTokenSource?.IsCancellationRequested ?? false;
@@ -114,8 +117,6 @@ namespace QuantConnect.Lean.Engine.Alphas
             AlphaManager = CreateAlphaManager();
             algorithm.AlphasGenerated += (algo, collection) => OnAlphasGenerated(collection);
 
-            _nextPredictionCountTimeUtc = algorithm.StartDate.RoundDown(Time.OneDay) + Time.OneDay;
-
             // chart for average scores over sample period
             var scoreChart = new Chart("Alpha");
             foreach (var scoreType in ScoreTypes)
@@ -127,11 +128,12 @@ namespace QuantConnect.Lean.Engine.Alphas
 
             // chart for prediction count over sample period
             var predictionCount = new Chart("Alpha Count");
-            predictionCount.AddSeries(_predictionCountSeries);
+            predictionCount.AddSeries(_totalAlphaCountSeries);
 
             Algorithm.AddChart(scoreChart);
             Algorithm.AddChart(predictionCount);
-            Algorithm.AddChart(_assetBreakdownChart);
+            Algorithm.AddChart(_totalAlphaCountPerSymbolChart);
+            Algorithm.AddChart(_dailyAlphaCountPerSymbolChart);
         }
 
         /// <inheritdoc />
@@ -143,6 +145,8 @@ namespace QuantConnect.Lean.Engine.Alphas
             }
 
             _lastChartSampleAlgorithmTimeUtc = algorithm.UtcTime;
+            _nextAlphaCountSampleTimeUtc = (algorithm.Time.RoundDown(Time.OneDay) + Time.OneDay).ConvertToUtc(algorithm.TimeZone);
+
             if (!LiveMode)
             {
                 // space out backtesting samples evenly
@@ -164,31 +168,20 @@ namespace QuantConnect.Lean.Engine.Alphas
                 return;
             }
 
-            if (Algorithm.UtcTime >= _nextPredictionCountTimeUtc)
+            if (Algorithm.UtcTime >= _nextAlphaCountSampleTimeUtc)
             {
-                // chart asset breakdown over sample period
-                var sumPredictions = 0;
-                foreach (var kvp in _alphaCountPerSymbol)
-                {
-                    var symbol = kvp.Key;
-                    var count = kvp.Value;
+                // populate charts with the daily alpha counts per symbol, resetting our storage
+                var sumPredictions = PopulateChartWithSeriesPerSymbol(_dailyAlphaCountPerSymbol, _dailyAlphaCountPerSymbolChart, SeriesType.StackedArea);
+                _dailyAlphaCountPerSymbol.Clear();
 
-                    Series series;
-                    if (!_assetBreakdownChart.Series.TryGetValue(symbol.Value, out series))
-                    {
-                        series = new Series(symbol.Value, SeriesType.StackedArea, "#");
-                        _assetBreakdownChart.Series.Add(series.Name, series);
-                    }
+                // add sum of daily alpha counts to the total alpha count series
+                _totalAlphaCountSeries.AddPoint(Algorithm.UtcTime, sumPredictions, LiveMode);
 
-                    sumPredictions += count;
-                    series.AddPoint(Algorithm.UtcTime, count, LiveMode);
-                }
-
-                _predictionCountSeries.AddPoint(Algorithm.UtcTime, sumPredictions, LiveMode);
+                // populate charts with the total alpha counts per symbol, no need to reset
+                PopulateChartWithSeriesPerSymbol(_alphaCountPerSymbol, _totalAlphaCountPerSymbolChart, SeriesType.Pie);
 
                 // reset for next sampling period
-                _alphaCountPerSymbol.Clear();
-                _nextPredictionCountTimeUtc += Time.OneDay;
+                _nextAlphaCountSampleTimeUtc += Time.OneDay;
             }
 
             // before updating scores, emit chart points for the previous sample period
@@ -214,20 +207,6 @@ namespace QuantConnect.Lean.Engine.Alphas
             {
                 Log.Error(err);
             }
-        }
-
-        private void UpdateCharts()
-        {
-            var updatedAlphas = AlphaManager.AllAlphas.Where(alpha =>
-                alpha.Score.UpdatedTimeUtc >= _lastChartSampleAlgorithmTimeUtc &&
-                alpha.Score.UpdatedTimeUtc <= _nextChartSampleAlgorithmTimeUtc
-            )
-            .ToList();
-
-            ChartAverageAlphaScores(updatedAlphas, Algorithm.UtcTime);
-
-            _lastChartSampleAlgorithmTimeUtc = _nextChartSampleAlgorithmTimeUtc;
-            _nextChartSampleAlgorithmTimeUtc = Algorithm.UtcTime + ChartUpdateInterval;
         }
 
         /// <inheritdoc />
@@ -343,7 +322,14 @@ namespace QuantConnect.Lean.Engine.Alphas
             // aggregate alpha counts per symbol
             foreach (var grouping in collection.Alphas.GroupBy(alpha => alpha.Symbol))
             {
-                _alphaCountPerSymbol.AddOrUpdate(grouping.Key, sym => grouping.Count(), (sym, cnt) => cnt + grouping.Count());
+                // predictions for this time step
+                var count = grouping.Count();
+
+                // track daily assets
+                _dailyAlphaCountPerSymbol.AddOrUpdate(grouping.Key, sym => count, (sym, cnt) => cnt + count);
+
+                // track total assets for life of backtest
+                _alphaCountPerSymbol.AddOrUpdate(grouping.Key, sym => count, (sym, cnt) => cnt + count);
             }
         }
 
@@ -357,19 +343,22 @@ namespace QuantConnect.Lean.Engine.Alphas
             return new AlphaManager(new AlgorithmSecurityValuesProvider(Algorithm), scoreFunctionProvider, 0);
         }
 
-        /// <summary>
-        /// Adds chart point for each alpha score type with an average value of the specified period
-        /// </summary>
-        /// <param name="alphas">The alphas to chart average scores for</param>
-        /// <param name="end">The analysis end time, used as time for chart points</param>
-        protected void ChartAverageAlphaScores(List<Algorithm.Framework.Alphas.Alpha> alphas, DateTime end)
+        private void UpdateCharts()
         {
+            // get scores that were finalized within this update period
+            var finalizedAlphaScores = AlphaManager.AllAlphas.Where(alpha =>
+                    alpha.Score.IsFinalScore &&
+                    alpha.Score.UpdatedTimeUtc >= _lastChartSampleAlgorithmTimeUtc &&
+                    alpha.Score.UpdatedTimeUtc <= _nextChartSampleAlgorithmTimeUtc
+                )
+                .ToList();
+
             // compute average score values for all alphas with updates over the last day
             var count = 0;
             var runningScoreTotals = ScoreTypes.ToDictionary(type => type, type => 0d);
 
-            // only chart averages of final scores
-            foreach (var alpha in alphas.Where(alpha => alpha.Score.IsFinalScore))
+            // only chart averages of scores finalized within the sample period
+            foreach (var alpha in finalizedAlphaScores)
             {
                 count++;
                 foreach (var scoreType in ScoreTypes)
@@ -392,12 +381,39 @@ namespace QuantConnect.Lean.Engine.Alphas
                 var scoreToPlot = 100 * average;
 
                 // ensure we're not violating the decimal type's range before plotting
-                if (Math.Abs(scoreToPlot) > (double) Extensions.GetDecimalEpsilon() &&
-                    Math.Abs(scoreToPlot) < (double) decimal.MaxValue)
+                if (Math.Abs(scoreToPlot) > (double)Extensions.GetDecimalEpsilon() &&
+                    Math.Abs(scoreToPlot) < (double)decimal.MaxValue)
                 {
-                    _seriesByScoreType[scoreType].AddPoint(end, (decimal) scoreToPlot, LiveMode);
+                    _seriesByScoreType[scoreType].AddPoint(_nextChartSampleAlgorithmTimeUtc, (decimal)scoreToPlot, LiveMode);
                 }
             }
+
+            _lastChartSampleAlgorithmTimeUtc = _nextChartSampleAlgorithmTimeUtc;
+            _nextChartSampleAlgorithmTimeUtc = Algorithm.UtcTime + ChartUpdateInterval;
+        }
+
+        /// <summary>
+        /// Creates series for each symbol and adds a value corresponding to the specified data
+        /// </summary>
+        private int PopulateChartWithSeriesPerSymbol(ConcurrentDictionary<Symbol, int> data, Chart chart, SeriesType seriesType)
+        {
+            var sum = 0;
+            foreach (var kvp in data)
+            {
+                var symbol = kvp.Key;
+                var count = kvp.Value;
+
+                Series series;
+                if (!chart.Series.TryGetValue(symbol.Value, out series))
+                {
+                    series = new Series(symbol.Value, seriesType, "#");
+                    chart.Series.Add(series.Name, series);
+                }
+
+                sum += count;
+                series.AddPoint(Algorithm.UtcTime, count, LiveMode);
+            }
+            return sum;
         }
     }
 }

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="result">The results to save</param>
         public virtual void SaveResults(string name, Result result)
         {
-            File.WriteAllText(Path.Combine(Directory.GetCurrentDirectory(), name), JsonConvert.SerializeObject(result));
+            File.WriteAllText(Path.Combine(Directory.GetCurrentDirectory(), name), JsonConvert.SerializeObject(result, Formatting.Indented));
         }
     }
 }

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -697,13 +697,31 @@ namespace QuantConnect.Lean.Engine.Results
                     foreach (var series in update.Series.Values)
                     {
                         //If we don't already have this record, its the first packet
-                        if (!Charts[update.Name].Series.ContainsKey(series.Name))
+                        var chart = Charts[update.Name];
+                        if (!chart.Series.ContainsKey(series.Name))
                         {
-                            Charts[update.Name].Series.Add(series.Name, new Series(series.Name, series.SeriesType, series.Index, series.Unit));
+                            chart.Series.Add(series.Name, new Series(series.Name, series.SeriesType, series.Index, series.Unit)
+                            {
+                                Color = series.Color, ScatterMarkerSymbol = series.ScatterMarkerSymbol
+                            });
                         }
 
-                        //We already have this record, so just the new samples to the end:
-                        Charts[update.Name].Series[series.Name].Values.AddRange(series.Values);
+                        var thisSeries = chart.Series[series.Name];
+                        if (series.Values.Count > 0)
+                        {
+                            // only keep last point for pie charts
+                            if (series.SeriesType == SeriesType.Pie)
+                            {
+                                var lastValue = series.Values.Last();
+                                thisSeries.Purge();
+                                thisSeries.Values.Add(lastValue);
+                            }
+                            else
+                            {
+                                //We already have this record, so just the new samples to the end:
+                                chart.Series[series.Name].Values.AddRange(series.Values);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Add `SeriesType.Pie` -- result handlers only save last data point in each series
Add 'Alpha Assets' pie chart for total population asset breakdown over life of algorithm
Use `Formatting.Indented` when serializing results to disk in `BaseResultHandler` (makes life easier for me :) )
Fixes bug in reporting finalized alpha scores