### PR TITLE
Adds overload to Plot method to handle indicator special cases

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -378,11 +378,29 @@ namespace QuantConnect.Algorithm
         /// <seealso cref="Plot(string,decimal)"/>
         public void Plot(string series, PyObject pyObject)
         {
+            IIndicator<IndicatorDataPoint> indicator;
+
             using (Py.GIL())
             {
-                var value = ((dynamic)pyObject).Current.Value;
-                Plot(series, (decimal)value);
+                var pythonType = pyObject.GetPythonType();
+
+                try
+                {
+                    var type = pythonType.As<Type>();
+                    indicator = pyObject.AsManagedObject(type) as IIndicator<IndicatorDataPoint>;
+
+                    if (indicator == null)
+                    {
+                        throw new ArgumentException();
+                    }
+                }
+                catch
+                {
+                    throw new ArgumentException($"QCAlgorithm.Plot(): The last argument should be a QuantConnect Indicator object, {pythonType.Repr()} was provided.");
+                }
             }
+
+            Plot(series, indicator.Current.Value);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -381,7 +381,7 @@ namespace QuantConnect.Algorithm
             using (Py.GIL())
             {
                 var value = ((dynamic)pyObject).Current.Value;
-                Plot(series, value);
+                Plot(series, (decimal)value);
             }
         }
 

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -371,6 +371,21 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Plot a chart using string series name, with value.
+        /// </summary>
+        /// <param name="series">Name of the plot series</param>
+        /// <param name="pyObject">PyObject with the value to plot</param>
+        /// <seealso cref="Plot(string,decimal)"/>
+        public void Plot(string series, PyObject pyObject)
+        {
+            using (Py.GIL())
+            {
+                var value = ((dynamic)pyObject).Current.Value;
+                Plot(series, value);
+            }
+        }
+
+        /// <summary>
         /// Plots the value of each indicator on the chart
         /// </summary>
         /// <param name="chart">The chart's name</param>

--- a/Tests/Python/MethodOverloadTests.cs
+++ b/Tests/Python/MethodOverloadTests.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using System;
+using System.IO;
+
+namespace QuantConnect.Tests.Python
+{
+    [TestFixture, Ignore]
+    public class MethodOverloadTests
+    {
+        private dynamic _algorithm;
+
+        /// <summary>
+        /// Run before every test
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            var pythonPath = new DirectoryInfo("RegressionAlgorithms");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+
+            using (Py.GIL())
+            {
+                var module = Py.Import("Test_MethodOverload");
+                _algorithm = module.GetAttr("Test_MethodOverload").Invoke();
+                _algorithm.Initialize();
+            }
+        }
+
+        [Test]
+        public void CallPlotStdTest()
+        {
+            Assert.DoesNotThrow(() => _algorithm.call_plot_std_test());
+        }
+    }
+}

--- a/Tests/Python/MethodOverloadTests.cs
+++ b/Tests/Python/MethodOverloadTests.cs
@@ -44,9 +44,25 @@ namespace QuantConnect.Tests.Python
         }
 
         [Test]
-        public void CallPlotStdTest()
+        public void CallPlotTests()
         {
+            // self.Plot('NUMBER', 0.1)
+            Assert.DoesNotThrow(() => _algorithm.call_plot_number_test());
+
+            // self.Plot('STD', self.std), where self.sma = self.SMA('SPY', 20)
+            Assert.DoesNotThrow(() => _algorithm.call_plot_sma_test());
+
+            // self.Plot('SMA', self.sma), where self.std = self.STD('SPY', 20)
             Assert.DoesNotThrow(() => _algorithm.call_plot_std_test());
+
+            // self.Plot("ERROR", self.Name), where self.Name is IAlgorithm.Name: string
+            Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_test());
+
+            // self.Plot("ERROR", self.Portfolio), where self.Portfolio is IAlgorithm.Portfolio: instance of SecurityPortfolioManager
+            Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_managed_test());
+
+            // self.Plot("ERROR", self.a), where self.a is an instance of a python object
+            Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_pyobject_test());
         }
     }
 }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -323,6 +323,7 @@
     <Compile Include="Indicators\RateOfChangeTests.cs" />
     <Compile Include="Indicators\StochasticTests.cs" />
     <Compile Include="Messaging\StreamingMessageHandlerTests.cs" />
+    <Compile Include="Python\MethodOverloadTests.cs" />
     <Compile Include="Python\PandasConverterTests.cs" />
     <Compile Include="RegressionTests.cs" />
     <Compile Include="Symbols.cs" />
@@ -394,6 +395,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Content Include="Python\Indicators\IndicatorExtensionsTests.py" />
+    <Content Include="RegressionAlgorithms\Test_MethodOverload.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\FuturesExpiryFunctionsTestData.xml">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Tests/RegressionAlgorithms/Test_MethodOverload.py
+++ b/Tests/RegressionAlgorithms/Test_MethodOverload.py
@@ -24,10 +24,32 @@ from QuantConnect.Algorithm import *
 class Test_MethodOverload(QCAlgorithm):
     def Initialize(self):
         self.AddEquity("SPY", Resolution.Second)
+        self.sma = self.SMA('SPY', 20)
         self.std = self.STD('SPY', 20)
+        self.a = A()
 
     def OnData(self, data):
         pass
 
     def call_plot_std_test(self):
         self.Plot('STD', self.std)
+
+    def call_plot_sma_test(self):
+        self.Plot('SMA', self.sma)
+
+    def call_plot_number_test(self):
+        self.Plot('NUMBER', 0.1)
+
+    def call_plot_throw_test(self):
+        self.Plot("ERROR", self.Name)
+
+    def call_plot_throw_managed_test(self):
+        self.Plot("ERROR", self.Portfolio)
+
+    def call_plot_throw_pyobject_test(self):
+        self.Plot("ERROR", self.a)
+
+
+class A(object):
+   def __init__(self):
+       pass

--- a/Tests/RegressionAlgorithms/Test_MethodOverload.py
+++ b/Tests/RegressionAlgorithms/Test_MethodOverload.py
@@ -1,0 +1,33 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Indicators")
+AddReference("QuantConnect.Common")
+from System import *
+from QuantConnect import *
+from QuantConnect.Indicators import *
+from QuantConnect.Algorithm import *
+
+class Test_MethodOverload(QCAlgorithm):
+    def Initialize(self):
+        self.AddEquity("SPY", Resolution.Second)
+        self.std = self.STD('SPY', 20)
+
+    def OnData(self, data):
+        pass
+
+    def call_plot_std_test(self):
+        self.Plot('STD', self.std)


### PR DESCRIPTION
#### Description
For cases where implicit conversion to decimal from indicator was not properly handled by pythonnet, we expliticly get `Current.Value` and redirect to `Plot(string,decimal)` overload.

#### Related Issue
#1620

#### Motivation and Context
Since we have included implicit conversion in our pythonnet fork, it has been able to convert Lean indicator into decimal and, consequently, it founds the right overload for the Plot method. 
Apparently it has a bug in that implementation since it couldn't resolve `StandardDeviation` that derives from `Variance` and not directly from a `IndicatorBase<T>` class.

#### How Has This Been Tested?
Code provided in issue #1620 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`