### PR TITLE
Upgrade LEAN Python to 3.6 from 2.7

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -64,7 +64,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="RDotNet, Version=1.6.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\R.NET.Community.1.6.5\lib\net40\RDotNet.dll</HintPath>
@@ -215,10 +215,10 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Accord.3.6.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.6.0\build\Accord.targets'))" />
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <Import Project="..\packages\Accord.3.6.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.6.0\build\Accord.targets')" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Algorithm.CSharp/packages.config
+++ b/Algorithm.CSharp/packages.config
@@ -8,6 +8,6 @@
   <package id="MathNet.Numerics" version="3.19.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
   <package id="R.NET.Community" version="1.6.5" targetFramework="net452" />
 </packages>

--- a/Algorithm.FSharp/QuantConnect.Algorithm.FSharp.fsproj
+++ b/Algorithm.FSharp/QuantConnect.Algorithm.FSharp.fsproj
@@ -44,7 +44,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -88,12 +88,12 @@
     </Otherwise>
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Algorithm.FSharp/packages.config
+++ b/Algorithm.FSharp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
 </packages>

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -38,7 +38,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -94,11 +94,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
 </Project>

--- a/Algorithm.Framework/packages.config
+++ b/Algorithm.Framework/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
 </packages>

--- a/Algorithm.Python/AddRemoveSecurityRegressionAlgorithm.py
+++ b/Algorithm.Python/AddRemoveSecurityRegressionAlgorithm.py
@@ -33,7 +33,7 @@ class AddRemoveSecurityRegressionAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/BasicTemplateAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateAlgorithm.py
@@ -34,7 +34,7 @@ class BasicTemplateAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10, 7)  #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/BasicTemplateDailyAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateDailyAlgorithm.py
@@ -35,7 +35,7 @@ class BasicTemplateDailyAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,18)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/BasicTemplateFillForwardAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFillForwardAlgorithm.py
@@ -27,7 +27,7 @@ class BasicTemplateFillForwardAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
         
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,11,30)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/BasicTemplateForexAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateForexAlgorithm.py
@@ -40,7 +40,7 @@ class BasicTemplateForexAlgorithm(QCAlgorithm):
         self.SetCash(100000)
 
         # Start and end dates for the backtest.
-        self.SetStartDate(2013, 10, 07)
+        self.SetStartDate(2013, 10, 7)
         self.SetEndDate(2013, 10, 11)
 
         # Add FOREX contract you want to trade

--- a/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
@@ -43,7 +43,7 @@ class BasicTemplateFrameworkAlgorithm(QCAlgorithmFramework):
         # Set requested data resolution
         self.UniverseSettings.Resolution = Resolution.Minute
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
 

--- a/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
@@ -33,7 +33,7 @@ from datetime import timedelta
 class BasicTemplateFuturesAlgorithm(QCAlgorithm):
 
     def Initialize(self):
-        self.SetStartDate(2013, 10, 07)
+        self.SetStartDate(2013, 10, 7)
         self.SetEndDate(2013, 10, 11)
         self.SetCash(1000000)
 
@@ -49,7 +49,7 @@ class BasicTemplateFuturesAlgorithm(QCAlgorithm):
         if not self.Portfolio.Invested:
             for chain in slice.FutureChains:
                  # Get contracts expiring no earlier than in 90 days
-                contracts = filter(lambda x: x.Expiry > self.Time + timedelta(90), chain.Value)
+                contracts = list(filter(lambda x: x.Expiry > self.Time + timedelta(90), chain.Value))
 
                 # if there is any contract, trade the front contract
                 if len(contracts) == 0: continue

--- a/Algorithm.Python/BasicTemplateFuturesConsolidationAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesConsolidationAlgorithm.py
@@ -14,7 +14,6 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Algorithm")
-AddReference("QuantConnect.Indicators")
 AddReference("QuantConnect.Common")
 
 from System import *
@@ -22,7 +21,8 @@ from QuantConnect import *
 from QuantConnect.Data import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Indicators import *
-
+from QuantConnect.Securities import *
+from QuantConnect.Data.Consolidators import *
 from datetime import timedelta
 
 ### <summary>
@@ -35,7 +35,7 @@ from datetime import timedelta
 class BasicTemplateFuturesConsolidationAlgorithm(QCAlgorithm):
 
     def Initialize(self):
-        self.SetStartDate(2013, 10, 07)
+        self.SetStartDate(2013, 10, 7)
         self.SetEndDate(2013, 10, 11)
         self.SetCash(1000000)
 

--- a/Algorithm.Python/BasicTemplateFuturesHistoryAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesHistoryAlgorithm.py
@@ -14,14 +14,13 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Algorithm")
-AddReference("QuantConnect.Indicators")
 AddReference("QuantConnect.Common")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Data import *
 from QuantConnect.Algorithm import *
-from QuantConnect.Indicators import *
+from QuantConnect.Securities import *
 from datetime import timedelta
 
 ### <summary>

--- a/Algorithm.Python/BasicTemplateOptionsHistoryAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsHistoryAlgorithm.py
@@ -69,7 +69,7 @@ class BasicTemplateOptionsHistoryAlgorithm(QCAlgorithm):
                     contract.ImpliedVolatility))
 
     def OnSecuritiesChanged(self, changes):
-        if changes == SecurityChanges.None: return
+        if changes == None: return
         for change in changes.AddedSecurities:
             history = self.History(change.Symbol, 10, Resolution.Hour).sort_index(level='time', ascending=False)[:3]
 

--- a/Algorithm.Python/BrokerageModelAlgorithm.py
+++ b/Algorithm.Python/BrokerageModelAlgorithm.py
@@ -33,7 +33,7 @@ class BrokerageModelAlgorithm(QCAlgorithm):
     def Initialize(self):
 
         self.SetCash(100000)            # Set Strategy Cash
-        self.SetStartDate(2013,10,07)   # Set Start Date
+        self.SetStartDate(2013,10,7)    # Set Start Date
         self.SetEndDate(2013,10,11)     # Set End Date
         self.AddEquity("SPY", Resolution.Second)
         

--- a/Algorithm.Python/BubbleAlgorithm.py
+++ b/Algorithm.Python/BubbleAlgorithm.py
@@ -1,4 +1,4 @@
-﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+﻿ # QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
 # Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/Algorithm.Python/CoarseFineFundamentalComboAlgorithm.py
+++ b/Algorithm.Python/CoarseFineFundamentalComboAlgorithm.py
@@ -35,8 +35,8 @@ class CoarseFineFundamentalComboAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2014,01,01)  #Set Start Date
-        self.SetEndDate(2015,01,01)    #Set End Date
+        self.SetStartDate(2014,1,1)  #Set Start Date
+        self.SetEndDate(2015,1,1)    #Set End Date
         self.SetCash(50000)            #Set Strategy Cash
 
         # what resolution should the data *added* to the universe be?
@@ -49,7 +49,7 @@ class CoarseFineFundamentalComboAlgorithm(QCAlgorithm):
 
         self.__numberOfSymbols = 5
         self.__numberOfSymbolsFine = 2
-        self._changes = SecurityChanges.None
+        self._changes = None
 
 
     # sort the data by daily dollar volume and take the top 'NumberOfSymbols'
@@ -70,7 +70,7 @@ class CoarseFineFundamentalComboAlgorithm(QCAlgorithm):
 
     def OnData(self, data):
         # if we have no changes, do nothing
-        if self._changes == SecurityChanges.None: return
+        if self._changes == None: return
 
         # liquidate removed securities
         for security in self._changes.RemovedSecurities:
@@ -81,7 +81,7 @@ class CoarseFineFundamentalComboAlgorithm(QCAlgorithm):
         for security in self._changes.AddedSecurities:
             self.SetHoldings(security.Symbol, 0.2)
 
-        self._changes = SecurityChanges.None;
+        self._changes = None;
 
 
     # this event fires whenever we have changes to our universe

--- a/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
+++ b/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
@@ -32,8 +32,8 @@ from datetime import datetime
 class CoarseFineFundamentalRegressionAlgorithm(QCAlgorithm):
 
     def Initialize(self):
-        self.SetStartDate(2014,04,01)  #Set Start Date
-        self.SetEndDate(2014,04,30)    #Set End Date
+        self.SetStartDate(2014,4,1)    #Set Start Date
+        self.SetEndDate(2014,4,30)     #Set End Date
         self.SetCash(50000)            #Set Strategy Cash
 
         self.UniverseSettings.Resolution = Resolution.Daily

--- a/Algorithm.Python/CoarseFundamentalTop5Algorithm.py
+++ b/Algorithm.Python/CoarseFundamentalTop5Algorithm.py
@@ -13,12 +13,10 @@
 
 from clr import AddReference
 AddReference("System.Core")
-AddReference("System.Collections")
 AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Algorithm")
 
 from System import *
-from System.Collections.Generic import List
 from QuantConnect import *
 from QuantConnect.Algorithm import QCAlgorithm
 from QuantConnect.Data.UniverseSelection import *
@@ -35,8 +33,8 @@ class CoarseFundamentalTop5Algorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2014,01,01)  #Set Start Date
-        self.SetEndDate(2015,01,01)    #Set End Date
+        self.SetStartDate(2014,1,1)    #Set Start Date
+        self.SetEndDate(2015,1,1)      #Set End Date
         self.SetCash(50000)            #Set Strategy Cash
 
         # what resolution should the data *added* to the universe be?
@@ -47,7 +45,7 @@ class CoarseFundamentalTop5Algorithm(QCAlgorithm):
         self.AddUniverse(self.CoarseSelectionFunction)
 
         self.__numberOfSymbols = 5
-        self._changes = SecurityChanges.None
+        self._changes = None
 
 
     # sort the data by daily dollar volume and take the top 'NumberOfSymbols'
@@ -61,7 +59,7 @@ class CoarseFundamentalTop5Algorithm(QCAlgorithm):
 
     def OnData(self, data):
         # if we have no changes, do nothing
-        if self._changes == SecurityChanges.None: return
+        if self._changes == None: return
 
         # liquidate removed securities
         for security in self._changes.RemovedSecurities:
@@ -72,7 +70,7 @@ class CoarseFundamentalTop5Algorithm(QCAlgorithm):
         for security in self._changes.AddedSecurities:
             self.SetHoldings(security.Symbol, 0.2)
 
-        self._changes = SecurityChanges.None;
+        self._changes = None;
 
 
     # this event fires whenever we have changes to our universe

--- a/Algorithm.Python/CustomBenchmarkAlgorithm.py
+++ b/Algorithm.Python/CustomBenchmarkAlgorithm.py
@@ -30,7 +30,7 @@ class CustomBenchmarkAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/CustomChartingAlgorithm.py
+++ b/Algorithm.Python/CustomChartingAlgorithm.py
@@ -13,16 +13,12 @@
 
 from clr import AddReference
 AddReference("System")
-AddReference("System.Collections")
 AddReference("QuantConnect.Algorithm")
-AddReference("QuantConnect.Indicators")
 AddReference("QuantConnect.Common")
 
 from System import *
-from System.Collections.Generic import List
 from QuantConnect import *
 from QuantConnect.Algorithm import *
-from QuantConnect.Indicators import *
 
 import numpy as np
 import decimal as d
@@ -46,7 +42,7 @@ class CustomChartingAlgorithm(QCAlgorithm):
         self.AddEquity("SPY", Resolution.Daily)
 
         # In your initialize method:
-		# Chart - Master Container for the Chart:
+        # Chart - Master Container for the Chart:
         stockPlot = Chart("Trade Plot")
         # On the Trade Plotter Chart we want 3 series: trades and price:
         stockPlot.AddSeries(Series("Buy", SeriesType.Scatter, 0))
@@ -71,8 +67,8 @@ class CustomChartingAlgorithm(QCAlgorithm):
         self.lastPrice = slice["SPY"].Close
         if self.fastMA == 0: self.fastMA = self.lastPrice
         if self.slowMA == 0: self.slowMA = self.lastPrice
-        self.fastMA = (d.Decimal(0.01) * self.lastPrice) + (d.Decimal(0.99) * self.fastMA);
-        self.slowMA = (d.Decimal(0.001) * self.lastPrice) + (d.Decimal(0.999) * self.slowMA);
+        self.fastMA = (d.Decimal(0.01) * self.lastPrice) + (d.Decimal(0.99) * self.fastMA)
+        self.slowMA = (d.Decimal(0.001) * self.lastPrice) + (d.Decimal(0.999) * self.slowMA)
 
         if self.Time > self.resample:
             self.resample = self.Time  + self.resamplePeriod
@@ -89,4 +85,4 @@ class CustomChartingAlgorithm(QCAlgorithm):
 
     def OnEndOfDay(self):
        #Log the end of day prices:
-       self.Plot("Trade Plot", "Price", self.lastPrice);
+       self.Plot("Trade Plot", "Price", self.lastPrice)

--- a/Algorithm.Python/CustomDataRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataRegressionAlgorithm.py
@@ -13,7 +13,6 @@
 
 from clr import AddReference
 AddReference("System.Core")
-AddReference("System.Collections")
 AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Algorithm")
 

--- a/Algorithm.Python/CustomSecurityInitializerAlgorithm.py
+++ b/Algorithm.Python/CustomSecurityInitializerAlgorithm.py
@@ -43,8 +43,8 @@ class CustomSecurityInitializerAlgorithm(QCAlgorithm):
         func_security_seeder = FuncSecuritySeeder(Func[Security, BaseData](self.GetLastKnownPrice))
         self.SetSecurityInitializer(CustomSecurityInitializer(self.BrokerageModel, func_security_seeder, DataNormalizationMode.Raw))
         
-        self.SetStartDate(2013,10,01)
-        self.SetEndDate(2013,11,01)
+        self.SetStartDate(2013,10,1)
+        self.SetEndDate(2013,11,1)
 
         self.AddEquity("SPY", Resolution.Hour)
 
@@ -66,12 +66,12 @@ class CustomSecurityInitializer(BrokerageModelSecurityInitializer):
         self.base = BrokerageModelSecurityInitializer(brokerageModel, securitySeeder)
         self.dataNormalizationMode = dataNormalizationMode
 
-    def Initialize(self, security, seedSecurity):
+    def Initialize(self, security):
         '''Initializes the specified security by setting up the models
         security -- The security to be initialized
         seedSecurity -- True to seed the security, false otherwise'''
         # first call the default implementation
-        self.base.Initialize(security, seedSecurity)
+        self.base.Initialize(security)
 
         # now apply our data normalization mode
         security.SetDataNormalizationMode(self.dataNormalizationMode)

--- a/Algorithm.Python/CustomVolatilityModelAlgorithm.py
+++ b/Algorithm.Python/CustomVolatilityModelAlgorithm.py
@@ -32,8 +32,8 @@ import numpy as np
 class CustomVolatilityModelAlgorithm(QCAlgorithm):
 
     def Initialize(self):
-        self.SetStartDate(2013,10,07)  #Set Start Date
-        self.SetEndDate(2015,07,15)    #Set End Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
+        self.SetEndDate(2015,7,15)     #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
         self.equity = self.AddEquity("SPY", Resolution.Daily)

--- a/Algorithm.Python/DailyAlgorithm.py
+++ b/Algorithm.Python/DailyAlgorithm.py
@@ -33,8 +33,8 @@ class DailyAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,01,01)  #Set Start Date
-        self.SetEndDate(2014,01,01)    #Set End Date
+        self.SetStartDate(2013,1,1)    #Set Start Date
+        self.SetEndDate(2014,1,1)      #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
         self.AddEquity("SPY", Resolution.Daily)

--- a/Algorithm.Python/DailyFxAlgorithm.py
+++ b/Algorithm.Python/DailyFxAlgorithm.py
@@ -13,16 +13,13 @@
 
 from clr import AddReference
 AddReference("System.Core")
-AddReference("System.Collections")
 AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Algorithm")
 
 from System import *
-from System.Collections.Generic import List
 from QuantConnect import *
 from QuantConnect.Algorithm import QCAlgorithm
-from QuantConnect.Data.UniverseSelection import *
-
+from QuantConnect.Data.Custom import DailyFx
 import numpy as np
 
 ### <summary>
@@ -33,18 +30,17 @@ import numpy as np
 ### <meta name="tag" content="forex" />
 ### <meta name="tag" content="dailyfx" />
 class DailyFxAlgorithm(QCAlgorithm):
-
     ''' Add the Daily FX type to our algorithm and use its events. '''
 
     def Initialize(self):
         # Set the cash we'd like to use for our backtest
         self.SetCash(100000)
         # Set the start and the end date
-        self.SetStartDate(2016,05,26)
-        self.SetEndDate(2016,05,27)
+        self.SetStartDate(2016,5,26)
+        self.SetEndDate(2016,5,27)
         self._sliceCount = 0
         self._eventCount = 0
-        self.AddData[DailyFx]("DFX",Resolution.Second)
+        self.AddData[DailyFx]("DFX",Resolution.Second, TimeZones.Utc)
 
     def OnData(self, data):
 
@@ -54,4 +50,3 @@ class DailyFxAlgorithm(QCAlgorithm):
         result = data["DFX"]
         self._sliceCount +=1
         self.Log("SLICE >> {0} : {1}".format(self._sliceCount, result.ToString()))
-

--- a/Algorithm.Python/DataConsolidationAlgorithm.py
+++ b/Algorithm.Python/DataConsolidationAlgorithm.py
@@ -45,7 +45,7 @@ class DataConsolidationAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(DateTime(2013, 10, 07, 9, 30, 0))  #Set Start Date
+        self.SetStartDate(DateTime(2013, 10, 7, 9, 30, 0))  #Set Start Date
         self.SetEndDate(self.StartDate + timedelta(1))           #Set End Date
         # Find more symbols here: http://quantconnect.com/data
         self.AddEquity("SPY")

--- a/Algorithm.Python/DelistingEventsAlgorithm.py
+++ b/Algorithm.Python/DelistingEventsAlgorithm.py
@@ -35,8 +35,8 @@ class DelistingEventsAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2007, 05, 16)  #Set Start Date
-        self.SetEndDate(2007, 05, 25)    #Set End Date
+        self.SetStartDate(2007, 5, 16)  #Set Start Date
+        self.SetEndDate(2007, 5, 25)    #Set End Date
         self.SetCash(100000)             #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
         self.AddEquity("AAA", Resolution.Daily)

--- a/Algorithm.Python/DividendAlgorithm.py
+++ b/Algorithm.Python/DividendAlgorithm.py
@@ -35,8 +35,8 @@ class DividendAlgorithm(QCAlgorithm):
 
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
-        self.SetStartDate(1998,01,01)  #Set Start Date
-        self.SetEndDate(2006,01,21)    #Set End Date
+        self.SetStartDate(1998,1,1)  #Set Start Date
+        self.SetEndDate(2006,1,21)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
         equity = self.AddEquity("MSFT", Resolution.Daily)

--- a/Algorithm.Python/DropboxBaseDataUniverseSelectionAlgorithm.py
+++ b/Algorithm.Python/DropboxBaseDataUniverseSelectionAlgorithm.py
@@ -59,7 +59,7 @@ class DropboxBaseDataUniverseSelectionAlgorithm(QCAlgorithm):
     def OnData(self, slice):
 
         if slice.Bars.Count == 0: return
-        if self._changes == SecurityChanges.None: return
+        if self._changes == None: return
         
         # start fresh
         self.Liquidate()
@@ -69,7 +69,7 @@ class DropboxBaseDataUniverseSelectionAlgorithm(QCAlgorithm):
             self.SetHoldings(tradeBar.Symbol, percentage)
         
         # reset changes
-        self._changes = SecurityChanges.None
+        self._changes = None
     
     def OnSecuritiesChanged(self, changes):
         self._changes = changes

--- a/Algorithm.Python/EmaCrossUniverseSelectionAlgorithm.py
+++ b/Algorithm.Python/EmaCrossUniverseSelectionAlgorithm.py
@@ -38,8 +38,8 @@ class EmaCrossUniverseSelectionAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2010,01,01)  #Set Start Date
-        self.SetEndDate(2015,01,01)    #Set End Date
+        self.SetStartDate(2010,1,1)  #Set Start Date
+        self.SetEndDate(2015,1,1)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
 
         self.UniverseSettings.Resolution = Resolution.Daily
@@ -66,7 +66,7 @@ class EmaCrossUniverseSelectionAlgorithm(QCAlgorithm):
             avg.update(cf.EndTime, cf.Price)
 
         # Filter the values of the dict: we only want up-trending securities
-        values = filter(lambda x: x.is_uptrend, self.averages.values())
+        values = list(filter(lambda x: x.is_uptrend, self.averages.values()))
 
         # Sorts the values of the dict: we want those with greater difference between the moving averages
         values.sort(key=lambda x: x.scale, reverse=True)

--- a/Algorithm.Python/FinancialAdvisorDemoAlgorithm.py
+++ b/Algorithm.Python/FinancialAdvisorDemoAlgorithm.py
@@ -32,7 +32,7 @@ class FinancialAdvisorDemoAlgorithm(QCAlgorithm):
     def Initialize(self):
         # Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must be initialized.
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
 

--- a/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
+++ b/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
@@ -42,7 +42,7 @@ class FractionalQuantityRegressionAlgorithm(QCAlgorithm):
     def Initialize(self):
 
         self.SetStartDate(2015, 11, 12)
-        self.SetEndDate(2016, 04, 01)
+        self.SetEndDate(2016, 4, 1)
         self.SetCash(100000)
         self.SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash)
 

--- a/Algorithm.Python/FuturesMomentumAlgorithm.py
+++ b/Algorithm.Python/FuturesMomentumAlgorithm.py
@@ -43,7 +43,9 @@ class FuturesMomentumAlgorithm(QCAlgorithm):
         self.SetCash(100000)
         fastPeriod = 20
         slowPeriod = 60
-        self._tolerance = 0.001
+        self._tolerance = d.Decimal(1 + 0.001)
+        self.IsUpTrend = False
+        self.IsDownTrend = False
         self.SetWarmUp(max(fastPeriod, slowPeriod))
 
         # Adds SPY to be used in our EMA indicators
@@ -55,10 +57,11 @@ class FuturesMomentumAlgorithm(QCAlgorithm):
         future = self.AddFuture(Futures.Indices.SP500EMini)
         future.SetFilter(timedelta(0), timedelta(182))
 
+
     def OnData(self, slice):
         if self._slow.IsReady and self._fast.IsReady:
-            self.IsUpTrend = self._fast.Current.Value > self._slow.Current.Value * d.Decimal(1 + self._tolerance)
-            self.IsDownTrend = self._fast.Current.Value < self._slow.Current.Value * d.Decimal(1 + self._tolerance)
+            self.IsUpTrend = self._fast.Current.Value > self._slow.Current.Value * self._tolerance
+            self.IsDownTrend = self._fast.Current.Value < self._slow.Current.Value * self._tolerance
             if (not self.Portfolio.Invested) and self.IsUpTrend:
                 for chain in slice.FuturesChains:
                     # find the front contract expiring no earlier than in 90 days
@@ -76,7 +79,7 @@ class FuturesMomentumAlgorithm(QCAlgorithm):
             self.Plot("Indicator Signal", "EOD",1)
         elif self.IsDownTrend:
             self.Plot("Indicator Signal", "EOD",-1)
-        else:
+        elif self._slow.IsReady and self._fast.IsReady:
             self.Plot("Indicator Signal", "EOD",0)
 
 

--- a/Algorithm.Python/LimitFillRegressionAlgorithm.py
+++ b/Algorithm.Python/LimitFillRegressionAlgorithm.py
@@ -33,7 +33,7 @@ class LimitFillRegressionAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)  #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/MACDTrendAlgorithm.py
+++ b/Algorithm.Python/MACDTrendAlgorithm.py
@@ -34,8 +34,8 @@ class MACDTrendAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2004, 01, 01)  #Set Start Date
-        self.SetEndDate(2015, 01, 01)    #Set End Date
+        self.SetStartDate(2004, 1, 1)    #Set Start Date
+        self.SetEndDate(2015, 1, 1)      #Set End Date
         self.SetCash(100000)             #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
         self.AddEquity("SPY", Resolution.Daily)

--- a/Algorithm.Python/MarketOnOpenOnCloseAlgorithm.py
+++ b/Algorithm.Python/MarketOnOpenOnCloseAlgorithm.py
@@ -34,7 +34,7 @@ class MarketOnOpenOnCloseAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/MovingAverageCrossAlgorithm.py
+++ b/Algorithm.Python/MovingAverageCrossAlgorithm.py
@@ -37,8 +37,8 @@ class MovingAverageCrossAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2009, 01, 01)  #Set Start Date
-        self.SetEndDate(2015, 01, 01)    #Set End Date
+        self.SetStartDate(2009, 1, 1)    #Set Start Date
+        self.SetEndDate(2015, 1, 1)      #Set End Date
         self.SetCash(100000)             #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
         self.AddEquity("SPY")

--- a/Algorithm.Python/MultipleSymbolConsolidationAlgorithm.py
+++ b/Algorithm.Python/MultipleSymbolConsolidationAlgorithm.py
@@ -46,8 +46,8 @@ class MultipleSymbolConsolidationAlgorithm(QCAlgorithm):
         # Contains all of our forex symbols
         ForexSymbols =["EURUSD", "USDJPY", "EURGBP", "EURCHF", "USDCAD", "USDCHF", "AUDUSD","NZDUSD"]
         
-        self.SetStartDate(2014, 12, 01)
-        self.SetEndDate(2015, 02, 01)
+        self.SetStartDate(2014, 12, 1)
+        self.SetEndDate(2015, 2, 1)
         
         # initialize our equity data
         for symbol in EquitySymbols:

--- a/Algorithm.Python/OptionChainProviderAlgorithm.py
+++ b/Algorithm.Python/OptionChainProviderAlgorithm.py
@@ -15,14 +15,12 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Algorithm")
-AddReference("QuantConnect.Indicators")
 AddReference("QuantConnect.Common")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Data import *
 from QuantConnect.Algorithm import *
-from QuantConnect.Indicators import *
 import numpy as np
 from datetime import timedelta
 
@@ -36,11 +34,11 @@ from datetime import timedelta
 ### <meta name="tag" content="selecting options" />
 ### <meta name="tag" content="manual selection" />
 
-class BootCampTask(QCAlgorithm):
+class OptionChainProviderAlgorithm(QCAlgorithm):
 
     def Initialize(self):
-        self.SetStartDate(2017, 06, 01)
-        self.SetEndDate(2017, 07, 01)
+        self.SetStartDate(2017, 6, 1)
+        self.SetEndDate(2017, 7, 1)
         self.SetCash(100000)
         self.equity = self.AddEquity("AMZN", Resolution.Minute)
         

--- a/Algorithm.Python/OptionOpenInterestRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionOpenInterestRegressionAlgorithm.py
@@ -30,8 +30,8 @@ class OptionOpenInterestRegressionAlgorithm(QCAlgorithm):
 
     def Initialize(self):
         self.SetCash(1000000)
-        self.SetStartDate(2014,06,05)
-        self.SetEndDate(2014,06,06)
+        self.SetStartDate(2014,6,5)
+        self.SetEndDate(2014,6,6)
 
         option = self.AddOption("TWX")
 
@@ -47,12 +47,12 @@ class OptionOpenInterestRegressionAlgorithm(QCAlgorithm):
                 for contract in chain.Value:
                     if float(contract.Symbol.ID.StrikePrice) == 72.5 and \
                        contract.Symbol.ID.OptionRight == OptionRight.Call and \
-                       contract.Symbol.ID.Date == datetime(2016, 01, 15):
-                        if slice.Time.date() == datetime(2014, 06, 5).date() and contract.OpenInterest != 50:
+                       contract.Symbol.ID.Date == datetime(2016, 1, 15):
+                        if slice.Time.date() == datetime(2014, 6, 5).date() and contract.OpenInterest != 50:
                             raise ValueError("Regression test failed: current open interest was not correctly loaded and is not equal to 50")  
-                        if slice.Time.date() == datetime(2014, 06, 6).date() and contract.OpenInterest != 70:
+                        if slice.Time.date() == datetime(2014, 6, 6).date() and contract.OpenInterest != 70:
                             raise ValueError("Regression test failed: current open interest was not correctly loaded and is not equal to 70")  
-                        if slice.Time.date() == datetime(2014, 06, 6).date():
+                        if slice.Time.date() == datetime(2014, 6, 6).date():
                             self.MarketOrder(contract.Symbol, 1)
                             self.MarketOnCloseOrder(contract.Symbol, -1)
 

--- a/Algorithm.Python/OptionRenameRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionRenameRegressionAlgorithm.py
@@ -31,8 +31,8 @@ class OptionRenameRegressionAlgorithm(QCAlgorithm):
     def Initialize(self):
 
         self.SetCash(1000000)
-        self.SetStartDate(2013,06,28)
-        self.SetEndDate(2013,07,02)
+        self.SetStartDate(2013,6,28)
+        self.SetEndDate(2013,7,2)
         option = self.AddOption("FOXA")
 
         # set our strike/expiry filter for this option chain

--- a/Algorithm.Python/OrderTicketDemoAlgorithm.py
+++ b/Algorithm.Python/OrderTicketDemoAlgorithm.py
@@ -36,7 +36,7 @@ class OrderTicketDemoAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/ParameterizedAlgorithm.py
+++ b/Algorithm.Python/ParameterizedAlgorithm.py
@@ -34,9 +34,9 @@ class ParameterizedAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013, 10, 07)  #Set Start Date
+        self.SetStartDate(2013, 10, 7)   #Set Start Date
         self.SetEndDate(2013, 10, 11)    #Set End Date
-        self.SetCash(100000)           #Set Strategy Cash
+        self.SetCash(100000)             #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
         self.AddEquity("SPY")
 

--- a/Algorithm.Python/PythonPackageTestAlgorithm.py
+++ b/Algorithm.Python/PythonPackageTestAlgorithm.py
@@ -31,7 +31,6 @@ import itertools
 import math
 import operator
 import pytz
-import Queue
 import re
 import time
 import zlib
@@ -69,19 +68,19 @@ class PythonPackageTestAlgorithm(QCAlgorithm):
         self.AddEquity("SPY", Resolution.Daily)
 
         # numpy test
-        print "numpy test >>> print numpy.pi: " , numpy.pi
+        print ("numpy test >>> print numpy.pi: " , numpy.pi)
 
         # scipy test:
-        print "scipy test >>> print mean of 1 2 3 4 5:", scipy.mean(numpy.array([1, 2, 3, 4, 5]))
+        print ("scipy test >>> print mean of 1 2 3 4 5:", scipy.mean(numpy.array([1, 2, 3, 4, 5])))
 
         #sklearn test
-        print "sklearn test >>> default RandomForestClassifier:", RandomForestClassifier()
+        print ("sklearn test >>> default RandomForestClassifier:", RandomForestClassifier())
 
         # cvxopt matrix test
-        print "cvxopt >>>", cvxopt.matrix([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2,3))
+        print ("cvxopt >>>", cvxopt.matrix([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2,3)))
 
         # talib test
-        print "talib test >>>", talib.SMA(numpy.random.random(100))
+        print ("talib test >>>", talib.SMA(numpy.random.random(100)))
 
         # blaze test
         blaze_test()
@@ -116,7 +115,6 @@ class PythonPackageTestAlgorithm(QCAlgorithm):
         # deap test
         deap_test()
 
-
     def OnData(self, data): pass
 
 def blaze_test():
@@ -127,7 +125,7 @@ def blaze_test():
          [3, 'Charlie', 300],
          [4, 'Denis',   400],
          [5, 'Edith',  -500]]
-    print "blaze test >>>", list(blaze.compute(deadbeats, L))
+    print ("blaze test >>>", list(blaze.compute(deadbeats, L)))
 
 def grade(score, breakpoints=[60, 70, 80, 90], grades='FDCBA'):
     i = bisect(breakpoints, score)
@@ -144,9 +142,9 @@ def cvxpy_test():
     gamma = cvxpy.Parameter(sign='positive')
     ret = mu.T*w
     risk = cvxpy.quad_form(w, Sigma)
-    print "csvpy test >>> ", cvxpy.Problem(cvxpy.Maximize(ret - gamma*risk),
+    print ("csvpy test >>> ", cvxpy.Problem(cvxpy.Maximize(ret - gamma*risk),
                [cvxpy.sum_entries(w) == 1,
-                w >= 0])
+                w >= 0]))
 
 def statsmodels_test():
     nsample = 100
@@ -160,31 +158,31 @@ def statsmodels_test():
 
     model = sm.OLS(y, X)
     results = model.fit()
-    print "statsmodels tests >>>", results.summary()
+    print ("statsmodels tests >>>", results.summary())
 
 def pykalman_test():
     kf = KalmanFilter(transition_matrices = [[1, 1], [0, 1]], observation_matrices = [[0.1, 0.5], [-0.3, 0.0]])
     measurements = numpy.asarray([[1,0], [0,0], [0,1]])  # 3 observations
     kf = kf.em(measurements, n_iter=5)
-    print "pykalman test >>>", kf.filter(measurements)
+    print ("pykalman test >>>", kf.filter(measurements))
 
 def copulalib_test():
     x = numpy.random.normal(size=100)
     y = 2.5 * x + numpy.random.normal(size=100)
 
     #Make the instance of Copula class with x, y and clayton family::
-    print "copulalib test >>>", Copula(x, y, family='clayton')
+    print ("copulalib test >>>", Copula(x, y, family='clayton'))
 
 def theano_test():
     a = theano.tensor.vector() # declare variable
     out = a + a ** 10               # build symbolic expression
     f = theano.function([a], out)   # compile function
-    print "theano test >>>", f([0, 1, 2])
+    print ("theano test >>>", f([0, 1, 2])) 
 
 def xgboost_test():
     data = numpy.random.rand(5,10) # 5 entities, each contains 10 features
     label = numpy.random.randint(2, size=5) # binary target
-    print "xgboost test >>>", xgboost.DMatrix( data, label=label)
+    print ("xgboost test >>>", xgboost.DMatrix( data, label=label))
 
 def arch_test():
     r = numpy.array([0.945532630498276,
@@ -205,7 +203,7 @@ def arch_test():
 
     garch11 = arch_model(r, p=1, q=1)
     res = garch11.fit(update_freq=10)
-    print "arch test >>>", res.summary()
+    print ("arch test >>>", res.summary())
 
 def keras_test():
     # Initialize the constructor
@@ -220,14 +218,14 @@ def keras_test():
     # Add an output layer
     model.add(Dense(1, activation='sigmoid'))
 
-    print "keras test >>>", model
+    print ("keras test >>>", model)
 
 def tensorflow_test():
     node1 = tf.constant(3.0, tf.float32)
     node2 = tf.constant(4.0) # also tf.float32 implicitly
     sess = tf.Session()
     node3 = tf.add(node1, node2)
-    print "tensorflow test >>>", "sess.run(node3): ", sess.run(node3)
+    print ("tensorflow test >>>", "sess.run(node3): ", sess.run(node3))
 
 def deap_test():
     # onemax example evolves to print list of ones: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
@@ -257,4 +255,4 @@ def deap_test():
 
     pop, log = algorithms.eaSimple(pop, toolbox, cxpb=0.5, mutpb=0.2, ngen=30, 
                                    stats=stats, halloffame=hof, verbose=False) # change to verbose=True to see evolution table
-    print "deap test >>>", hof[0]
+    print ("deap test >>>", hof[0])

--- a/Algorithm.Python/QuandlImporterAlgorithm.py
+++ b/Algorithm.Python/QuandlImporterAlgorithm.py
@@ -42,7 +42,7 @@ class QuandlImporterAlgorithm(QCAlgorithm):
         self.SetStartDate(2013,1,1)                                 #Set Start Date
         self.SetEndDate(datetime.today() - timedelta(1))            #Set End Date
         self.SetCash(25000)                                         #Set Strategy Cash
-        self.AddData[Quandl](self.quandlCode, Resolution.Daily)
+        self.AddData[Quandl](self.quandlCode, Resolution.Daily, TimeZones.NewYork)
         self.sma = self.SMA(self.quandlCode, 14)
 
     def OnData(self, data):

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -145,7 +145,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -157,12 +157,12 @@
       ./build.sh
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -33,6 +33,7 @@
     <Compile Include="BasicTemplateFuturesAlgorithm.py" />
     <Compile Include="BasicTemplateFuturesConsolidationAlgorithm.py" />
     <Compile Include="BasicTemplateFuturesHistoryAlgorithm.py" />
+    <Compile Include="BasicTemplateLibrary.py" />
     <Compile Include="BasicTemplateOptionsAlgorithm.py" />
     <Compile Include="BasicTemplateOptionsFilterUniverseAlgorithm.py" />
     <Compile Include="BasicTemplateOptionsHistoryAlgorithm.py" />
@@ -61,6 +62,7 @@
     <Compile Include="EmaCrossUniverseSelectionAlgorithm.py" />
     <Compile Include="ETFGlobalRotationAlgorithm.py" />
     <Compile Include="FilteredIdentityAlgorithm.py" />
+    <Compile Include="FinancialAdvisorDemoAlgorithm.py" />
     <Compile Include="FractionalQuantityRegressionAlgorithm.py" />
     <Compile Include="FuturesMomentumAlgorithm.py" />
     <Compile Include="HistoryAlgorithm.py" />
@@ -73,6 +75,7 @@
     <Compile Include="MarginCallEventsAlgorithm.py" />
     <Compile Include="MarketOnOpenOnCloseAlgorithm.py" />
     <Compile Include="MovingAverageCrossAlgorithm.py" />
+    <Compile Include="MultipleSymbolConsolidationAlgorithm.py" />
     <Compile Include="OptionChainConsistencyRegressionAlgorithm.py" />
     <Compile Include="OptionChainProviderAlgorithm.py" />
     <Compile Include="OptionExerciseAssignRegressionAlgorithm.py" />

--- a/Algorithm.Python/RegressionAlgorithm.py
+++ b/Algorithm.Python/RegressionAlgorithm.py
@@ -31,7 +31,7 @@ class RegressionAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(10000000)         #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/RegressionChannelAlgorithm.py
+++ b/Algorithm.Python/RegressionChannelAlgorithm.py
@@ -13,13 +13,11 @@
 
 from clr import AddReference
 AddReference("System")
-AddReference("System.Collections")
 AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Indicators")
 AddReference("QuantConnect.Common")
 
 from System import *
-from System.Collections.Generic import List
 from QuantConnect import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Indicators import *

--- a/Algorithm.Python/ScheduledEventsAlgorithm.py
+++ b/Algorithm.Python/ScheduledEventsAlgorithm.py
@@ -33,7 +33,7 @@ class ScheduledEventsAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data

--- a/Algorithm.Python/UniverseSelectionDefinitionsAlgorithm.py
+++ b/Algorithm.Python/UniverseSelectionDefinitionsAlgorithm.py
@@ -37,7 +37,7 @@ class UniverseSelectionDefinitionsAlgorithm(QCAlgorithm):
         # force securities to remain in the universe for a minimm of 30 minutes
         self.UniverseSettings.MinimumTimeInUniverse = timedelta(minutes=30)
 
-        self.SetStartDate(2013,10,07)   # Set Start Date
+        self.SetStartDate(2013,10,7)    # Set Start Date
         self.SetEndDate(2013,10,11)     # Set End Date
         self.SetCash(100000)            # Set Strategy Cash
 
@@ -53,10 +53,10 @@ class UniverseSelectionDefinitionsAlgorithm(QCAlgorithm):
         # add universe for stocks between the 70th and 80th dollar volume percentile
         self.AddUniverse(self.Universe.DollarVolume.Percentile(70.0, 80.0))
 
-        self.changes = SecurityChanges.None
+        self.changes = None
 
     def OnData(self, data):
-        if self.changes == SecurityChanges.None: return
+        if self.changes == None: return
 
         # liquidate securities that fell out of our universe
         for security in self.changes.RemovedSecurities:
@@ -68,7 +68,7 @@ class UniverseSelectionDefinitionsAlgorithm(QCAlgorithm):
             if not security.Invested:
                 self.MarketOrder(security.Symbol, 10)
 
-        self.changes = SecurityChanges.None;
+        self.changes = None;
 
 
     # this event fires whenever we have changes to our universe

--- a/Algorithm.Python/UniverseSelectionRegressionAlgorithm.py
+++ b/Algorithm.Python/UniverseSelectionRegressionAlgorithm.py
@@ -31,8 +31,8 @@ class UniverseSelectionRegressionAlgorithm(QCAlgorithm):
     
     def Initialize(self):
         
-        self.SetStartDate(2014,03,22)  #Set Start Date
-        self.SetEndDate(2014,04,07)    #Set End Date
+        self.SetStartDate(2014,3,22)   #Set Start Date
+        self.SetEndDate(2014,4,7)      #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
         # security that exists with no mappings

--- a/Algorithm.Python/UpdateOrderRegressionAlgorithm.py
+++ b/Algorithm.Python/UpdateOrderRegressionAlgorithm.py
@@ -38,8 +38,8 @@ class UpdateOrderRegressionAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,01,01)  #Set Start Date
-        self.SetEndDate(2015,01,01)    #Set End Date
+        self.SetStartDate(2013,1,1)    #Set Start Date
+        self.SetEndDate(2015,1,1)      #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
 

--- a/Algorithm.Python/main.py
+++ b/Algorithm.Python/main.py
@@ -14,13 +14,11 @@
 import clr
 clr.AddReference("System")
 clr.AddReference("QuantConnect.Algorithm")
-clr.AddReference("QuantConnect.Indicators")
 clr.AddReference("QuantConnect.Common")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import *
-from QuantConnect.Indicators import *
 
 
 class BasicTemplateAlgorithm(QCAlgorithm):
@@ -29,11 +27,11 @@ class BasicTemplateAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
         
-        self.SetStartDate(2013,10,07)  #Set Start Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
-        self.AddSecurity(SecurityType.Equity, "SPY", Resolution.Second)
+        self.AddEquity("SPY", Resolution.Second)
 
     def OnData(self, data):
         '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.

--- a/Algorithm.Python/packages.config
+++ b/Algorithm.Python/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
 </packages>

--- a/Algorithm.Python/readme.md
+++ b/Algorithm.Python/readme.md
@@ -6,21 +6,21 @@ QuantConnect Python Algorithm Project:
 
 1.1 Visual Studio 2017 Community edition can be downloaded free from [https://www.visualstudio.com](https://www.visualstudio.com). VS comes with Python (if you install Python Tools for Visual Studio) but it doesn't seem to add Python to the system path. We'll need to reinstall python manually. If you already have VS installed you should be able to skip this step.
 
-**2. Install Python:**
+**2. Install Python 3.6:**
 
-2.1 Use the Windows x86-64 MSI installer from [https://www.python.org/downloads/release/python-2713](https://www.python.org/downloads/release/python-2713).
+2.1 Use the Windows x86-64 MSI installer from [https://www.python.org/downloads/release/python-364/](https://www.python.org/downloads/release/python-364/).
 
 2.2 When asked to select the features to be installed, make sure you select "Add python.exe to Path"
 
-2.3 Once installed confirm the python27.dll is in place in *C:\Windows\System32*.
+2.3 Once installed confirm the python36.dll is in place in *C:\Windows\System32*.
 
-2.4 Add python27.dll location to the system path:
+2.4 Add python36.dll location to the system path:
  
 2.4.1 Right mouse button on My Computer. Click Properties.
 
 2.4.2 Click Advanced System Settings -> Environment Variables -> System Variables
 
-2.4.3 On the "Path" section click New and enter the python27.dll path, in our example this was *C:\Windows\System32*
+2.4.3 On the "Path" section click New and enter the python36.dll path, in our example this was *C:\Windows\System32*
 
 2.4.4 *C:\Windows\System32* is normally in the path, thus this procedure is not necessary.
 
@@ -32,9 +32,9 @@ QuantConnect Python Algorithm Project:
 
 3.2 Prepare Python.Runtime.dll. This is needed to run Python algorithms in LEAN.
 
-3.2.1 Delete the existing files in \Lean\packages\QuantConnect.pythonnet.1.0.5.4\lib
+3.2.1 Delete the existing files in \Lean\packages\QuantConnect.pythonnet.1.0.5.5\lib
 
-3.2.2 Using windows you'll need to copy the \Lean\packages\QuantConnect.pythonnet.1.0.5.4\build\*Python.Runtime.win* file into the ..\lib\ directory and rename it to Python.Runtime.dll.
+3.2.2 Using windows you'll need to copy the \Lean\packages\QuantConnect.pythonnet.1.0.5.5\build\*Python.Runtime.win* file into the ..\lib\ directory and rename it to Python.Runtime.dll.
 
 **4 Run LEAN:**
 
@@ -58,22 +58,22 @@ QuantConnect Python Algorithm Project:
 
 1.1 Visual Studio 2017 Community edition can be downloaded free from [https://www.visualstudio.com/visual-studio-mac](https://www.visualstudio.com/visual-studio-mac). VS will install Mono that is a requirement for running Windows executables like Lean. If you already have VS and/or Mono installed you should be able to skip this step.
 
-**2. Install Python:**
+**2. Install Python 3.6:**
 
 2.1 By default, macOS has python installed.
 
-2.2 Confirm the libpython2.7.dylib is in place in */usr/lib*.
+2.2 Confirm the libpython3.6.dylib is in place in */usr/lib*.
 
-2.3 If libpython2.7.dylib is not in */usr/lib*, find and link it into */usr/lib*:
+2.3 If libpython3.6.dylib is not in */usr/lib*, find and link it into */usr/lib*:
 ```
-$ find / -name libpython2.7.dylib
-/System/Library/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib
-$ ln -s /System/Library/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib /usr/lib/libpython2.7.dylib
+$ find / -name libpython3.6.dylib
+/System/Library/Frameworks/Python.framework/Versions/3.6/lib/libpython3.6.dylib
+$ ln -s /System/Library/Frameworks/Python.framework/Versions/3.6/lib/libpython3.6.dylib /usr/lib/libpython3.6.dylib
 ```
 
 2.3.1 Common Mistake: Often you may get a permissions error when trying to setup this sym link - you should check if the file already exists in the */usr/lib* directory. If its there you don't need to add the sym link.
 
-2.4 If libpython2.7.dylib cannot be found, reinstall python.
+2.4 If libpython3.6.dylib cannot be found, reinstall python.
 
 2.5 Install [pandas](https://pandas.pydata.org/) and its [dependencies](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies)
 
@@ -88,9 +88,9 @@ $ sudo easy-install pip
 
 3.2 Prepare Python.Runtime.dll. This is needed to run Python algorithms in LEAN.
 
-3.2.1 Delete the existing files in \Lean\packages\QuantConnect.pythonnet.1.0.5.4\lib
+3.2.1 Delete the existing files in \Lean\packages\QuantConnect.pythonnet.1.0.5.5\lib
 
-3.2.2 Using macOS you'll need to copy the \Lean\packages\QuantConnect.pythonnet.1.0.5.4\build\*Python.Runtime.mac* file into the ..\lib\ directory and rename it to Python.Runtime.dll.
+3.2.2 Using macOS you'll need to copy the \Lean\packages\QuantConnect.pythonnet.1.0.5.5\build\*Python.Runtime.mac* file into the ..\lib\ directory and rename it to Python.Runtime.dll.
 
 **4 Run LEAN:**
 
@@ -113,15 +113,28 @@ $ sudo easy-install pip
 ### Linux
 **1. Follow the installation instructions [here](https://github.com/QuantConnect/Lean#linux-debian-ubuntu)**
 
-1.1 You should see this exit successfully with a list of the algorithm statistics and 1 trade.
+**2. Install Python 3.6 with Miniconda:**
+```
+export PATH="/root/miniconda3/bin:$PATH"
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+bash Miniconda3-latest-Linux-x86_64.sh -b
+rm -rf Miniconda3-latest-Linux-x86_64.sh
+ln -s /root/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6.so
+conda update -y python conda pip
+conda install -y cython pandas
+```
 
-1.2 Update the [config](https://github.com/QuantConnect/Lean/blob/master/Launcher/config.json) to run the python algorithm:
+**3 Run LEAN:**
+
+3.1 You should see this exit successfully with a list of the algorithm statistics and 1 trade.
+
+3.2 Update the [config](https://github.com/QuantConnect/Lean/blob/master/Launcher/config.json) to run the python algorithm:
 ```json
 "algorithm-type-name": "BasicTemplateAlgorithm",
 "algorithm-language": "Python",
 "algorithm-location": "../../../Algorithm.Python/BasicTemplateAlgorithm.py",
 ```
-1.2.1 You should see the same result of 1.1.
+1.2.1 You should see the same result of 3.1.
 
 ___
 #### Python.Runtime.dll compilation
@@ -135,21 +148,21 @@ Below we can find the compilation flags that create a suitable Python.Runtime.dl
 
 **Windows**
 ```
-msbuild pythonnet.sln /nologo /v:quiet /t:Clean;Rebuild /p:Platform=x64 /p:PythonInteropFile="interop27.cs" /p:Configuration=ReleaseWin /p:DefineConstants="PYTHON27,PYTHON2,UCS2"
+msbuild pythonnet.sln /nologo /v:quiet /t:Clean;Rebuild /p:Platform=x64 /p:PythonInteropFile="interop36.cs" /p:Configuration=ReleaseWin /p:DefineConstants="PYTHON36,PYTHON3,UCS2"
 ```
 
 **macOS UCS2**
 ```
-msbuild pythonnet.sln /nologo /v:quiet /t:Clean;Rebuild /p:Platform=x64 /p:PythonInteropFile="interop27.cs" /p:Configuration=ReleaseMono /p:DefineConstants="PYTHON27,PYTHON2,UCS2,MONO_OSX"
+msbuild pythonnet.sln /nologo /v:quiet /t:Clean;Rebuild /p:Platform=x64 /p:PythonInteropFile="interop36.cs" /p:Configuration=ReleaseMono /p:DefineConstants="PYTHON36,PYTHON3,UCS2,MONO_OSX"
 ```
 
 **macOS UCS4**
 ```
-msbuild pythonnet.sln /nologo /v:quiet /t:Clean;Rebuild /p:Platform=x64 /p:PythonInteropFile="interop27.cs" /p:Configuration=ReleaseMono /p:DefineConstants="PYTHON27,PYTHON2,UCS4,MONO_OSX"
+msbuild pythonnet.sln /nologo /v:quiet /t:Clean;Rebuild /p:Platform=x64 /p:PythonInteropFile="interop36.cs" /p:Configuration=ReleaseMono /p:DefineConstants="PYTHON36,PYTHON3,UCS4,MONO_OSX"
 ```
 
 
 **Linux**
 ```
-msbuild pythonnet.sln /nologo /v:quiet /t:Clean;Rebuild /p:Platform=x64 /p:PythonInteropFile="interop27.cs" /p:Configuration=ReleaseMono /p:DefineConstants="PYTHON27,PYTHON2,UCS4,MONO_LINUX"
+msbuild pythonnet.sln /nologo /v:quiet /t:Clean;Rebuild /p:Platform=x64 /p:PythonInteropFile="interop36.cs" /p:Configuration=ReleaseMono /p:DefineConstants="PYTHON36,PYTHON3,UCS4,MONO_LINUX"
 ```

--- a/Algorithm.Python/readme.md
+++ b/Algorithm.Python/readme.md
@@ -115,11 +115,11 @@ $ sudo easy-install pip
 
 **2. Install Python 3.6 with Miniconda:**
 ```
-export PATH="/root/miniconda3/bin:$PATH"
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-bash Miniconda3-latest-Linux-x86_64.sh -b
-rm -rf Miniconda3-latest-Linux-x86_64.sh
-ln -s /root/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6.so
+export PATH="/opt/miniconda3/bin:$PATH"
+wget https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
+bash Miniconda3-4.3.31-Linux-x86_64.sh -b
+rm -rf Miniconda3-4.3.31-Linux-x86_64.sh
+ln -s /opt/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6.so
 conda update -y python conda pip
 conda install -y cython pandas
 ```

--- a/Algorithm.Python/readme.md
+++ b/Algorithm.Python/readme.md
@@ -116,7 +116,7 @@ $ sudo easy-install pip
 **2. Install Python 3.6 with Miniconda:**
 ```
 export PATH="/opt/miniconda3/bin:$PATH"
-wget https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
+wget http://cdn.quantconnect.com.s3.amazonaws.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
 bash Miniconda3-4.3.31-Linux-x86_64.sh -b
 rm -rf Miniconda3-4.3.31-Linux-x86_64.sh
 ln -s /opt/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6.so

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -74,7 +74,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -126,12 +126,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Algorithm/packages.config
+++ b/Algorithm/packages.config
@@ -3,5 +3,5 @@
   <package id="MathNet.Numerics" version="3.19.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
 </packages>

--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -146,7 +146,7 @@ namespace QuantConnect.AlgorithmFactory
             //File does not exist.
             if (!File.Exists(assemblyPath))
             {
-                errorMessage = "Loader.TryCreatePythonAlgorithm(): Unable to find py file: " + assemblyPath;
+                errorMessage = $"Loader.TryCreatePythonAlgorithm(): Unable to find py file: {assemblyPath}";
                 return false;
             }
 
@@ -168,12 +168,12 @@ namespace QuantConnect.AlgorithmFactory
                 // Import Python module
                 using (Py.GIL())
                 {
-                    Log.Trace("Loader.TryCreatePythonAlgorithm(): Importing python module " + moduleName);
+                    Log.Trace($"Loader.TryCreatePythonAlgorithm(): Python version {PythonEngine.Version}: Importing python module {moduleName}");
                     var module = Py.Import(moduleName);
 
                     if (module == null)
                     {
-                        errorMessage = "Loader.TryCreatePythonAlgorithm(): Unable to import python module " + assemblyPath + ". Check for errors in the python scripts.";
+                        errorMessage = $"Loader.TryCreatePythonAlgorithm(): Unable to import python module {assemblyPath}. Check for errors in the python scripts.";
                         return false;
                     }
 
@@ -186,7 +186,7 @@ namespace QuantConnect.AlgorithmFactory
             catch (Exception e)
             {
                 Log.Error(e);
-                errorMessage = "Loader.TryCreatePythonAlgorithm(): Unable to import python module " + assemblyPath + ". " + e.Message;
+                errorMessage = $"Loader.TryCreatePythonAlgorithm(): Unable to import python module {assemblyPath}. {e.Message}";
             }
 
             //Successful load.

--- a/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
+++ b/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
@@ -41,7 +41,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -83,12 +83,12 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/AlgorithmFactory/packages.config
+++ b/AlgorithmFactory/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
 </packages>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -109,7 +109,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="QLNet, Version=1.9.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\QLNet.1.9.2\lib\net45\QLNet.dll</HintPath>
@@ -589,12 +589,12 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Common/packages.config
+++ b/Common/packages.config
@@ -7,6 +7,6 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
   <package id="QLNet" version="1.9.2" targetFramework="net452" />
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
 </packages>

--- a/DockerfileJupyter
+++ b/DockerfileJupyter
@@ -1,5 +1,5 @@
 #
-#	LEAN Jupyter Docker Container 20170803
+#	LEAN Jupyter Docker Container 20180223
 #
 
 # Use base system for cleaning up wayward processes
@@ -14,12 +14,12 @@ RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.10.0/tini 
     chmod +x /usr/local/bin/tini
 
 #Install Jupyter and Python.NET
-RUN apt-get update && apt-get install -y git libglib2.0-dev && \
+RUN apt-get update && apt-get install -y clang git libglib2.0-dev && \
     pip install --egg jsonschema jupyter git+https://github.com/QuantConnect/pythonnet
 
 # Setting some environment variables
 ENV WORK /root/Lean/Jupyter/bin/Debug
-ENV LEAN /usr/lib/python2.7/Lean
+ENV LEAN /opt/miniconda3/Lean
 ENV PYTHONPATH=${LEAN}:${PYTHONPATH}
 
 # Copy Lean files to convinient locations

--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -39,14 +39,14 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
     rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/oracle-jdk8-installer
 
 # Install IB Gateway: Installs to ~/Jts
-RUN wget http://data.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64-v968.2d.sh && \
+RUN wget http://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64-v968.2d.sh && \
     chmod 777 ibgateway-latest-standalone-linux-x64-v968.2d.sh && \
     ./ibgateway-latest-standalone-linux-x64-v968.2d.sh -q && \
-    wget -O ~/Jts/jts.ini http://data.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64-v968.2d.jts.ini && \
+    wget -O ~/Jts/jts.ini http://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64-v968.2d.jts.ini && \
     rm ibgateway-latest-standalone-linux-x64-v968.2d.sh
 
 # Install IB Controller: Installs to ~/IBController
-RUN wget http://data.quantconnect.com/interactive/IBController-QuantConnect-3.2.0.2.zip && \
+RUN wget http://cdn.quantconnect.com/interactive/IBController-QuantConnect-3.2.0.2.zip && \
     unzip IBController-QuantConnect-3.2.0.2.zip -d ~/IBController && \
     chmod -R 777 ~/IBController && \
     rm IBController-QuantConnect-3.2.0.2.zip

--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y wget bzip2 python3-pip python-opengl &&
 
 # Install miniconda and supported third party python packages
 ENV PATH="/opt/miniconda3/bin:${PATH}"
-RUN wget https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh && \
+RUN wget http://cdn.quantconnect.com.s3.amazonaws.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh && \
     bash Miniconda3-4.3.31-Linux-x86_64.sh -b -p /opt/miniconda3 && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh && \
     ln -s /opt/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6.so && \

--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -1,5 +1,5 @@
 #
-#	LEAN Foundation Docker Container 20171229
+#	LEAN Foundation Docker Container 20180223
 #	Cross platform deployment for multiple brokerages
 #	Intended to be used in conjunction with DockerfileLeanAlgorithm. This is just the foundation common OS+Dependencies required.
 #
@@ -14,35 +14,39 @@ CMD ["/sbin/my_init"]
 
 # Install OS Packages:
 # Misc tools for running Python.NET and IB inside a headless container.
-RUN \
-  apt-get update && \
-  apt-get install -y wget xvfb unzip curl libxrender1 libxtst6 libxi6 python-pip && \
-  pip install --upgrade pip && pip install --upgrade cython && \
-  pip install pycparser pandas scipy numpy sklearn  && \
-  pip install blaze cvxopt cvxpy pykalman statistics statsmodels arch copulalib && \
-  pip install xgboost theano keras tensorflow deap
+RUN apt-get update && apt-get install -y wget bzip2 python3-pip python-opengl && \
+    apt-get install -y xvfb unzip curl libxrender1 libxtst6 libxi6
+
+# Install miniconda and supported third party python packages
+ENV PATH="/opt/miniconda3/bin:${PATH}"
+RUN wget https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh && \
+    bash Miniconda3-4.3.31-Linux-x86_64.sh -b -p /opt/miniconda3 && \
+    rm -rf Miniconda3-latest-Linux-x86_64.sh && \
+    ln -s /opt/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6.so && \
+    conda update -y python conda pip && \
+    conda install -y cython pandas && \
+    conda install -y blaze cvxopt keras nltk tensorflow theano && \
+    conda install -y pytorch torchvision -c pytorch && \
+    pip install arch copulalib cvxpy deap gym pykalman pyro-ppl  && \
+    pip install sklearn statistics tensorforce xgboost && \
+    conda clean -y --all
 
 # Java for running IB inside container:
 # https://github.com/dockerfile/java/blob/master/oracle-java8/Dockerfile
-RUN \
-  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-  add-apt-repository -y ppa:webupd8team/java && \
-  apt-get update && \
-  apt-get install -y oracle-java8-installer && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/cache/oracle-jdk8-installer
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+    add-apt-repository -y ppa:webupd8team/java && \
+    apt-get update && apt-get install -y oracle-java8-installer && \
+    rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/oracle-jdk8-installer
 
 # Install IB Gateway: Installs to ~/Jts
-RUN \
-    wget http://data.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64-v968.2d.sh && \
+RUN wget http://data.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64-v968.2d.sh && \
     chmod 777 ibgateway-latest-standalone-linux-x64-v968.2d.sh && \
     ./ibgateway-latest-standalone-linux-x64-v968.2d.sh -q && \
     wget -O ~/Jts/jts.ini http://data.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64-v968.2d.jts.ini && \
     rm ibgateway-latest-standalone-linux-x64-v968.2d.sh
 
 # Install IB Controller: Installs to ~/IBController
-RUN \
-    wget http://data.quantconnect.com/interactive/IBController-QuantConnect-3.2.0.2.zip && \
+RUN wget http://data.quantconnect.com/interactive/IBController-QuantConnect-3.2.0.2.zip && \
     unzip IBController-QuantConnect-3.2.0.2.zip -d ~/IBController && \
     chmod -R 777 ~/IBController && \
     rm IBController-QuantConnect-3.2.0.2.zip
@@ -51,30 +55,23 @@ RUN \
 # From https://github.com/mono/docker/blob/master/
 RUN apt-get update && rm -rf /var/lib/apt/lists/*
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.6.1.5 main" > /etc/apt/sources.list.d/mono-xamarin.list \
-  && apt-get update \
-  && apt-get install -y binutils mono-complete ca-certificates-mono mono-vbnc nuget referenceassemblies-pcl \
-  && apt-get install -y fsharp && rm -rf /var/lib/apt/lists/* /tmp/*
+RUN echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/5.8.0.108 main" > /etc/apt/sources.list.d/mono-xamarin.list && \
+    apt-get update && apt-get install -y binutils mono-complete ca-certificates-mono mono-vbnc nuget referenceassemblies-pcl && \
+    apt-get install -y fsharp && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Install Python.NET
 # Have to add env TZ=UTC. See https://github.com/dotnet/coreclr/issues/602
-RUN env TZ=UTC nuget install QuantConnect.pythonnet -Version 1.0.5.4 \
-    && cp QuantConnect.pythonnet.1.0.5.4/lib/Python.Runtime.dll /usr/lib
-
-RUN ln -s /usr/lib/x86_64-linux-gnu/libpython2.7.so /usr/lib/libpython27.so
+RUN env TZ=UTC nuget install QuantConnect.pythonnet -Version 1.0.5.5 && \
+    cp QuantConnect.pythonnet.1.0.5.5/lib/Python.Runtime.dll /usr/lib
 
 # Install TA-lib for python
-RUN wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz \
-    && tar -zxvf ta-lib-0.4.0-src.tar.gz \
-    && cd ta-lib \
-    && ./configure --prefix=/usr \
-    && make \
-    && make install \
-    && pip install TA-lib \
-    && cd ..
+RUN wget http://data.quantconnect.com/ta-lib/ta-lib-0.4.0-src.tar.gz && \
+    tar -zxvf ta-lib-0.4.0-src.tar.gz && cd ta-lib && \
+    ./configure --prefix=/usr && make && make install && \
+    pip install TA-lib
 
 # Install R
-RUN apt-get update \
-    && apt-get install -y r-base \
-    && apt-get install -y pandoc \
-    && apt-get install -y libcurl4-openssl-dev
+RUN apt-get update && \
+    apt-get install -y r-base && \
+    apt-get install -y pandoc && \
+    apt-get install -y libcurl4-openssl-dev

--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -65,7 +65,7 @@ RUN env TZ=UTC nuget install QuantConnect.pythonnet -Version 1.0.5.5 && \
     cp QuantConnect.pythonnet.1.0.5.5/lib/Python.Runtime.dll /usr/lib
 
 # Install TA-lib for python
-RUN wget http://data.quantconnect.com/ta-lib/ta-lib-0.4.0-src.tar.gz && \
+RUN wget http://cdn.quantconnect.com/ta-lib/ta-lib-0.4.0-src.tar.gz && \
     tar -zxvf ta-lib-0.4.0-src.tar.gz && cd ta-lib && \
     ./configure --prefix=/usr && make && make install && \
     pip install TA-lib

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -41,7 +41,7 @@
       <HintPath>..\packages\MathNet.Numerics.3.19.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -214,12 +214,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Indicators/packages.config
+++ b/Indicators/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MathNet.Numerics" version="3.19.0" targetFramework="net452" />
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
 </packages>

--- a/Jupyter/QuantConnect.Jupyter.csproj
+++ b/Jupyter/QuantConnect.Jupyter.csproj
@@ -40,7 +40,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -106,12 +106,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Jupyter/packages.config
+++ b/Jupyter/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
 </packages>

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -69,7 +69,7 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.4\lib\Python.Runtime.dll</HintPath>
+      <HintPath>..\packages\QuantConnect.pythonnet.1.0.5.5\lib\Python.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="QuantConnect.Fxcm, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -698,12 +698,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" />
+  <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.4\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.5\build\QuantConnect.pythonnet.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -10,7 +10,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
-  <package id="QuantConnect.pythonnet" version="1.0.5.4" targetFramework="net452" />
+  <package id="QuantConnect.pythonnet" version="1.0.5.5" targetFramework="net452" />
   <package id="RestSharp" version="105.2.3" targetFramework="net45" requireReinstallation="true" />
   <package id="WebSocketSharpFork" version="1.0.4.0" targetFramework="net45" />
 </packages>

--- a/readme.md
+++ b/readme.md
@@ -82,9 +82,9 @@ echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | sudo tee /
 sudo apt-get update
 sudo apt-get install -y binutils mono-complete ca-certificates-mono referenceassemblies-pcl fsharp
 ```
-- Install Nuget and Python
+- Install Nuget
 ```
-sudo apt-get update && sudo apt-get install -y nuget python-pip
+sudo apt-get update && sudo apt-get install -y nuget
 ```
 - Restore NuGet packages then compile:
 ```


### PR DESCRIPTION
Slightly reworked version of https://github.com/QuantConnect/Lean/pull/1526

The biggest change from #1526 is that we're now installing miniconda into `/opt/` so it's available to all users.

---
#### Description from #1526 
In this pull request we propose changes that enables python 3.6 in Lean.
- Adds log to display the python version the algorithm is using.
- Fixes python algorithms that were failing because of small subtleties like leading zeroes.
- Updates pythonnet with a version compiled with python 3.6 flags

Also included via #1526:
- Changes in DockerfileFoundation: we now use miniconda to manage the python environment. Took the opportunity to add NTLK (#1349), Tensorforce (#1369) and PyTorch/Pyro (#1385).
- Changes readme in Algorithm.Python to show steps to install miniconda