### PR TITLE
Option split bug fixes

### DIFF
--- a/Common/Securities/Option/OptionHolding.cs
+++ b/Common/Securities/Option/OptionHolding.cs
@@ -1,19 +1,17 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-using System;
-using QuantConnect.Orders;
 
 namespace QuantConnect.Securities.Option
 {
@@ -64,6 +62,7 @@ namespace QuantConnect.Securities.Option
                 // even split (e.g. 2 for 1): we adjust position size and strike price
                 Quantity = (int)(Quantity * inverseFactor);
                 AveragePrice *= splitFactor;
+                Price *= splitFactor;
             }
             else
             {

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -396,8 +396,7 @@ namespace QuantConnect
         /// <returns>True if both symbols are not equal, otherwise false</returns>
         public static bool operator !=(Symbol left, Symbol right)
         {
-            if (ReferenceEquals(left, null)) return ReferenceEquals(right, null);
-            return !left.Equals(right);
+            return !(left == right);
         }
 
         #endregion

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -442,7 +442,7 @@ namespace QuantConnect.Lean.Engine
                     try
                     {
                         Log.Debug($"AlgorithmManager.Run(): {algorithm.Time}: Applying Split for {split.Symbol}");
-                        algorithm.Portfolio.ApplySplit(split);
+                        algorithm.Portfolio.ApplySplit(algorithm, split);
                         // apply the split to open orders as well in raw mode, all other modes are split adjusted
                         if (_liveMode || algorithm.Securities[split.Symbol].DataNormalizationMode == DataNormalizationMode.Raw)
                         {

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,6 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Tests.Common
@@ -71,7 +70,7 @@ namespace QuantConnect.Tests.Common
 
         [Test]
         public void UsesSidForDictionaryKey()
-        {   
+        {
             var sid = SecurityIdentifier.GenerateEquity("SPY", Market.USA);
             var dictionary = new Dictionary<Symbol, int>
             {
@@ -81,7 +80,7 @@ namespace QuantConnect.Tests.Common
             var key = new Symbol(sid, "other value");
             Assert.IsTrue(dictionary.ContainsKey(key));
         }
-        
+
         [Test]
         public void SurvivesRoundtripSerialization()
         {
@@ -191,7 +190,7 @@ namespace QuantConnect.Tests.Common
                     "'Value':0.72157,'Price':0.72157}," +
 
                     "]}";
-            
+
             var actual = JsonConvert.DeserializeObject<List<BaseData>>(json, Settings);
             Assert.IsFalse(actual.All(x => x.Symbol == new Symbol(SecurityIdentifier.GenerateForex("EURUSD", Market.FXCM), "EURUSD")));
         }
@@ -268,6 +267,22 @@ namespace QuantConnect.Tests.Common
         {
             var a = new Symbol(SecurityIdentifier.GenerateForex("a", Market.FXCM), "a");
             Assert.AreEqual(0, a.CompareTo("A"));
+        }
+
+        [Test]
+        public void ComparesAgainstNull()
+        {
+            var validSymbol = Symbols.SPY;
+            var emptySymbol = Symbol.Empty;
+            Symbol nullSymbol = null;
+
+            Assert.IsTrue(validSymbol != null);
+            Assert.IsTrue(emptySymbol != null);
+            Assert.IsTrue(nullSymbol == null);
+
+            Assert.IsFalse(validSymbol == null);
+            Assert.IsFalse(emptySymbol == null);
+            Assert.IsFalse(nullSymbol != null);
         }
 
         [Test]

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -391,7 +391,7 @@ namespace QuantConnect.Tests
                 {"Average Win", "0.00%"},
                 {"Average Loss", "0%"},
                 {"Compounding Annual Return", "0.198%"},
-                {"Drawdown", "0.500%"},
+                {"Drawdown", "0.100%"},
                 {"Expectancy", "0"},
                 {"Net Profit", "0.002%"},
                 {"Sharpe Ratio", "0.609"},


### PR DESCRIPTION
### Fix split adjustment for option holding price
This bug was causing equity sampling (after the split, before market open) to use a non-split-adjusted price in the calculation of `TotalPortfolioValue`.

The `Drawdown` regression stat for `OptionSplitRegressionAlgorithm` has changed due to the removal of the price spike and has been corrected.

### Fix option split handling for symbols added with AddOptionContract
Option contracts added to the algorithm with `AddOptionContract` were not replaced with new symbols after underlying splits, causing the algorithm to stop receiving data for them and invalid holdings in the portfolio.