### PR TITLE
Fix error when using SetWarmup with Tick resolution

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -780,11 +780,20 @@ namespace QuantConnect.Lean.Engine
                             var security = algorithm.Securities[symbol];
                             var data = slice[symbol];
                             var list = new List<BaseData>();
-                            var ticks = data as List<Tick>;
-                            if (ticks != null) list.AddRange(ticks);
-                            else               list.Add(data);
+                            Type dataType;
 
-                            Type dataType = data.GetType();
+                            var ticks = data as List<Tick>;
+                            if (ticks != null)
+                            {
+                                list.AddRange(ticks);
+                                dataType = typeof(Tick);
+                            }
+                            else
+                            {
+                                list.Add(data);
+                                dataType = data.GetType();
+                            }
+
                             var config = security.Subscriptions.FirstOrDefault(subscription => dataType.IsAssignableFrom(subscription.Type));
                             if (config == null)
                             {
@@ -793,6 +802,7 @@ namespace QuantConnect.Lean.Engine
 
                             paired.Add(new DataFeedPacket(security, config, list));
                         }
+
                         timeSlice = TimeSlice.Create(slice.Time.ConvertToUtc(timeZone), timeZone, algorithm.Portfolio.CashBook, paired, SecurityChanges.None);
                     }
                     catch (Exception err)


### PR DESCRIPTION

#### Description
When processing the warmup history slices, the wrong data type was used to find the subscription configuration (`List<Tick>` instead of `Tick`).

#### Related Issue
Fixes #1716

#### Motivation and Context
This fix is required because a runtime error is thrown when the first data point is received.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Manually ran the test algorithm included in #1716  + regression tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`