### PR TITLE
Fix buying power calculation in CashBuyingPowerModel.HasSufficientBuyingPowerForOrder

### DIFF
--- a/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
@@ -323,6 +323,14 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
             StringAssert.Contains(expected, actual);
 
+            // spin for a few seconds, waiting for the GBPUSD tick
+            var start = DateTime.UtcNow;
+            var timeout = start.AddSeconds(5);
+            while (_unit.Ticks.Count == 0 && DateTime.UtcNow < timeout)
+            {
+                Thread.Sleep(1);
+            }
+
             // only rate conversion ticks are received during subscribe
             Assert.AreEqual(1, _unit.Ticks.Count);
             Assert.AreEqual("GBPUSD", _unit.Ticks[0].Symbol.Value);

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -453,15 +453,15 @@ namespace QuantConnect.Tests.Common.Securities
             // Maximum we can market buy with 20000 EUR is 1.995 BTC
             // target value = 30000 EUR = 20000 EUR in cash + 10000 EUR in BTC
             var targetValue = 30000m * _portfolio.CashBook["EUR"].ConversionRate;
-            Assert.AreEqual(1.995m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btceur, targetValue));
+            Assert.AreEqual(1.995m, _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_portfolio, _btceur, targetValue).Quantity);
 
             // Available cash = 20000 EUR, can buy 1.995 BTC at 10000 (plus fees)
             var order = new MarketOrder(_btceur.Symbol, 1.995m, DateTime.UtcNow);
-            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order));
+            Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order).IsSufficient);
 
             // Available cash = 20000 EUR, cannot buy 2 BTC at 10000 (plus fees)
             order = new MarketOrder(_btceur.Symbol, 2m, DateTime.UtcNow);
-            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order));
+            Assert.IsFalse(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btceur, order).IsSufficient);
         }
 
         private void SubmitLimitOrder(Symbol symbol, decimal quantity, decimal limitPrice)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
`HasSufficientBuyingPowerForOrder` returns true when attempting to buy a quantity greater than the quantity returned by `GetMaximumOrderQuantityForTargetValue`.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/QuantConnect/Lean/issues/1618

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Excessive buying power returned by `HasSufficientBuyingPowerForOrder`

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test included

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->