### PR TITLE
Increase accuracy of order quantity calculation in CashBuyingPowerModel

### DIFF
--- a/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
@@ -60,7 +60,8 @@ namespace QuantConnect.Algorithm.CSharp
                 }
 
                 var btcHoldings = Portfolio.CashBook["BTC"].Amount;
-                Log($"{Time} - BTC holdings: {btcHoldings:F8}");
+                var usdCash = Portfolio.CashBook["USD"].Amount;
+                Log($"{Time} - BTC holdings: {btcHoldings:F8} - USD cash: {usdCash:F2}");
             }
         }
     }

--- a/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
@@ -57,4 +57,4 @@ class BasicTemplateCryptoAlgorithm(QCAlgorithm):
 
             btcHoldings = self.Portfolio.CashBook["BTC"].Amount
             usdCash = self.Portfolio.CashBook["USD"].Amount
-            self.Log("{0} - BTC holdings: {1} - USD cash: {2}".format(str(self.Time), str(btcHoldings), str(usdCash)))
+            self.Log("{} - BTC holdings: {} - USD cash: {}".format(self.Time, btcHoldings, usdCash))

--- a/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
@@ -56,4 +56,5 @@ class BasicTemplateCryptoAlgorithm(QCAlgorithm):
                 self.Liquidate()
 
             btcHoldings = self.Portfolio.CashBook["BTC"].Amount
-            self.Log("{0} - BTC holdings: {1}".format(str(self.Time), str(btcHoldings)))
+            usdCash = self.Portfolio.CashBook["USD"].Amount
+            self.Log("{0} - BTC holdings: {1} - USD cash: {2}".format(str(self.Time), str(btcHoldings), str(usdCash)))

--- a/Common/Orders/Fees/GDAXFeeModel.cs
+++ b/Common/Orders/Fees/GDAXFeeModel.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 
 namespace QuantConnect.Orders.Fees
@@ -55,7 +54,10 @@ namespace QuantConnect.Orders.Fees
             Fees.TryGetValue(security.Symbol.Value, out fee);
 
             // get order value in account currency, then apply fee factor
-            return Math.Abs(order.GetValue(security)) * fee;
+            var unitPrice = order.Direction == OrderDirection.Buy ? security.AskPrice : security.BidPrice;
+            unitPrice *= security.QuoteCurrency.ConversionRate * security.SymbolProperties.ContractMultiplier;
+
+            return unitPrice * order.AbsoluteQuantity * fee;
         }
     }
 }

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -683,18 +683,18 @@ namespace QuantConnect.Tests
                 {"Drawdown", "5.400%"},
                 {"Expectancy", "-1"},
                 {"Net Profit", "-5.656%"},
-                {"Sharpe Ratio", "-20.375"},
+                {"Sharpe Ratio", "-20.372"},
                 {"Loss Rate", "100%"},
                 {"Win Rate", "0%"},
                 {"Profit-Loss Ratio", "0"},
                 {"Alpha", "-11.165"},
-                {"Beta", "574.802"},
+                {"Beta", "574.85"},
                 {"Annual Standard Deviation", "0.353"},
                 {"Annual Variance", "0.125"},
-                {"Information Ratio", "-20.43"},
+                {"Information Ratio", "-20.427"},
                 {"Tracking Error", "0.353"},
                 {"Treynor Ratio", "-0.013"},
-                {"Total Fees", "$6076.32"}
+                {"Total Fees", "$6076.08"}
             };
 
             var indicatorSuiteAlgorithmStatistics = new Dictionary<string, string>


### PR DESCRIPTION

#### Description
The `CashBuyingPowerModel` has been updated to use quotes (if available) to calculate the maximum order quantity.

#### Related Issue
Fixes #1680

#### Motivation and Context
This change should reduce the likelihood of getting negative Cash values in backtesting.

#### Requires Documentation Change
No

#### How Has This Been Tested?
New added unit test and regression tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`