### PR TITLE
Restore Security.MarginModel property

### DIFF
--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -238,6 +238,15 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Gets the buying power model used for this security, an alias for <see cref="BuyingPowerModel"/>
+        /// </summary>
+        public IBuyingPowerModel MarginModel
+        {
+            get { return BuyingPowerModel; }
+            set { BuyingPowerModel = value; }
+        }
+
+        /// <summary>
         /// Gets the settlement model used for this security
         /// </summary>
         public ISettlementModel SettlementModel


### PR DESCRIPTION
This property has been restored and is now an alias for `Security.BuyingPowerModel`