### PR TITLE
Fix error in SetHoldings(symbol, 0) with Crypto

### DIFF
--- a/Common/Securities/GetMaximumOrderQuantityForTargetValueResult.cs
+++ b/Common/Securities/GetMaximumOrderQuantityForTargetValueResult.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Securities
         {
             Quantity = quantity;
             Reason = reason ?? string.Empty;
-            IsError = reason != string.Empty;
+            IsError = Reason != string.Empty;
         }
 
         /// <summary>

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -484,6 +484,31 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsTrue(_buyingPowerModel.HasSufficientBuyingPowerForOrder(_portfolio, _btcusd, order).IsSufficient);
         }
 
+        [Test]
+        public void ZeroTargetWithZeroHoldingsIsNotAnError()
+        {
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+
+            var result = _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_algorithm.Portfolio, _btcusd, 0);
+
+            Assert.AreEqual(0, result.Quantity);
+            Assert.AreEqual(string.Empty, result.Reason);
+            Assert.AreEqual(false, result.IsError);
+        }
+
+        [Test]
+        public void ZeroTargetWithNonZeroHoldingsReturnsNegativeOfQuantity()
+        {
+            _btcusd = _algorithm.AddCrypto("BTCUSD");
+            _portfolio.CashBook.Add("BTC", 1m, 12000m);
+
+            var result = _buyingPowerModel.GetMaximumOrderQuantityForTargetValue(_algorithm.Portfolio, _btcusd, 0);
+
+            Assert.AreEqual(-1, result.Quantity);
+            Assert.AreEqual(string.Empty, result.Reason);
+            Assert.AreEqual(false, result.IsError);
+        }
+
         private void SubmitLimitOrder(Symbol symbol, decimal quantity, decimal limitPrice)
         {
             using (var resetEvent = new ManualResetEvent(false))


### PR DESCRIPTION

#### Description
The `GetMaximumOrderQuantityForTargetValue` method in `CashBuyingPowerModel` is now setting the error flag properly when called with a zero target value.

#### Related Issue
Fixes #1731

#### Motivation and Context
An invalid error message is displayed.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually tested in test algorithm + new unit tests included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`