### PR TITLE
Adds overloads with PyObject to Logging and Debug methods

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -779,6 +779,48 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Send a debug message to the web console:
+        /// </summary>
+        /// <param name="message">Message to send to debug console</param>
+        /// <seealso cref="Log(PyObject)"/>
+        /// <seealso cref="Error(PyObject)"/>
+        public void Debug(PyObject message)
+        {
+            Debug(message.ToSafeString());
+        }
+
+        /// <summary>
+        /// Send a string error message to the Console.
+        /// </summary>
+        /// <param name="message">Message to display in errors grid</param>
+        /// <seealso cref="Debug(PyObject)"/>
+        /// <seealso cref="Log(PyObject)"/>
+        public void Error(PyObject message)
+        {
+            Error(message.ToSafeString());
+        }
+
+        /// <summary>
+        /// Added another method for logging if user guessed.
+        /// </summary>
+        /// <param name="message">String message to log.</param>
+        /// <seealso cref="Debug(PyObject)"/>
+        /// <seealso cref="Error(PyObject)"/>
+        public void Log(PyObject message)
+        {
+            Log(message.ToSafeString());
+        }
+
+        /// <summary>
+        /// Terminate the algorithm after processing the current event handler.
+        /// </summary>
+        /// <param name="message">Exit message to display on quitting</param>
+        public void Quit(PyObject message)
+        {
+            Quit(message.ToSafeString());
+        }
+
+        /// <summary>
         /// Gets indicator base type
         /// </summary>
         /// <param name="type">Indicator type</param>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1723,7 +1723,7 @@ namespace QuantConnect.Algorithm
         /// Send a debug message to the web console:
         /// </summary>
         /// <param name="message">Message to send to debug console</param>
-        /// <seealso cref="Log"/>
+        /// <seealso cref="Log(string)"/>
         /// <seealso cref="Error(string)"/>
         public void Debug(string message)
         {
@@ -1736,7 +1736,7 @@ namespace QuantConnect.Algorithm
         /// Added another method for logging if user guessed.
         /// </summary>
         /// <param name="message">String message to log.</param>
-        /// <seealso cref="Debug"/>
+        /// <seealso cref="Debug(string)"/>
         /// <seealso cref="Error(string)"/>
         public void Log(string message)
         {
@@ -1748,8 +1748,8 @@ namespace QuantConnect.Algorithm
         /// Send a string error message to the Console.
         /// </summary>
         /// <param name="message">Message to display in errors grid</param>
-        /// <seealso cref="Debug"/>
-        /// <seealso cref="Log"/>
+        /// <seealso cref="Debug(string)"/>
+        /// <seealso cref="Log(string)"/>
         public void Error(string message)
         {
             if (!_liveMode && (message == "" || _previousErrorMessage == message)) return;
@@ -1761,8 +1761,8 @@ namespace QuantConnect.Algorithm
         /// Send a string error message to the Console.
         /// </summary>
         /// <param name="error">Exception object captured from a try catch loop</param>
-        /// <seealso cref="Debug"/>
-        /// <seealso cref="Log"/>
+        /// <seealso cref="Debug(string)"/>
+        /// <seealso cref="Log(string)"/>
         public void Error(Exception error)
         {
             var message = error.Message;


### PR DESCRIPTION
We enable Logging and Debug methods to accept python objects to avoid the need of calling the str method.
Those objects are safely converted into string objects.