### PR TITLE
Fix bug in Symbol inequality operator

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -302,7 +302,7 @@ namespace QuantConnect.Algorithm
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<TradeBar> History(Symbol symbol, int periods, Resolution? resolution = null)
         {
-            if (symbol == QuantConnect.Symbol.Empty) throw new ArgumentException(_symbolEmptyErrorMessage);
+            if (symbol == null) throw new ArgumentException(_symbolEmptyErrorMessage);
             var security = Securities[symbol];
             var start = GetStartTimeAlgoTz(symbol, periods, resolution);
 
@@ -328,7 +328,7 @@ namespace QuantConnect.Algorithm
             where T : IBaseData
         {
             if (resolution == Resolution.Tick) throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
-            if (symbol == QuantConnect.Symbol.Empty) throw new ArgumentException(_symbolEmptyErrorMessage);
+            if (symbol == null) throw new ArgumentException(_symbolEmptyErrorMessage);
 
             var security = Securities[symbol];
             // verify the types match
@@ -355,7 +355,7 @@ namespace QuantConnect.Algorithm
         public IEnumerable<T> History<T>(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null)
             where T : IBaseData
         {
-            if (symbol == QuantConnect.Symbol.Empty) throw new ArgumentException(_symbolEmptyErrorMessage);
+            if (symbol == null) throw new ArgumentException(_symbolEmptyErrorMessage);
             var security = Securities[symbol];
             // verify the types match
             var requestedType = typeof(T);

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -766,12 +766,11 @@ namespace QuantConnect.Algorithm
         public List<int> Liquidate(Symbol symbolToLiquidate = null, string tag = "Liquidated")
         {
             var orderIdList = new List<int>();
-            symbolToLiquidate = symbolToLiquidate ?? QuantConnect.Symbol.Empty;
 
             foreach (var symbol in Securities.Keys.OrderBy(x => x.Value))
             {
                 // symbol not matching, do nothing
-                if (symbol != symbolToLiquidate && symbolToLiquidate != QuantConnect.Symbol.Empty)
+                if (symbol != symbolToLiquidate && symbolToLiquidate != null)
                     continue;
 
                 // get open orders

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -504,7 +504,7 @@ namespace QuantConnect.Algorithm
             // if the benchmark hasn't been set yet, set it
             if (Benchmark == null)
             {
-                if (_benchmarkSymbol != null && _benchmarkSymbol != QuantConnect.Symbol.Empty)
+                if (_benchmarkSymbol != null)
                 {
                     // if the requested benchmark symbol wasn't already added, then add it now
                     // we do a simple compare here for simplicity, also it avoids confusion over

--- a/Brokerages/Fxcm/FxcmSymbolMapper.cs
+++ b/Brokerages/Fxcm/FxcmSymbolMapper.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.Brokerages.Fxcm
         /// <returns>The FXCM symbol</returns>
         public string GetBrokerageSymbol(Symbol symbol)
         {
-            if (symbol == null || symbol == Symbol.Empty || string.IsNullOrWhiteSpace(symbol.Value))
+            if (symbol == null || string.IsNullOrWhiteSpace(symbol.Value))
                 throw new ArgumentException("Invalid symbol: " + (symbol == null ? "null" : symbol.ToString()));
 
             if (symbol.ID.SecurityType != SecurityType.Forex && symbol.ID.SecurityType != SecurityType.Cfd)

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <returns>The InteractiveBrokers symbol</returns>
         public string GetBrokerageSymbol(Symbol symbol)
         {
-            if (symbol == null || symbol == Symbol.Empty || string.IsNullOrWhiteSpace(symbol.Value))
+            if (symbol == null || string.IsNullOrWhiteSpace(symbol.Value))
                 throw new ArgumentException("Invalid symbol: " + (symbol == null ? "null" : symbol.ToString()));
 
             if (symbol.ID.SecurityType != SecurityType.Forex &&

--- a/Brokerages/Oanda/OandaSymbolMapper.cs
+++ b/Brokerages/Oanda/OandaSymbolMapper.cs
@@ -888,7 +888,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// <returns>The Oanda symbol</returns>
         public string GetBrokerageSymbol(Symbol symbol)
         {
-            if (symbol == null || symbol == Symbol.Empty || string.IsNullOrWhiteSpace(symbol.Value))
+            if (symbol == null || string.IsNullOrWhiteSpace(symbol.Value))
                 throw new ArgumentException("Invalid symbol: " + (symbol == null ? "null" : symbol.ToString()));
 
             if (symbol.ID.SecurityType != SecurityType.Forex && symbol.ID.SecurityType != SecurityType.Cfd)

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -396,8 +396,7 @@ namespace QuantConnect
         /// <returns>True if both symbols are not equal, otherwise false</returns>
         public static bool operator !=(Symbol left, Symbol right)
         {
-            if (ReferenceEquals(left, null)) return ReferenceEquals(right, null);
-            return !left.Equals(right);
+            return !(left == right);
         }
 
         #endregion

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -384,7 +384,7 @@ namespace QuantConnect
         /// <returns>True if both symbols are equal, otherwise false</returns>
         public static bool operator ==(Symbol left, Symbol right)
         {
-            if (ReferenceEquals(left, null)) return ReferenceEquals(right, null);
+            if (ReferenceEquals(left, null) || left.Equals(Empty)) return ReferenceEquals(right, null) || right.Equals(Empty);
             return left.Equals(right);
         }
 

--- a/Tests/Common/Securities/Options/OptionChainProviderTests.cs
+++ b/Tests/Common/Securities/Options/OptionChainProviderTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,6 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Tests.Common
@@ -71,7 +70,7 @@ namespace QuantConnect.Tests.Common
 
         [Test]
         public void UsesSidForDictionaryKey()
-        {   
+        {
             var sid = SecurityIdentifier.GenerateEquity("SPY", Market.USA);
             var dictionary = new Dictionary<Symbol, int>
             {
@@ -81,7 +80,7 @@ namespace QuantConnect.Tests.Common
             var key = new Symbol(sid, "other value");
             Assert.IsTrue(dictionary.ContainsKey(key));
         }
-        
+
         [Test]
         public void SurvivesRoundtripSerialization()
         {
@@ -191,7 +190,7 @@ namespace QuantConnect.Tests.Common
                     "'Value':0.72157,'Price':0.72157}," +
 
                     "]}";
-            
+
             var actual = JsonConvert.DeserializeObject<List<BaseData>>(json, Settings);
             Assert.IsFalse(actual.All(x => x.Symbol == new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.FXCM), "EURUSD")));
         }
@@ -268,6 +267,22 @@ namespace QuantConnect.Tests.Common
         {
             var a = new Symbol(SecurityIdentifier.GenerateForex("a", Market.FXCM), "a");
             Assert.AreEqual(0, a.CompareTo("A"));
+        }
+
+        [Test]
+        public void ComparesAgainstNull()
+        {
+            var validSymbol = Symbols.SPY;
+            var emptySymbol = Symbol.Empty;
+            Symbol nullSymbol = null;
+
+            Assert.IsTrue(validSymbol != null);
+            Assert.IsTrue(emptySymbol != null);
+            Assert.IsTrue(nullSymbol == null);
+
+            Assert.IsFalse(validSymbol == null);
+            Assert.IsFalse(emptySymbol == null);
+            Assert.IsFalse(nullSymbol != null);
         }
 
         [Test]

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -270,19 +270,49 @@ namespace QuantConnect.Tests.Common
         }
 
         [Test]
-        public void ComparesAgainstNull()
+        public void ComparesAgainstNullOrEmpty()
         {
             var validSymbol = Symbols.SPY;
             var emptySymbol = Symbol.Empty;
             Symbol nullSymbol = null;
 
+            Assert.IsTrue(nullSymbol == emptySymbol);
+            Assert.IsFalse(nullSymbol != emptySymbol);
+
+            Assert.IsTrue(emptySymbol == nullSymbol);
+            Assert.IsFalse(emptySymbol != nullSymbol);
+
             Assert.IsTrue(validSymbol != null);
-            Assert.IsTrue(emptySymbol != null);
+            Assert.IsTrue(emptySymbol == null);
             Assert.IsTrue(nullSymbol == null);
 
             Assert.IsFalse(validSymbol == null);
-            Assert.IsFalse(emptySymbol == null);
+            Assert.IsFalse(emptySymbol != null);
             Assert.IsFalse(nullSymbol != null);
+
+            Assert.IsTrue(validSymbol != Symbol.Empty);
+            Assert.IsTrue(emptySymbol == Symbol.Empty);
+            Assert.IsTrue(nullSymbol == Symbol.Empty);
+
+            Assert.IsFalse(validSymbol == Symbol.Empty);
+            Assert.IsFalse(emptySymbol != Symbol.Empty);
+            Assert.IsFalse(nullSymbol != Symbol.Empty);
+
+            Assert.IsTrue(null != validSymbol);
+            Assert.IsTrue(null == emptySymbol);
+            Assert.IsTrue(null == nullSymbol);
+
+            Assert.IsFalse(null == validSymbol);
+            Assert.IsFalse(null != emptySymbol);
+            Assert.IsFalse(null != nullSymbol);
+
+            Assert.IsTrue(Symbol.Empty != validSymbol);
+            Assert.IsTrue(Symbol.Empty == emptySymbol);
+            Assert.IsTrue(Symbol.Empty == nullSymbol);
+
+            Assert.IsFalse(Symbol.Empty == validSymbol);
+            Assert.IsFalse(Symbol.Empty != emptySymbol);
+            Assert.IsFalse(Symbol.Empty != nullSymbol);
         }
 
         [Test]

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
     [TestFixture]
     public class FineFundamentalSubscriptionEnumeratorFactoryTests
     {
-        [Test, TestCaseSource("GetFineFundamentalTestParameters")]
+        [Test, TestCaseSource(nameof(GetFineFundamentalTestParameters))]
         public void ReadsFineFundamental(FineFundamentalTestParameters parameters)
         {
             var stopwatch = Stopwatch.StartNew();
@@ -60,8 +60,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             var row = rows[0];
             Assert.AreEqual(parameters.CompanyShortName, row.CompanyReference.ShortName);
             Assert.AreEqual(parameters.Symbol, row.Symbol);
-            Assert.AreEqual(parameters.Symbol != Symbol.Empty ? parameters.Symbol.Value : null, row.CompanyReference.PrimarySymbol);
-            Assert.AreEqual(parameters.Symbol != Symbol.Empty ? parameters.Symbol.Value : null, row.SecurityReference.SecuritySymbol);
+            Assert.IsTrue(row.CompanyReference.PrimarySymbol == parameters.Symbol.Value || row.CompanyReference.PrimarySymbol == null);
+            Assert.IsTrue(row.SecurityReference.SecuritySymbol == parameters.Symbol.Value || row.SecurityReference.SecuritySymbol == null);
             Assert.AreEqual(parameters.Ebitda3M, row.FinancialStatements.IncomeStatement.EBITDA.ThreeMonths);
             Assert.AreEqual(parameters.Ebitda12M, row.FinancialStatements.IncomeStatement.EBITDA.TwelveMonths);
             Assert.AreEqual(parameters.Ebitda12M, row.FinancialStatements.IncomeStatement.EBITDA);
@@ -86,7 +86,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 },
                 new FineFundamentalTestParameters("AAPL-BeforeFirstDate")
                 {
-                    Symbol = Symbol.Empty,
+                    Symbol = Symbols.AAPL,
                     StartDate = new DateTime(2014, 2, 20),
                     EndDate = new DateTime(2014, 2, 20),
                     RowCount = 1
@@ -153,7 +153,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
 
         public class FineFundamentalTestParameters
         {
-            public string Name { get; private set; }
+            public string Name { get; }
             public Symbol Symbol { get; set; }
             public DateTime StartDate { get; set; }
             public DateTime EndDate { get; set; }

--- a/ToolBox/DukascopyDownloader/DukascopySymbolMapper.cs
+++ b/ToolBox/DukascopyDownloader/DukascopySymbolMapper.cs
@@ -159,7 +159,7 @@ namespace QuantConnect.ToolBox.DukascopyDownloader
         /// <returns>The Dukascopy symbol</returns>
         public string GetBrokerageSymbol(Symbol symbol)
         {
-            if (symbol == null || symbol == Symbol.Empty || string.IsNullOrWhiteSpace(symbol.Value))
+            if (symbol == null || string.IsNullOrWhiteSpace(symbol.Value))
                 throw new ArgumentException("Invalid symbol: " + (symbol == null ? "null" : symbol.ToString()));
 
             if (symbol.ID.SecurityType != SecurityType.Forex && symbol.ID.SecurityType != SecurityType.Cfd)


### PR DESCRIPTION
The operator method was returning true when comparing a null symbol against null.

Fixes #1454 