### PR TITLE
#1341 - Create skeleton DesktopLeanManager with required config changes

### DIFF
--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -94,13 +94,16 @@ namespace QuantConnect.Lean.Launcher
 
             if (environment.EndsWith("-desktop"))
             {
-                var info = new ProcessStartInfo
-                {
-                    UseShellExecute = false,
-                    FileName  = Config.Get("desktop-exe"),
-                    Arguments = Config.Get("desktop-http-port")
-                };
-                Process.Start(info);
+                // For the web version of the Lean Desktop Client launch the webpage rather than the application
+                var httpProtocol = Config.Get("desktop-http-protocol", "http");
+                var httpHost = Config.Get("desktop-http-host", "localhost");
+                var httpPort = Config.Get("desktop-http-port", "1234");
+                var url = string.Format("{0}://{1}:{2}", httpProtocol, httpHost, httpPort);
+
+                // Once the webserver is in place launch it here first
+
+                // Open the default webpage for the Lean Desktop website
+                Process.Start(url);
             }
 
             // if the job version doesn't match this instance version then we can't process it

--- a/Launcher/QuantConnect.Lean.Launcher.csproj
+++ b/Launcher/QuantConnect.Lean.Launcher.csproj
@@ -126,6 +126,10 @@
       <Project>{ac9a142c-b485-44d7-91ff-015c22c43d05}</Project>
       <Name>QuantConnect.ToolBox</Name>
     </ProjectReference>
+    <ProjectReference Include="..\UserInterface\QuantConnect.Views.csproj">
+      <Project>{C68BEEED-B0C0-4002-94D4-1E871133D02A}</Project>
+      <Name>QuantConnect.Views</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -222,23 +222,24 @@
     // defines the 'backtesting-desktop' environment
     "backtesting-desktop": {
       "live-mode": false,
-      "send-via-api": true,
+      "send-via-api": false,
 
       "setup-handler": "QuantConnect.Lean.Engine.Setup.ConsoleSetupHandler",
       "result-handler": "QuantConnect.Lean.Engine.Results.BacktestingResultHandler",
       "data-feed-handler": "QuantConnect.Lean.Engine.DataFeeds.FileSystemDataFeed",
       "real-time-handler": "QuantConnect.Lean.Engine.RealTime.BacktestingRealTimeHandler",
       "transaction-handler": "QuantConnect.Lean.Engine.TransactionHandlers.BacktestingTransactionHandler",
-      "messaging-handler": "QuantConnect.Messaging.StreamingMessageHandler",
       "log-handler": "QuantConnect.Logging.QueueLogHandler",
       "desktop-http-port": "1234",
-      "desktop-exe": "../../../UserInterface/bin/Debug/QuantConnect.Views.exe"
+      "desktop-http-hostname": "localhost",
+      "desktop-http-protocol": "http",
+      "lean-manager-type": "QuantConnect.Views.DesktopLeanManager"
     },
 
     // defines the 'live-desktop' environment
     "live-desktop": {
       "live-mode": true,
-      "send-via-api": true,
+      "send-via-api": false,
 
       // Set your own brokerage and data queue handlers here.
       // Live desktop charting isn't as cool as on quantconnect.com but its pretty neat!
@@ -249,10 +250,11 @@
       "data-feed-handler": "QuantConnect.Lean.Engine.DataFeeds.LiveTradingDataFeed",
       "real-time-handler": "QuantConnect.Lean.Engine.RealTime.LiveTradingRealTimeHandler",
       "transaction-handler": "QuantConnect.Lean.Engine.TransactionHandlers.BrokerageTransactionHandler",
-      "messaging-handler": "QuantConnect.Messaging.StreamingMessageHandler",
       "log-handler": "QuantConnect.Logging.QueueLogHandler",
       "desktop-http-port": "1234",
-      "desktop-exe": "../../../UserInterface/bin/Release/QuantConnect.Views.exe"
+      "desktop-http-hostname": "localhost",
+      "desktop-http-protocol": "http",
+      "lean-manager-type": "QuantConnect.Views.DesktopLeanManager"
     },
 
     "live-gdax": {

--- a/UserInterface/DesktopLeanManager.cs
+++ b/UserInterface/DesktopLeanManager.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine;
+using QuantConnect.Lean.Engine.Server;
+using QuantConnect.Packets;
+
+namespace QuantConnect.Views
+{
+    /// <summary>
+    /// Desktop implementation of the ILeanManager interface for use with a REST endpoint
+    /// </summary>          
+    public class DesktopLeanManager : ILeanManager
+    {
+
+        public DesktopLeanManager()
+        {
+        }
+
+        /// <summary>
+        /// Initialize the DesktopLeanManager
+        /// </summary>
+        /// <param name="systemHandlers">Exposes lean engine system handlers running LEAN</param>
+        /// <param name="algorithmHandlers">Exposes the lean algorithm handlers running lean</param>
+        /// <param name="job">The job packet representing either a live or backtest Lean instance</param>
+        /// <param name="algorithmManager">The Algorithm manager</param>
+        public void Initialize(LeanEngineSystemHandlers systemHandlers, LeanEngineAlgorithmHandlers algorithmHandlers, AlgorithmNodePacket job, AlgorithmManager algorithmManager)
+        {
+            Console.WriteLine("Initializing Desktop Lean Manager");
+        }
+
+        /// <summary>
+        /// Sets the IAlgorithm instance in the ILeanManager
+        /// </summary>
+        /// <param name="algorithm">The IAlgorithm instance being run</param>
+        public void SetAlgorithm(IAlgorithm algorithm)
+        {
+            Console.WriteLine("Set Algorithm Desktop Lean Manager");
+        }
+
+        /// <summary>
+        /// Update ILeanManager with the IAlgorithm instance
+        /// </summary>
+        public void Update()
+        {
+            Console.WriteLine("Update the Desktop Lean Manager");
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Console.WriteLine("Dispose the Desktop Lean Manager");
+        }
+    }
+}

--- a/UserInterface/QuantConnect.Views.csproj
+++ b/UserInterface/QuantConnect.Views.csproj
@@ -118,6 +118,7 @@
     <Compile Include="WinForms\LeanWinForm.Designer.cs">
       <DependentUpon>LeanWinForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="DesktopLeanManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Algorithm.CSharp\QuantConnect.Algorithm.CSharp.csproj">


### PR DESCRIPTION
* Includes an empty DesktopLeanManager in the QuantConnect.Views project.
* Added a project reference from the QuantConnect.LeanLauncher project to the QuantConnect.Views project in order to reference the DesktopLeanManager.
* Amended the desktop configuration for backtest-desktop and live-desktop by setting:
   * send-via-api to false
   * lean-manager-type to QuantConnect.Views.DesktopLeanManager
   * removing the message-handler configuration item
   * removing desktop-exe configuration item
* Removed launching of the desktop-exe when in desktop mode and replaced with launching of the root web page

The default environment is unaltered, to test you need to change the environment to backtesting-desktop. The QuantConnect.Views project is still an exe output type, I presume in #1342 we can change this to a library once the desktop is gone.

I have code ready for most of this project so as soon as you are happy with each stage I can submit the next piece.