### PR TITLE
TotalCloseProfitPips method added to ForexHolding

### DIFF
--- a/Common/Securities/Forex/ForexHolding.cs
+++ b/Common/Securities/Forex/ForexHolding.cs
@@ -43,6 +43,5 @@ namespace QuantConnect.Securities.Forex
             var pipCashCurrencyValue = (pipDecimal * AbsoluteQuantity * exchangeRate);
             return Round((TotalCloseProfit() / pipCashCurrencyValue), 1);
         }
-        
     }
 }

--- a/Common/Securities/Forex/ForexHolding.cs
+++ b/Common/Securities/Forex/ForexHolding.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using static System.Math;
+
 namespace QuantConnect.Securities.Forex 
 {
     /// <summary>
@@ -29,5 +31,18 @@ namespace QuantConnect.Securities.Forex
             : base(security)
         {
         }
+
+        /// <summary>
+        /// Profit in pips if we closed the holdings right now including the approximate fees
+        /// </summary>
+        public decimal TotalCloseProfitPips()
+        {
+            var pipDecimal = Security.SymbolProperties.MinimumPriceVariation * 10;
+            var exchangeRate = Security.QuoteCurrency.ConversionRate;
+
+            var pipCashCurrencyValue = (pipDecimal * AbsoluteQuantity * exchangeRate);
+            return Round((TotalCloseProfit() / pipCashCurrencyValue), 1);
+        }
+        
     }
 }

--- a/Tests/Common/Securities/Forex/ForexHoldingTest.cs
+++ b/Tests/Common/Securities/Forex/ForexHoldingTest.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Forex;
+
+namespace QuantConnect.Tests.Common.Securities.Forex
+{
+    [TestFixture]
+    public class ForexHoldingTests
+    {
+        [TestCase("EURUSD", 1, 0.00001, 1000, 1.23456, 50, 10000)]
+        [TestCase("USDJPY", 0.9, 0.001, 1000, 100.30, -40, 10000)]
+        [TestCase("EURGBP", 1.1, 0.00001, 1000, 0.89012, 100, 10000)]
+        public void TotalProfitIsCorrectlyEstimated(string ticker, decimal conversionRate,
+                                                    decimal minimumPriceVariation,
+                                                    int lotSize, decimal entryPrice, decimal pips, int entryQuantity)
+        {
+            // Arrange
+            var timeKeeper = new TimeKeeper(DateTime.Now, TimeZones.NewYork);
+
+            var symbol = Symbol.Create(ticker, SecurityType.Forex, Market.FXCM);
+            var pairQuoteCurrency = symbol.Value.Substring(startIndex: 3);
+            var cash = new Cash(pairQuoteCurrency, amount: 100000, conversionRate: conversionRate);
+            var subscription = new SubscriptionDataConfig(typeof(QuoteBar), symbol, Resolution.Daily,
+                                                          TimeZones.NewYork, TimeZones.NewYork, fillForward: true,
+                                                          extendedHours: true, isInternalFeed: true);
+
+            var pair = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                                                               cash, subscription,
+                                                               new SymbolProperties("", pairQuoteCurrency, 1,
+                                                                                    minimumPriceVariation, lotSize));
+            pair.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            pair.SetFeeModel(new ConstantFeeModel(decimal.Zero));
+            var forexHolding = new ForexHolding(pair);
+            // Act
+            forexHolding.SetHoldings(entryPrice, entryQuantity);
+            var priceVariation = pips * 10 * minimumPriceVariation;
+            forexHolding.UpdateMarketPrice(entryPrice + priceVariation);
+            var actualPips = forexHolding.TotalCloseProfitPips();
+            // Assert
+            Assert.AreEqual(pips, actualPips);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Common\Orders\Fills\LatestPriceFillModelTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />
     <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />
+    <Compile Include="Common\Securities\Forex\ForexHoldingTest.cs" />
     <Compile Include="Common\Securities\FutureFilterTests.cs" />
     <Compile Include="Common\Securities\Futures\FuturesExpiryFunctionsTests.cs" />
     <Compile Include="Common\Securities\Futures\FuturesExpiryUtilityFunctionsTests.cs" />


### PR DESCRIPTION
This PR adds a new method to the ForexHolding class to get the total profit in pips. #1378 

[Here](https://gist.github.com/Jay-Jay-D/80b33ec27e1a115438a0a4d0541cfacd) is a simple QCAlgorithm to test it.