### PR TITLE
Provide better default margin model for GDAX cash accounts

### DIFF
--- a/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
+++ b/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
@@ -77,10 +77,11 @@ namespace QuantConnect.Algorithm.CSharp
             /// Initializes the specified security by setting up the models
             /// </summary>
             /// <param name="security">The security to be initialized</param>
-            public override void Initialize(Security security)
+            /// <param name="cashBook">The portfolio's cashbook</param>
+            public override void Initialize(Security security, CashBook cashBook)
             {
                 // first call the default implementation
-                base.Initialize(security);
+                base.Initialize(security, cashBook);
 
                 // now apply our data normalization mode
                 security.SetDataNormalizationMode(_dataNormalizationMode);

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -964,7 +964,7 @@ namespace QuantConnect.Algorithm
         /// <param name="accountType">The account type (Cash or Margin)</param>
         public void SetBrokerageModel(BrokerageName brokerage, AccountType accountType = AccountType.Margin)
         {
-            SetBrokerageModel(Brokerages.BrokerageModel.Create(brokerage, accountType));
+            SetBrokerageModel(Brokerages.BrokerageModel.Create(brokerage, accountType, Portfolio.CashBook));
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -964,7 +964,7 @@ namespace QuantConnect.Algorithm
         /// <param name="accountType">The account type (Cash or Margin)</param>
         public void SetBrokerageModel(BrokerageName brokerage, AccountType accountType = AccountType.Margin)
         {
-            SetBrokerageModel(Brokerages.BrokerageModel.Create(brokerage, accountType, Portfolio.CashBook));
+            SetBrokerageModel(Brokerages.BrokerageModel.Create(brokerage, accountType));
         }
 
         /// <summary>
@@ -990,7 +990,7 @@ namespace QuantConnect.Algorithm
                     // SetSecurityInitializer must be called before SetBrokerageModel
                     var leverage = security.Leverage;
 
-                    SecurityInitializer.Initialize(security);
+                    SecurityInitializer.Initialize(security, Portfolio.CashBook);
 
                     // restore the saved leverage
                     security.SetLeverage(leverage);

--- a/Brokerages/GDAX/GDAXBrokerageFactory.cs
+++ b/Brokerages/GDAX/GDAXBrokerageFactory.cs
@@ -27,6 +27,8 @@ namespace QuantConnect.Brokerages.GDAX
     /// </summary>
     public class GDAXBrokerageFactory : BrokerageFactory
     {
+        private IAlgorithm _algorithm;
+
         /// <summary>
         /// Factory constructor
         /// </summary>
@@ -53,9 +55,10 @@ namespace QuantConnect.Brokerages.GDAX
         };
 
         /// <summary>
-        /// The brokerage model
+        /// The brokerage model. This uses the alorithm instance passed in <see cref="CreateBrokerage"/>
+        /// in order to properly populate the model with a reference to the algorithm's cashbook
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new GDAXBrokerageModel();
+        public override IBrokerageModel BrokerageModel => new GDAXBrokerageModel(_algorithm?.Portfolio?.CashBook);
 
         /// <summary>
         /// Create the Brokerage instance

--- a/Brokerages/GDAX/GDAXBrokerageFactory.cs
+++ b/Brokerages/GDAX/GDAXBrokerageFactory.cs
@@ -27,8 +27,6 @@ namespace QuantConnect.Brokerages.GDAX
     /// </summary>
     public class GDAXBrokerageFactory : BrokerageFactory
     {
-        private IAlgorithm _algorithm;
-
         /// <summary>
         /// Factory constructor
         /// </summary>
@@ -58,7 +56,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// The brokerage model. This uses the alorithm instance passed in <see cref="CreateBrokerage"/>
         /// in order to properly populate the model with a reference to the algorithm's cashbook
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new GDAXBrokerageModel(_algorithm?.Portfolio?.CashBook);
+        public override IBrokerageModel BrokerageModel => new GDAXBrokerageModel();
 
         /// <summary>
         /// Create the Brokerage instance

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,7 @@ namespace QuantConnect.Brokerages
         /// </summary>
         public virtual AccountType AccountType
         {
-            get; 
+            get;
             private set;
         }
 
@@ -67,7 +67,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to 
+        /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="QuantConnect.AccountType.Margin"/></param>
         public DefaultBrokerageModel(AccountType accountType = AccountType.Margin)
         {
@@ -107,7 +107,7 @@ namespace QuantConnect.Brokerages
 
         /// <summary>
         /// Returns true if the brokerage would be able to execute this order at this time assuming
-        /// market prices are sufficient for the fill to take place. This is used to emulate the 
+        /// market prices are sufficient for the fill to take place. This is used to emulate the
         /// brokerage fills in backtesting and paper trading. For example some brokerages may not perform
         /// executions during extended market hours. This is not intended to be checking whether or not
         /// the exchange is open, that is handled in the Security.Exchange property.
@@ -151,7 +151,7 @@ namespace QuantConnect.Brokerages
             {
                 return 1m;
             }
-                    
+
             switch (security.Type)
             {
                 case SecurityType.Equity:
@@ -258,5 +258,21 @@ namespace QuantConnect.Brokerages
             return new ImmediateSettlementModel();
         }
 
+        /// <summary>
+        /// Gets a new margin model for the security, returning the default model with the security's configured leverage.
+        /// For cash accounts, leverage = 1 is used.
+        /// </summary>
+        /// <param name="security">The security to get a margin model for</param>
+        /// <param name="accountType">The account type</param>
+        /// <returns>The margin model for this brokerage/security</returns>
+        public virtual ISecurityMarginModel GetMarginModel(Security security, AccountType accountType)
+        {
+            if (accountType == AccountType.Cash)
+            {
+                return new SecurityMarginModel(1m);
+            }
+
+            return new SecurityMarginModel(security.Leverage);
+        }
     }
 }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
@@ -50,19 +49,12 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Gets or sets the account type used by this model
         /// </summary>
-        public virtual AccountType AccountType
-        {
-            get;
-            private set;
-        }
+        public virtual AccountType AccountType { get; }
 
         /// <summary>
         /// Gets a map of the default markets to be used for each security type
         /// </summary>
-        public virtual IReadOnlyDictionary<SecurityType, string> DefaultMarkets
-        {
-            get { return DefaultMarketMap; }
-        }
+        public virtual IReadOnlyDictionary<SecurityType, string> DefaultMarkets => DefaultMarketMap;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
@@ -263,13 +255,14 @@ namespace QuantConnect.Brokerages
         /// For cash accounts, leverage = 1 is used.
         /// </summary>
         /// <param name="security">The security to get a margin model for</param>
+        /// <param name="cashBook">The portfolio's cashbook</param>
         /// <param name="accountType">The account type</param>
         /// <returns>The margin model for this brokerage/security</returns>
-        public virtual ISecurityMarginModel GetMarginModel(Security security, AccountType accountType)
+        public virtual ISecurityMarginModel GetMarginModel(Security security, CashBook cashBook, AccountType accountType)
         {
             if (accountType == AccountType.Cash)
             {
-                return new SecurityMarginModel(1m);
+                return new CashAccountMarginModel(cashBook);
             }
 
             return new SecurityMarginModel(security.Leverage);

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -166,7 +166,7 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
-        /// Gets a new margin model for the security. For cash accounts the <see cref="NonShortableCashAccountMarginModel"/>
+        /// Gets a new margin model for the security. For cash accounts the <see cref="CashAccountMarginModel"/>
         /// is returned, while margin accounts will return the default margin model
         /// </summary>
         /// <param name="security">The security to get a margin model for</param>
@@ -176,7 +176,7 @@ namespace QuantConnect.Brokerages
         {
             if (accountType == AccountType.Cash)
             {
-                return new NonShortableCashAccountMarginModel(_cashBook);
+                return new CashAccountMarginModel(_cashBook);
             }
 
             return base.GetMarginModel(security, accountType);

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -28,7 +28,6 @@ namespace QuantConnect.Brokerages
     /// </summary>
     public class GDAXBrokerageModel : DefaultBrokerageModel
     {
-        private readonly CashBook _cashBook;
         private static readonly BrokerageMessageEvent UpdateNotSupportedErrorMessage = new BrokerageMessageEvent(BrokerageMessageType.Warning, 0, "Brokerage does not support update. You must cancel and re-create instead.");
 
         // https://support.gdax.com/customer/portal/articles/2725970-trading-rules
@@ -58,14 +57,12 @@ namespace QuantConnect.Brokerages
         /// </summary>
         /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="AccountType.Margin"/></param>
-        public GDAXBrokerageModel(CashBook cashBook, AccountType accountType = AccountType.Margin)
+        public GDAXBrokerageModel(AccountType accountType = AccountType.Cash)
             : base(accountType)
         {
-            _cashBook = cashBook;
             if (accountType == AccountType.Margin)
             {
-                new BrokerageMessageEvent(BrokerageMessageType.Warning, 0,
-                    "It is recommend to use a cash account. Margin trading is currently in pre-Alpha. Use at your own risk and please report any issues encountered.");
+                throw new Exception("The GDAX brokerage does not currently support Margin trading.");
             }
         }
 
@@ -163,23 +160,6 @@ namespace QuantConnect.Brokerages
         public override IFillModel GetFillModel(Security security)
         {
             return new LatestPriceFillModel();
-        }
-
-        /// <summary>
-        /// Gets a new margin model for the security. For cash accounts the <see cref="CashAccountMarginModel"/>
-        /// is returned, while margin accounts will return the default margin model
-        /// </summary>
-        /// <param name="security">The security to get a margin model for</param>
-        /// <param name="accountType">The account type</param>
-        /// <returns>The margin model for this brokerage/security</returns>
-        public override ISecurityMarginModel GetMarginModel(Security security, AccountType accountType)
-        {
-            if (accountType == AccountType.Cash)
-            {
-                return new CashAccountMarginModel(_cashBook);
-            }
-
-            return base.GetMarginModel(security, accountType);
         }
     }
 }

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -140,8 +140,9 @@ namespace QuantConnect.Brokerages
         /// </summary>
         /// <param name="brokerage">The name of the brokerage</param>
         /// <param name="accountType">The account type</param>
+        /// <param name="cashBook">The portfolio's cashbook</param>
         /// <returns>The model for the specified brokerage</returns>
-        public static IBrokerageModel Create(BrokerageName brokerage, AccountType accountType)
+        public static IBrokerageModel Create(BrokerageName brokerage, AccountType accountType, CashBook cashBook)
         {
             switch (brokerage)
             {
@@ -164,7 +165,7 @@ namespace QuantConnect.Brokerages
                     return new DefaultBrokerageModel(accountType);
 
                 case BrokerageName.GDAX:
-                    return new GDAXBrokerageModel(accountType);
+                    return new GDAXBrokerageModel(cashBook, accountType);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(brokerage), brokerage, null);

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -68,7 +68,7 @@ namespace QuantConnect.Brokerages
 
         /// <summary>
         /// Returns true if the brokerage would be able to execute this order at this time assuming
-        /// market prices are sufficient for the fill to take place. This is used to emulate the 
+        /// market prices are sufficient for the fill to take place. This is used to emulate the
         /// brokerage fills in backtesting and paper trading. For example some brokerages may not perform
         /// executions during extended market hours. This is not intended to be checking whether or not
         /// the exchange is open, that is handled in the Security.Exchange property.
@@ -121,6 +121,13 @@ namespace QuantConnect.Brokerages
         /// <returns>The settlement model for this brokerage</returns>
         ISettlementModel GetSettlementModel(Security security, AccountType accountType);
 
+        /// <summary>
+        /// Gets a new margin model for the security
+        /// </summary>
+        /// <param name="security">The security to get a margin model for</param>
+        /// <param name="accountType">The account type</param>
+        /// <returns>The margin model for this brokerage/security</returns>
+        ISecurityMarginModel GetMarginModel(Security security, AccountType accountType);
     }
 
     /// <summary>
@@ -146,10 +153,10 @@ namespace QuantConnect.Brokerages
 
                 case BrokerageName.TradierBrokerage:
                     return new TradierBrokerageModel(accountType);
-                    
+
                 case BrokerageName.OandaBrokerage:
                     return new OandaBrokerageModel(accountType);
-                    
+
                 case BrokerageName.FxcmBrokerage:
                     return new FxcmBrokerageModel(accountType);
 
@@ -160,7 +167,7 @@ namespace QuantConnect.Brokerages
                     return new GDAXBrokerageModel(accountType);
 
                 default:
-                    throw new ArgumentOutOfRangeException("brokerage", brokerage, null);
+                    throw new ArgumentOutOfRangeException(nameof(brokerage), brokerage, null);
             }
         }
     }

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -125,9 +125,10 @@ namespace QuantConnect.Brokerages
         /// Gets a new margin model for the security
         /// </summary>
         /// <param name="security">The security to get a margin model for</param>
+        /// <param name="cashBook">The portfolio's cashbook</param>
         /// <param name="accountType">The account type</param>
         /// <returns>The margin model for this brokerage/security</returns>
-        ISecurityMarginModel GetMarginModel(Security security, AccountType accountType);
+        ISecurityMarginModel GetMarginModel(Security security, CashBook cashBook, AccountType accountType);
     }
 
     /// <summary>
@@ -140,9 +141,8 @@ namespace QuantConnect.Brokerages
         /// </summary>
         /// <param name="brokerage">The name of the brokerage</param>
         /// <param name="accountType">The account type</param>
-        /// <param name="cashBook">The portfolio's cashbook</param>
         /// <returns>The model for the specified brokerage</returns>
-        public static IBrokerageModel Create(BrokerageName brokerage, AccountType accountType, CashBook cashBook)
+        public static IBrokerageModel Create(BrokerageName brokerage, AccountType accountType)
         {
             switch (brokerage)
             {
@@ -165,7 +165,7 @@ namespace QuantConnect.Brokerages
                     return new DefaultBrokerageModel(accountType);
 
                 case BrokerageName.GDAX:
-                    return new GDAXBrokerageModel(cashBook, accountType);
+                    return new GDAXBrokerageModel(accountType);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(brokerage), brokerage, null);

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Python
 
         /// <summary>
         /// Returns true if the brokerage would be able to execute this order at this time assuming
-        /// market prices are sufficient for the fill to take place. This is used to emulate the 
+        /// market prices are sufficient for the fill to take place. This is used to emulate the
         /// brokerage fills in backtesting and paper trading. For example some brokerages may not perform
         /// executions during extended market hours. This is not intended to be checking whether or not
         /// the exchange is open, that is handled in the Security.Exchange property.
@@ -185,6 +185,20 @@ namespace QuantConnect.Python
             using (Py.GIL())
             {
                 return _model.GetSettlementModel(security, accountType);
+            }
+        }
+
+        /// <summary>
+        /// Gets a new margin model for the security
+        /// </summary>
+        /// <param name="security">The security to get a margin model for</param>
+        /// <param name="accountType">The account type</param>
+        /// <returns>The margin model for this brokerage/security</returns>
+        public ISecurityMarginModel GetMarginModel(Security security, AccountType accountType)
+        {
+            using (Py.GIL())
+            {
+                return _model.GetMarginModel(security, accountType);
             }
         }
 

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -192,13 +192,14 @@ namespace QuantConnect.Python
         /// Gets a new margin model for the security
         /// </summary>
         /// <param name="security">The security to get a margin model for</param>
+        /// <param name="cashBook">The portfolio's cashbook</param>
         /// <param name="accountType">The account type</param>
         /// <returns>The margin model for this brokerage/security</returns>
-        public ISecurityMarginModel GetMarginModel(Security security, AccountType accountType)
+        public ISecurityMarginModel GetMarginModel(Security security, CashBook cashBook, AccountType accountType)
         {
             using (Py.GIL())
             {
-                return _model.GetMarginModel(security, accountType);
+                return _model.GetMarginModel(security, cashBook, accountType);
             }
         }
 

--- a/Common/Python/SecurityInitializerPythonWrapper.cs
+++ b/Common/Python/SecurityInitializerPythonWrapper.cs
@@ -38,11 +38,12 @@ namespace QuantConnect.Python
         /// Initializes the specified security
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        public void Initialize(Security security)
+        /// <param name="cashBook">The portfolio's cashbook</param>
+        public void Initialize(Security security, CashBook cashBook)
         {
             using (Py.GIL())
             {
-                _model.Initialize(security);
+                _model.Initialize(security, cashBook);
             }
         }
     }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Python\FeeModelPythonWrapper.cs" />
     <Compile Include="Securities\IBaseCurrencySymbol.cs" />
     <Compile Include="Securities\Future\EmptyFutureChainProvider.cs" />
+    <Compile Include="Securities\NonShortableCashAccountMarginModel.cs" />
     <Compile Include="Securities\Option\EmptyOptionChainProvider.cs" />
     <Compile Include="Interfaces\IOptionChainProvider.cs" />
     <Compile Include="Brokerages\OandaTransactionModel.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -187,7 +187,7 @@
     <Compile Include="Python\FeeModelPythonWrapper.cs" />
     <Compile Include="Securities\IBaseCurrencySymbol.cs" />
     <Compile Include="Securities\Future\EmptyFutureChainProvider.cs" />
-    <Compile Include="Securities\NonShortableCashAccountMarginModel.cs" />
+    <Compile Include="Securities\CashAccountMarginModel.cs" />
     <Compile Include="Securities\Option\EmptyOptionChainProvider.cs" />
     <Compile Include="Interfaces\IOptionChainProvider.cs" />
     <Compile Include="Brokerages\OandaTransactionModel.cs" />

--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -61,6 +61,7 @@ namespace QuantConnect.Securities
             security.FeeModel = _brokerageModel.GetFeeModel(security);
             security.SlippageModel = _brokerageModel.GetSlippageModel(security);
             security.SettlementModel = _brokerageModel.GetSettlementModel(security, _brokerageModel.AccountType);
+            security.MarginModel = _brokerageModel.GetMarginModel(security, _brokerageModel.AccountType);
 
             _securitySeeder.SeedSecurity(security);
         }

--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -53,7 +53,8 @@ namespace QuantConnect.Securities
         /// Initializes the specified security by setting up the models
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        public virtual void Initialize(Security security)
+        /// <param name="cashBook">The portfolio's cashbook</param>
+        public virtual void Initialize(Security security, CashBook cashBook)
         {
             // set leverage and models
             security.SetLeverage(_brokerageModel.GetLeverage(security));
@@ -61,7 +62,7 @@ namespace QuantConnect.Securities
             security.FeeModel = _brokerageModel.GetFeeModel(security);
             security.SlippageModel = _brokerageModel.GetSlippageModel(security);
             security.SettlementModel = _brokerageModel.GetSettlementModel(security, _brokerageModel.AccountType);
-            security.MarginModel = _brokerageModel.GetMarginModel(security, _brokerageModel.AccountType);
+            security.MarginModel = _brokerageModel.GetMarginModel(security, cashBook, _brokerageModel.AccountType);
 
             _securitySeeder.SeedSecurity(security);
         }

--- a/Common/Securities/CashAccountMarginModel.cs
+++ b/Common/Securities/CashAccountMarginModel.cs
@@ -23,15 +23,15 @@ namespace QuantConnect.Securities
     /// currency to exist in the portfolio to make trades. This also only applies to securities where shorting
     /// is not an option. IOW, holdings.Quantity >= 0 at all times.
     /// </summary>
-    public class NonShortableCashAccountMarginModel : ISecurityMarginModel
+    public class CashAccountMarginModel : ISecurityMarginModel
     {
         private readonly CashBook _cashBook;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NonShortableCashAccountMarginModel"/> class
+        /// Initializes a new instance of the <see cref="CashAccountMarginModel"/> class
         /// </summary>
         /// <param name="cashBook">The portfolio's cashbook</param>
-        public NonShortableCashAccountMarginModel(CashBook cashBook)
+        public CashAccountMarginModel(CashBook cashBook)
         {
             _cashBook = cashBook;
         }

--- a/Common/Securities/CompositeSecurityInitializer.cs
+++ b/Common/Securities/CompositeSecurityInitializer.cs
@@ -37,11 +37,12 @@ namespace QuantConnect.Securities
         /// Execute each of the internally held initializers in sequence
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        public void Initialize(Security security)
+        /// <param name="cashBook">The portfolio's cashbook</param>
+        public void Initialize(Security security, CashBook cashBook)
         {
             foreach (var initializer in _initializers)
             {
-                initializer.Initialize(security);
+                initializer.Initialize(security, cashBook);
             }
         }
     }

--- a/Common/Securities/FuncSecurityInitializer.cs
+++ b/Common/Securities/FuncSecurityInitializer.cs
@@ -38,7 +38,8 @@ namespace QuantConnect.Securities
         /// Initializes the specified security
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        public void Initialize(Security security)
+        /// <param name="cashBook">The portfolio's cashbook</param>
+        public void Initialize(Security security, CashBook cashBook)
         {
             _initializer(security);
         }

--- a/Common/Securities/ISecurityInitializer.cs
+++ b/Common/Securities/ISecurityInitializer.cs
@@ -25,7 +25,8 @@ namespace QuantConnect.Securities
         /// Initializes the specified security
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        void Initialize(Security security);
+        /// <param name="cashBook">The portfolio's cashbook</param>
+        void Initialize(Security security, CashBook cashBook);
     }
 
     /// <summary>
@@ -40,7 +41,7 @@ namespace QuantConnect.Securities
 
         private sealed class NullSecurityInitializer : ISecurityInitializer
         {
-            public void Initialize(Security security) { }
+            public void Initialize(Security security, CashBook cashBook) { }
         }
     }
 }

--- a/Common/Securities/NonShortableCashAccountMarginModel.cs
+++ b/Common/Securities/NonShortableCashAccountMarginModel.cs
@@ -1,0 +1,158 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="ISecurityMarginModel"/> that requires cash of the correct
+    /// currency to exist in the portfolio to make trades. This also only applies to securities where shorting
+    /// is not an option. IOW, holdings.Quantity >= 0 at all times.
+    /// </summary>
+    public class NonShortableCashAccountMarginModel : ISecurityMarginModel
+    {
+        private readonly CashBook _cashBook;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NonShortableCashAccountMarginModel"/> class
+        /// </summary>
+        /// <param name="cashBook">The portfolio's cashbook</param>
+        public NonShortableCashAccountMarginModel(CashBook cashBook)
+        {
+            _cashBook = cashBook;
+        }
+
+        /// <summary>
+        /// Cash accounts require the full value of the order plus any fees
+        /// </summary>
+        /// <param name="security"></param>
+        /// <param name="order">The order to be executed</param>
+        /// <returns>The total margin in terms of the currency quoted in the order</returns>
+        public decimal GetInitialMarginRequiredForOrder(Security security, Order order)
+        {
+            var fees = security.FeeModel.GetOrderFee(security, order);
+            var marginRequiredInAccountCurrency = order.GetValue(security) + fees;
+
+            switch (order.Direction)
+            {
+                case OrderDirection.Hold:
+                case OrderDirection.Buy:
+                    // convert the order value to the quote currency
+                    return marginRequiredInAccountCurrency / security.QuoteCurrency.ConversionRate;
+
+                case OrderDirection.Sell:
+                    // remaining margin in units of the base currency ( can't sell what we don't have )
+                    var baseCurrency = security as IBaseCurrencySymbol;
+                    if (baseCurrency != null)
+                    {
+                        // we have this much 'cash' that can be sold
+                        var feesInBaseCurrency = _cashBook.Convert(fees, CashBook.AccountCurrency, baseCurrency.BaseCurrencySymbol);
+                        return order.AbsoluteQuantity + feesInBaseCurrency;
+                    }
+
+                    // assuming these are 'units' of stock priced in the account currency
+                    return marginRequiredInAccountCurrency;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        /// <summary>
+        /// Gets the margin cash available for a trade in units of the currency required.
+        /// When increasing a position, this is the quote currency, when decreasing a position this is the base currency
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="security">The security to be traded</param>
+        /// <param name="direction">The direction of the trade</param>
+        /// <returns>The margin available for the trade</returns>
+        public decimal GetMarginRemaining(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)
+        {
+            switch (direction)
+            {
+                case OrderDirection.Hold:
+                case OrderDirection.Buy:
+                    // increasing position, purchasing in units of the quote currency
+                    return security.QuoteCurrency.Amount;
+
+                case OrderDirection.Sell:
+                    // remaining margin in units of the base currency ( can't sell what we don't have )
+                    var baseCurrency = security as IBaseCurrencySymbol;
+                    if (baseCurrency != null)
+                    {
+                        // we have this much 'cash' that can be sold
+                        return _cashBook[baseCurrency.BaseCurrencySymbol].Amount;
+                    }
+
+                    // we have this much stock value that can be sold... this is in the account currency,
+                    // the assumption being that since the security doesn't implement IBaseCurrencySymbol
+                    // that the holdings are either 'units' of stock or similar and not currency swaps/virtual positions
+                    return security.Holdings.AbsoluteHoldingsValue;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+            }
+        }
+
+        /// <summary>
+        /// Returns 1. Cash accounts have no leverage.
+        /// </summary>
+        /// <param name="security">The security to get leverage for</param>
+        /// <returns>The current leverage in the security</returns>
+        public decimal GetLeverage(Security security)
+        {
+            return 1m;
+        }
+
+        /// <summary>
+        /// No action performed. This model always uses a leverage = 1
+        /// </summary>
+        /// <param name="security">The security to set leverage for</param>
+        /// <param name="leverage">The new leverage</param>
+        public void SetLeverage(Security security, decimal leverage)
+        {
+            // NOP
+        }
+
+        /// <summary>
+        /// Returns 0. Since we're purchasing stock out right, the position doesn't continue to weigh down the portfolio
+        /// </summary>
+        /// <param name="security">The security to compute maintenance margin for</param>
+        /// <returns>The maintenance margin required for the </returns>
+        public decimal GetMaintenanceMargin(Security security)
+        {
+            return 0m;
+        }
+
+        /// <summary>
+        /// Returns 1. Cash accounts have no leverage and require 100% at the time of order
+        /// </summary>
+        public decimal GetInitialMarginRequirement(Security security)
+        {
+            return 1m;
+        }
+
+        /// <summary>
+        /// Returns 0. Since we're purchasing currencies outright, the position doesn't consume margin
+        /// </summary>
+        public decimal GetMaintenanceMarginRequirement(Security security)
+        {
+            // since we purchased the stock/currency outright, there is no maintenance requirement
+            return 0m;
+        }
+    }
+}

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -408,7 +408,7 @@ namespace QuantConnect.Securities
             security.AddData(configList);
 
             // invoke the security initializer
-            securityInitializer.Initialize(security);
+            securityInitializer.Initialize(security, securityPortfolioManager.CashBook);
 
             // if leverage was specified then apply to security after the initializer has run, parameters of this
             // method take precedence over the intializer

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -272,6 +272,16 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Get a list of open orders satisfying the filter.
+        /// </summary>
+        /// <returns>List of open orders.</returns>
+        public List<Order> GetOpenOrders(Func<Order, bool> filter)
+        {
+            filter = filter ?? (x => true);
+            return _orderProcessor.GetOrders(x => x.Status.IsOpen() && filter(x)).ToList();
+        }
+
+        /// <summary>
         /// Gets the current number of orders that have been processed
         /// </summary>
         public int OrdersCount

--- a/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
@@ -62,9 +62,9 @@ namespace QuantConnect.Tests.Brokerages.GDAX
             var webSocketClient = new WebSocketWrapper();
 
             var algorithm = new Mock<IAlgorithm>();
-            algorithm.Setup(a => a.BrokerageModel).Returns(new GDAXBrokerageModel(AccountType.Cash));
+            algorithm.Setup(a => a.BrokerageModel).Returns(new GDAXBrokerageModel(new CashBook(), AccountType.Cash));
 
-            return new GDAXBrokerage(Config.Get("gdax-url", "wss://ws-feed.gdax.com"), webSocketClient, restClient, Config.Get("gdax-api-key"), Config.Get("gdax-api-secret"), 
+            return new GDAXBrokerage(Config.Get("gdax-url", "wss://ws-feed.gdax.com"), webSocketClient, restClient, Config.Get("gdax-api-key"), Config.Get("gdax-api-secret"),
                 Config.Get("gdax-passphrase"), algorithm.Object);
         }
 

--- a/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
@@ -1,15 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 using QuantConnect.Brokerages.GDAX;
 using NUnit.Framework;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 using QuantConnect.Configuration;
 using QuantConnect.Orders;
-using System.Reflection;
 using Moq;
 using QuantConnect.Brokerages;
 using RestSharp;
@@ -19,7 +28,6 @@ namespace QuantConnect.Tests.Brokerages.GDAX
     [TestFixture, Ignore("This test requires a configured and active account")]
     public class GDAXBrokerageIntegrationTests : BrokerageTests
     {
-
         #region Properties
         protected override Symbol Symbol
         {
@@ -62,7 +70,7 @@ namespace QuantConnect.Tests.Brokerages.GDAX
             var webSocketClient = new WebSocketWrapper();
 
             var algorithm = new Mock<IAlgorithm>();
-            algorithm.Setup(a => a.BrokerageModel).Returns(new GDAXBrokerageModel(new CashBook(), AccountType.Cash));
+            algorithm.Setup(a => a.BrokerageModel).Returns(new GDAXBrokerageModel());
 
             return new GDAXBrokerage(Config.Get("gdax-url", "wss://ws-feed.gdax.com"), webSocketClient, restClient, Config.Get("gdax-api-key"), Config.Get("gdax-api-secret"),
                 Config.Get("gdax-passphrase"), algorithm.Object);

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
@@ -29,7 +30,7 @@ namespace QuantConnect.Tests.Common.Brokerages
     public class GDAXBrokerageModelTests
     {
 
-        GDAXBrokerageModel _unit = new GDAXBrokerageModel();
+        GDAXBrokerageModel _unit = new GDAXBrokerageModel(new CashBook());
 
         [Test()]
         public void GetLeverageTest()

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -22,20 +22,18 @@ using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
-using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
     [TestFixture()]
     public class GDAXBrokerageModelTests
     {
-
-        GDAXBrokerageModel _unit = new GDAXBrokerageModel(new CashBook());
+        private readonly GDAXBrokerageModel _unit = new GDAXBrokerageModel();
 
         [Test()]
         public void GetLeverageTest()
         {
-            Assert.AreEqual(3, _unit.GetLeverage(GDAXTestsHelpers.GetSecurity()));
+            Assert.AreEqual(1, _unit.GetLeverage(GDAXTestsHelpers.GetSecurity()));
         }
 
         [Test()]

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             Assert.AreEqual(_tradeBarSecurity.Leverage, 1.0);
 
-            _brokerageInitializer.Initialize(_tradeBarSecurity);
+            _brokerageInitializer.Initialize(_tradeBarSecurity, _algo.Portfolio.CashBook);
 
             Assert.AreEqual(_tradeBarSecurity.Leverage, 2.0);
         }
@@ -105,7 +105,7 @@ namespace QuantConnect.Tests.Common.Securities
             _algo.SetDateTime(dateForWhichDataExist);
 
             // Act
-            _brokerageInitializer.Initialize(_tradeBarSecurity);
+            _brokerageInitializer.Initialize(_tradeBarSecurity, _algo.Portfolio.CashBook);
 
             // Assert
             Assert.IsFalse(_tradeBarSecurity.Price == 0);
@@ -119,7 +119,7 @@ namespace QuantConnect.Tests.Common.Securities
             _algo.SetDateTime(dateForWhichDataExist);
 
             // Act
-            _brokerageInitializer.Initialize(_quoteBarSecurity);
+            _brokerageInitializer.Initialize(_quoteBarSecurity, _algo.Portfolio.CashBook);
 
             // Assert
             Assert.IsFalse(_quoteBarSecurity.Price == 0);
@@ -133,7 +133,7 @@ namespace QuantConnect.Tests.Common.Securities
             _algo.SetDateTime(dateForWhichDataDoesNotExist);
 
             // Act
-            _brokerageInitializer.Initialize(_tradeBarSecurity);
+            _brokerageInitializer.Initialize(_tradeBarSecurity, _algo.Portfolio.CashBook);
 
             // Assert
             Assert.IsTrue(_tradeBarSecurity.Price == 0);

--- a/Tests/Common/Securities/CashAccountMarginModelTests.cs
+++ b/Tests/Common/Securities/CashAccountMarginModelTests.cs
@@ -1,0 +1,326 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages.Backtesting;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Crypto;
+using QuantConnect.Tests.Engine;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class CashAccountMarginModelTests
+    {
+        private QuantConnect.Securities.Equity.Equity _spy;
+        private Crypto _btcusd;
+        private Crypto _btceur;
+        private Crypto _ethusd;
+        private Crypto _ethbtc;
+        private SecurityPortfolioManager _portfolio;
+        private BacktestingTransactionHandler _transactionHandler;
+        private BacktestingBrokerage _brokerage;
+        private CashAccountMarginModel _marginModel;
+        private QCAlgorithm _algorithm;
+
+        [SetUp]
+        public void Initialize()
+        {
+            _algorithm = new QCAlgorithm();
+            _portfolio = _algorithm.Portfolio;
+            _portfolio.CashBook.Add("EUR", 0, 1.20m);
+            _portfolio.CashBook.Add("BTC", 0, 15000m);
+            _portfolio.CashBook.Add("ETH", 0, 1000m);
+
+            _transactionHandler = new BacktestingTransactionHandler();
+            _brokerage = new BacktestingBrokerage(_algorithm);
+            _transactionHandler.Initialize(_algorithm, _brokerage, new TestResultHandler());
+            new Thread(_transactionHandler.Run) { IsBackground = true }.Start();
+
+            _algorithm.Transactions.SetOrderProcessor(_transactionHandler);
+
+            var tz = TimeZones.NewYork;
+            _spy = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                _portfolio.CashBook[CashBook.AccountCurrency],
+                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+
+            _btcusd = new Crypto(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                _portfolio.CashBook[CashBook.AccountCurrency],
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCUSD, Resolution.Minute, tz, tz, true, false, false),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+
+            _ethusd = new Crypto(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                _portfolio.CashBook[CashBook.AccountCurrency],
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.ETHUSD, Resolution.Minute, tz, tz, true, false, false),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+
+            _btceur = new Crypto(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                _portfolio.CashBook["EUR"],
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCEUR, Resolution.Minute, tz, tz, true, false, false),
+                SymbolProperties.GetDefault("EUR"));
+
+            _ethbtc = new Crypto(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                _portfolio.CashBook["BTC"],
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.ETHBTC, Resolution.Minute, tz, tz, true, false, false),
+                SymbolProperties.GetDefault("BTC"));
+
+            _marginModel = new CashAccountMarginModel(_portfolio.CashBook);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _transactionHandler.Exit();
+        }
+
+        [Test]
+        public void InitializesCorrectly()
+        {
+            Assert.AreEqual(1m, _marginModel.GetLeverage(_spy));
+            Assert.AreEqual(1m, _marginModel.GetInitialMarginRequirement(_spy));
+            Assert.AreEqual(0m, _marginModel.GetMaintenanceMargin(_spy));
+            Assert.AreEqual(0m, _marginModel.GetMaintenanceMarginRequirement(_spy));
+        }
+
+        [Test]
+        public void SetLeverageDoesNotUpdateLeverage()
+        {
+            // leverage cannot be set, will always be 1x
+            _marginModel.SetLeverage(_spy, 50m);
+            Assert.AreEqual(1m, _marginModel.GetLeverage(_spy));
+        }
+
+        [Test]
+        public void EquityBuyOrderRequiresFullMargin()
+        {
+            _spy.SetMarketPrice(new Tick { Value = 250m });
+
+            var order = new MarketOrder(_spy.Symbol, 2, DateTime.UtcNow);
+            var initialMargin = _marginModel.GetInitialMarginRequiredForOrder(_spy, order);
+
+            Assert.AreEqual(501m, initialMargin);
+        }
+
+        [Test]
+        public void EquitySellOrderRequiresHolding()
+        {
+            _spy = _algorithm.AddEquity("SPY");
+            _portfolio[_spy.Symbol].SetHoldings(150, 2);
+            _spy.SetMarketPrice(new Tick { Value = 250m });
+            _algorithm.SetFinishedWarmingUp();
+
+            var order = new MarketOrder(_spy.Symbol, -2, DateTime.UtcNow);
+            var initialMargin = _marginModel.GetInitialMarginRequiredForOrder(_spy, order);
+
+            Assert.AreEqual(-499m, initialMargin);
+        }
+
+        [Test]
+        public void MarginToBuyEquityEqualsCashAvailable()
+        {
+            _portfolio.SetCash(5000);
+
+            Assert.AreEqual(5000m, _marginModel.GetMarginRemaining(_portfolio, _spy, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void MarginToBuyCryptoEqualsQuoteCurrencyAvailable()
+        {
+            _portfolio.SetCash(5000);
+            _portfolio.CashBook["EUR"].SetAmount(1000);
+            _portfolio.CashBook["BTC"].SetAmount(0.5m);
+
+            Assert.AreEqual(5000m, _marginModel.GetMarginRemaining(_portfolio, _btcusd, OrderDirection.Buy));
+            Assert.AreEqual(1000m, _marginModel.GetMarginRemaining(_portfolio, _btceur, OrderDirection.Buy));
+            Assert.AreEqual(0.5m, _marginModel.GetMarginRemaining(_portfolio, _ethbtc, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void MarginToSellEquityEqualsZeroWithNoHoldings()
+        {
+            _portfolio.SetCash(5000);
+
+            Assert.AreEqual(0m, _marginModel.GetMarginRemaining(_portfolio, _spy, OrderDirection.Sell));
+        }
+
+        [Test]
+        public void MarginToSellCryptoEqualsZeroWithNoHoldings()
+        {
+            _portfolio.SetCash(5000);
+
+            Assert.AreEqual(0m, _marginModel.GetMarginRemaining(_portfolio, _btcusd, OrderDirection.Sell));
+            Assert.AreEqual(0m, _marginModel.GetMarginRemaining(_portfolio, _btceur, OrderDirection.Sell));
+            Assert.AreEqual(0m, _marginModel.GetMarginRemaining(_portfolio, _ethbtc, OrderDirection.Sell));
+        }
+
+        [Test]
+        public void MarginToSellEquityEqualsHoldingsCost()
+        {
+            _portfolio.SetCash(0);
+
+            _spy = _algorithm.AddEquity("SPY");
+            _portfolio[_spy.Symbol].SetHoldings(150, 2);
+
+            // price goes up, margin does not change
+            _spy.SetMarketPrice(new Tick { Value = 250m });
+            Assert.AreEqual(300m, _marginModel.GetMarginRemaining(_portfolio, _spy, OrderDirection.Sell));
+
+            // price goes down, margin does not change
+            _spy.SetMarketPrice(new Tick { Value = 100m });
+            Assert.AreEqual(300m, _marginModel.GetMarginRemaining(_portfolio, _spy, OrderDirection.Sell));
+        }
+
+        [Test]
+        public void MarginToSellCryptoEqualsBaseCurrencyAvailable()
+        {
+            _portfolio.SetCash(5000);
+            _portfolio.CashBook["BTC"].SetAmount(0.5m);
+            _portfolio.CashBook["ETH"].SetAmount(2m);
+
+            Assert.AreEqual(0.5m, _marginModel.GetMarginRemaining(_portfolio, _btcusd, OrderDirection.Sell));
+            Assert.AreEqual(0.5m, _marginModel.GetMarginRemaining(_portfolio, _btceur, OrderDirection.Sell));
+            Assert.AreEqual(2m, _marginModel.GetMarginRemaining(_portfolio, _ethbtc, OrderDirection.Sell));
+        }
+
+        [Test]
+        public void MarginToBuyEquityIncludesOpenOrders()
+        {
+            _portfolio.SetCash(5000);
+
+            _spy = _algorithm.AddEquity("SPY");
+            _spy.SetMarketPrice(new Tick { Value = 250m });
+            _algorithm.SetFinishedWarmingUp();
+
+            SubmitLimitOrder(_spy.Symbol, 2, 200m);
+
+            Assert.AreEqual(4600m, _marginModel.GetMarginRemaining(_portfolio, _spy, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void MarginToSellEquityIncludesOpenOrders()
+        {
+            _portfolio.SetCash(0);
+
+            _spy = _algorithm.AddEquity("SPY");
+            _portfolio[_spy.Symbol].SetHoldings(150, 5);
+            _spy.SetMarketPrice(new Tick { Value = 250m });
+            _algorithm.SetFinishedWarmingUp();
+
+            SubmitLimitOrder(_spy.Symbol, -1, 300m);
+
+            Assert.AreEqual(600m, _marginModel.GetMarginRemaining(_portfolio, _spy, OrderDirection.Sell));
+        }
+
+        [Test]
+        public void MarginToBuyCryptoWithUsdIncludesOpenOrders()
+        {
+            _portfolio.SetCash(5000);
+
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+            _btcusd.SetMarketPrice(new Tick { Value = 15000m });
+            _ethusd = _algorithm.AddCrypto("ETHUSD");
+            _ethusd.SetMarketPrice(new Tick { Value = 1000m });
+            _algorithm.SetFinishedWarmingUp();
+
+            // BTCUSD buy order decreases available USD
+            SubmitLimitOrder(_btcusd.Symbol, 0.1m, 15000m);
+
+            // ETHUSD buy order decreases available USD
+            SubmitLimitOrder(_ethusd.Symbol, 3m, 1000m);
+
+            Assert.AreEqual(500m, _marginModel.GetMarginRemaining(_portfolio, _btcusd, OrderDirection.Buy));
+            Assert.AreEqual(500m, _marginModel.GetMarginRemaining(_portfolio, _ethusd, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void MarginToBuyCryptoWithBtcIncludesOpenOrders()
+        {
+            _portfolio.CashBook["BTC"].SetAmount(1m);
+            _portfolio.CashBook["ETH"].SetAmount(1m);
+
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+            _btcusd.SetMarketPrice(new Tick { Value = 15000m });
+            _ethusd = _algorithm.AddCrypto("ETHUSD");
+            _ethusd.SetMarketPrice(new Tick { Value = 1000m });
+            _ethbtc = _algorithm.AddCrypto("ETHBTC");
+            _ethbtc.SetMarketPrice(new Tick { Value = 0.1m });
+            _algorithm.SetFinishedWarmingUp();
+
+            // BTCUSD sell order decreases available BTC
+            SubmitLimitOrder(_btcusd.Symbol, -0.2m, 15000m);
+
+            // ETHUSD sell order decreases available ETH
+            SubmitLimitOrder(_ethusd.Symbol, -1m, 1000m);
+
+            // ETHBTC buy order decreases available BTC
+            SubmitLimitOrder(_ethbtc.Symbol, 1m, 0.1m);
+
+            Assert.AreEqual(0.7m, _marginModel.GetMarginRemaining(_portfolio, _ethbtc, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void MarginToSellCryptoIncludesOpenOrders()
+        {
+            _portfolio.SetCash(5000);
+            _portfolio.CashBook["BTC"].SetAmount(1m);
+            _portfolio.CashBook["ETH"].SetAmount(3m);
+
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+            _btcusd.SetMarketPrice(new Tick { Value = 15000m });
+            _ethusd = _algorithm.AddCrypto("ETHUSD");
+            _ethusd.SetMarketPrice(new Tick { Value = 1000m });
+            _ethbtc = _algorithm.AddCrypto("ETHBTC");
+            _ethbtc.SetMarketPrice(new Tick { Value = 0.1m });
+            _algorithm.SetFinishedWarmingUp();
+
+            // BTCUSD sell order decreases available BTC
+            SubmitLimitOrder(_btcusd.Symbol, -0.1m, 15000m);
+
+            // ETHUSD sell order decreases available ETH
+            SubmitLimitOrder(_ethusd.Symbol, -1m, 1000m);
+
+            // ETHBTC buy order decreases available BTC
+            SubmitLimitOrder(_ethbtc.Symbol, 1m, 0.1m);
+
+            Assert.AreEqual(0.8m, _marginModel.GetMarginRemaining(_portfolio, _btcusd, OrderDirection.Sell));
+            Assert.AreEqual(2m, _marginModel.GetMarginRemaining(_portfolio, _ethusd, OrderDirection.Sell));
+            Assert.AreEqual(2m, _marginModel.GetMarginRemaining(_portfolio, _ethbtc, OrderDirection.Sell));
+        }
+
+        private void SubmitLimitOrder(Symbol symbol, decimal quantity, decimal limitPrice)
+        {
+            var resetEvent = new ManualResetEvent(false);
+
+            _brokerage.OrderStatusChanged += (s, e) => { resetEvent.Set(); };
+
+            _algorithm.LimitOrder(symbol, quantity, limitPrice);
+
+            resetEvent.WaitOne();
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Common\Orders\Fills\LatestPriceFillModelTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />
     <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />
+    <Compile Include="Common\Securities\CashAccountMarginModelTests.cs" />
     <Compile Include="Common\Securities\FutureFilterTests.cs" />
     <Compile Include="Common\Securities\Futures\FuturesExpiryFunctionsTests.cs" />
     <Compile Include="Common\Securities\Futures\FuturesExpiryUtilityFunctionsTests.cs" />

--- a/Tests/Symbols.cs
+++ b/Tests/Symbols.cs
@@ -39,6 +39,8 @@ namespace QuantConnect.Tests
         public static readonly Symbol BTCUSD = CreateCryptoSymbol("BTCUSD");
         public static readonly Symbol LTCUSD = CreateCryptoSymbol("LTCUSD");
         public static readonly Symbol ETHUSD = CreateCryptoSymbol("ETHUSD");
+        public static readonly Symbol BTCEUR = CreateCryptoSymbol("BTCEUR");
+        public static readonly Symbol ETHBTC = CreateCryptoSymbol("ETHBTC");
 
         public static readonly Symbol DE10YBEUR = CreateCfdSymbol("DE10YBEUR", Market.FXCM);
         public static readonly Symbol XAGUSD = CreateCfdSymbol("XAGUSD", Market.FXCM);


### PR DESCRIPTION
> READY TO BE REVIEWED/MERGED
---
> NOTE: FractionalQuantityRegressionAlgorithm is failing due to recent changes in minimum order sizes. This PR has no ill effect on the regression suit.
---

#### GDAXBrokerageModel.GetMarginModel -> NonShortableCashAccountMarginModel

GDAX cash accounts aren't allowed to short and require sufficient quantity of quote currency
to purchase and sufficient quantity of base currency to sell. This model aims to enforce
these constraints

#### Add IBrokerageModel.GetMarginModel and invoke from BrokerageModelSecurityInitializer

It seems all the other models are being provided via the brokerage model but all the margin models
are assigned via the security constructors. This allows us to set margin models using the same
pattern that we used for overriding default margin models. This becomes particularly important
when considering how different exchanges/brokerages manage cash and margin in the account.

#### Add NonShortableCashAccountMarginModel

This margin model forces us to purchase everthing outright with cash.
This also means there's no maintenance margin. This also means that in order
to buy/sell currency pairs we require the quote currency to buy and the base
currency to sell. For example, you can't purchase LTCBTC with USD, and likewise
you can't sell LTCBTC without having LTC to sell.