### PR TITLE
Fix data consolidation with python custom data

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -904,11 +904,12 @@ namespace QuantConnect.Algorithm
                 {
                     an = new AssemblyName(type.Repr().Split('\'')[1]);
                 }
-                var moduleBuilder = AppDomain.CurrentDomain
+                var typeBuilder = AppDomain.CurrentDomain
                     .DefineDynamicAssembly(an, AssemblyBuilderAccess.Run)
-                    .DefineDynamicModule("MainModule");
+                    .DefineDynamicModule("MainModule")
+                    .DefineType(an.Name, TypeAttributes.Class, typeof(DynamicData));
 
-                pythonType = new PythonActivator(moduleBuilder.DefineType(an.Name).CreateType(), type);
+                pythonType = new PythonActivator(typeBuilder.CreateType(), type);
 
                 ObjectActivator.AddActivator(pythonType.Type, pythonType.Factory);
 

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -10,6 +10,7 @@ using QuantConnect.AlgorithmFactory.Python.Wrappers;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
@@ -127,6 +128,26 @@ namespace QuantConnect.Tests.Algorithm
 
             var quandlFactory = (BaseData)ObjectActivator.GetActivator(quandlSubscription.Type).Invoke(new object[] { quandlSubscription.Type });
             Assert.DoesNotThrow(() => quandlFactory.GetSource(quandlSubscription, DateTime.UtcNow, false));
+        }
+
+        [Test, Ignore]
+        public void PythonCustomDataTypes_AreAddedToConsolidator_Successfully()
+        {
+            var pythonPath = new System.IO.DirectoryInfo("RegressionAlgorithms");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+
+            var qcAlgorithm = new AlgorithmPythonWrapper("Test_CustomDataAlgorithm");
+
+            // Initialize contains the statements:
+            // self.AddData(Nifty, "NIFTY")
+            // self.AddData(QuandlFuture, "SCF/CME_CL1_ON", Resolution.Daily)
+            qcAlgorithm.Initialize();
+
+            var niftyConsolidator = new DynamicDataConsolidator(TimeSpan.FromDays(2));
+            Assert.DoesNotThrow(() => qcAlgorithm.SubscriptionManager.AddConsolidator("NIFTY", niftyConsolidator));
+
+            var quandlConsolidator = new DynamicDataConsolidator(TimeSpan.FromDays(2));
+            Assert.DoesNotThrow(() => qcAlgorithm.SubscriptionManager.AddConsolidator("SCF/CME_CL1_ON", quandlConsolidator));
         }
 
         private static SubscriptionDataConfig GetMatchingSubscription(Security security, Type type)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When creating a CRL type in runtime to represent a python custom data class, we need define `DynamicData` as its parent class so that it passes the `IsAssignableFrom` condition in `SubscriptionManager.AddConsolidator`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1693 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Custom data from python algorithms cannot be consolidated.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test and algorithm in issue #1693 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->