### PR TITLE
Fix duplicate AddSecurity requests

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1827,8 +1827,13 @@ namespace QuantConnect.Algorithm
                 symbol = QuantConnect.Symbol.Create(ticker, securityType, market);
             }
 
-            var security = SecurityManager.CreateSecurity(Portfolio, SubscriptionManager, MarketHoursDatabase, _symbolPropertiesDatabase, SecurityInitializer,
-                symbol, resolution, fillDataForward, leverage, extendedMarketHours, false, false, LiveMode);
+            Security security;
+            if (!Securities.TryGetValue(symbol, out security))
+            {
+                security = SecurityManager.CreateSecurity(Portfolio, SubscriptionManager, MarketHoursDatabase, _symbolPropertiesDatabase, SecurityInitializer,
+                    symbol, resolution, fillDataForward, leverage, extendedMarketHours, false, false, LiveMode);
+            }
+
             AddToUserDefinedUniverse(security);
             return (T)security;
         }


### PR DESCRIPTION
Previously, when adding the same security more than once, new instances were created, causing issues with consolidators and indicators.
Now, the existing security will be returned.