### PR TITLE
Revert class name changes from #1506

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -402,7 +402,7 @@
     <Compile Include="Securities\Future\FutureExchange.cs" />
     <Compile Include="Securities\Future\FutureHolding.cs" />
     <Compile Include="Securities\Future\Futures.cs" />
-    <Compile Include="Securities\Future\FutureMarginBuyingPowerModel.cs" />
+    <Compile Include="Securities\Future\FutureMarginModel.cs" />
     <Compile Include="Securities\IDerivativeSecurityFilter.cs" />
     <Compile Include="Securities\Volatility\IndicatorVolatilityModel.cs" />
     <Compile Include="Securities\Interfaces\IContinuousContractModel.cs" />
@@ -431,9 +431,9 @@
     <Compile Include="Securities\Option\OptionStrategies.cs" />
     <Compile Include="Securities\Option\OptionStrategy.cs" />
     <Compile Include="Securities\Option\OptionSymbolProperties.cs" />
-    <Compile Include="Securities\Option\OptionMarginBuyingPowerModel.cs" />
+    <Compile Include="Securities\Option\OptionMarginModel.cs" />
     <Compile Include="Securities\Option\QLOptionPriceModel.cs" />
-    <Compile Include="Securities\PatternDayTradingMarginBuyingPowerModel.cs" />
+    <Compile Include="Securities\PatternDayTradingMarginModel.cs" />
     <Compile Include="Securities\Volatility\StandardDeviationOfReturnsVolatilityModel.cs" />
     <Compile Include="Securities\Volatility\RelativeStandardDeviationVolatilityModel.cs" />
     <Compile Include="Securities\SecurityDatabaseKey.cs" />
@@ -446,7 +446,7 @@
     <Compile Include="Securities\ISecurityPortfolioModel.cs" />
     <Compile Include="Securities\DefaultMarginCallModel.cs" />
     <Compile Include="Securities\SecurityPortfolioModel.cs" />
-    <Compile Include="Securities\SecurityMarginBuyingPowerModel.cs" />
+    <Compile Include="Securities\SecurityMarginModel.cs" />
     <Compile Include="Securities\ImmediateSettlementModel.cs" />
     <Compile Include="Securities\SymbolProperties.cs" />
     <Compile Include="Securities\SymbolPropertiesDatabase.cs" />

--- a/Common/Securities/Cfd/Cfd.cs
+++ b/Common/Securities/Cfd/Cfd.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Securities.Cfd
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(50m),
+                new SecurityMarginModel(50m),
                 new CfdDataFilter(),
                 new SecurityPriceVariationModel()
                 )
@@ -73,7 +73,7 @@ namespace QuantConnect.Securities.Cfd
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(50m),
+                new SecurityMarginModel(50m),
                 new CfdDataFilter(),
                 new SecurityPriceVariationModel()
                 )

--- a/Common/Securities/Crypto/Crypto.cs
+++ b/Common/Securities/Crypto/Crypto.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Securities.Crypto
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(50m),
+                new SecurityMarginModel(50m),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel()
                 )
@@ -79,7 +79,7 @@ namespace QuantConnect.Securities.Crypto
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(50m),
+                new SecurityMarginModel(50m),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel()
                 )

--- a/Common/Securities/DefaultMarginCallModel.cs
+++ b/Common/Securities/DefaultMarginCallModel.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.Securities
 
                     if (security.Holdings.Quantity != 0 && security.Price != 0)
                     {
-                        var buyingPowerModel = security.BuyingPowerModel as SecurityMarginBuyingPowerModel;
+                        var buyingPowerModel = security.BuyingPowerModel as SecurityMarginModel;
                         if (buyingPowerModel != null)
                         {
                             var maintenanceMarginRequirement = buyingPowerModel.GetMaintenanceMarginRequirement(security);

--- a/Common/Securities/Equity/Equity.cs
+++ b/Common/Securities/Equity/Equity.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.Securities.Equity
                 new ConstantSlippageModel(0m),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(2m),
+                new SecurityMarginModel(2m),
                 new EquityDataFilter(),
                 new AdjustedPriceVariationModel()
                 )
@@ -76,7 +76,7 @@ namespace QuantConnect.Securities.Equity
                 new ConstantSlippageModel(0m),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(2m),
+                new SecurityMarginModel(2m),
                 new EquityDataFilter(),
                 new AdjustedPriceVariationModel()
                 )

--- a/Common/Securities/Forex/Forex.cs
+++ b/Common/Securities/Forex/Forex.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Securities.Forex
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(50m),
+                new SecurityMarginModel(50m),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel()
                 )
@@ -78,7 +78,7 @@ namespace QuantConnect.Securities.Forex
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(50m),
+                new SecurityMarginModel(50m),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel()
                 )

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.Securities.Future
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new FutureMarginBuyingPowerModel(),
+                new FutureMarginModel(),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel()
                 )
@@ -89,7 +89,7 @@ namespace QuantConnect.Securities.Future
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new FutureMarginBuyingPowerModel(),
+                new FutureMarginModel(),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel()
                 )

--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -25,7 +25,7 @@ namespace QuantConnect.Securities.Future
     /// <summary>
     /// Represents a simple margining model for margining futures. Margin file contains Initial and Maintenance margins
     /// </summary>
-    public class FutureMarginBuyingPowerModel : SecurityMarginBuyingPowerModel
+    public class FutureMarginModel : SecurityMarginModel
     {
         private static readonly object DataFolderSymbolLock = new object();
 

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Securities.Option
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new OptionMarginBuyingPowerModel(),
+                new OptionMarginModel(),
                 new OptionDataFilter(),
                 new SecurityPriceVariationModel()
                 )
@@ -92,7 +92,7 @@ namespace QuantConnect.Securities.Option
                new ConstantSlippageModel(0),
                new ImmediateSettlementModel(),
                Securities.VolatilityModel.Null,
-               new OptionMarginBuyingPowerModel(),
+               new OptionMarginModel(),
                new OptionDataFilter(),
                new SecurityPriceVariationModel()
                )

--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -25,7 +25,7 @@ namespace QuantConnect.Securities.Option
     /// Options are not traded on margin. Margin requirements exist though for those portfolios with short positions.
     /// Current implementation covers only single long/naked short option positions.
     /// </remarks>
-    public class OptionMarginBuyingPowerModel : SecurityMarginBuyingPowerModel
+    public class OptionMarginModel : SecurityMarginModel
     {
         // initial margin
         private const decimal OptionMarginRequirement = 1;

--- a/Common/Securities/PatternDayTradingMarginModel.cs
+++ b/Common/Securities/PatternDayTradingMarginModel.cs
@@ -19,24 +19,24 @@ namespace QuantConnect.Securities
     /// Represents a simple margining model where margin/leverage depends on market state (open or close).
     /// During regular market hours, leverage is 4x, otherwise 2x
     /// </summary>
-    public class PatternDayTradingMarginBuyingPowerModel : SecurityMarginBuyingPowerModel
+    public class PatternDayTradingMarginModel : SecurityMarginModel
     {
         private readonly decimal _closedMarginCorrectionFactor;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PatternDayTradingMarginBuyingPowerModel" />
+        /// Initializes a new instance of the <see cref="PatternDayTradingMarginModel" />
         /// </summary>
-        public PatternDayTradingMarginBuyingPowerModel()
+        public PatternDayTradingMarginModel()
             : this(2.0m, 4.0m)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PatternDayTradingMarginBuyingPowerModel" />
+        /// Initializes a new instance of the <see cref="PatternDayTradingMarginModel" />
         /// </summary>
         /// <param name="closedMarketLeverage">Leverage used outside regular market hours</param>
         /// <param name="openMarketLeverage">Leverage used during regular market hours</param>
-        public PatternDayTradingMarginBuyingPowerModel(decimal closedMarketLeverage, decimal openMarketLeverage)
+        public PatternDayTradingMarginModel(decimal closedMarketLeverage, decimal openMarketLeverage)
             : base(openMarketLeverage)
         {
             _closedMarginCorrectionFactor = openMarketLeverage/closedMarketLeverage;

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -296,7 +296,7 @@ namespace QuantConnect.Securities
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(1m),
+                new SecurityMarginModel(1m),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel())
         {
@@ -317,7 +317,7 @@ namespace QuantConnect.Securities
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginBuyingPowerModel(1m),
+                new SecurityMarginModel(1m),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel()
                 )

--- a/Common/Securities/SecurityMarginModel.cs
+++ b/Common/Securities/SecurityMarginModel.cs
@@ -22,26 +22,26 @@ namespace QuantConnect.Securities
     /// <summary>
     /// Represents a simple, constant margining model by specifying the percentages of required margin.
     /// </summary>
-    public class SecurityMarginBuyingPowerModel : IBuyingPowerModel
+    public class SecurityMarginModel : IBuyingPowerModel
     {
         private decimal _initialMarginRequirement;
         private decimal _maintenanceMarginRequirement;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SecurityMarginBuyingPowerModel"/> with no leverage (1x)
+        /// Initializes a new instance of the <see cref="SecurityMarginModel"/> with no leverage (1x)
         /// </summary>
-        public SecurityMarginBuyingPowerModel() : this(1m)
+        public SecurityMarginModel() : this(1m)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SecurityMarginBuyingPowerModel"/>
+        /// Initializes a new instance of the <see cref="SecurityMarginModel"/>
         /// </summary>
         /// <param name="initialMarginRequirement">The percentage of an order's absolute cost
         /// that must be held in free cash in order to place the order</param>
         /// <param name="maintenanceMarginRequirement">The percentage of the holding's absolute
         /// cost that must be held in free cash in order to avoid a margin call</param>
-        public SecurityMarginBuyingPowerModel(decimal initialMarginRequirement, decimal maintenanceMarginRequirement)
+        public SecurityMarginModel(decimal initialMarginRequirement, decimal maintenanceMarginRequirement)
         {
             if (initialMarginRequirement < 0 || initialMarginRequirement > 1)
             {
@@ -58,10 +58,10 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SecurityMarginBuyingPowerModel"/>
+        /// Initializes a new instance of the <see cref="SecurityMarginModel"/>
         /// </summary>
         /// <param name="leverage">The leverage</param>
-        public SecurityMarginBuyingPowerModel(decimal leverage)
+        public SecurityMarginModel(decimal leverage)
         {
             if (leverage < 1)
             {

--- a/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
+++ b/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
@@ -29,9 +29,9 @@ namespace QuantConnect.Tests.Algorithm
     public class AlgorithmSetHoldingsTests
     {
         // Test class to enable calling protected methods
-        public class TestSecurityMarginBuyingPowerModel : SecurityMarginBuyingPowerModel
+        public class TestSecurityMarginModel : SecurityMarginModel
         {
-            public TestSecurityMarginBuyingPowerModel(decimal leverage) : base(leverage) { }
+            public TestSecurityMarginModel(decimal leverage) : base(leverage) { }
 
             public new decimal GetInitialMarginRequiredForOrder(Security security, Order order)
             {
@@ -142,7 +142,7 @@ namespace QuantConnect.Tests.Algorithm
             security.FeeModel = _feeModels[feeType];
             security.SetLeverage(leverage);
 
-            var buyingPowerModel = new TestSecurityMarginBuyingPowerModel(leverage);
+            var buyingPowerModel = new TestSecurityMarginModel(leverage);
             security.BuyingPowerModel = buyingPowerModel;
 
             algorithm.SetCash(Cash);

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1197,7 +1197,7 @@ namespace QuantConnect.Tests.Algorithm
             algo.SetCash(100000);
             algo.Securities[Symbols.MSFT].TransactionModel = new ConstantFeeTransactionModel(fee);
             msft = algo.Securities[Symbols.MSFT];
-            msft.BuyingPowerModel = new SecurityMarginBuyingPowerModel(initialMarginRequirement, maintenanceMarginRequirement);
+            msft.BuyingPowerModel = new SecurityMarginModel(initialMarginRequirement, maintenanceMarginRequirement);
             return algo;
         }
 

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Tests.Common.Securities
     public class FutureMarginBuyingPowerModelTests
     {
         // Test class to enable calling protected methods
-        public class TestFutureMarginBuyingPowerModel : FutureMarginBuyingPowerModel
+        public class TestFutureMarginModel : FutureMarginModel
         {
             public new decimal GetMaintenanceMargin(Security security)
             {
@@ -51,7 +51,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
-            var buyingPowerModel = new TestFutureMarginBuyingPowerModel();
+            var buyingPowerModel = new TestFutureMarginModel();
             Assert.AreEqual(2900m, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
         }
 
@@ -71,7 +71,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
-            var buyingPowerModel = new TestFutureMarginBuyingPowerModel();
+            var buyingPowerModel = new TestFutureMarginModel();
             Assert.AreEqual(0m, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
         }
 
@@ -91,7 +91,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
-            var buyingPowerModel = new TestFutureMarginBuyingPowerModel();
+            var buyingPowerModel = new TestFutureMarginModel();
             Assert.AreEqual(625m, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
 
             // now we move forward to exact date when margin req changed

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -29,9 +29,9 @@ namespace QuantConnect.Tests.Common.Securities
     public class MarginCallModelTests
     {
         // Test class to enable calling protected methods
-        public class TestSecurityMarginBuyingPowerModel : SecurityMarginBuyingPowerModel
+        public class TestSecurityMarginModel : SecurityMarginModel
         {
-            public TestSecurityMarginBuyingPowerModel(decimal leverage) : base(leverage) {}
+            public TestSecurityMarginModel(decimal leverage) : base(leverage) {}
 
             public new decimal GetInitialMarginRequiredForOrder(Security security, Order order)
             {
@@ -49,7 +49,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             const decimal actual = 2;
             var security = GetSecurity(Symbols.AAPL);
-            security.BuyingPowerModel = new SecurityMarginBuyingPowerModel(actual);
+            security.BuyingPowerModel = new SecurityMarginModel(actual);
             var expected = security.Leverage;
 
             Assert.AreEqual(expected, actual);
@@ -59,7 +59,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SetAndGetLeverageTest()
         {
             var security = GetSecurity(Symbols.AAPL);
-            security.BuyingPowerModel = new SecurityMarginBuyingPowerModel(2);
+            security.BuyingPowerModel = new SecurityMarginModel(2);
 
             const decimal actual = 50;
             security.SetLeverage(actual);
@@ -76,7 +76,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void GetInitialMarginRequiredForOrderTest()
         {
             var security = GetSecurity(Symbols.AAPL);
-            var buyingPowerModel = new TestSecurityMarginBuyingPowerModel(2);
+            var buyingPowerModel = new TestSecurityMarginModel(2);
             security.BuyingPowerModel = buyingPowerModel;
             var order = new MarketOrder(security.Symbol, 100, DateTime.Now);
             var actual = buyingPowerModel.GetInitialMarginRequiredForOrder(security, order);
@@ -92,7 +92,7 @@ namespace QuantConnect.Tests.Common.Securities
             var expected = quantity / leverage;
 
             var security = GetSecurity(Symbols.AAPL);
-            security.BuyingPowerModel = new SecurityMarginBuyingPowerModel(leverage);
+            security.BuyingPowerModel = new SecurityMarginModel(leverage);
             security.Holdings.SetHoldings(1m, quantity);
             var actual = security.BuyingPowerModel.GetReservedBuyingPowerForPosition(security);
 
@@ -108,7 +108,7 @@ namespace QuantConnect.Tests.Common.Securities
             var portfolio = GetPortfolio(orderProcessor, quantity);
 
             var security = GetSecurity(Symbols.AAPL);
-            var buyingPowerModel = new TestSecurityMarginBuyingPowerModel(leverage);
+            var buyingPowerModel = new TestSecurityMarginModel(leverage);
             security.BuyingPowerModel = buyingPowerModel;
             portfolio.Securities.Add(security);
 

--- a/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Tests.Common.Securities
     public class OptionMarginBuyingPowerModelTests
     {
         // Test class to enable calling protected methods
-        public class TestOptionMarginBuyingPowerModel : OptionMarginBuyingPowerModel
+        public class TestOptionMarginModel : OptionMarginModel
         {
             public new decimal GetMaintenanceMargin(Security security)
             {
@@ -42,7 +42,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var tz = TimeZones.NewYork;
             var option = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
-            var buyingPowerModel = new OptionMarginBuyingPowerModel();
+            var buyingPowerModel = new OptionMarginModel();
 
             // we test that options dont have leverage (100%) and it cannot be changed
             Assert.AreEqual(1m, buyingPowerModel.GetLeverage(option));
@@ -70,7 +70,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(1.5m, 2);
 
-            var buyingPowerModel = new TestOptionMarginBuyingPowerModel();
+            var buyingPowerModel = new TestOptionMarginModel();
 
             // we expect long positions to be 100% charged.
             Assert.AreEqual(optionPut.Holdings.AbsoluteHoldingsCost, buyingPowerModel.GetMaintenanceMargin(optionPut));
@@ -92,7 +92,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginBuyingPowerModel();
+            var buyingPowerModel = new TestOptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (14 + 0.2 * 196) = 10640
@@ -114,7 +114,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginBuyingPowerModel();
+            var buyingPowerModel = new TestOptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (14 + 0.2 * 180 - (192 - 180)) = 7600
@@ -136,7 +136,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginBuyingPowerModel();
+            var buyingPowerModel = new TestOptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (14 + 0.2 * 182) = 10080
@@ -158,7 +158,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginBuyingPowerModel();
+            var buyingPowerModel = new TestOptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (14 + 0.2 * 196 - (196 - 192)) = 9840
@@ -181,7 +181,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginBuyingPowerModel();
+            var buyingPowerModel = new TestOptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (0.18 + 0.2 * 200) = 8036
@@ -206,7 +206,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(optionPriceStart, -2);
 
-            var buyingPowerModel = new TestOptionMarginBuyingPowerModel();
+            var buyingPowerModel = new TestOptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (4.68 + 0.2 * 192) = 8616

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -29,13 +29,13 @@ namespace QuantConnect.Tests.Common.Securities
     public class PatternDayTradingMarginBuyingPowerModelTests
     {
         // Test class to enable calling protected methods
-        public class TestPatternDayTradingMarginBuyingPowerModel : PatternDayTradingMarginBuyingPowerModel
+        public class TestPatternDayTradingMarginModel : PatternDayTradingMarginModel
         {
-            public TestPatternDayTradingMarginBuyingPowerModel()
+            public TestPatternDayTradingMarginModel()
             {
             }
 
-            public TestPatternDayTradingMarginBuyingPowerModel(decimal closedMarketLeverage, decimal openMarketLeverage)
+            public TestPatternDayTradingMarginModel(decimal closedMarketLeverage, decimal openMarketLeverage)
                 : base(closedMarketLeverage, openMarketLeverage)
             {
             }
@@ -61,12 +61,12 @@ namespace QuantConnect.Tests.Common.Securities
         public void InitializationTests()
         {
             // No parameters initialization, used default PDT 4x leverage open market and 2x leverage otherwise
-            var model = new PatternDayTradingMarginBuyingPowerModel();
+            var model = new PatternDayTradingMarginModel();
             var leverage = model.GetLeverage(CreateSecurity(Noon));
 
             Assert.AreEqual(4.0m, leverage);
 
-            model = new PatternDayTradingMarginBuyingPowerModel(2.0m, 5.0m);
+            model = new PatternDayTradingMarginModel(2.0m, 5.0m);
             leverage = model.GetLeverage(CreateSecurity(Noon));
 
             Assert.AreEqual(5.0m, leverage);
@@ -75,12 +75,12 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void SetLeverageTest()
         {
-            var model = new PatternDayTradingMarginBuyingPowerModel();
+            var model = new PatternDayTradingMarginModel();
 
             // Open market
             var security = CreateSecurity(Noon);
 
-            security.BuyingPowerModel = new PatternDayTradingMarginBuyingPowerModel();
+            security.BuyingPowerModel = new PatternDayTradingMarginModel();
 
             model.SetLeverage(security, 10m);
             Assert.AreNotEqual(10m, model.GetLeverage(security));
@@ -102,7 +102,7 @@ namespace QuantConnect.Tests.Common.Securities
             var leverage = 4m;
             var expected = 100 * 100m / leverage + 1;
 
-            var model = new TestPatternDayTradingMarginBuyingPowerModel();
+            var model = new TestPatternDayTradingMarginModel();
             var security = CreateSecurity(Noon);
             var order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
@@ -118,7 +118,7 @@ namespace QuantConnect.Tests.Common.Securities
             var leverage = 5m;
             var expected = 100 * 100m / leverage + 1;
 
-            var model = new TestPatternDayTradingMarginBuyingPowerModel(2m, leverage);
+            var model = new TestPatternDayTradingMarginModel(2m, leverage);
             var security = CreateSecurity(Noon);
             var order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
@@ -132,7 +132,7 @@ namespace QuantConnect.Tests.Common.Securities
             var leverage = 2m;
             var expected = 100 * 100m / leverage + 1;
 
-            var model = new TestPatternDayTradingMarginBuyingPowerModel();
+            var model = new TestPatternDayTradingMarginModel();
 
             // Market is Closed on Tuesday, Feb, 16th 2016 at Midnight
             var security = CreateSecurity(Midnight);
@@ -162,7 +162,7 @@ namespace QuantConnect.Tests.Common.Securities
             var leverage = 3m;
             var expected = 100 * 100m / leverage + 1;
 
-            var model = new TestPatternDayTradingMarginBuyingPowerModel(leverage, 4m);
+            var model = new TestPatternDayTradingMarginModel(leverage, 4m);
 
             // Market is Closed on Tuesday, Feb, 16th 2016 at Midnight
             var security = CreateSecurity(Midnight);
@@ -189,7 +189,7 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void VerifyMaintenaceMargin()
         {
-            var model = new TestPatternDayTradingMarginBuyingPowerModel();
+            var model = new TestPatternDayTradingMarginModel();
 
             // Open Market
             var security = CreateSecurity(Noon);
@@ -214,7 +214,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var orderProcessor = new MarginCallModelTests.OrderProcessor();
             var portfolio = GetPortfolio(orderProcessor, quantity);
-            var model = new PatternDayTradingMarginBuyingPowerModel();
+            var model = new PatternDayTradingMarginModel();
 
             // Open Market
             var security = CreateSecurity(Noon);
@@ -245,7 +245,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var orderProcessor = new MarginCallModelTests.OrderProcessor();
             var portfolio = GetPortfolio(orderProcessor, quantity);
-            var model = new PatternDayTradingMarginBuyingPowerModel();
+            var model = new PatternDayTradingMarginModel();
 
             // Open Market
             var security = CreateSecurity(Noon);

--- a/Tests/Common/Securities/SecurityTests.cs
+++ b/Tests/Common/Securities/SecurityTests.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsNotNull(security.SettlementModel);
             Assert.IsInstanceOf<ImmediateSettlementModel>(security.SettlementModel);
             Assert.IsNotNull(security.BuyingPowerModel);
-            Assert.IsInstanceOf<SecurityMarginBuyingPowerModel>(security.BuyingPowerModel);
+            Assert.IsInstanceOf<SecurityMarginModel>(security.BuyingPowerModel);
             Assert.IsNotNull(security.DataFilter);
             Assert.IsInstanceOf<SecurityDataFilter>(security.DataFilter);
         }


### PR DESCRIPTION
This caused several user algorithms to break. Also, its still correct to call these margin models.