### PR TITLE
Fix calculation in GDAXFeeModel

### DIFF
--- a/Common/Orders/Fees/GDAXFeeModel.cs
+++ b/Common/Orders/Fees/GDAXFeeModel.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 
 namespace QuantConnect.Orders.Fees
@@ -54,7 +55,7 @@ namespace QuantConnect.Orders.Fees
             Fees.TryGetValue(security.Symbol.Value, out fee);
 
             // get order value in account currency, then apply fee factor
-            return order.GetValue(security) * fee;
+            return Math.Abs(order.GetValue(security)) * fee;
         }
     }
 }


### PR DESCRIPTION
The model was returning negative fees for sell market orders.