### PR TITLE
Moves GetStringBetweenChars to Extensions from PythonUtil

### DIFF
--- a/Common/Exceptions/DllNotFoundPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/DllNotFoundPythonExceptionInterpreter.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Exceptions
         {
             var dnfe = (DllNotFoundException)exception;
 
-            var dllName = PythonUtil.GetStringBetweenChars(dnfe.Message, '\'', '\'');
+            var dllName = dnfe.Message.GetStringBetweenChars('\'', '\'');
             var platform = Environment.OSVersion.Platform.ToString();
             var message = $"The dynamic-link library for {dllName} could not be found. Please visit https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/readme.md for instructions on how to enable python support in {platform}";
             return new DllNotFoundException(message, dnfe);

--- a/Common/Exceptions/InvalidTokenPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/InvalidTokenPythonExceptionInterpreter.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Exceptions
             var pe = (PythonException)exception;
 
             var message = "Trying to include an invalid token/character in any statement throws a SyntaxError exception. To prevent the exception, ensure no invalid token are mistakenly included (e.g: leading zero).";
-            var errorLine = PythonUtil.GetStringBetweenChars(pe.Message, '(', ')');
+            var errorLine = pe.Message.GetStringBetweenChars('(', ')');
 
             return new Exception($"{message}{Environment.NewLine}  in {errorLine}{Environment.NewLine}", pe);
         }

--- a/Common/Exceptions/KeyErrorPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/KeyErrorPythonExceptionInterpreter.cs
@@ -49,11 +49,11 @@ namespace QuantConnect.Exceptions
             var key = string.Empty;
             if (pe.Message.Contains("["))
             {
-                key = PythonUtil.GetStringBetweenChars(pe.Message, '[', ']');
+                key = pe.Message.GetStringBetweenChars('[', ']');
             }
             else if (pe.Message.Contains("\'"))
             {
-                key = PythonUtil.GetStringBetweenChars(pe.Message, '\'', '\'');
+                key = pe.Message.GetStringBetweenChars('\'', '\'');
             }
             var message = $"Trying to retrieve an element from a collection using a key that does not exist in that collection throws a KeyError exception. To prevent the exception, ensure that the {key} key exist in the collection and/or that collection is not empty.";
 

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -890,6 +890,26 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Get the first occurence of a string between two characters from another string
+        /// </summary>
+        /// <param name="value">The original string</param>
+        /// <param name="left">Left bound of the substring</param>
+        /// <param name="right">Right bound of the substring</param>
+        /// <returns>Substring from original string bounded by the two characters</returns>
+        public static string GetStringBetweenChars(this string value, char left, char right)
+        {
+            var startIndex = 1 + value.IndexOf(left);
+            var length = value.IndexOf(right, startIndex) - startIndex;
+            if (length > 0)
+            {
+                value = value.Substring(startIndex, length);
+                startIndex = 1 + value.IndexOf(left);
+                return value.Substring(startIndex).Trim();
+            }
+            return string.Empty;
+        }
+
+        /// <summary>
         /// Return the first in the series of names, or find the one that matches the configured algirithmTypeName
         /// </summary>
         /// <param name="names">The list of class names</param>

--- a/Common/Util/PythonUtil.cs
+++ b/Common/Util/PythonUtil.cs
@@ -87,24 +87,6 @@ namespace QuantConnect.Util
         }
 
         /// <summary>
-        /// Get a string between two characters from another string
-        /// </summary>
-        /// <param name="value">The original string</param>
-        /// <param name="left">Left bound of the substring</param>
-        /// <param name="right">Right bound of the substring</param>
-        /// <returns>Substring from original string bounded by the two characters</returns>
-        public static string GetStringBetweenChars(string value, char left, char right)
-        {
-            var startIndex = 1 + value.IndexOf(left);
-            var length = value.IndexOf(right, startIndex) - startIndex;
-            if (length > 0)
-            {
-                return value.Substring(startIndex, length);
-            }
-            return null;
-        }
-
-        /// <summary>
         /// Parsers <see cref="PythonException.StackTrace"/> into a readable message 
         /// </summary>
         /// <param name="value">String with the stacktrace information</param>
@@ -144,11 +126,11 @@ namespace QuantConnect.Util
                     var method = info[2].Replace("in", "at");
                     var statement = stack[i + 1].Trim();
 
-                    errorLine += $"{Environment.NewLine}  {method} in {script}:line {line} :: {statement}{Environment.NewLine}";
+                    errorLine += $"{Environment.NewLine}  {method} in {script}:line {line} :: {statement}";
                 }
             }
 
-            return errorLine;
+            return $"{errorLine}{(errorLine.Length > 1 ? Environment.NewLine : string.Empty)}";
         }
 
         /// <summary>

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -297,6 +297,39 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(time, roundedTime);
         }
 
+        [Test]
+        public void GetStringBetweenCharsTests()
+        {
+            const string expected = "python3.6";
+
+            // Different characters cases
+            var input = "[ python3.6 ]";
+            var actual = input.GetStringBetweenChars('[', ']');
+            Assert.AreEqual(expected, actual);
+
+            input = "[ python3.6 ] [ python2.7 ]";
+            actual = input.GetStringBetweenChars('[', ']');
+            Assert.AreEqual(expected, actual);
+
+            input = "[ python2.7 [ python3.6 ] ]";
+            actual = input.GetStringBetweenChars('[', ']');
+            Assert.AreEqual(expected, actual);
+
+            // Same character cases
+            input = "\'python3.6\'";
+            actual = input.GetStringBetweenChars('\'', '\'');
+            Assert.AreEqual(expected, actual);
+
+            input = "\' python3.6 \' \' python2.7 \'";
+            actual = input.GetStringBetweenChars('\'', '\'');
+            Assert.AreEqual(expected, actual);
+
+            // In this case, it is not equal
+            input = "\' python2.7 \' python3.6 \' \'";
+            actual = input.GetStringBetweenChars('\'', '\'');
+            Assert.AreNotEqual(expected, actual);
+        }
+
         private class Super<T>
         {
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Since this method is not exclusive of python algorithms, it is being moved to Extension methods.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1677, #1659 and #1630 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See description above

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->