### PR TITLE
Remove universe symbols from history requests

### DIFF
--- a/Algorithm.CSharp/HistoryAlgorithm.cs
+++ b/Algorithm.CSharp/HistoryAlgorithm.cs
@@ -46,8 +46,8 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);             //Set Strategy Cash
 
             // Find more symbols here: http://quantconnect.com/data
-            AddSecurity(SecurityType.Equity, "SPY", Resolution.Daily);
-            AddData<QuandlFuture>("CHRIS/CME_SP1", Resolution.Daily);
+            var SPY = AddSecurity(SecurityType.Equity, "SPY", Resolution.Daily).Symbol;
+            var CME_SP1 = AddData<QuandlFuture>("CHRIS/CME_SP1", Resolution.Daily).Symbol;
             // specifying the exchange will allow the history methods that accept a number of bars to return to work properly
             Securities["CHRIS/CME_SP1"].Exchange = new EquityExchange();
 
@@ -56,19 +56,19 @@ namespace QuantConnect.Algorithm.CSharp
 
             // get the last calendar year's worth of SPY data at the configured resolution (daily)
             var tradeBarHistory = History<TradeBar>("SPY", TimeSpan.FromDays(365));
-            AssertHistoryCount("History<TradeBar>(\"SPY\", TimeSpan.FromDays(365))", tradeBarHistory, 250);
+            AssertHistoryCount("History<TradeBar>(\"SPY\", TimeSpan.FromDays(365))", tradeBarHistory, 250, SPY);
 
             // get the last calendar day's worth of SPY data at the specified resolution
             tradeBarHistory = History<TradeBar>("SPY", TimeSpan.FromDays(1), Resolution.Minute);
-            AssertHistoryCount("History<TradeBar>(\"SPY\", TimeSpan.FromDays(1), Resolution.Minute)", tradeBarHistory, 390);
+            AssertHistoryCount("History<TradeBar>(\"SPY\", TimeSpan.FromDays(1), Resolution.Minute)", tradeBarHistory, 390, SPY);
 
             // get the last 14 bars of SPY at the configured resolution (daily)
             tradeBarHistory = History<TradeBar>("SPY", 14).ToList();
-            AssertHistoryCount("History<TradeBar>(\"SPY\", 14)", tradeBarHistory, 14);
+            AssertHistoryCount("History<TradeBar>(\"SPY\", 14)", tradeBarHistory, 14, SPY);
 
             // get the last 14 minute bars of SPY
             tradeBarHistory = History<TradeBar>("SPY", 14, Resolution.Minute);
-            AssertHistoryCount("History<TradeBar>(\"SPY\", 14, Resolution.Minute)", tradeBarHistory, 14);
+            AssertHistoryCount("History<TradeBar>(\"SPY\", 14, Resolution.Minute)", tradeBarHistory, 14, SPY);
 
             // we can loop over the return value from these functions and we get TradeBars
             // we can use these TradeBars to initialize indicators or perform other math
@@ -79,11 +79,11 @@ namespace QuantConnect.Algorithm.CSharp
 
             // get the last calendar year's worth of quandl data at the configured resolution (daily)
             var quandlHistory = History<QuandlFuture>("CHRIS/CME_SP1", TimeSpan.FromDays(365));
-            AssertHistoryCount("History<Quandl>(\"CHRIS/CME_SP1\", TimeSpan.FromDays(365))", quandlHistory, 250);
+            AssertHistoryCount("History<Quandl>(\"CHRIS/CME_SP1\", TimeSpan.FromDays(365))", quandlHistory, 250, CME_SP1);
 
             // get the last 14 bars of SPY at the configured resolution (daily)
             quandlHistory = History<QuandlFuture>("CHRIS/CME_SP1", 14);
-            AssertHistoryCount("History<Quandl>(\"CHRIS/CME_SP1\", 14)", quandlHistory, 14);
+            AssertHistoryCount("History<Quandl>(\"CHRIS/CME_SP1\", 14)", quandlHistory, 14, CME_SP1);
 
             // get the last 14 minute bars of SPY
 
@@ -97,11 +97,11 @@ namespace QuantConnect.Algorithm.CSharp
 
             // get the last year's worth of all configured Quandl data at the configured resolution (daily)
             var allQuandlData = History<QuandlFuture>(TimeSpan.FromDays(365));
-            AssertHistoryCount("History<QuandlFuture>(TimeSpan.FromDays(365))", allQuandlData, 250);
+            AssertHistoryCount("History<QuandlFuture>(TimeSpan.FromDays(365))", allQuandlData, 250, CME_SP1);
 
             // get the last 14 bars worth of Quandl data for the specified symbols at the configured resolution (daily)
             allQuandlData = History<QuandlFuture>(Securities.Keys, 14);
-            AssertHistoryCount("History<QuandlFuture>(Securities.Keys, 14)", allQuandlData, 14);
+            AssertHistoryCount("History<QuandlFuture>(Securities.Keys, 14)", allQuandlData, 14, CME_SP1);
 
             // NOTE: using different resolutions require that they are properly implemented in your data type, since
             //  Quandl doesn't support minute data, this won't actually work, but if your custom data source has
@@ -115,7 +115,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             // get the last calendar year's worth of all quandl data
             allQuandlData = History<QuandlFuture>(Securities.Keys, TimeSpan.FromDays(365));
-            AssertHistoryCount("History<QuandlFuture>(Securities.Keys, TimeSpan.FromDays(365))", allQuandlData, 250);
+            AssertHistoryCount("History<QuandlFuture>(Securities.Keys, TimeSpan.FromDays(365))", allQuandlData, 250, CME_SP1);
 
             // the return is a series of dictionaries containing all quandl data at each time
             // we can loop over it to get the individual dictionaries
@@ -128,7 +128,7 @@ namespace QuantConnect.Algorithm.CSharp
             // we can also access the return value from the multiple symbol functions to request a single
             // symbol and then loop over it
             var singleSymbolQuandl = allQuandlData.Get("CHRIS/CME_SP1");
-            AssertHistoryCount("allQuandlData.Get(\"CHRIS/CME_SP1\")", singleSymbolQuandl, 250);
+            AssertHistoryCount("allQuandlData.Get(\"CHRIS/CME_SP1\")", singleSymbolQuandl, 250, CME_SP1);
             foreach (QuandlFuture quandl in singleSymbolQuandl)
             {
                 // do something with 'CHRIS/CME_SP1' quandl data
@@ -140,33 +140,33 @@ namespace QuantConnect.Algorithm.CSharp
             AssertHistoryCount("allQuandlData.Get(\"CHRIS/CME_SP1\", \"Low\")", quandlSpyLows, 250);
             foreach (decimal low in quandlSpyLows)
             {
-                // do something we each low value
+                // do something with each low value
             }
 
             // sometimes it's necessary to get the history for many configured symbols
 
             // request the last year's worth of history for all configured symbols at their configured resolutions
             var allHistory = History(TimeSpan.FromDays(365));
-            AssertHistoryCount("History(TimeSpan.FromDays(365))", allHistory, 250);
+            AssertHistoryCount("History(TimeSpan.FromDays(365))", allHistory, 250, SPY, CME_SP1);
 
             // request the last days's worth of history at the minute resolution
             allHistory = History(TimeSpan.FromDays(1), Resolution.Minute);
-            AssertHistoryCount("History(TimeSpan.FromDays(1), Resolution.Minute)", allHistory, 391);
+            AssertHistoryCount("History(TimeSpan.FromDays(1), Resolution.Minute)", allHistory, 391, SPY, CME_SP1);
 
             // request the last 100 bars for the specified securities at the configured resolution
             allHistory = History(Securities.Keys, 100);
-            AssertHistoryCount("History(Securities.Keys, 100)", allHistory, 100);
+            AssertHistoryCount("History(Securities.Keys, 100)", allHistory, 100, SPY, CME_SP1);
 
             // request the last 100 minute bars for the specified securities
             allHistory = History(Securities.Keys, 100, Resolution.Minute);
-            AssertHistoryCount("History(Securities.Keys, 100, Resolution.Minute)", allHistory, 101);
+            AssertHistoryCount("History(Securities.Keys, 100, Resolution.Minute)", allHistory, 101, SPY, CME_SP1);
 
             // request the last calendar years worth of history for the specified securities
             allHistory = History(Securities.Keys, TimeSpan.FromDays(365));
-            AssertHistoryCount("History(Securities.Keys, TimeSpan.FromDays(365))", allHistory, 250);
-            // we can also specify the resolutin
+            AssertHistoryCount("History(Securities.Keys, TimeSpan.FromDays(365))", allHistory, 250, SPY, CME_SP1);
+            // we can also specify the resolution
             allHistory = History(Securities.Keys, TimeSpan.FromDays(1), Resolution.Minute);
-            AssertHistoryCount("History(Securities.Keys, TimeSpan.FromDays(1), Resolution.Minute)", allHistory, 391);
+            AssertHistoryCount("History(Securities.Keys, TimeSpan.FromDays(1), Resolution.Minute)", allHistory, 391, SPY, CME_SP1);
 
             // if we loop over this allHistory, we get Slice objects
             foreach (Slice slice in allHistory)
@@ -179,7 +179,7 @@ namespace QuantConnect.Algorithm.CSharp
             // we can access the history for individual symbols from the all history by specifying the symbol
             // the type must be a trade bar!
             tradeBarHistory = allHistory.Get<TradeBar>("SPY");
-            AssertHistoryCount("allHistory.Get(\"SPY\")", tradeBarHistory, 390);
+            AssertHistoryCount("allHistory.Get(\"SPY\")", tradeBarHistory, 390, SPY);
 
             // we can access all the closing prices in chronological order using this get function
             var closeHistory = allHistory.Get("SPY", Field.Close);
@@ -191,6 +191,16 @@ namespace QuantConnect.Algorithm.CSharp
 
             // we can convert the close history into your normal double array (double[]) using the ToDoubleArray method
             double[] doubleArray = closeHistory.ToDoubleArray();
+
+            // for the purposes of regression testing, we're explicitly requesting history
+            // using the universe symbols. Requests for universe symbols are filtered out
+            // and never sent to the history provider.
+            var universeSecurityHistory = History(UniverseManager.Keys, TimeSpan.FromDays(10)).ToList();
+            if (universeSecurityHistory.Count != 0)
+            {
+                throw new Exception("History request for universe symbols incorrectly returned data. "
+                    + "These requests are intended to be filtered out and never sent to the history provider.");
+            }
         }
 
         /// <summary>
@@ -213,12 +223,60 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
-        private static void AssertHistoryCount<T>(string methodCall, IEnumerable<T> tradeBarHistory, int expected)
+        private void AssertHistoryCount<T>(string methodCall, IEnumerable<T> history, int expected, params Symbol[] expectedSymbols)
         {
-            var count = tradeBarHistory.Count();
+            history = history.ToList();
+            var count = history.Count();
             if (count != expected)
             {
                 throw new Exception(methodCall + " expected " + expected + ", but received " + count);
+            }
+
+            IEnumerable<Symbol> unexpectedSymbols = null;
+            if (typeof(T) == typeof(Slice))
+            {
+                var slices = (IEnumerable<Slice>) history;
+                unexpectedSymbols = slices.SelectMany(slice => slice.Keys)
+                    .Distinct()
+                    .Where(sym => !expectedSymbols.Contains(sym))
+                    .ToList();
+            }
+            else if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(DataDictionary<>))
+            {
+                if (typeof(T).GetGenericArguments()[0] == typeof(QuandlFuture))
+                {
+                    var dictionaries = (IEnumerable<DataDictionary<QuandlFuture>>) history;
+                    unexpectedSymbols = dictionaries.SelectMany(dd => dd.Keys)
+                        .Distinct()
+                        .Where(sym => !expectedSymbols.Contains(sym))
+                        .ToList();
+                }
+            }
+            else if (typeof(IBaseData).IsAssignableFrom(typeof(T)))
+            {
+                var slices = (IEnumerable<IBaseData>)history;
+                unexpectedSymbols = slices.Select(data => data.Symbol)
+                    .Distinct()
+                    .Where(sym => !expectedSymbols.Contains(sym))
+                    .ToList();
+            }
+            else if (typeof(T) == typeof(decimal))
+            {
+                // if the enumerable doesn't contain symbols then we can't assert that certain symbols exist
+                // this case is used when testing data dictionary extensions that select a property value,
+                // such as dataDictionaries.Get("MySymbol", "MyProperty") => IEnumerable<decimal>
+                return;
+            }
+
+            if (unexpectedSymbols == null)
+            {
+                throw new Exception("Unhandled case: " + typeof(T).GetBetterTypeName());
+            }
+
+            var unexpectedSymbolsString = string.Join(" | ", unexpectedSymbols);
+            if (!string.IsNullOrWhiteSpace(unexpectedSymbolsString))
+            {
+                throw new Exception($"{methodCall} contains unexpected symbols: {unexpectedSymbolsString}");
             }
         }
     }

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -569,7 +569,8 @@ namespace QuantConnect.Algorithm
         private IEnumerable<Slice> History(IEnumerable<HistoryRequest> requests, DateTimeZone timeZone)
         {
             var sentMessage = false;
-            var reqs = requests.ToList();
+            // filter out any universe securities that may have made it this far
+            var reqs = requests.Where(hr => !UniverseManager.ContainsKey(hr.Symbol)) .ToList();
             foreach (var request in reqs)
             {
                 // prevent future requests

--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -115,7 +115,7 @@ namespace QuantConnect.Lean.Engine.Setup
         /// <param name="assemblyPath">The path to the assembly's location</param>
         /// <param name="algorithmNodePacket">Details of the task required</param>
         /// <returns>A new instance of IAlgorithm, or throws an exception if there was an error</returns>
-        public IAlgorithm CreateAlgorithmInstance(AlgorithmNodePacket algorithmNodePacket, string assemblyPath)
+        public virtual IAlgorithm CreateAlgorithmInstance(AlgorithmNodePacket algorithmNodePacket, string assemblyPath)
         {
             string error;
             IAlgorithm algorithm;

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -19,13 +19,20 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Configuration;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine;
 using QuantConnect.Lean.Engine.Alphas;
+using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Lean.Engine.Results;
+using QuantConnect.Lean.Engine.Setup;
 using QuantConnect.Logging;
+using QuantConnect.Packets;
 using QuantConnect.Util;
+using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests
 {
@@ -53,6 +60,8 @@ namespace QuantConnect.Tests
                 Config.Set("environment", "");
                 Config.Set("messaging-handler", "QuantConnect.Messaging.Messaging");
                 Config.Set("job-queue-handler", "QuantConnect.Queues.JobQueue");
+                Config.Set("setup-handler", "RegressionSetupHandlerWrapper");
+                Config.Set("history-provider", "RegressionHistoryProviderWrapper");
                 Config.Set("api-handler", "QuantConnect.Api.Api");
                 Config.Set("result-handler", "QuantConnect.Lean.Engine.Results.RegressionResultHandler");
                 Config.Set("algorithm-language", language.ToString());
@@ -150,6 +159,35 @@ namespace QuantConnect.Tests
             else
             {
                 Assert.AreEqual(expectedValue, actualValue, "Failed on alpha statistics " + field);
+            }
+        }
+
+        /// <summary>
+        /// Used to intercept the algorithm instance to aid the <see cref="RegressionHistoryProviderWrapper"/>
+        /// </summary>
+        class RegressionSetupHandlerWrapper : BacktestingSetupHandler
+        {
+            public static IAlgorithm Algorithm { get; private set; }
+            public override IAlgorithm CreateAlgorithmInstance(AlgorithmNodePacket algorithmNodePacket, string assemblyPath)
+            {
+                Algorithm = base.CreateAlgorithmInstance(algorithmNodePacket, assemblyPath);
+                return Algorithm;
+            }
+        }
+
+        /// <summary>
+        /// Used to perform checks against history requests for all regression algorithms
+        /// </summary>
+        class RegressionHistoryProviderWrapper : SubscriptionDataReaderHistoryProvider
+        {
+            public override IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+            {
+                requests = requests.ToList();
+                if (requests.Any(r => RegressionSetupHandlerWrapper.Algorithm.UniverseManager.ContainsKey(r.Symbol)))
+                {
+                    throw new Exception("History requests should not be submitted for universe symbols");
+                }
+                return base.GetHistory(requests, sliceTimeZone);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The engine defines securities for each universe to properly track them within the data feed. These securities are not tradable and have no price data associated with them, and as such, we should not be sending history requests for these symbols. This change removes all universe symbols from history requests.
>NOTE: Requests made directly to the history provider are not filtered out, as the
filtering happens within the QCAlgorithm implementation.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1658

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Universe securities aren't actual securities and no history data exists for them. Because of this, there's no point in sending a history request that for these symbols.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Regression test suite was upgraded to enforce this constraint on all regression algorithms by intercepting the history requests and checking for universe symbols. The `HistoryAlgorithm` was updated to explicitly request history for only universe symbols and confirms that no data is returned.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->