### PR TITLE
Subscription sync interface

### DIFF
--- a/Algorithm.CSharp/CoarseUniverseTop5DollarVolumeAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseUniverseTop5DollarVolumeAlgorithm.cs
@@ -13,10 +13,12 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Orders;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -64,6 +66,8 @@ namespace QuantConnect.Algorithm.CSharp
         //Data Event Handler: New data arrives here. "TradeBars" type is a dictionary of strings so you can access it by symbol.
         public void OnData(TradeBars data)
         {
+            Console.WriteLine($"OnData({UtcTime:o}): Keys: {string.Join(", ", data.Keys.OrderBy(x => x))}");
+
             // if we have no changes, do nothing
             if (_changes == SecurityChanges.None) return;
 
@@ -89,6 +93,11 @@ namespace QuantConnect.Algorithm.CSharp
         public override void OnSecuritiesChanged(SecurityChanges changes)
         {
             _changes = changes;
+        }
+
+        public override void OnOrderEvent(OrderEvent fill)
+        {
+            Console.WriteLine($"OnOrderEvent({UtcTime:o}):: {fill}");
         }
     }
 }

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -50,7 +50,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private SubscriptionCollection _subscriptions;
         private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private UniverseSelection _universeSelection;
-        private DateTime _frontierUtc;
         private SubscriptionDataReaderSubscriptionEnumeratorFactory _subscriptionfactory;
 
         /// <summary>
@@ -367,13 +366,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             args.Action == NotifyCollectionChangedAction.Add ? args.NewItems :
                             args.Action == NotifyCollectionChangedAction.Remove ? args.OldItems : null;
 
-                        if (items == null || _frontierUtc == DateTime.MinValue) return;
+                        if (items == null) return;
 
                         var symbol = items.OfType<Symbol>().FirstOrDefault();
                         if (symbol == null) return;
 
-                        var collection = new BaseDataCollection(_frontierUtc, symbol);
-                        var changes = _universeSelection.ApplyUniverseSelection(universe, _frontierUtc, collection);
+                        var collection = new BaseDataCollection(_algorithm.UtcTime, symbol);
+                        var changes = _universeSelection.ApplyUniverseSelection(universe, _algorithm.UtcTime, collection);
                         _algorithm.OnSecuritiesChanged(changes);
                     };
 
@@ -450,14 +449,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public IEnumerator<TimeSlice> GetEnumerator()
         {
             // compute initial frontier time
-            _frontierUtc = GetInitialFrontierTime();
-            Log.Trace(string.Format("FileSystemDataFeed.GetEnumerator(): Begin: {0} UTC", _frontierUtc));
+            var frontierUtc = GetInitialFrontierTime();
+            Log.Trace(string.Format("FileSystemDataFeed.GetEnumerator(): Begin: {0} UTC", frontierUtc));
 
             var syncer = new SubscriptionSynchronizer(_universeSelection);
             syncer.SubscriptionFinished += (sender, subscription) =>
             {
                 RemoveSubscription(subscription.Configuration);
-                Log.Debug(string.Format("FileSystemDataFeed.GetEnumerator(): Finished subscription: {0} at {1} UTC", subscription.Configuration, _frontierUtc));
+                Log.Debug(string.Format("FileSystemDataFeed.GetEnumerator(): Finished subscription: {0} at {1} UTC", subscription.Configuration, frontierUtc));
             };
 
             while (!_cancellationTokenSource.IsCancellationRequested)
@@ -467,7 +466,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                 try
                 {
-                    timeSlice = syncer.Sync(_frontierUtc, Subscriptions, _algorithm.TimeZone, _algorithm.Portfolio.CashBook, out nextFrontier);
+                    timeSlice = syncer.Sync(frontierUtc, Subscriptions, _algorithm.TimeZone, _algorithm.Portfolio.CashBook, out nextFrontier);
                 }
                 catch (Exception err)
                 {
@@ -488,7 +487,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // end of data signal
                     if (nextFrontier == DateTime.MaxValue) break;
 
-                    _frontierUtc = nextFrontier;
+                    frontierUtc = nextFrontier;
                 }
                 else if (timeSlice.SecurityChanges == SecurityChanges.None)
                 {
@@ -506,7 +505,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             if (_subscriptionfactory != null)
                 _subscriptionfactory.Dispose();
 
-            Log.Trace(string.Format("FileSystemDataFeed.Run(): Data Feed Completed at {0} UTC", _frontierUtc));
+            Log.Trace(string.Format("FileSystemDataFeed.Run(): Data Feed Completed at {0} UTC", frontierUtc));
         }
 
         /// <summary>

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -452,7 +452,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var frontierUtc = GetInitialFrontierTime();
             Log.Trace(string.Format("FileSystemDataFeed.GetEnumerator(): Begin: {0} UTC", frontierUtc));
 
-            var syncer = new SubscriptionSynchronizer(_universeSelection, frontierUtc);
+            var syncer = new SubscriptionSynchronizer(_universeSelection, _algorithm.TimeZone, _algorithm.Portfolio.CashBook, frontierUtc);
             syncer.SubscriptionFinished += (sender, subscription) =>
             {
                 RemoveSubscription(subscription.Configuration);
@@ -465,7 +465,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                 try
                 {
-                    timeSlice = syncer.Sync(Subscriptions, _algorithm.TimeZone, _algorithm.Portfolio.CashBook);
+                    timeSlice = syncer.Sync(Subscriptions);
                 }
                 catch (Exception err)
                 {

--- a/Engine/DataFeeds/ISubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/ISubscriptionSynchronizer.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// Provides the ability to synchronize subscriptions into time slices
+    /// </summary>
+    public interface ISubscriptionSynchronizer
+    {
+        /// <summary>
+        /// Event fired when a subscription is finished
+        /// </summary>
+        event EventHandler<Subscription> SubscriptionFinished;
+
+        /// <summary>
+        /// Syncs the specified subscriptions. The frontier time used for synchronization is
+        /// managed internally and dependent upon previous synchronization operations.
+        /// </summary>
+        /// <param name="subscriptions">The subscriptions to sync</param>
+        TimeSlice Sync(IEnumerable<Subscription> subscriptions);
+    }
+}

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -151,6 +151,7 @@
     <Compile Include="DataFeeds\CachingOptionChainProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\Factories\LiveCustomDataSubscriptionEnumeratorFactory.cs" />
     <Compile Include="DataFeeds\Enumerators\QuoteBarFillForwardEnumerator.cs" />
+    <Compile Include="DataFeeds\ISubscriptionSynchronizer.cs" />
     <Compile Include="DataFeeds\LiveFutureChainProvider.cs" />
     <Compile Include="DataFeeds\LiveOptionChainProvider.cs" />
     <Compile Include="DataFeeds\SingleEntryDataCacheProvider.cs" />

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -534,6 +534,14 @@ namespace QuantConnect.Lean.Engine.Results
                 Console.SetOut(debug);
                 Console.SetError(error);
             }
+            else
+            {
+                // we need to forward Console.Write messages to the standard Log functions
+                var debug = new FuncTextWriter(msg => Log.Trace(msg));
+                var error = new FuncTextWriter(msg => Log.Error(msg));
+                Console.SetOut(debug);
+                Console.SetError(error);
+            }
         }
 
         /// <summary>

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -366,12 +366,12 @@ namespace QuantConnect.Tests
                 {"Win Rate", "20%"},
                 {"Profit-Loss Ratio", "2.44"},
                 {"Alpha", "-0.008"},
-                {"Beta", "0.025"},
+                {"Beta", "0.028"},
                 {"Annual Standard Deviation", "0.026"},
                 {"Annual Variance", "0.001"},
-                {"Information Ratio", "-1.01"},
+                {"Information Ratio", "-1.012"},
                 {"Tracking Error", "0.026"},
-                {"Treynor Ratio", "-0.284"},
+                {"Treynor Ratio", "-0.249"},
                 {"Total Fees", "$10.61"},
             };
 

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -26,6 +26,7 @@ namespace QuantConnect.Tests
         public void AlgorithmStatisticsRegression(AlgorithmStatisticsTestParameters parameters)
         {
             QuantConnect.Configuration.Config.Set("quandl-auth-token", "WyAazVXnq7ATy_fefTqm");
+            QuantConnect.Configuration.Config.Set("forward-console-messages", "false");
 
             if (parameters.Algorithm == "OptionChainConsistencyRegressionAlgorithm")
             {


### PR DESCRIPTION
Built on top of https://github.com/QuantConnect/Lean/pull/1538

Extracts an interface for synchronizing subscriptions which can support easily swapping out the synchronization implementation. The synchronizer implementation is expected to manage the frontier of the subscriptions provided.