### PR TITLE
Fix concurrency issue in QCAlgorithm charts

### DIFF
--- a/Algorithm/QCAlgorithm.Plotting.cs
+++ b/Algorithm/QCAlgorithm.Plotting.cs
@@ -50,10 +50,7 @@ namespace QuantConnect.Algorithm
         /// <seealso cref="Plot(string,string,decimal)"/>
         public void AddChart(Chart chart)
         {
-            if (!_charts.ContainsKey(chart.Name))
-            {
-                _charts.TryAdd(chart.Name, chart);
-            }
+            _charts.TryAdd(chart.Name, chart);
         }
 
         /// <summary>
@@ -175,10 +172,7 @@ namespace QuantConnect.Algorithm
             }
 
             // If we don't have the chart, create it:
-            if (!_charts.ContainsKey(chart))
-            {
-                _charts.TryAdd(chart, new Chart(chart));
-            }
+            _charts.TryAdd(chart, new Chart(chart));
 
             var thisChart = _charts[chart];
             if (!thisChart.Series.ContainsKey(series))

--- a/Algorithm/QCAlgorithm.Plotting.cs
+++ b/Algorithm/QCAlgorithm.Plotting.cs
@@ -25,7 +25,7 @@ namespace QuantConnect.Algorithm
 {
     public partial class QCAlgorithm
     {
-        private readonly Dictionary<string, Chart> _charts = new Dictionary<string, Chart>();
+        private readonly ConcurrentDictionary<string, Chart> _charts = new ConcurrentDictionary<string, Chart>();
 
         private static readonly Dictionary<string, List<string>> ReservedChartSeriesNames = new Dictionary<string, List<string>>
         {
@@ -52,7 +52,7 @@ namespace QuantConnect.Algorithm
         {
             if (!_charts.ContainsKey(chart.Name))
             {
-                _charts.Add(chart.Name, chart);
+                _charts.TryAdd(chart.Name, chart);
             }
         }
 
@@ -177,14 +177,14 @@ namespace QuantConnect.Algorithm
             // If we don't have the chart, create it:
             if (!_charts.ContainsKey(chart))
             {
-                _charts.Add(chart, new Chart(chart));
+                _charts.TryAdd(chart, new Chart(chart));
             }
 
             var thisChart = _charts[chart];
             if (!thisChart.Series.ContainsKey(series))
             {
                 //Number of series in total, excluding reserved charts
-                var seriesCount = _charts.Values.Sum(c => ReservedChartSeriesNames.TryGetValue(c.Name, out reservedSeriesNames)
+                var seriesCount = _charts.Select(x => x.Value).Sum(c => ReservedChartSeriesNames.TryGetValue(c.Name, out reservedSeriesNames)
                     ? c.Series.Values.Count(s => reservedSeriesNames.Count > 0 && !reservedSeriesNames.Contains(s.Name))
                     : c.Series.Count);
 
@@ -334,7 +334,7 @@ namespace QuantConnect.Algorithm
         /// <remarks>GetChartUpdates returns the latest updates since previous request.</remarks>
         public List<Chart> GetChartUpdates(bool clearChartData = false)
         {
-            var updates = _charts.Values.Select(chart => chart.GetUpdates()).ToList();
+            var updates = _charts.Select(x => x.Value).Select(chart => chart.GetUpdates()).ToList();
 
             if (clearChartData)
             {

--- a/Tests/Algorithm/AlgorithmPlottingTests.cs
+++ b/Tests/Algorithm/AlgorithmPlottingTests.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmPlottingTests
+    {
+        [Test]
+        public void TestGetChartUpdatesWhileAdding()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var task1 = Task.Factory.StartNew(() =>
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    algorithm.AddChart(new Chart($"Test_{i}"));
+                    Thread.Sleep(1);
+                }
+            });
+
+            var task2 = Task.Factory.StartNew(() =>
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    algorithm.GetChartUpdates(true);
+                    Thread.Sleep(1);
+                }
+            });
+
+            Task.WaitAll(task1, task2);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="AlgorithmRunner.cs" />
     <Compile Include="Algorithm\AlgorithmAddDataTests.cs" />
     <Compile Include="Algorithm\AlgorithmInitializeTests.cs" />
+    <Compile Include="Algorithm\AlgorithmPlottingTests.cs" />
     <Compile Include="Algorithm\AlgorithmResolveConsolidatorTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetBrokerageTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetHoldingsTests.cs" />


### PR DESCRIPTION

#### Description
The type of the `_charts` member in `QCAlgorithm.Plotting.cs` has been changed from `Dictionary` to `ConcurrentDictionary`. 

#### Related Issue
Fixes #1640

#### Motivation and Context
The dictionary can be read and updated concurrently from multiple threads.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`