### PR TITLE
Creates wrapper for Slice (python custom data)

### DIFF
--- a/Algorithm.Python/BubbleAlgorithm.py
+++ b/Algorithm.Python/BubbleAlgorithm.py
@@ -14,11 +14,13 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Indicators")
 AddReference("QuantConnect.Common")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import *
+from QuantConnect.Indicators import *
 from QuantConnect.Data import SubscriptionDataSource
 from QuantConnect.Python import PythonData
 from datetime import date, timedelta, datetime
@@ -83,7 +85,6 @@ class BubbleAlgorithm(QCAlgorithm):
             try:
                 # Bubble territory
                 if self._currCape > 20 and self._newLow == False:
-                    self.Log(" Time " + str(self.Time))
                     for stock in self._symbols:
                     # Order stock based on MACD
                     # During market hours, stock is trading, and sufficient cash
@@ -120,7 +121,7 @@ class BubbleAlgorithm(QCAlgorithm):
                 # Do nothing
                 return None       
 
-        if "CAPE" not in data: return
+        if not data.ContainsKey("CAPE"): return
         self._newLow = False
         # Adds first four Cape Ratios to array c
         self._currCape = data["CAPE"].Cape

--- a/Algorithm.Python/CustomDataBitcoinAlgorithm.py
+++ b/Algorithm.Python/CustomDataBitcoinAlgorithm.py
@@ -46,7 +46,7 @@ class CustomDataBitcoinAlgorithm(QCAlgorithm):
 
 
     def OnData(self, data):
-        if "BTC" not in data: return
+        if not data.ContainsKey("BTC"): return
 
         close = data["BTC"].Close
 

--- a/Algorithm.Python/CustomDataNIFTYAlgorithm.py
+++ b/Algorithm.Python/CustomDataNIFTYAlgorithm.py
@@ -51,11 +51,11 @@ class CustomDataNIFTYAlgorithm(QCAlgorithm):
 
 
     def OnData(self, data):
-        if "USDINR" in data:
+        if data.ContainsKey("USDINR"):
             self.today = CorrelationPair(self.Time)
             self.today.CurrencyPrice = data["USDINR"].Close
 
-        if "NIFTY" not in data: return
+        if not data.ContainsKey("NIFTY"): return
 
         self.today.NiftyPrice = data["NIFTY"].Close
 

--- a/Algorithm.Python/QCUWeatherBasedRebalancing.py
+++ b/Algorithm.Python/QCUWeatherBasedRebalancing.py
@@ -51,7 +51,7 @@ class QCUWeatherBasedRebalancing(QCAlgorithm):
 
     # When we have a new event trigger, buy some stock:
     def OnData(self, data):
-        if self.weather not in data: return
+        if not data.ContainsKey(self.weather): return
 
         # Scale from -5C to +25C :: -5C == 100%, +25C = 0% invested
         fraction = -(data[self.weather].MinC + 5) / 30 if self.weather in data else 0

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -63,9 +63,6 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
 
                     var baseClass = module.GetAttr("QCAlgorithm");
 
-                    // Set PythonSlice converter
-                    PythonSlice.SetConverter();
-
                     var moduleName = module.Repr().Split('\'')[1];
 
                     foreach (var name in module.Dir())

--- a/Common/Python/PythonSlice.cs
+++ b/Common/Python/PythonSlice.cs
@@ -28,8 +28,29 @@ namespace QuantConnect.Python
     public class PythonSlice : Slice
     {
         private Slice _slice;
-        private static PyObject _converter;
- 
+        private static readonly PyObject _converter;
+
+        static PythonSlice()
+        {
+            // Python Data class: Converts custom data (PythonData) into a python object'''
+            _converter = PythonEngine.ModuleFromString("converter",
+                "import decimal\n" +
+
+                "class Data(object):\n" +
+                "    def __init__(self, data):\n" +
+                "        self.data = data\n" +
+                "        members = [attr for attr in dir(data) if not callable(attr) and not attr.startswith(\"__\")]\n" +
+                "        for member in members:\n" +
+                "            setattr(self, member, getattr(data, member))\n" +
+                "        for kvp in data.GetStorageDictionary():\n" +
+                "           name = kvp.Key.replace('-',' ').replace('.',' ').title().replace(' ', '')\n" +
+                "           value = decimal.Decimal(kvp.Value) if isinstance(kvp.Value, float) else kvp.Value\n" +
+                "           setattr(self, name, value)\n" +
+
+                "    def __str__(self):\n" +
+                "        return self.data.ToString()");
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PythonSlice"/> class
         /// </summary>
@@ -128,32 +149,6 @@ namespace QuantConnect.Python
         public new bool TryGetValue(Symbol symbol, out dynamic data)
         {
             return _slice.TryGetValue(symbol, out data);
-        }
-
-        /// <summary>
-        /// Sets the converter
-        /// </summary>
-        public static void SetConverter()
-        {
-            if (_converter != null) return;
-
-            // Python Data class: Converts custom data (PythonData) into a python object'''
-            _converter = PythonEngine.ModuleFromString("converter", 
-                "import decimal\n" +
-
-                "class Data(object):\n" +
-                "    def __init__(self, data):\n" +
-                "        self.data = data\n" +
-                "        members = [attr for attr in dir(data) if not callable(attr) and not attr.startswith(\"__\")]\n" +
-                "        for member in members:\n" +
-                "            setattr(self, member, getattr(data, member))\n" +
-                "        for kvp in data.GetStorageDictionary():\n" +
-                "           name = kvp.Key.replace('-',' ').replace('.',' ').title().replace(' ', '')\n" +
-                "           value = decimal.Decimal(kvp.Value) if isinstance(kvp.Value, float) else kvp.Value\n" +
-                "           setattr(self, name, value)\n" +
-
-                "    def __str__(self):\n" +
-                "        return self.data.ToString()");
         }
     }
 }

--- a/Common/Python/PythonSlice.cs
+++ b/Common/Python/PythonSlice.cs
@@ -1,0 +1,159 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Python.Runtime;
+using QuantConnect.Data;
+using QuantConnect.Data.Custom;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Python
+{
+    /// <summary>
+    /// Provides a data structure for all of an algorithm's data at a single time step
+    /// </summary>
+    public class PythonSlice : Slice
+    {
+        private Slice _slice;
+        private static PyObject _converter;
+ 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PythonSlice"/> class
+        /// </summary>
+        /// <param name="slice">slice object to wrap</param>
+        public PythonSlice(Slice slice)
+            : base(slice.Time,
+                Enumerable.Empty<BaseData>(),
+                slice.Bars,
+                slice.QuoteBars,
+                slice.Ticks,
+                slice.OptionChains,
+                slice.FuturesChains,
+                slice.Splits,
+                slice.Dividends,
+                slice.Delistings,
+                slice.SymbolChangedEvents,
+                slice.HasData
+                )
+        {
+            _slice = slice;
+        }
+
+        /// <summary>
+        /// Gets the number of symbols held in this slice
+        /// </summary>
+        public new int Count
+        {
+            get { return _slice.Count; }
+        }
+
+        /// <summary>
+        /// Gets all the symbols in this slice
+        /// </summary>
+        public new IReadOnlyList<Symbol> Keys
+        {
+            get { return _slice.Keys; }
+        }
+
+        /// <summary>
+        /// Gets a list of all the data in this slice
+        /// </summary>
+        public new IReadOnlyList<BaseData> Values
+        {
+            get { return _slice.Values; }
+        }
+
+        /// <summary>
+        /// Gets the data corresponding to the specified symbol. If the requested data
+        /// is of <see cref="MarketDataType.Tick"/>, then a <see cref="List{Tick}"/> will
+        /// be returned, otherwise, it will be the subscribed type, for example, <see cref="TradeBar"/>
+        /// or event <see cref="Quandl"/> for custom data.
+        /// </summary>
+        /// <param name="symbol">The data's symbols</param>
+        /// <returns>The data for the specified symbol</returns>
+        public new dynamic this[Symbol symbol]
+        {
+            get
+            {
+                var data = _slice[symbol];
+
+                var dynamicData = data as DynamicData;
+                if (dynamicData != null)
+                {
+                    try
+                    {
+                        using (Py.GIL())
+                        {
+                            return _converter.InvokeMethod("Data", new[] { dynamicData.ToPython() });
+                        }
+                    }
+                    catch
+                    {
+                        // NOP
+                    }
+                }
+                return data;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether this instance contains data for the specified symbol
+        /// </summary>
+        /// <param name="symbol">The symbol we seek data for</param>
+        /// <returns>True if this instance contains data for the symbol, false otherwise</returns>
+        public new bool ContainsKey(Symbol symbol)
+        {
+            return _slice.ContainsKey(symbol);
+        }
+
+        /// <summary>
+        /// Gets the data associated with the specified symbol
+        /// </summary>
+        /// <param name="symbol">The symbol we want data for</param>
+        /// <param name="data">The data for the specifed symbol, or null if no data was found</param>
+        /// <returns>True if data was found, false otherwise</returns>
+        public new bool TryGetValue(Symbol symbol, out dynamic data)
+        {
+            return _slice.TryGetValue(symbol, out data);
+        }
+
+        /// <summary>
+        /// Sets the converter
+        /// </summary>
+        public static void SetConverter()
+        {
+            if (_converter != null) return;
+
+            // Python Data class: Converts custom data (PythonData) into a python object'''
+            _converter = PythonEngine.ModuleFromString("converter", 
+                "import decimal\n" +
+
+                "class Data(object):\n" +
+                "    def __init__(self, data):\n" +
+                "        self.data = data\n" +
+                "        members = [attr for attr in dir(data) if not callable(attr) and not attr.startswith(\"__\")]\n" +
+                "        for member in members:\n" +
+                "            setattr(self, member, getattr(data, member))\n" +
+                "        for kvp in data.GetStorageDictionary():\n" +
+                "           name = kvp.Key.replace('-',' ').replace('.',' ').title().replace(' ', '')\n" +
+                "           value = decimal.Decimal(kvp.Value) if isinstance(kvp.Value, float) else kvp.Value\n" +
+                "           setattr(self, name, value)\n" +
+
+                "    def __str__(self):\n" +
+                "        return self.data.ToString()");
+        }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Packets\AlphaNodePacket.cs" />
     <Compile Include="Packets\AlphaResultPacket.cs" />
     <Compile Include="Python\BrokerageModelPythonWrapper.cs" />
+    <Compile Include="Python\PythonSlice.cs" />
     <Compile Include="Python\VolatilityModelPythonWrapper.cs" />
     <Compile Include="Python\PandasData.cs" />
     <Compile Include="Python\SecurityInitializerPythonWrapper.cs" />


### PR DESCRIPTION
Python algorithms with custom data requires an operation that converts a dictionary key into a attribute. In the current implementation the Slice object was converted into a python dictionary. This was not optimal, since we just need to make this conversion when the value of a key in the Slice is accessed.
This implementation proposes a wrapper for the Slice object, PythonSlice, that would just perform the operation described above when needed.
- Fixes custom data algos to reflect changes from previous commit
- Fixes issue #1482