### PR TITLE
Add back MarketHoursDatabase.AlwaysOpen

### DIFF
--- a/Common/Securities/MarketHoursDatabase.cs
+++ b/Common/Securities/MarketHoursDatabase.cs
@@ -42,6 +42,11 @@ namespace QuantConnect.Securities
         public List<KeyValuePair<SecurityDatabaseKey,Entry>> ExchangeHoursListing => _entries.ToList();
 
         /// <summary>
+        /// Gets a <see cref="MarketHoursDatabase"/> that always returns <see cref="SecurityExchangeHours.AlwaysOpen"/>
+        /// </summary>
+        public static MarketHoursDatabase AlwaysOpen { get; } = new AlwaysOpenMarketHoursDatabaseImpl();
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MarketHoursDatabase"/> class
         /// </summary>
         /// <param name="exchangeHours">The full listing of exchange hours by key</param>
@@ -261,6 +266,24 @@ namespace QuantConnect.Securities
             {
                 DataTimeZone = dataTimeZone;
                 ExchangeHours = exchangeHours;
+            }
+        }
+
+        class AlwaysOpenMarketHoursDatabaseImpl : MarketHoursDatabase
+        {
+            public override Entry GetEntry(string market, string symbol, SecurityType securityType)
+            {
+                var key = new SecurityDatabaseKey(market, symbol, securityType);
+                var tz = ContainsKey(key)
+                    ? base.GetEntry(market, symbol, securityType).ExchangeHours.TimeZone
+                    : DateTimeZone.Utc;
+
+                return new Entry(tz, SecurityExchangeHours.AlwaysOpen(tz));
+            }
+
+            public AlwaysOpenMarketHoursDatabaseImpl()
+                : base(FromDataFolder().ExchangeHoursListing.ToDictionary())
+            {
             }
         }
     }

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.Tests.Common.Securities
         private static readonly SecurityExchangeHours SecurityExchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZone);
         private static readonly IReadOnlyDictionary<SecurityType, string> MarketMap = DefaultBrokerageModel.DefaultMarketMap;
         private static readonly AlgorithmSettings AlgorithmSettings = new AlgorithmSettings();
-        private static readonly MarketHoursDatabase AlwaysOpenMarketHoursDatabase = new AlwaysOpenMarketHoursDatabaseImpl();
+        private static readonly MarketHoursDatabase AlwaysOpenMarketHoursDatabase = MarketHoursDatabase.AlwaysOpen;
 
         [Test]
         public void ConstructorCapitalizedSymbol()
@@ -264,24 +264,6 @@ namespace QuantConnect.Tests.Common.Securities
         private static TimeKeeper TimeKeeper
         {
             get { return new TimeKeeper(DateTime.Now, new[] { TimeZone }); }
-        }
-
-        class AlwaysOpenMarketHoursDatabaseImpl : MarketHoursDatabase
-        {
-            public override Entry GetEntry(string market, string symbol, SecurityType securityType)
-            {
-                var key = new SecurityDatabaseKey(market, symbol, securityType);
-                var tz = ContainsKey(key)
-                    ? base.GetEntry(market, symbol, securityType).ExchangeHours.TimeZone
-                    : DateTimeZone.Utc;
-
-                return new Entry(tz, SecurityExchangeHours.AlwaysOpen(tz));
-            }
-
-            public AlwaysOpenMarketHoursDatabaseImpl()
-                : base(FromDataFolder().ExchangeHoursListing.ToDictionary())
-            {
-            }
         }
     }
 }


### PR DESCRIPTION
Some other code depends on this implementation. Removing it was an oversight.