### PR TITLE
Improves History Feature in QuantBook

### DIFF
--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -72,6 +72,9 @@ namespace QuantConnect.Jupyter
                 var mapFileProvider = algorithmHandlers.MapFileProvider;
                 HistoryProvider = composer.GetExportedValueByTypeName<IHistoryProvider>(Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider"));
                 HistoryProvider.Initialize(null, algorithmHandlers.DataProvider, _dataCacheProvider, mapFileProvider, algorithmHandlers.FactorFileProvider, null);
+
+                SetOptionChainProvider(new CachingOptionChainProvider(new BacktestingOptionChainProvider()));
+                SetFutureChainProvider(new CachingFutureChainProvider(new BacktestingFutureChainProvider()));
             }
             catch (Exception exception)
             {
@@ -208,70 +211,58 @@ namespace QuantConnect.Jupyter
         /// <param name="date">Date of the data</param>
         /// <param name="resolution">The resolution to request</param>
         /// <returns>A <see cref="OptionHistory"/> object that contains historical option data.</returns>
-        public OptionHistory GetOptionHistory(Symbol symbol, DateTime date, Resolution? resolution = null)
+        public OptionHistory GetOptionHistory(Symbol symbol, DateTime start, DateTime? end = null, Resolution? resolution = null)
         {
-            SetStartDate(date.AddDays(1));
+            if (!end.HasValue || end.Value.Date == start.Date)
+            {
+                end = start.AddDays(1);
+            }
+
             var option = Securities[symbol] as Option;
             var underlying = AddEquity(symbol.Underlying.Value, option.Resolution);
 
-            var provider = new BacktestingOptionChainProvider();
-            var allSymbols = provider.GetOptionContractList(symbol.Underlying, date);
-            
-            var requests = base.History(symbol.Underlying, TimeSpan.FromDays(1), resolution)
-                .SelectMany(x => option.ContractFilter.Filter(new OptionFilterUniverse(allSymbols, x)))
-                .Distinct()
-                .Select(x =>
-                     new HistoryRequest(date.AddDays(-1), 
-                                        date, 
-                                        typeof(QuoteBar), 
-                                        x, 
-                                        resolution ?? option.Resolution, 
-                                        underlying.Exchange.Hours,
-                                        MarketHoursDatabase.FromDataFolder().GetDataTimeZone(underlying.Symbol.ID.Market, underlying.Symbol, underlying.Type),
-                                        Resolution.Minute, 
-                                        underlying.IsExtendedMarketHours, 
-                                        underlying.IsCustomData(), 
-                                        DataNormalizationMode.Raw,
-                                        LeanData.GetCommonTickTypeForCommonDataTypes(typeof(QuoteBar), underlying.Type))
-                    );
+            var allSymbols = new List<Symbol>();
+            for (var date = start; date < end; date = date.AddDays(1))
+            {
+                if (option.Exchange.DateIsOpen(date))
+                {
+                    allSymbols.AddRange(OptionChainProvider.GetOptionContractList(symbol.Underlying, date));
+                }
+            }
+            var symbols = base.History(symbol.Underlying, start, end.Value, resolution)
+                .SelectMany(x => option.ContractFilter.Filter(new OptionFilterUniverse(allSymbols.Distinct(), x)))
+                .Distinct().Concat(new[] { symbol.Underlying });
 
-            requests = requests.Union(new[] { new HistoryRequest(underlying.Subscriptions.FirstOrDefault(), underlying.Exchange.Hours, date.AddDays(-1), date) });
-
-            return new OptionHistory(HistoryProvider.GetHistory(requests.OrderByDescending(x => x.Symbol.SecurityType), TimeZone).Memoize());
+            return new OptionHistory(History(symbols, start, end.Value, resolution));
         }
 
         /// <summary>
         /// Gets <see cref="FutureHistory"/> object for a given symbol, date and resolution
         /// </summary>
         /// <param name="symbol">The symbol to retrieve historical future data for</param>
-        /// <param name="date">Date of the data</param>
+        /// <param name="start">Date of the data</param>
         /// <param name="resolution">The resolution to request</param>
         /// <returns>A <see cref="FutureHistory"/> object that contains historical future data.</returns>
-        public FutureHistory GetFutureHistory(Symbol symbol, DateTime date, Resolution? resolution = null)
+        public FutureHistory GetFutureHistory(Symbol symbol, DateTime start, DateTime? end = null, Resolution? resolution = null)
         {
-            SetStartDate(date.AddDays(1));
+            if (!end.HasValue || end.Value.Date == start.Date)
+            {
+                end = start.AddDays(1);
+            }
+
             var future = Securities[symbol] as Future;
 
-            var provider = new BacktestingFutureChainProvider();
-            var allSymbols = provider.GetFutureContractList(future.Symbol, date);
+            var allSymbols = new List<Symbol>();
+            for (var date = start; date < end; date = date.AddDays(1))
+            {
+                if (future.Exchange.DateIsOpen(date))
+                {
+                    allSymbols.AddRange(FutureChainProvider.GetFutureContractList(future.Symbol, date));
+                }
+            }
+            var symbols = allSymbols.Distinct();
 
-            var requests = future.ContractFilter.Filter(new FutureFilterUniverse(allSymbols, new Tick { Time = date }))
-                .Select(x =>
-                     new HistoryRequest(date.AddDays(-1),
-                                        date,
-                                        typeof(QuoteBar),
-                                        x,
-                                        resolution ?? future.Resolution,
-                                        future.Exchange.Hours,
-                                        MarketHoursDatabase.FromDataFolder().GetDataTimeZone(future.Symbol.ID.Market, future.Symbol, future.Type),
-                                        Resolution.Minute,
-                                        future.IsExtendedMarketHours,
-                                        future.IsCustomData(),
-                                        DataNormalizationMode.Raw,
-                                        LeanData.GetCommonTickTypeForCommonDataTypes(typeof(QuoteBar), future.Type))
-                    );
-
-            return new FutureHistory(HistoryProvider.GetHistory(requests, TimeZone).Memoize());
+            return new FutureHistory(History(symbols, start, end.Value, resolution));
         }
 
         /// <summary>

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -25,10 +25,6 @@ using QuantConnect.Lean.Engine;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Python;
 using QuantConnect.Securities;
-using QuantConnect.Securities.Cfd;
-using QuantConnect.Securities.Crypto;
-using QuantConnect.Securities.Equity;
-using QuantConnect.Securities.Forex;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Option;
 using QuantConnect.Statistics;
@@ -115,10 +111,9 @@ namespace QuantConnect.Jupyter
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
-        public new PyObject History<T>(Symbol symbol, TimeSpan span, Resolution? resolution = null)
-            where T : IBaseData
+        public new PyObject History(Symbol symbol, TimeSpan span, Resolution? resolution = null)
         {
-            return PandasConverter.GetDataFrame(History<T>(symbol, Time - span, Time, resolution).Memoize());
+            return History(symbol.ToPython(), span, resolution);
         }
 
         /// <summary>
@@ -222,7 +217,7 @@ namespace QuantConnect.Jupyter
             var provider = new BacktestingOptionChainProvider();
             var allSymbols = provider.GetOptionContractList(symbol.Underlying, date);
             
-            var requests = History(symbol.Underlying, TimeSpan.FromDays(1), resolution)
+            var requests = base.History(symbol.Underlying, TimeSpan.FromDays(1), resolution)
                 .SelectMany(x => option.ContractFilter.Filter(new OptionFilterUniverse(allSymbols, x)))
                 .Distinct()
                 .Select(x =>

--- a/Tests/Jupyter/QuantBookHistoryTests.cs
+++ b/Tests/Jupyter/QuantBookHistoryTests.cs
@@ -1,0 +1,131 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Securities;
+using System;
+using System.IO;
+
+namespace QuantConnect.Tests.Jupyter
+{
+    [TestFixture, Ignore]
+    public class QuantBookHistoryTests
+    {
+        dynamic _module;
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            var pythonPath = new DirectoryInfo("Jupyter/RegressionScripts");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+            using (Py.GIL())
+            {
+                _module = Py.Import("Test_QuantBookHistory");
+            }
+        }
+
+        [Test]
+        [TestCase(2013, 10, 11, SecurityType.Equity, "SPY")]
+        [TestCase(2014, 5, 9, SecurityType.Forex, "EURUSD")]
+        [TestCase(2016, 10, 9, SecurityType.Crypto, "BTCUSD")]
+        public void SecurityQuantBookHistoryTests(int year, int month, int day, SecurityType securityType, string symbol)
+        {
+            var startDate = new DateTime(year, month, day);
+            var securityTestHistory = _module.SecurityHistoryTest(startDate, securityType, symbol);
+
+            // Get the last 10 candles
+            var periodHistory = securityTestHistory.test_period_overload(10);
+            var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
+            Assert.AreEqual(10, count);
+
+            // Get the one day of data
+            var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(1));
+            var firstIndex = (DateTime)(timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+            Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
+
+            // Get the one day of data, ending one day before start date
+            var startEndHistory = securityTestHistory.test_daterange_overload(startDate.AddDays(-1));
+            firstIndex = (DateTime)(startEndHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+            Assert.GreaterOrEqual(startDate.AddDays(-2).Date, firstIndex.Date);
+        }
+
+        [Test]
+        [TestCase(2014, 5, 9, "Nifty", "NIFTY")]
+        public void CustomDataQuantBookHistoryTests(int year, int month, int day, string customDataType, string symbol)
+        {
+            var startDate = new DateTime(year, month, day);
+            var securityTestHistory = _module.CustomDataHistoryTest(startDate, customDataType, symbol);
+
+            // Get the last 5 candles
+            var periodHistory = securityTestHistory.test_period_overload(5);
+            var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
+            Assert.AreEqual(5, count);
+
+            // Get the one day of data
+            var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(8));
+            var firstIndex = (DateTime)(timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+            Assert.AreEqual(startDate.AddDays(-7), firstIndex);
+
+            // Get the one day of data, ending one day before start date
+            var startEndHistory = securityTestHistory.test_daterange_overload(startDate.AddDays(-2));
+            firstIndex = (DateTime)(startEndHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+            Assert.AreEqual(startDate.AddDays(-2).Date, firstIndex.Date);
+        }
+
+        [Test]
+        public void MultipleSecuritiesQuantBookHistoryTests()
+        {
+            var startDate = new DateTime(2014, 5, 9);
+            var securityTestHistory = _module.MultipleSecuritiesHistoryTest(startDate, null, null);
+
+            // Get the last 5 candles
+            var periodHistory = securityTestHistory.test_period_overload(5);
+            var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
+            Assert.AreEqual(6, count);
+
+            // Get the one day of data
+            var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(8));
+            var firstIndex = (DateTime)(timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+            Assert.AreEqual(startDate.AddDays(-8), firstIndex);
+        }
+
+        [Test]
+        public void OptionQuantBookHistoryTests()
+        {
+            var symbol = "TWX";
+            var startDate = new DateTime(2014, 6, 6);
+            var securityTestHistory = _module.OptionHistoryTest(startDate, SecurityType.Option, symbol);
+
+            // Get the one day of data, ending on start date
+            var startEndHistory = securityTestHistory.test_daterange_overload(startDate);
+            var firstIndex = (DateTime)(startEndHistory.index.values[0][4] as PyObject).AsManagedObject(typeof(DateTime));
+            Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
+        }
+
+        [Test]
+        public void FutureQuantBookHistoryTests()
+        {
+            var symbol = Futures.Indices.SP500EMini;
+            var startDate = new DateTime(2013, 10, 11);
+            var securityTestHistory = _module.FutureHistoryTest(startDate, SecurityType.Future, symbol);
+
+            // Get the one day of data, ending on start date
+            var startEndHistory = securityTestHistory.test_daterange_overload(startDate);
+            var firstIndex = (DateTime)(startEndHistory.index.values[0][2] as PyObject).AsManagedObject(typeof(DateTime));
+            Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
+        }
+    }
+}

--- a/Tests/Jupyter/RegressionScripts/Test_QuantBookHistory.py
+++ b/Tests/Jupyter/RegressionScripts/Test_QuantBookHistory.py
@@ -1,0 +1,84 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+import pandas
+AddReference("System")
+AddReference("QuantConnect.Jupyter")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Jupyter import *
+from datetime import datetime, timedelta
+from custom_data import QuandlFuture, Nifty
+import pandas as pd
+
+class SecurityHistoryTest():
+    def __init__(self, start_date, security_type, symbol):
+        self.qb = QuantBook()
+        self.qb.SetStartDate(start_date)
+        self.symbol = self.qb.AddSecurity(security_type, symbol).Symbol
+        self.column = 'close' if security_type == SecurityType.Equity else 'bidclose'
+
+    def __str__(self):
+        return "{} on {}".format(self.symbol.ID, self.qb.StartDate)
+
+    def test_period_overload(self, period):
+        history = self.qb.History(self.symbol, period)
+        return history[self.column].unstack(level=0)
+
+    def test_daterange_overload(self, end):
+        start = end - timedelta(1)
+        history = self.qb.History(self.symbol, start, end)
+        return history[self.column].unstack(level=0)
+
+class OptionHistoryTest(SecurityHistoryTest):
+    def test_daterange_overload(self, end):
+        start = end - timedelta(1)
+        history = self.qb.GetOptionHistory(self.symbol, start, end)
+        return history.GetAllData()
+
+class FutureHistoryTest(SecurityHistoryTest):
+    def test_daterange_overload(self, end):
+        start = end - timedelta(1)
+        history = self.qb.GetFutureHistory(self.symbol, start, end)
+        return history.GetAllData()
+
+class CustomDataHistoryTest(SecurityHistoryTest):
+    def __init__(self, start_date, security_type, symbol):
+        self.qb = QuantBook()
+        self.qb.SetStartDate(start_date)
+
+        if security_type == 'Nifty':
+            type = Nifty
+            self.column = 'close'
+        elif security_type == 'QuandlFuture':
+            type = QuandlFuture
+            self.column = 'settle'
+        else:
+            raise
+
+        self.symbol = self.qb.AddData(type, symbol, Resolution.Daily).Symbol
+
+class MultipleSecuritiesHistoryTest(SecurityHistoryTest):
+    def __init__(self, start_date, security_type, symbol):
+        self.qb = QuantBook()
+        self.qb.SetStartDate(start_date)
+        self.qb.AddEquity('SPY', Resolution.Daily)
+        self.qb.AddForex('EURUSD', Resolution.Daily)
+        self.qb.AddCrypto('BTCUSD', Resolution.Daily)
+
+    def test_period_overload(self, period):
+        history = self.qb.History(period)
+        return history['close'].unstack(level=0)

--- a/Tests/Jupyter/RegressionScripts/custom_data.py
+++ b/Tests/Jupyter/RegressionScripts/custom_data.py
@@ -1,0 +1,64 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Data import SubscriptionDataSource
+from QuantConnect.Python import PythonData, PythonQuandl
+from datetime import datetime
+import decimal
+
+class QuandlFuture(PythonQuandl):
+    '''Custom quandl data type for setting customized value column name. Value column is used for the primary trading calculations and charting.'''
+    def __init__(self):
+        # Define ValueColumnName: cannot be None, Empty or non-existant column name
+        # If ValueColumnName is "Close", do not use PythonQuandl, use Quandl:
+        # self.AddData[QuandlFuture](self.crude, Resolution.Daily)
+        self.ValueColumnName = "Settle"
+
+
+class Nifty(PythonData):
+    '''NIFTY Custom Data Class'''
+    def GetSource(self, config, date, isLiveMode):
+        return SubscriptionDataSource("https://www.dropbox.com/s/rsmg44jr6wexn2h/CNXNIFTY.csv?dl=1", SubscriptionTransportMedium.RemoteFile);
+
+
+    def Reader(self, config, line, date, isLiveMode):
+        if not (line.strip() and line[0].isdigit()): return None
+
+        # New Nifty object
+        index = Nifty();
+        index.Symbol = config.Symbol
+
+        try:
+            # Example File Format:
+            # Date,       Open       High        Low       Close     Volume      Turnover
+            # 2011-09-13  7792.9    7799.9     7722.65    7748.7    116534670    6107.78
+            data = line.split(',')
+            index.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            index.Value = decimal.Decimal(data[4])
+            index["Open"] = float(data[1])
+            index["High"] = float(data[2])
+            index["Low"] = float(data[3])
+            index["Close"] = float(data[4])
+
+
+        except ValueError:
+                # Do nothing
+                return None
+
+        return index

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -338,6 +338,7 @@
     <Compile Include="Indicators\RateOfChangePercentTests.cs" />
     <Compile Include="Indicators\RateOfChangeTests.cs" />
     <Compile Include="Indicators\StochasticTests.cs" />
+    <Compile Include="Jupyter\QuantBookHistoryTests.cs" />
     <Compile Include="Messaging\StreamingMessageHandlerTests.cs" />
     <Compile Include="Python\AlgorithmPythonWrapperTests.cs" />
     <Compile Include="Python\MethodOverloadTests.cs" />
@@ -411,6 +412,12 @@
     <None Include="TestData\CashTestingStrategy.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="Jupyter\RegressionScripts\custom_data.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Jupyter\RegressionScripts\Test_QuantBookHistory.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Python\Indicators\IndicatorExtensionsTests.py" />
     <Content Include="RegressionAlgorithms\Test_AlgorithmPythonWrapper.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -549,6 +556,10 @@
     <ProjectReference Include="..\Indicators\QuantConnect.Indicators.csproj">
       <Project>{73fb2522-c3ed-4e47-8e3d-afad48a6b888}</Project>
       <Name>QuantConnect.Indicators</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Jupyter\QuantConnect.Jupyter.csproj">
+      <Project>{9561d14a-467e-40ad-928e-ee9f758d7d98}</Project>
+      <Name>QuantConnect.Jupyter</Name>
     </ProjectReference>
     <ProjectReference Include="..\Launcher\QuantConnect.Lean.Launcher.csproj">
       <Project>{09e7b916-e58b-4021-bd8b-c10b4446e226}</Project>


### PR DESCRIPTION
#### Description
- Units tests were added to cover History data requests in `QuantBook`. 
- In the previous implementation, the history requests were created in `QuantBook` and the Historical data request were made directly with `HistoryProvider.GetHistory`. Now we use `QCAlgorithm.History` which made the code simpler and the date mismatch between requested and retrieved is solved.

- Refactors `PandasConverter` and `PandasData`
   Since Lean/QuantConnect data from a symbol can be found in `Slice.Ticks`, `Slice.Bars` and `Slice.QuoteBars`, information for all of this members must be used in order present all information in the `pandas.DataFrame`.

#### Related Issue
#1698 

#### Motivation and Context
The `QuantConnect.Jupyter` project (`QuantBook`) doesn't have unit tests that systematically assure that all features are working as expected. After we added unit tests for the History data requests, we have found some issues with this feature.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`