### PR TITLE
Remove Guid string from ScheduledEvent.Name

### DIFF
--- a/Common/Scheduling/IEventSchedule.cs
+++ b/Common/Scheduling/IEventSchedule.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,15 +22,15 @@ namespace QuantConnect.Scheduling
     public interface IEventSchedule
     {
         /// <summary>
-        /// Adds the specified event to the schedule using the <see cref="ScheduledEvent.Name"/> as a key.
+        /// Adds the specified event to the schedule
         /// </summary>
         /// <param name="scheduledEvent">The event to be scheduled, including the date/times the event fires and the callback</param>
         void Add(ScheduledEvent scheduledEvent);
 
         /// <summary>
-        /// Removes the event with the specified name from the schedule
+        /// Removes the specified event from the schedule
         /// </summary>
-        /// <param name="name">The name of the event to be removed</param>
-        void Remove(string name);
+        /// <param name="scheduledEvent">The event to be removed</param>
+        void Remove(ScheduledEvent scheduledEvent);
     }
 }

--- a/Common/Scheduling/ScheduleManager.cs
+++ b/Common/Scheduling/ScheduleManager.cs
@@ -37,12 +37,12 @@ namespace QuantConnect.Scheduling
         /// <summary>
         /// Gets the date rules helper object to make specifying dates for events easier
         /// </summary>
-        public DateRules DateRules { get; private set; }
+        public DateRules DateRules { get; }
 
         /// <summary>
         /// Gets the time rules helper object to make specifying times for events easier
         /// </summary>
-        public TimeRules TimeRules { get; private set; }
+        public TimeRules TimeRules { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ScheduleManager"/> class
@@ -67,7 +67,7 @@ namespace QuantConnect.Scheduling
         {
             if (eventSchedule == null)
             {
-                throw new ArgumentNullException("eventSchedule");
+                throw new ArgumentNullException(nameof(eventSchedule));
             }
 
             lock (_eventScheduleLock)
@@ -83,7 +83,7 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
-        /// Adds the specified event to the schedule using the <see cref="ScheduledEvent.Name"/> as a key.
+        /// Adds the specified event to the schedule
         /// </summary>
         /// <param name="scheduledEvent">The event to be scheduled, including the date/times the event fires and the callback</param>
         public void Add(ScheduledEvent scheduledEvent)
@@ -102,20 +102,20 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
-        /// Removes the event with the specified name from the schedule
+        /// Removes the specified event from the schedule
         /// </summary>
-        /// <param name="name">The name of the event to be removed</param>
-        public void Remove(string name)
+        /// <param name="scheduledEvent">The event to be removed</param>
+        public void Remove(ScheduledEvent scheduledEvent)
         {
             lock (_eventScheduleLock)
             {
                 if (_eventSchedule != null)
                 {
-                    _eventSchedule.Remove(name);
+                    _eventSchedule.Remove(scheduledEvent);
                 }
                 else
                 {
-                    _preInitializedEvents.RemoveAll(se => se.Name == name);
+                    _preInitializedEvents.RemoveAll(se => Equals(se, scheduledEvent));
                 }
             }
         }

--- a/Common/Scheduling/ScheduledEvent.cs
+++ b/Common/Scheduling/ScheduledEvent.cs
@@ -110,9 +110,7 @@ namespace QuantConnect.Scheduling
         /// <param name="callback">Delegate to be called each time an event passes</param>
         public ScheduledEvent(string name, IEnumerator<DateTime> orderedEventUtcTimes, Action<string, DateTime> callback = null)
         {
-            // make the event name unique
-            _name = name + "-" + Guid.NewGuid().ToString("N");
-
+            _name = name;
             _callback = callback;
             _orderedEventUtcTimes = orderedEventUtcTimes;
 
@@ -120,6 +118,23 @@ namespace QuantConnect.Scheduling
             _endOfScheduledEvents = !_orderedEventUtcTimes.MoveNext();
 
             Enabled = true;
+        }
+
+        /// <summary>Serves as the default hash function. </summary>
+        /// <returns>A hash code for the current object.</returns>
+        /// <filterpriority>2</filterpriority>
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
+
+        /// <summary>Determines whether the specified object is equal to the current object.</summary>
+        /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        /// <filterpriority>2</filterpriority>
+        public override bool Equals(object obj)
+        {
+            return !ReferenceEquals(null, obj) && ReferenceEquals(this, obj);
         }
 
         /// <summary>

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Lean.Engine.RealTime
         private IResultHandler _resultHandler;
         // initialize this immediately since the Initialize method gets called after IAlgorithm.Initialize,
         // so we want to be ready to accept events as soon as possible
-        private readonly ConcurrentDictionary<string, ScheduledEvent> _scheduledEvents = new ConcurrentDictionary<string, ScheduledEvent>();
+        private readonly ConcurrentDictionary<ScheduledEvent, ScheduledEvent> _scheduledEvents = new ConcurrentDictionary<ScheduledEvent, ScheduledEvent>();
 
         private List<ScheduledEvent> _scheduledEventsSortedByTime = new List<ScheduledEvent>();
 
@@ -97,7 +97,8 @@ namespace QuantConnect.Lean.Engine.RealTime
                 scheduledEvent.SkipEventsUntil(_algorithm.UtcTime);
             }
 
-            _scheduledEvents[scheduledEvent.Name] = scheduledEvent;
+            _scheduledEvents.AddOrUpdate(scheduledEvent, scheduledEvent);
+
             if (Log.DebuggingEnabled)
             {
                 scheduledEvent.IsLoggingEnabled = true;
@@ -109,11 +110,10 @@ namespace QuantConnect.Lean.Engine.RealTime
         /// <summary>
         /// Removes the specified event from the schedule
         /// </summary>
-        /// <param name="name">The name of the event to remove</param>
-        public void Remove(string name)
+        /// <param name="scheduledEvent">The event to be removed</param>
+        public void Remove(ScheduledEvent scheduledEvent)
         {
-            ScheduledEvent scheduledEvent;
-            _scheduledEvents.TryRemove(name, out scheduledEvent);
+            _scheduledEvents.TryRemove(scheduledEvent, out scheduledEvent);
 
             _scheduledEventsSortedByTime = GetScheduledEventsSortedByTime();
         }

--- a/Tests/Common/Scheduling/ScheduleManagerTests.cs
+++ b/Tests/Common/Scheduling/ScheduleManagerTests.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Lean.Engine.RealTime;
+
+namespace QuantConnect.Tests.Common.Scheduling
+{
+    [TestFixture]
+    public class ScheduleManagerTests
+    {
+        [Test]
+        public void DuplicateScheduledEventsAreBothFired()
+        {
+            var algorithm = new QCAlgorithm();
+
+            var handler = new BacktestingRealTimeHandler();
+            handler.Setup(algorithm, null, null, null);
+
+            algorithm.Schedule.SetEventSchedule(handler);
+
+            var time = new DateTime(2018, 1, 1);
+            algorithm.SetDateTime(time);
+
+            var count1 = 0;
+            var count2 = 0;
+            algorithm.Schedule.On(algorithm.Schedule.DateRules.EveryDay(), algorithm.Schedule.TimeRules.Every(TimeSpan.FromHours(1)), () => { count1++; });
+            algorithm.Schedule.On(algorithm.Schedule.DateRules.EveryDay(), algorithm.Schedule.TimeRules.Every(TimeSpan.FromHours(1)), () => { count2++; });
+
+            const int timeSteps = 12;
+
+            for (var i = 0; i < timeSteps; i++)
+            {
+                handler.SetTime(time);
+                time = time.AddHours(1);
+            }
+
+            Assert.AreEqual(timeSteps, count1);
+            Assert.AreEqual(timeSteps, count2);
+        }
+    }
+}

--- a/Tests/Common/Scheduling/ScheduledEventTests.cs
+++ b/Tests/Common/Scheduling/ScheduledEventTests.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Tests.Common.Scheduling
         [Test]
         public void FiresSkippedEventsInSameCallToScan()
         {
-            int count = 0;
+            var count = 0;
             var time = new DateTime(2015, 08, 11, 10, 30, 0);
             var sevent = new ScheduledEvent("test", new[] { time.AddSeconds(-2), time.AddSeconds(-1), time}, (n, t) => count++);
             sevent.Scan(time);
@@ -64,12 +64,13 @@ namespace QuantConnect.Tests.Common.Scheduling
         [Test]
         public void SkipsEventsUntilTime()
         {
-            int count = 0;
+            var count = 0;
             var time = new DateTime(2015, 08, 11, 10, 30, 0);
             var sevent = new ScheduledEvent("test", new[] { time.AddSeconds(-2), time.AddSeconds(-1), time }, (n, t) => count++);
             // skips all preceding events, not including the specified time
             sevent.SkipEventsUntil(time);
             Assert.AreEqual(time, sevent.NextEventUtcTime);
+            Assert.AreEqual(0, count);
         }
 
         [Test]
@@ -79,8 +80,8 @@ namespace QuantConnect.Tests.Common.Scheduling
             var se = new ScheduledEvent("test", new DateTime(2015, 08, 07), (name, triggerTime) =>
             {
                 triggered = true;
-            });
-            se.IsLoggingEnabled = true;
+            })
+            { IsLoggingEnabled = true };
 
             se.Scan(new DateTime(2015, 08, 06));
             Assert.IsFalse(triggered);
@@ -96,8 +97,8 @@ namespace QuantConnect.Tests.Common.Scheduling
             var se = new ScheduledEvent("test", new DateTime(2015, 08, 07), (name, triggerTime) =>
             {
                 triggered = true;
-            });
-            se.IsLoggingEnabled = true;
+            })
+            { IsLoggingEnabled = true };
 
             se.Scan(new DateTime(2015, 08, 06));
             Assert.IsFalse(triggered);
@@ -143,13 +144,35 @@ namespace QuantConnect.Tests.Common.Scheduling
         }
 
         [Test]
-        public void ScheduledEventsHaveUniqueName()
+        public void ScheduledEventsWithSameNameAreDifferent()
         {
             var first = DateTime.UtcNow;
             var se1 = new ScheduledEvent("test", first);
             var se2 = new ScheduledEvent("test", first);
 
-            Assert.IsTrue(se1.Name != se2.Name);
+            Assert.AreEqual(se1.Name, se2.Name);
+            Assert.AreNotEqual(se1, se2);
+        }
+
+        [Test]
+        public void CompareToItselfReturnsTrue()
+        {
+            var time = DateTime.UtcNow;
+            var se1 = new ScheduledEvent("test", time);
+            var se2 = se1;
+
+            Assert.IsTrue(Equals(se1, se2));
+            Assert.AreEqual(se1, se2);
+        }
+
+        [Test]
+        public void CompareToNullReturnsFalse()
+        {
+            var time = DateTime.UtcNow;
+            var se = new ScheduledEvent("test", time);
+
+            Assert.IsFalse(Equals(se, null));
+            Assert.AreNotEqual(se, null);
         }
     }
 }

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -358,7 +358,7 @@ namespace QuantConnect.Tests.Engine
             {
             }
 
-            public void Remove(string name)
+            public void Remove(ScheduledEvent scheduledEvent)
             {
             }
 

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Common\Exceptions\ScheduledEventExceptionInterpreterTests.cs" />
     <Compile Include="Common\Orders\Fills\LatestPriceFillModelTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />
+    <Compile Include="Common\Scheduling\ScheduleManagerTests.cs" />
     <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />
     <Compile Include="Common\Securities\CashBuyingPowerModelTests.cs" />
     <Compile Include="Common\Securities\Forex\ForexHoldingTest.cs" />


### PR DESCRIPTION

#### Description
The `Name` property of `ScheduledEvent` is now the same as when the event was created.

#### Related Issue
Fixes #1674

#### Motivation and Context
Currently a `Guid` string was automatically appended to the scheduled event name, reducing readability of error messages and logs.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Unit tests included + all regression tests passing

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`