### PR TITLE
Set GDAXFeeModel as default fee model for Crypto securities

### DIFF
--- a/Common/Securities/Crypto/Crypto.cs
+++ b/Common/Securities/Crypto/Crypto.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Securities.Crypto
                 new ForexCache(),
                 new SecurityPortfolioModel(),
                 new ImmediateFillModel(),
-                new ConstantFeeModel(0),
+                new GDAXFeeModel(),
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,


### PR DESCRIPTION
This prevents getting always zero fees in backtesting when not calling `SetBrokerageModel`