### PR TITLE
Prevent GDAX websocket error event from causing runtime error

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -175,7 +175,7 @@ namespace QuantConnect.Brokerages.GDAX
                 {
                     Log.Error($"GDAXBrokerage.OnMessage.error(): Data: {Environment.NewLine}{e.Message}");
                     var error = JsonConvert.DeserializeObject<Messages.Error>(e.Message, JsonSettings);
-                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, -1, $"GDAXBrokerage.OnMessage: {error.Message} {error.Reason}"));
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, -1, $"GDAXBrokerage.OnMessage: {error.Message} {error.Reason}"));
                     return;
                 }
                 else if (raw.Type == "done")


### PR DESCRIPTION

#### Description
- Prevent GDAX websocket error event from causing runtime error
- Update failing GDAX brokerage unit tests

#### Related Issue
#1601

#### Motivation and Context
- Previously, when receiving GDAX error events, `BrokerageMessageEvent.Error` was returned, causing a runtime error and the algorithm stopping. These events have been downgraded to `BrokerageMessageEvent.Warning`, so the messages are displayed but the algorithm can continue running.
- Some of these tests have been obsoleted by changes to the brokerage implementation, others only needed to be updated to pass. Also, these tests are no longer ignored.

#### Requires Documentation Change
No

#### How Has This Been Tested?
In addition to the new/updated unit tests, this change was also tested with a GDAX live algorithm attempting to subscribe a non existing symbol. Previously the algorithm would stop with a runtime error, now it will display an error and continue running.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`
