### PR TITLE
Fix CashBook serialization error

### DIFF
--- a/Common/SymbolJsonConverter.cs
+++ b/Common/SymbolJsonConverter.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,12 +17,11 @@
 using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using QuantConnect.Securities;
 
 namespace QuantConnect
 {
     /// <summary>
-    /// Defines a <see cref="JsonConverter"/> to be used when deserializing to 
+    /// Defines a <see cref="JsonConverter"/> to be used when deserializing to
     /// the <see cref="Symbol"/> class.
     /// </summary>
     public class SymbolJsonConverter : JsonConverter
@@ -34,7 +33,7 @@ namespace QuantConnect
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var symbol = value as Symbol;
-            if (symbol == null) return;
+            if (ReferenceEquals(symbol, null)) return;
 
             writer.WriteStartObject();
             writer.WritePropertyName("$type");

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Brokerages;
@@ -259,6 +260,22 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var cash = new Cash(symbol, 1, 1);
             Assert.AreEqual(currencySymbol, cash.CurrencySymbol);
+        }
+
+        [Test]
+        public void CashBookWithUsdCanBeSerializedAfterEnsureCurrencyDataFeed()
+        {
+            var book = new CashBook
+            {
+                {"USD", new Cash("USD", 100, 1) },
+                {"EUR", new Cash("EUR", 100, 1.2m) }
+            };
+            var subscriptions = new SubscriptionManager(AlgorithmSettings, TimeKeeper);
+            var securities = new SecurityManager(TimeKeeper);
+
+            book.EnsureCurrencyDataFeeds(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap);
+
+            Assert.DoesNotThrow(() => JsonConvert.SerializeObject(book, Formatting.Indented));
         }
 
         private static TimeKeeper TimeKeeper


### PR DESCRIPTION
The following error was being thrown in `BaseResultsHandler.SaveResults`:
_Token PropertyName in state Property would result in an invalid JSON object. Path 'Cash.USD'._