### PR TITLE
Fix GDAX error "Product not found" when submitting orders

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Utility.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Utility.cs
@@ -127,7 +127,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// <returns>gdax product id</returns>
         protected static string ConvertSymbol(Symbol symbol)
         {
-            return symbol.Value.Substring(0, 3).ToLower() + "-" + symbol.Value.Substring(3, 3).ToLower();
+            return symbol.Value.Substring(0, 3).ToUpper() + "-" + symbol.Value.Substring(3, 3).ToUpper();
         }
 
         private static Orders.OrderStatus ConvertOrderStatus(Messages.Order order)


### PR DESCRIPTION
GDAX API now requires uppercase symbol names, previously we were submitting REST requests with symbols in lowercase.