### PR TITLE
Add rate limiting for GDAX brokerage API calls

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Brokerages.GDAX
             req.AddJsonBody(payload);
 
             GetAuthenticationToken(req);
-            var response = RestClient.Execute(req);
+            var response = ExecuteRestRequest(req, GdaxEndpointType.Private);
 
             if (response.StatusCode == HttpStatusCode.OK && response.Content != null)
             {
@@ -148,7 +148,7 @@ namespace QuantConnect.Brokerages.GDAX
             {
                 var req = new RestRequest("/orders/" + id, Method.DELETE);
                 GetAuthenticationToken(req);
-                var response = RestClient.Execute(req);
+                var response = ExecuteRestRequest(req, GdaxEndpointType.Private);
                 success.Add(response.StatusCode == HttpStatusCode.OK);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
@@ -179,7 +179,7 @@ namespace QuantConnect.Brokerages.GDAX
 
             var req = new RestRequest("/orders?status=open&status=pending", Method.GET);
             GetAuthenticationToken(req);
-            var response = RestClient.Execute(req);
+            var response = ExecuteRestRequest(req, GdaxEndpointType.Private);
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
@@ -231,7 +231,6 @@ namespace QuantConnect.Brokerages.GDAX
             }
 
             return list;
-
         }
 
         /// <summary>
@@ -258,7 +257,7 @@ namespace QuantConnect.Brokerages.GDAX
 
             var request = new RestRequest("/accounts", Method.GET);
             GetAuthenticationToken(request);
-            var response = RestClient.Execute(request);
+            var response = ExecuteRestRequest(request, GdaxEndpointType.Private);
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
@@ -310,7 +309,7 @@ namespace QuantConnect.Brokerages.GDAX
             {
                 var req = new RestRequest("/orders/" + item, Method.GET);
                 GetAuthenticationToken(req);
-                var response = RestClient.Execute(req);
+                var response = ExecuteRestRequest(req, GdaxEndpointType.Private);
 
                 if (response.StatusCode != HttpStatusCode.OK)
                 {
@@ -325,5 +324,13 @@ namespace QuantConnect.Brokerages.GDAX
             return totalFee;
         }
 
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public override void Dispose()
+        {
+            _publicEndpointRateLimiter.Dispose();
+            _privateEndpointRateLimiter.Dispose();
+        }
     }
 }

--- a/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+using QuantConnect.Brokerages.GDAX;
+using QuantConnect.Configuration;
+using RestSharp;
+
+namespace QuantConnect.Tests.Brokerages.GDAX
+{
+    [TestFixture, Ignore("These tests requires a configured and active GDAX account.")]
+    public class GDAXBrokerageAdditionalTests
+    {
+        [Test]
+        public void PublicEndpointCallsAreRateLimited()
+        {
+            using (var brokerage = GetBrokerage())
+            {
+                Assert.IsTrue(brokerage.IsConnected);
+
+                for (var i = 0; i < 50; i++)
+                {
+                    Assert.DoesNotThrow(() => brokerage.GetTick(Symbols.BTCEUR));
+                }
+            }
+        }
+
+        [Test]
+        public void PrivateEndpointCallsAreRateLimited()
+        {
+            using (var brokerage = GetBrokerage())
+            {
+                Assert.IsTrue(brokerage.IsConnected);
+
+                for (var i = 0; i < 50; i++)
+                {
+                    Assert.DoesNotThrow(() => brokerage.GetOpenOrders());
+                }
+            }
+        }
+
+        private static GDAXBrokerage GetBrokerage()
+        {
+            var wssUrl = Config.Get("gdax-url", "wss://ws-feed.gdax.com");
+            var webSocketClient = new WebSocketWrapper();
+            var restClient = new RestClient("https://api.gdax.com");
+            var apiKey = Config.Get("gdax-api-key");
+            var apiSecret = Config.Get("gdax-api-secret");
+            var passPhrase = Config.Get("gdax-passphrase");
+            var algorithm = new QCAlgorithm();
+
+            var brokerage = new GDAXBrokerage(wssUrl, webSocketClient, restClient, apiKey, apiSecret, passPhrase, algorithm);
+            brokerage.Connect();
+
+            return brokerage;
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Brokerages\Fxcm\FxcmLimitOrderTestParameters.cs" />
     <Compile Include="Brokerages\Fxcm\FxcmStopMarketOrderTestParameters.cs" />
     <Compile Include="Brokerages\Fxcm\FxcmSymbolMapperTests.cs" />
+    <Compile Include="Brokerages\GDAX\GDAXBrokerageAdditionalTests.cs" />
     <Compile Include="Common\Brokerages\GDAXBrokerageModelTests.cs" />
     <Compile Include="Brokerages\GDAX\GDAXBrokerageIntegrationTests.cs" />
     <Compile Include="Brokerages\GDAX\GDAXBrokerageTests.cs" />


### PR DESCRIPTION

#### Description
- All GDAX REST API calls are now rate limited, using different limits for public and private endpoints.
- If for some reason (e.g. server overload) API calls are rejected with a 429 error, calls will be retried up to a maximum of 10 attempts.

#### Related Issue
Fixes #1639

#### Motivation and Context
GDAX imposes rate limits on API clients: https://docs.gdax.com/#rate-limits
Algorithms calling GDAX API more frequently than allowed were being terminated with the following error:
`request failed: [429] Too Many Requests, Content: {"message":"Rate limit exceeded"}`

#### Requires Documentation Change
No

#### How Has This Been Tested?
Unit tests included for both private and public endpoints.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`