### PR TITLE
Add NullExecutionModel and NullPortfolioConstructionModel

### DIFF
--- a/Algorithm.Framework/Execution/NullExecutionModel.cs
+++ b/Algorithm.Framework/Execution/NullExecutionModel.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Algorithm.Framework.Execution
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IExecutionModel"/> that does nothing
+    /// </summary>
+    public class NullExecutionModel : IExecutionModel
+    {
+        public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        {
+        }
+
+        public void Execute(QCAlgorithmFramework algorithm, IEnumerable<IPortfolioTarget> targets)
+        {
+        }
+    }
+}

--- a/Algorithm.Framework/Portfolio/NullPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/NullPortfolioConstructionModel.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Algorithm.Framework.Portfolio
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IPortfolioConstructionModel"/> that does nothing
+    /// </summary>
+    public class NullPortfolioConstructionModel : IPortfolioConstructionModel
+    {
+        public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        {
+        }
+
+        public IEnumerable<IPortfolioTarget> CreateTargets(QCAlgorithmFramework algorithm, List<Alpha> alphas)
+        {
+            return Enumerable.Empty<IPortfolioTarget>();
+        }
+    }
+}

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -55,9 +55,11 @@
     </Compile>
     <Compile Include="Execution\IExecutionModel.cs" />
     <Compile Include="Execution\ImmediateExecutionModel.cs" />
+    <Compile Include="Execution\NullExecutionModel.cs" />
     <Compile Include="INotifiedSecurityChanges.cs" />
     <Compile Include="NotifiedSecurityChanges.cs" />
     <Compile Include="Portfolio\IPortfolioConstructionModel.cs" />
+    <Compile Include="Portfolio\NullPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\SimplePortfolioConstructionModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QCAlgorithmFramework.cs" />


### PR DESCRIPTION
When focusing on generating alpha signals we don't need t both with execution or portfolio construction models. Instead we can judge how well we do based on our generated alphas. By not submitting orders, backtests and live performance is greatly improved.