### PR TITLE
Cash buying power model for GDAX

### DIFF
--- a/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
@@ -1,0 +1,67 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Brokerages;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Basic template algorithm simply initializes the date range and cash. This is a skeleton
+    /// framework you can use for designing an algorithm.
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="using quantconnect" />
+    /// <meta name="tag" content="trading and orders" />
+    public class BasicTemplateCryptoAlgorithm : QCAlgorithm
+    {
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2016, 10, 7);  //Set Start Date
+            SetEndDate(2016, 10, 7);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+
+            SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
+
+            // Find more symbols here: http://quantconnect.com/data
+            AddCrypto("BTCUSD");
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (Time.Minute == 0)
+            {
+                if (!Portfolio.Invested)
+                {
+                    SetHoldings("BTCUSD", 1m);
+                }
+                else
+                {
+                    Liquidate();
+                }
+
+                var btcHoldings = Portfolio.CashBook["BTC"].Amount;
+                Log($"{Time} - BTC holdings: {btcHoldings:F8}");
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
@@ -40,7 +40,11 @@ namespace QuantConnect.Algorithm.CSharp
 
             SetTimeZone(NodaTime.DateTimeZone.Utc);
             var security = AddSecurity(SecurityType.Crypto, "BTCUSD", Resolution.Daily, Market.GDAX, false, 3.3m, true);
+
+            // The default buying power model for the Crypto security type is now CashBuyingPowerModel.
+            // Since this test algorithm uses leverage we need to set a buying power model with margin.
             security.BuyingPowerModel = new SecurityMarginBuyingPowerModel(3.3m);
+
             var con = new QuoteBarConsolidator(1);
             SubscriptionManager.AddConsolidator("BTCUSD", con);
             con.DataConsolidated += DataConsolidated;

--- a/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             // The default buying power model for the Crypto security type is now CashBuyingPowerModel.
             // Since this test algorithm uses leverage we need to set a buying power model with margin.
-            security.BuyingPowerModel = new SecurityMarginBuyingPowerModel(3.3m);
+            security.BuyingPowerModel = new SecurityMarginModel(3.3m);
 
             var con = new QuoteBarConsolidator(1);
             SubscriptionManager.AddConsolidator("BTCUSD", con);

--- a/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
@@ -17,6 +17,7 @@ using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using System;
 using QuantConnect.Brokerages;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -39,6 +40,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             SetTimeZone(NodaTime.DateTimeZone.Utc);
             var security = AddSecurity(SecurityType.Crypto, "BTCUSD", Resolution.Daily, Market.GDAX, false, 3.3m, true);
+            security.BuyingPowerModel = new SecurityMarginBuyingPowerModel(3.3m);
             var con = new QuoteBarConsolidator(1);
             SubscriptionManager.AddConsolidator("BTCUSD", con);
             con.DataConsolidated += DataConsolidated;

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -84,6 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
+    <Compile Include="BasicTemplateCryptoAlgorithm.cs" />
     <Compile Include="BasicTemplateIntrinioEconomicData.cs" />
     <Compile Include="BasicTemplateFrameworkAlgorithm.cs" />
     <Compile Include="BasicTemplateLibrary.cs" />

--- a/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
@@ -28,7 +28,7 @@ from QuantConnect.Brokerages import *
 ### <meta name="tag" content="using data" />
 ### <meta name="tag" content="using quantconnect" />
 ### <meta name="tag" content="trading and orders" />
-class BasicTemplateAlgorithm(QCAlgorithm):
+class BasicTemplateCryptoAlgorithm(QCAlgorithm):
     '''Basic template algorithm simply initializes the date range and cash'''
 
     def Initialize(self):

--- a/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
@@ -1,0 +1,59 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Brokerages import *
+
+### <summary>
+### Basic template algorithm simply initializes the date range and cash. This is a skeleton
+### framework you can use for designing an algorithm.
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="using quantconnect" />
+### <meta name="tag" content="trading and orders" />
+class BasicTemplateAlgorithm(QCAlgorithm):
+    '''Basic template algorithm simply initializes the date range and cash'''
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        self.SetStartDate(2016, 10, 7)  #Set Start Date
+        self.SetEndDate(2016, 10, 7)    #Set End Date
+        self.SetCash(100000)          #Set Strategy Cash
+
+        self.SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash)
+
+        # Find more symbols here: http://quantconnect.com/data
+        self.AddCrypto("BTCUSD", Resolution.Minute)
+
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+
+        Arguments:
+            data: Slice object keyed by symbol containing the stock data
+        '''
+        if self.Time.minute == 0:
+            if not self.Portfolio.Invested:
+                self.SetHoldings("BTCUSD", 1)
+            else:
+                self.Liquidate()
+
+            btcHoldings = self.Portfolio.CashBook["BTC"].Amount
+            self.Log("{0} - BTC holdings: {1}".format(str(self.Time), str(btcHoldings)))

--- a/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
+++ b/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
@@ -23,6 +23,7 @@ from NodaTime import DateTimeZone
 from QuantConnect import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Brokerages import *
+from QuantConnect.Securities import *
 from QuantConnect.Data.Market import *
 from QuantConnect.Data.Consolidators import *
 
@@ -48,6 +49,7 @@ class FractionalQuantityRegressionAlgorithm(QCAlgorithm):
         self.SetTimeZone(DateTimeZone.Utc)
 
         security = self.AddSecurity(SecurityType.Crypto, "BTCUSD", Resolution.Daily, Market.GDAX, False, 3.3, True)
+        security.BuyingPowerModel = SecurityMarginBuyingPowerModel(3.3);
         con = QuoteBarConsolidator(timedelta(1))
         self.SubscriptionManager.AddConsolidator("BTCUSD", con)
         con.DataConsolidated += self.DataConsolidated

--- a/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
+++ b/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
@@ -49,7 +49,11 @@ class FractionalQuantityRegressionAlgorithm(QCAlgorithm):
         self.SetTimeZone(DateTimeZone.Utc)
 
         security = self.AddSecurity(SecurityType.Crypto, "BTCUSD", Resolution.Daily, Market.GDAX, False, 3.3, True)
+
+        ### The default buying power model for the Crypto security type is now CashBuyingPowerModel.
+        ### Since this test algorithm uses leverage we need to set a buying power model with margin.
         security.BuyingPowerModel = SecurityMarginBuyingPowerModel(3.3);
+
         con = QuoteBarConsolidator(timedelta(1))
         self.SubscriptionManager.AddConsolidator("BTCUSD", con)
         con.DataConsolidated += self.DataConsolidated

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -135,6 +135,7 @@
     <None Include="CustomSecurityInitializerAlgorithm.py" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="BasicTemplateCryptoAlgorithm.py" />
     <Content Include="BasicTemplateFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateLibrary.py" />
     <Content Include="CustomIndicatorAlgorithm.py" />

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -274,16 +274,16 @@ namespace QuantConnect.Brokerages
 
                 case SecurityType.Forex:
                 case SecurityType.Cfd:
-                    return new SecurityMarginBuyingPowerModel(50m);
+                    return new SecurityMarginModel(50m);
 
                 case SecurityType.Option:
-                    return new OptionMarginBuyingPowerModel();
+                    return new OptionMarginModel();
 
                 case SecurityType.Future:
-                    return new FutureMarginBuyingPowerModel();
+                    return new FutureMarginModel();
 
                 default:
-                    return new SecurityMarginBuyingPowerModel(2m);
+                    return new SecurityMarginModel(2m);
             }
         }
     }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -21,6 +21,7 @@ using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Slippage;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Equity;
+using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Option;
 using QuantConnect.Util;
 
@@ -266,7 +267,24 @@ namespace QuantConnect.Brokerages
         /// <returns>The buying power model for this brokerage/security</returns>
         public virtual IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType)
         {
-            return security.BuyingPowerModel;
+            switch (security.Type)
+            {
+                case SecurityType.Crypto:
+                    return new CashBuyingPowerModel();
+
+                case SecurityType.Forex:
+                case SecurityType.Cfd:
+                    return new SecurityMarginBuyingPowerModel(50m);
+
+                case SecurityType.Option:
+                    return new OptionMarginBuyingPowerModel();
+
+                case SecurityType.Future:
+                    return new FutureMarginBuyingPowerModel();
+
+                default:
+                    return new SecurityMarginBuyingPowerModel(2m);
+            }
         }
     }
 }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
@@ -52,7 +51,7 @@ namespace QuantConnect.Brokerages
         /// </summary>
         public virtual AccountType AccountType
         {
-            get; 
+            get;
             private set;
         }
 
@@ -67,7 +66,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to 
+        /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="QuantConnect.AccountType.Margin"/></param>
         public DefaultBrokerageModel(AccountType accountType = AccountType.Margin)
         {
@@ -107,7 +106,7 @@ namespace QuantConnect.Brokerages
 
         /// <summary>
         /// Returns true if the brokerage would be able to execute this order at this time assuming
-        /// market prices are sufficient for the fill to take place. This is used to emulate the 
+        /// market prices are sufficient for the fill to take place. This is used to emulate the
         /// brokerage fills in backtesting and paper trading. For example some brokerages may not perform
         /// executions during extended market hours. This is not intended to be checking whether or not
         /// the exchange is open, that is handled in the Security.Exchange property.
@@ -151,7 +150,7 @@ namespace QuantConnect.Brokerages
             {
                 return 1m;
             }
-                    
+
             switch (security.Type)
             {
                 case SecurityType.Equity:
@@ -258,5 +257,16 @@ namespace QuantConnect.Brokerages
             return new ImmediateSettlementModel();
         }
 
+        /// <summary>
+        /// Gets a new buying power model for the security, returning the default model with the security's configured leverage.
+        /// For cash accounts, leverage = 1 is used.
+        /// </summary>
+        /// <param name="security">The security to get a buying power model for</param>
+        /// <param name="accountType">The account type</param>
+        /// <returns>The buying power model for this brokerage/security</returns>
+        public virtual IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType)
+        {
+            return security.BuyingPowerModel;
+        }
     }
 }

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -57,13 +57,12 @@ namespace QuantConnect.Brokerages
         /// </summary>
         /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="AccountType.Margin"/></param>
-        public GDAXBrokerageModel(AccountType accountType = AccountType.Margin)
+        public GDAXBrokerageModel(AccountType accountType = AccountType.Cash)
             : base(accountType)
         {
             if (accountType == AccountType.Margin)
             {
-                new BrokerageMessageEvent(BrokerageMessageType.Warning, 0,
-                    "It is recommend to use a cash account. Margin trading is currently in pre-Alpha. Use at your own risk and please report any issues encountered.");
+                throw new Exception("The GDAX brokerage does not currently support Margin trading.");
             }
         }
 
@@ -74,12 +73,8 @@ namespace QuantConnect.Brokerages
         /// <returns></returns>
         public override decimal GetLeverage(Security security)
         {
-            if (AccountType == AccountType.Cash)
-            {
-                return 1m;
-            }
-
-            return 3m;
+            // margin trading is not currently supported by GDAX
+            return 1m;
         }
 
         /// <summary>
@@ -161,6 +156,19 @@ namespace QuantConnect.Brokerages
         public override IFillModel GetFillModel(Security security)
         {
             return new LatestPriceFillModel();
+        }
+
+        /// <summary>
+        /// Gets a new buying power model for the security, returning the default model with the security's configured leverage.
+        /// For cash accounts, leverage = 1 is used.
+        /// </summary>
+        /// <param name="security">The security to get a buying power model for</param>
+        /// <param name="accountType">The account type</param>
+        /// <returns>The buying power model for this brokerage/security</returns>
+        public override IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType)
+        {
+            // margin trading is not currently supported by GDAX
+            return new CashBuyingPowerModel();
         }
     }
 }

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Brokerages
         /// Initializes a new instance of the <see cref="GDAXBrokerageModel"/> class
         /// </summary>
         /// <param name="accountType">The type of account to be modelled, defaults to
-        /// <see cref="AccountType.Margin"/></param>
+        /// <see cref="AccountType.Cash"/></param>
         public GDAXBrokerageModel(AccountType accountType = AccountType.Cash)
             : base(accountType)
         {

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -68,7 +68,7 @@ namespace QuantConnect.Brokerages
 
         /// <summary>
         /// Returns true if the brokerage would be able to execute this order at this time assuming
-        /// market prices are sufficient for the fill to take place. This is used to emulate the 
+        /// market prices are sufficient for the fill to take place. This is used to emulate the
         /// brokerage fills in backtesting and paper trading. For example some brokerages may not perform
         /// executions during extended market hours. This is not intended to be checking whether or not
         /// the exchange is open, that is handled in the Security.Exchange property.
@@ -121,6 +121,13 @@ namespace QuantConnect.Brokerages
         /// <returns>The settlement model for this brokerage</returns>
         ISettlementModel GetSettlementModel(Security security, AccountType accountType);
 
+        /// <summary>
+        /// Gets a new buying power model for the security
+        /// </summary>
+        /// <param name="security">The security to get a buying power model for</param>
+        /// <param name="accountType">The account type</param>
+        /// <returns>The buying power model for this brokerage/security</returns>
+        IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType);
     }
 
     /// <summary>
@@ -146,10 +153,10 @@ namespace QuantConnect.Brokerages
 
                 case BrokerageName.TradierBrokerage:
                     return new TradierBrokerageModel(accountType);
-                    
+
                 case BrokerageName.OandaBrokerage:
                     return new OandaBrokerageModel(accountType);
-                    
+
                 case BrokerageName.FxcmBrokerage:
                     return new FxcmBrokerageModel(accountType);
 
@@ -157,7 +164,7 @@ namespace QuantConnect.Brokerages
                     return new DefaultBrokerageModel(accountType);
 
                 case BrokerageName.GDAX:
-                    return new GDAXBrokerageModel(accountType);
+                    return new GDAXBrokerageModel();
 
                 default:
                     throw new ArgumentOutOfRangeException("brokerage", brokerage, null);

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -164,10 +164,10 @@ namespace QuantConnect.Brokerages
                     return new DefaultBrokerageModel(accountType);
 
                 case BrokerageName.GDAX:
-                    return new GDAXBrokerageModel();
+                    return new GDAXBrokerageModel(accountType);
 
                 default:
-                    throw new ArgumentOutOfRangeException("brokerage", brokerage, null);
+                    throw new ArgumentOutOfRangeException(nameof(brokerage), brokerage, null);
             }
         }
     }

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Python
 
         /// <summary>
         /// Returns true if the brokerage would be able to execute this order at this time assuming
-        /// market prices are sufficient for the fill to take place. This is used to emulate the 
+        /// market prices are sufficient for the fill to take place. This is used to emulate the
         /// brokerage fills in backtesting and paper trading. For example some brokerages may not perform
         /// executions during extended market hours. This is not intended to be checking whether or not
         /// the exchange is open, that is handled in the Security.Exchange property.
@@ -198,6 +198,21 @@ namespace QuantConnect.Python
             using (Py.GIL())
             {
                 return _model.GetSlippageModel(security);
+            }
+        }
+
+        /// <summary>
+        /// Gets a new buying power model for the security, returning the default model with the security's configured leverage.
+        /// For cash accounts, leverage = 1 is used.
+        /// </summary>
+        /// <param name="security">The security to get a buying power model for</param>
+        /// <param name="accountType">The account type</param>
+        /// <returns>The buying power model for this brokerage/security</returns>
+        public IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType)
+        {
+            using (Py.GIL())
+            {
+                return _model.GetBuyingPowerModel(security, accountType);
             }
         }
     }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Python\FillModelPythonWrapper.cs" />
     <Compile Include="Python\PandasConverter.cs" />
     <Compile Include="Python\FeeModelPythonWrapper.cs" />
+    <Compile Include="Securities\CashBuyingPowerModel.cs" />
     <Compile Include="Securities\IBaseCurrencySymbol.cs" />
     <Compile Include="Securities\Future\EmptyFutureChainProvider.cs" />
     <Compile Include="Securities\Option\EmptyOptionChainProvider.cs" />

--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -61,6 +61,7 @@ namespace QuantConnect.Securities
             security.FeeModel = _brokerageModel.GetFeeModel(security);
             security.SlippageModel = _brokerageModel.GetSlippageModel(security);
             security.SettlementModel = _brokerageModel.GetSettlementModel(security, _brokerageModel.AccountType);
+            security.BuyingPowerModel = _brokerageModel.GetBuyingPowerModel(security, _brokerageModel.AccountType);
 
             _securitySeeder.SeedSecurity(security);
         }

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -272,7 +272,9 @@ namespace QuantConnect.Securities
             var openOrders = portfolio.Transactions.GetOpenOrders(x =>
                 {
                     OrderDirection dir;
-                    return symbolDirectionPairs.TryGetValue(x.Symbol, out dir) && dir == x.Direction;
+                    return symbolDirectionPairs.TryGetValue(x.Symbol, out dir) &&
+                           dir == x.Direction &&
+                           x.Type == OrderType.Limit;
                 }
             );
 

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -1,0 +1,301 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Represents a buying power model for cash accounts
+    /// </summary>
+    public class CashBuyingPowerModel : IBuyingPowerModel
+    {
+        /// <summary>
+        /// Gets the current leverage of the security
+        /// </summary>
+        /// <param name="security">The security to get leverage for</param>
+        /// <returns>The current leverage in the security</returns>
+        public decimal GetLeverage(Security security)
+        {
+            // Always returns 1. Cash accounts have no leverage.
+            return 1m;
+        }
+
+        /// <summary>
+        /// Sets the leverage for the applicable securities, i.e, equities
+        /// </summary>
+        /// <remarks>
+        /// This is added to maintain backwards compatibility with the old margin/leverage system
+        /// </remarks>
+        /// <param name="security">The security to set leverage for</param>
+        /// <param name="leverage">The new leverage</param>
+        public void SetLeverage(Security security, decimal leverage)
+        {
+            // No action performed. This model always uses a leverage = 1
+        }
+
+        /// <summary>
+        /// Check if there is sufficient buying power to execute this order.
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="security">The security to be traded</param>
+        /// <param name="order">The order to be checked</param>
+        /// <returns>Returns true if there is sufficient buying power to execute the order, false otherwise</returns>
+        public bool HasSufficientBuyingPowerForOrder(SecurityPortfolioManager portfolio, Security security, Order order)
+        {
+            var baseCurrency = security as IBaseCurrencySymbol;
+            if (baseCurrency == null) return false;
+
+            decimal totalQuantity;
+            decimal orderQuantity;
+            if (order.Direction == OrderDirection.Buy)
+            {
+                // quantity available for buying in quote currency
+                totalQuantity = portfolio.CashBook[security.QuoteCurrency.Symbol].Amount;
+                orderQuantity = order.AbsoluteQuantity * GetOrderPrice(security, order);
+            }
+            else
+            {
+                // quantity available for selling in base currency
+                totalQuantity = portfolio.CashBook[baseCurrency.BaseCurrencySymbol].Amount;
+                orderQuantity = order.AbsoluteQuantity;
+            }
+
+            // calculate reserved quantity for open orders (in quote or base currency depending on direction)
+            var openOrdersReservedQuantity = GetOpenOrdersReservedQuantity(portfolio, security, order.Direction);
+
+            if (order.Type == OrderType.Market)
+            {
+                // find a target value in account currency for market orders
+                var targetValue = order.Direction == OrderDirection.Buy
+                    ? portfolio.CashBook.ConvertToAccountCurrency(totalQuantity - openOrdersReservedQuantity, security.QuoteCurrency.Symbol)
+                    : portfolio.CashBook.ConvertToAccountCurrency(openOrdersReservedQuantity, baseCurrency.BaseCurrencySymbol);
+
+                var maximumQuantity = GetMaximumOrderQuantityForTargetValue(portfolio, security, targetValue);
+                if (order.Direction == OrderDirection.Buy)
+                {
+                    maximumQuantity *= GetOrderPrice(security, order);
+                }
+                return orderQuantity <= Math.Abs(maximumQuantity);
+            }
+
+            // for non market orders, add fees to the order cost
+            var orderFee = security.FeeModel.GetOrderFee(security, order);
+            orderFee = portfolio.CashBook.Convert(orderFee, CashBook.AccountCurrency,
+                order.Direction == OrderDirection.Buy
+                    ? security.QuoteCurrency.Symbol
+                    : baseCurrency.BaseCurrencySymbol);
+
+            return orderQuantity <= totalQuantity - openOrdersReservedQuantity - orderFee;
+        }
+
+        /// <summary>
+        /// Get the maximum market order quantity to obtain a position with a given value in account currency
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="security">The security to be traded</param>
+        /// <param name="targetPortfolioValue">The value in account currency that we want our holding to have</param>
+        /// <returns>Returns the maximum allowed market order quantity</returns>
+        public decimal GetMaximumOrderQuantityForTargetValue(SecurityPortfolioManager portfolio, Security security, decimal targetPortfolioValue)
+        {
+            // TODO: still needs cleanup + fix account currency conversions
+
+            var baseCurrency = security as IBaseCurrencySymbol;
+            if (baseCurrency == null) return 0;
+
+            var baseCurrencyPosition = portfolio.CashBook[baseCurrency.BaseCurrencySymbol].Amount;
+            var quoteCurrencyPosition = portfolio.CashBook[security.QuoteCurrency.Symbol].Amount;
+
+            // determine the unit price in terms of the account currency
+            var unitPrice = new MarketOrder(security.Symbol, 1, DateTime.UtcNow).GetValue(security) / security.QuoteCurrency.ConversionRate;
+            if (unitPrice == 0) return 0;
+
+            var currentHoldingsValue = baseCurrencyPosition * portfolio.CashBook[baseCurrency.BaseCurrencySymbol].ConversionRate;
+
+
+            // remove directionality, we'll work in the land of absolutes
+            var targetOrderValue = Math.Abs(targetPortfolioValue - currentHoldingsValue);
+            var direction = targetPortfolioValue > currentHoldingsValue ? OrderDirection.Buy : OrderDirection.Sell;
+
+
+            // calculate the total margin available
+            var marginRemaining = direction == OrderDirection.Buy ? quoteCurrencyPosition : currentHoldingsValue;
+            if (marginRemaining <= 0) return 0;
+
+            // continue iterating while we do not have enough margin for the order
+            decimal marginRequired;
+            decimal orderValue;
+            decimal orderFees;
+            var feeToPriceRatio = 0m;
+
+            // compute the initial order quantity
+            var orderQuantity = targetOrderValue / unitPrice;
+
+            // rounding off Order Quantity to the nearest multiple of Lot Size
+            orderQuantity -= orderQuantity % security.SymbolProperties.LotSize;
+
+            do
+            {
+                // reduce order quantity by feeToPriceRatio, since it is faster than by lot size
+                // if it becomes nonpositive, return zero
+                orderQuantity -= feeToPriceRatio;
+                if (orderQuantity <= 0) return 0;
+
+                // generate the order
+                var order = new MarketOrder(security.Symbol, orderQuantity, DateTime.UtcNow);
+                orderValue = order.GetValue(security);
+                orderFees = security.FeeModel.GetOrderFee(security, order);
+
+                // find an incremental delta value for the next iteration step
+                feeToPriceRatio = orderFees / unitPrice;
+                feeToPriceRatio -= feeToPriceRatio % security.SymbolProperties.LotSize;
+                if (feeToPriceRatio < security.SymbolProperties.LotSize)
+                {
+                    feeToPriceRatio = security.SymbolProperties.LotSize;
+                }
+
+                // calculate the margin required for the order
+                marginRequired = orderValue;
+
+            } while (marginRequired > marginRemaining || orderValue + orderFees > targetOrderValue);
+
+            // add directionality back in
+            return (direction == OrderDirection.Sell ? -1 : 1) * orderQuantity;
+        }
+
+        /// <summary>
+        /// Gets the amount of buying power reserved to maintain the specified position
+        /// </summary>
+        /// <param name="security">The security for the position</param>
+        /// <returns>The reserved buying power in account currency</returns>
+        public decimal GetReservedBuyingPowerForPosition(Security security)
+        {
+            // Always returns 0. Since we're purchasing currencies outright, the position doesn't consume buying power
+            return 0;
+        }
+
+        /// <summary>
+        /// Gets the buying power available for a trade
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="security">The security to be traded</param>
+        /// <param name="direction">The direction of the trade</param>
+        /// <returns>The buying power available for the trade</returns>
+        public decimal GetBuyingPower(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)
+        {
+            var baseCurrency = security as IBaseCurrencySymbol;
+            if (baseCurrency == null) return 0;
+
+            var baseCurrencyPosition = portfolio.CashBook[baseCurrency.BaseCurrencySymbol].Amount;
+            var quoteCurrencyPosition = portfolio.CashBook[security.QuoteCurrency.Symbol].Amount;
+
+            // determine the unit price in terms of the quote currency
+            var unitPrice = new MarketOrder(security.Symbol, 1, DateTime.UtcNow).GetValue(security) / security.QuoteCurrency.ConversionRate;
+            if (unitPrice == 0) return 0;
+
+            if (direction == OrderDirection.Buy)
+                return quoteCurrencyPosition / unitPrice;
+
+            if (direction == OrderDirection.Sell)
+                return baseCurrencyPosition;
+
+            return 0;
+        }
+
+        private static decimal GetOrderPrice(Security security, Order order)
+        {
+            var orderPrice = 0m;
+            switch (order.Type)
+            {
+                case OrderType.Market:
+                    orderPrice = security.Price;
+                    break;
+
+                case OrderType.Limit:
+                    orderPrice = ((LimitOrder)order).LimitPrice;
+                    break;
+
+                case OrderType.StopMarket:
+                    orderPrice = ((StopMarketOrder)order).StopPrice;
+                    break;
+
+                case OrderType.StopLimit:
+                    orderPrice = ((StopLimitOrder)order).LimitPrice;
+                    break;
+            }
+
+            return orderPrice;
+        }
+
+        private static decimal GetOpenOrdersReservedQuantity(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)
+        {
+            var baseCurrency = security as IBaseCurrencySymbol;
+            if (baseCurrency == null) return 0;
+
+            // find the target currency for the requested direction and the securities potentially involved
+            var targetCurrency = direction == OrderDirection.Buy
+                ? security.QuoteCurrency.Symbol
+                : baseCurrency.BaseCurrencySymbol;
+
+            var symbolDirectionPairs = new Dictionary<Symbol, OrderDirection>();
+            foreach (var portfolioSecurity in portfolio.Securities.Values)
+            {
+                var basePortfolioSecurity = portfolioSecurity as IBaseCurrencySymbol;
+                if (basePortfolioSecurity == null) continue;
+
+                if (basePortfolioSecurity.BaseCurrencySymbol == targetCurrency)
+                {
+                    symbolDirectionPairs.Add(portfolioSecurity.Symbol, OrderDirection.Sell);
+                }
+                else if (portfolioSecurity.QuoteCurrency.Symbol == targetCurrency)
+                {
+                    symbolDirectionPairs.Add(portfolioSecurity.Symbol, OrderDirection.Buy);
+                }
+            }
+
+            // fetch open orders with matching symbol/side
+            var openOrders = portfolio.Transactions.GetOpenOrders(x =>
+                {
+                    OrderDirection dir;
+                    return symbolDirectionPairs.TryGetValue(x.Symbol, out dir) && dir == x.Direction;
+                }
+            );
+
+            // calculate reserved quantity for selected orders
+            var openOrdersReservedQuantity = 0m;
+            foreach (var openOrder in openOrders)
+            {
+                var orderSecurity = portfolio.Securities[openOrder.Symbol];
+                var orderBaseCurrency = orderSecurity as IBaseCurrencySymbol;
+
+                if (orderBaseCurrency != null)
+                {
+                    // convert order value to target currency
+                    var quantityInTargetCurrency = openOrder.AbsoluteQuantity;
+                    if (orderSecurity.QuoteCurrency.Symbol == targetCurrency)
+                    {
+                        quantityInTargetCurrency *= GetOrderPrice(security, openOrder);
+                    }
+
+                    openOrdersReservedQuantity += quantityInTargetCurrency;
+                }
+            }
+
+            return openOrdersReservedQuantity;
+        }
+    }
+}

--- a/Common/Securities/Crypto/Crypto.cs
+++ b/Common/Securities/Crypto/Crypto.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Securities.Crypto
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginModel(50m),
+                new CashBuyingPowerModel(),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel()
                 )
@@ -75,11 +75,11 @@ namespace QuantConnect.Securities.Crypto
                 new ForexCache(),
                 new SecurityPortfolioModel(),
                 new ImmediateFillModel(),
-                new ConstantFeeModel(0),
+                new GDAXFeeModel(),
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginModel(50m),
+                new CashBuyingPowerModel(),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel()
                 )

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -273,6 +273,16 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Get a list of open orders satisfying the filter.
+        /// </summary>
+        /// <returns>List of open orders.</returns>
+        public List<Order> GetOpenOrders(Func<Order, bool> filter)
+        {
+            filter = filter ?? (x => true);
+            return _orderProcessor.GetOrders(x => x.Status.IsOpen() && filter(x)).ToList();
+        }
+
+        /// <summary>
         /// Gets the current number of orders that have been processed
         /// </summary>
         public int OrdersCount

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -984,9 +984,9 @@ namespace QuantConnect.Tests.Algorithm
             btcusd.TransactionModel = new ConstantFeeTransactionModel(0);
             // Set Price to $26
             Update(btcusd, 26);
-            // So -100000/26 = 3846.153846153846, After Rounding off becomes -3846.15384615, since lot size is 0.00000001
+            // Cash model does not allow shorts
             actual = algo.CalculateOrderQuantity(Symbols.BTCUSD, -1m);
-            Assert.AreEqual(-3846.15384615m, actual);
+            Assert.AreEqual(0, actual);
         }
 
         [Test]

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -22,33 +22,39 @@ using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
-    [TestFixture()]
+    [TestFixture]
     public class GDAXBrokerageModelTests
     {
+        private readonly GDAXBrokerageModel _unit = new GDAXBrokerageModel();
 
-        GDAXBrokerageModel _unit = new GDAXBrokerageModel();
-
-        [Test()]
+        [Test]
         public void GetLeverageTest()
         {
-            Assert.AreEqual(3, _unit.GetLeverage(GDAXTestsHelpers.GetSecurity()));
+            Assert.AreEqual(1, _unit.GetLeverage(GDAXTestsHelpers.GetSecurity()));
         }
 
-        [Test()]
+        [Test]
         public void GetFeeModelTest()
         {
             Assert.IsInstanceOf<GDAXFeeModel>(_unit.GetFeeModel(GDAXTestsHelpers.GetSecurity()));
         }
 
-        [Test()]
+        [Test]
+        public void GetBuyingPowerModelTest()
+        {
+            Assert.IsInstanceOf<CashBuyingPowerModel>(_unit.GetBuyingPowerModel(GDAXTestsHelpers.GetSecurity(), AccountType.Cash));
+        }
+
+        [Test]
         public void CanUpdateOrderTest()
         {
             BrokerageMessageEvent message;
-            Assert.AreEqual(false, _unit.CanUpdateOrder(GDAXTestsHelpers.GetSecurity(), Mock.Of<QuantConnect.Orders.Order>(),
-                new QuantConnect.Orders.UpdateOrderRequest(DateTime.UtcNow, 1, new QuantConnect.Orders.UpdateOrderFields()), out message));
+            Assert.AreEqual(false, _unit.CanUpdateOrder(GDAXTestsHelpers.GetSecurity(), Mock.Of<Order>(),
+                new UpdateOrderRequest(DateTime.UtcNow, 1, new UpdateOrderFields()), out message));
         }
 
         [TestCase(true)]
@@ -56,7 +62,7 @@ namespace QuantConnect.Tests.Common.Brokerages
         public void CanSubmitOrder_WhenBrokerageIdIsCorrect(bool isUpdate)
         {
             BrokerageMessageEvent message;
-            var order = new Mock<QuantConnect.Orders.Order>();
+            var order = new Mock<Order>();
             order.Object.Quantity = 10.0m;
 
             if (isUpdate)
@@ -72,7 +78,7 @@ namespace QuantConnect.Tests.Common.Brokerages
         public void CanSubmitOrder_WhenQuantityIsLargeEnough(decimal orderQuantity, bool isValidOrderQuantity)
         {
             BrokerageMessageEvent message;
-            var order = new Mock<QuantConnect.Orders.Order>();
+            var order = new Mock<Order>();
 
             order.Object.Quantity = orderQuantity;
 
@@ -88,7 +94,7 @@ namespace QuantConnect.Tests.Common.Brokerages
         public void CanOnlySubmitCryptoOrders(SecurityType securityType, bool isValidSecurityType)
         {
             BrokerageMessageEvent message;
-            var order = new Mock<QuantConnect.Orders.Order>();
+            var order = new Mock<Order>();
             order.Object.Quantity = 10.0m;
 
             Assert.AreEqual(isValidSecurityType, _unit.CanSubmitOrder(GDAXTestsHelpers.GetSecurity(1.0m, securityType), order.Object, out message));

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -136,5 +136,14 @@ namespace QuantConnect.Tests.Common.Brokerages
 
             Assert.AreEqual(0, orderFee);
         }
+
+        [Test]
+        public void ThrowsWhenCalledWithMarginAccountType()
+        {
+            Assert.Throws<Exception>(() =>
+            {
+                new GDAXBrokerageModel(AccountType.Margin);
+            }, "The GDAX brokerage does not currently support Margin trading.");
+        }
     }
 }

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -293,13 +293,13 @@ namespace QuantConnect.Tests.Common.Securities
             _btcusd.SetMarketPrice(new Tick { Value = 10000m });
             _portfolio.SetCash("BTC", 0.5m, 10000m);
 
-            // 0.5 BTC in portfolio, cannot sell 0.5 BTC (fees are excluded)
+            // 0.5 BTC in portfolio, can sell 0.5 BTC
             var order = new MarketOrder(_btcusd.Symbol, -0.5m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
-
-            // 0.5 BTC in portfolio, can sell 0.45 BTC (plus fees)
-            order = new MarketOrder(_btcusd.Symbol, -0.45m, DateTime.UtcNow);
             Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // 0.5 BTC in portfolio, cannot sell 0.51 BTC
+            order = new MarketOrder(_btcusd.Symbol, -0.51m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
 
             // Maximum we can market sell with 0.5 BTC is 0.49875 BTC
             Assert.AreEqual(-0.49875m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 0));
@@ -358,16 +358,16 @@ namespace QuantConnect.Tests.Common.Securities
             // ETHBTC buy order decreases available BTC (0.9 - 0.1 = 0.8 BTC)
             SubmitLimitOrder(_ethbtc.Symbol, 1m, 0.1m);
 
-            // Maximum we can market sell with 0.8 BTC is 0.798 BTC
+            // Maximum we can market sell with 0.8 BTC is 0.798 BTC (for a target position of 0.2 BTC)
             // target value = (1 - 0.8) * price
             Assert.AreEqual(-0.798m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 0.2m * 15000));
 
-            // 0.8 BTC available, can sell 0.79 BTC at any price
-            var order = new MarketOrder(_btcusd.Symbol, -0.79m, DateTime.UtcNow);
+            // 0.8 BTC available, can sell 0.80 BTC at market
+            var order = new MarketOrder(_btcusd.Symbol, -0.80m, DateTime.UtcNow);
             Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
 
-            // 0.8 BTC available, cannot sell 0.8 BTC at any price
-            order = new MarketOrder(_btcusd.Symbol, -0.8m, DateTime.UtcNow);
+            // 0.8 BTC available, cannot sell 0.81 BTC at market
+            order = new MarketOrder(_btcusd.Symbol, -0.81m, DateTime.UtcNow);
             Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
         }
 

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -1,0 +1,400 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages.Backtesting;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Crypto;
+using QuantConnect.Tests.Engine;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class CashBuyingPowerModelTests
+    {
+        private Crypto _btcusd;
+        private Crypto _btceur;
+        private Crypto _ethusd;
+        private Crypto _ethbtc;
+        private SecurityPortfolioManager _portfolio;
+        private BacktestingTransactionHandler _transactionHandler;
+        private BacktestingBrokerage _brokerage;
+        private CashBuyingPowerModel _buyingPowerModel;
+        private QCAlgorithm _algorithm;
+
+        [SetUp]
+        public void Initialize()
+        {
+            _algorithm = new QCAlgorithm();
+            _portfolio = _algorithm.Portfolio;
+            _portfolio.CashBook.Add("EUR", 0, 1.20m);
+            _portfolio.CashBook.Add("BTC", 0, 15000m);
+            _portfolio.CashBook.Add("ETH", 0, 1000m);
+
+            _transactionHandler = new BacktestingTransactionHandler();
+            _brokerage = new BacktestingBrokerage(_algorithm);
+            _transactionHandler.Initialize(_algorithm, _brokerage, new TestResultHandler());
+            new Thread(_transactionHandler.Run) { IsBackground = true }.Start();
+
+            _algorithm.Transactions.SetOrderProcessor(_transactionHandler);
+
+            var tz = TimeZones.NewYork;
+            _btcusd = new Crypto(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                _portfolio.CashBook[CashBook.AccountCurrency],
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCUSD, Resolution.Minute, tz, tz, true, false, false),
+                new SymbolProperties("BTCUSD", "USD", 1, 0.01m, 0.00000001m))
+            {
+                FeeModel = new GDAXFeeModel()
+            };
+
+            _ethusd = new Crypto(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                _portfolio.CashBook[CashBook.AccountCurrency],
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.ETHUSD, Resolution.Minute, tz, tz, true, false, false),
+                new SymbolProperties("ETHUSD", "USD", 1, 0.01m, 0.00000001m))
+            {
+                FeeModel = new GDAXFeeModel()
+            };
+
+            _btceur = new Crypto(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                _portfolio.CashBook["EUR"],
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCEUR, Resolution.Minute, tz, tz, true, false, false),
+                new SymbolProperties("BTCEUR", "EUR", 1, 0.01m, 0.00000001m))
+            {
+                FeeModel = new GDAXFeeModel()
+            };
+
+            _ethbtc = new Crypto(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                _portfolio.CashBook["BTC"],
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.ETHBTC, Resolution.Minute, tz, tz, true, false, false),
+                new SymbolProperties("ETHBTC", "BTC", 1, 0.00001m, 0.00000001m))
+            {
+                FeeModel = new GDAXFeeModel()
+            };
+
+            _buyingPowerModel = new CashBuyingPowerModel();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _transactionHandler.Exit();
+        }
+
+        [Test]
+        public void InitializesCorrectly()
+        {
+            Assert.AreEqual(1m, _buyingPowerModel.GetLeverage(_btcusd));
+            Assert.AreEqual(0m, _buyingPowerModel.GetReservedBuyingPowerForPosition(_btcusd));
+        }
+
+        [Test]
+        public void SetLeverageDoesNotUpdateLeverage()
+        {
+            // leverage cannot be set, will always be 1x
+            _buyingPowerModel.SetLeverage(_btcusd, 50m);
+            Assert.AreEqual(1m, _buyingPowerModel.GetLeverage(_btcusd));
+        }
+
+        [Test]
+        public void LimitBuyOrderRequiresQuoteCurrencyInPortfolio()
+        {
+            _portfolio.SetCash(20000);
+
+            // Available cash = 20000, can buy 2 BTC at 10000
+            var order = new LimitOrder(_btcusd.Symbol, 2m, 10000m, DateTime.UtcNow);
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // Available cash = 20000, cannot buy 2.1 BTC at 10000, need 21000
+            order = new LimitOrder(_btcusd.Symbol, 2.1m, 10000m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // Available cash = 20000, cannot buy 2 BTC at 11000, need 22000
+            order = new LimitOrder(_btcusd.Symbol, 2m, 11000m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+        }
+
+        [Test]
+        public void LimitSellOrderRequiresBaseCurrencyInPortfolio()
+        {
+            _portfolio.SetCash(0);
+            _portfolio.CashBook["BTC"].SetAmount(0.5m);
+
+            // 0.5 BTC in portfolio, can sell 0.5 BTC at any price
+            var order = new LimitOrder(_btcusd.Symbol, -0.5m, 10000m, DateTime.UtcNow);
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // 0.5 BTC in portfolio, cannot sell 0.6 BTC at any price
+            order = new LimitOrder(_btcusd.Symbol, -0.6m, 10000m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+        }
+
+        [Test]
+        public void LimitBuyOrderChecksOpenOrders()
+        {
+            _portfolio.SetCash(5000);
+
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+            _btcusd.FeeModel = new GDAXFeeModel();
+            _btcusd.SetMarketPrice(new Tick { Value = 15000m });
+
+            _ethusd = _algorithm.AddCrypto("ETHUSD");
+            _ethusd.FeeModel = new GDAXFeeModel();
+            _ethusd.SetMarketPrice(new Tick { Value = 1000m });
+            _algorithm.SetFinishedWarmingUp();
+
+            // BTCUSD buy order decreases available USD (5000 - 1500 = 3500 USD)
+            SubmitLimitOrder(_btcusd.Symbol, 0.1m, 15000m);
+
+            // ETHUSD buy order decreases available USD (3500 - 3000 = 500 USD)
+            SubmitLimitOrder(_ethusd.Symbol, 3m, 1000m);
+
+            // 500 USD available, can buy 0.05 BTC at 10000
+            var order = new LimitOrder(_btcusd.Symbol, 0.05m, 10000m, DateTime.UtcNow);
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // 500 USD available, cannot buy 0.06 BTC at 10000
+            order = new LimitOrder(_btcusd.Symbol, 0.06m, 10000m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+        }
+
+        [Test]
+        public void LimitSellOrderChecksOpenOrders()
+        {
+            _portfolio.SetCash(5000);
+            _portfolio.CashBook["BTC"].SetAmount(1m);
+            _portfolio.CashBook["ETH"].SetAmount(3m);
+
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+            _btcusd.FeeModel = new GDAXFeeModel();
+            _btcusd.SetMarketPrice(new Tick { Value = 15000m });
+
+            _ethusd = _algorithm.AddCrypto("ETHUSD");
+            _ethusd.FeeModel = new GDAXFeeModel();
+            _ethusd.SetMarketPrice(new Tick { Value = 1000m });
+
+            _ethbtc = _algorithm.AddCrypto("ETHBTC");
+            _ethbtc.FeeModel = new GDAXFeeModel();
+            _ethbtc.SetMarketPrice(new Tick { Value = 0.1m });
+            _algorithm.SetFinishedWarmingUp();
+
+            // BTCUSD sell order decreases available BTC (1 - 0.1 = 0.9 BTC)
+            SubmitLimitOrder(_btcusd.Symbol, -0.1m, 15000m);
+
+            // ETHUSD sell order decreases available ETH (3 - 1 = 2 ETH)
+            SubmitLimitOrder(_ethusd.Symbol, -1m, 1000m);
+
+            // ETHBTC buy order decreases available BTC (0.9 - 0.1 = 0.8 BTC)
+            SubmitLimitOrder(_ethbtc.Symbol, 1m, 0.1m);
+
+            // 0.8 BTC available, can sell 0.8 BTC at any price
+            var order = new LimitOrder(_btcusd.Symbol, -0.8m, 10000m, DateTime.UtcNow);
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // 0.8 BTC available, cannot sell 0.9 BTC at any price
+            order = new LimitOrder(_btcusd.Symbol, -0.9m, 10000m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // 2 ETH available, can sell 2 ETH at any price
+            order = new LimitOrder(_ethusd.Symbol, -2m, 1200m, DateTime.UtcNow);
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _ethusd, order));
+
+            // 2 ETH available, cannot sell 2.1 ETH at any price
+            order = new LimitOrder(_ethusd.Symbol, -2.1m, 2000m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _ethusd, order));
+        }
+
+        [Test]
+        public void MarketBuyOrderRequiresQuoteCurrencyInPortfolioPlusFees()
+        {
+            _portfolio.SetCash(20000);
+
+            _btcusd.SetMarketPrice(new Tick { Value = 10000m });
+            _portfolio.SetCash("BTC", 0, 10000m);
+
+            // Available cash = 20000, cannot buy 2 BTC at 10000 (fees are excluded)
+            var order = new MarketOrder(_btcusd.Symbol, 2m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // Maximum we can market buy with 20000 USD is 1.995 BTC
+            Assert.AreEqual(1.995m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 20000));
+
+            _btcusd.SetMarketPrice(new Tick { Value = 9900m });
+            _portfolio.SetCash("BTC", 0, 9900m);
+
+            // Available cash = 20000, can buy 2 BTC at 9900 (plus fees)
+            order = new MarketOrder(_btcusd.Symbol, 2m, DateTime.UtcNow);
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+        }
+
+        [Test]
+        public void MarketSellOrderRequiresBaseCurrencyInPortfolioPlusFees()
+        {
+            _portfolio.SetCash(0);
+
+            _btcusd.SetMarketPrice(new Tick { Value = 10000m });
+            _portfolio.SetCash("BTC", 0.5m, 10000m);
+
+            // 0.5 BTC in portfolio, cannot sell 0.5 BTC (fees are excluded)
+            var order = new MarketOrder(_btcusd.Symbol, -0.5m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // 0.5 BTC in portfolio, can sell 0.45 BTC (plus fees)
+            order = new MarketOrder(_btcusd.Symbol, -0.45m, DateTime.UtcNow);
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // Maximum we can market sell with 0.5 BTC is 0.49875 BTC
+            Assert.AreEqual(-0.49875m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 0));
+        }
+
+        [Test]
+        public void MarketBuyOrderChecksOpenOrders()
+        {
+            _portfolio.SetCash(5000);
+
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+            _btcusd.FeeModel = new GDAXFeeModel();
+            _btcusd.SetMarketPrice(new Tick { Value = 15000m });
+
+            _ethusd = _algorithm.AddCrypto("ETHUSD");
+            _ethusd.FeeModel = new GDAXFeeModel();
+            _ethusd.SetMarketPrice(new Tick { Value = 1000m });
+            _algorithm.SetFinishedWarmingUp();
+
+            // BTCUSD buy order decreases available USD (5000 - 1500 = 3500 USD)
+            SubmitLimitOrder(_btcusd.Symbol, 0.1m, 15000m);
+
+            // ETHUSD buy order decreases available USD (3500 - 3000 = 500 USD)
+            SubmitLimitOrder(_ethusd.Symbol, 3m, 1000m);
+
+            // Maximum we can market buy with 500 USD is 0.03325 BTC
+            Assert.AreEqual(0.03325m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 500));
+
+            // 500 USD available, can buy 0.03 BTC at 15000
+            var order = new MarketOrder(_btcusd.Symbol, 0.03m, DateTime.UtcNow);
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // 500 USD available, cannot buy 0.04 BTC at 15000
+            order = new MarketOrder(_btcusd.Symbol, 0.04m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+        }
+
+        [Test]
+        public void MarketSellOrderChecksOpenOrders()
+        {
+            _portfolio.SetCash(5000);
+            _portfolio.CashBook["BTC"].SetAmount(1m);
+            _portfolio.CashBook["ETH"].SetAmount(3m);
+
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+            _btcusd.FeeModel = new GDAXFeeModel();
+            _btcusd.SetMarketPrice(new Tick { Value = 15000m });
+
+            _ethusd = _algorithm.AddCrypto("ETHUSD");
+            _ethusd.FeeModel = new GDAXFeeModel();
+            _ethusd.SetMarketPrice(new Tick { Value = 1000m });
+
+            _ethbtc = _algorithm.AddCrypto("ETHBTC");
+            _ethbtc.FeeModel = new GDAXFeeModel();
+            _ethbtc.SetMarketPrice(new Tick { Value = 0.1m });
+            _algorithm.SetFinishedWarmingUp();
+
+            // BTCUSD sell order decreases available BTC (1 - 0.1 = 0.9 BTC)
+            SubmitLimitOrder(_btcusd.Symbol, -0.1m, 15000m);
+
+            // ETHBTC buy order decreases available BTC (0.9 - 0.1 = 0.8 BTC)
+            SubmitLimitOrder(_ethbtc.Symbol, 1m, 0.1m);
+
+            // Maximum we can market sell with 0.8 BTC is 0.798 BTC
+            // target value = (1 - 0.8) * price
+            Assert.AreEqual(-0.798m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 0.2m * 15000));
+
+            // 0.8 BTC available, can sell 0.79 BTC at any price
+            var order = new MarketOrder(_btcusd.Symbol, -0.79m, DateTime.UtcNow);
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // 0.8 BTC available, cannot sell 0.8 BTC at any price
+            order = new MarketOrder(_btcusd.Symbol, -0.8m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+        }
+
+        [Test]
+        public void LimitBuyOrderIncludesFees()
+        {
+            _portfolio.SetCash(20000);
+            _btcusd.FeeModel = new ConstantFeeModel(50);
+
+            // Available cash = 20000, cannot buy 2 BTC at 10000 because of order fee
+            var order = new LimitOrder(_btcusd.Symbol, 2m, 10000m, DateTime.UtcNow);
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+
+            // deposit another 50 USD
+            _portfolio.CashBook["USD"].AddAmount(50);
+
+            // now the order is allowed
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+        }
+
+        [Test]
+        public void CalculatesMaximumOrderQuantityCorrectly()
+        {
+            _portfolio.SetCash(10000);
+
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+            _btcusd.FeeModel = new GDAXFeeModel();
+            _btcusd.SetMarketPrice(new Tick { Value = 15000m });
+
+            _ethusd = _algorithm.AddCrypto("ETHUSD");
+            _ethusd.FeeModel = new GDAXFeeModel();
+            _ethusd.SetMarketPrice(new Tick { Value = 1000m });
+
+            _ethbtc = _algorithm.AddCrypto("ETHBTC");
+            _ethbtc.FeeModel = new GDAXFeeModel();
+            _ethbtc.SetMarketPrice(new Tick { Value = 0.1m });
+            _algorithm.SetFinishedWarmingUp();
+
+            // 0.665 * 15000 + fees <= 10000 USD
+            Assert.AreEqual(0.665m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 10000));
+
+            // 9.97 * 1000 + fees <= 10000 USD
+            Assert.AreEqual(9.97m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _ethusd, 10000));
+
+            // no BTC in portfolio, cannot buy ETH with BTC
+            Assert.AreEqual(0m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _ethbtc, 10000));
+        }
+
+        private void SubmitLimitOrder(Symbol symbol, decimal quantity, decimal limitPrice)
+        {
+            var resetEvent = new ManualResetEvent(false);
+
+            _brokerage.OrderStatusChanged += (s, e) => { resetEvent.Set(); };
+
+            _algorithm.LimitOrder(symbol, quantity, limitPrice);
+
+            resetEvent.WaitOne();
+        }
+    }
+}

--- a/Tests/Common/Util/LeanDataPathComponentsTests.cs
+++ b/Tests/Common/Util/LeanDataPathComponentsTests.cs
@@ -43,6 +43,7 @@ namespace QuantConnect.Tests.Common.Util
 
             var results = (
                 from securityType in securityTypes
+                where securityType != SecurityType.Commodity
                 from market in markets
                 from resolution in resolutions
                 from tickType in tickTypes

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Common\Orders\Fills\LatestPriceFillModelTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />
     <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />
+    <Compile Include="Common\Securities\CashBuyingPowerModelTests.cs" />
     <Compile Include="Common\Securities\Forex\ForexHoldingTest.cs" />
     <Compile Include="Common\Securities\FutureFilterTests.cs" />
     <Compile Include="Common\Securities\Futures\FuturesExpiryFunctionsTests.cs" />

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -674,6 +674,29 @@ namespace QuantConnect.Tests
                 {"Total Fees", "$14.80"}
             };
 
+            var basicTemplateCryptoAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "25"},
+                {"Average Win", "0%"},
+                {"Average Loss", "-0.46%"},
+                {"Compounding Annual Return", "-100.000%"},
+                {"Drawdown", "5.400%"},
+                {"Expectancy", "-1"},
+                {"Net Profit", "-5.656%"},
+                {"Sharpe Ratio", "-20.375"},
+                {"Loss Rate", "100%"},
+                {"Win Rate", "0%"},
+                {"Profit-Loss Ratio", "0"},
+                {"Alpha", "-11.165"},
+                {"Beta", "574.802"},
+                {"Annual Standard Deviation", "0.353"},
+                {"Annual Variance", "0.125"},
+                {"Information Ratio", "-20.43"},
+                {"Tracking Error", "0.353"},
+                {"Treynor Ratio", "-0.013"},
+                {"Total Fees", "$6076.32"}
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -704,6 +727,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("HourSplitRegressionAlgorithm", hourSplitStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("HourReverseSplitRegressionAlgorithm", hourReverseSplitStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("FractionalQuantityRegressionAlgorithm", fractionalQuantityRegressionStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("BasicTemplateCryptoAlgorithm", basicTemplateCryptoAlgorithmStatistics, Language.CSharp),
 
                 // Python
                 // new AlgorithmStatisticsTestParameters("BasicTemplateFuturesAlgorithmDaily", basicTemplateFuturesAlgorithmDailyStatistics, Language.Python),
@@ -733,6 +757,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("HourReverseSplitRegressionAlgorithm", hourReverseSplitStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("FractionalQuantityRegressionAlgorithm", fractionalQuantityRegressionStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("CustomIndicatorAlgorithm", basicTemplateStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("BasicTemplateCryptoAlgorithm", basicTemplateCryptoAlgorithmStatistics, Language.Python)
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),

--- a/Tests/Symbols.cs
+++ b/Tests/Symbols.cs
@@ -39,6 +39,8 @@ namespace QuantConnect.Tests
         public static readonly Symbol BTCUSD = CreateCryptoSymbol("BTCUSD");
         public static readonly Symbol LTCUSD = CreateCryptoSymbol("LTCUSD");
         public static readonly Symbol ETHUSD = CreateCryptoSymbol("ETHUSD");
+        public static readonly Symbol BTCEUR = CreateCryptoSymbol("BTCEUR");
+        public static readonly Symbol ETHBTC = CreateCryptoSymbol("ETHBTC");
 
         public static readonly Symbol DE10YBEUR = CreateCfdSymbol("DE10YBEUR", Market.FXCM);
         public static readonly Symbol XAGUSD = CreateCfdSymbol("XAGUSD", Market.FXCM);


### PR DESCRIPTION
This PR replaces PR #1420 and is chained to PR #1506.

#### Changes from PR #1506
- The `IMarginModel` interface was renamed to a more generic `IBuyingPowerModel` with new methods independent from margin calculations. Existing margin models were also renamed to corresponding buying power models.
- Margin specific code in `QCAlgorithm` and `SecurityPortfolioManager` was moved to the  `SecurityMarginBuyingPowerModel` class (previously called `SecurityMarginModel`), specifically the methods `GetSufficientCapitalForOrder` and `CalculateOrderQuantity`.
- The `IMarginCallModel` interface was also extended with a new `GetMarginCallOrders` method. This allows margin call model logic to be entirely contained in the implementations. Margin call model specific code in `SecurityPortfolioManager.ScanForMarginCall` was moved into the `DefaultMarginCallModel` class.

#### Changes in this PR
- The new `CashBuyingPowerModel` was added to support brokerages with Cash only accounts (e.g. GDAX)
  - when calculating buying (or selling) power, it takes open orders into account
  - this model is now the default buying power model for the `Crypto` security type and for `GDAXBrokerageModel`
- The default `AccountType` for GDAX has been changed to `AccountType.Cash`, since they do not currently support margin trading.
- New `BasicTemplateCryptoAlgorithm` was added (C# and Python)