### PR TITLE
Sets Equity data to raw in option algorithms II

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1547,6 +1547,12 @@ namespace QuantConnect.Algorithm
             {
                 equity = AddEquity(underlying.Value, option.Resolution, underlying.ID.Market, false);
             }
+            else if (equity.DataNormalizationMode != DataNormalizationMode.Raw)
+            {
+                Debug($"Warning: The {underlying.ToString()} equity security was set the raw price normalization mode to work with options.");
+            }
+            equity.SetDataNormalizationMode(DataNormalizationMode.Raw);
+
             option.Underlying = equity;
 
             AddToUserDefinedUniverse(option);


### PR DESCRIPTION
In [#1390](https://github.com/QuantConnect/Lean/pull/1390), we have implemented a feature that assured that prices from an option underlying are set to raw. If the algorithm adds options contracts with `AddOptionContract` method, that rule was not applied.

This is important for algorithms that combine universe selection with options trading, since the underlying is not defined in `Initialize` (the user can define the `DataNormalizationMode` with `UniverseSettings`, but we cover the case he doesn't).