### PR TITLE
Exclude memory leak tests from Travis build

### DIFF
--- a/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactoryTests.cs
@@ -30,7 +30,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
     [TestFixture]
     public class BaseDataSubscriptionEnumeratorFactoryTests
     {
-        [Test]
+        // This test reports higher memory usage when ran with Travis, so we exclude it for now
+        [Test, Category("TravisExclude")]
         public void DoesNotLeakMemory()
         {
             var symbol = Symbols.AAPL;

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
@@ -74,7 +74,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             Assert.AreEqual(parameters.PeRatio, row.ValuationRatios.PERatio);
         }
 
-        [Test]
+        // This test reports higher memory usage when ran with Travis, so we exclude it for now
+        [Test, Category("TravisExclude")]
         public void DoesNotLeakMemory()
         {
             var symbol = Symbols.AAPL;


### PR DESCRIPTION
These tests occasionally fail when ran with Travis, so we only exclude them from Travis build.