### PR TITLE
Remove orderby timeslice create

### DIFF
--- a/Engine/DataFeeds/Subscription.cs
+++ b/Engine/DataFeeds/Subscription.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -181,7 +181,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        /// Serves as a hash function for a particular type. 
+        /// Serves as a hash function for a particular type.
         /// </summary>
         /// <returns>
         /// A hash code for the current <see cref="T:System.Object"/>.
@@ -190,6 +190,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public override int GetHashCode()
         {
             return Configuration.Symbol.GetHashCode();
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        /// <filterpriority>2</filterpriority>
+        public override string ToString()
+        {
+            return Configuration.ToString();
         }
     }
 }

--- a/Engine/DataFeeds/SubscriptionCollection.cs
+++ b/Engine/DataFeeds/SubscriptionCollection.cs
@@ -119,9 +119,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
         private void SortSubscriptions()
         {
+            // it's important that we enumerate underlying securities before derivatives to this end,
+            // we order by security type so that equity subscriptions are enumerated before option
+            // securities to ensure the underlying data is available when we process the options data
             _subscriptionsByTickType = _subscriptions
                 .Select(x => x.Value)
-                .OrderBy(x => x.Configuration.TickType)
+                .OrderBy(x => x.Configuration.SecurityType)
+                .ThenBy(x => x.Configuration.TickType)
                 .ToList();
         }
     }

--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -134,7 +134,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var symbolChanges = new SymbolChangedEvents(algorithmTime);
 
             // ensure we read equity data before option data, so we can set the current underlying price
-            foreach (var packet in data.OrderBy(x => x.Configuration.Symbol.SecurityType))
+            foreach (var packet in data)
             {
                 var list = packet.Data;
                 var symbol = packet.Security.Symbol;


### PR DESCRIPTION
#### Move security type ordering to SubscriptionCollection

This will change the order in which we enumerate subscriptions so we don't need to re-sort inside of `TimeSlice.Create`

#### Add Subscription.ToString override

Makes debugging much easier when we can easily see what a subscription is for