### PR TITLE
Add OnWarmupFinished method to QCAlgorithm

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -143,6 +143,9 @@ namespace QuantConnect.Algorithm
         public void SetFinishedWarmingUp()
         {
             IsWarmingUp = false;
+
+            // notify the algorithm
+            OnWarmupFinished();
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -642,7 +642,7 @@ namespace QuantConnect.Algorithm
         {
             if (IsWarmingUp)
             {
-                return OrderResponse.Error(request, OrderResponseErrorCode.NotAllowedDuringWarmup, $"This operation is not allowed in Initialize or during warm up: OrderRequest.{request.OrderRequestType}. Please move this code to the OnWarmupFinished() method.");
+                return OrderResponse.WarmingUp(request);
             }
 
             //Most order methods use security objects; so this isn't really used.

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -640,6 +640,11 @@ namespace QuantConnect.Algorithm
         /// <returns>OrderResponse. If no error, order request is submitted.</returns>
         private OrderResponse PreOrderChecksImpl(SubmitOrderRequest request)
         {
+            if (IsWarmingUp)
+            {
+                return OrderResponse.Error(request, OrderResponseErrorCode.NotAllowedDuringWarmup, $"This operation is not allowed in Initialize or during warm up: OrderRequest.{request.OrderRequestType}. Please move this code to the OnWarmupFinished() method.");
+            }
+
             //Most order methods use security objects; so this isn't really used.
             // todo: Left here for now but should review
             Security security;

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.Algorithm
             SubscriptionManager = new SubscriptionManager(Settings, _timeKeeper);
 
             Securities = new SecurityManager(_timeKeeper);
-            Transactions = new SecurityTransactionManager(Securities);
+            Transactions = new SecurityTransactionManager(this, Securities);
             Portfolio = new SecurityPortfolioManager(Securities, Transactions, DefaultOrderProperties);
             BrokerageModel = new DefaultBrokerageModel();
             Notify = new NotificationManager(false); // Notification manager defaults to disabled.
@@ -562,6 +562,13 @@ namespace QuantConnect.Algorithm
                     equity.VolatilityModel = new StandardDeviationOfReturnsVolatilityModel(periods);
                 }
             }
+        }
+
+        /// <summary>
+        /// Called when the algorithm has completed initialization and warm up.
+        /// </summary>
+        public virtual void OnWarmupFinished()
+        {
         }
 
         /// <summary>

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -919,6 +919,17 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         }
 
         /// <summary>
+        /// Called when the algorithm has completed initialization and warm up.
+        /// </summary>
+        public void OnWarmupFinished()
+        {
+            using (Py.GIL())
+            {
+                _algorithm.OnWarmupFinished();
+            }
+        }
+
+        /// <summary>
         /// Removes the security with the specified symbol. This will cancel all
         /// open orders and then liquidate any existing holdings
         /// </summary>

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -340,6 +340,11 @@ namespace QuantConnect.Interfaces
         void PostInitialize();
 
         /// <summary>
+        /// Called when the algorithm has completed initialization and warm up.
+        /// </summary>
+        void OnWarmupFinished();
+
+        /// <summary>
         /// Gets the parameter with the specified name. If a parameter
         /// with the specified name does not exist, null is returned
         /// </summary>

--- a/Common/Orders/OrderResponse.cs
+++ b/Common/Orders/OrderResponse.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -164,7 +164,7 @@ namespace QuantConnect.Orders
         /// </summary>
         public static OrderResponse WarmingUp(OrderRequest request)
         {
-            return Error(request, OrderResponseErrorCode.AlgorithmWarmingUp, "Algorithm in warmup.");
+            return Error(request, OrderResponseErrorCode.AlgorithmWarmingUp, $"This operation is not allowed in Initialize or during warm up: OrderRequest.{request.OrderRequestType}. Please move this code to the OnWarmupFinished() method.");
         }
 
         #endregion

--- a/Common/Orders/OrderResponseErrorCode.cs
+++ b/Common/Orders/OrderResponseErrorCode.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,7 +36,7 @@ namespace QuantConnect.Orders
         OrderAlreadyExists = -2,
 
         /// <summary>
-        /// Not enough money to to submit order 
+        /// Not enough money to to submit order
         /// </summary>
         InsufficientBuyingPower = -3,
 
@@ -173,6 +173,11 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Cannot submit or update orders with quantity that is less than lot size
         /// </summary>
-        OrderQuantityLessThanLoteSize = -30
+        OrderQuantityLessThanLoteSize = -30,
+
+        /// <summary>
+        /// Operation not allowed during initialize/warmup
+        /// </summary>
+        NotAllowedDuringWarmup = -31
     }
 }

--- a/Common/Orders/OrderResponseErrorCode.cs
+++ b/Common/Orders/OrderResponseErrorCode.cs
@@ -173,11 +173,6 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Cannot submit or update orders with quantity that is less than lot size
         /// </summary>
-        OrderQuantityLessThanLoteSize = -30,
-
-        /// <summary>
-        /// Operation not allowed during initialize/warmup
-        /// </summary>
-        NotAllowedDuringWarmup = -31
+        OrderQuantityLessThanLoteSize = -30
     }
 }

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -135,7 +135,7 @@ namespace QuantConnect.Securities
         {
             if (_algorithm != null && _algorithm.IsWarmingUp)
             {
-                throw new Exception(OrderResponse.Error(request, OrderResponseErrorCode.NotAllowedDuringWarmup, $"This operation is not allowed in Initialize or during warm up: OrderRequest.{request.OrderRequestType}. Please move this code to the OnWarmupFinished() method.").ToString());
+                throw new Exception(OrderResponse.WarmingUp(request).ToString());
             }
 
             var submit = request as SubmitOrderRequest;

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,16 +17,18 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
 
-namespace QuantConnect.Securities 
+namespace QuantConnect.Securities
 {
     /// <summary>
     /// Algorithm Transactions Manager - Recording Transactions
     /// </summary>
     public class SecurityTransactionManager : IOrderProvider
     {
+        private readonly IAlgorithm _algorithm;
         private int _orderId;
         private readonly SecurityManager _securities;
         private const decimal _minimumOrderSize = 0;
@@ -43,12 +45,14 @@ namespace QuantConnect.Securities
         {
             get { return _securities.UtcTime; }
         }
-        
+
         /// <summary>
         /// Initialise the transaction manager for holding and processing orders.
         /// </summary>
-        public SecurityTransactionManager(SecurityManager security)
+        public SecurityTransactionManager(IAlgorithm algorithm, SecurityManager security)
         {
+            _algorithm = algorithm;
+
             //Private reference for processing transactions
             _securities = security;
 
@@ -75,9 +79,9 @@ namespace QuantConnect.Securities
         /// Configurable minimum order value to ignore bad orders, or orders with unrealistic sizes
         /// </summary>
         /// <remarks>Default minimum order size is $0 value</remarks>
-        public decimal MinimumOrderSize 
+        public decimal MinimumOrderSize
         {
-            get 
+            get
             {
                 return _minimumOrderSize;
             }
@@ -87,9 +91,9 @@ namespace QuantConnect.Securities
         /// Configurable minimum order size to ignore bad orders, or orders with unrealistic sizes
         /// </summary>
         /// <remarks>Default minimum order size is 0 shares</remarks>
-        public int MinimumOrderQuantity 
+        public int MinimumOrderQuantity
         {
-            get 
+            get
             {
                 return _minimumOrderQuantity;
             }
@@ -129,6 +133,11 @@ namespace QuantConnect.Securities
         /// <returns>The order ticket for the request</returns>
         public OrderTicket ProcessRequest(OrderRequest request)
         {
+            if (_algorithm != null && _algorithm.IsWarmingUp)
+            {
+                throw new Exception(OrderResponse.Error(request, OrderResponseErrorCode.NotAllowedDuringWarmup, $"This operation is not allowed in Initialize or during warm up: OrderRequest.{request.OrderRequestType}. Please move this code to the OnWarmupFinished() method.").ToString());
+            }
+
             var submit = request as SubmitOrderRequest;
             if (submit != null)
             {
@@ -158,7 +167,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Added alias for RemoveOrder - 
+        /// Added alias for RemoveOrder -
         /// </summary>
         /// <param name="orderId">Order id we wish to cancel</param>
         /// <param name="orderTag">Tag to indicate from where this method was called</param>
@@ -174,6 +183,11 @@ namespace QuantConnect.Securities
         /// <returns>List containing the cancelled order tickets</returns>
         public List<OrderTicket> CancelOpenOrders(Symbol symbol)
         {
+            if (_algorithm != null && _algorithm.IsWarmingUp)
+            {
+                throw new Exception("This operation is not allowed in Initialize or during warm up: CancelOpenOrders. Please move this code to the OnWarmupFinished() method.");
+            }
+
             var cancelledOrders = new List<OrderTicket>();
             foreach (var ticket in GetOrderTickets(x => x.Symbol == symbol && x.Status.IsOpen()))
             {
@@ -334,7 +348,7 @@ namespace QuantConnect.Securities
                         Quantity = option.Symbol.ID.OptionRight == OptionRight.Call ? quantity : -quantity
                     };
 
-                    // we continue with this call for underlying 
+                    // we continue with this call for underlying
                     return GetSufficientCapitalForOrder(portfolio, newOrder);
                 }
 

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1115,6 +1115,8 @@ namespace QuantConnect.Tests.Algorithm
         {
             Security msft;
             var algo = GetAlgorithm(out msft, 1, 0);
+            algo.SetFinishedWarmingUp();
+
             //Set price to $25
             Update(msft, 25);
 

--- a/Tests/Common/Securities/DelayedSettlementModelTests.cs
+++ b/Tests/Common/Securities/DelayedSettlementModelTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SellOnMondaySettleOnThursday()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             // settlement at T+3, 8:00 AM
             var model = new DelayedSettlementModel(3, TimeSpan.FromHours(8));
@@ -78,7 +78,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SellOnThursdaySettleOnTuesday()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             // settlement at T+3, 8:00 AM
             var model = new DelayedSettlementModel(3, TimeSpan.FromHours(8));

--- a/Tests/Common/Securities/ImmediateSettlementModelTests.cs
+++ b/Tests/Common/Securities/ImmediateSettlementModelTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void FundsAreSettledImmediately()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             var model = new ImmediateSettlementModel();
             var config = CreateTradeBarConfig();

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -94,7 +94,7 @@ namespace QuantConnect.Tests.Common.Securities
             var security = GetSecurity(Symbols.AAPL);
             security.MarginModel = new SecurityMarginModel(leverage);
             portfolio.Securities.Add(security);
-            
+
             security.Holdings.SetHoldings(1m, quantity);
             var actual1 = security.MarginModel.GetMarginRemaining(portfolio, security, OrderDirection.Buy);
             Assert.AreEqual(quantity / leverage, actual1);
@@ -166,7 +166,7 @@ namespace QuantConnect.Tests.Common.Securities
             // now the stock plummets, so we should have negative margin remaining
             time = time.AddDays(1);
             const decimal lowPrice = buyPrice/2;
-            security.SetMarketPrice(new Tick(time, Symbols.AAPL, lowPrice, lowPrice)); 
+            security.SetMarketPrice(new Tick(time, Symbols.AAPL, lowPrice, lowPrice));
 
             Assert.AreEqual(-quantity/2m, portfolio.MarginRemaining);
             Assert.AreEqual(quantity, portfolio.TotalMarginUsed);
@@ -190,7 +190,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsTrue(issueMarginCallWarning);
             Assert.AreEqual(0, marginCallOrders.Count);
 
-            // Price drops again to previous low, margin call orders will be issued 
+            // Price drops again to previous low, margin call orders will be issued
             security.SetMarketPrice(new Tick(time, Symbols.AAPL, lowPrice, lowPrice));
 
             order = new MarketOrder(Symbols.AAPL, quantity, time) { Price = buyPrice };
@@ -208,7 +208,7 @@ namespace QuantConnect.Tests.Common.Securities
         private SecurityPortfolioManager GetPortfolio(IOrderProcessor orderProcessor, int quantity)
         {
             var securities = new SecurityManager(new TimeKeeper(DateTime.Now, new[] { TimeZones.NewYork }));
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             transactions.SetOrderProcessor(orderProcessor);
 
             var portfolio = new SecurityPortfolioManager(securities, transactions);
@@ -225,7 +225,7 @@ namespace QuantConnect.Tests.Common.Securities
                 new Cash(CashBook.AccountCurrency, 0, 1m),
                 SymbolProperties.GetDefault(CashBook.AccountCurrency));
         }
-        
+
         public class OrderProcessor : IOrderProcessor
         {
             private readonly ConcurrentDictionary<int, Order> _orders = new ConcurrentDictionary<int, Order>();

--- a/Tests/Common/Securities/PatternDayTradingMarginModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginModelTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -246,7 +246,7 @@ namespace QuantConnect.Tests.Common.Securities
         private SecurityPortfolioManager GetPortfolio(IOrderProcessor orderProcessor, int quantity)
         {
             var securities = new SecurityManager(new TimeKeeper(DateTime.Now, new[] { TimeZones.NewYork }));
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             transactions.SetOrderProcessor(orderProcessor);
 
             var portfolio = new SecurityPortfolioManager(securities, transactions);

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var timeKeeper = new TimeKeeper(new DateTime(2015, 12, 07));
             _securityManager = new SecurityManager(timeKeeper);
-            _securityTransactionManager = new SecurityTransactionManager(_securityManager);
+            _securityTransactionManager = new SecurityTransactionManager(null, _securityManager);
             _securityPortfolioManager = new SecurityPortfolioManager(_securityManager, _securityTransactionManager);
             _subscriptionManager = new SubscriptionManager(new AlgorithmSettings(), timeKeeper);
             _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -67,10 +67,10 @@ namespace QuantConnect.Tests.Common.Securities
             var fills = XDocument.Load(fillsFile).Descendants("OrderEvent").Select(x => new OrderEvent(
                 x.Get<int>("OrderId"),
                 SymbolMap[x.Get<string>("Symbol")],
-                DateTime.MinValue, 
+                DateTime.MinValue,
                 x.Get<OrderStatus>("Status"),
-                x.Get<int>("FillQuantity") < 0 ? OrderDirection.Sell 
-              : x.Get<int>("FillQuantity") > 0 ? OrderDirection.Buy 
+                x.Get<int>("FillQuantity") < 0 ? OrderDirection.Sell
+              : x.Get<int>("FillQuantity") > 0 ? OrderDirection.Buy
                                                : OrderDirection.Hold,
                 x.Get<decimal>("FillPrice"),
                 x.Get<int>("FillQuantity"),
@@ -89,7 +89,7 @@ namespace QuantConnect.Tests.Common.Securities
             var security = new Security(SecurityExchangeHours, subscriptions.Add(CASH, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
             security.SetLeverage(10m);
             securities.Add(CASH, security);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(equity[0]);
 
@@ -111,7 +111,7 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void ForexCashFills()
         {
-            // this test asserts the portfolio behaves according to the Test_Cash algo, but for a Forex security, 
+            // this test asserts the portfolio behaves according to the Test_Cash algo, but for a Forex security,
             // see TestData\CashTestingStrategy.csv; also "https://www.dropbox.com/s/oiliumoyqqj1ovl/2013-cash.csv?dl=1"
 
             const string fillsFile = "TestData\\test_forex_fills.xml";
@@ -124,8 +124,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SymbolMap[x.Get<string>("Symbol")],
                 DateTime.MinValue,
                 x.Get<OrderStatus>("Status"),
-                x.Get<int>("FillQuantity") < 0 ? OrderDirection.Sell 
-              : x.Get<int>("FillQuantity") > 0 ? OrderDirection.Buy 
+                x.Get<int>("FillQuantity") < 0 ? OrderDirection.Sell
+              : x.Get<int>("FillQuantity") > 0 ? OrderDirection.Buy
                                                : OrderDirection.Hold,
                 x.Get<decimal>("FillPrice"),
                 x.Get<int>("FillQuantity"),
@@ -149,7 +149,7 @@ namespace QuantConnect.Tests.Common.Securities
             // we're going to process fills and very our equity after each fill
             var subscriptions = new SubscriptionManager(AlgorithmSettings, TimeKeeper);
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(equity[0]);
             portfolio.CashBook.Add("MCH", mchQuantity[0], 0);
@@ -165,7 +165,7 @@ namespace QuantConnect.Tests.Common.Securities
             mchUsdSecurity.SetLeverage(10m);
             var usdJwbSecurity = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours, mchCash, subscriptions.Add(USDJWB, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork), SymbolProperties.GetDefault(mchCash.Symbol));
             usdJwbSecurity.SetLeverage(10m);
-            
+
             // no fee model
             mchJwbSecurity.TransactionModel = new SecurityTransactionModel();
             mchUsdSecurity.TransactionModel = new SecurityTransactionModel();
@@ -235,7 +235,7 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal leverage = 1m;
             const int quantity = (int) (1000*leverage);
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var orderProcessor = new OrderProcessor();
             transactions.SetOrderProcessor(orderProcessor);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
@@ -313,7 +313,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsTrue(issueMarginCallWarning);
             Assert.AreEqual(0, marginCallOrders.Count);
 
-            // Price drops again to previous low, margin call orders will be issued 
+            // Price drops again to previous low, margin call orders will be issued
             security.SetMarketPrice(new TradeBar(time, Symbols.AAPL, lowPrice, lowPrice, lowPrice, lowPrice, 1));
 
             order = new MarketOrder(Symbols.AAPL, quantity, time) { Price = buyPrice };
@@ -334,7 +334,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void MarginComputesProperlyWithMultipleSecurities()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var orderProcessor = new OrderProcessor();
             transactions.SetOrderProcessor(orderProcessor);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
@@ -406,7 +406,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void BuyingSellingFuturesDoesntAddToCash()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
@@ -429,7 +429,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void BuyingSellingFuturesAddsToCashOnClose()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
@@ -452,7 +452,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void BuyingSellingFuturesAddsCorrectSales()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
@@ -473,7 +473,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SellingShortFromZeroAddsToCash()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
@@ -490,7 +490,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SellingShortFromLongAddsToCash()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
@@ -508,7 +508,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SellingShortFromShortAddsToCash()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
@@ -527,7 +527,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void ForexFillUpdatesCashCorrectly()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(1000);
             portfolio.CashBook.Add("EUR", 0, 1.1000m);
@@ -550,12 +550,12 @@ namespace QuantConnect.Tests.Common.Securities
         public void CryptoFillUpdatesCashCorrectly()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(10000);
             portfolio.CashBook.Add("BTC", 0, 4000.01m);
 
-            securities.Add(Symbols.BTCUSD, new QuantConnect.Securities.Crypto.Crypto(SecurityExchangeHours, portfolio.CashBook["USD"], CreateTradeBarDataConfig(SecurityType.Crypto, 
+            securities.Add(Symbols.BTCUSD, new QuantConnect.Securities.Crypto.Crypto(SecurityExchangeHours, portfolio.CashBook["USD"], CreateTradeBarDataConfig(SecurityType.Crypto,
                 Symbols.BTCUSD), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             var security = securities[Symbols.BTCUSD];
             Assert.AreEqual(0, security.Holdings.Quantity);
@@ -575,7 +575,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var securityExchangeHours = SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(1000);
             securities.Add(Symbols.AAPL, new QuantConnect.Securities.Equity.Equity(securityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
@@ -625,7 +625,7 @@ namespace QuantConnect.Tests.Common.Securities
             const int amount = 1000;
             const int quantity = (int)(amount * leverage);
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var orderProcessor = new OrderProcessor();
             transactions.SetOrderProcessor(orderProcessor);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
@@ -635,7 +635,7 @@ namespace QuantConnect.Tests.Common.Securities
             securities.Add(new Security(SecurityExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             var security = securities[Symbols.AAPL];
             security.SetLeverage(leverage);
-            
+
             var time = DateTime.Now;
             const decimal buyPrice = 1m;
             security.SetMarketPrice(new TradeBar(time, Symbols.AAPL, buyPrice, buyPrice, buyPrice, buyPrice, 1));
@@ -682,7 +682,7 @@ namespace QuantConnect.Tests.Common.Securities
             const int amount = 1000;
             const int quantity = (int)(amount * leverage);
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var orderProcessor = new OrderProcessor();
             transactions.SetOrderProcessor(orderProcessor);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
@@ -737,16 +737,16 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
             algorithm.Securities = securities;
             transactionHandler.Initialize(algorithm, new BacktestingBrokerage(algorithm), new TestResultHandler(Console.WriteLine));
             transactions.SetOrderProcessor(transactionHandler);
-            
+
             // Adding cash: strike price times number of shares
-            portfolio.SetCash(192 * 100); 
+            portfolio.SetCash(192 * 100);
 
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
@@ -780,7 +780,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -821,7 +821,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -864,14 +864,14 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
             algorithm.Securities = securities;
             transactionHandler.Initialize(algorithm, new BacktestingBrokerage(algorithm), new TestResultHandler(Console.WriteLine));
             transactions.SetOrderProcessor(transactionHandler);
-            portfolio.SetCash(0); 
+            portfolio.SetCash(0);
 
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             securities.Add(Symbols.SPY_P_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016)));
@@ -905,7 +905,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -914,7 +914,7 @@ namespace QuantConnect.Tests.Common.Securities
             transactions.SetOrderProcessor(transactionHandler);
 
             // Adding cash: strike price times number of shares
-            portfolio.SetCash(192 * 100); 
+            portfolio.SetCash(192 * 100);
 
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
@@ -948,14 +948,14 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
             algorithm.Securities = securities;
             transactionHandler.Initialize(algorithm, new BacktestingBrokerage(algorithm), new TestResultHandler(Console.WriteLine));
             transactions.SetOrderProcessor(transactionHandler);
-            portfolio.SetCash(0); 
+            portfolio.SetCash(0);
 
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
@@ -995,7 +995,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1040,7 +1040,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1086,7 +1086,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1127,7 +1127,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1168,7 +1168,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1208,7 +1208,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var orderProcessor = new OrderProcessor();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1250,7 +1250,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var orderProcessor = new OrderProcessor();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1292,7 +1292,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1332,7 +1332,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1377,7 +1377,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1422,7 +1422,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 
@@ -1468,7 +1468,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var algorithm = new QCAlgorithm();
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(securities);
+            var transactions = new SecurityTransactionManager(null, securities);
             var transactionHandler = new BacktestingTransactionHandler();
             var portfolio = new SecurityPortfolioManager(securities, transactions);
 

--- a/Tests/Common/Securities/SecurityPortfolioModelTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioModelTests.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -196,7 +196,7 @@ namespace QuantConnect.Tests.Common.Securities
             var timeKeeper = new TimeKeeper(reference);
             var securityManager = new SecurityManager(timeKeeper);
             securityManager.Add(security);
-            var transactionManager = new SecurityTransactionManager(securityManager);
+            var transactionManager = new SecurityTransactionManager(null, securityManager);
             portfolio = new SecurityPortfolioManager(securityManager, transactionManager);
             portfolio.SetCash("USD", 100 * 1000m, 1m);
             Assert.AreEqual(0, security.Holdings.Quantity);


### PR DESCRIPTION
This method is being added to allow algorithms to complete initialization tasks that cannot be executed during `Initialize`, such as cancelling existing open orders in live trading.
This method will be called only once, when the warmup task is complete.

Closes #1043

#### C#:

``` C#
    public override void OnWarmupFinished()
    {
        Transactions.CancelOpenOrders("BTCEUR");
    }
```

#### Python:

``` Python
    def OnWarmupFinished(self):
        self.Transactions.CancelOpenOrders("BTCEUR")
```
