### PR TITLE
Fixes stack overflow ex when running multiple regression algos

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -30,6 +30,7 @@ using QuantConnect.Packets;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
 using System.Diagnostics;
+using System.IO;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Lean.Engine.Results
@@ -39,6 +40,10 @@ namespace QuantConnect.Lean.Engine.Results
     /// </summary>
     public class BacktestingResultHandler : BaseResultsHandler, IResultHandler
     {
+        // used for resetting out/error upon completion
+        private static readonly TextWriter StandardOut = Console.Out;
+        private static readonly TextWriter StandardError = Console.Error;
+
         private bool _exitTriggered = false;
         private BacktestNodePacket _job;
         private int _jobDays = 0;
@@ -139,8 +144,6 @@ namespace QuantConnect.Lean.Engine.Results
                 return _isActive;
             }
         }
-
-
 
         /// <summary>
         /// Sampling period for timespans between resamples of the charting equity.
@@ -264,6 +267,10 @@ namespace QuantConnect.Lean.Engine.Results
 
             Log.Trace("BacktestingResultHandler.Run(): Ending Thread...");
             _isActive = false;
+
+            // reset standard out/error
+            Console.SetOut(StandardOut);
+            Console.SetError(StandardError);
         } // End Run();
 
         /// <summary>
@@ -529,18 +536,14 @@ namespace QuantConnect.Lean.Engine.Results
             if (Config.GetBool("forward-console-messages", true))
             {
                 // we need to forward Console.Write messages to the algorithm's Debug function
-                var debug = new FuncTextWriter(algorithm.Debug);
-                var error = new FuncTextWriter(algorithm.Error);
-                Console.SetOut(debug);
-                Console.SetError(error);
+                Console.SetOut(new FuncTextWriter(algorithm.Debug));
+                Console.SetError(new FuncTextWriter(algorithm.Error));
             }
             else
             {
                 // we need to forward Console.Write messages to the standard Log functions
-                var debug = new FuncTextWriter(msg => Log.Trace(msg));
-                var error = new FuncTextWriter(msg => Log.Error(msg));
-                Console.SetOut(debug);
-                Console.SetError(error);
+                Console.SetOut(new FuncTextWriter(msg => Log.Trace(msg)));
+                Console.SetError(new FuncTextWriter(msg => Log.Error(msg)));
             }
         }
 

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -733,7 +733,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("HourReverseSplitRegressionAlgorithm", hourReverseSplitStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("FractionalQuantityRegressionAlgorithm", fractionalQuantityRegressionStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("CustomIndicatorAlgorithm", basicTemplateStatistics, Language.Python),
-                
+
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),
 


### PR DESCRIPTION
This appears to have been an oversight on my part. This updates the backtesting result handler to return `Console.Out` and `Console.Error` to the state they were in when the application started (technically when the `BacktestingResultHandler` type is loaded). This fixes an infinite loop created by piping console messages directly to the log handler, which itself, can point at `Console.Out` and `Console.Error` via the  `ConsoleLogHandler`