### PR TITLE
Reduce full locking on ConcurrentDictionary objects

### DIFF
--- a/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.cs
+++ b/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using QuantConnect.Data.UniverseSelection;
 
 namespace QuantConnect.Algorithm.Framework.Risk
@@ -26,7 +27,7 @@ namespace QuantConnect.Algorithm.Framework.Risk
         /// <param name="algorithm">The algorithm instance</param>
         public void ManageRisk(QCAlgorithmFramework algorithm)
         {
-            foreach (var security in algorithm.Securities.Values)
+            foreach (var security in algorithm.Securities.Select(x => x.Value))
             {
                 if (!security.Invested)
                 {

--- a/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.cs
+++ b/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.cs
@@ -1,5 +1,20 @@
-﻿using System;
-using System.Linq;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
 using QuantConnect.Data.UniverseSelection;
 
 namespace QuantConnect.Algorithm.Framework.Risk
@@ -27,8 +42,10 @@ namespace QuantConnect.Algorithm.Framework.Risk
         /// <param name="algorithm">The algorithm instance</param>
         public void ManageRisk(QCAlgorithmFramework algorithm)
         {
-            foreach (var security in algorithm.Securities.Select(x => x.Value))
+            foreach (var kvp in algorithm.Securities)
             {
+                var security = kvp.Value;
+
                 if (!security.Invested)
                 {
                     continue;

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         public UniverseDefinitions Universe
         {
-            get; 
+            get;
             private set;
         }
 
@@ -321,7 +321,7 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Adds the security to the user defined universe for the specified 
+        /// Adds the security to the user defined universe for the specified
         /// </summary>
         private void AddToUserDefinedUniverse(Security security)
         {
@@ -331,7 +331,7 @@ namespace QuantConnect.Algorithm
             {
                 if (!security.IsInternalFeed() && existingSecurity.Symbol == _benchmarkSymbol)
                 {
-                    var securityUniverse = UniverseManager.Values.OfType<UserDefinedUniverse>().FirstOrDefault(x => x.Members.ContainsKey(security.Symbol));
+                    var securityUniverse = UniverseManager.Select(x => x.Value).OfType<UserDefinedUniverse>().FirstOrDefault(x => x.Members.ContainsKey(security.Symbol));
                     if (securityUniverse != null)
                     {
                         securityUniverse.Remove(security.Symbol);
@@ -360,7 +360,7 @@ namespace QuantConnect.Algorithm
                     );
                 UniverseManager.Add(universeSymbol, universe);
             }
-            
+
             var userDefinedUniverse = universe as UserDefinedUniverse;
             if (userDefinedUniverse != null)
             {

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -971,8 +971,10 @@ namespace QuantConnect.Algorithm
                 SecurityInitializer = new BrokerageModelSecurityInitializer(model, new FuncSecuritySeeder(GetLastKnownPrice));
 
                 // update models on securities added earlier (before SetBrokerageModel is called)
-                foreach (var security in Securities.Select(x => x.Value))
+                foreach (var kvp in Securities)
                 {
+                    var security = kvp.Value;
+
                     // save the existing leverage specified in AddSecurity,
                     // if Leverage needs to be set in a SecurityInitializer,
                     // SetSecurityInitializer must be called before SetBrokerageModel

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -541,7 +541,7 @@ namespace QuantConnect.Algorithm
                     equity = AddEquity(underlying.Value, option.Resolution, underlying.ID.Market, false);
                 }
                 // In the options trading, the strike price, the options settlement and exercise are
-                // all based on the raw price of the underlying asset instead of the adjusted price. 
+                // all based on the raw price of the underlying asset instead of the adjusted price.
                 // In order to select the accurate contracts, we need to set
                 // the data normalization mode of the underlying asset to be raw
                 else if (equity.DataNormalizationMode != DataNormalizationMode.Raw)
@@ -971,7 +971,7 @@ namespace QuantConnect.Algorithm
                 SecurityInitializer = new BrokerageModelSecurityInitializer(model, new FuncSecuritySeeder(GetLastKnownPrice));
 
                 // update models on securities added earlier (before SetBrokerageModel is called)
-                foreach (var security in Securities.Values)
+                foreach (var security in Securities.Select(x => x.Value))
                 {
                     // save the existing leverage specified in AddSecurity,
                     // if Leverage needs to be set in a SecurityInitializer,
@@ -1615,7 +1615,7 @@ namespace QuantConnect.Algorithm
                 // liquidate if invested
                 if (security.Invested) Liquidate(security.Symbol);
 
-                var universe = UniverseManager.Values.OfType<UserDefinedUniverse>().FirstOrDefault(x => x.Members.ContainsKey(symbol));
+                var universe = UniverseManager.Select(x => x.Value).OfType<UserDefinedUniverse>().FirstOrDefault(x => x.Members.ContainsKey(symbol));
                 if (universe != null)
                 {
                     var ret = universe.Remove(symbol);

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -106,9 +106,9 @@ namespace QuantConnect.Brokerages.Backtesting
         public override List<Holding> GetAccountHoldings()
         {
             // grab everything from the portfolio with a non-zero absolute quantity
-            return (from security in Algorithm.Portfolio.Securities.Select(x => x.Value).OrderBy(x => x.Symbol)
-                    where security.Holdings.AbsoluteQuantity > 0
-                    select new Holding(security)).ToList();
+            return (from kvp in Algorithm.Portfolio.Securities.OrderBy(x => x.Value.Symbol)
+                    where kvp.Value.Holdings.AbsoluteQuantity > 0
+                    select new Holding(kvp.Value)).ToList();
         }
 
         /// <summary>

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -106,7 +106,7 @@ namespace QuantConnect.Brokerages.Backtesting
         public override List<Holding> GetAccountHoldings()
         {
             // grab everything from the portfolio with a non-zero absolute quantity
-            return (from security in Algorithm.Portfolio.Securities.Values.OrderBy(x => x.Symbol)
+            return (from security in Algorithm.Portfolio.Securities.Select(x => x.Value).OrderBy(x => x.Symbol)
                     where security.Holdings.AbsoluteQuantity > 0
                     select new Holding(security)).ToList();
         }
@@ -117,7 +117,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <returns>The current cash balance for each currency available for trading</returns>
         public override List<Cash> GetCashBalance()
         {
-            return Algorithm.Portfolio.CashBook.Values.ToList();
+            return Algorithm.Portfolio.CashBook.Select(x => x.Value).ToList();
         }
 
         /// <summary>

--- a/Brokerages/Backtesting/BasicOptionAssignmentSimulation.cs
+++ b/Brokerages/Backtesting/BasicOptionAssignmentSimulation.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.Brokerages.Backtesting
             if (_lastUpdate == DateTime.MinValue ||
                 algorithm.UtcTime - _lastUpdate > _securitiesRescanPeriod)
             {
-                var expirations = algorithm.Securities.Keys
+                var expirations = algorithm.Securities.Select(x => x.Key)
                             .Where(x => x.ID.SecurityType == SecurityType.Option &&
                                         x.ID.Date > algorithm.Time &&
                                         x.ID.Date - algorithm.Time <= _securitiesRescanPeriod)

--- a/Brokerages/Paper/PaperBrokerage.cs
+++ b/Brokerages/Paper/PaperBrokerage.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,7 +35,7 @@ namespace QuantConnect.Brokerages.Paper
         /// </summary>
         /// <param name="algorithm">The algorithm under analysis</param>
         /// <param name="job">The job packet</param>
-        public PaperBrokerage(IAlgorithm algorithm, LiveNodePacket job) 
+        public PaperBrokerage(IAlgorithm algorithm, LiveNodePacket job)
             : base(algorithm, "Paper Brokerage")
         {
             _job = job;
@@ -56,7 +56,7 @@ namespace QuantConnect.Brokerages.Paper
             }
 
             // if we've already begun running, just return the current state
-            return Algorithm.Portfolio.CashBook.Values.ToList();
+            return Algorithm.Portfolio.CashBook.Select(x => x.Value).ToList();
         }
     }
 }

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -159,7 +159,7 @@ namespace QuantConnect.Securities
             // if we've made it here we didn't find a subscription, so we'll need to add one
 
             // Create a SecurityType to Market mapping with the markets from SecurityManager members
-            var markets = securities.Keys.GroupBy(x => x.SecurityType).ToDictionary(x => x.Key, y => y.First().ID.Market);
+            var markets = securities.Select(x => x.Key).GroupBy(x => x.SecurityType).ToDictionary(x => x.Key, y => y.First().ID.Market);
             if (markets.ContainsKey(SecurityType.Cfd) && !markets.ContainsKey(SecurityType.Forex))
             {
                 markets.Add(SecurityType.Forex, markets[SecurityType.Cfd]);

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,7 +42,7 @@ namespace QuantConnect.Securities
         /// </summary>
         public decimal TotalValueInAccountCurrency
         {
-            get { return _currencies.Values.Sum(x => x.ValueInAccountCurrency); }
+            get { return _currencies.Select(x => x.Value).Sum(x => x.ValueInAccountCurrency); }
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace QuantConnect.Securities
         public List<Security> EnsureCurrencyDataFeeds(SecurityManager securities, SubscriptionManager subscriptions, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase, IReadOnlyDictionary<SecurityType, string> marketMap)
         {
             var addedSecurities = new List<Security>();
-            foreach (var cash in _currencies.Values)
+            foreach (var cash in _currencies.Select(x => x.Value))
             {
                 var security = cash.EnsureCurrencyDataFeed(securities, subscriptions, marketHoursDatabase, symbolPropertiesDatabase, marketMap, this);
                 if (security != null)
@@ -127,13 +127,13 @@ namespace QuantConnect.Securities
         {
             var sb = new StringBuilder();
             sb.AppendLine(string.Format("{0} {1,13}    {2,10} = {3}", "Symbol", "Quantity", "Conversion", "Value in " + AccountCurrency));
-            foreach (var value in Values)
+            foreach (var value in _currencies.Select(x => x.Value))
             {
                 sb.AppendLine(value.ToString());
             }
             sb.AppendLine("-------------------------------------------------");
-            sb.AppendLine(string.Format("CashBook Total Value:                {0}{1}", 
-                Currencies.GetCurrencySymbol(AccountCurrency), 
+            sb.AppendLine(string.Format("CashBook Total Value:                {0}{1}",
+                Currencies.GetCurrencySymbol(AccountCurrency),
                 Math.Round(TotalValueInAccountCurrency, 2))
                 );
 
@@ -146,10 +146,7 @@ namespace QuantConnect.Securities
         /// Gets the count of Cash items in this CashBook.
         /// </summary>
         /// <value>The count.</value>
-        public int Count
-        {
-            get { return _currencies.Count; }
-        }
+        public int Count => _currencies.Skip(0).Count();
 
         /// <summary>
         /// Gets a value indicating whether this instance is read only.
@@ -283,19 +280,13 @@ namespace QuantConnect.Securities
         /// Gets the keys.
         /// </summary>
         /// <value>The keys.</value>
-        public ICollection<string> Keys
-        {
-            get { return _currencies.Keys; }
-        }
+        public ICollection<string> Keys => _currencies.Select(x => x.Key).ToList();
 
         /// <summary>
         /// Gets the values.
         /// </summary>
         /// <value>The values.</value>
-        public ICollection<Cash> Values
-        {
-            get { return _currencies.Values; }
-        }
+        public ICollection<Cash> Values => _currencies.Select(x => x.Value).ToList();
 
         /// <summary>
         /// Gets the enumerator.

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Securities
         /// </summary>
         public decimal TotalValueInAccountCurrency
         {
-            get { return _currencies.Select(x => x.Value).Sum(x => x.ValueInAccountCurrency); }
+            get { return _currencies.Sum(x => x.Value.ValueInAccountCurrency); }
         }
 
         /// <summary>
@@ -79,8 +79,10 @@ namespace QuantConnect.Securities
         public List<Security> EnsureCurrencyDataFeeds(SecurityManager securities, SubscriptionManager subscriptions, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase, IReadOnlyDictionary<SecurityType, string> marketMap)
         {
             var addedSecurities = new List<Security>();
-            foreach (var cash in _currencies.Select(x => x.Value))
+            foreach (var kvp in _currencies)
             {
+                var cash = kvp.Value;
+
                 var security = cash.EnsureCurrencyDataFeed(securities, subscriptions, marketHoursDatabase, symbolPropertiesDatabase, marketMap, this);
                 if (security != null)
                 {

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -140,10 +140,7 @@ namespace QuantConnect.Securities
         /// Count of the number of securities in the collection.
         /// </summary>
         /// <remarks>IDictionary implementation</remarks>
-        public int Count
-        {
-            get { return _securityManager.Count; }
-        }
+        public int Count => _securityManager.Skip(0).Count();
 
         /// <summary>
         /// Flag indicating if the internal arrray is read only.
@@ -185,10 +182,7 @@ namespace QuantConnect.Securities
         /// List of the symbol-keys in the collection of securities.
         /// </summary>
         /// <remarks>IDictionary implementation</remarks>
-        public ICollection<Symbol> Keys
-        {
-            get { return _securityManager.Keys; }
-        }
+        public ICollection<Symbol> Keys => _securityManager.Select(x => x.Key).ToList();
 
         /// <summary>
         /// Try and get this security object with matching symbol and return true on success.
@@ -206,10 +200,7 @@ namespace QuantConnect.Securities
         /// Get a list of the security objects for this collection.
         /// </summary>
         /// <remarks>IDictionary implementation</remarks>
-        public ICollection<Security> Values
-        {
-            get { return _securityManager.Values; }
-        }
+        public ICollection<Security> Values => _securityManager.Select(x => x.Value).ToList();
 
         /// <summary>
         /// Get the enumerator for this security collection.
@@ -334,14 +325,14 @@ namespace QuantConnect.Securities
 
             // Add the symbol to Data Manager -- generate unified data streams for algorithm events
             var configList = new SubscriptionDataConfigList(symbol);
-            configList.AddRange(from subscriptionDataType 
+            configList.AddRange(from subscriptionDataType
                                 in subscriptionDataTypes
                                 let dataType = subscriptionDataType.Item1
                                 let tickType = subscriptionDataType.Item2
-                                select subscriptionManager.Add(dataType, tickType, 
-                                                               symbol, resolution, dataTimeZone, 
-                                                               exchangeHours.TimeZone, isCustomData, 
-                                                               fillDataForward, extendedMarketHours, 
+                                select subscriptionManager.Add(dataType, tickType,
+                                                               symbol, resolution, dataTimeZone,
+                                                               exchangeHours.TimeZone, isCustomData,
+                                                               fillDataForward, extendedMarketHours,
                                                                isInternalFeed, isFilteredSubscription));
 
             // verify the cash book is in a ready state
@@ -418,7 +409,7 @@ namespace QuantConnect.Securities
 
             // invoke the security initializer
             securityInitializer.Initialize(security, true);
-            
+
             // if leverage was specified then apply to security after the initializer has run, parameters of this
             // method take precedence over the intializer
             if (leverage > 0)

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -208,8 +208,8 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from asset in Securities.Select(x => x.Value)
-                        select asset.Holdings).ToList();
+                return (from kvp in Securities
+                        select kvp.Value.Holdings).ToList();
             }
         }
 
@@ -283,8 +283,8 @@ namespace QuantConnect.Securities
             get
             {
                 //Sum of unlevered cost of holdings
-                return (from position in Securities.Select(x => x.Value)
-                        select position.Holdings.UnleveredAbsoluteHoldingsCost).Sum();
+                return (from kvp in Securities
+                        select kvp.Value.Holdings.UnleveredAbsoluteHoldingsCost).Sum();
             }
         }
 
@@ -305,8 +305,8 @@ namespace QuantConnect.Securities
             get
             {
                 //Sum sum of holdings
-                return (from position in Securities.Select(x => x.Value)
-                        select position.Holdings.AbsoluteHoldingsValue).Sum();
+                return (from kvp in Securities
+                        select kvp.Value.Holdings.AbsoluteHoldingsValue).Sum();
             }
         }
 
@@ -336,8 +336,8 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from position in Securities.Select(x => x.Value)
-                        select position.Holdings.UnrealizedProfit).Sum();
+                return (from kvp in Securities
+                        select kvp.Value.Holdings.UnrealizedProfit).Sum();
             }
         }
 
@@ -385,8 +385,8 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from position in Securities.Select(x => x.Value)
-                        select position.Holdings.TotalFees).Sum();
+                return (from kvp in Securities
+                        select kvp.Value.Holdings.TotalFees).Sum();
             }
         }
 
@@ -397,8 +397,8 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from position in Securities.Select(x => x.Value)
-                        select position.Holdings.Profit).Sum();
+                return (from kvp in Securities
+                        select kvp.Value.Holdings.Profit).Sum();
             }
         }
 
@@ -409,8 +409,8 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from position in Securities.Select(x => x.Value)
-                        select position.Holdings.TotalSaleVolume).Sum();
+                return (from kvp in Securities
+                        select kvp.Value.Holdings.TotalSaleVolume).Sum();
             }
         }
 
@@ -422,8 +422,10 @@ namespace QuantConnect.Securities
             get
             {
                 decimal sum = 0;
-                foreach (var security in Securities.Select(x => x.Value))
+                foreach (var kvp in Securities)
                 {
+                    var security = kvp.Value;
+
                     sum += security.MarginModel.GetMaintenanceMargin(security);
                 }
                 return sum;
@@ -574,13 +576,18 @@ namespace QuantConnect.Securities
             if (marginRemaining <= 0)
             {
                 // skip securities that have no price data or no holdings, we can't liquidate nothingness
-                foreach (var security in Securities.Select(x => x.Value).Where(x => x.Holdings.Quantity != 0 && x.Price != 0))
+                foreach (var kvp in Securities)
                 {
-                    var maintenanceMarginRequirement = security.MarginModel.GetMaintenanceMarginRequirement(security);
-                    var marginCallOrder = MarginCallModel.GenerateMarginCallOrder(security, totalPortfolioValue, totalMarginUsed, maintenanceMarginRequirement);
-                    if (marginCallOrder != null && marginCallOrder.Quantity != 0)
+                    var security = kvp.Value;
+
+                    if (security.Holdings.Quantity != 0 && security.Price != 0)
                     {
-                        marginCallOrders.Add(marginCallOrder);
+                        var maintenanceMarginRequirement = security.MarginModel.GetMaintenanceMarginRequirement(security);
+                        var marginCallOrder = MarginCallModel.GenerateMarginCallOrder(security, totalPortfolioValue, totalMarginUsed, maintenanceMarginRequirement);
+                        if (marginCallOrder != null && marginCallOrder.Quantity != 0)
+                        {
+                            marginCallOrders.Add(marginCallOrder);
+                        }
                     }
                 }
                 issueMarginCallWarning = marginCallOrders.Count > 0;

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -208,7 +208,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from asset in Securities.Values
+                return (from asset in Securities.Select(x => x.Value)
                         select asset.Holdings).ToList();
             }
         }
@@ -283,7 +283,7 @@ namespace QuantConnect.Securities
             get
             {
                 //Sum of unlevered cost of holdings
-                return (from position in Securities.Values
+                return (from position in Securities.Select(x => x.Value)
                         select position.Holdings.UnleveredAbsoluteHoldingsCost).Sum();
             }
         }
@@ -305,7 +305,7 @@ namespace QuantConnect.Securities
             get
             {
                 //Sum sum of holdings
-                return (from position in Securities.Values
+                return (from position in Securities.Select(x => x.Value)
                         select position.Holdings.AbsoluteHoldingsValue).Sum();
             }
         }
@@ -336,7 +336,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from position in Securities.Values
+                return (from position in Securities.Select(x => x.Value)
                         select position.Holdings.UnrealizedProfit).Sum();
             }
         }
@@ -385,7 +385,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from position in Securities.Values
+                return (from position in Securities.Select(x => x.Value)
                         select position.Holdings.TotalFees).Sum();
             }
         }
@@ -397,7 +397,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from position in Securities.Values
+                return (from position in Securities.Select(x => x.Value)
                         select position.Holdings.Profit).Sum();
             }
         }
@@ -409,7 +409,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return (from position in Securities.Values
+                return (from position in Securities.Select(x => x.Value)
                         select position.Holdings.TotalSaleVolume).Sum();
             }
         }
@@ -422,9 +422,8 @@ namespace QuantConnect.Securities
             get
             {
                 decimal sum = 0;
-                foreach (var kvp in Securities)
+                foreach (var security in Securities.Select(x => x.Value))
                 {
-                    var security = kvp.Value;
                     sum += security.MarginModel.GetMaintenanceMargin(security);
                 }
                 return sum;
@@ -575,7 +574,7 @@ namespace QuantConnect.Securities
             if (marginRemaining <= 0)
             {
                 // skip securities that have no price data or no holdings, we can't liquidate nothingness
-                foreach (var security in Securities.Values.Where(x => x.Holdings.Quantity != 0 && x.Price != 0))
+                foreach (var security in Securities.Select(x => x.Value).Where(x => x.Holdings.Quantity != 0 && x.Price != 0))
                 {
                     var maintenanceMarginRequirement = security.MarginModel.GetMaintenanceMarginRequirement(security);
                     var marginCallOrder = MarginCallModel.GenerateMarginCallOrder(security, totalPortfolioValue, totalMarginUsed, maintenanceMarginRequirement);

--- a/Common/Securities/UniverseManager.cs
+++ b/Common/Securities/UniverseManager.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -127,10 +127,7 @@ namespace QuantConnect.Securities
         /// <returns>
         /// The number of elements contained in the <see cref="T:System.Collections.Generic.ICollection`1"/>.
         /// </returns>
-        public int Count
-        {
-            get { return _universes.Count; }
-        }
+        public int Count => _universes.Skip(0).Count();
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1"/> is read-only.
@@ -236,10 +233,7 @@ namespace QuantConnect.Securities
         /// <returns>
         /// An <see cref="T:System.Collections.Generic.ICollection`1"/> containing the keys of the object that implements <see cref="T:System.Collections.Generic.IDictionary`2"/>.
         /// </returns>
-        public ICollection<Symbol> Keys
-        {
-            get { return _universes.Keys; }
-        }
+        public ICollection<Symbol> Keys => _universes.Select(x => x.Key).ToList();
 
         /// <summary>
         /// Gets an <see cref="T:System.Collections.Generic.ICollection`1"/> containing the values in the <see cref="T:System.Collections.Generic.IDictionary`2"/>.
@@ -247,10 +241,7 @@ namespace QuantConnect.Securities
         /// <returns>
         /// An <see cref="T:System.Collections.Generic.ICollection`1"/> containing the values in the object that implements <see cref="T:System.Collections.Generic.IDictionary`2"/>.
         /// </returns>
-        public ICollection<Universe> Values
-        {
-            get { return _universes.Values; }
-        }
+        public ICollection<Universe> Values => _universes.Select(x => x.Value).ToList();
 
         #endregion
 

--- a/Common/TradingCalendar.cs
+++ b/Common/TradingCalendar.cs
@@ -116,7 +116,7 @@ namespace QuantConnect
                                 currentDate.DayOfWeek == DayOfWeek.Saturday;
                 var businessDay = !publicHoliday && !weekend;
 
-                yield return 
+                yield return
                     new TradingDay
                     {
                         Date = currentDate,

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -859,7 +859,7 @@ namespace QuantConnect.Lean.Engine
         {
             Log.Trace("AlgorithmManager.ProcessVolatilityHistoryRequirements(): Updating volatility models with historical data...");
 
-            foreach (var security in algorithm.Securities.Values)
+            foreach (var security in algorithm.Securities.Select(x => x.Value))
             {
                 if (security.VolatilityModel != VolatilityModel.Null)
                 {

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -859,8 +859,10 @@ namespace QuantConnect.Lean.Engine
         {
             Log.Trace("AlgorithmManager.ProcessVolatilityHistoryRequirements(): Updating volatility models with historical data...");
 
-            foreach (var security in algorithm.Securities.Select(x => x.Value))
+            foreach (var kvp in algorithm.Securities)
             {
+                var security = kvp.Value;
+
                 if (security.VolatilityModel != VolatilityModel.Null)
                 {
                     var historyReq = security.VolatilityModel.GetHistoryRequirements(security, algorithm.UtcTime);

--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -120,7 +120,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var optionUnderlyingUpdates = new Dictionary<Symbol, BaseData>();
 
             var cashSecurities = new HashSet<Symbol>();
-            foreach (var cashItem in cashBook.Values)
+            foreach (var cashItem in cashBook.Select(x => x.Value))
             {
                 cashSecurities.Add(cashItem.SecuritySymbol);
             }
@@ -264,12 +264,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // patch through calls to conversion rate to compue it on the fly using Security.Price
                     if (cashSecurities.Contains(packet.Security.Symbol))
                     {
-                        foreach (var cashKvp in cashBook)
+                        foreach (var cashItem in cashBook.Select(x => x.Value))
                         {
-                            if (cashKvp.Value.SecuritySymbol == packet.Security.Symbol)
+                            if (cashItem.SecuritySymbol == packet.Security.Symbol)
                             {
                                 var cashUpdates = new List<BaseData> {securityUpdate[securityUpdate.Count - 1]};
-                                cash.Add(new UpdateData<Cash>(cashKvp.Value, packet.Configuration.Type, cashUpdates));
+                                cash.Add(new UpdateData<Cash>(cashItem, packet.Configuration.Type, cashUpdates));
                             }
                         }
                     }

--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -120,9 +120,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var optionUnderlyingUpdates = new Dictionary<Symbol, BaseData>();
 
             var cashSecurities = new HashSet<Symbol>();
-            foreach (var cashItem in cashBook.Select(x => x.Value))
+            foreach (var kvp in cashBook)
             {
-                cashSecurities.Add(cashItem.SecuritySymbol);
+                cashSecurities.Add(kvp.Value.SecuritySymbol);
             }
 
             Split split;
@@ -264,8 +264,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // patch through calls to conversion rate to compue it on the fly using Security.Price
                     if (cashSecurities.Contains(packet.Security.Symbol))
                     {
-                        foreach (var cashItem in cashBook.Select(x => x.Value))
+                        foreach (var kvp in cashBook)
                         {
+                            var cashItem = kvp.Value;
+
                             if (cashItem.SecuritySymbol == packet.Security.Symbol)
                             {
                                 var cashUpdates = new List<BaseData> {securityUpdate[securityUpdate.Count - 1]};

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Logging;
@@ -59,9 +58,14 @@ namespace QuantConnect.Lean.Engine.RealTime
             Add(ScheduledEventFactory.EveryAlgorithmEndOfDay(_algorithm, _resultHandler, _algorithm.StartDate, _algorithm.EndDate, ScheduledEvent.AlgorithmEndOfDayDelta));
 
             // set up the events for each security to fire every tradeable date before market close
-            foreach (var security in _algorithm.Securities.Select(x => x.Value).Where(x => !x.IsInternalFeed()))
+            foreach (var kvp in _algorithm.Securities)
             {
-                Add(ScheduledEventFactory.EverySecurityEndOfDay(_algorithm, _resultHandler, security, algorithm.StartDate, _algorithm.EndDate, ScheduledEvent.SecurityEndOfDayDelta));
+                var security = kvp.Value;
+
+                if (!security.IsInternalFeed())
+                {
+                    Add(ScheduledEventFactory.EverySecurityEndOfDay(_algorithm, _resultHandler, security, algorithm.StartDate, _algorithm.EndDate, ScheduledEvent.SecurityEndOfDayDelta));
+                }
             }
 
             foreach (var scheduledEvent in _scheduledEvents)

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             Add(ScheduledEventFactory.EveryAlgorithmEndOfDay(_algorithm, _resultHandler, _algorithm.StartDate, _algorithm.EndDate, ScheduledEvent.AlgorithmEndOfDayDelta));
 
             // set up the events for each security to fire every tradeable date before market close
-            foreach (var security in _algorithm.Securities.Values.Where(x => !x.IsInternalFeed()))
+            foreach (var security in _algorithm.Securities.Select(x => x.Value).Where(x => !x.IsInternalFeed()))
             {
                 Add(ScheduledEventFactory.EverySecurityEndOfDay(_algorithm, _resultHandler, security, algorithm.StartDate, _algorithm.EndDate, ScheduledEvent.SecurityEndOfDayDelta));
             }

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -78,7 +78,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             Add(ScheduledEventFactory.EveryAlgorithmEndOfDay(_algorithm, _resultHandler, todayInAlgorithmTimeZone, Time.EndOfTime, ScheduledEvent.AlgorithmEndOfDayDelta, DateTime.UtcNow));
 
             // add end of trading day events for each security
-            foreach (var security in _algorithm.Securities.Values.Where(x => !x.IsInternalFeed()))
+            foreach (var security in _algorithm.Securities.Select(x => x.Value).Where(x => !x.IsInternalFeed()))
             {
                 // assumes security.Exchange has been updated with today's hours via RefreshMarketHoursToday
                 Add(ScheduledEventFactory.EverySecurityEndOfDay(_algorithm, _resultHandler, security, todayInAlgorithmTimeZone, Time.EndOfTime, ScheduledEvent.SecurityEndOfDayDelta, DateTime.UtcNow));
@@ -146,7 +146,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             date = date.Date;
 
             // update market hours for each security
-            foreach (var security in _algorithm.Securities.Values)
+            foreach (var security in _algorithm.Securities.Select(x => x.Value))
             {
                 var marketHours = _api.MarketToday(date, security.Symbol);
                 security.Exchange.SetMarketHours(marketHours, date.DayOfWeek);

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -78,10 +78,15 @@ namespace QuantConnect.Lean.Engine.RealTime
             Add(ScheduledEventFactory.EveryAlgorithmEndOfDay(_algorithm, _resultHandler, todayInAlgorithmTimeZone, Time.EndOfTime, ScheduledEvent.AlgorithmEndOfDayDelta, DateTime.UtcNow));
 
             // add end of trading day events for each security
-            foreach (var security in _algorithm.Securities.Select(x => x.Value).Where(x => !x.IsInternalFeed()))
+            foreach (var kvp in _algorithm.Securities)
             {
-                // assumes security.Exchange has been updated with today's hours via RefreshMarketHoursToday
-                Add(ScheduledEventFactory.EverySecurityEndOfDay(_algorithm, _resultHandler, security, todayInAlgorithmTimeZone, Time.EndOfTime, ScheduledEvent.SecurityEndOfDayDelta, DateTime.UtcNow));
+                var security = kvp.Value;
+
+                if (!security.IsInternalFeed())
+                {
+                    // assumes security.Exchange has been updated with today's hours via RefreshMarketHoursToday
+                    Add(ScheduledEventFactory.EverySecurityEndOfDay(_algorithm, _resultHandler, security, todayInAlgorithmTimeZone, Time.EndOfTime, ScheduledEvent.SecurityEndOfDayDelta, DateTime.UtcNow));
+                }
             }
 
             foreach (var scheduledEvent in _scheduledEvents)
@@ -146,8 +151,10 @@ namespace QuantConnect.Lean.Engine.RealTime
             date = date.Date;
 
             // update market hours for each security
-            foreach (var security in _algorithm.Securities.Select(x => x.Value))
+            foreach (var kvp in _algorithm.Securities)
             {
+                var security = kvp.Value;
+
                 var marketHours = _api.MarketToday(date, security.Symbol);
                 security.Exchange.SetMarketHours(marketHours, date.DayOfWeek);
                 var localMarketHours = security.Exchange.Hours.MarketHours[date.DayOfWeek];

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -506,8 +506,10 @@ namespace QuantConnect.Lean.Engine.Results
 
             //Set the security / market types.
             var types = new List<SecurityType>();
-            foreach (var security in _algorithm.Securities.Select(x => x.Value))
+            foreach (var kvp in _algorithm.Securities)
             {
+                var security = kvp.Value;
+
                 if (!types.Contains(security.Type)) types.Add(security.Type);
             }
             SecurityType(types);
@@ -832,8 +834,10 @@ namespace QuantConnect.Lean.Engine.Results
                 SampleRange(_algorithm.GetChartUpdates());
 
                 //Sample the asset pricing:
-                foreach (var security in _algorithm.Securities.Select(x => x.Value))
+                foreach (var kvp in _algorithm.Securities)
                 {
+                    var security = kvp.Value;
+
                     SampleAssetPrices(security.Symbol, time, security.Price);
                 }
             }

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -506,7 +506,7 @@ namespace QuantConnect.Lean.Engine.Results
 
             //Set the security / market types.
             var types = new List<SecurityType>();
-            foreach (var security in _algorithm.Securities.Values)
+            foreach (var security in _algorithm.Securities.Select(x => x.Value))
             {
                 if (!types.Contains(security.Type)) types.Add(security.Type);
             }
@@ -832,7 +832,7 @@ namespace QuantConnect.Lean.Engine.Results
                 SampleRange(_algorithm.GetChartUpdates());
 
                 //Sample the asset pricing:
-                foreach (var security in _algorithm.Securities.Values)
+                foreach (var security in _algorithm.Securities.Select(x => x.Value))
                 {
                     SampleAssetPrices(security.Symbol, time, security.Price);
                 }

--- a/Engine/Results/DesktopResultHandler.cs
+++ b/Engine/Results/DesktopResultHandler.cs
@@ -27,6 +27,7 @@ using QuantConnect.Orders;
 using QuantConnect.Packets;
 using QuantConnect.Statistics;
 using System.Diagnostics;
+using System.Linq;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Lean.Engine.Results
@@ -462,7 +463,7 @@ namespace QuantConnect.Lean.Engine.Results
                 SampleRange(_algorithm.GetChartUpdates());
 
                 //Sample the asset pricing:
-                foreach (var security in _algorithm.Securities.Values)
+                foreach (var security in _algorithm.Securities.Select(x => x.Value))
                 {
                     SampleAssetPrices(security.Symbol, time, security.Price);
                 }

--- a/Engine/Results/DesktopResultHandler.cs
+++ b/Engine/Results/DesktopResultHandler.cs
@@ -27,7 +27,6 @@ using QuantConnect.Orders;
 using QuantConnect.Packets;
 using QuantConnect.Statistics;
 using System.Diagnostics;
-using System.Linq;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Lean.Engine.Results
@@ -463,8 +462,10 @@ namespace QuantConnect.Lean.Engine.Results
                 SampleRange(_algorithm.GetChartUpdates());
 
                 //Sample the asset pricing:
-                foreach (var security in _algorithm.Securities.Select(x => x.Value))
+                foreach (var kvp in _algorithm.Securities)
                 {
+                    var security = kvp.Value;
+
                     SampleAssetPrices(security.Symbol, time, security.Price);
                 }
             }

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -296,7 +296,7 @@ namespace QuantConnect.Lean.Engine.Results
                     serverStatistics["Total RAM (MB)"] = _job.Controls.RamAllocation.ToString();
 
                     // Only send holdings updates when we have changes in orders, except for first time, then we want to send all
-                    foreach (var asset in _algorithm.Securities.Values.Where(x => !x.IsInternalFeed() && !x.Symbol.IsCanonical()).OrderBy(x => x.Symbol.Value))
+                    foreach (var asset in _algorithm.Securities.Select(x => x.Value).Where(x => !x.IsInternalFeed() && !x.Symbol.IsCanonical()).OrderBy(x => x.Symbol.Value))
                     {
                         holdings.Add(asset.Symbol.Value, new Holding(asset));
                     }
@@ -737,7 +737,7 @@ namespace QuantConnect.Lean.Engine.Results
             _algorithm = algorithm;
 
             var types = new List<SecurityType>();
-            foreach (var security in _algorithm.Securities.Values)
+            foreach (var security in _algorithm.Securities.Select(x => x.Value))
             {
                 if (!types.Contains(security.Type)) types.Add(security.Type);
             }
@@ -1071,7 +1071,7 @@ namespace QuantConnect.Lean.Engine.Results
                                 security.SetRealTimePrice(last);
 
                                 // Update CashBook for Forex securities
-                                var cash = (from c in _algorithm.Portfolio.CashBook.Values
+                                var cash = (from c in _algorithm.Portfolio.CashBook.Select(x => x.Value)
                                     where c.SecuritySymbol == last.Symbol
                                     select c).SingleOrDefault();
 

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -296,9 +296,14 @@ namespace QuantConnect.Lean.Engine.Results
                     serverStatistics["Total RAM (MB)"] = _job.Controls.RamAllocation.ToString();
 
                     // Only send holdings updates when we have changes in orders, except for first time, then we want to send all
-                    foreach (var asset in _algorithm.Securities.Select(x => x.Value).Where(x => !x.IsInternalFeed() && !x.Symbol.IsCanonical()).OrderBy(x => x.Symbol.Value))
+                    foreach (var kvp in _algorithm.Securities.OrderBy(x => x.Key.Value))
                     {
-                        holdings.Add(asset.Symbol.Value, new Holding(asset));
+                        var security = kvp.Value;
+
+                        if (!security.IsInternalFeed() && !security.Symbol.IsCanonical())
+                        {
+                            holdings.Add(security.Symbol.Value, new Holding(security));
+                        }
                     }
 
                     //Add the algorithm statistics first.
@@ -737,8 +742,10 @@ namespace QuantConnect.Lean.Engine.Results
             _algorithm = algorithm;
 
             var types = new List<SecurityType>();
-            foreach (var security in _algorithm.Securities.Select(x => x.Value))
+            foreach (var kvp in _algorithm.Securities)
             {
+                var security = kvp.Value;
+
                 if (!types.Contains(security.Type)) types.Add(security.Type);
             }
             SecurityType(types);
@@ -1071,9 +1078,9 @@ namespace QuantConnect.Lean.Engine.Results
                                 security.SetRealTimePrice(last);
 
                                 // Update CashBook for Forex securities
-                                var cash = (from c in _algorithm.Portfolio.CashBook.Select(x => x.Value)
-                                    where c.SecuritySymbol == last.Symbol
-                                    select c).SingleOrDefault();
+                                var cash = (from c in _algorithm.Portfolio.CashBook
+                                    where c.Value.SecuritySymbol == last.Symbol
+                                    select c.Value).SingleOrDefault();
 
                                 if (cash != null)
                                 {

--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -28,7 +28,6 @@ using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Logging;
 using QuantConnect.Packets;
 using QuantConnect.Data;
-using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 
@@ -278,10 +277,9 @@ namespace QuantConnect.Lean.Engine.Setup
                 .Sum();
 
             // universe coarse/fine/custom subscriptions
-            var universeSubscriptions = universeManager.Select(x => x.Value)
+            var universeSubscriptions = universeManager
                 // use max limit for universes without explicitly added securities
-                .Select(u => u.Members.Count == 0 ? controls.GetLimit(u.UniverseSettings.Resolution) : u.Members.Count)
-                .Sum();
+                .Sum(u => u.Value.Members.Count == 0 ? controls.GetLimit(u.Value.UniverseSettings.Resolution) : u.Value.Members.Count);
 
             var subscriptionCount = derivativeSubscriptions + universeSubscriptions;
 

--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -278,7 +278,7 @@ namespace QuantConnect.Lean.Engine.Setup
                 .Sum();
 
             // universe coarse/fine/custom subscriptions
-            var universeSubscriptions = universeManager.Values
+            var universeSubscriptions = universeManager.Select(x => x.Value)
                 // use max limit for universes without explicitly added securities
                 .Select(u => u.Members.Count == 0 ? controls.GetLimit(u.UniverseSettings.Resolution) : u.Members.Count)
                 .Sum();

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -552,7 +552,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 }
 
                 // if we were returned our balances, update everything and flip our flag as having performed sync today
-                foreach (var cash in _algorithm.Portfolio.CashBook.Values)
+                foreach (var cash in _algorithm.Portfolio.CashBook.Select(x => x.Value))
                 {
                     var balanceCash = balances.FirstOrDefault(balance => balance.Symbol == cash.Symbol);
                     //update the cash if the entry if found in the balances

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -552,8 +552,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 }
 
                 // if we were returned our balances, update everything and flip our flag as having performed sync today
-                foreach (var cash in _algorithm.Portfolio.CashBook.Select(x => x.Value))
+                foreach (var kvp in _algorithm.Portfolio.CashBook)
                 {
+                    var cash = kvp.Value;
+
                     var balanceCash = balances.FirstOrDefault(balance => balance.Symbol == cash.Symbol);
                     //update the cash if the entry if found in the balances
                     if (balanceCash != null)


### PR DESCRIPTION
This PR is an attempt to reduce contention in concurrent dictionaries, replacing method calls using full locks with lock-free equivalents:

- `dictionary.Count` -> `dictionary.Skip(0).Count()`
- `dictionary.Keys` -> `dictionary.Select(x => x.Key)`
- `dictionary.Values` -> `dictionary.Select(x => x.Value)`

The most frequent usages of these methods are: `CashBook`, `SecurityManager`, `UniverseManager` and indirectly, `SecurityPortfolioManager`.

The reasons for this update are explained very clearly in this article:
https://arbel.net/2013/02/03/best-practices-for-using-concurrentdictionary/