### PR TITLE
Apply security changes at end of time step

### DIFF
--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -26,6 +26,13 @@ namespace QuantConnect.Algorithm
 {
     public partial class QCAlgorithm
     {
+        // save universe additions and apply at end of time step
+        // this removes temporal dependencies from w/in initialize method
+        // original motivation: adding equity/options to enforce equity raw data mode
+        private readonly object _pendingUniverseAdditionsLock = new object();
+        private readonly Dictionary<Security, UserDefinedUniverse> _pendingUserDefinedUniverseSecurityAdditions = new Dictionary<Security, UserDefinedUniverse>();
+        private readonly List<Universe> _pendingUniverseAdditions = new List<Universe>();
+
         /// <summary>
         /// Gets universe manager which holds universes keyed by their symbol
         /// </summary>
@@ -42,6 +49,75 @@ namespace QuantConnect.Algorithm
         {
             get;
             private set;
+        }
+
+        /// <summary>
+        /// Invoked at the end of every time step. This allows the algorithm
+        /// to process events before advancing to the next time step.
+        /// </summary>
+        public void OnEndOfTimeStep()
+        {
+            if (_pendingUniverseAdditions.Count + _pendingUserDefinedUniverseSecurityAdditions.Count == 0)
+            {
+                // no point in looping through everything if there's no pending changes
+                return;
+            }
+
+            // rewrite securities w/ derivatives to be in raw mode
+            lock (_pendingUniverseAdditionsLock)
+            {
+
+                foreach (var security in Securities.Select(kvp => kvp.Value).Union(_pendingUserDefinedUniverseSecurityAdditions.Keys))
+                {
+                    // check for any derivative securities and mark the underlying as raw
+                    if (Securities.Any(skvp => skvp.Key.HasUnderlyingSymbol(security.Symbol)))
+                    {
+                        // set data mode raw and default volatility model
+                        ConfigureUnderlyingSecurity(security);
+                    }
+
+                    if (security.Symbol.HasUnderlying)
+                    {
+                        Security underlyingSecurity;
+                        var underlyingSymbol = security.Symbol.Underlying;
+
+                        // create the underlying security object if it doesn't already exist
+                        if (!Securities.TryGetValue(underlyingSymbol, out underlyingSecurity))
+                        {
+                            underlyingSecurity = AddSecurity(underlyingSymbol.SecurityType, underlyingSymbol.Value, security.Resolution,
+                                underlyingSymbol.ID.Market, false, 0, security.IsExtendedMarketHours);
+                        }
+
+                        // set data mode raw and default volatility model
+                        ConfigureUnderlyingSecurity(underlyingSecurity);
+
+                        // set the underying security on the derivative -- we do this in two places since it's possible
+                        // to do AddOptionContract w/out the underlying already added and normalized properly
+                        var derivative = security as IDerivativeSecurity;
+                        if (derivative != null)
+                        {
+                            derivative.Underlying = underlyingSecurity;
+                        }
+                    }
+                }
+
+                // add securities to their respective user defined universes
+                foreach (var kvp in _pendingUserDefinedUniverseSecurityAdditions)
+                {
+                    var security = kvp.Key;
+                    var userDefinedUniverse = kvp.Value;
+                    userDefinedUniverse.Add(security.Symbol);
+                }
+
+                // finally add any pending universes, this will make them available to the data feed
+                foreach (var universe in _pendingUniverseAdditions)
+                {
+                    UniverseManager.Add(universe.Configuration.Symbol, universe);
+                }
+
+                _pendingUniverseAdditions.Clear();
+                _pendingUserDefinedUniverseSecurityAdditions.Clear();
+            }
         }
 
         /// <summary>
@@ -344,37 +420,64 @@ namespace QuantConnect.Algorithm
             Universe universe;
             var subscription = security.Subscriptions.First();
             var universeSymbol = UserDefinedUniverse.CreateSymbol(subscription.SecurityType, subscription.Market);
-            if (!UniverseManager.TryGetValue(universeSymbol, out universe))
+            lock (_pendingUniverseAdditionsLock)
             {
-                // create a new universe, these subscription settings don't currently get used
-                // since universe selection proper is never invoked on this type of universe
-                var uconfig = new SubscriptionDataConfig(subscription, symbol: universeSymbol, isInternalFeed: true, fillForward: false);
-
-                if (security.Type == SecurityType.Base)
+                if (!UniverseManager.TryGetValue(universeSymbol, out universe))
                 {
-                    // set entry in market hours database for the universe subscription to match the custom data
-                    var symbolString = MarketHoursDatabase.GetDatabaseSymbolKey(uconfig.Symbol);
-                    MarketHoursDatabase.SetEntry(uconfig.Market, symbolString, uconfig.SecurityType, security.Exchange.Hours, uconfig.DataTimeZone);
-                }
+                    // create a new universe, these subscription settings don't currently get used
+                    // since universe selection proper is never invoked on this type of universe
+                    var uconfig = new SubscriptionDataConfig(subscription, symbol: universeSymbol, isInternalFeed: true, fillForward: false);
 
-                universe = new UserDefinedUniverse(uconfig,
-                    new UniverseSettings(security.Resolution, security.Leverage, security.IsFillDataForward, security.IsExtendedMarketHours, TimeSpan.Zero),
-                    SecurityInitializer,
-                    QuantConnect.Time.MaxTimeSpan,
-                    new List<Symbol> { security.Symbol }
+                    if (security.Type == SecurityType.Base)
+                    {
+                        // set entry in market hours database for the universe subscription to match the custom data
+                        var symbolString = MarketHoursDatabase.GetDatabaseSymbolKey(uconfig.Symbol);
+                        MarketHoursDatabase.SetEntry(uconfig.Market, symbolString, uconfig.SecurityType, security.Exchange.Hours, uconfig.DataTimeZone);
+                    }
+
+                    universe = new UserDefinedUniverse(uconfig,
+                        new UniverseSettings(security.Resolution, security.Leverage, security.IsFillDataForward, security.IsExtendedMarketHours,
+                            TimeSpan.Zero),
+                        SecurityInitializer,
+                        QuantConnect.Time.MaxTimeSpan,
+                        new List<Symbol> {security.Symbol}
                     );
-                UniverseManager.Add(universeSymbol, universe);
+                    _pendingUniverseAdditions.Add(universe);
+                }
             }
 
             var userDefinedUniverse = universe as UserDefinedUniverse;
             if (userDefinedUniverse != null)
             {
-                userDefinedUniverse.Add(security.Symbol);
+                lock (_pendingUniverseAdditionsLock)
+                {
+                    _pendingUserDefinedUniverseSecurityAdditions.Add(security, userDefinedUniverse);
+                }
             }
             else
             {
                 // should never happen, someone would need to add a non-user defined universe with this symbol
                 throw new Exception("Expected universe with symbol '" + universeSymbol.Value + "' to be of type UserDefinedUniverse.");
+            }
+        }
+
+        /// <summary>
+        /// Configures the security to be in raw data mode and ensures that a reasonable default volatility model is supplied
+        /// </summary>
+        /// <param name="security">The underlying security</param>
+        private void ConfigureUnderlyingSecurity(Security security)
+        {
+            // force underlying securities to be raw data mode
+            if (security.DataNormalizationMode != DataNormalizationMode.Raw)
+            {
+                Debug($"Warning: The {security.Symbol.Value} equity security was set the raw price normalization mode to work with options.");
+                security.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            }
+
+            // ensure a volatility model has been set on the underlying
+            if (security.VolatilityModel == VolatilityModel.Null)
+            {
+                security.VolatilityModel = new StandardDeviationOfReturnsVolatilityModel(periods: 30);
             }
         }
     }

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -401,6 +401,15 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
             => _baseAlgorithm.AddOptionContract(symbol, resolution, fillDataForward, leverage);
 
         /// <summary>
+        /// Invoked at the end of every time step. This allows the algorithm
+        /// to process events before advancing to the next time step.
+        /// </summary>
+        public void OnEndOfTimeStep()
+        {
+            _baseAlgorithm.OnEndOfTimeStep();
+        }
+
+        /// <summary>
         /// Send debug message
         /// </summary>
         /// <param name="message">String message</param>

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -379,7 +379,7 @@ namespace QuantConnect.Data
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            return Symbol.Value + "," + MappedSymbol + "," + Resolution + "," + Type.Name + "," + TickType;
+            return Symbol.Value + "," + MappedSymbol + "," + Resolution + "," + Type.Name + "," + TickType + "," + DataNormalizationMode;
         }
     }
 }

--- a/Common/Data/UniverseSelection/FuturesChainUniverse.cs
+++ b/Common/Data/UniverseSelection/FuturesChainUniverse.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,7 +46,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="universeSettings">The universe settings to be used for new subscriptions</param>
         /// <param name="subscriptionManager">The subscription manager used to return available data types</param>
         /// <param name="securityInitializer">The security initializer to use on newly created securities</param>
-        public FuturesChainUniverse(Future future, 
+        public FuturesChainUniverse(Future future,
                                     UniverseSettings universeSettings,
                                     SubscriptionManager subscriptionManager,
                                     ISecurityInitializer securityInitializer = null)
@@ -87,7 +87,7 @@ namespace QuantConnect.Data.UniverseSelection
             }
 
             var availableContracts = futuresUniverseDataCollection.Data.Select(x => x.Symbol);
-            var results = (FutureFilterUniverse)_future.ContractFilter.Filter(new FutureFilterUniverse(availableContracts, underlying));
+            var results = _future.ContractFilter.Filter(new FutureFilterUniverse(availableContracts, underlying));
 
             // if results are not dynamic, we cache them and won't call filtering till the end of the day
             if (!results.IsDynamic)

--- a/Common/Data/UniverseSelection/OptionChainUniverse.cs
+++ b/Common/Data/UniverseSelection/OptionChainUniverse.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,8 +47,8 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="universeSettings">The universe settings to be used for new subscriptions</param>
         /// <param name="securityInitializer">The security initializer to use on newly created securities</param>
         /// <param name="liveMode">True if we're running in live mode, false for backtest mode</param>
-        public OptionChainUniverse(Option option, 
-                                   UniverseSettings universeSettings, 
+        public OptionChainUniverse(Option option,
+                                   UniverseSettings universeSettings,
                                    ISecurityInitializer securityInitializer,
                                    bool liveMode)
             : base(option.SubscriptionDataConfig, securityInitializer)
@@ -94,7 +94,7 @@ namespace QuantConnect.Data.UniverseSelection
             }
 
             var availableContracts = optionsUniverseDataCollection.Data.Select(x => x.Symbol);
-            var results = (OptionFilterUniverse)_option.ContractFilter.Filter(new OptionFilterUniverse(availableContracts, _underlying));
+            var results = _option.ContractFilter.Filter(new OptionFilterUniverse(availableContracts, _underlying));
 
             // if results are not dynamic, we cache them and won't call filtering till the end of the day
             if (!results.IsDynamic)
@@ -127,7 +127,7 @@ namespace QuantConnect.Data.UniverseSelection
                 return false;
             }
 
-            // method take into account the case, when the option has experienced an adjustment 
+            // method take into account the case, when the option has experienced an adjustment
             // we update member reference in this case
             if (Securities.Any(x => x.Value.Security == security))
             {

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -409,6 +409,12 @@ namespace QuantConnect.Interfaces
         void OnFrameworkSecuritiesChanged(SecurityChanges changes);
 
         /// <summary>
+        /// Invoked at the end of every time step. This allows the algorithm
+        /// to process events before advancing to the next time step.
+        /// </summary>
+        void OnEndOfTimeStep();
+
+        /// <summary>
         /// Send debug message
         /// </summary>
         /// <param name="message"></param>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Securities\HasSufficientBuyingPowerForOrderResult.cs" />
     <Compile Include="Securities\IBaseCurrencySymbol.cs" />
     <Compile Include="Securities\Future\EmptyFutureChainProvider.cs" />
+    <Compile Include="Securities\IDerivativeSecurity.cs" />
     <Compile Include="Securities\Option\EmptyOptionChainProvider.cs" />
     <Compile Include="Interfaces\IOptionChainProvider.cs" />
     <Compile Include="Brokerages\OandaTransactionModel.cs" />

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Securities.Future
     /// Futures Security Object Implementation for Futures Assets
     /// </summary>
     /// <seealso cref="Security"/>
-    public class Future : Security
+    public class Future : Security, IDerivativeSecurity
     {
         /// <summary>
         /// The default number of days required to settle a futures sale
@@ -118,7 +118,7 @@ namespace QuantConnect.Securities.Future
         /// </summary>
         public SettlementType SettlementType
         {
-            get; set; 
+            get; set;
         }
 
         /// <summary>

--- a/Common/Securities/IDerivativeSecurity.cs
+++ b/Common/Securities/IDerivativeSecurity.cs
@@ -1,0 +1,13 @@
+﻿namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Defines a security as a derivative of another security
+    /// </summary>
+    public interface IDerivativeSecurity
+    {
+        /// <summary>
+        /// Gets or sets the underlying security for the derivative
+        /// </summary>
+        Security Underlying { get; set; }
+    }
+}

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Securities.Option
     /// Option Security Object Implementation for Option Assets
     /// </summary>
     /// <seealso cref="Security"/>
-    public class Option : Security
+    public class Option : Security, IDerivativeSecurity
     {
         /// <summary>
         /// The default number of days required to settle an equity sale

--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@ namespace QuantConnect.Securities
 {
     /// <summary>
     /// Represents options symbols universe used in filtering.
-    /// </summary> 
+    /// </summary>
     public class OptionFilterUniverse : IDerivativeSecurityFilterUniverse
     {
         /// <summary>
@@ -262,7 +262,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Applies filter selecting options contracts based on a range of expiration dates relative to the current day 
+        /// Applies filter selecting options contracts based on a range of expiration dates relative to the current day
         /// </summary>
         /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
         /// would exclude contracts expiring in less than 10 days</param>
@@ -316,7 +316,7 @@ namespace QuantConnect.Securities
     public static class OptionFilterUniverseEx
     {
         /// <summary>
-        /// Filters universe 
+        /// Filters universe
         /// </summary>
         /// <param name="universe"></param>
         /// <param name="predicate"></param>
@@ -329,7 +329,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Maps universe 
+        /// Maps universe
         /// </summary>
         public static OptionFilterUniverse Select(this OptionFilterUniverse universe, Func<Symbol, Symbol> mapFunc)
         {
@@ -339,7 +339,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Binds universe 
+        /// Binds universe
         /// </summary>
         public static OptionFilterUniverse SelectMany(this OptionFilterUniverse universe, Func<Symbol, IEnumerable<Symbol>> mapFunc)
         {

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -174,6 +174,27 @@ namespace QuantConnect
                 ID.Date == SecurityIdentifier.DefaultDate;
         }
 
+        /// <summary>
+        /// Determines if the specified <paramref name="symbol"/> is an underlying of this symbol instance
+        /// </summary>
+        /// <param name="symbol">The underlying to check for</param>
+        /// <returns>True if the specified <paramref name="symbol"/> is an underlying of this symbol instance</returns>
+        public bool HasUnderlyingSymbol(Symbol symbol)
+        {
+            var current = this;
+            while (current.HasUnderlying)
+            {
+                if (current.Underlying == symbol)
+                {
+                    return true;
+                }
+
+                current = current.Underlying;
+            }
+
+            return false;
+        }
+
         #region Properties
 
         /// <summary>

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -618,6 +618,9 @@ namespace QuantConnect.Lean.Engine
                 // Process any required events of the results handler such as sampling assets, equity, or stock prices.
                 results.ProcessSynchronousEvents();
 
+                // poke the algorithm at the end of each time step
+                algorithm.OnEndOfTimeStep();
+
             } // End of ForEach feed.Bridge.GetConsumingEnumerable
 
             // stop timing the loops

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -438,6 +438,18 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(new DateTime(2016, 02, 05)/*Friday*/, OptionSymbol.GetLastDayOfTrading(weeklySymbol));
         }
 
+        [Test]
+        public void HasUnderlyingSymbolReturnsTrueWhenSpecifyingCorrectUnderlying()
+        {
+            Assert.IsTrue(Symbols.SPY_C_192_Feb19_2016.HasUnderlyingSymbol(Symbols.SPY));
+        }
+
+        [Test]
+        public void HasUnderlyingSymbolReturnsFalsWhenSpecifyingIncorrectUnderlying()
+        {
+            Assert.IsFalse(Symbols.SPY_C_192_Feb19_2016.HasUnderlyingSymbol(Symbols.AAPL));
+        }
+
         class OldSymbol
         {
             public string Value { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When calling `AddSecurity` methods, we now save the changes to a pending list to be applied at the end of the current time step. This gives the algorithm a chance to properly configure the newly created security object (normalization mode was original culprit here) *before* the data feed grabs it and creates a subscription for it. Once the DF has created a subscription for it, any further changes to the subscription properties will not take effect.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1689 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Options algorithms were running with the adjust data normalization mode because by the time we configured it to use raw mode, the data feed had already grabbed the subscription and started enumerating the data source.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Extensive manual testing. There is a related options regression algorithm that I have locally, but it has some issues I'm still trying to understand, but didn't want that learning exercise to prevent this bug fix from getting into `master`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

>NOTE: `OptionExerciseAssignRegressionAlgorithm` is a flickering test. It appears to be caused by the ordering of fills. It passes 100% of the time when I run it by itself, but 50% when run as part of the entire regression suite. I confirmed this issue also exists on the current `master`. Also, no additional tests were added to cover this, but one is forthcoming. I'm creating an options regression algorithm that hopefully covers many of the common options issues, but it requires more time to properly validate the results.

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->