### PR TITLE
Adds IExceptionInterpreter.Order property

### DIFF
--- a/Common/Exceptions/DllNotFoundPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/DllNotFoundPythonExceptionInterpreter.cs
@@ -24,6 +24,11 @@ namespace QuantConnect.Exceptions
     public class DllNotFoundPythonExceptionInterpreter : IExceptionInterpreter
     {
         /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public int Order => 0;
+
+        /// <summary>
         /// Determines if this interpreter should be applied to the specified exception.
         /// </summary>
         /// <param name="exception">The exception to check</param>

--- a/Common/Exceptions/IExceptionInterpreter.cs
+++ b/Common/Exceptions/IExceptionInterpreter.cs
@@ -24,6 +24,11 @@ namespace QuantConnect.Exceptions
     public interface IExceptionInterpreter
     {
         /// <summary>
+        /// Determines the order that a class that implements this interface should be called
+        /// </summary>
+        int Order { get; }
+
+        /// <summary>
         /// Determines if this interpreter should be applied to the specified exception.
         /// </summary>
         /// <param name="exception">The exception to check</param>

--- a/Common/Exceptions/InvalidTokenPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/InvalidTokenPythonExceptionInterpreter.cs
@@ -25,6 +25,11 @@ namespace QuantConnect.Exceptions
     public class InvalidTokenPythonExceptionInterpreter : IExceptionInterpreter
     {
         /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public int Order => 0;
+
+        /// <summary>
         /// Determines if this interpreter should be applied to the specified exception.
         /// </summary>
         /// <param name="exception">The exception to check</param>

--- a/Common/Exceptions/KeyErrorPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/KeyErrorPythonExceptionInterpreter.cs
@@ -26,6 +26,11 @@ namespace QuantConnect.Exceptions
     public class KeyErrorPythonExceptionInterpreter : IExceptionInterpreter
     {
         /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public int Order => 0;
+
+        /// <summary>
         /// Determines if this interpreter should be applied to the specified exception.
         /// </summary>
         /// <param name="exception">The exception to check</param>

--- a/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
@@ -25,6 +25,11 @@ namespace QuantConnect.Exceptions
     public class NoMethodMatchPythonExceptionInterpreter : IExceptionInterpreter
     {
         /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public int Order => 0;
+
+        /// <summary>
         /// Determines if this interpreter should be applied to the specified exception.
         /// </summary>
         /// <param name="exception">The exception to check</param>

--- a/Common/Exceptions/ScheduledEventExceptionInterpreter.cs
+++ b/Common/Exceptions/ScheduledEventExceptionInterpreter.cs
@@ -24,6 +24,11 @@ namespace QuantConnect.Exceptions
     public class ScheduledEventExceptionInterpreter : IExceptionInterpreter
     {
         /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public int Order => 0;
+
+        /// <summary>
         /// Determines if this interpreter should be applied to the specified exception.
         /// </summary>
         /// <param name="exception">The exception to check</param>

--- a/Common/Exceptions/StackExceptionInterpreter.cs
+++ b/Common/Exceptions/StackExceptionInterpreter.cs
@@ -29,12 +29,17 @@ namespace QuantConnect.Exceptions
         private readonly List<IExceptionInterpreter> _interpreters;
 
         /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public int Order => 0;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="StackExceptionInterpreter"/> class
         /// </summary>
         /// <param name="interpreters">The interpreters to use</param>
         public StackExceptionInterpreter(IEnumerable<IExceptionInterpreter> interpreters)
         {
-            _interpreters = interpreters.ToList();
+            _interpreters = interpreters.OrderBy(x => x.Order).ToList();
         }
 
         /// <summary>

--- a/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreter.cs
@@ -25,6 +25,11 @@ namespace QuantConnect.Exceptions
     public class UnsupportedOperandPythonExceptionInterpreter : IExceptionInterpreter
     {
         /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public int Order => 0;
+
+        /// <summary>
         /// Determines if this interpreter should be applied to the specified exception.
         /// </summary>
         /// <param name="exception">The exception to check</param>

--- a/Tests/Common/Exceptions/FakeExceptionInterpreter.cs
+++ b/Tests/Common/Exceptions/FakeExceptionInterpreter.cs
@@ -23,8 +23,11 @@ namespace QuantConnect.Tests.Common.Exceptions
     /// </summary>
     public class FakeExceptionInterpreter : IExceptionInterpreter
     {
+        private readonly int _order = 0;
         private readonly Func<Exception, bool> _canInterpret;
         private readonly Func<Exception, Exception> _interpret;
+
+        public int Order => _order;
 
         public FakeExceptionInterpreter()
         {
@@ -41,10 +44,11 @@ namespace QuantConnect.Tests.Common.Exceptions
             };
         }
 
-        public FakeExceptionInterpreter(Func<Exception, bool> canInterpret, Func<Exception, Exception> interpret)
+        public FakeExceptionInterpreter(Func<Exception, bool> canInterpret, Func<Exception, Exception> interpret, int order = 0)
         {
             _canInterpret = canInterpret;
             _interpret = interpret;
+            _order = order;
         }
 
         public bool CanInterpret(Exception exception)

--- a/Tests/Common/Exceptions/NullExceptionInterpreter.cs
+++ b/Tests/Common/Exceptions/NullExceptionInterpreter.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Tests.Common.Exceptions
     {
         public static readonly IExceptionInterpreter Instance = new NullExceptionInterpreter();
 
+        public int Order => int.MaxValue;
+
         private NullExceptionInterpreter()
         {
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The Order property can be used to give priority on exception interpreters calls.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1672 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If two or more interpreters can be used by a particular exception, priorities need to be defined.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->