### PR TITLE
Fix consolidator updating during warmup

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -783,7 +783,15 @@ namespace QuantConnect.Lean.Engine
                             var ticks = data as List<Tick>;
                             if (ticks != null) list.AddRange(ticks);
                             else               list.Add(data);
-                            paired.Add(new DataFeedPacket(security, security.Subscriptions.First(), list));
+
+                            Type dataType = data.GetType();
+                            var config = security.Subscriptions.FirstOrDefault(subscription => subscription.Type == dataType);
+                            if (config == null)
+                            {
+                                throw new Exception($"A data subscription for type '{dataType.Name}' was not found.");
+                            }
+
+                            paired.Add(new DataFeedPacket(security, config, list));
                         }
                         timeSlice = TimeSlice.Create(slice.Time.ConvertToUtc(timeZone), timeZone, algorithm.Portfolio.CashBook, paired, SecurityChanges.None);
                     }


### PR DESCRIPTION
When creating time slices for warmup history requests, data for security types with multiple tick types (`Crypto`, `Futures`, `Options`) were being matched to the configuration for the first subscription, instead of using the correct data type.

For example, with the `Crypto` security type, historical data of type `TradeBar` was passed to `TimeSlice.Create` with a `SubscriptionDataConfig` object for the `QuoteBar` data type.