### PR TITLE
Fixes bug w/ data feed initial frontier when changing default tz

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -941,6 +941,9 @@ namespace QuantConnect.Algorithm
 
             // the time rules need to know the default time zone as well
             TimeRules.SetDefaultTimeZone(timeZone);
+
+            // reset the current time according to the time zone
+            SetDateTime(_startDate.ConvertToUtc(TimeZone));
         }
 
         /// <summary>

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -98,7 +98,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         foreach (var universe in args.NewItems.OfType<Universe>())
                         {
                             var config = universe.Configuration;
-                            var start = _frontierUtc != DateTime.MinValue ? _frontierUtc : _algorithm.StartDate.ConvertToUtc(_algorithm.TimeZone);
+                            var start = _algorithm.UtcTime;
 
                             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
                             var exchangeHours = marketHoursDatabase.GetExchangeHours(config);


### PR DESCRIPTION
Changing the default time zone after `SetStartDate` is set ends up with the algorithm's `UtcTime` being incorrect. This can lead to incorrect start times in the data feed as well