### PR TITLE
Add benchmark for subscription synchronizer

### DIFF
--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Tests.Engine
             Log.Trace("COUNT: " + feed.Count + "  KPS: " + thousands/seconds);
         }
 
-        class MockDataFeed : IDataFeed
+        public class MockDataFeed : IDataFeed
         {
             private DateTime _frontierUtc;
             private DateTime _endTimeUtc;

--- a/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture, Category("TravisExclude")]
+    public class SubscriptionSynchronizerTests
+    {
+        [Test]
+        public void TestsSubscriptionSynchronizerSpeed_SingleSubscription()
+        {
+            var algorithm = PerformanceBenchmarkAlgorithms.SingleSecurity_Second;
+            algorithm.Initialize();
+
+            // set exchanges to be always open
+            foreach (var kvp in algorithm.Securities)
+            {
+                var security = kvp.Value;
+                security.Exchange = new SecurityExchange(SecurityExchangeHours.AlwaysOpen(security.Exchange.TimeZone));
+            }
+
+            var startTimeUtc = algorithm.StartDate.ConvertToUtc(TimeZones.NewYork);
+            var endTimeUtc = algorithm.EndDate.ConvertToUtc(TimeZones.NewYork);
+
+            var feed = new AlgorithmManagerTests.MockDataFeed();
+            var universeSelection = new UniverseSelection(feed, algorithm);
+            var synchronizer = new SubscriptionSynchronizer(universeSelection, algorithm.TimeZone, algorithm.Portfolio.CashBook, startTimeUtc);
+
+            var subscriptions = new List<Subscription>
+            {
+                CreateSubscription(algorithm, algorithm.Securities.Single().Value, startTimeUtc, endTimeUtc)
+            };
+
+            var count = 0;
+            TimeSlice slice;
+            var stopwatch = Stopwatch.StartNew();
+            do
+            {
+                slice = synchronizer.Sync(subscriptions);
+                count++;
+                if (slice.Time == DateTime.MaxValue)
+                {
+                    break;
+                }
+            }
+            while (slice.Time < endTimeUtc);
+            stopwatch.Stop();
+
+            var kps = count/1000d/ stopwatch.Elapsed.TotalSeconds;
+            Console.WriteLine($"Current Time: {slice.Time}:: Elapsed time: {stopwatch.Elapsed}  COUNT: {count}    KPS: {kps:.00}");
+        }
+
+        private Subscription CreateSubscription(QCAlgorithm algorithm, Security security, DateTime startTimeUtc, DateTime endTimeUtc)
+        {
+            var universe = algorithm.UniverseManager.Values.OfType<UserDefinedUniverse>()
+                .Single(u => u.SelectSymbols(default(DateTime), null).Contains(security.Symbol));
+
+            var config = security.Subscriptions.First();
+            var enumerator = DataTradeBarEnumerator(algorithm.StartDate, algorithm.EndDate, Time.OneSecond);
+            var offsetProvider = new TimeZoneOffsetProvider(TimeZones.NewYork, startTimeUtc, endTimeUtc);
+            return new Subscription(universe, security, config, enumerator, offsetProvider, endTimeUtc, endTimeUtc, false);
+        }
+
+        private IEnumerator<BaseData> DataTradeBarEnumerator(DateTime startTimeLocal, DateTime endTimeLocal, TimeSpan increment)
+        {
+            var currentDataStartTime = startTimeLocal - increment;
+            var currentDataEndTime = startTimeLocal;
+            while (currentDataEndTime <= endTimeLocal)
+            {
+                var data = new TradeBar
+                {
+                    Time = currentDataStartTime,
+                    EndTime = currentDataEndTime
+                };
+
+                yield return data;
+
+                currentDataStartTime = currentDataEndTime;
+                currentDataEndTime = currentDataEndTime + increment;
+            }
+        }
+    }
+}

--- a/Tests/Engine/PerformanceBenchmarkAlgorithms.cs
+++ b/Tests/Engine/PerformanceBenchmarkAlgorithms.cs
@@ -1,10 +1,28 @@
-﻿using QuantConnect.Algorithm;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Linq;
+using QuantConnect.Algorithm;
 
 namespace QuantConnect.Tests.Engine
 {
     public static class PerformanceBenchmarkAlgorithms
     {
         public static QCAlgorithm SingleSecurity_Second => new SingleSecurity_Second_BenchmarkTest();
+        public static QCAlgorithm FiveHundredSecurity_Second => new FiveHundredSecurity_Second_BenchmarkTest();
 
         private class SingleSecurity_Second_BenchmarkTest : QCAlgorithm
         {
@@ -15,6 +33,21 @@ namespace QuantConnect.Tests.Engine
                 SetCash(100000);
                 SetBenchmark(time => 0m);
                 AddEquity("SPY", Resolution.Second, "usa", true);
+            }
+        }
+
+        private class FiveHundredSecurity_Second_BenchmarkTest : QCAlgorithm
+        {
+            public override void Initialize()
+            {
+                SetStartDate(2018, 02, 01);
+                SetEndDate(2018, 02, 01);
+                SetCash(100000);
+                SetBenchmark(time => 0m);
+                foreach (var symbol in QuantConnect.Algorithm.CSharp.Benchmarks.Symbols.Equity.All.Take(500))
+                {
+                    AddEquity(symbol, Resolution.Second);
+                }
             }
         }
     }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -259,6 +259,7 @@
     <Compile Include="Engine\DataFeeds\FuncDataQueueHandler.cs" />
     <Compile Include="Engine\DataFeeds\LiveTradingDataFeedTests.cs" />
     <Compile Include="Engine\DataFeeds\SubscriptionCollectionTests.cs" />
+    <Compile Include="Engine\DataFeeds\SubscriptionSynchronizerTests.cs" />
     <Compile Include="Engine\DataFeeds\TimeSliceTests.cs" />
     <Compile Include="Engine\DataFeeds\ZipEntryNameSubsciptionFactoryTests.cs" />
     <Compile Include="Engine\DataProviders\DefaultDataProviderTests.cs" />

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -733,7 +733,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("HourReverseSplitRegressionAlgorithm", hourReverseSplitStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("FractionalQuantityRegressionAlgorithm", fractionalQuantityRegressionStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("CustomIndicatorAlgorithm", basicTemplateStatistics, Language.Python),
-                
+
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),
 


### PR DESCRIPTION
If we add additional sychronizer implementations, this test can easily be extended to accommodate those new implementations.