### PR TITLE
Fix IB GetHistory with multiple API calls

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2661,7 +2661,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             var history = new List<TradeBar>();
             var dataDownloading = new AutoResetEvent(false);
-            var dataDownloaded = new ManualResetEvent(false);
+            var dataDownloaded = new AutoResetEvent(false);
 
             var useRegularTradingHours = Convert.ToInt32(!request.IncludeExtendedMarketHours);
 
@@ -2750,7 +2750,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 var filteredPiece = historyPiece.OrderBy(x => x.Time);
 
-                history.AddRange(filteredPiece);
+                history.InsertRange(0, filteredPiece);
 
                 // moving endTime to the new position to proceed with next request (if needed)
                 endTime = filteredPiece.First().Time;

--- a/Tests/Engine/DataFeeds/BaseDataExchangeTests.cs
+++ b/Tests/Engine/DataFeeds/BaseDataExchangeTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,24 +18,21 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Indicators;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
-using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
 {
     [TestFixture]
     public class BaseDataExchangeTests
     {
-        // This is a default timeout for all tests to wait if something went wrong 
-        const int DefaultTimeout = 10000;
+        // This is a default timeout for all tests to wait if something went wrong
+        const int DefaultTimeout = 30000;
 
         [Test]
         public void FiresCorrectHandlerBySymbol()
@@ -209,7 +206,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var errorCaught = new AutoResetEvent(true);
             BaseData last = null;
 
-            exchange.SetErrorHandler(error => 
+            exchange.SetErrorHandler(error =>
             {
                 errorCaught.Set();
                 return true;


### PR DESCRIPTION

#### Description
Two bugs have been fixed in `InteractiveBrokersBrokerage.GetHistory` with multiple IB API requests:
- the `ManualResetEvent` used in the method was not being manually reset in the loop: it has been replaced with an `AutoResetEvent`
- multiple blocks are now concatenated properly

#### Related Issue
Fixes #1637

#### Motivation and Context
The `InteractiveBrokersBrokerage.GetHistory` method was returning less data points than expected.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`