### PR TITLE
RestSubscriptionStreamReader issue.

### DIFF
--- a/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
     {
         private readonly RestClient _client;
         private readonly RestRequest _request;
+        private bool _delivered;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RestSubscriptionStreamReader"/> class.
@@ -37,6 +38,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// <param name="headers">Defines header values to add to the request</param>
         public RestSubscriptionStreamReader(string source, IEnumerable<KeyValuePair<string, string>> headers)
         {
+            _delivered = false;
             _client = new RestClient(source);
             _request = new RestRequest(Method.GET);
 
@@ -62,7 +64,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// </summary>
         public bool EndOfStream
         {
-            get { return false; }
+            get { return _delivered; }
         }
 
         /// <summary>
@@ -75,6 +77,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
                 var response = _client.Execute(_request);
                 if (response != null)
                 {
+                    _delivered = true;
                     return response.Content;
                 }
             }


### PR DESCRIPTION
#1483 

The problem has no to do with the `DailyFx` class itself, instead the `CollectionSubscriptionDataSourceReader` never reaches the end of the stream when the `SubscriptionTransportMedium` is `Rest`. And in this case is because, as you can see in the `RestSubscriptionStreamReader` implementation, [it never _ends_ to read the stream](https://github.com/QuantConnect/Lean/blob/42c782e312efb8ba210285daa95136d9c39b526d/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs#L65).

The fix was simply to incorporate a static bool variable called ´delivered´; that variable will flag once the whole content of the collection is pumped in via the `ReadLine` method and it will encapsulated by the `EndOfStream` method.