### PR TITLE
Adds OrderResponse error message for quantity less than lot size

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -649,9 +649,14 @@ namespace QuantConnect.Algorithm
             }
 
             //Ordering 0 is useless.
-            if (request.Quantity == 0 || request.Symbol == null || request.Symbol == QuantConnect.Symbol.Empty || Math.Abs(request.Quantity) < security.SymbolProperties.LotSize)
+            if (request.Quantity == 0)
             {
                 return OrderResponse.ZeroQuantity(request);
+            }
+
+            if (Math.Abs(request.Quantity) < security.SymbolProperties.LotSize)
+            {
+                return OrderResponse.Error(request, OrderResponseErrorCode.OrderQuantityLessThanLoteSize, $"Unable to {request.OrderRequestType.ToString().ToLower()} order with id {request.OrderId} which quantity ({Math.Abs(request.Quantity)}) is less than lot size ({security.SymbolProperties.LotSize}).");
             }
 
             if (!security.IsTradable)

--- a/Common/Orders/OrderResponseErrorCode.cs
+++ b/Common/Orders/OrderResponseErrorCode.cs
@@ -168,6 +168,11 @@ namespace QuantConnect.Orders
         /// <summary>
         /// The order's symbol references a non-exercisable security
         /// </summary>
-        NonExercisableSecurity = -29
+        NonExercisableSecurity = -29,
+
+        /// <summary>
+        /// Cannot submit or update orders with quantity that is less than lot size
+        /// </summary>
+        OrderQuantityLessThanLoteSize = -30
     }
 }


### PR DESCRIPTION
Invalid orders due to quantity less than lot size were marked as zero quantity. In order to improve error message, independent order response errors were implemented and hold more information. 