### PR TITLE
Fix IB error with Market On Close (MOC) orders

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1614,6 +1614,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 ibOrder.Tif = IB.TimeInForce.MarketOnOpen;
             }
+            else if (order.Type == OrderType.MarketOnClose)
+            {
+                ibOrder.Tif = IB.TimeInForce.Day;
+            }
 
             var limitOrder = order as LimitOrder;
             var stopMarketOrder = order as StopMarketOrder;


### PR DESCRIPTION
Market On Close (`MOC`) orders were being rejected because the `TimeInForce` setting was incorrectly set to `GTC` instead of `DAY`.