### PR TITLE
Fixes python version of BasicTemplateFrameworkAlgorithm

### DIFF
--- a/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
@@ -26,6 +26,7 @@ from QuantConnect.Algorithm.Framework.Portfolio import *
 from QuantConnect.Algorithm.Framework.Risk import *
 from QuantConnect.Algorithm.Framework.Selection import *
 from QuantConnect.Algorithm.Framework.Alphas import *
+from datetime import timedelta
 import numpy as np
 
 ### <summary>
@@ -55,13 +56,11 @@ class BasicTemplateFrameworkAlgorithm(QCAlgorithmFramework):
 
         # set algorithm framework models
         self.PortfolioSelection = ManualPortfolioSelectionModel(symbols)
-        self.Alpha = ConstantAlphaModel(AlphaType.Price, AlphaDirection.Up, TimeSpan.FromMinutes(20), 0.025, None)
+        self.Alpha = ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(minutes = 20), 0.025, None)
         self.PortfolioConstruction = SimplePortfolioConstructionModel()
+        self.Execution = ImmediateExecutionModel()
+        self.RiskManagement = NullRiskManagementModel()
 
-        # these are the default values for Execution and RiskManagement models
-        #self.Execution = ImmediateExecutionModel()
-        #self.RiskManagement = NullRiskManagementModel()
-        
         self.Debug("numpy test >>> print numpy.pi: " + str(np.pi))
 
     def OnOrderEvent(self, orderEvent):

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -783,6 +783,7 @@ namespace QuantConnect.Tests
                 // new AlgorithmStatisticsTestParameters("BasicTemplateFuturesAlgorithmDaily", basicTemplateFuturesAlgorithmDailyStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("AddRemoveSecurityRegressionAlgorithm", addRemoveSecurityRegressionStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("BasicTemplateFrameworkAlgorithm", basicTemplateFrameworkStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("BasicTemplateOptionsAlgorithm", basicTemplateOptionsStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("CustomDataRegressionAlgorithm", customDataRegressionStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("DropboxBaseDataUniverseSelectionAlgorithm", dropboxBaseDataUniverseSelectionStatistics, Language.Python),


### PR DESCRIPTION
#### Description
Renames AlphaType for `InsightType` and `AlphaDirection` for `InsightDirection`, since these `enum` were renamed in a previsous commit.
Adds this algorithm to regression tests.

#### Related Issue
#1713 

#### Motivation and Context
Pull request that renamed `Alpha` -> `Insight` broke the python version of BasicTemplateFrameworkAlgorithm.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`