### PR TITLE
Fixes subscription not found due to PythonData warm up history request

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -785,7 +785,7 @@ namespace QuantConnect.Lean.Engine
                             else               list.Add(data);
 
                             Type dataType = data.GetType();
-                            var config = security.Subscriptions.FirstOrDefault(subscription => subscription.Type == dataType);
+                            var config = security.Subscriptions.FirstOrDefault(subscription => dataType.IsAssignableFrom(subscription.Type));
                             if (config == null)
                             {
                                 throw new Exception($"A data subscription for type '{dataType.Name}' was not found.");


### PR DESCRIPTION
In algorithms that use custom data defined in itself, using the PythonData wrapper, the subscription type is the child class while the data type is still PythonData. Due to this particularity, the comparison between the two types results to false, therefore we need to test whether PythonData is assignable from the child class.