### PR TITLE
Fix subscription removal in SubscriptionCollection.TryRemove

### DIFF
--- a/Brokerages/Tradier/TradierBrokerage.DataQueueHandler.cs
+++ b/Brokerages/Tradier/TradierBrokerage.DataQueueHandler.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -69,7 +69,7 @@ namespace QuantConnect.Brokerages.Tradier
                     pipe.MoveNext();
                     _refresh = false;
                 }
-                
+
                 if (pipe != null && pipe.Current != null)
                 {
                     var tsd = pipe.Current;
@@ -135,7 +135,7 @@ namespace QuantConnect.Brokerages.Tradier
             _refreshDelay.Elapsed += (sender, args) =>
             {
                 _refresh = true;
-                Log.Trace("TradierBrokerage.DataQueueHandler.Refresh(): Updating tickers..." + string.Join(",", _subscriptions.Values));
+                Log.Trace("TradierBrokerage.DataQueueHandler.Refresh(): Updating tickers..." + string.Join(",", _subscriptions.Select(x => x.Value)));
                 CloseStream();
                 _refreshDelay.Stop();
             };
@@ -148,8 +148,9 @@ namespace QuantConnect.Brokerages.Tradier
         /// <returns>List of string tickers</returns>
         private List<string> GetTickers()
         {
-            Log.Trace("TradierBrokerage.DataQueueHandler.GetTickers(): " + string.Join(",", _subscriptions.Values));
-            return _subscriptions.Values.ToList();
+            var values = _subscriptions.Select(x => x.Value).ToList();
+            Log.Trace("TradierBrokerage.DataQueueHandler.GetTickers(): " + string.Join(",", values));
+            return values;
         }
 
         /// <summary>

--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Securities
                     if (seedData != null)
                     {
                         security.SetMarketPrice(seedData);
-                        Log.Trace("BrokerageModelSecurityInitializer.Initialize(): Seeded security: " + seedData.Symbol.Value + ": " + seedData.Value);
+                        Log.Debug("BrokerageModelSecurityInitializer.Initialize(): Seeded security: " + seedData.Symbol.Value + ": " + seedData.Value);
                     }
                     else
                     {

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -429,7 +429,7 @@ namespace QuantConnect.Lean.Engine
                 // apply dividends
                 foreach (var dividend in timeSlice.Slice.Dividends.Values)
                 {
-                    Log.Trace("AlgorithmManager.Run(): {0}: Applying Dividend for {1}", algorithm.Time, dividend.Symbol.ToString());
+                    Log.Debug($"AlgorithmManager.Run(): {algorithm.Time}: Applying Dividend for {dividend.Symbol}");
                     algorithm.Portfolio.ApplyDividend(dividend);
                 }
 
@@ -438,7 +438,7 @@ namespace QuantConnect.Lean.Engine
                 {
                     try
                     {
-                        Log.Trace("AlgorithmManager.Run(): {0}: Applying Split for {1}", algorithm.Time, split.Symbol.ToString());
+                        Log.Debug($"AlgorithmManager.Run(): {algorithm.Time}: Applying Split for {split.Symbol}");
                         algorithm.Portfolio.ApplySplit(split);
                         // apply the split to open orders as well in raw mode, all other modes are split adjusted
                         if (_liveMode || algorithm.Securities[split.Symbol].DataNormalizationMode == DataNormalizationMode.Raw)

--- a/Engine/DataFeeds/SubscriptionCollection.cs
+++ b/Engine/DataFeeds/SubscriptionCollection.cs
@@ -139,7 +139,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 return false;
             }
 
-            return dictionary.Any() || _subscriptions.TryRemove(configuration.Symbol, out dictionary);
+            if (!dictionary.Any())
+            {
+                _subscriptions.TryRemove(configuration.Symbol, out dictionary);
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/SubscriptionCollection.cs
+++ b/Engine/DataFeeds/SubscriptionCollection.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 return false;
             }
 
-            subscriptions = dictionary.Values;
+            subscriptions = dictionary.Select(x => x.Value).ToList();
             return true;
         }
 
@@ -133,7 +133,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 return false;
             }
 
-            return dictionary.TryRemove(configuration, out subscription);
+            if (!dictionary.TryRemove(configuration, out subscription))
+            {
+                subscription = null;
+                return false;
+            }
+
+            return dictionary.Any() || _subscriptions.TryRemove(configuration.Symbol, out dictionary);
         }
 
         /// <summary>
@@ -151,7 +157,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 return false;
             }
 
-            subscriptions = dictionary.Values;
+            subscriptions = dictionary.Select(x => x.Value).ToList();
             return true;
         }
 

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -310,8 +310,10 @@ namespace QuantConnect.Lean.Engine.Results
                 lock (_chartLock)
                 {
                     //Get the updates since the last chart
-                    foreach (var chart in Charts.Values)
+                    foreach (var kvp in Charts)
                     {
+                        var chart = kvp.Value;
+
                         deltaCharts.Add(chart.Name, chart.GetUpdates());
                     }
                 }


### PR DESCRIPTION
This method was not removing the symbol dictionary entry when removing the last subscription, allowing the collection to grow excessively over time (especially with universe selection algorithms).

This PR also includes a few minor performance fixes.