### PR TITLE
Fix multiple symbol addition in AddToUserDefinedUniverse

### DIFF
--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -424,25 +424,29 @@ namespace QuantConnect.Algorithm
             {
                 if (!UniverseManager.TryGetValue(universeSymbol, out universe))
                 {
-                    // create a new universe, these subscription settings don't currently get used
-                    // since universe selection proper is never invoked on this type of universe
-                    var uconfig = new SubscriptionDataConfig(subscription, symbol: universeSymbol, isInternalFeed: true, fillForward: false);
-
-                    if (security.Type == SecurityType.Base)
+                    universe = _pendingUniverseAdditions.FirstOrDefault(x => x.Configuration.Symbol == universeSymbol);
+                    if (universe == null)
                     {
-                        // set entry in market hours database for the universe subscription to match the custom data
-                        var symbolString = MarketHoursDatabase.GetDatabaseSymbolKey(uconfig.Symbol);
-                        MarketHoursDatabase.SetEntry(uconfig.Market, symbolString, uconfig.SecurityType, security.Exchange.Hours, uconfig.DataTimeZone);
-                    }
+                        // create a new universe, these subscription settings don't currently get used
+                        // since universe selection proper is never invoked on this type of universe
+                        var uconfig = new SubscriptionDataConfig(subscription, symbol: universeSymbol, isInternalFeed: true, fillForward: false);
 
-                    universe = new UserDefinedUniverse(uconfig,
-                        new UniverseSettings(security.Resolution, security.Leverage, security.IsFillDataForward, security.IsExtendedMarketHours,
-                            TimeSpan.Zero),
-                        SecurityInitializer,
-                        QuantConnect.Time.MaxTimeSpan,
-                        new List<Symbol> {security.Symbol}
-                    );
-                    _pendingUniverseAdditions.Add(universe);
+                        if (security.Type == SecurityType.Base)
+                        {
+                            // set entry in market hours database for the universe subscription to match the custom data
+                            var symbolString = MarketHoursDatabase.GetDatabaseSymbolKey(uconfig.Symbol);
+                            MarketHoursDatabase.SetEntry(uconfig.Market, symbolString, uconfig.SecurityType, security.Exchange.Hours, uconfig.DataTimeZone);
+                        }
+
+                        universe = new UserDefinedUniverse(uconfig,
+                            new UniverseSettings(security.Resolution, security.Leverage, security.IsFillDataForward, security.IsExtendedMarketHours,
+                                TimeSpan.Zero),
+                            SecurityInitializer,
+                            QuantConnect.Time.MaxTimeSpan,
+                            new List<Symbol> {security.Symbol}
+                        );
+                        _pendingUniverseAdditions.Add(universe);
+                    }
                 }
             }
 


### PR DESCRIPTION

#### Description
The missing check for a pending universe addition has been added.

#### Related Issue
Fixes #1733

#### Motivation and Context
No data for multiple symbols in `OnData`.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually tested with test algorithm in #1733.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`