### PR TITLE
Fix error message with empty reason in SetHoldings

### DIFF
--- a/Common/Securities/SecurityMarginModel.cs
+++ b/Common/Securities/SecurityMarginModel.cs
@@ -283,7 +283,7 @@ namespace QuantConnect.Securities
             // if targeting zero, simply return the negative of the quantity
             if (targetPortfolioValue == 0)
             {
-                return new GetMaximumOrderQuantityForTargetValueResult(-security.Holdings.Quantity);
+                return new GetMaximumOrderQuantityForTargetValueResult(-security.Holdings.Quantity, string.Empty, false);
             }
 
             var currentHoldingsValue = security.Holdings.HoldingsValue;

--- a/Tests/Common/Securities/SecurityMarginModelTests.cs
+++ b/Tests/Common/Securities/SecurityMarginModelTests.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class SecurityMarginModelTests
+    {
+        [Test]
+        public void ZeroTargetWithZeroHoldingsIsNotAnError()
+        {
+            var algorithm = new QCAlgorithm();
+            var security = algorithm.AddEquity("SPY");
+
+            var model = new SecurityMarginModel();
+            var result = model.GetMaximumOrderQuantityForTargetValue(algorithm.Portfolio, security, 0);
+
+            Assert.AreEqual(0, result.Quantity);
+            Assert.AreEqual(string.Empty, result.Reason);
+            Assert.AreEqual(false, result.IsError);
+        }
+
+        [Test]
+        public void ZeroTargetWithNonZeroHoldingsReturnsNegativeOfQuantity()
+        {
+            var algorithm = new QCAlgorithm();
+            var security = algorithm.AddEquity("SPY");
+            security.Holdings.SetHoldings(200, 10);
+
+            var model = new SecurityMarginModel();
+            var result = model.GetMaximumOrderQuantityForTargetValue(algorithm.Portfolio, security, 0);
+
+            Assert.AreEqual(-10, result.Quantity);
+            Assert.AreEqual(string.Empty, result.Reason);
+            Assert.AreEqual(false, result.IsError);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Common\Securities\Futures\FuturesExpiryFunctionsTests.cs" />
     <Compile Include="Common\Securities\Futures\FuturesExpiryUtilityFunctionsTests.cs" />
     <Compile Include="Common\Securities\Options\OptionChainProviderTests.cs" />
+    <Compile Include="Common\Securities\SecurityMarginModelTests.cs" />
     <Compile Include="Common\Securities\StandardDeviationOfReturnsVolatilityModelTests.cs" />
     <Compile Include="Common\Data\Auxiliary\LocalDiskFactorFileProviderTests.cs" />
     <Compile Include="Common\Data\Auxiliary\LocalDiskMapFileProviderTests.cs" />


### PR DESCRIPTION

#### Description
Prevents this message from being displayed when calling `SetHoldings(security, 0)` when the security has no holdings:
`The order quantity for XYZ cannot be calculated: Reason: .`

#### Related Issue
Fixes #1664

#### Requires Documentation Change
No

#### How Has This Been Tested?
Unit tests included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`