### PR TITLE
Exclude data feed packets for removed symbols

### DIFF
--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -41,6 +41,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private readonly Dictionary<DateTime, Dictionary<Symbol, Security>> _pendingSecurityAdditions = new Dictionary<DateTime, Dictionary<Symbol, Security>>();
 
         /// <summary>
+        /// Returns a list of symbols unselected from the universe but kept in it because of open orders or positions
+        /// </summary>
+        public IEnumerable<Symbol> PendingRemovals => _pendingRemovals.Select(x => x.Symbol);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="UniverseSelection"/> class
         /// </summary>
         /// <param name="dataFeed">The data feed to add/remove subscriptions from</param>


### PR DESCRIPTION
With universe selection, data packets for symbols just removed from the universe were still being added to the `TimeSlice` (in the same time step) and also included in the `Slice` passed to `OnData`.