### PR TITLE
Fixes multiple OnEndOfDay error message in python algorithms

### DIFF
--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -750,9 +750,9 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
             // Only throws if there is an error in its implementation body
             catch (PythonException exception)
             {
-                if (!exception.Message.Equals("TypeError : OnEndOfDay() takes exactly 2 arguments (1 given)"))
+                if (!exception.Message.StartsWith("TypeError : OnEndOfDay()"))
                 {
-                    throw exception;
+                    _baseAlgorithm.SetRunTimeError(exception);
                 }
             }
         }
@@ -778,9 +778,9 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
             // Only throws if there is an error in its implementation body
             catch (PythonException exception)
             {
-                if (!exception.Message.Equals("TypeError : OnEndOfDay() takes exactly 1 argument (2 given)"))
+                if (!exception.Message.StartsWith("TypeError : OnEndOfDay()"))
                 {
-                    throw exception;
+                    _baseAlgorithm.SetRunTimeError(exception);
                 }
             }
         }

--- a/Tests/Python/AlgorithmPythonWrapperTests.cs
+++ b/Tests/Python/AlgorithmPythonWrapperTests.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.AlgorithmFactory.Python.Wrappers;
+using System;
+using System.IO;
+
+namespace QuantConnect.Tests.Python
+{
+    [TestFixture, Ignore]
+    public class AlgorithmPythonWrapperTests
+    {
+        private string _baseCode;
+
+        [SetUp]
+        public void Setup()
+        {
+            var pythonPath = new DirectoryInfo("RegressionAlgorithms");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+            _baseCode = File.ReadAllText(Path.Combine(pythonPath.FullName, "Test_AlgorithmPythonWrapper.py"));
+        }
+
+        [Test]
+        [TestCase("def OnEndOfDay(self): pass")]
+        [TestCase("def OnEndOfDay(self, symbol): pass")]
+        public void CallOnEndOfDayDoesNotThrow(string code)
+        {
+            // If we define either one or the other overload of OnEndOfDay.
+            // the algorithm will not throw or log the error
+            using (Py.GIL())
+            {
+                var algorithm = GetAlgorithm(code);
+
+                Assert.Null(algorithm.RunTimeError);
+                Assert.DoesNotThrow(() => algorithm.OnEndOfDay());
+                Assert.Null(algorithm.RunTimeError);
+                Assert.DoesNotThrow(() => algorithm.OnEndOfDay(Symbols.SPY));
+                Assert.Null(algorithm.RunTimeError);
+            }
+        }
+
+        [Test]
+        public void CallOnEndOfDayExceptionNoParameter()
+        {
+            // When we define OnEndOfDay without a parameter and it has an user error (divide by zero)
+            // it doesn't throw and stop the algorithm, but set its RuntimeError
+            using (Py.GIL())
+            {
+                var algorithm = GetAlgorithm("def OnEndOfDay(self): 1/0");
+
+                Assert.Null(algorithm.RunTimeError);
+                Assert.DoesNotThrow(() => algorithm.OnEndOfDay());
+                Assert.NotNull(algorithm.RunTimeError);
+            }
+        }
+
+        [Test]
+        public void CallOnEndOfDayExceptionWithParameter()
+        {
+            // When we define OnEndOfDay with the Symbol parameter and it has an user error (divide by zero)
+            // it doesn't throw and stop the algorithm, but set its RuntimeError
+            using (Py.GIL())
+            {
+                var algorithm = GetAlgorithm("def OnEndOfDay(self, symbol): 1/0");
+
+                Assert.Null(algorithm.RunTimeError);
+                Assert.DoesNotThrow(() => algorithm.OnEndOfDay(Symbols.SPY));
+                Assert.NotNull(algorithm.RunTimeError);
+            }
+        }
+
+        private AlgorithmPythonWrapper GetAlgorithm(string code)
+        {
+            code = $"{_baseCode}{Environment.NewLine}    {code}";
+
+            using (Py.GIL())
+            {
+                var module = PythonEngine.ModuleFromString("Test_AlgorithmPythonWrapper", code);
+                return new AlgorithmPythonWrapper(module);
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -328,6 +328,7 @@
     <Compile Include="Indicators\RateOfChangeTests.cs" />
     <Compile Include="Indicators\StochasticTests.cs" />
     <Compile Include="Messaging\StreamingMessageHandlerTests.cs" />
+    <Compile Include="Python\AlgorithmPythonWrapperTests.cs" />
     <Compile Include="Python\MethodOverloadTests.cs" />
     <Compile Include="Python\PandasConverterTests.cs" />
     <Compile Include="RegressionTests.cs" />
@@ -400,6 +401,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Content Include="Python\Indicators\IndicatorExtensionsTests.py" />
+    <Content Include="RegressionAlgorithms\Test_AlgorithmPythonWrapper.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="RegressionAlgorithms\Test_CustomDataAlgorithm.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Tests/RegressionAlgorithms/Test_AlgorithmPythonWrapper.py
+++ b/Tests/RegressionAlgorithms/Test_AlgorithmPythonWrapper.py
@@ -1,0 +1,29 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+
+class Test_AlgorithmPythonWrapper(QCAlgorithm):
+
+    def Initialize(self):
+        pass
+
+    def OnData(self, slice):
+        pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The error message it was used to bypass the the error logging has been changed from `takes exactly x arguments (y given)` to `takes x positional argument but y were given`. In the previous implementation, an error in `OnEndOfDay` would be logged, but wouldn't not stop the execution.  

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1644 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since python does not support method overload and `IAlgorithm` implements two overloads of `OnEndOfDay`, when this method is implemented in the python script, both overloads are called and one of them will throw an exception due the wrong number of parameters. 
This change is required because of unnecessary exception throwing. Also runtime errors that are originated by the user show stop the execution unless it has been handled by the user.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code provided in #1644 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->