### PR TITLE
 Fixes RegisterIndicator for python algorithms

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -28,6 +28,7 @@ using NodaTime;
 using Python.Runtime;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
+using QuantConnect.Util;
 using Timer = System.Timers.Timer;
 
 namespace QuantConnect
@@ -1025,6 +1026,39 @@ namespace QuantConnect
                 }
                 return value;
             }
+        }
+
+        /// <summary>
+        /// Tries to convert a <see cref="PyObject"/> into a managed object
+        /// </summary>
+        /// <typeparam name="T">Target type of the resulting managed object</typeparam>
+        /// <param name="pyObject">PyObject to be converted</param>
+        /// <param name="result">Managed object </param>
+        /// <returns>True if successful conversion</returns>
+        public static bool TryConvert<T>(this PyObject pyObject, out T result)
+            where T : class
+        {
+            result = default(T);
+
+            if (pyObject == null)
+            {
+                return true;
+            }
+
+            using (Py.GIL())
+            {
+                try
+                {
+                    result = pyObject.AsManagedObject(typeof(T)) as T;
+                }
+                catch
+                {
+                    // Do not throw or log the exception.
+                    // Return false as an exception means that the conversion could not be made.
+                }
+            }
+
+            return result != default(T);
         }
     }
 }

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1050,6 +1050,7 @@ namespace QuantConnect
                 try
                 {
                     result = pyObject.AsManagedObject(typeof(T)) as T;
+                    return true;
                 }
                 catch
                 {
@@ -1058,7 +1059,7 @@ namespace QuantConnect
                 }
             }
 
-            return result != default(T);
+            return false;
         }
     }
 }

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -63,18 +63,20 @@ namespace QuantConnect.Tests.Algorithm
                     {
                         var indicator = (indicatorTest as CommonIndicatorTests<IndicatorDataPoint>).Indicator;
                         Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute, Field.Close));
+                        expected++;
                     }
                     else if (key == typeof(IBaseDataBar))
                     {
                         var indicator = (indicatorTest as CommonIndicatorTests<IBaseDataBar>).Indicator;
                         Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
+                        expected++;
                     }
                     else if (key == typeof(TradeBar))
                     {
                         var indicator = (indicatorTest as CommonIndicatorTests<TradeBar>).Indicator;
                         Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
+                        expected++;
                     }
-                    expected++;
                     var actual = _algorithm.SubscriptionManager.Subscriptions.FirstOrDefault().Consolidators.Count;
                     Assert.AreEqual(expected, actual);
                 }
@@ -98,6 +100,7 @@ namespace QuantConnect.Tests.Algorithm
                             var indicator = (indicatorTest as CommonIndicatorTests<IndicatorDataPoint>).Indicator.ToPython();
                             Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
                         }
+                        expected++;
                     }
                     else if (key == typeof(IBaseDataBar))
                     {
@@ -106,6 +109,7 @@ namespace QuantConnect.Tests.Algorithm
                             var indicator = (indicatorTest as CommonIndicatorTests<IBaseDataBar>).Indicator.ToPython();
                             Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
                         }
+                        expected++;
                     }
                     else if (key == typeof(TradeBar))
                     {
@@ -114,8 +118,8 @@ namespace QuantConnect.Tests.Algorithm
                             var indicator = (indicatorTest as CommonIndicatorTests<TradeBar>).Indicator.ToPython();
                             Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
                         }
+                        expected++;
                     }
-                    expected++;
                     var actual = _algorithm.SubscriptionManager.Subscriptions.FirstOrDefault().Consolidators.Count;
                     Assert.AreEqual(expected, actual);
                 }

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -1,0 +1,153 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+using QuantConnect.Tests.Indicators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmRegisterIndicatorTests
+    {
+        private Symbol _spy;
+        private QCAlgorithm _algorithm;
+        private IEnumerable<IGrouping<Type, Type>> _indicatorTestsGroups;
+
+        [SetUp]
+        public void Setup()
+        {
+            _algorithm = new QCAlgorithm();
+            _spy = _algorithm.AddEquity("SPY").Symbol;
+
+            _indicatorTestsGroups =
+                from type in GetType().Assembly.GetTypes()
+                where type.IsPublic && !type.IsAbstract
+                where
+                   typeof(CommonIndicatorTests<TradeBar>).IsAssignableFrom(type) ||
+                   typeof(CommonIndicatorTests<IBaseDataBar>).IsAssignableFrom(type) ||
+                   typeof(CommonIndicatorTests<IndicatorDataPoint>).IsAssignableFrom(type)
+                group type by type.BaseType.GetGenericArguments().FirstOrDefault();
+        }
+
+        [Test]
+        public void RegistersIndicatorProperly()
+        {
+            var expected = 0;
+            foreach (var group in _indicatorTestsGroups)
+            {
+                var key = group.Key;
+                foreach (var type in group)
+                {
+                    var indicatorTest = Activator.CreateInstance(type);
+                    if (key == typeof(IndicatorDataPoint))
+                    {
+                        var indicator = (indicatorTest as CommonIndicatorTests<IndicatorDataPoint>).Indicator;
+                        Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute, Field.Close));
+                    }
+                    else if (key == typeof(IBaseDataBar))
+                    {
+                        var indicator = (indicatorTest as CommonIndicatorTests<IBaseDataBar>).Indicator;
+                        Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
+                    }
+                    else if (key == typeof(TradeBar))
+                    {
+                        var indicator = (indicatorTest as CommonIndicatorTests<TradeBar>).Indicator;
+                        Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
+                    }
+                    expected++;
+                    var actual = _algorithm.SubscriptionManager.Subscriptions.FirstOrDefault().Consolidators.Count;
+                    Assert.AreEqual(expected, actual);
+                }
+            }
+        }
+
+        [Test, Ignore]
+        public void RegistersIndicatorProperlyPython()
+        {
+            var expected = 0;
+            foreach (var group in _indicatorTestsGroups)
+            {
+                var key = group.Key;
+                foreach (var type in group)
+                {
+                    var indicatorTest = Activator.CreateInstance(type);
+                    if (key == typeof(IndicatorDataPoint))
+                    {
+                        using (Py.GIL())
+                        {
+                            var indicator = (indicatorTest as CommonIndicatorTests<IndicatorDataPoint>).Indicator.ToPython();
+                            Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
+                        }
+                    }
+                    else if (key == typeof(IBaseDataBar))
+                    {
+                        using (Py.GIL())
+                        {
+                            var indicator = (indicatorTest as CommonIndicatorTests<IBaseDataBar>).Indicator.ToPython();
+                            Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
+                        }
+                    }
+                    else if (key == typeof(TradeBar))
+                    {
+                        using (Py.GIL())
+                        {
+                            var indicator = (indicatorTest as CommonIndicatorTests<TradeBar>).Indicator.ToPython();
+                            Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
+                        }
+                    }
+                    expected++;
+                    var actual = _algorithm.SubscriptionManager.Subscriptions.FirstOrDefault().Consolidators.Count;
+                    Assert.AreEqual(expected, actual);
+                }
+            }
+        }
+
+        [Test, Ignore]
+        public void RegisterPythonCustomIndicatorProperly()
+        {
+            using (Py.GIL())
+            {
+                var module = PythonEngine.ModuleFromString("x",
+                    "class GoodCustomIndicator:\n" +
+                    "    def __init__(self):\n" +
+                    "        pass\n" +
+                    "    def Update(self, input):\n" +
+                    "        return input\n" +
+                    "class BadCustomIndicator:\n" +
+                    "    def __init__(self):\n" +
+                    "        pass\n" +
+                    "    def Updat(self, input):\n" +
+                    "        return input");
+
+                var goodIndicator = module.GetAttr("GoodCustomIndicator").Invoke();
+                Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, goodIndicator, Resolution.Minute));
+
+                var actual = _algorithm.SubscriptionManager.Subscriptions.FirstOrDefault().Consolidators.Count;
+                Assert.AreEqual(1, actual);
+
+                var badIndicator = module.GetAttr("BadCustomIndicator").Invoke();
+                Assert.Throws<ArgumentException>(() => _algorithm.RegisterIndicator(_spy, badIndicator, Resolution.Minute));
+            }
+        }
+    }
+}

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -18,6 +18,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Util
@@ -329,6 +332,96 @@ namespace QuantConnect.Tests.Common.Util
             actual = input.GetStringBetweenChars('\'', '\'');
             Assert.AreNotEqual(expected, actual);
         }
+
+        [Test, Ignore]
+        public void PyObjectTryConvertQuoteBar()
+        {
+            // Wrap a QuoteBar around a PyObject and convert it back
+            var value = ConvertToPyObject(new QuoteBar());
+
+            QuoteBar quoteBar;
+            var canConvert = value.TryConvert(out quoteBar);
+            Assert.IsTrue(canConvert);
+            Assert.IsNotNull(quoteBar);
+            Assert.IsAssignableFrom<QuoteBar>(quoteBar);
+        }
+
+        [Test, Ignore]
+        public void PyObjectTryConvertSMA()
+        {
+            // Wrap a SimpleMovingAverage around a PyObject and convert it back
+            var value = ConvertToPyObject(new SimpleMovingAverage(14));
+
+            IndicatorBase<IndicatorDataPoint> indicatorBaseDataPoint;
+            var canConvert = value.TryConvert(out indicatorBaseDataPoint);
+            Assert.IsTrue(canConvert);
+            Assert.IsNotNull(indicatorBaseDataPoint);
+            Assert.IsAssignableFrom<SimpleMovingAverage>(indicatorBaseDataPoint);
+        }
+
+        [Test, Ignore]
+        public void PyObjectTryConvertATR()
+        {
+            // Wrap a AverageTrueRange around a PyObject and convert it back
+            var value = ConvertToPyObject(new AverageTrueRange(14, MovingAverageType.Simple));
+
+            IndicatorBase<IBaseDataBar> indicatorBaseDataBar;
+            var canConvert = value.TryConvert(out indicatorBaseDataBar);
+            Assert.IsTrue(canConvert);
+            Assert.IsNotNull(indicatorBaseDataBar);
+            Assert.IsAssignableFrom<AverageTrueRange>(indicatorBaseDataBar);
+        }
+
+        [Test, Ignore]
+        public void PyObjectTryConvertAD()
+        {
+            // Wrap a AccumulationDistribution around a PyObject and convert it back
+            var value = ConvertToPyObject(new AccumulationDistribution("AD"));
+
+            IndicatorBase<TradeBar> indicatorBaseTradeBar;
+            var canConvert = value.TryConvert(out indicatorBaseTradeBar);
+            Assert.IsTrue(canConvert);
+            Assert.IsNotNull(indicatorBaseTradeBar);
+            Assert.IsAssignableFrom<AccumulationDistribution>(indicatorBaseTradeBar);
+
+        }
+
+        [Test, Ignore]
+        public void PyObjectTryConvertFailCSharp()
+        {
+            // Try to convert a AccumulationDistribution as a QuoteBar
+            var value = ConvertToPyObject(new AccumulationDistribution("AD"));
+
+            QuoteBar quoteBar;
+            bool canConvert = value.TryConvert(out quoteBar);
+            Assert.IsFalse(canConvert);
+            Assert.IsNull(quoteBar);
+        }
+
+        [Test, Ignore]
+        public void PyObjectTryConvertFailPython()
+        {
+            using (Py.GIL())
+            {
+                // Try to convert a python object as a IndicatorBase<TradeBar>
+                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(), "class A:\n    pass");
+                var value = module.GetAttr("A").Invoke();
+
+                IndicatorBase<TradeBar> indicatorBaseTradeBar;
+                bool canConvert = value.TryConvert(out indicatorBaseTradeBar);
+                Assert.IsFalse(canConvert);
+                Assert.IsNull(indicatorBaseTradeBar);
+            }
+        }
+
+        private PyObject ConvertToPyObject(object value)
+        {
+            using (Py.GIL())
+            {
+                return value.ToPython();
+            }
+        }
+
 
         private class Super<T>
         {

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
@@ -52,6 +53,14 @@ namespace QuantConnect.Tests.Indicators
                 TestHelper.TestIndicatorReset(indicator as IndicatorBase<TradeBar>, TestFileName);
             else
                 throw new NotSupportedException("ResetsProperly: Unsupported indicator data type: " + typeof(T));
+        }
+
+        public PyObject GetIndicatorAsPyObject()
+        {
+            using (Py.GIL())
+            {
+                return Indicator.ToPython();
+            }
         }
 
         public IndicatorBase<T> Indicator => CreateIndicator();

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -54,6 +54,8 @@ namespace QuantConnect.Tests.Indicators
                 throw new NotSupportedException("ResetsProperly: Unsupported indicator data type: " + typeof(T));
         }
 
+        public IndicatorBase<T> Indicator => CreateIndicator();
+
         /// <summary>
         /// Executes a test of the specified indicator
         /// </summary>

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Algorithm\AlgorithmAddDataTests.cs" />
     <Compile Include="Algorithm\AlgorithmInitializeTests.cs" />
     <Compile Include="Algorithm\AlgorithmPlottingTests.cs" />
+    <Compile Include="Algorithm\AlgorithmRegisterIndicatorTests.cs" />
     <Compile Include="Algorithm\AlgorithmResolveConsolidatorTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetBrokerageTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetHoldingsTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Refactors the `RegisterIndicator(Symbol, PyObject, IDataConsolidator, PyObject)` to check whether a C# object inherits from `IndicatorBase<T>` instead of some of its children classes (`Indicator`, `BarIndicator` and `TradeBarIndicator`).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1636 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves the impossibility to register indicators that don't inherit from `Indicator`, `BarIndicator` and `TradeBarIndicator`, but directly from `IndicatorBase<T>`, and also from `WindowIndicator<T>`.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->