### PR TITLE
Fix FineFundamental universe selection resource leak

### DIFF
--- a/Common/Util/DisposableExtensions.cs
+++ b/Common/Util/DisposableExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 using System;
 using QuantConnect.Logging;
 

--- a/Engine/DataFeeds/DefaultDataProvider.cs
+++ b/Engine/DataFeeds/DefaultDataProvider.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,7 +15,6 @@
 
 using System;
 using System.IO;
-using Ionic.Zip;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 


### PR DESCRIPTION
The `FineFundamentalSubscriptionEnumeratorFactory` used in combination with `SingleEntryDataCacheProvider` and `DefaultDataProvider` was never disposing of the underlying file stream, leaving files open.