### PR TITLE
Fixed EndTime/Period on QuoteBar

### DIFF
--- a/Common/Data/Consolidators/QuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/QuoteBarConsolidator.cs
@@ -69,7 +69,8 @@ namespace QuantConnect.Data.Consolidators
                     Symbol = data.Symbol,
                     Time = GetRoundedBarTime(data.Time),
                     Bid = bid == null ? null : bid.Clone(),
-                    Ask = ask == null ? null : ask.Clone()
+                    Ask = ask == null ? null : ask.Clone(),
+                    EndTime = data.EndTime
                 };
             }
 
@@ -104,6 +105,7 @@ namespace QuantConnect.Data.Consolidators
             }
 
             workingBar.Value = data.Value;
+            if (workingBar.EndTime < data.EndTime) workingBar.EndTime = data.EndTime;
         }
     }
 }

--- a/Common/Data/Consolidators/QuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/QuoteBarConsolidator.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Data.Consolidators
                     Time = GetRoundedBarTime(data.Time),
                     Bid = bid == null ? null : bid.Clone(),
                     Ask = ask == null ? null : ask.Clone(),
-                    EndTime = data.EndTime
+                    Period = IsTimeBased && Period.HasValue ? (TimeSpan)Period : data.Period
                 };
             }
 
@@ -105,7 +105,7 @@ namespace QuantConnect.Data.Consolidators
             }
 
             workingBar.Value = data.Value;
-            if (workingBar.EndTime < data.EndTime) workingBar.EndTime = data.EndTime;
+            if (!IsTimeBased) workingBar.Period += data.Period;
         }
     }
 }

--- a/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
@@ -85,6 +85,7 @@ namespace QuantConnect.Data.Consolidators
 
             // update the bid and ask
             workingBar.Update(0, data.BidPrice, data.AskPrice, 0, data.BidSize, data.AskSize);
+            if (!Period.HasValue) workingBar.EndTime = GetRoundedBarTime(data.EndTime);
         }
     }
 }

--- a/Tests/Common/Data/BaseDataConsolidatorTests.cs
+++ b/Tests/Common/Data/BaseDataConsolidatorTests.cs
@@ -79,6 +79,7 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(bar2.Value, newTradeBar.High);
             Assert.AreEqual(bar3.Value, newTradeBar.Low);
             Assert.AreEqual(bar4.Value, newTradeBar.Close);
+            Assert.AreEqual(bar4.EndTime, newTradeBar.EndTime);
 
             // base data can't aggregate volume
             Assert.AreEqual(0, newTradeBar.Volume);

--- a/Tests/Common/Data/BaseDataConsolidatorTests.cs
+++ b/Tests/Common/Data/BaseDataConsolidatorTests.cs
@@ -25,7 +25,7 @@ namespace QuantConnect.Tests.Common.Data
     public class BaseDataConsolidatorTests
     {
         [Test]
-        public void AggregatesNewTradeBarProperly()
+        public void AggregatesTickToNewTradeBarProperly()
         {
             TradeBar newTradeBar = null;
             var creator = new BaseDataConsolidator(4);
@@ -82,6 +82,82 @@ namespace QuantConnect.Tests.Common.Data
 
             // base data can't aggregate volume
             Assert.AreEqual(0, newTradeBar.Volume);
+        }
+
+        [Test]
+        public void AggregatesTradeBarsProperly()
+        {
+            TradeBar newTradeBar = null;
+            var creator = new TradeBarConsolidator(4);
+            creator.DataConsolidated += (sender, args) =>
+            {
+                newTradeBar = args;
+            };
+
+            var time = DateTime.Today;
+            var period = TimeSpan.FromMinutes(1);
+            var bar1 = new TradeBar
+            {
+                Time = time,
+                Symbol = Symbols.SPY,
+                Open = 1,
+                High = 2,
+                Low = 0.75m,
+                Close = 1.25m,
+                Period = period
+            };
+            creator.Update(bar1);
+            Assert.IsNull(newTradeBar);
+
+            var bar2 = new TradeBar
+            {
+                Time = time + TimeSpan.FromMinutes(1),
+                Symbol = Symbols.SPY,
+                Open = 1.1m,
+                High = 2.2m,
+                Low = 0.9m,
+                Close = 2.1m,
+                Period = period
+            };
+            creator.Update(bar2);
+            Assert.IsNull(newTradeBar);
+
+            var bar3 = new TradeBar
+            {
+                Time = time + TimeSpan.FromMinutes(2),
+                Symbol = Symbols.SPY,
+                Open = 1,
+                High = 2,
+                Low = 0.1m,
+                Close = 1.75m,
+                Period = period
+            };
+            creator.Update(bar3);
+            Assert.IsNull(newTradeBar);
+
+            var bar4 = new TradeBar
+            {
+                Time = time + TimeSpan.FromMinutes(3),
+                Symbol = Symbols.SPY,
+                Open = 1,
+                High = 7,
+                Low = 0.5m,
+                Close = 4.4m,
+                Period = period
+            };
+            creator.Update(bar4);
+            Assert.IsNotNull(newTradeBar);
+            Assert.AreEqual(bar1.Symbol, newTradeBar.Symbol);
+            Assert.AreEqual(1, newTradeBar.Open);
+            Assert.AreEqual(7, newTradeBar.High);
+            Assert.AreEqual(0.1m, newTradeBar.Low);
+            Assert.AreEqual(4.4m, newTradeBar.Close);
+            Assert.AreEqual(newTradeBar.Close, newTradeBar.Value);
+            Assert.AreEqual(bar4.EndTime, newTradeBar.EndTime);
+            Assert.AreEqual(TimeSpan.FromMinutes(4), newTradeBar.Period);
+            
+            Assert.AreEqual(bar1.Volume + bar2.Volume + bar3.Volume + bar4.Volume, newTradeBar.Volume);
+
         }
 
 

--- a/Tests/Common/Data/DynamicDataConsolidatorTests.cs
+++ b/Tests/Common/Data/DynamicDataConsolidatorTests.cs
@@ -76,6 +76,7 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(bar3.Value, newTradeBar.Low);
             Assert.AreEqual(bar4.Value, newTradeBar.Close);
             Assert.AreEqual(0, newTradeBar.Volume);
+            Assert.AreEqual(bar4.EndTime, newTradeBar.EndTime);
         }
 
         [Test]

--- a/Tests/Common/Data/QuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/QuoteBarConsolidatorTests.cs
@@ -102,7 +102,6 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(bar3.LastBidSize, quoteBar.LastBidSize);
             Assert.AreEqual(bar4.LastAskSize, quoteBar.LastAskSize);
             Assert.AreEqual(bar1.Value, quoteBar.Value);
-            Assert.AreEqual(bar4.EndTime, quoteBar.EndTime);
         }
 
         [Test]

--- a/Tests/Common/Data/QuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/QuoteBarConsolidatorTests.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(bar3.LastBidSize, quoteBar.LastBidSize);
             Assert.AreEqual(bar4.LastAskSize, quoteBar.LastAskSize);
             Assert.AreEqual(bar1.Value, quoteBar.Value);
-            Assert.AreEqual(time + TimeSpan.FromMinutes(4), quoteBar.EndTime);
+            Assert.AreEqual(bar4.EndTime, quoteBar.EndTime);
         }
 
         [Test]

--- a/Tests/Common/Data/QuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/QuoteBarConsolidatorTests.cs
@@ -142,6 +142,7 @@ namespace QuantConnect.Tests.Common.Data
                 Period = period
             };
             creator.Update(bar2);
+            Assert.IsNull(quoteBar);
 
             // pushing another bar to force the fire
             var bar3 = new QuoteBar

--- a/Tests/Common/Data/QuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/QuoteBarConsolidatorTests.cs
@@ -24,7 +24,7 @@ namespace QuantConnect.Tests.Common.Data
     public class QuoteBarConsolidatorTests
     {
         [Test]
-        public void AggregatesNewQuoteBarProperly()
+        public void AggregatesNewCountQuoteBarProperly()
         {
             QuoteBar quoteBar = null;
             var creator = new QuoteBarConsolidator(4);
@@ -34,6 +34,7 @@ namespace QuantConnect.Tests.Common.Data
             };
 
             var time = DateTime.Today;
+            var period = TimeSpan.FromMinutes(1);
             var bar1 = new QuoteBar
             {
                 Time = time,
@@ -42,46 +43,50 @@ namespace QuantConnect.Tests.Common.Data
                 LastBidSize = 3,
                 Ask = null,
                 LastAskSize = 0,
-                Value = 1
+                Value = 1,
+                Period = period
             };
             creator.Update(bar1);
             Assert.IsNull(quoteBar);
 
             var bar2 = new QuoteBar
             {
-                Time = time,
+                Time = time + TimeSpan.FromMinutes(1),
                 Symbol = Symbols.SPY,
                 Bid = new Bar(1.1m, 2.2m, 0.9m, 2.1m),
                 LastBidSize = 3,
                 Ask = new Bar(2.2m, 4.4m, 3.3m, 3.3m),
                 LastAskSize = 0,
-                Value = 1
+                Value = 1,
+                Period = period
             };
             creator.Update(bar2);
             Assert.IsNull(quoteBar);
 
             var bar3 = new QuoteBar
             {
-                Time = time,
+                Time = time + TimeSpan.FromMinutes(2),
                 Symbol = Symbols.SPY,
                 Bid = new Bar(1, 2, 0.5m, 1.75m),
                 LastBidSize = 3,
                 Ask = null,
                 LastAskSize = 0,
-                Value = 1
+                Value = 1,
+                Period = period
             };
             creator.Update(bar3);
             Assert.IsNull(quoteBar);
 
             var bar4 = new QuoteBar
             {
-                Time = time,
+                Time = time + TimeSpan.FromMinutes(3),
                 Symbol = Symbols.SPY,
                 Bid = null,
                 LastBidSize = 0,
                 Ask = new Bar(1, 7, 0.5m, 4.4m),
                 LastAskSize = 4,
-                Value = 1
+                Value = 1,
+                Period = period
             };
             creator.Update(bar4);
             Assert.IsNotNull(quoteBar);
@@ -97,6 +102,86 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(bar3.LastBidSize, quoteBar.LastBidSize);
             Assert.AreEqual(bar4.LastAskSize, quoteBar.LastAskSize);
             Assert.AreEqual(bar1.Value, quoteBar.Value);
+            Assert.AreEqual(time + TimeSpan.FromMinutes(4), quoteBar.EndTime);
+        }
+
+        [Test]
+        public void AggregatesNewTimeSpanQuoteBarProperly()
+        {
+            QuoteBar quoteBar = null;
+            var creator = new QuoteBarConsolidator(TimeSpan.FromMinutes(2));
+            creator.DataConsolidated += (sender, args) =>
+            {
+                quoteBar = args;
+            };
+
+            var time = DateTime.Today;
+            var period = TimeSpan.FromMinutes(1);
+            var bar1 = new QuoteBar
+            {
+                Time = time,
+                Symbol = Symbols.SPY,
+                Bid = new Bar(1, 2, 0.75m, 1.25m),
+                LastBidSize = 3,
+                Ask = null,
+                LastAskSize = 0,
+                Value = 1,
+                Period = period
+            };
+            creator.Update(bar1);
+            Assert.IsNull(quoteBar);
+
+            var bar2 = new QuoteBar
+            {
+                Time = time + TimeSpan.FromMinutes(1),
+                Symbol = Symbols.SPY,
+                Bid = new Bar(1.1m, 2.2m, 0.9m, 2.1m),
+                LastBidSize = 3,
+                Ask = new Bar(2.2m, 4.4m, 3.3m, 3.3m),
+                LastAskSize = 0,
+                Value = 1,
+                Period = period
+            };
+            creator.Update(bar2);
+
+            // pushing another bar to force the fire
+            var bar3 = new QuoteBar
+            {
+                Time = time + TimeSpan.FromMinutes(2),
+                Symbol = Symbols.SPY,
+                Bid = new Bar(1, 2, 0.5m, 1.75m),
+                LastBidSize = 3,
+                Ask = null,
+                LastAskSize = 0,
+                Value = 1,
+                Period = period
+            };
+            creator.Update(bar3);
+
+
+            Assert.IsNotNull(quoteBar);
+
+            
+            Assert.AreEqual(bar1.Symbol, quoteBar.Symbol);
+            Assert.AreEqual(bar1.Time, quoteBar.Time);
+            Assert.AreEqual(time + TimeSpan.FromMinutes(2), quoteBar.EndTime);
+            Assert.AreEqual(TimeSpan.FromMinutes(2), quoteBar.Period);
+
+            // Bid
+            Assert.AreEqual(bar1.Bid.Open, quoteBar.Bid.Open);
+            Assert.AreEqual(bar2.Bid.Close, quoteBar.Bid.Close);
+            Assert.AreEqual(Math.Max(bar2.Bid.High, bar1.Bid.High), quoteBar.Bid.High);
+            Assert.AreEqual(Math.Min(bar2.Bid.Low, bar1.Bid.Low), quoteBar.Bid.Low);
+
+            // Ask
+            Assert.AreEqual(bar2.Ask.Open, quoteBar.Ask.Open);
+            Assert.AreEqual(bar2.Ask.Close, quoteBar.Ask.Close);
+            Assert.AreEqual(bar2.Ask.High, quoteBar.Ask.High);
+            Assert.AreEqual(bar2.Ask.Low, quoteBar.Ask.Low);
+            Assert.AreEqual(bar1.LastAskSize, quoteBar.LastAskSize);
+
+            Assert.AreEqual(1, quoteBar.Value);
+                        
         }
     }
 }

--- a/Tests/Common/Data/TickConsolidatorTests.cs
+++ b/Tests/Common/Data/TickConsolidatorTests.cs
@@ -78,6 +78,7 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(bar2.Value, newTradeBar.High);
             Assert.AreEqual(bar3.Value, newTradeBar.Low);
             Assert.AreEqual(bar4.Value, newTradeBar.Close);
+            Assert.AreEqual(bar4.EndTime, newTradeBar.EndTime);
             Assert.AreEqual(bar1.Quantity + bar2.Quantity + bar3.Quantity + bar4.Quantity, newTradeBar.Volume);
         }
 

--- a/Tests/Common/Data/TickQuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/TickQuoteBarConsolidatorTests.cs
@@ -94,6 +94,7 @@ namespace QuantConnect.Tests.Common.Data
 
             Assert.AreEqual(Symbols.SPY, quoteBar.Symbol);
             Assert.AreEqual(tick1.Time, quoteBar.Time);
+            Assert.AreEqual(tick4.EndTime, quoteBar.EndTime);
             Assert.AreEqual(tick1.BidPrice, quoteBar.Bid.Open);
             Assert.AreEqual(tick1.BidPrice, quoteBar.Bid.Low);
             Assert.AreEqual(tick3.BidPrice, quoteBar.Bid.High);


### PR DESCRIPTION
When a consolidator is used, the produced `QuoteBar` does not have the Period/EndTime set, and thus always appears as a 1 minute bar. I believe this is exclusive to QuoteBar Consolidators.

This is my fix, I can only confirm that it fixed my problem but have tried to fix all of the aggregators too, to try and save some work for people. It needs a review from someone in the know.
