### PR TITLE
Exclude failing test for Travis build

### DIFF
--- a/Tests/Common/Securities/SecurityIdentifierTests.cs
+++ b/Tests/Common/Securities/SecurityIdentifierTests.cs
@@ -272,7 +272,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(sid.ToString(), value);
         }
 
-        [Test]
+        [Test, Category("TravisExclude")]
         public void ParsesFromStringFastEnough()
         {
             const string value = "SPY R735QTJ8XC9X";


### PR DESCRIPTION
This SecurityIdentifier test is speed sensitive and might occasionally fail, so it is being excluded from the Travis build.