### PR TITLE
Properly resolve contract multipler for IB option orders

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1782,7 +1782,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 contract.Right = symbol.ID.OptionRight == OptionRight.Call ? IB.RightType.Call : IB.RightType.Put;
                 contract.Strike = Convert.ToDouble(symbol.ID.StrikePrice);
                 contract.Symbol = ibSymbol;
-                contract.Multiplier = "100";
+                contract.Multiplier = _securityProvider.GetSecurity(symbol)?.SymbolProperties.ContractMultiplier.ToString(CultureInfo.InvariantCulture) ?? "100";
                 contract.TradingClass = GetTradingClass(contract);
             }
 


### PR DESCRIPTION
While there are typically 100 shares per options contract, contract adjustments and mini options can have different multipliers. This change fetches the correct multiplier from the security's symbol properties, defaulting to 100 if we can't find the security.

I noticed this while reviewing IB option ordering logic.