### PR TITLE
Add short selling pre-order check

### DIFF
--- a/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
@@ -75,7 +75,9 @@ namespace QuantConnect.Algorithm.CSharp
                 //should fail (below minimum order quantity)
                 Order("BTCUSD", 0.00001);
 
+                // should fail (short selling not allowed)
                 SetHoldings("BTCUSD", -2.0m);
+
                 SetHoldings("BTCUSD", 2.0m);
                 Quit();
             }

--- a/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
+++ b/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
@@ -74,6 +74,9 @@ class FractionalQuantityRegressionAlgorithm(QCAlgorithm):
         elif btc_qnty == quantity + 0.09:
             # should fail (below minimum order quantity)
             self.Order("BTCUSD", 0.00001)
+
+            # should fail (short selling not allowed)
             self.SetHoldings("BTCUSD", -2.0)
+
             self.SetHoldings("BTCUSD", 2.0)
             self.Quit()

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -286,5 +286,14 @@ namespace QuantConnect.Brokerages
                     return new SecurityMarginModel(2m);
             }
         }
+
+        /// <summary>
+        /// Returns true if short selling is allowed for the security
+        /// </summary>
+        /// <returns>true if shorting allowed, false otherwise</returns>
+        public virtual bool IsShortSellingAllowed(Security security)
+        {
+            return true;
+        }
     }
 }

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -170,5 +170,15 @@ namespace QuantConnect.Brokerages
             // margin trading is not currently supported by GDAX
             return new CashBuyingPowerModel();
         }
+
+        /// <summary>
+        /// Returns true if short selling is allowed for the security
+        /// </summary>
+        /// <returns>true if shorting allowed, false otherwise</returns>
+        public override bool IsShortSellingAllowed(Security security)
+        {
+            // shorting is not currently supported by GDAX
+            return false;
+        }
     }
 }

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -128,6 +128,12 @@ namespace QuantConnect.Brokerages
         /// <param name="accountType">The account type</param>
         /// <returns>The buying power model for this brokerage/security</returns>
         IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType);
+
+        /// <summary>
+        /// Returns true if short selling is allowed for the security
+        /// </summary>
+        /// <returns>true if shorting allowed, false otherwise</returns>
+        bool IsShortSellingAllowed(Security security);
     }
 
     /// <summary>

--- a/Common/Orders/OrderResponseErrorCode.cs
+++ b/Common/Orders/OrderResponseErrorCode.cs
@@ -173,6 +173,11 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Cannot submit or update orders with quantity that is less than lot size
         /// </summary>
-        OrderQuantityLessThanLoteSize = -30
+        OrderQuantityLessThanLoteSize = -30,
+
+        /// <summary>
+        /// Short selling is not allowed
+        /// </summary>
+        ShortSellingNotAllowed = -31
     }
 }

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -215,5 +215,17 @@ namespace QuantConnect.Python
                 return _model.GetBuyingPowerModel(security, accountType);
             }
         }
+
+        /// <summary>
+        /// Returns true if short selling is allowed for the security
+        /// </summary>
+        /// <returns>true if shorting allowed, false otherwise</returns>
+        public bool IsShortSellingAllowed(Security security)
+        {
+            using (Py.GIL())
+            {
+                return _model.IsShortSellingAllowed(security);
+            }
+        }
     }
 }

--- a/Tests/Algorithm/CashModelAlgorithmTradingTests.cs
+++ b/Tests/Algorithm/CashModelAlgorithmTradingTests.cs
@@ -546,6 +546,7 @@ namespace QuantConnect.Tests.Algorithm
             algo.Buy(_symbol, 1.0m);
             algo.Buy(_symbol, 1.0f);
 
+            // shorts not allowed
             algo.Sell(_symbol, 1);
             algo.Sell(_symbol, 1.0);
             algo.Sell(_symbol, 1.0m);
@@ -582,7 +583,7 @@ namespace QuantConnect.Tests.Algorithm
             algo.SetHoldings(_symbol, 1.0m);
             algo.SetHoldings(_symbol, 1.0f);
 
-            const int expected = 32;
+            const int expected = 28;
             Assert.AreEqual(expected, algo.Transactions.LastOrderId);
         }
 

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -145,5 +145,12 @@ namespace QuantConnect.Tests.Common.Brokerages
                 new GDAXBrokerageModel(AccountType.Margin);
             }, "The GDAX brokerage does not currently support Margin trading.");
         }
+
+        [Test]
+        public void ShortingIsNotAllowed()
+        {
+            var cashModel = new GDAXBrokerageModel();
+            Assert.IsFalse(cashModel.IsShortSellingAllowed(GDAXTestsHelpers.GetSecurity()));
+        }
     }
 }

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -630,25 +630,25 @@ namespace QuantConnect.Tests
 
             var fractionalQuantityRegressionStatistics = new Dictionary<string, string>
             {
-                {"Total Trades", "6"},
-                {"Average Win", "0.95%"},
-                {"Average Loss", "-2.02%"},
-                {"Compounding Annual Return", "254.081%"},
-                {"Drawdown", "6.600%"},
-                {"Expectancy", "-0.018"},
-                {"Net Profit", "1.395%"},
-                {"Sharpe Ratio", "1.176"},
-                {"Loss Rate", "33%"},
-                {"Win Rate", "67%"},
-                {"Profit-Loss Ratio", "0.47"},
-                {"Alpha", "-1.18"},
-                {"Beta", "1.249"},
-                {"Annual Standard Deviation", "0.813"},
-                {"Annual Variance", "0.66"},
-                {"Information Ratio", "-4.245"},
-                {"Tracking Error", "0.178"},
-                {"Treynor Ratio", "0.765"},
-                {"Total Fees", "$2045.20"}
+                {"Total Trades", "5"},
+                {"Average Win", "0.00%"},
+                {"Average Loss", "0%"},
+                {"Compounding Annual Return", "1309.939%"},
+                {"Drawdown", "5.200%"},
+                {"Expectancy", "0"},
+                {"Net Profit", "2.942%"},
+                {"Sharpe Ratio", "2.229"},
+                {"Loss Rate", "0%"},
+                {"Win Rate", "100%"},
+                {"Profit-Loss Ratio", "0"},
+                {"Alpha", "-0.294"},
+                {"Beta", "1.158"},
+                {"Annual Standard Deviation", "0.756"},
+                {"Annual Variance", "0.572"},
+                {"Information Ratio", "-0.171"},
+                {"Tracking Error", "0.14"},
+                {"Treynor Ratio", "1.456"},
+                {"Total Fees", "$507.64"}
             };
 
             var basicTemplateFuturesAlgorithmDailyStatistics = new Dictionary<string, string>


### PR DESCRIPTION
Currently, when using a cash model and calling `SetHoldings` with a negative percentage (to go short), `CalculateOrderQuantity` is returning a quantity of zero as expected, so no order is submitted and no error or warning message is shown.

In this PR, the `IsShortSellingAllowed` method has been added to the `IBrokerageModel` interface, all order methods call it and an error message is shown if the short position is not allowed.