### PR TITLE
 Implementing live mode flag into RestSubscriptionStreamReader

### DIFF
--- a/Common/Data/SubscriptionDataSource.cs
+++ b/Common/Data/SubscriptionDataSource.cs
@@ -58,8 +58,8 @@ namespace QuantConnect.Data
         /// Initializes a new instance of the <see cref="SubscriptionDataSource"/> class.
         /// </summary>
         /// <param name="source">The subscription's data source location</param>
-        /// <param name="format">The format of the data within the source</param>
         /// <param name="transportMedium">The transport medium to be used to retrieve the subscription's data from the source</param>
+        /// <param name="format">The format of the data within the source</param>
         public SubscriptionDataSource(string source, SubscriptionTransportMedium transportMedium, FileFormat format)
             : this(source, transportMedium, format, null)
         {

--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 {
                     default:
                     case SubscriptionTransportMedium.Rest:
-                        reader = new RestSubscriptionStreamReader(source.Source, source.Headers);
+                        reader = new RestSubscriptionStreamReader(source.Source, source.Headers, _isLiveMode);
                         break;
                     case SubscriptionTransportMedium.LocalFile:
                         reader = new LocalFileSubscriptionStreamReader(_dataCacheProvider, source.Source);

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -129,7 +129,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     break;
 
                 case SubscriptionTransportMedium.Rest:
-                    reader = new RestSubscriptionStreamReader(subscriptionDataSource.Source, subscriptionDataSource.Headers);
+                    reader = new RestSubscriptionStreamReader(subscriptionDataSource.Source, subscriptionDataSource.Headers, _isLiveMode);
                     break;
 
                 default:

--- a/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
@@ -29,16 +29,20 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
     {
         private readonly RestClient _client;
         private readonly RestRequest _request;
+        private bool _isLiveMode;
+        private bool _delivered;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RestSubscriptionStreamReader"/> class.
         /// </summary>
         /// <param name="source">The source url to poll with a GET</param>
         /// <param name="headers">Defines header values to add to the request</param>
-        public RestSubscriptionStreamReader(string source, IEnumerable<KeyValuePair<string, string>> headers)
+        public RestSubscriptionStreamReader(string source, IEnumerable<KeyValuePair<string, string>> headers, bool isLiveMode)
         {
             _client = new RestClient(source);
             _request = new RestRequest(Method.GET);
+            _isLiveMode = isLiveMode;
+            _delivered = false;
 
             if (headers != null)
             {
@@ -62,7 +66,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// </summary>
         public bool EndOfStream
         {
-            get { return false; }
+            get { return !_isLiveMode && _delivered; }
         }
 
         /// <summary>
@@ -75,6 +79,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
                 var response = _client.Execute(_request);
                 if (response != null)
                 {
+                    _delivered = true;
                     return response.Content;
                 }
             }


### PR DESCRIPTION
This PR implements a new behavior for the `RestSubscriptionStreamReader`, depending if the algorithm is running live or not. ~The argument is passed through the `SubscriptionDataSource` class.~

- In live mode it behaves as default, i.e. the `RestSubscriptionStreamReader.EndOfStream` is always false.
- In backtesting mode, the `RestSubscriptionStreamReader.EndOfStream` will be true once the file content is delivered.

This implementation is a better, correct implementation of the #1500 and fixes the issue #1483.