### PR TITLE
Log all order events to dedicate file in regression

### DIFF
--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -211,6 +211,7 @@
     <Compile Include="DataFeeds\ZipDataCacheProvider.cs" />
     <Compile Include="DataFeeds\ZipEntryNameSubscriptionDataSourceReader.cs" />
     <Compile Include="Results\BaseResultsHandler.cs" />
+    <Compile Include="Results\RegressionResultHandler.cs" />
     <Compile Include="Server\LocalLeanManager.cs" />
     <Compile Include="HistoricalData\BrokerageHistoryProvider.cs" />
     <Compile Include="HistoricalData\SubscriptionDataReaderHistoryProvider.cs" />

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -757,7 +757,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Terminate the result thread and apply any required exit procedures.
         /// </summary>
-        public void Exit()
+        public virtual void Exit()
         {
             // Only process the logs once
             if (!_exitTriggered)
@@ -776,11 +776,10 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         /// <remarks>In backtesting the order events are not sent because it would generate a high load of messaging.</remarks>
         /// <param name="newEvent">New order event details</param>
-        public void OrderEvent(OrderEvent newEvent)
+        public virtual void OrderEvent(OrderEvent newEvent)
         {
             // NOP. Don't do any order event processing for results in backtest mode.
         }
-
 
         /// <summary>
         /// Send an algorithm status update to the browser.

--- a/Engine/Results/RegressionResultHandler.cs
+++ b/Engine/Results/RegressionResultHandler.cs
@@ -1,0 +1,81 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.IO;
+using QuantConnect.Configuration;
+using QuantConnect.Orders;
+using QuantConnect.Util;
+
+namespace QuantConnect.Lean.Engine.Results
+{
+    /// <summary>
+    /// Provides a wrapper over the <see cref="BacktestingResultHandler"/> that logs all order events
+    /// to a separate file
+    /// </summary>
+    public class RegressionResultHandler : BacktestingResultHandler
+    {
+        private string AlgorithmTypeName => Algorithm.GetType().Name;
+        private Language Language => Config.GetValue<Language>("algorithm-language");
+        private readonly Lazy<StreamWriter> OrdersLogStreamWriter;
+
+        /// <summary>
+        /// Gets the path used for logging all order events
+        /// </summary>
+        public string OrdersLogFilePath => $"./regression/{AlgorithmTypeName}.{Language.ToLower()}.orders.log";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegressionResultHandler"/> class
+        /// </summary>
+        public RegressionResultHandler()
+        {
+            OrdersLogStreamWriter = new Lazy<StreamWriter>(() =>
+            {
+                var fileInfo = new FileInfo(OrdersLogFilePath);
+                Directory.CreateDirectory(fileInfo.DirectoryName);
+                if (fileInfo.Exists) fileInfo.Delete();
+                return new StreamWriter(OrdersLogFilePath);
+            });
+        }
+
+        /// <summary>
+        /// Log the order and order event to the dedicated log file for this regression algorithm
+        /// </summary>
+        /// <remarks>In backtesting the order events are not sent because it would generate a high load of messaging.</remarks>
+        /// <param name="newEvent">New order event details</param>
+        public override void OrderEvent(OrderEvent newEvent)
+        {
+            // log order events to a separate file for easier diffing of regression runs
+            var order = Algorithm.Transactions.GetOrderById(newEvent.OrderId);
+            OrdersLogStreamWriter.Value.WriteLine($"{Algorithm.UtcTime}: Order: {order}  OrderEvent: {newEvent}");
+
+            base.OrderEvent(newEvent);
+        }
+
+        /// <summary>
+        /// Terminate the result thread and apply any required exit procedures.
+        /// Save orders log files to disk.
+        /// </summary>
+        public override void Exit()
+        {
+            base.Exit();
+            if (OrdersLogStreamWriter.IsValueCreated)
+            {
+                OrdersLogStreamWriter.Value.DisposeSafely();
+            }
+        }
+    }
+}


### PR DESCRIPTION
When inspecting regression differences, the first thing that should be looked at are the fills. Some of the regression algorithms log this data making it possible to inspect whie others do not. In addition, for algorithms with many securities the log can quickly become fills with noise from scheduled event logging.

This change aims to make it very easy to compare any regressions in orders/fills against the most recent successful run of the specified regression algorithm.