### PR TITLE
Fixes AlgorithmPythonWrapper.InsightsGenerated

### DIFF
--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -80,10 +80,6 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
                             // IAlgorithm reference for LEAN internal C# calls (without going from C# to Python and back)
                             _baseAlgorithm = _algorithm.AsManagedObject(type);
 
-                            // write events such that when the base handles an event it
-                            // will also invoke event handlers defined on this instance
-                            _baseAlgorithm.InsightsGenerated += InsightsGenerated;
-
                             // determines whether OnData method was defined or inherits from QCAlgorithm
                             // If it is not, OnData from the base class will not be called
                             var pythonType = (_algorithm as PyObject).GetAttr("OnData").GetPythonType();
@@ -326,7 +322,18 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// <summary>
         /// Event fired when an algorithm generates a insight
         /// </summary>
-        public event AlgorithmEvent<InsightCollection> InsightsGenerated;
+        public event AlgorithmEvent<InsightCollection> InsightsGenerated
+        {
+            add
+            {
+                _baseAlgorithm.InsightsGenerated += value;
+            }
+
+            remove
+            {
+                _baseAlgorithm.InsightsGenerated -= value;
+            }
+        }
 
         /// <summary>
         /// Data subscription manager controls the information and subscriptions the algorithms recieves.


### PR DESCRIPTION
#### Description
`AlgorithmPythonWrapper.InsightsGenerated` was not properly wrapped.
When `IAlgorithm.InsightsGenerated` is set in `IAlphaHandler`, it should be directed to the base algorithm, whereas it was set to a null variable.

#### Related Issue
#1717 

#### Motivation and Context
Alpha runtime statistics were missing in the algorithm result.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test: the python version of `BasicTemplateFrameworkAlgorithm` was not passing in the regression test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
I haven't, because it is covered by existing unit test.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`