### PR TITLE
Disable automatic security seeding

### DIFF
--- a/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
+++ b/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             // set our initializer to our custom type
             SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage);
-            SetSecurityInitializer(new CustomSecurityInitializer(BrokerageModel, new FuncSecuritySeeder(GetLastKnownPrice), DataNormalizationMode.Raw));
+            SetSecurityInitializer(new CustomSecurityInitializer(BrokerageModel, SecuritySeeder.Null, DataNormalizationMode.Raw));
 
             SetStartDate(2013, 10, 01);
             SetEndDate(2013, 11, 01);
@@ -77,11 +77,10 @@ namespace QuantConnect.Algorithm.CSharp
             /// Initializes the specified security by setting up the models
             /// </summary>
             /// <param name="security">The security to be initialized</param>
-            /// <param name="seedSecurity">True to seed the security, false otherwise</param>
-            public override void Initialize(Security security, bool seedSecurity)
+            public override void Initialize(Security security)
             {
                 // first call the default implementation
-                base.Initialize(security, seedSecurity);
+                base.Initialize(security);
 
                 // now apply our data normalization mode
                 security.SetDataNormalizationMode(_dataNormalizationMode);

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -716,13 +716,6 @@ namespace QuantConnect.Algorithm
                 return;
             }
 
-            var securityInitializer2 = PythonUtil.ToAction<Security, bool>(securityInitializer);
-            if (securityInitializer2 != null)
-            {
-                SetSecurityInitializer(securityInitializer2);
-                return;
-            }
-
             SetSecurityInitializer(new SecurityInitializerPythonWrapper(securityInitializer));
         }
 

--- a/Common/Python/SecurityInitializerPythonWrapper.cs
+++ b/Common/Python/SecurityInitializerPythonWrapper.cs
@@ -38,12 +38,11 @@ namespace QuantConnect.Python
         /// Initializes the specified security
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        /// <param name="seedSecurity">True to seed the security, false otherwise</param>
-        public void Initialize(Security security, bool seedSecurity)
+        public void Initialize(Security security)
         {
             using (Py.GIL())
             {
-                _model.Initialize(security, seedSecurity);
+                _model.Initialize(security);
             }
         }
     }

--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -15,8 +15,6 @@
 */
 
 using QuantConnect.Brokerages;
-using QuantConnect.Data;
-using QuantConnect.Logging;
 
 namespace QuantConnect.Securities
 {
@@ -55,8 +53,7 @@ namespace QuantConnect.Securities
         /// Initializes the specified security by setting up the models
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        /// <param name="seedSecurity">True to seed the security, false otherwise</param>
-        public virtual void Initialize(Security security, bool seedSecurity)
+        public virtual void Initialize(Security security)
         {
             // set leverage and models
             security.SetLeverage(_brokerageModel.GetLeverage(security));
@@ -65,23 +62,7 @@ namespace QuantConnect.Securities
             security.SlippageModel = _brokerageModel.GetSlippageModel(security);
             security.SettlementModel = _brokerageModel.GetSettlementModel(security, _brokerageModel.AccountType);
 
-            if (seedSecurity)
-            {
-                // Do not seed canonical symbols
-                if (!security.Symbol.IsCanonical())
-                {
-                    BaseData seedData = _securitySeeder.GetSeedData(security);
-                    if (seedData != null)
-                    {
-                        security.SetMarketPrice(seedData);
-                        Log.Debug("BrokerageModelSecurityInitializer.Initialize(): Seeded security: " + seedData.Symbol.Value + ": " + seedData.Value);
-                    }
-                    else
-                    {
-                        Log.Trace("BrokerageModelSecurityInitializer.Initialize(): Unable to seed security: " + security.Symbol.Value);
-                    }
-                }
-            }
+            _securitySeeder.SeedSecurity(security);
         }
     }
 }

--- a/Common/Securities/CompositeSecurityInitializer.cs
+++ b/Common/Securities/CompositeSecurityInitializer.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,12 +37,11 @@ namespace QuantConnect.Securities
         /// Execute each of the internally held initializers in sequence
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        /// <param name="seedSecurity">True to seed the security, false otherwise</param>
-        public void Initialize(Security security, bool seedSecurity)
+        public void Initialize(Security security)
         {
             foreach (var initializer in _initializers)
             {
-                initializer.Initialize(security, seedSecurity);
+                initializer.Initialize(security);
             }
         }
     }

--- a/Common/Securities/FuncSecurityInitializer.cs
+++ b/Common/Securities/FuncSecurityInitializer.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,13 +23,13 @@ namespace QuantConnect.Securities
     /// </summary>
     public class FuncSecurityInitializer : ISecurityInitializer
     {
-        private readonly Action<Security, bool> _initializer;
+        private readonly Action<Security> _initializer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FuncSecurityInitializer"/> class
         /// </summary>
         /// <param name="initializer">The functional implementation of <see cref="ISecurityInitializer.Initialize"/></param>
-        public FuncSecurityInitializer(Action<Security, bool> initializer)
+        public FuncSecurityInitializer(Action<Security> initializer)
         {
             _initializer = initializer;
         }
@@ -38,10 +38,9 @@ namespace QuantConnect.Securities
         /// Initializes the specified security
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        /// <param name="seedSecurity">True to seed the security, false otherwise</param>
-        public void Initialize(Security security, bool seedSecurity)
+        public void Initialize(Security security)
         {
-            _initializer(security, seedSecurity);
+            _initializer(security);
         }
     }
 }

--- a/Common/Securities/FuncSecuritySeeder.cs
+++ b/Common/Securities/FuncSecuritySeeder.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,22 +37,37 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Get the last data point using the seed function
+        /// Seed the security
         /// </summary>
         /// <param name="security"><see cref="Security"/> being seeded</param>
-        /// <returns><see cref="BaseData"/> representing the last known data of the security</returns>
-        public BaseData GetSeedData(Security security)
+        /// <returns>true if the security was seeded, false otherwise</returns>
+        public bool SeedSecurity(Security security)
         {
             try
             {
-                return _seedFunction(security);
+                // Do not seed canonical symbols
+                if (!security.Symbol.IsCanonical())
+                {
+                    var seedData = _seedFunction(security);
+                    if (seedData != null)
+                    {
+                        security.SetMarketPrice(seedData);
+                        Log.Debug("FuncSecuritySeeder.SeedSecurity(): Seeded security: " + seedData.Symbol.Value + ": " + seedData.Value);
+                    }
+                    else
+                    {
+                        Log.Trace("FuncSecuritySeeder.SeedSecurity(): Unable to seed security: " + security.Symbol.Value);
+                        return false;
+                    }
+                }
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                Log.Error("FuncSecuritySeeder.GetSeedPrice():  Could not seed price for security {0}: {1}", security.Symbol, ex.GetBaseException());
+                Log.Trace("FuncSecuritySeeder.SeedSecurity(): Could not seed price for security {0}: {1}", security.Symbol, exception);
+                return false;
             }
 
-            return null;
+            return true;
         }
     }
 }

--- a/Common/Securities/ISecurityInitializer.cs
+++ b/Common/Securities/ISecurityInitializer.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,8 +25,7 @@ namespace QuantConnect.Securities
         /// Initializes the specified security
         /// </summary>
         /// <param name="security">The security to be initialized</param>
-        /// <param name="seedSecurity">True to seed the security, false otherwise</param>
-        void Initialize(Security security, bool seedSecurity);
+        void Initialize(Security security);
     }
 
     /// <summary>
@@ -41,7 +40,7 @@ namespace QuantConnect.Securities
 
         private sealed class NullSecurityInitializer : ISecurityInitializer
         {
-            public void Initialize(Security security, bool seedSecurity) { }
+            public void Initialize(Security security) { }
         }
     }
 }

--- a/Common/Securities/ISecuritySeeder.cs
+++ b/Common/Securities/ISecuritySeeder.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,8 +13,6 @@
  * limitations under the License.
  *
 */
-
-using QuantConnect.Data;
 
 namespace QuantConnect.Securities
 {
@@ -24,10 +22,29 @@ namespace QuantConnect.Securities
     public interface ISecuritySeeder
     {
         /// <summary>
-        /// Get the last data point using the seed function
+        /// Seed the security
         /// </summary>
         /// <param name="security"><see cref="Security"/> being seeded</param>
-        /// <returns><see cref="BaseData"/> representing the last known data of the security</returns>
-        BaseData GetSeedData(Security security);
+        /// <returns>true if the security was seeded, false otherwise</returns>
+        bool SeedSecurity(Security security);
+    }
+
+    /// <summary>
+    /// Provides access to a null implementation for <see cref="ISecuritySeeder"/>
+    /// </summary>
+    public static class SecuritySeeder
+    {
+        /// <summary>
+        /// Gets an instance of <see cref="ISecuritySeeder"/> that is a no-op
+        /// </summary>
+        public static readonly ISecuritySeeder Null = new NullSecuritySeeder();
+
+        private sealed class NullSecuritySeeder : ISecuritySeeder
+        {
+            public bool SeedSecurity(Security security)
+            {
+                return true;
+            }
+        }
     }
 }

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -408,7 +408,7 @@ namespace QuantConnect.Securities
             security.AddData(configList);
 
             // invoke the security initializer
-            securityInitializer.Initialize(security, true);
+            securityInitializer.Initialize(security);
 
             // if leverage was specified then apply to security after the initializer has run, parameters of this
             // method take precedence over the intializer

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,8 +83,7 @@ namespace QuantConnect.Tests.Common.Securities
                                     new Cash(CashBook.AccountCurrency, 0, 1m),
                                     SymbolProperties.GetDefault(CashBook.AccountCurrency));
 
-            _brokerageInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(),
-                                                                             new FuncSecuritySeeder(_algo.GetLastKnownPrice));
+            _brokerageInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(), SecuritySeeder.Null);
         }
 
         [Test]
@@ -92,7 +91,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             Assert.AreEqual(_tradeBarSecurity.Leverage, 1.0);
 
-            _brokerageInitializer.Initialize(_tradeBarSecurity, true);
+            _brokerageInitializer.Initialize(_tradeBarSecurity);
 
             Assert.AreEqual(_tradeBarSecurity.Leverage, 2.0);
         }
@@ -103,9 +102,9 @@ namespace QuantConnect.Tests.Common.Securities
             // Arrange
             var dateForWhichDataExist = new DateTime(2013, 10, 10, 12, 0, 0);
             _algo.SetDateTime(dateForWhichDataExist);
-            
+
             // Act
-            _brokerageInitializer.Initialize(_tradeBarSecurity, true);
+            _brokerageInitializer.Initialize(_tradeBarSecurity);
 
             // Assert
             Assert.IsFalse(_tradeBarSecurity.Price == 0);
@@ -119,7 +118,7 @@ namespace QuantConnect.Tests.Common.Securities
             _algo.SetDateTime(dateForWhichDataExist);
 
             // Act
-            _brokerageInitializer.Initialize(_quoteBarSecurity, true);
+            _brokerageInitializer.Initialize(_quoteBarSecurity);
 
             // Assert
             Assert.IsFalse(_quoteBarSecurity.Price == 0);
@@ -133,7 +132,7 @@ namespace QuantConnect.Tests.Common.Securities
             _algo.SetDateTime(dateForWhichDataDoesNotExist);
 
             // Act
-            _brokerageInitializer.Initialize(_tradeBarSecurity, true);
+            _brokerageInitializer.Initialize(_tradeBarSecurity);
 
             // Assert
             Assert.IsTrue(_tradeBarSecurity.Price == 0);

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -83,7 +83,8 @@ namespace QuantConnect.Tests.Common.Securities
                                     new Cash(CashBook.AccountCurrency, 0, 1m),
                                     SymbolProperties.GetDefault(CashBook.AccountCurrency));
 
-            _brokerageInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(), SecuritySeeder.Null);
+            _brokerageInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(),
+                                                                          new FuncSecuritySeeder(_algo.GetLastKnownPrice));
         }
 
         [Test]
@@ -107,7 +108,7 @@ namespace QuantConnect.Tests.Common.Securities
             _brokerageInitializer.Initialize(_tradeBarSecurity);
 
             // Assert
-            Assert.IsTrue(_tradeBarSecurity.Price == 0);
+            Assert.IsFalse(_tradeBarSecurity.Price == 0);
         }
 
         [Test]
@@ -121,7 +122,7 @@ namespace QuantConnect.Tests.Common.Securities
             _brokerageInitializer.Initialize(_quoteBarSecurity);
 
             // Assert
-            Assert.IsTrue(_quoteBarSecurity.Price == 0);
+            Assert.IsFalse(_quoteBarSecurity.Price == 0);
         }
 
         [Test]

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -107,7 +107,7 @@ namespace QuantConnect.Tests.Common.Securities
             _brokerageInitializer.Initialize(_tradeBarSecurity);
 
             // Assert
-            Assert.IsFalse(_tradeBarSecurity.Price == 0);
+            Assert.IsTrue(_tradeBarSecurity.Price == 0);
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace QuantConnect.Tests.Common.Securities
             _brokerageInitializer.Initialize(_quoteBarSecurity);
 
             // Assert
-            Assert.IsFalse(_quoteBarSecurity.Price == 0);
+            Assert.IsTrue(_quoteBarSecurity.Price == 0);
         }
 
         [Test]


### PR DESCRIPTION
In this PR we are disabling the default security seeding (automatically getting the last price for a security when added to the algorithm) for a couple reasons, both when using large universes:
- In live trading, these history requests are sent to a history server, potentially causing timeouts
- In backtesting, depending on the algorithm this could also cause slowdowns up to 30%