### PR TITLE
Prevent adding universe securities to SecurityChanges in live mode

### DIFF
--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -200,7 +200,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             // keep track of security changes, we emit these to the algorithm
             // as notifications, used in universe selection
-            _changes += SecurityChanges.Added(request.Security);
+            if (!request.IsUniverseSubscription)
+            {
+                _changes += SecurityChanges.Added(request.Security);
+            }
 
             UpdateFillForwardResolution();
 
@@ -240,8 +243,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             // keep track of security changes, we emit these to the algorithm
             // as notications, used in universe selection
-            _changes += SecurityChanges.Removed(security);
-
+            if (!subscription.IsUniverseSelectionSubscription)
+            {
+                _changes += SecurityChanges.Removed(security);
+            }
 
             Log.Trace("LiveTradingDataFeed.RemoveSubscription(): Removed " + configuration);
             UpdateFillForwardResolution();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The LiveTradingDataFeed was not checking if a subscription is for a universe or not, this led to us adding universe securities to the SecurityChanges collection. This fix simply checks if the subscription is for universe selection, and if it is, does not add the security to the SecurityChanges collection.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1656

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `SecurityChanges` collection is not supposed to contain universe securities. It's a common pattern to loop over `SecurityChanges.AddedSecurities` and set up indicators and other security specific initialization. If this set contains universe securities, then errors are thrown when we can't properly resolve the security's consolidator.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was manually tested via branch deployment in the cloud.

Explicit tests are forthcoming. This PR is posted as a hotfix to solve the immediate production issue. Unit tests will be added to cover that `LiveTradingDataFeed.AddSubscription` and `LiveTradingDataFeed.RemoveSubscription` do not add securities for universe subscriptions to the `SecurityChanges` collection in the next PR

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->