### PR TITLE
Set correct time zone for custom data in MarketHoursDatabase

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -84,13 +84,13 @@ namespace QuantConnect.Algorithm
         /// <returns>The new <see cref="Security"/></returns>
         public Security AddData(Type dataType, string symbol, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
         {
-            var marketHoursDbEntry = MarketHoursDatabase.GetEntry(Market.USA, symbol, SecurityType.Base, timeZone);
+            var marketHoursDbEntry = MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, symbol, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
             var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA), symbol);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(Market.USA, symbol, SecurityType.Base, CashBook.AccountCurrency);
 
-            //Add this new generic data as a tradeable security: 
+            //Add this new generic data as a tradeable security:
             var security = SecurityManager.CreateSecurity(dataType, Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone,
                 symbolProperties, SecurityInitializer, symbolObject, resolution, fillDataForward, leverage, true, false, true, LiveMode);
 
@@ -497,7 +497,7 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Gets the historical data for the specified symbol. The exact number of bars will be returned. 
+        /// Gets the historical data for the specified symbol. The exact number of bars will be returned.
         /// The symbol must exist in the Securities collection.
         /// </summary>
         /// <param name="tickers">The symbols to retrieve historical data for</param>
@@ -592,7 +592,7 @@ namespace QuantConnect.Algorithm
                 var config = security.Subscriptions.OrderByDescending(s => s.Resolution)
                         .FirstOrDefault(s => s.Type.BaseType == CreateType(type).BaseType);
                 if (config == null) return null;
-                
+
                 Resolution? res = resolution ?? security.Resolution;
                 var start = GetStartTimeAlgoTz(x, periods, resolution).ConvertToUtc(TimeZone);
                 return CreateHistoryRequest(security, config, start, UtcTime.RoundDown(res.Value.ToTimeSpan()), resolution);
@@ -654,7 +654,7 @@ namespace QuantConnect.Algorithm
         public PyObject History(PyObject type, Symbol symbol, int periods, Resolution? resolution = null)
         {
             if (resolution == Resolution.Tick) throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
-            
+
             var start = GetStartTimeAlgoTz(symbol, periods, resolution);
             var end = Time.RoundDown((resolution ?? Securities[symbol].Resolution).ToTimeSpan());
             return History(type, symbol, start, end, resolution);
@@ -673,7 +673,7 @@ namespace QuantConnect.Algorithm
         {
             return History(type, symbol, Time - span, Time, resolution);
         }
-                
+
         /// <summary>
         /// Sets the specified function as the benchmark, this function provides the value of
         /// the benchmark at each date/time requested

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -352,6 +352,14 @@ namespace QuantConnect.Algorithm
                 // create a new universe, these subscription settings don't currently get used
                 // since universe selection proper is never invoked on this type of universe
                 var uconfig = new SubscriptionDataConfig(subscription, symbol: universeSymbol, isInternalFeed: true, fillForward: false);
+
+                if (security.Type == SecurityType.Base)
+                {
+                    // set entry in market hours database for the universe subscription to match the custom data
+                    var symbolString = MarketHoursDatabase.GetDatabaseSymbolKey(uconfig.Symbol);
+                    MarketHoursDatabase.SetEntry(uconfig.Market, symbolString, uconfig.SecurityType, security.Exchange.Hours, uconfig.DataTimeZone);
+                }
+
                 universe = new UserDefinedUniverse(uconfig,
                     new UniverseSettings(security.Resolution, security.Leverage, security.IsFillDataForward, security.IsExtendedMarketHours, TimeSpan.Zero),
                     SecurityInitializer,

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1694,7 +1694,8 @@ namespace QuantConnect.Algorithm
         public Security AddData<T>(string symbol, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
-            var marketHoursDbEntry = MarketHoursDatabase.GetEntry(Market.USA, symbol, SecurityType.Base, timeZone);
+            //Add this custom symbol to our market hours database
+            var marketHoursDbEntry = MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, symbol, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
             var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA), symbol);

--- a/Common/Brokerages/TradierBrokerageModel.cs
+++ b/Common/Brokerages/TradierBrokerageModel.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,13 +29,13 @@ namespace QuantConnect.Brokerages
     /// </summary>
     public class TradierBrokerageModel : DefaultBrokerageModel
     {
-        private static readonly EquityExchange EquityExchange = 
-            new EquityExchange(MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, null, SecurityType.Equity, TimeZones.NewYork));
-        
+        private static readonly EquityExchange EquityExchange =
+            new EquityExchange(MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, null, SecurityType.Equity));
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to 
+        /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="QuantConnect.AccountType.Margin"/></param>
         public TradierBrokerageModel(AccountType accountType = AccountType.Margin)
             : base(accountType)
@@ -63,7 +63,7 @@ namespace QuantConnect.Brokerages
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     "This model only supports equities."
                     );
-                
+
                 return false;
             }
 
@@ -114,7 +114,7 @@ namespace QuantConnect.Brokerages
 
         /// <summary>
         /// Returns true if the brokerage would be able to execute this order at this time assuming
-        /// market prices are sufficient for the fill to take place. This is used to emulate the 
+        /// market prices are sufficient for the fill to take place. This is used to emulate the
         /// brokerage fills in backtesting and paper trading. For example some brokerages may not perform
         /// executions during extended market hours. This is not intended to be checking whether or not
         /// the exchange is open, that is handled in the Security.Exchange property.

--- a/Common/Securities/Crypto/CryptoExchange.cs
+++ b/Common/Securities/Crypto/CryptoExchange.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-namespace QuantConnect.Securities.Crypto 
+namespace QuantConnect.Securities.Crypto
 {
     /// <summary>
     /// Crypto exchange class - information and helper tools for Crypto exchange properties
@@ -27,7 +27,7 @@ namespace QuantConnect.Securities.Crypto
         /// derived from the market-hours-database for the Crypto market
         /// </summary>
         public CryptoExchange(string market)
-            : base(MarketHoursDatabase.FromDataFolder().GetExchangeHours(market, null, SecurityType.Crypto, TimeZones.Utc))
+            : base(MarketHoursDatabase.FromDataFolder().GetExchangeHours(market, null, SecurityType.Crypto))
         {
         }
 

--- a/Common/Securities/Equity/EquityExchange.cs
+++ b/Common/Securities/Equity/EquityExchange.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@
 namespace QuantConnect.Securities.Equity
 {
     /// <summary>
-    /// Equity exchange information 
+    /// Equity exchange information
     /// </summary>
     /// <seealso cref="SecurityExchange"/>
     public class EquityExchange : SecurityExchange
@@ -34,7 +34,7 @@ namespace QuantConnect.Securities.Equity
         /// derived from the market-hours-database for the USA Equity market
         /// </summary>
         public EquityExchange()
-            : base(MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, null, SecurityType.Equity, TimeZones.NewYork))
+            : base(MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, null, SecurityType.Equity))
         {
         }
 

--- a/Common/Securities/Forex/ForexExchange.cs
+++ b/Common/Securities/Forex/ForexExchange.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-namespace QuantConnect.Securities.Forex 
+namespace QuantConnect.Securities.Forex
 {
     /// <summary>
     /// Forex exchange class - information and helper tools for forex exchange properties
@@ -35,7 +35,7 @@ namespace QuantConnect.Securities.Forex
         /// derived from the market-hours-database for the FXCM Forex market
         /// </summary>
         public ForexExchange()
-            : base(MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.FXCM, null, SecurityType.Forex, TimeZones.NewYork))
+            : base(MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.FXCM, null, SecurityType.Forex))
         {
         }
 

--- a/Common/Securities/MarketHoursDatabase.cs
+++ b/Common/Securities/MarketHoursDatabase.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,24 +34,12 @@ namespace QuantConnect.Securities
         private static MarketHoursDatabase _dataFolderMarketHoursDatabase;
         private static readonly object DataFolderMarketHoursDatabaseLock = new object();
 
-        private readonly IReadOnlyDictionary<SecurityDatabaseKey, Entry> _entries;
-
-        /// <summary>
-        /// Gets an instant of <see cref="MarketHoursDatabase"/> that will always return <see cref="SecurityExchangeHours.AlwaysOpen"/>
-        /// for each call to <see cref="GetExchangeHours(string, Symbol, SecurityType,DateTimeZone)"/>
-        /// </summary>
-        public static MarketHoursDatabase AlwaysOpen
-        {
-            get { return new AlwaysOpenMarketHoursDatabase(); }
-        }
+        private readonly Dictionary<SecurityDatabaseKey, Entry> _entries;
 
         /// <summary>
         /// Gets all the exchange hours held by this provider
         /// </summary>
-        public List<KeyValuePair<SecurityDatabaseKey,Entry>> ExchangeHoursListing
-        {
-            get { return _entries.ToList(); }
-        }
+        public List<KeyValuePair<SecurityDatabaseKey,Entry>> ExchangeHoursListing => _entries.ToList();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MarketHoursDatabase"/> class
@@ -62,40 +50,26 @@ namespace QuantConnect.Securities
             _entries = exchangeHours.ToDictionary();
         }
 
-        private MarketHoursDatabase()
-        {
-            // used for the always open implementation
-        }
-
         /// <summary>
-        /// Performs a lookup using the specified information and returns the exchange hours if found,
-        /// if exchange hours are not found, an exception is thrown
+        /// Convenience method for retrieving exchange hours from market hours database using a subscription config
         /// </summary>
         /// <param name="configuration">The subscription data config to get exchange hours for</param>
-        /// <param name="overrideTimeZone">Specify this time zone to override the resolved time zone from the market hours database.
-        /// This value will also be used as the time zone for SecurityType.Base with no market hours database entry.
-        /// If null is specified, no override will be performed. If null is specified, and it's SecurityType.Base, then Utc will be used.</param>
-        public SecurityExchangeHours GetExchangeHours(SubscriptionDataConfig configuration, DateTimeZone overrideTimeZone = null)
+        /// <returns>The configure exchange hours for the specified configuration</returns>
+        public SecurityExchangeHours GetExchangeHours(SubscriptionDataConfig configuration)
         {
-            // we don't expect base security types to be in the market-hours-database, so set overrideTimeZone
-            if (configuration.SecurityType == SecurityType.Base && overrideTimeZone == null) overrideTimeZone = configuration.ExchangeTimeZone;
-            return GetExchangeHours(configuration.Market, configuration.Symbol, configuration.SecurityType, overrideTimeZone);
+            return GetExchangeHours(configuration.Market, configuration.Symbol, configuration.SecurityType);
         }
 
         /// <summary>
-        /// Performs a lookup using the specified information and returns the exchange hours if found,
-        /// if exchange hours are not found, an exception is thrown
+        /// Convenience method for retrieving exchange hours from market hours database using a subscription config
         /// </summary>
         /// <param name="market">The market the exchange resides in, i.e, 'usa', 'fxcm', ect...</param>
         /// <param name="symbol">The particular symbol being traded</param>
         /// <param name="securityType">The security type of the symbol</param>
-        /// <param name="overrideTimeZone">Specify this time zone to override the resolved time zone from the market hours database.
-        /// This value will also be used as the time zone for SecurityType.Base with no market hours database entry.
-        /// If null is specified, no override will be performed. If null is specified, and it's SecurityType.Base, then Utc will be used.</param>
         /// <returns>The exchange hours for the specified security</returns>
-        public SecurityExchangeHours GetExchangeHours(string market, Symbol symbol, SecurityType securityType, DateTimeZone overrideTimeZone = null)
+        public SecurityExchangeHours GetExchangeHours(string market, Symbol symbol, SecurityType securityType)
         {
-            return GetEntry(market, symbol, securityType, overrideTimeZone).ExchangeHours;
+            return GetEntry(market, symbol, securityType).ExchangeHours;
         }
 
         /// <summary>
@@ -152,16 +126,49 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Sets the entry for the specified market/symbol/security-type.
+        /// This is intended to be used by custom data and other data sources that don't have explicit
+        /// entries in market-hours-database.csv. At run time, the algorithm can update the market hours
+        /// database via calls to AddData.
+        /// </summary>
+        /// <param name="market">The market the exchange resides in, i.e, 'usa', 'fxcm', ect...</param>
+        /// <param name="symbol">The particular symbol being traded</param>
+        /// <param name="securityType">The security type of the symbol</param>
+        /// <param name="exchangeHours">The exchange hours for the specified symbol</param>
+        /// <param name="dataTimeZone">The time zone of the symbol's raw data. Optional, defaults to the exchange time zone</param>
+        /// <returns>The entry matching the specified market/symbol/security-type</returns>
+        public virtual Entry SetEntry(string market, string symbol, SecurityType securityType, SecurityExchangeHours exchangeHours, DateTimeZone dataTimeZone = null)
+        {
+            dataTimeZone = dataTimeZone ?? exchangeHours.TimeZone;
+            var key = new SecurityDatabaseKey(market, symbol, securityType);
+            var entry = new Entry(dataTimeZone, exchangeHours);
+            _entries[key] = entry;
+            return entry;
+        }
+
+        /// <summary>
+        /// Convenience method for the common custom data case.
+        /// Sets the entry for the specified symbol using SecurityExchangeHours.AlwaysOpen(timeZone)
+        /// This sets the data time zone equal to the exchange time zone as well.
+        /// </summary>
+        /// <param name="market">The market the exchange resides in, i.e, 'usa', 'fxcm', ect...</param>
+        /// <param name="symbol">The particular symbol being traded</param>
+        /// <param name="securityType">The security type of the symbol</param>
+        /// <param name="timeZone">The time zone of the symbol's exchange and raw data</param>
+        /// <returns>The entry matching the specified market/symbol/security-type</returns>
+        public virtual Entry SetEntryAlwaysOpen(string market, string symbol, SecurityType securityType, DateTimeZone timeZone)
+        {
+            return SetEntry(market, symbol, securityType, SecurityExchangeHours.AlwaysOpen(timeZone));
+        }
+
+        /// <summary>
         /// Gets the entry for the specified market/symbol/security-type
         /// </summary>
         /// <param name="market">The market the exchange resides in, i.e, 'usa', 'fxcm', ect...</param>
         /// <param name="symbol">The particular symbol being traded</param>
         /// <param name="securityType">The security type of the symbol</param>
-        /// <param name="overrideTimeZone">Specify this time zone to override the resolved time zone from the market hours database.
-        /// This value will also be used as the time zone for SecurityType.Base with no market hours database entry.
-        /// If null is specified, no override will be performed. If null is specified, and it's SecurityType.Base, then Utc will be used.</param>
         /// <returns>The entry matching the specified market/symbol/security-type</returns>
-        public virtual Entry GetEntry(string market, string symbol, SecurityType securityType, DateTimeZone overrideTimeZone = null)
+        public virtual Entry GetEntry(string market, string symbol, SecurityType securityType)
         {
             Entry entry;
             var key = new SecurityDatabaseKey(market, symbol, securityType);
@@ -170,28 +177,11 @@ namespace QuantConnect.Securities
                 // now check with null symbol key
                 if (!_entries.TryGetValue(new SecurityDatabaseKey(market, null, securityType), out entry))
                 {
-                    if (securityType == SecurityType.Base)
-                    {
-                        if (overrideTimeZone == null)
-                        {
-                            overrideTimeZone = TimeZones.Utc;
-                            Log.Error("MarketHoursDatabase.GetExchangeHours(): Custom data no time zone specified, default to UTC. " + key);
-                        }
-                        // base securities are always open by default and have equal data time zone and exchange time zones
-                        return new Entry(overrideTimeZone, SecurityExchangeHours.AlwaysOpen(overrideTimeZone));
-                    }
-
-                    Log.Error(string.Format("MarketHoursDatabase.GetExchangeHours(): Unable to locate exchange hours for {0}." + "Available keys: {1}", key, string.Join(", ", _entries.Keys)));
+                    var keys = string.Join(", ", _entries.Keys);
+                    Log.Error($"MarketHoursDatabase.GetExchangeHours(): Unable to locate exchange hours for {key}.Available keys: {keys}");
 
                     // there was nothing that really matched exactly... what should we do here?
                     throw new ArgumentException("Unable to locate exchange hours for " + key);
-                }
-
-                // perform time zone override if requested, we'll use the same exact local hours
-                // and holidays, but we'll express them in a different time zone
-                if (overrideTimeZone != null && !entry.ExchangeHours.TimeZone.Equals(overrideTimeZone))
-                {
-                    return new Entry(overrideTimeZone, new SecurityExchangeHours(overrideTimeZone, entry.ExchangeHours.Holidays, entry.ExchangeHours.MarketHours, entry.ExchangeHours.EarlyCloses));
                 }
             }
 
@@ -204,18 +194,49 @@ namespace QuantConnect.Securities
         /// <param name="market">The market the exchange resides in, i.e, 'usa', 'fxcm', ect...</param>
         /// <param name="symbol">The particular symbol being traded (Symbol class)</param>
         /// <param name="securityType">The security type of the symbol</param>
-        /// <param name="overrideTimeZone">Specify this time zone to override the resolved time zone from the market hours database.
-        /// This value will also be used as the time zone for SecurityType.Base with no market hours database entry.
-        /// If null is specified, no override will be performed. If null is specified, and it's SecurityType.Base, then Utc will be used.</param>
         /// <returns>The entry matching the specified market/symbol/security-type</returns>
-        public virtual Entry GetEntry(string market, Symbol symbol, SecurityType securityType, DateTimeZone overrideTimeZone = null)
+        public virtual Entry GetEntry(string market, Symbol symbol, SecurityType securityType)
         {
-            var stringSymbol = symbol == null ? string.Empty : 
-                (symbol.ID.SecurityType == SecurityType.Option ? (symbol.HasUnderlying ? symbol.Underlying.Value : string.Empty) :
-                (symbol.ID.SecurityType == SecurityType.Future ? symbol.ID.Symbol : 
-                symbol.Value));
+            return GetEntry(market, GetDatabaseSymbolKey(symbol), securityType);
+        }
 
-            return GetEntry(market, stringSymbol, securityType, overrideTimeZone);
+        /// <summary>
+        /// Gets the correct string symbol to use as a database key
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <returns>The symbol string used in the database ke</returns>
+        public static string GetDatabaseSymbolKey(Symbol symbol)
+        {
+            string stringSymbol;
+            if (symbol == null)
+            {
+                stringSymbol = string.Empty;
+            }
+            else
+            {
+                switch (symbol.ID.SecurityType)
+                {
+                    case SecurityType.Option:
+                        stringSymbol = symbol.HasUnderlying ? symbol.Underlying.Value : string.Empty;
+                        break;
+
+                    default:
+                        stringSymbol = symbol.ID.SecurityType == SecurityType.Future ? symbol.ID.Symbol : symbol.Value;
+                        break;
+                }
+            }
+
+            return stringSymbol;
+        }
+
+        /// <summary>
+        /// Determines if the database contains the specified key
+        /// </summary>
+        /// <param name="key">The key to search for</param>
+        /// <returns>True if an entry is found, otherwise false</returns>
+        protected bool ContainsKey(SecurityDatabaseKey key)
+        {
+            return _entries.ContainsKey(key);
         }
 
         /// <summary>
@@ -240,15 +261,6 @@ namespace QuantConnect.Securities
             {
                 DataTimeZone = dataTimeZone;
                 ExchangeHours = exchangeHours;
-            }
-        }
-
-        class AlwaysOpenMarketHoursDatabase : MarketHoursDatabase
-        {
-            public override Entry GetEntry(string market, string symbol, SecurityType securityType, DateTimeZone overrideTimeZone = null)
-            {
-                var tz = overrideTimeZone ?? TimeZones.Utc;
-                return new Entry(tz, SecurityExchangeHours.AlwaysOpen(tz));
             }
         }
     }

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -33,6 +33,7 @@ namespace QuantConnect.Tests.Common.Securities
         private static readonly SecurityExchangeHours SecurityExchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZone);
         private static readonly IReadOnlyDictionary<SecurityType, string> MarketMap = DefaultBrokerageModel.DefaultMarketMap;
         private static readonly AlgorithmSettings AlgorithmSettings = new AlgorithmSettings();
+        private static readonly MarketHoursDatabase AlwaysOpenMarketHoursDatabase = new AlwaysOpenMarketHoursDatabaseImpl();
 
         [Test]
         public void ConstructorCapitalizedSymbol()
@@ -88,7 +89,7 @@ namespace QuantConnect.Tests.Common.Securities
             var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, abcConfig, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketHoursDatabase.AlwaysOpen, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
             Assert.AreEqual(1, subscriptions.Subscriptions.Count(x => x.Symbol == Symbols.USDJPY));
             Assert.AreEqual(1, securities.Values.Count(x => x.Symbol == Symbols.USDJPY));
         }
@@ -108,7 +109,7 @@ namespace QuantConnect.Tests.Common.Securities
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             securities.Add(Symbols.EURUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.EURUSD, minimumResolution, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketHoursDatabase.AlwaysOpen, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
             Assert.AreEqual(minimumResolution, subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY).Resolution);
         }
 
@@ -125,7 +126,7 @@ namespace QuantConnect.Tests.Common.Securities
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.EURUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.EURUSD, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketHoursDatabase.AlwaysOpen, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
             var config = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY);
             Assert.IsTrue(config.IsInternalFeed);
         }
@@ -143,7 +144,7 @@ namespace QuantConnect.Tests.Common.Securities
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.USDJPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketHoursDatabase.AlwaysOpen, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
             var config = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY);
             Assert.IsFalse(config.IsInternalFeed);
         }
@@ -165,11 +166,11 @@ namespace QuantConnect.Tests.Common.Securities
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(symbol, new Security(SecurityExchangeHours, subscriptions.Add(symbol, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
-            cashJPY.EnsureCurrencyDataFeed(securities, subscriptions, MarketHoursDatabase.AlwaysOpen, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
+            cashJPY.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
             var config1 = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY);
             Assert.IsTrue(config1.IsInternalFeed);
 
-            cashGBP.EnsureCurrencyDataFeed(securities, subscriptions, MarketHoursDatabase.AlwaysOpen, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
+            cashGBP.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
             var config2 = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.GBPUSD);
             Assert.IsTrue(config2.IsInternalFeed);
         }
@@ -192,7 +193,7 @@ namespace QuantConnect.Tests.Common.Securities
             var subscriptions = new SubscriptionManager(AlgorithmSettings, TimeKeeper);
             var securities = new SecurityManager(TimeKeeper);
 
-            book.EnsureCurrencyDataFeeds(securities, subscriptions, MarketHoursDatabase.AlwaysOpen, SymbolPropertiesDatabase.FromDataFolder(), MarketMap);
+            book.EnsureCurrencyDataFeeds(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap);
 
             var symbols = subscriptions.Subscriptions.Select(sdc => sdc.Symbol).ToHashSet();
 
@@ -218,7 +219,7 @@ namespace QuantConnect.Tests.Common.Securities
             securities.Add(Symbols.USDJPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
             // we need to get subscription index
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketHoursDatabase.AlwaysOpen, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
 
             var last = 120m;
             cash.Update(new Tick(DateTime.Now, Symbols.USDJPY, last, 119.95m, 120.05m));
@@ -241,7 +242,7 @@ namespace QuantConnect.Tests.Common.Securities
             securities.Add(Symbols.GBPUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.GBPUSD, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
             // we need to get subscription index
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketHoursDatabase.AlwaysOpen, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook);
 
             var last = 1.5m;
             cash.Update(new Tick(DateTime.Now, Symbols.GBPUSD, last, last * 1.009m, last * 0.009m));
@@ -263,6 +264,24 @@ namespace QuantConnect.Tests.Common.Securities
         private static TimeKeeper TimeKeeper
         {
             get { return new TimeKeeper(DateTime.Now, new[] { TimeZone }); }
+        }
+
+        class AlwaysOpenMarketHoursDatabaseImpl : MarketHoursDatabase
+        {
+            public override Entry GetEntry(string market, string symbol, SecurityType securityType)
+            {
+                var key = new SecurityDatabaseKey(market, symbol, securityType);
+                var tz = ContainsKey(key)
+                    ? base.GetEntry(market, symbol, securityType).ExchangeHours.TimeZone
+                    : DateTimeZone.Utc;
+
+                return new Entry(tz, SecurityExchangeHours.AlwaysOpen(tz));
+            }
+
+            public AlwaysOpenMarketHoursDatabaseImpl()
+                : base(FromDataFolder().ExchangeHoursListing.ToDictionary())
+            {
+            }
         }
     }
 }

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -243,7 +243,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SecurityManagerCanCreate_CustomSecurities_WithCorrectSubscriptions()
         {
             var equitySymbol = new Symbol(SecurityIdentifier.GenerateBase("BTC", Market.USA), "BTC");
-            var equityMarketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "BTC", SecurityType.Base, TimeZones.NewYork);
+            var equityMarketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "BTC", SecurityType.Base, TimeZones.NewYork);
             var equitySymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(equitySymbol.ID.Market, equitySymbol, equitySymbol.ID.SecurityType, CashBook.AccountCurrency);
 
             var equity = SecurityManager.CreateSecurity(typeof(Bitcoin),
@@ -273,7 +273,7 @@ namespace QuantConnect.Tests.Common.Securities
             var underlying = SecurityIdentifier.GenerateEquity(new DateTime(1998, 01, 02), "SPY", Market.USA);
             var optionIdentifier = SecurityIdentifier.GenerateOption(new DateTime(2015, 09, 18), underlying, Market.USA, 195.50m, OptionRight.Put, OptionStyle.European);
             var optionSymbol = new Symbol(optionIdentifier, "SPY", Symbol.Empty);
-            var optionMarketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "SPY", SecurityType.Equity, TimeZones.NewYork);
+            var optionMarketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "SPY", SecurityType.Equity, TimeZones.NewYork);
             var optionSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(optionSymbol.ID.Market, "SPY", optionSymbol.ID.SecurityType, CashBook.AccountCurrency);
 
             var subscriptionTypes = new List<Tuple<Type, TickType>>
@@ -312,7 +312,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var identifier = SecurityIdentifier.GenerateFuture(new DateTime(2020, 12, 15), "ED", Market.USA);
             var symbol = new Symbol(identifier, "ED", Symbol.Empty);
-            var marketHoursDbEntry = _marketHoursDatabase.GetEntry(Market.USA, "ED", SecurityType.Equity, TimeZones.NewYork);
+            var marketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "ED", SecurityType.Equity, TimeZones.NewYork);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, "ED", symbol.ID.SecurityType, CashBook.AccountCurrency);
 
             var subscriptionTypes = new List<Tuple<Type, TickType>>


### PR DESCRIPTION
Add MarketHoursDatabase.SetEntry and SetEntryAlwaysOpen. This allows runtime modification of the
market hours database which is necessary for correct custom data time zone handling.

Extracts complicate ternary logic into its own method and make it human readable.
Set the market hours entry for custom data universe subscriptions defaulting to the security's time zone.

Supersedes #1348 
  