### PR TITLE
Passes inner exception to ScheduleEvent exception

### DIFF
--- a/Common/Scheduling/ScheduledEvent.cs
+++ b/Common/Scheduling/ScheduledEvent.cs
@@ -248,7 +248,7 @@ namespace QuantConnect.Scheduling
 
                 // This scheduled event failed, so don't repeat the same event
                 _needsMoveNext = true;
-                throw new ScheduledEventException(ex.ToString(), ex);
+                throw new ScheduledEventException(ex.Message, ex);
             }
         }
     }

--- a/Common/Scheduling/ScheduledEvent.cs
+++ b/Common/Scheduling/ScheduledEvent.cs
@@ -248,7 +248,7 @@ namespace QuantConnect.Scheduling
 
                 // This scheduled event failed, so don't repeat the same event
                 _needsMoveNext = true;
-                throw new ScheduledEventException(ex.ToString());
+                throw new ScheduledEventException(ex.ToString(), ex);
             }
         }
     }
@@ -259,17 +259,13 @@ namespace QuantConnect.Scheduling
     public class ScheduledEventException : Exception
     {
         /// <summary>
-        /// Exception message
-        /// </summary>
-        public string ScheduledEventExceptionMessage { get; }
-
-        /// <summary>
         /// ScheduledEventException constructor
         /// </summary>
-        /// <param name="exceptionMessage">The exception as a string</param>
-        public ScheduledEventException(string exceptionMessage) : base(exceptionMessage)
+        /// <param name="message">The exception as a string</param>
+        /// <param name="innerException">The exception that is the cause of the current exception</param>
+        public ScheduledEventException(string message, Exception innerException) : base(message, innerException)
         {
-            ScheduledEventExceptionMessage = exceptionMessage;
+
         }
     }
 }

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -151,7 +151,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                     {
                         var errorMessage = $"BacktestingRealTimeHandler.Run(): There was an error in a scheduled event {scheduledEvent.Name}. The error was {scheduledEventException.Message}";
 
-                        Log.Error(errorMessage);
+                        Log.Error(scheduledEventException, errorMessage);
 
                         _resultHandler.RuntimeError(errorMessage);
 

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                     }
                     catch (ScheduledEventException scheduledEventException)
                     {
-                        var errorMessage = $"BacktestingRealTimeHandler.Run(): There was an error in a scheduled event {scheduledEvent.Name}. The error was {scheduledEventException.ScheduledEventExceptionMessage}";
+                        var errorMessage = $"BacktestingRealTimeHandler.Run(): There was an error in a scheduled event {scheduledEvent.Name}. The error was {scheduledEventException.Message}";
 
                         Log.Error(errorMessage);
 

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                     {
                         var errorMessage = $"LiveTradingRealTimeHandler.Run(): There was an error in a scheduled event {scheduledEvent.Key}. The error was {scheduledEventException.Message}";
 
-                        Log.Error(errorMessage);
+                        Log.Error(scheduledEventException, errorMessage);
 
                         _resultHandler.RuntimeError(errorMessage);
 

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -126,7 +126,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                     }
                     catch (ScheduledEventException scheduledEventException)
                     {
-                        var errorMessage = $"LiveTradingRealTimeHandler.Run(): There was an error in a scheduled event {scheduledEvent.Key}. The error was {scheduledEventException.ScheduledEventExceptionMessage}";
+                        var errorMessage = $"LiveTradingRealTimeHandler.Run(): There was an error in a scheduled event {scheduledEvent.Key}. The error was {scheduledEventException.Message}";
 
                         Log.Error(errorMessage);
 


### PR DESCRIPTION
Without the inner exception, information on the user exception is lost. In python algorithm, the stack trace is completely lost.
Removes ScheduledEventExceptionMessage property as it is redundant to Message property inherited from parent class.