### PR TITLE
Make HeikinAshi work with Forex data

### DIFF
--- a/Indicators/HeikinAshi.cs
+++ b/Indicators/HeikinAshi.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Indicators
     /// HA_High[0] = MAX(High[0], HA_Open[0], HA_Close[0])
     /// HA_Low[0] = MIN(Low[0], HA_Open[0], HA_Close[0])
     /// </summary>
-    public class HeikinAshi : TradeBarIndicator
+    public class HeikinAshi : BarIndicator
     {
         /// <summary>
         /// Gets the Heikin-Ashi Open
@@ -96,7 +96,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns> A new value for this indicator </returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             if (!IsReady)
             {
@@ -112,9 +112,7 @@ namespace QuantConnect.Indicators
                 High.Update(new IndicatorDataPoint(input.Time, Math.Max(input.High, Math.Max(Open, Close))));
                 Low.Update(new IndicatorDataPoint(input.Time, Math.Min(input.Low, Math.Min(Open, Close))));
             }
-
-            Volume.Update(new IndicatorDataPoint(input.Time, input.Volume));
-
+            
             return Close;
         }
 

--- a/Indicators/HeikinAshi.cs
+++ b/Indicators/HeikinAshi.cs
@@ -112,7 +112,11 @@ namespace QuantConnect.Indicators
                 High.Update(new IndicatorDataPoint(input.Time, Math.Max(input.High, Math.Max(Open, Close))));
                 Low.Update(new IndicatorDataPoint(input.Time, Math.Min(input.Low, Math.Min(Open, Close))));
             }
-            
+
+            // Sets the volume should the input be of TradeBar type; to allow chaining the indicator.
+            var tradeBar = input as TradeBar;
+            Volume.Update(new IndicatorDataPoint(input.EndTime, tradeBar == null ? 0m : tradeBar.Volume));
+
             return Close;
         }
 

--- a/Tests/Indicators/HeikinAshiTests.cs
+++ b/Tests/Indicators/HeikinAshiTests.cs
@@ -20,9 +20,9 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class HeikinAshiTests : CommonIndicatorTests<TradeBar>
+    public class HeikinAshiTests : CommonIndicatorTests<IBaseDataBar>
     {
-        protected override IndicatorBase<TradeBar> CreateIndicator()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
             return new HeikinAshi();
         }
@@ -44,7 +44,6 @@ namespace QuantConnect.Tests.Indicators
             TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "HA_High", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).High.Current.Value, 1e-3));
             TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "HA_Low", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Low.Current.Value, 1e-3));
             TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "HA_Close", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Close.Current.Value, 1e-3));
-            TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "Volume", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Volume.Current.Value, 1e-3));
         }
 
         [Test]
@@ -60,8 +59,6 @@ namespace QuantConnect.Tests.Indicators
                 TestHelper.TestIndicator(indicator, TestFileName, "HA_Low", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Low.Current.Value, 1e-3));
                 indicator.Reset();
                 TestHelper.TestIndicator(indicator, TestFileName, "HA_Close", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Close.Current.Value, 1e-3));
-                indicator.Reset();
-                TestHelper.TestIndicator(indicator, TestFileName, "Volume", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Volume.Current.Value, 1e-3));
                 indicator.Reset();
             }
         }

--- a/Tests/Indicators/HeikinAshiTests.cs
+++ b/Tests/Indicators/HeikinAshiTests.cs
@@ -44,6 +44,7 @@ namespace QuantConnect.Tests.Indicators
             TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "HA_High", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).High.Current.Value, 1e-3));
             TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "HA_Low", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Low.Current.Value, 1e-3));
             TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "HA_Close", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Close.Current.Value, 1e-3));
+            TestHelper.TestIndicator(new HeikinAshi(), TestFileName, "Volume", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Volume.Current.Value, 1e-3));
         }
 
         [Test]
@@ -59,6 +60,8 @@ namespace QuantConnect.Tests.Indicators
                 TestHelper.TestIndicator(indicator, TestFileName, "HA_Low", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Low.Current.Value, 1e-3));
                 indicator.Reset();
                 TestHelper.TestIndicator(indicator, TestFileName, "HA_Close", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Close.Current.Value, 1e-3));
+                indicator.Reset();
+                TestHelper.TestIndicator(indicator, TestFileName, "Volume", (ind, expected) => Assert.AreEqual(expected, (double)((HeikinAshi)ind).Volume.Current.Value, 1e-3));
                 indicator.Reset();
             }
         }


### PR DESCRIPTION
Changed HeikinAshi to inherit from BarIndicator instead of TradeBarIndicator to facilitate forex data. This is done by removing volume as it is unnecessary in HeikinAshi.

Fixes #1286