### PR TITLE
Short circuit limit orders with post-only set

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -298,6 +298,12 @@ namespace QuantConnect.Brokerages.GDAX
         /// <returns></returns>
         public decimal GetFee(Order order)
         {
+            var gdaxOrderProperties = order.Properties as GDAXOrderProperties;
+            if (order.Type == OrderType.Limit && gdaxOrderProperties?.PostOnly == true)
+            {
+                return 0m;
+            }
+
             var totalFee = 0m;
 
             foreach (var item in order.BrokerId)


### PR DESCRIPTION
GDAX has zero order fees and a 'post-only' switch that guarantees zero order fees for limit orders posted. This change detects the case and prevents an extra api call to fetch the order fee.