### PR TITLE
Better error formatting

### DIFF
--- a/Common/Exceptions/ScheduledEventExceptionInterpreter.cs
+++ b/Common/Exceptions/ScheduledEventExceptionInterpreter.cs
@@ -43,14 +43,15 @@ namespace QuantConnect.Exceptions
         {
             var see = (ScheduledEventException) exception;
 
+            var inner = innerInterpreter.Interpret(see.InnerException, innerInterpreter);
+
             // prepend the scheduled event name
             var message = exception.Message;
             if (!message.Contains(see.ScheduledEventName))
             {
-                message = $"In Scheduled Event '{see.ScheduledEventName}', {message}";
+                message = $"In Scheduled Event '{see.ScheduledEventName}',";
             }
 
-            var inner = innerInterpreter.Interpret(see.InnerException, innerInterpreter);
             return new ScheduledEventException(see.ScheduledEventName, message, inner);
         }
     }

--- a/Common/Exceptions/StackExceptionInterpreter.cs
+++ b/Common/Exceptions/StackExceptionInterpreter.cs
@@ -88,12 +88,11 @@ namespace QuantConnect.Exceptions
         }
 
         /// <summary>
-        /// Interprets the specified exception as a string. This will traverse the inner
-        /// exceptions compiling an end string for the user.
+        /// Combines the exception messages from this exception and all inner exceptions.
         /// </summary>
-        /// <param name="exception">The interpreted exception</param>
-        /// <returns>A single string to describe the entire exception stack</returns>
-        public string ToString(Exception exception)
+        /// <param name="exception">The exception to create a collated message from</param>
+        /// <returns>The collate exception message</returns>
+        public string GetExceptionMessageHeader(Exception exception)
         {
             return string.Join(" ", InnersAndSelf(exception).Select(e => e.Message));
         }

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -439,10 +439,10 @@ namespace QuantConnect.Lean.Engine
                 // perform exception interpretation
                 err = _exceptionInterpreter.Interpret(err, _exceptionInterpreter);
 
-                var message = "Runtime Error: " + err;
+                var message = "Runtime Error: " + _exceptionInterpreter.GetExceptionMessageHeader(err);
                 Log.Trace("Engine.Run(): Sending runtime error to user...");
                 _algorithmHandlers.Results.LogMessage(message);
-                _algorithmHandlers.Results.RuntimeError(message, err.StackTrace);
+                _algorithmHandlers.Results.RuntimeError(message, err.ToString());
                 _systemHandlers.Api.SetAlgorithmStatus(job.AlgorithmId, AlgorithmStatus.RuntimeError, message + " Stack Trace: " + err);
             }
         }

--- a/Tests/Common/Exceptions/StackExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/StackExceptionInterpreterTests.cs
@@ -100,13 +100,16 @@ namespace QuantConnect.Tests.Common.Exceptions
         }
 
         [Test]
-        public void RecursivelyFlattensExceptionMessages()
+        public void GetsExceptionMessageHeaderAsAllInnersJoinedBySpace()
         {
             var inner = new Exception("inner");
             var middle = new Exception("middle", inner);
             var outter = new Exception("outter", middle);
-            var message = new StackExceptionInterpreter(Enumerable.Empty<IExceptionInterpreter>()).ToString(outter);
-            Assert.AreEqual("outter middle inner", message);
+            var message = new StackExceptionInterpreter(Enumerable.Empty<IExceptionInterpreter>()).GetExceptionMessageHeader(outter);
+
+            // header line w/ exception message and then the full detail on a new line
+            var expectedMessage = "outter middle inner";
+            Assert.AreEqual(expectedMessage, message);
         }
     }
 }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -150,7 +150,7 @@
     <Compile Include="Common\Data\SubscriptionManagerTests.cs" />
     <Compile Include="Common\Exceptions\FakeExceptionInterpreter.cs" />
     <Compile Include="Common\Exceptions\NullExceptionInterpreter.cs" />
-    <Compile Include="Common\Exceptions\ScheduledEventExceptionProjectionTests.cs" />
+    <Compile Include="Common\Exceptions\ScheduledEventExceptionInterpreterTests.cs" />
     <Compile Include="Common\Orders\Fills\LatestPriceFillModelTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />
     <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Formats run time errors such that a header line containing the collated exception message (including inners) is displayed on the first line and then the complete exception detail is on the following lines.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1646 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is part of an effort to provide better, actionable error messages to users.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests were added to cover the new formatting as well as manual testing by throwing an exception from within a scheduled event.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->