### PR TITLE
Update buying power model interface for better messaging

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -915,10 +915,6 @@ namespace QuantConnect.Algorithm
             {
                 MarketOrder(symbol, quantity, false, tag);
             }
-            else
-            {
-                Error($"Unable to SetHoldings('{symbol.Value}', {percentage.Normalize()}) because CalculateOrderQuantity returned zero quantity.");
-            }
         }
 
         /// <summary>
@@ -945,12 +941,22 @@ namespace QuantConnect.Algorithm
             var security = Securities[symbol];
 
             // can't order it if we don't have data
-            if (security.Price == 0) return 0;
+            if (security.Price == 0)
+            {
+                Error($"The order quantity for {symbol.Value} cannot be calculated: the price of the security is zero.");
+                return 0;
+            }
 
             // this is the value in account currency that we want our holdings to have
             var targetPortfolioValue = target * Portfolio.TotalPortfolioValue;
 
-            return security.BuyingPowerModel.GetMaximumOrderQuantityForTargetValue(Portfolio, security, targetPortfolioValue);
+            var result = security.BuyingPowerModel.GetMaximumOrderQuantityForTargetValue(Portfolio, security, targetPortfolioValue);
+            if (result.Quantity == 0)
+            {
+                Error($"The order quantity for {symbol.Value} cannot be calculated: Reason: {result.Reason}.");
+            }
+
+            return result.Quantity;
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -917,7 +917,7 @@ namespace QuantConnect.Algorithm
             }
             else
             {
-                Error($"Unable to SetHoldings('{symbol.Value}', {percentage}) because CalculateOrderQuantity returned zero quantity.");
+                Error($"Unable to SetHoldings('{symbol.Value}', {percentage.Normalize()}) because CalculateOrderQuantity returned zero quantity.");
             }
         }
 

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -915,6 +915,10 @@ namespace QuantConnect.Algorithm
             {
                 MarketOrder(symbol, quantity, false, tag);
             }
+            else
+            {
+                Error($"Unable to SetHoldings('{symbol.Value}', {percentage}) because CalculateOrderQuantity returned zero quantity.");
+            }
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -951,7 +951,7 @@ namespace QuantConnect.Algorithm
             var targetPortfolioValue = target * Portfolio.TotalPortfolioValue;
 
             var result = security.BuyingPowerModel.GetMaximumOrderQuantityForTargetValue(Portfolio, security, targetPortfolioValue);
-            if (result.Quantity == 0)
+            if (result.Quantity == 0 && result.IsError)
             {
                 Error($"The order quantity for {symbol.Value} cannot be calculated: Reason: {result.Reason}.");
             }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Python\PandasConverter.cs" />
     <Compile Include="Python\FeeModelPythonWrapper.cs" />
     <Compile Include="Securities\CashBuyingPowerModel.cs" />
+    <Compile Include="Securities\HasSufficientBuyingPowerForOrderResult.cs" />
     <Compile Include="Securities\IBaseCurrencySymbol.cs" />
     <Compile Include="Securities\Future\EmptyFutureChainProvider.cs" />
     <Compile Include="Securities\Option\EmptyOptionChainProvider.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -109,7 +109,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="QLNet, Version=1.9.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\QLNet.1.9.2\lib\net45\QLNet.dll</HintPath>
@@ -188,6 +188,7 @@
     <Compile Include="Python\PandasConverter.cs" />
     <Compile Include="Python\FeeModelPythonWrapper.cs" />
     <Compile Include="Securities\CashBuyingPowerModel.cs" />
+    <Compile Include="Securities\GetMaximumOrderQuantityForTargetValueResult.cs" />
     <Compile Include="Securities\HasSufficientBuyingPowerForOrderResult.cs" />
     <Compile Include="Securities\IBaseCurrencySymbol.cs" />
     <Compile Include="Securities\Future\EmptyFutureChainProvider.cs" />
@@ -590,12 +591,12 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -109,7 +109,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="QLNet, Version=1.9.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\QLNet.1.9.2\lib\net45\QLNet.dll</HintPath>
@@ -591,14 +591,14 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -177,7 +177,7 @@ namespace QuantConnect.Securities
             var unitPrice = new MarketOrder(security.Symbol, 1, DateTime.UtcNow).GetValue(security);
             if (unitPrice == 0)
             {
-                return new GetMaximumOrderQuantityForTargetValueResult(0, "The price of the security is zero.");
+                return new GetMaximumOrderQuantityForTargetValueResult(0, $"The price of the {security.Symbol.Value} security is zero because it does not have any market data yet. When the security price is set this security will be ready for trading.");
             }
 
             // remove directionality, we'll work in the land of absolutes
@@ -205,7 +205,7 @@ namespace QuantConnect.Securities
             orderQuantity -= orderQuantity % security.SymbolProperties.LotSize;
             if (orderQuantity == 0)
             {
-                return new GetMaximumOrderQuantityForTargetValueResult(0, $"The order quantity is less than the lot size of {security.SymbolProperties.LotSize} and has been rounded to zero.");
+                return new GetMaximumOrderQuantityForTargetValueResult(0, $"The order quantity is less than the lot size of {security.SymbolProperties.LotSize} and has been rounded to zero.", false);
             }
 
             do

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.Securities
             var baseCurrency = security as IBaseCurrencySymbol;
             if (baseCurrency == null)
             {
-                return new HasSufficientBuyingPowerForOrderResult(false, "The security is not a currency swap.");
+                return new HasSufficientBuyingPowerForOrderResult(false, $"The '{security.Symbol.Value}' security is not a currency swap.");
             }
 
             decimal totalQuantity;

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -88,7 +88,7 @@ namespace QuantConnect.Securities
                 // can sell available and non-reserved quantities
                 isSufficient = orderQuantity <= totalQuantity - openOrdersReservedQuantity;
                 reason = isSufficient ? string.Empty
-                    : $"Order quantity: {orderQuantity} {baseCurrency.BaseCurrencySymbol}, Total quantity: {totalQuantity} {baseCurrency.BaseCurrencySymbol}, Quantity reserved for open orders: {openOrdersReservedQuantity} {baseCurrency.BaseCurrencySymbol}";
+                    : $"Order quantity: {orderQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}, Total quantity: {totalQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}, Quantity reserved for open orders: {openOrdersReservedQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}";
                 return new HasSufficientBuyingPowerForOrderResult(isSufficient, reason);
             }
 
@@ -109,7 +109,7 @@ namespace QuantConnect.Securities
 
                 isSufficient = orderQuantity <= Math.Abs(maximumQuantity) + holdingsValue;
                 reason = isSufficient ? string.Empty
-                    : $"Order quantity: {orderQuantity} {CashBook.AccountCurrency}, Maximum quantity: {Math.Abs(maximumQuantity)} {CashBook.AccountCurrency}, Value of holdings: {openOrdersReservedQuantity} {CashBook.AccountCurrency}";
+                    : $"Order quantity: {orderQuantity.Normalize()} {CashBook.AccountCurrency}, Maximum quantity: {Math.Abs(maximumQuantity).Normalize()} {CashBook.AccountCurrency}, Value of holdings: {holdingsValue.Normalize()} {CashBook.AccountCurrency}";
                 return new HasSufficientBuyingPowerForOrderResult(isSufficient, reason);
             }
 
@@ -123,7 +123,7 @@ namespace QuantConnect.Securities
 
             isSufficient = orderQuantity <= totalQuantity - openOrdersReservedQuantity - orderFee;
             reason = isSufficient ? string.Empty
-                : $"Order quantity: {orderQuantity} {security.QuoteCurrency.Symbol}, Total quantity: {totalQuantity} {security.QuoteCurrency.Symbol}, Quantity reserved for open orders: {openOrdersReservedQuantity} {security.QuoteCurrency.Symbol}, Order fee: {orderFee} {security.QuoteCurrency.Symbol}";
+                : $"Order quantity: {orderQuantity.Normalize()} {security.QuoteCurrency.Symbol}, Total quantity: {totalQuantity.Normalize()} {security.QuoteCurrency.Symbol}, Quantity reserved for open orders: {openOrdersReservedQuantity.Normalize()} {security.QuoteCurrency.Symbol}, Order fee: {orderFee.Normalize()} {security.QuoteCurrency.Symbol}";
             return new HasSufficientBuyingPowerForOrderResult(isSufficient, reason);
         }
 

--- a/Common/Securities/GetMaximumOrderQuantityForTargetValueResult.cs
+++ b/Common/Securities/GetMaximumOrderQuantityForTargetValueResult.cs
@@ -16,28 +16,28 @@
 namespace QuantConnect.Securities
 {
     /// <summary>
-    /// Contains the information returned by <see cref="IBuyingPowerModel.HasSufficientBuyingPowerForOrder"/>
+    /// Contains the information returned by <see cref="IBuyingPowerModel.GetMaximumOrderQuantityForTargetValue"/>
     /// </summary>
-    public class HasSufficientBuyingPowerForOrderResult
+    public class GetMaximumOrderQuantityForTargetValueResult
     {
         /// <summary>
-        /// Returns true if there is sufficient buying power to execute an order
+        /// Returns the maximum quantity for the order
         /// </summary>
-        public bool IsSufficient { get; }
+        public decimal Quantity { get; }
 
         /// <summary>
-        /// Returns the reason for insufficient buying power to execute an order
+        /// Returns the reason for which the maximum order quantity is zero
         /// </summary>
         public string Reason { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="HasSufficientBuyingPowerForOrderResult"/> class
+        /// Initializes a new instance of the <see cref="GetMaximumOrderQuantityForTargetValueResult"/> class
         /// </summary>
-        /// <param name="isSufficient">True if the order can be executed</param>
-        /// <param name="reason">The reason for insufficient buying power</param>
-        public HasSufficientBuyingPowerForOrderResult(bool isSufficient, string reason = null)
+        /// <param name="quantity">Returns the maximum quantity for the order</param>
+        /// <param name="reason">The reason for which the maximum order quantity is zero</param>
+        public GetMaximumOrderQuantityForTargetValueResult(decimal quantity, string reason = null)
         {
-            IsSufficient = isSufficient;
+            Quantity = quantity;
             Reason = reason ?? string.Empty;
         }
     }

--- a/Common/Securities/GetMaximumOrderQuantityForTargetValueResult.cs
+++ b/Common/Securities/GetMaximumOrderQuantityForTargetValueResult.cs
@@ -31,6 +31,11 @@ namespace QuantConnect.Securities
         public string Reason { get; }
 
         /// <summary>
+        /// Returns true if the zero order quantity is an error condition and will be shown to the user.
+        /// </summary>
+        public bool IsError { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="GetMaximumOrderQuantityForTargetValueResult"/> class
         /// </summary>
         /// <param name="quantity">Returns the maximum quantity for the order</param>
@@ -39,6 +44,20 @@ namespace QuantConnect.Securities
         {
             Quantity = quantity;
             Reason = reason ?? string.Empty;
+            IsError = reason != string.Empty;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetMaximumOrderQuantityForTargetValueResult"/> class
+        /// </summary>
+        /// <param name="quantity">Returns the maximum quantity for the order</param>
+        /// <param name="reason">The reason for which the maximum order quantity is zero</param>
+        /// <param name="isError">True if the zero order quantity is an error condition</param>
+        public GetMaximumOrderQuantityForTargetValueResult(decimal quantity, string reason, bool isError = true)
+        {
+            Quantity = quantity;
+            Reason = reason ?? string.Empty;
+            IsError = isError;
         }
     }
 }

--- a/Common/Securities/HasSufficientBuyingPowerForOrderResult.cs
+++ b/Common/Securities/HasSufficientBuyingPowerForOrderResult.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Contains the information returned by <see cref="IBuyingPowerModel.GetBuyingPowerForOrder"/>
+    /// </summary>
+    public class HasSufficientBuyingPowerForOrderResult
+    {
+        /// <summary>
+        /// Returns true if there is sufficient buying power to execute an order
+        /// </summary>
+        public bool IsSufficient { get; }
+
+        /// <summary>
+        /// Returns the reason for insufficient buying power to execute an order
+        /// </summary>
+        public string Reason { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HasSufficientBuyingPowerForOrderResult"/> class
+        /// </summary>
+        /// <param name="isSufficient">True if the order can be executed</param>
+        /// <param name="reason">The reason for insufficient buying power</param>
+        public HasSufficientBuyingPowerForOrderResult(bool isSufficient, string reason)
+        {
+            IsSufficient = isSufficient;
+            Reason = reason;
+        }
+    }
+}

--- a/Common/Securities/IBuyingPowerModel.cs
+++ b/Common/Securities/IBuyingPowerModel.cs
@@ -54,8 +54,8 @@ namespace QuantConnect.Securities
         /// <param name="portfolio">The algorithm's portfolio</param>
         /// <param name="security">The security to be traded</param>
         /// <param name="targetPortfolioValue">The value in account currency that we want our holding to have</param>
-        /// <returns>Returns the maximum allowed market order quantity</returns>
-        decimal GetMaximumOrderQuantityForTargetValue(SecurityPortfolioManager portfolio, Security security, decimal targetPortfolioValue);
+        /// <returns>Returns the maximum allowed market order quantity and if zero, also the reason</returns>
+        GetMaximumOrderQuantityForTargetValueResult GetMaximumOrderQuantityForTargetValue(SecurityPortfolioManager portfolio, Security security, decimal targetPortfolioValue);
 
         /// <summary>
         /// Gets the amount of buying power reserved to maintain the specified position

--- a/Common/Securities/IBuyingPowerModel.cs
+++ b/Common/Securities/IBuyingPowerModel.cs
@@ -45,8 +45,8 @@ namespace QuantConnect.Securities
         /// <param name="portfolio">The algorithm's portfolio</param>
         /// <param name="security">The security to be traded</param>
         /// <param name="order">The order to be checked</param>
-        /// <returns>Returns true if there is sufficient buying power to execute the order, false otherwise</returns>
-        bool HasSufficientBuyingPowerForOrder(SecurityPortfolioManager portfolio, Security security, Order order);
+        /// <returns>Returns buying power information for an order</returns>
+        HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(SecurityPortfolioManager portfolio, Security security, Order order);
 
         /// <summary>
         /// Get the maximum market order quantity to obtain a position with a given value in account currency

--- a/Common/Securities/SecurityMarginModel.cs
+++ b/Common/Securities/SecurityMarginModel.cs
@@ -296,7 +296,7 @@ namespace QuantConnect.Securities
             var unitPrice = new MarketOrder(security.Symbol, 1, DateTime.UtcNow).GetValue(security);
             if (unitPrice == 0)
             {
-                return new GetMaximumOrderQuantityForTargetValueResult(0, "The price of the security is zero.");
+                return new GetMaximumOrderQuantityForTargetValueResult(0, $"The price of the {security.Symbol.Value} security is zero because it does not have any market data yet. When the security price is set this security will be ready for trading.");
             }
 
             // calculate the total margin available
@@ -319,7 +319,7 @@ namespace QuantConnect.Securities
             orderQuantity -= orderQuantity % security.SymbolProperties.LotSize;
             if (orderQuantity == 0)
             {
-                return new GetMaximumOrderQuantityForTargetValueResult(0, $"The order quantity is less than the lot size of {security.SymbolProperties.LotSize} and has been rounded to zero.");
+                return new GetMaximumOrderQuantityForTargetValueResult(0, $"The order quantity is less than the lot size of {security.SymbolProperties.LotSize} and has been rounded to zero.", false);
             }
 
             do

--- a/Common/Securities/SecurityMarginModel.cs
+++ b/Common/Securities/SecurityMarginModel.cs
@@ -260,7 +260,7 @@ namespace QuantConnect.Securities
 
             if (Math.Abs(initialMarginRequiredForRemainderOfOrder) > freeMargin)
             {
-                var reason = $"Id: {order.Id}, Initial Margin: {initialMarginRequiredForRemainderOfOrder}, Free Margin: {freeMargin}";
+                var reason = $"Id: {order.Id}, Initial Margin: {initialMarginRequiredForRemainderOfOrder.Normalize()}, Free Margin: {freeMargin.Normalize()}";
                 Log.Error($"SecurityMarginModel.HasSufficientBuyingPowerForOrder(): {reason}");
                 return new HasSufficientBuyingPowerForOrderResult(false, reason);
             }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -685,10 +685,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             }
 
             // check to see if we have enough money to place the order
-            bool hasSufficientBuyingPower;
+            HasSufficientBuyingPowerForOrderResult hasSufficientBuyingPowerResult;
             try
             {
-                hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(_algorithm.Portfolio, security, order);
+                hasSufficientBuyingPowerResult = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(_algorithm.Portfolio, security, order);
             }
             catch (Exception err)
             {
@@ -698,12 +698,13 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 return OrderResponse.Error(request, OrderResponseErrorCode.ProcessingError, "Error in GetSufficientCapitalForOrder");
             }
 
-            if (!hasSufficientBuyingPower)
+            if (!hasSufficientBuyingPowerResult.IsSufficient)
             {
                 order.Status = OrderStatus.Invalid;
-                var response = OrderResponse.Error(request, OrderResponseErrorCode.InsufficientBuyingPower, string.Format("Order Error: id: {0}, Insufficient buying power to complete order (Value:{1}).", order.Id, order.GetValue(security).SmartRounding()));
+                var errorMessage = $"Order Error: id: {order.Id}, Insufficient buying power to complete order (Value:{order.GetValue(security).SmartRounding()}), Reason: {hasSufficientBuyingPowerResult.Reason}";
+                var response = OrderResponse.Error(request, OrderResponseErrorCode.InsufficientBuyingPower, errorMessage);
                 _algorithm.Error(response.ErrorMessage);
-                HandleOrderEvent(new OrderEvent(order, _algorithm.UtcTime, 0m, "Insufficient buying power to complete order"));
+                HandleOrderEvent(new OrderEvent(order, _algorithm.UtcTime, 0m, errorMessage));
                 return response;
             }
 

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -117,15 +117,15 @@ namespace QuantConnect.Tests.Common.Securities
 
             // Available cash = 20000 USD, can buy 2 BTC at 10000
             var order = new LimitOrder(_btcusd.Symbol, 2m, 10000m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // Available cash = 20000 USD, cannot buy 2.1 BTC at 10000, need 21000
             order = new LimitOrder(_btcusd.Symbol, 2.1m, 10000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // Available cash = 20000 USD, cannot buy 2 BTC at 11000, need 22000
             order = new LimitOrder(_btcusd.Symbol, 2m, 11000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
         }
 
         [Test]
@@ -135,15 +135,15 @@ namespace QuantConnect.Tests.Common.Securities
 
             // Available cash = 20000 EUR, can buy 2 BTC at 10000
             var order = new LimitOrder(_btceur.Symbol, 2m, 10000m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order).IsSufficient);
 
             // Available cash = 20000 EUR, cannot buy 2.1 BTC at 10000, need 21000
             order = new LimitOrder(_btceur.Symbol, 2.1m, 10000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order).IsSufficient);
 
             // Available cash = 20000 EUR, cannot buy 2 BTC at 11000, need 22000
             order = new LimitOrder(_btceur.Symbol, 2m, 11000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order).IsSufficient);
         }
 
         [Test]
@@ -154,11 +154,11 @@ namespace QuantConnect.Tests.Common.Securities
 
             // 0.5 BTC in portfolio, can sell 0.5 BTC at any price
             var order = new LimitOrder(_btcusd.Symbol, -0.5m, 10000m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // 0.5 BTC in portfolio, cannot sell 0.6 BTC at any price
             order = new LimitOrder(_btcusd.Symbol, -0.6m, 10000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
         }
 
         [Test]
@@ -181,11 +181,11 @@ namespace QuantConnect.Tests.Common.Securities
 
             // 500 USD available, can buy 0.05 BTC at 10000
             var order = new LimitOrder(_btcusd.Symbol, 0.05m, 10000m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // 500 USD available, cannot buy 0.06 BTC at 10000
             order = new LimitOrder(_btcusd.Symbol, 0.06m, 10000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
         }
 
         [Test]
@@ -219,27 +219,27 @@ namespace QuantConnect.Tests.Common.Securities
 
             // 0.7 BTC available, can sell 0.7 BTC at any price
             var order = new LimitOrder(_btcusd.Symbol, -0.7m, 10000m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // 0.7 BTC available, cannot sell 0.8 BTC at any price
             order = new LimitOrder(_btcusd.Symbol, -0.8m, 10000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // 2 ETH available, can sell 2 ETH at any price
             order = new LimitOrder(_ethusd.Symbol, -2m, 1200m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _ethusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _ethusd, order).IsSufficient);
 
             // 2 ETH available, cannot sell 2.1 ETH at any price
             order = new LimitOrder(_ethusd.Symbol, -2.1m, 2000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _ethusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _ethusd, order).IsSufficient);
 
             // 0.7 BTC available, can sell stop 0.7 BTC at any price
             var stopOrder = new StopMarketOrder(_btcusd.Symbol, -0.7m, 5000m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, stopOrder));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, stopOrder).IsSufficient);
 
             // 0.7 BTC available, cannot sell stop 0.8 BTC at any price
             stopOrder = new StopMarketOrder(_btcusd.Symbol, -0.8m, 5000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, stopOrder));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, stopOrder).IsSufficient);
         }
 
         [Test]
@@ -251,7 +251,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // Available cash = 20000 USD, cannot buy 2 BTC at 10000 (fees are excluded)
             var order = new MarketOrder(_btcusd.Symbol, 2m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // Maximum we can market buy with 20000 USD is 1.995 BTC
             Assert.AreEqual(1.995m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 20000));
@@ -260,7 +260,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // Available cash = 20000 USD, can buy 2 BTC at 9900 (plus fees)
             order = new MarketOrder(_btcusd.Symbol, 2m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
         }
 
         [Test]
@@ -272,7 +272,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // Available cash = 20000 EUR, cannot buy 2 BTC at 10000 (fees are excluded)
             var order = new MarketOrder(_btceur.Symbol, 2m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order).IsSufficient);
 
             // Maximum we can market buy with 20000 EUR is 1.995 BTC
             var targetValue = 20000m * _portfolio.CashBook["EUR"].ConversionRate;
@@ -282,7 +282,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // Available cash = 20000 EUR, can buy 2 BTC at 9900 (plus fees)
             order = new MarketOrder(_btceur.Symbol, 2m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order).IsSufficient);
         }
 
         [Test]
@@ -295,11 +295,11 @@ namespace QuantConnect.Tests.Common.Securities
 
             // 0.5 BTC in portfolio, can sell 0.5 BTC
             var order = new MarketOrder(_btcusd.Symbol, -0.5m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // 0.5 BTC in portfolio, cannot sell 0.51 BTC
             order = new MarketOrder(_btcusd.Symbol, -0.51m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // Maximum we can market sell with 0.5 BTC is 0.5 BTC
             Assert.AreEqual(-0.5m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 0));
@@ -328,11 +328,11 @@ namespace QuantConnect.Tests.Common.Securities
 
             // 500 USD available, can buy 0.03 BTC at 15000
             var order = new MarketOrder(_btcusd.Symbol, 0.03m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // 500 USD available, cannot buy 0.04 BTC at 15000
             order = new MarketOrder(_btcusd.Symbol, 0.04m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
         }
 
         [Test]
@@ -364,11 +364,11 @@ namespace QuantConnect.Tests.Common.Securities
 
             // 0.8 BTC available, can sell 0.80 BTC at market
             var order = new MarketOrder(_btcusd.Symbol, -0.80m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // 0.8 BTC available, cannot sell 0.81 BTC at market
             order = new MarketOrder(_btcusd.Symbol, -0.81m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
         }
 
         [Test]
@@ -379,13 +379,13 @@ namespace QuantConnect.Tests.Common.Securities
 
             // Available cash = 20000, cannot buy 2 BTC at 10000 because of order fee
             var order = new LimitOrder(_btcusd.Symbol, 2m, 10000m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // deposit another 50 USD
             _portfolio.CashBook["USD"].AddAmount(50);
 
             // now the order is allowed
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
         }
 
         [Test]
@@ -439,7 +439,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // the maximum order quantity can be executed
             var order = new MarketOrder(_btcusd.Symbol, quantity, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
         }
 
         private void SubmitLimitOrder(Symbol symbol, decimal quantity, decimal limitPrice)

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -254,7 +254,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // Maximum we can market buy with 20000 USD is 1.995 BTC
-            Assert.AreEqual(1.995m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 20000));
+            Assert.AreEqual(1.995m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 20000).Quantity);
 
             _btcusd.SetMarketPrice(new Tick { Value = 9900m });
 
@@ -276,7 +276,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // Maximum we can market buy with 20000 EUR is 1.995 BTC
             var targetValue = 20000m * _portfolio.CashBook["EUR"].ConversionRate;
-            Assert.AreEqual(1.995m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btceur, targetValue));
+            Assert.AreEqual(1.995m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btceur, targetValue).Quantity);
 
             _btceur.SetMarketPrice(new Tick { Value = 9900m });
 
@@ -302,7 +302,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
 
             // Maximum we can market sell with 0.5 BTC is 0.5 BTC
-            Assert.AreEqual(-0.5m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 0));
+            Assert.AreEqual(-0.5m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 0).Quantity);
         }
 
         [Test]
@@ -324,7 +324,7 @@ namespace QuantConnect.Tests.Common.Securities
             SubmitLimitOrder(_ethusd.Symbol, 3m, 1000m);
 
             // Maximum we can market buy with 500 USD is 0.03325 BTC
-            Assert.AreEqual(0.03325m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 500));
+            Assert.AreEqual(0.03325m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 500).Quantity);
 
             // 500 USD available, can buy 0.03 BTC at 15000
             var order = new MarketOrder(_btcusd.Symbol, 0.03m, DateTime.UtcNow);
@@ -360,7 +360,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // Maximum we can market sell with 0.8 BTC is 0.798 BTC (for a target position of 0.2 BTC)
             // target value = (1 - 0.8) * price
-            Assert.AreEqual(-0.798m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 0.2m * 15000));
+            Assert.AreEqual(-0.798m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 0.2m * 15000).Quantity);
 
             // 0.8 BTC available, can sell 0.80 BTC at market
             var order = new MarketOrder(_btcusd.Symbol, -0.80m, DateTime.UtcNow);
@@ -408,17 +408,17 @@ namespace QuantConnect.Tests.Common.Securities
             _algorithm.SetFinishedWarmingUp();
 
             // 0.665 * 15000 + fees <= 10000 USD
-            Assert.AreEqual(0.665m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 10000));
+            Assert.AreEqual(0.665m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 10000).Quantity);
 
             // 9.97 * 1000 + fees <= 10000 USD
-            Assert.AreEqual(9.97m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _ethusd, 10000));
+            Assert.AreEqual(9.97m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _ethusd, 10000).Quantity);
 
             // no BTC in portfolio, cannot buy ETH with BTC
-            Assert.AreEqual(0m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _ethbtc, 10000));
+            Assert.AreEqual(0m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _ethbtc, 10000).Quantity);
 
             // 0.83125 * 12000 + fees <= 10000 EUR
             var targetValue = 10000m * _portfolio.CashBook["EUR"].ConversionRate;
-            Assert.AreEqual(0.83125m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btceur, targetValue));
+            Assert.AreEqual(0.83125m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btceur, targetValue).Quantity);
         }
 
         [Test]
@@ -434,7 +434,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(10000m, _portfolio.TotalPortfolioValue);
 
             // Maximum we can market buy for (10000-2000) = 8000 USD is 0.798 BTC
-            var quantity = _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 10000m);
+            var quantity = _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btcusd, 10000m).Quantity;
             Assert.AreEqual(0.798m, quantity);
 
             // the maximum order quantity can be executed

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -163,7 +163,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // we shouldn't be able to place a trader
             var newOrder = new MarketOrder(Symbols.AAPL, 1, time.AddSeconds(1)) {Price = buyPrice};
-            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsFalse(hasSufficientBuyingPower);
 
             // now the stock doubles, so we should have margin remaining
@@ -177,7 +177,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // we shouldn't be able to place a trader
             var anotherOrder = new MarketOrder(Symbols.AAPL, 1, time.AddSeconds(1)) { Price = highPrice };
-            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, anotherOrder);
+            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, anotherOrder).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
 
             // now the stock plummets, so we should have negative margin remaining

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -266,7 +266,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // we shouldn't be able to place a trader
             var newOrder = new MarketOrder(Symbols.AAPL, 1, time.AddSeconds(1)) {Price = buyPrice};
-            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsFalse(hasSufficientBuyingPower);
 
             // now the stock doubles, so we should have margin remaining
@@ -281,7 +281,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             // we shouldn't be able to place a trader
             var anotherOrder = new MarketOrder(Symbols.AAPL, 1, time.AddSeconds(1)) { Price = highPrice };
-            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, anotherOrder);
+            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, anotherOrder).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
 
             // now the stock plummets, so we should have negative margin remaining
@@ -371,11 +371,11 @@ namespace QuantConnect.Tests.Common.Securities
             request.SetOrderId(0);
             orderProcessor.AddTicket(new OrderTicket(null, request));
             var security = securities[Symbols.AAPL];
-            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, acceptedOrder);
+            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, acceptedOrder).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
 
             var rejectedOrder = new MarketOrder(Symbols.AAPL, 102, DateTime.Now) { Price = 100 };
-            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, rejectedOrder);
+            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, rejectedOrder).IsSufficient;
             Assert.IsFalse(hasSufficientBuyingPower);
         }
 
@@ -628,12 +628,12 @@ namespace QuantConnect.Tests.Common.Securities
 
             // we shouldn't be able to place a new buy order
             var newOrder = new MarketOrder(Symbols.AAPL, 1, time.AddSeconds(1)) { Price = buyPrice };
-            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsFalse(hasSufficientBuyingPower);
 
             // we should be able to place sell to zero
             newOrder = new MarketOrder(Symbols.AAPL, -quantity, time.AddSeconds(1)) { Price = buyPrice };
-            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
 
             // now the stock plummets, so we should have negative margin remaining
@@ -643,12 +643,12 @@ namespace QuantConnect.Tests.Common.Securities
 
             // we still should be able to place sell to zero
             newOrder = new MarketOrder(Symbols.AAPL, -quantity, time.AddSeconds(1)) { Price = lowPrice };
-            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
 
             // we shouldn't be able to place sell to short
             newOrder = new MarketOrder(Symbols.AAPL, -quantity - 1, time.AddSeconds(1)) { Price = lowPrice };
-            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsFalse(hasSufficientBuyingPower);
         }
 
@@ -685,12 +685,12 @@ namespace QuantConnect.Tests.Common.Securities
 
             // we shouldn't be able to place a new short order
             var newOrder = new MarketOrder(Symbols.AAPL, -1, time.AddSeconds(1)) { Price = sellPrice };
-            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsFalse(hasSufficientBuyingPower);
 
             // we should be able to place cover to zero
             newOrder = new MarketOrder(Symbols.AAPL, quantity, time.AddSeconds(1)) { Price = sellPrice };
-            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
 
             // now the stock doubles, so we should have negative margin remaining
@@ -700,12 +700,12 @@ namespace QuantConnect.Tests.Common.Securities
 
             // we still shouldn be able to place cover to zero
             newOrder = new MarketOrder(Symbols.AAPL, quantity, time.AddSeconds(1)) { Price = highPrice };
-            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
 
             // we shouldn't be able to place cover to long
             newOrder = new MarketOrder(Symbols.AAPL, quantity + 1, time.AddSeconds(1)) { Price = highPrice };
-            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder);
+            hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, newOrder).IsSufficient;
             Assert.IsFalse(hasSufficientBuyingPower);
         }
 
@@ -1208,7 +1208,7 @@ namespace QuantConnect.Tests.Common.Securities
             var request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
             orderProcessor.AddTicket(new OrderTicket(null, request));
-            var hasSufficientBuyingPower = option.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, option, order);
+            var hasSufficientBuyingPower = option.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, option, order).IsSufficient;
             Assert.IsFalse(hasSufficientBuyingPower);
 
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 150 });
@@ -1218,7 +1218,7 @@ namespace QuantConnect.Tests.Common.Securities
             request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
             orderProcessor.AddTicket(new OrderTicket(null, request));
-            hasSufficientBuyingPower = option.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, option, order);
+            hasSufficientBuyingPower = option.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, option, order).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
         }
 
@@ -1250,7 +1250,7 @@ namespace QuantConnect.Tests.Common.Securities
             var request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
             orderProcessor.AddTicket(new OrderTicket(null, request));
-            var hasSufficientBuyingPower = option.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, option, order);
+            var hasSufficientBuyingPower = option.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, option, order).IsSufficient;
             Assert.IsFalse(hasSufficientBuyingPower);
 
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 150 });
@@ -1260,7 +1260,7 @@ namespace QuantConnect.Tests.Common.Securities
             request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
             orderProcessor.AddTicket(new OrderTicket(null, request));
-            hasSufficientBuyingPower = option.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, option, order);
+            hasSufficientBuyingPower = option.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, option, order).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
         }
 


### PR DESCRIPTION
The `HasSufficientBuyingPowerForOrder` method has been updated to return a result object including the reason the order cannot be executed.

The `SetHoldings` method has also been updated to display a message if `CalculateOrderQuantity` returns zero.

Fixes #1576 