### PR TITLE
Fix misleading error message in AlgorithmManager.

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -112,7 +112,9 @@ namespace QuantConnect.Lean.Engine
             {
                 if (CurrentTimeStepElapsed > _timeLoopMaximum)
                 {
-                    return "Algorithm took longer than 10 minutes on a single time loop.";
+                    return ("Algorithm took longer than " +
+                            Config.GetDouble("algorithm-manager-time-loop-maximum", 20) +
+                            " minutes on a single time loop.");
                 }
 
                 return null;

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -113,7 +113,7 @@ namespace QuantConnect.Lean.Engine
                 if (CurrentTimeStepElapsed > _timeLoopMaximum)
                 {
                     return ("Algorithm took longer than " +
-                            Config.GetDouble("algorithm-manager-time-loop-maximum", 20) +
+                            _timeLoopMaximum.TotalMinutes.ToString() +
                             " minutes on a single time loop.");
                 }
 


### PR DESCRIPTION
AlgorithmManager error message previously indicated that the manager took longer than 10 minutes on a single time loop regardless of what the time loop maximum actually was (the default was 20.)  