### PR TITLE
Add split warning event

### DIFF
--- a/Common/Data/Market/Delisting.cs
+++ b/Common/Data/Market/Delisting.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -70,8 +70,8 @@ namespace QuantConnect.Data.Market
         }
 
         /// <summary>
-        /// Reader converts each line of the data source into BaseData objects. Each data type creates its own factory method, and returns a new instance of the object 
-        /// each time it is called. 
+        /// Reader converts each line of the data source into BaseData objects. Each data type creates its own factory method, and returns a new instance of the object
+        /// each time it is called.
         /// </summary>
         /// <param name="config">Subscription data config setup object</param>
         /// <param name="line">Line of the source document</param>
@@ -84,7 +84,7 @@ namespace QuantConnect.Data.Market
         }
 
         /// <summary>
-        /// Return the URL string source of the file. This will be converted to a stream 
+        /// Return the URL string source of the file. This will be converted to a stream
         /// </summary>
         /// <param name="config">Configuration object</param>
         /// <param name="date">Date of this source file</param>
@@ -105,6 +105,16 @@ namespace QuantConnect.Data.Market
         public override BaseData Clone()
         {
             return new Delisting(Symbol, Time, Price, Type);
+        }
+
+        /// <summary>
+        /// Formats a string with the symbol and value.
+        /// </summary>
+        /// <returns>string - a string formatted as SPY: 167.753</returns>
+        public override string ToString()
+        {
+            var type = Type == DelistingType.Warning ? "Delisting Warning" : "Delisted";
+            return $"{type}: {Symbol} {EndTime}";
         }
     }
 }

--- a/Common/Data/Market/Split.cs
+++ b/Common/Data/Market/Split.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,27 +24,11 @@ namespace QuantConnect.Data.Market
     public class Split : BaseData
     {
         /// <summary>
-        /// Initializes a new instance of the Split class
+        ///Gets the type of split event, warning or split.
         /// </summary>
-        public Split()
+        public SplitType Type
         {
-            DataType = MarketDataType.Auxiliary;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the Split class
-        /// </summary>
-        /// <param name="symbol">The symbol</param>
-        /// <param name="date">The date</param>
-        /// <param name="price">The price at the time of the split</param>
-        /// <param name="splitFactor">The split factor to be applied to current holdings</param>
-        public Split(Symbol symbol, DateTime date, decimal price, decimal splitFactor)
-             : this()
-        {
-            Symbol = symbol;
-            Time = date;
-            ReferencePrice = price;
-            SplitFactor = splitFactor;
+            get; private set;
         }
 
         /// <summary>
@@ -65,8 +49,35 @@ namespace QuantConnect.Data.Market
         }
 
         /// <summary>
-        /// Reader converts each line of the data source into BaseData objects. Each data type creates its own factory method, and returns a new instance of the object 
-        /// each time it is called. 
+        /// Initializes a new instance of the Split class
+        /// </summary>
+        public Split()
+        {
+            Type = SplitType.SplitOccurred;
+            DataType = MarketDataType.Auxiliary;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Split class
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="date">The date</param>
+        /// <param name="price">The price at the time of the split</param>
+        /// <param name="splitFactor">The split factor to be applied to current holdings</param>
+        /// <param name="type">The type of split event, warning or split occurred</param>
+        public Split(Symbol symbol, DateTime date, decimal price, decimal splitFactor, SplitType type)
+             : this()
+        {
+            Symbol = symbol;
+            Time = date;
+            ReferencePrice = price;
+            SplitFactor = splitFactor;
+            Type = type;
+        }
+
+        /// <summary>
+        /// Reader converts each line of the data source into BaseData objects. Each data type creates its own factory method, and returns a new instance of the object
+        /// each time it is called.
         /// </summary>
         /// <param name="config">Subscription data config setup object</param>
         /// <param name="line">Line of the source document</param>
@@ -80,7 +91,7 @@ namespace QuantConnect.Data.Market
         }
 
         /// <summary>
-        /// Return the URL string source of the file. This will be converted to a stream 
+        /// Return the URL string source of the file. This will be converted to a stream
         /// </summary>
         /// <param name="config">Configuration object</param>
         /// <param name="date">Date of this source file</param>
@@ -98,7 +109,8 @@ namespace QuantConnect.Data.Market
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="QuantConnect.Data.Market.Split"/>.</returns>
         public override string ToString()
         {
-            return string.Format("{0}: {1}", Symbol, SplitFactor);
+            var type = Type == SplitType.Warning ? "Split Warning" : "Split";
+            return $"{type}: {Symbol}: {SplitFactor}";
         }
 
         /// <summary>
@@ -110,7 +122,7 @@ namespace QuantConnect.Data.Market
         /// <returns>A clone of the current object</returns>
         public override BaseData Clone()
         {
-            return new Split(Symbol, Time, Price, SplitFactor);
+            return new Split(Symbol, Time, Price, SplitFactor, Type);
         }
     }
 }

--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -412,6 +412,22 @@ namespace QuantConnect
     }
 
     /// <summary>
+    /// Specifies the type of <see cref="QuantConnect.Data.Market.Split"/> data
+    /// </summary>
+    public enum SplitType
+    {
+        /// <summary>
+        /// Specifies a warning of an imminent split event
+        /// </summary>
+        Warning = 0,
+
+        /// <summary>
+        /// Specifies the symbol has been split
+        /// </summary>
+        SplitOccurred = 1
+    }
+
+    /// <summary>
     /// Resolution of data requested.
     /// </summary>
     /// <remarks>Always sort the enum from the smallest to largest resolution</remarks>

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -124,7 +124,7 @@ namespace QuantConnect.ToolBox.IQFeed
 
                                 if (symbol.ID.SecurityType == SecurityType.Future && symbol.IsCanonical())
                                 {
-                                    // do nothing for now. Later might add continuous contract symbol. 
+                                    // do nothing for now. Later might add continuous contract symbol.
                                     return;
                                 }
 
@@ -420,7 +420,7 @@ namespace QuantConnect.ToolBox.IQFeed
                     _prices.TryGetValue(e.Symbol, out referencePrice);
 
                     var symbol = GetLeanSymbol(e.Symbol);
-                    var split = new Split(symbol, FeedTime, (decimal)referencePrice, (decimal)e.SplitFactor1);
+                    var split = new Split(symbol, FeedTime, (decimal)referencePrice, (decimal)e.SplitFactor1, SplitType.SplitOccurred);
                     _dataQueue.Add(split);
                 }
             }
@@ -551,7 +551,7 @@ namespace QuantConnect.ToolBox.IQFeed
         }
 
         /// <summary>
-        /// Method returns a collection of Symbols that are available at the data source. 
+        /// Method returns a collection of Symbols that are available at the data source.
         /// </summary>
         /// <param name="lookupName">String representing the name to lookup</param>
         /// <param name="securityType">Expected security type of the returned symbols (if any)</param>
@@ -574,7 +574,7 @@ namespace QuantConnect.ToolBox.IQFeed
             private readonly IQFeedDataQueueUniverseProvider _symbolUniverse;
 
             /// <summary>
-            /// ... 
+            /// ...
             /// </summary>
             public HistoryPort(IQFeedDataQueueUniverseProvider symbolUniverse)
                 : base(80)
@@ -605,7 +605,7 @@ namespace QuantConnect.ToolBox.IQFeed
             /// </summary>
             public IEnumerable<Slice> ProcessHistoryRequests(HistoryRequest request)
             {
-                // skipping universe and canonical symbols 
+                // skipping universe and canonical symbols
                 if (!CanHandle(request.Symbol) ||
                     (request.Symbol.ID.SecurityType == SecurityType.Option && request.Symbol.IsCanonical()) ||
                     (request.Symbol.ID.SecurityType == SecurityType.Future && request.Symbol.IsCanonical()))
@@ -680,7 +680,7 @@ namespace QuantConnect.ToolBox.IQFeed
                 return lookupType + id.ToString("0000000");
             }
 
-            
+
             /// <summary>
             /// Method called when a new Lookup event is fired
             /// </summary>
@@ -728,7 +728,7 @@ namespace QuantConnect.ToolBox.IQFeed
                     current.Add(data);
                 }
             }
-            
+
             /// <summary>
             /// Transform received data into BaseData object
             /// </summary>


### PR DESCRIPTION
#### Add Delisting.ToString override

These overrides are super useful when debugging and logging various events.

#### Add split warning events

This follows the pattern used by delisting events, where we send a warning event before the start of trading on the trading day before the split will happen. This change also adds a SplitType enum having a Warning and SplitOccurred values.