### PR TITLE
bug-1692-use-tradebar-data-when-no-quotebar-data-is-available

### DIFF
--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 
@@ -104,9 +103,9 @@ namespace QuantConnect.Securities
 
             // Only cache no fill-forward data.
             if (data.IsFillForward) return;
-            
+
             // If the _dataByType dictionary is not populated or it only has one MarketDataType, just use the last value.
-            if (_lastData == null)
+            if (_dataByType.Keys.Count <= 1)
             {
                 _lastData = data;
                 _dataByType[data.GetType()] = data;

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -95,18 +95,18 @@ namespace QuantConnect.Securities
         /// </summary>
         public void AddData(BaseData data)
         {
-            // Only cache no fill-forward data.
-            if (data.IsFillForward) return;
-
             var openInterest = data as OpenInterest;
             if (openInterest != null)
             {
                 OpenInterest = (long)openInterest.Value;
                 return;
             }
+
+            // Only cache no fill-forward data.
+            if (data.IsFillForward) return;
             
             // If the _dataByType dictionary is not populated or it only has one MarketDataType, just use the last value.
-            if (_dataByType.Keys.Count <= 1)
+            if (_lastData == null)
             {
                 _lastData = data;
                 _dataByType[data.GetType()] = data;

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -705,19 +705,19 @@ namespace QuantConnect.Tests
                 {"Compounding Annual Return", "-100.000%"},
                 {"Drawdown", "5.400%"},
                 {"Expectancy", "-1"},
-                {"Net Profit", "-5.656%"},
-                {"Sharpe Ratio", "-20.372"},
+                {"Net Profit", "-5.603%"},
+                {"Sharpe Ratio", "-19.82"},
                 {"Loss Rate", "100%"},
                 {"Win Rate", "0%"},
                 {"Profit-Loss Ratio", "0"},
                 {"Alpha", "-11.165"},
-                {"Beta", "574.85"},
-                {"Annual Standard Deviation", "0.353"},
-                {"Annual Variance", "0.125"},
-                {"Information Ratio", "-20.427"},
-                {"Tracking Error", "0.353"},
-                {"Treynor Ratio", "-0.013"},
-                {"Total Fees", "$6076.08"}
+                {"Beta", "585.081"},
+                {"Annual Standard Deviation", "0.36"},
+                {"Annual Variance", "0.129"},
+                {"Information Ratio", "-19.873"},
+                {"Tracking Error", "0.359"},
+                {"Treynor Ratio", "-0.012"},
+                {"Total Fees", "$6076.49"}
             };
 
             var indicatorSuiteAlgorithmStatistics = new Dictionary<string, string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR implements the following chages in the `SecurityCache` class:
- fill-forward data is not cached.
- in case of multiple `MarketDataType`it returns the one with the latest timestamp.
- prioritize the quotebars.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1692 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before this PR, if no quote data was available, then the algorithm equity  was flat until new quote data was available.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The method for testing was using an basic template algorithm (it buys 100% of one security at the beginning) and confirm the equity follows perfectly the security close data when there is only tradebar data available. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->