### PR TITLE
Fix consolidators not updating during warmup with tick resolution

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -781,20 +781,23 @@ namespace QuantConnect.Lean.Engine
                             var data = slice[symbol];
                             var list = new List<BaseData>();
                             Type dataType;
+                            SubscriptionDataConfig config;
 
                             var ticks = data as List<Tick>;
                             if (ticks != null)
                             {
                                 list.AddRange(ticks);
                                 dataType = typeof(Tick);
+                                config = algorithm.SubscriptionManager.Subscriptions.FirstOrDefault(
+                                    subscription => subscription.Symbol == symbol && dataType.IsAssignableFrom(subscription.Type));
                             }
                             else
                             {
                                 list.Add(data);
                                 dataType = data.GetType();
+                                config = security.Subscriptions.FirstOrDefault(subscription => dataType.IsAssignableFrom(subscription.Type));
                             }
 
-                            var config = security.Subscriptions.FirstOrDefault(subscription => dataType.IsAssignableFrom(subscription.Type));
                             if (config == null)
                             {
                                 throw new Exception($"A data subscription for type '{dataType.Name}' was not found.");


### PR DESCRIPTION

#### Description
In `AlgorithmManager.Stream`, with Tick resolution the subscription config is now searched using the same storage used to resolve consolidators.

#### Related Issue
Fixes #1724

#### Motivation and Context
This fix is required because consolidators are not updated during warm up with Tick resolution.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Manually ran the test algorithm included in #1724 + regression tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`