### PR TITLE
Add buying power model check for shorting in SetHoldings

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -893,6 +893,13 @@ namespace QuantConnect.Algorithm
                 return;
             }
 
+            // check if shorting allowed
+            if (percentage < 0 && !security.BuyingPowerModel.IsShortSellingAllowed(security))
+            {
+                Error($"The {security.BuyingPowerModel.GetType().Name} does not allow short positions.");
+                return;
+            }
+
             //If they triggered a liquidate
             if (liquidateExistingHoldings)
             {

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -222,6 +222,15 @@ namespace QuantConnect.Securities
             return 0;
         }
 
+        /// <summary>
+        /// Returns true if short selling is allowed for a security
+        /// </summary>
+        /// <returns>true if shorting allowed, false otherwise</returns>
+        public bool IsShortSellingAllowed(Security security)
+        {
+            return false;
+        }
+
         private static decimal GetOrderPrice(Security security, Order order)
         {
             var orderPrice = 0m;

--- a/Common/Securities/IBuyingPowerModel.cs
+++ b/Common/Securities/IBuyingPowerModel.cs
@@ -72,5 +72,11 @@ namespace QuantConnect.Securities
         /// <param name="direction">The direction of the trade</param>
         /// <returns>The buying power available for the trade</returns>
         decimal GetBuyingPower(SecurityPortfolioManager portfolio, Security security, OrderDirection direction);
+
+        /// <summary>
+        /// Returns true if short selling is allowed for a security
+        /// </summary>
+        /// <returns>true if shorting allowed, false otherwise</returns>
+        bool IsShortSellingAllowed(Security security);
     }
 }

--- a/Common/Securities/SecurityMarginModel.cs
+++ b/Common/Securities/SecurityMarginModel.cs
@@ -351,5 +351,14 @@ namespace QuantConnect.Securities
         {
             return GetMarginRemaining(portfolio, security, direction);
         }
+
+        /// <summary>
+        /// Returns true if short selling is allowed for a security
+        /// </summary>
+        /// <returns>true if shorting allowed, false otherwise</returns>
+        public bool IsShortSellingAllowed(Security security)
+        {
+            return true;
+        }
     }
 }

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -111,6 +111,12 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void ShortingIsNotAllowed()
+        {
+            Assert.IsFalse(_buyingPowerModel.IsShortSellingAllowed(_btcusd));
+        }
+
+        [Test]
         public void LimitBuyBtcWithUsdRequiresUsdInPortfolio()
         {
             _portfolio.SetCash(20000);

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -36,6 +36,17 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void ShortingIsAllowed()
+        {
+            var tz = TimeZones.NewYork;
+            var symbol = Symbol.CreateFuture(QuantConnect.Securities.Futures.Softs.Coffee, Market.USA, new DateTime(2017, 1, 1));
+            var future = new Future(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+
+            var buyingPowerModel = new TestFutureMarginModel();
+            Assert.IsTrue(buyingPowerModel.IsShortSellingAllowed(future));
+        }
+
+        [Test]
         public void TestMarginForSymbolWithOneLinerHistory()
         {
             const decimal price = 1.2345m;

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -45,6 +45,14 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void ShortingIsAllowed()
+        {
+            var security = GetSecurity(Symbols.AAPL);
+
+            Assert.IsTrue(security.BuyingPowerModel.IsShortSellingAllowed(security));
+        }
+
+        [Test]
         public void InitializationTest()
         {
             const decimal actual = 2;

--- a/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
@@ -38,6 +38,16 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void ShortingIsAllowed()
+        {
+            var tz = TimeZones.NewYork;
+            var option = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+
+            var buyingPowerModel = new OptionMarginModel();
+            Assert.IsTrue(buyingPowerModel.IsShortSellingAllowed(option));
+        }
+
+        [Test]
         public void OptionMarginBuyingPowerModelInitializationTests()
         {
             var tz = TimeZones.NewYork;


### PR DESCRIPTION
Currently, when using a cash model and calling `SetHoldings` with a negative percentage (to go short), `CalculateOrderQuantity` is returning a quantity of zero as expected, so no order is submitted and no error or warning message is shown.

With this PR, the `IsShortSellingAllowed` method has been added to the `IBuyingPowerModel` interface, `SetHoldings` calls it and shows a warning message if the short position is not allowed.