### PR TITLE
Fix universe/framework algorithms selecting forex/crypto/cfd types

### DIFF
--- a/Algorithm.CSharp/BasicTemplateCryptoFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateCryptoFrameworkAlgorithm.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Brokerages;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Basic template framework algorithm uses framework components to define the algorithm.
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="using quantconnect" />
+    /// <meta name="tag" content="trading and orders" />
+    public class BasicTemplateFrameworkCryptoAlgorithm : QCAlgorithmFramework
+    {
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            // Set requested data resolution
+            UniverseSettings.Resolution = Resolution.Minute;
+
+            SetStartDate(2016, 10, 7);  //Set Start Date
+            SetEndDate(2016, 10, 7);    //Set End Date
+            SetCash(100000);            //Set Strategy Cash
+
+            // Find more symbols here: http://quantconnect.com/data
+            // Forex, CFD, Equities Resolutions: Tick, Second, Minute, Hour, Daily.
+            // Futures Resolution: Tick, Second, Minute
+            // Options Resolution: Minute Only.
+
+            SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
+
+            // set algorithm framework models
+            PortfolioSelection = new ManualPortfolioSelectionModel(QuantConnect.Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX));
+            Alpha = new ConstantAlphaModel(AlphaType.Price, AlphaDirection.Up, TimeSpan.FromMinutes(20), 0.025, null);
+            PortfolioConstruction = new SimplePortfolioConstructionModel();
+            Execution = new ImmediateExecutionModel();
+            RiskManagement = new Algorithm.Framework.Risk.NullRiskManagementModel();
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status.IsFill())
+            {
+                Debug($"Purchased Stock: {orderEvent.Symbol}");
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -85,6 +85,7 @@
   <ItemGroup>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
     <Compile Include="BasicTemplateCryptoAlgorithm.cs" />
+    <Compile Include="BasicTemplateCryptoFrameworkAlgorithm.cs" />
     <Compile Include="BasicTemplateIntrinioEconomicData.cs" />
     <Compile Include="BasicTemplateFrameworkAlgorithm.cs" />
     <Compile Include="BasicTemplateLibrary.cs" />

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Logging;
 
 namespace QuantConnect.Securities
@@ -143,9 +144,24 @@ namespace QuantConnect.Securities
         /// <param name="symbolPropertiesDatabase">A symbol properties database instance</param>
         /// <param name="marketMap">The market map that decides which market the new security should be in</param>
         /// <param name="cashBook">The cash book - used for resolving quote currencies for created conversion securities</param>
+        /// <param name="changes"></param>
         /// <returns>Returns the added currency security if needed, otherwise null</returns>
-        public Security EnsureCurrencyDataFeed(SecurityManager securities, SubscriptionManager subscriptions, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase, IReadOnlyDictionary<SecurityType, string> marketMap, CashBook cashBook)
+        public Security EnsureCurrencyDataFeed(SecurityManager securities,
+            SubscriptionManager subscriptions,
+            MarketHoursDatabase marketHoursDatabase,
+            SymbolPropertiesDatabase symbolPropertiesDatabase,
+            IReadOnlyDictionary<SecurityType, string> marketMap,
+            CashBook cashBook,
+            SecurityChanges changes
+            )
         {
+            // this gets called every time we add securities using universe selection,
+            // so must of the time we've already resolved the value and don't need to again
+            if (ConversionRateSecurity != null)
+            {
+                return null;
+            }
+
             if (Symbol == CashBook.AccountCurrency)
             {
                 ConversionRateSecurity = null;
@@ -154,25 +170,28 @@ namespace QuantConnect.Securities
                 return null;
             }
 
-            // we require a subscription that converts this into the base currency
+            // we require a security that converts this into the base currency
             string normal = Symbol + CashBook.AccountCurrency;
             string invert = CashBook.AccountCurrency + Symbol;
-            foreach (var config in subscriptions.Subscriptions.Where(config => config.SecurityType == SecurityType.Forex || config.SecurityType == SecurityType.Cfd ||
-            config.SecurityType == SecurityType.Crypto))
+            var securitiesToSearch = securities.Select(kvp => kvp.Value)
+                .Concat(changes.AddedSecurities)
+                .Where(s => s.Type == SecurityType.Forex || s.Type == SecurityType.Cfd || s.Type == SecurityType.Crypto);
+
+            foreach (var security in securitiesToSearch)
             {
-                if (config.Symbol.Value == normal)
+                if (security.Symbol.Value == normal)
                 {
-                    ConversionRateSecurity = securities[config.Symbol];
+                    ConversionRateSecurity = security;
                     return null;
                 }
-                if (config.Symbol.Value == invert)
+                if (security.Symbol.Value == invert)
                 {
-                    ConversionRateSecurity = securities[config.Symbol];
+                    ConversionRateSecurity = security;
                     _invertRealTimePrice = true;
                     return null;
                 }
             }
-            // if we've made it here we didn't find a subscription, so we'll need to add one
+            // if we've made it here we didn't find a security, so we'll need to add one
 
             // Create a SecurityType to Market mapping with the markets from SecurityManager members
             var markets = securities.Select(x => x.Key).GroupBy(x => x.SecurityType).ToDictionary(x => x.Key, y => y.First().ID.Market);

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Text;
 using QuantConnect.Data;
 using System.Collections.Concurrent;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Logging;
 
 namespace QuantConnect.Securities
@@ -76,14 +77,14 @@ namespace QuantConnect.Securities
         /// <param name="symbolPropertiesDatabase">A symbol properties database instance</param>
         /// <param name="marketMap">The market map that decides which market the new security should be in</param>
         /// <returns>Returns a list of added currency securities</returns>
-        public List<Security> EnsureCurrencyDataFeeds(SecurityManager securities, SubscriptionManager subscriptions, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase, IReadOnlyDictionary<SecurityType, string> marketMap)
+        public List<Security> EnsureCurrencyDataFeeds(SecurityManager securities, SubscriptionManager subscriptions, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase, IReadOnlyDictionary<SecurityType, string> marketMap, SecurityChanges changes)
         {
             var addedSecurities = new List<Security>();
             foreach (var kvp in _currencies)
             {
                 var cash = kvp.Value;
 
-                var security = cash.EnsureCurrencyDataFeed(securities, subscriptions, marketHoursDatabase, symbolPropertiesDatabase, marketMap, this);
+                var security = cash.EnsureCurrencyDataFeed(securities, subscriptions, marketHoursDatabase, symbolPropertiesDatabase, marketMap, this, changes);
                 if (security != null)
                 {
                     addedSecurities.Add(security);

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -209,21 +209,21 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
             }
 
+            // return None if there's no changes, otherwise return what we've modified
+            var securityChanges = additions.Count + removals.Count != 0
+                ? new SecurityChanges(additions, removals)
+                : SecurityChanges.None;
+
             // Add currency data feeds that weren't explicitly added in Initialize
             if (additions.Count > 0)
             {
-                var addedSecurities = _algorithm.Portfolio.CashBook.EnsureCurrencyDataFeeds(_algorithm.Securities, _algorithm.SubscriptionManager, _marketHoursDatabase, _symbolPropertiesDatabase, _algorithm.BrokerageModel.DefaultMarkets);
+                var addedSecurities = _algorithm.Portfolio.CashBook.EnsureCurrencyDataFeeds(_algorithm.Securities, _algorithm.SubscriptionManager, _marketHoursDatabase, _symbolPropertiesDatabase, _algorithm.BrokerageModel.DefaultMarkets, securityChanges);
                 foreach (var security in addedSecurities)
                 {
                     // assume currency feeds are always one subscription per, these are typically quote subscriptions
                     _dataFeed.AddSubscription(new SubscriptionRequest(false, universe, security, new SubscriptionDataConfig(security.Subscriptions.First()), dateTimeUtc, algorithmEndDateUtc));
                 }
             }
-
-            // return None if there's no changes, otherwise return what we've modified
-            var securityChanges = additions.Count + removals.Count != 0
-                ? new SecurityChanges(additions, removals)
-                : SecurityChanges.None;
 
             if (securityChanges != SecurityChanges.None)
             {

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -32,6 +32,7 @@ using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Brokerages.Backtesting;
 using QuantConnect.Tests.Engine;
 using QuantConnect.Algorithm;
+using QuantConnect.Data.UniverseSelection;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -175,7 +176,7 @@ namespace QuantConnect.Tests.Common.Securities
             securities.Add(usdJwbSecurity);
             securities.Add(mchUsdSecurity);
 
-            portfolio.CashBook.EnsureCurrencyDataFeeds(securities, subscriptions, MarketHoursDatabase.FromDataFolder(), SymbolPropertiesDatabase.FromDataFolder(), DefaultBrokerageModel.DefaultMarketMap);
+            portfolio.CashBook.EnsureCurrencyDataFeeds(securities, subscriptions, MarketHoursDatabase.FromDataFolder(), SymbolPropertiesDatabase.FromDataFolder(), DefaultBrokerageModel.DefaultMarketMap, SecurityChanges.None);
 
             for (int i = 0; i < fills.Count; i++)
             {

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -751,6 +751,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("HourReverseSplitRegressionAlgorithm", hourReverseSplitStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("FractionalQuantityRegressionAlgorithm", fractionalQuantityRegressionStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("BasicTemplateCryptoAlgorithm", basicTemplateCryptoAlgorithmStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("BasicTemplateFrameworkCryptoAlgorithm", basicTemplateCryptoAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("IndicatorSuiteAlgorithm", indicatorSuiteAlgorithmStatistics, Language.CSharp),
 
                 // Python


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When using universe selection or a framework algorithm, selecting a security that requires a conversion feed, such as `BTCUSD`, threw and exception. The reason was because universe selection performs the `EnsureCurrencyDataFeeds` check *before* we add the security to the security manager in the algorithm manager time loop. The fix here was to pass in the `SecurityChanges` from universe selection so we can select the security from the set of newly added securities as well. A regression test was added to cover a framework crypto algorithm, which is how this was initially found.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1635

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows universe selection (and by proxy, framework algorithms) to select forex/crypto/cfd or any other security type that requires a currency data feed without throwing an exception.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new unit test was added to ensure we pull the security from `SecurityChanges`. A new regression algorithm was also added, `BasicTemplateCryptoFramworkAlgorithm`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->