### PR TITLE
Restore GDAX subscription for BCHBTC and BCHEUR

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.Brokerages.GDAX
                     "LTCUSD", "LTCEUR", "LTCBTC",
                     "BTCUSD", "BTCEUR", "BTCGBP",
                     "ETHBTC", "ETHUSD", "ETHEUR",
-                    "BCHUSD"
+                    "BCHBTC", "BCHUSD", "BCHEUR"
                 };
                 Subscribe(tickers.Select(ticker => Symbol.Create(ticker, SecurityType.Crypto, Market.GDAX)));
             };


### PR DESCRIPTION
Trading of these symbols was enabled in January 2018.

Ref. https://github.com/QuantConnect/Lean/pull/1434