### PR TITLE
Remove cash updates from time slice

### DIFF
--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -34,8 +34,16 @@ namespace QuantConnect.Securities
 
         /// <summary>
         /// Gets the symbol of the security required to provide conversion rates.
+        /// If this cash represents the account currency, then <see cref="QuantConnect.Symbol.Empty"/>
+        /// is returned
         /// </summary>
-        public Symbol SecuritySymbol { get; private set; }
+        public Symbol SecuritySymbol => ConversionRateSecurity?.Symbol ?? QuantConnect.Symbol.Empty;
+
+        /// <summary>
+        /// Gets the security used to apply conversion rates.
+        /// If this cash represents the account currency, then null is returned.
+        /// </summary>
+        public Security ConversionRateSecurity { get; private set; }
 
         /// <summary>
         /// Gets the symbol used to represent this cash
@@ -138,7 +146,7 @@ namespace QuantConnect.Securities
         {
             if (Symbol == CashBook.AccountCurrency)
             {
-                SecuritySymbol = QuantConnect.Symbol.Empty;
+                ConversionRateSecurity = null;
                 _isBaseCurrency = true;
                 ConversionRate = 1.0m;
                 return null;
@@ -152,12 +160,12 @@ namespace QuantConnect.Securities
             {
                 if (config.Symbol.Value == normal)
                 {
-                    SecuritySymbol = config.Symbol;
+                    ConversionRateSecurity = securities[config.Symbol];
                     return null;
                 }
                 if (config.Symbol.Value == invert)
                 {
-                    SecuritySymbol = config.Symbol;
+                    ConversionRateSecurity = securities[config.Symbol];
                     _invertRealTimePrice = true;
                     return null;
                 }
@@ -197,7 +205,6 @@ namespace QuantConnect.Securities
                     var exchangeHours = marketHoursDbEntry.ExchangeHours;
                     // set this as an internal feed so that the data doesn't get sent into the algorithm's OnData events
                     var config = subscriptions.Add(objectType, TickType.Quote, symbol, minimumResolution, marketHoursDbEntry.DataTimeZone, exchangeHours.TimeZone, false, true, false, true);
-                    SecuritySymbol = config.Symbol;
 
                     Security security;
                     if (securityType == SecurityType.Cfd)
@@ -212,6 +219,8 @@ namespace QuantConnect.Securities
                     {
                         security = new Forex.Forex(exchangeHours, quoteCash, config, symbolProperties);
                     }
+
+                    ConversionRateSecurity = security;
                     securities.Add(config.Symbol, security);
                     Log.Trace("Cash.EnsureCurrencyDataFeed(): Adding " + symbol.Value + " for cash " + Symbol + " currency feed");
                     return security;

--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -52,11 +52,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public Slice Slice { get; private set; }
 
         /// <summary>
-        /// Gets the data used to update the cash book
-        /// </summary>
-        public List<UpdateData<Cash>> CashBookUpdateData { get; private set; }
-
-        /// <summary>
         /// Gets the data used to update securities
         /// </summary>
         public List<UpdateData<Security>> SecuritiesUpdateData { get; private set; }
@@ -83,7 +78,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             int dataPointCount,
             Slice slice,
             List<DataFeedPacket> data,
-            List<UpdateData<Cash>> cashBookUpdateData,
             List<UpdateData<Security>> securitiesUpdateData,
             List<UpdateData<SubscriptionDataConfig>> consolidatorUpdateData,
             List<UpdateData<Security>> customData,
@@ -94,7 +88,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             Slice = slice;
             CustomData = customData;
             DataPointCount = dataPointCount;
-            CashBookUpdateData = cashBookUpdateData;
             SecuritiesUpdateData = securitiesUpdateData;
             ConsolidatorUpdateData = consolidatorUpdateData;
             SecurityChanges = securityChanges;
@@ -116,14 +109,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var custom = new List<UpdateData<Security>>();
             var consolidator = new List<UpdateData<SubscriptionDataConfig>>();
             var allDataForAlgorithm = new List<BaseData>(data.Count);
-            var cash = new List<UpdateData<Cash>>(cashBook.Count);
             var optionUnderlyingUpdates = new Dictionary<Symbol, BaseData>();
-
-            var cashSecurities = new HashSet<Symbol>();
-            foreach (var kvp in cashBook)
-            {
-                cashSecurities.Add(kvp.Value.SecuritySymbol);
-            }
 
             Split split;
             Dividend dividend;
@@ -258,24 +244,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                 if (securityUpdate.Count > 0)
                 {
-                    // check for 'cash securities' if we found valid update data for this symbol
-                    // and we need this data to update cash conversion rates, long term we should
-                    // have Cash hold onto it's security, then he can update himself, or rather, just
-                    // patch through calls to conversion rate to compue it on the fly using Security.Price
-                    if (cashSecurities.Contains(packet.Security.Symbol))
-                    {
-                        foreach (var kvp in cashBook)
-                        {
-                            var cashItem = kvp.Value;
-
-                            if (cashItem.SecuritySymbol == packet.Security.Symbol)
-                            {
-                                var cashUpdates = new List<BaseData> {securityUpdate[securityUpdate.Count - 1]};
-                                cash.Add(new UpdateData<Cash>(cashItem, packet.Configuration.Type, cashUpdates));
-                            }
-                        }
-                    }
-
                     security.Add(new UpdateData<Security>(packet.Security, packet.Configuration.Type, securityUpdate));
                 }
                 if (consolidatorUpdate.Count > 0)
@@ -286,7 +254,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             slice = new Slice(algorithmTime, allDataForAlgorithm, tradeBars, quoteBars, ticks, optionChains, futuresChains, splits, dividends, delistings, symbolChanges, allDataForAlgorithm.Count > 0);
 
-            return new TimeSlice(utcDateTime, count, slice, data, cash, security, consolidator, custom, changes);
+            return new TimeSlice(utcDateTime, count, slice, data, security, consolidator, custom, changes);
         }
 
         /// <summary>

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -111,13 +111,12 @@ namespace QuantConnect.Tests.Engine
                 var delistings = new Delistings();
                 var symbolChanges = new SymbolChangedEvents();
                 var dataFeedPackets = new List<DataFeedPacket>();
-                var cashUpdateData = new List<UpdateData<Cash>>();
                 var customData = new List<UpdateData<Security>>();
                 var changes = SecurityChanges.None;
                 do
                 {
                     var slice = new Slice(default(DateTime), _data, bars, quotes, ticks, options, futures, splits, dividends, delistings, symbolChanges);
-                    var timeSlice = new TimeSlice(_frontierUtc, _data.Count, slice, dataFeedPackets, cashUpdateData, securitiesUpdateData, _consolidatorUpdateData, customData, changes);
+                    var timeSlice = new TimeSlice(_frontierUtc, _data.Count, slice, dataFeedPackets, securitiesUpdateData, _consolidatorUpdateData, customData, changes);
                     yield return timeSlice;
                     _frontierUtc += FrontierStepSize;
                 }


### PR DESCRIPTION
Instead of tracking just the security's symbol in the cash object we're now maintaining a reference to the actual security object. This removes the need to worry about cash update data in the time slice create method.