### PR TITLE
Fixes Custom Data for Python

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -34,6 +34,8 @@ namespace QuantConnect.Algorithm
 {
     public partial class QCAlgorithm
     {
+        private readonly Dictionary<IntPtr, PythonActivator> _pythonActivators = new Dictionary<IntPtr, PythonActivator>();
+
         public PandasConverter PandasConverter { get; private set; }
 
         /// <summary>
@@ -902,22 +904,26 @@ namespace QuantConnect.Algorithm
         /// <returns>Type object</returns>
         private Type CreateType(PyObject type)
         {
-            using (Py.GIL())
+            PythonActivator pythonType;
+            if (!_pythonActivators.TryGetValue(type.Handle, out pythonType))
             {
-                var an = new AssemblyName(type.Repr().Split('.')[1].Replace("\'>", ""));
-                var assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run);
-                var moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
-                return moduleBuilder.DefineType(an.Name,
-                        TypeAttributes.Public |
-                        TypeAttributes.Class |
-                        TypeAttributes.AutoClass |
-                        TypeAttributes.AnsiClass |
-                        TypeAttributes.BeforeFieldInit |
-                        TypeAttributes.AutoLayout,
-                        // If the type has IsAuthCodeSet member, it is a PythonQuandl
-                        type.HasAttr("IsAuthCodeSet") ? typeof(PythonQuandl) : typeof(PythonData))
-                    .CreateType();
+                AssemblyName an;
+                using (Py.GIL())
+                {
+                    an = new AssemblyName(type.Repr().Split('\'')[1]);
+                }
+                var moduleBuilder = AppDomain.CurrentDomain
+                    .DefineDynamicAssembly(an, AssemblyBuilderAccess.Run)
+                    .DefineDynamicModule("MainModule");
+
+                pythonType = new PythonActivator(moduleBuilder.DefineType(an.Name).CreateType(), type);
+
+                ObjectActivator.AddActivator(pythonType.Type, pythonType.Factory);
+
+                // Save to prevent future additions
+                _pythonActivators.Add(type.Handle, pythonType);
             }
+            return pythonType.Type;
         }
     }
 }

--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -180,7 +180,6 @@ namespace QuantConnect.AlgorithmFactory
                     Log.Trace("Loader.TryCreatePythonAlgorithm(): Creating IAlgorithm instance.");
 
                     algorithmInstance = new AlgorithmPythonWrapper(module);
-                    ObjectActivator.SetPythonModule(module);
                 }
             }
             catch (Exception e)

--- a/Common/Python/PythonActivator.cs
+++ b/Common/Python/PythonActivator.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Python.Runtime;
+using System;
+
+namespace QuantConnect.Python
+{
+    /// <summary>
+    /// Provides methods for creating new instances of python custom data objects
+    /// </summary>
+    public class PythonActivator
+    {
+        /// <summary>
+        /// <see cref="System.Type"/> of the object we wish to create
+        /// </summary>
+        public Type Type { get; }
+
+        /// <summary>
+        /// Method to return an instance of object
+        /// </summary>
+        public Func<object[], object> Factory { get;  }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="PythonActivator"/>
+        /// </summary>
+        /// <param name="type"><see cref="System.Type"/> of the object we wish to create</param>
+        /// <param name="value"><see cref="PyObject"/> that contains the python type</param>
+        public PythonActivator(Type type, PyObject value)
+        {
+            Type = type;
+
+            var isPythonQuandl = false;
+
+            using (Py.GIL())
+            {
+                var pythonType = value.Invoke().GetPythonType();
+                isPythonQuandl = pythonType.As<Type>() == typeof(PythonQuandl) ;
+            }
+
+            if (isPythonQuandl)
+            {
+                Factory = x =>
+                {
+                    using (Py.GIL())
+                    {
+                        var instance = value.Invoke();
+                        var valueColumnName = instance.GetAttr("ValueColumnName").ToString();
+                        return new PythonQuandl(valueColumnName);
+                    }
+                };
+            }
+            else
+            {
+                Factory = x =>
+                {
+                    using (Py.GIL())
+                    {
+                        var instance = value.Invoke();
+                        return new PythonData(instance);
+                    }
+                };
+            };
+        }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Packets\AlphaNodePacket.cs" />
     <Compile Include="Packets\AlphaResultPacket.cs" />
     <Compile Include="Python\BrokerageModelPythonWrapper.cs" />
+    <Compile Include="Python\PythonActivator.cs" />
     <Compile Include="Python\PythonSlice.cs" />
     <Compile Include="Python\VolatilityModelPythonWrapper.cs" />
     <Compile Include="Python\PandasData.cs" />

--- a/Common/Util/ObjectActivator.cs
+++ b/Common/Util/ObjectActivator.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using CloneExtensions;
 using Fasterflect;
+using QuantConnect.Logging;
 
 namespace QuantConnect.Util
 {
@@ -133,6 +134,10 @@ namespace QuantConnect.Util
             if (!_activatorsByType.ContainsKey(key))
             {
                 _activatorsByType.Add(key, value);
+            }
+            else
+            {
+                throw new ArgumentException($"ObjectActivator.AddActivator(): a method to return an instance of {key.Name} has already been added");
             }
         }
 

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -3,14 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Algorithm;
 using QuantConnect.Algorithm.CSharp;
+using QuantConnect.AlgorithmFactory.Python.Wrappers;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
+using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Algorithm
 {
@@ -100,6 +103,35 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(quandlSubscription.Type, typeof(Quandl));
         }
 
+        [Test, Ignore]
+        public void PythonCustomDataTypes_AreAddedToSubscriptions_Successfully()
+        {
+            var pythonPath = new System.IO.DirectoryInfo("RegressionAlgorithms");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+
+            using (Py.GIL())
+            {
+                var module = Py.Import("Test_CustomDataAlgorithm");
+                var qcAlgorithm = new AlgorithmPythonWrapper(module);
+
+                // Initialize contains the statements:
+                // self.AddData(Nifty, "NIFTY")
+                // self.AddData(QuandlFuture, "SCF/CME_CL1_ON", Resolution.Daily)
+                qcAlgorithm.Initialize();
+
+                var niftySubscription = qcAlgorithm.SubscriptionManager.Subscriptions.FirstOrDefault(x => x.Symbol.Value == "NIFTY");
+                Assert.IsNotNull(niftySubscription);
+
+                var niftyFactory = (BaseData)ObjectActivator.GetActivator(niftySubscription.Type).Invoke(new object[] { niftySubscription.Type });
+                Assert.DoesNotThrow(() => niftyFactory.GetSource(niftySubscription, DateTime.UtcNow, false));
+
+                var quandlSubscription = qcAlgorithm.SubscriptionManager.Subscriptions.FirstOrDefault(x => x.Symbol.Value == "SCF/CME_CL1_ON");
+                Assert.IsNotNull(quandlSubscription);
+
+                var quandlFactory = (BaseData)ObjectActivator.GetActivator(quandlSubscription.Type).Invoke(new object[] { quandlSubscription.Type });
+                Assert.DoesNotThrow(() => quandlFactory.GetSource(quandlSubscription, DateTime.UtcNow, false));
+            }
+        }
 
         private static SubscriptionDataConfig GetMatchingSubscription(Security security, Type type)
         {

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -400,6 +400,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Content Include="Python\Indicators\IndicatorExtensionsTests.py" />
+    <Content Include="RegressionAlgorithms\Test_CustomDataAlgorithm.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="RegressionAlgorithms\Test_MethodOverload.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Tests/RegressionAlgorithms/Test_CustomDataAlgorithm.py
+++ b/Tests/RegressionAlgorithms/Test_CustomDataAlgorithm.py
@@ -1,0 +1,73 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Data import SubscriptionDataSource
+from QuantConnect.Python import PythonData, PythonQuandl
+from datetime import datetime
+import decimal
+
+class Test_CustomDataAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.AddData(Nifty, "NIFTY")
+        self.AddData(QuandlFuture, "SCF/CME_CL1_ON", Resolution.Daily)
+
+
+class QuandlFuture(PythonQuandl):
+    '''Custom quandl data type for setting customized value column name. Value column is used for the primary trading calculations and charting.'''
+    def __init__(self):
+        # Define ValueColumnName: cannot be None, Empty or non-existant column name
+        # If ValueColumnName is "Close", do not use PythonQuandl, use Quandl:
+        # self.AddData[QuandlFuture](self.crude, Resolution.Daily)
+        self.ValueColumnName = "Settle"
+
+
+class Nifty(PythonData):
+    '''NIFTY Custom Data Class'''
+    def GetSource(self, config, date, isLiveMode):
+        return SubscriptionDataSource("https://www.dropbox.com/s/rsmg44jr6wexn2h/CNXNIFTY.csv?dl=1", SubscriptionTransportMedium.RemoteFile);
+
+
+    def Reader(self, config, line, date, isLiveMode):
+        if not (line.strip() and line[0].isdigit()): return None
+
+        # New Nifty object
+        index = Nifty();
+        index.Symbol = config.Symbol
+
+        try:
+            # Example File Format:
+            # Date,       Open       High        Low       Close     Volume      Turnover
+            # 2011-09-13  7792.9    7799.9     7722.65    7748.7    116534670    6107.78
+            data = line.split(',')
+            index.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            index.Value = decimal.Decimal(data[4])
+            index["Open"] = float(data[1])
+            index["High"] = float(data[2])
+            index["Low"] = float(data[3])
+            index["Close"] = float(data[4])
+
+
+        except ValueError:
+                # Do nothing
+                return None
+
+        return index


### PR DESCRIPTION
In order to access the custom data classes, the module containing them was added to the ObjectActivator. This was unnecessary if it wasn't a custom data algorithm.
Also, this operation would not be taken into account if the custom data class were defined after the algorithm was created: this is the case for QuantBook.
We refactor how custom data is handled: a new class was added to provide a instance creation factory that creates an instance of each python custom type.