### PR TITLE
fix ETH display signal

### DIFF
--- a/Common/Currencies.cs
+++ b/Common/Currencies.cs
@@ -292,7 +292,7 @@ namespace QuantConnect
             {"BTC", "฿"},
             {"BCH", "฿"},
             {"LTC", "Ł"},
-            {"ETH", "Ether"}
+            {"ETH", "Ξ"}
         };
 
         /// <summary>


### PR DESCRIPTION
Update display signal of Ether from previous value of **ETH** to **Ξ**. From issue #1438 reported by @Haumed

The previous value was ETH. Was this intentional due to some character limit or is Ξ acceptable?