### PR TITLE
Adds Volume property to FutureContract and OptionContract objects

### DIFF
--- a/Common/Data/Market/FuturesContract.cs
+++ b/Common/Data/Market/FuturesContract.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,16 +14,11 @@
 */
 
 using System;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using QuantConnect.Securities;
-using QuantConnect.Securities.Future;
 
 namespace QuantConnect.Data.Market
 {
     /// <summary>
-    /// Defines a single futures contract at a specific expiration 
+    /// Defines a single futures contract at a specific expiration
     /// </summary>
     public class FuturesContract
     {
@@ -43,14 +38,10 @@ namespace QuantConnect.Data.Market
             get; private set;
         }
 
-
         /// <summary>
         /// Gets the expiration date
         /// </summary>
-        public DateTime Expiry
-        {
-            get { return Symbol.ID.Date; }
-        }
+        public DateTime Expiry => Symbol.ID.Date;
 
         /// <summary>
         /// Gets the local date time this contract's data was last updated
@@ -72,6 +63,14 @@ namespace QuantConnect.Data.Market
         /// Gets the last price this contract traded at
         /// </summary>
         public decimal LastPrice
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Gets the last volume this contract traded at
+        /// </summary>
+        public long Volume
         {
             get; set;
         }
@@ -125,9 +124,6 @@ namespace QuantConnect.Data.Market
         /// <returns>
         /// A string that represents the current object.
         /// </returns>
-        public override string ToString()
-        {
-            return Symbol.Value;
-        }
+        public override string ToString() => Symbol.Value;
     }
 }

--- a/Common/Data/Market/OptionContract.cs
+++ b/Common/Data/Market/OptionContract.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,10 +14,6 @@
 */
 
 using System;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Data.Market
@@ -49,50 +45,32 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// Gets the strike price
         /// </summary>
-        public decimal Strike
-        {
-            get { return Symbol.ID.StrikePrice; }
-        }
+        public decimal Strike => Symbol.ID.StrikePrice;
 
         /// <summary>
         /// Gets the expiration date
         /// </summary>
-        public DateTime Expiry
-        {
-            get { return Symbol.ID.Date; }
-        }
+        public DateTime Expiry => Symbol.ID.Date;
 
         /// <summary>
         /// Gets the right being purchased (call [right to buy] or put [right to sell])
         /// </summary>
-        public OptionRight Right
-        {
-            get { return Symbol.ID.OptionRight; }
-        }
+        public OptionRight Right => Symbol.ID.OptionRight;
 
         /// <summary>
         /// Gets the theoretical price of this option contract as computed by the <see cref="IOptionPriceModel"/>
         /// </summary>
-        public decimal TheoreticalPrice
-        {
-            get { return _optionPriceModelResult.Value.TheoreticalPrice; }
-        }
+        public decimal TheoreticalPrice => _optionPriceModelResult.Value.TheoreticalPrice;
 
         /// <summary>
         /// Gets the implied volatility of the option contract as computed by the <see cref="IOptionPriceModel"/>
         /// </summary>
-        public decimal ImpliedVolatility
-        {
-            get { return _optionPriceModelResult.Value.ImpliedVolatility; }
-        }
+        public decimal ImpliedVolatility => _optionPriceModelResult.Value.ImpliedVolatility;
 
         /// <summary>
         /// Gets the greeks for this contract
         /// </summary>
-        public Greeks Greeks
-        {
-            get { return _optionPriceModelResult.Value.Greeks; }
-        }
+        public Greeks Greeks => _optionPriceModelResult.Value.Greeks;
 
         /// <summary>
         /// Gets the local date time this contract's data was last updated
@@ -114,6 +92,14 @@ namespace QuantConnect.Data.Market
         /// Gets the last price this contract traded at
         /// </summary>
         public decimal LastPrice
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Gets the last volume this contract traded at
+        /// </summary>
+        public long Volume
         {
             get; set;
         }
@@ -184,9 +170,6 @@ namespace QuantConnect.Data.Market
         /// <returns>
         /// A string that represents the current object.
         /// </returns>
-        public override string ToString()
-        {
-            return string.Format("{0}{1}{2}{3:00000000}", Symbol.ID.Symbol, Expiry.ToString(DateFormat.EightCharacter), Right.ToString()[0], Strike*1000m);
-        }
+        public override string ToString() => Symbol.Value;
     }
 }

--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -341,6 +340,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 {
                     Time = baseData.EndTime,
                     LastPrice = security.Close,
+                    Volume = (long)security.Volume,
                     BidPrice = security.BidPrice,
                     BidSize = (long)security.BidSize,
                     AskPrice = security.AskPrice,
@@ -369,7 +369,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 case MarketDataType.TradeBar:
                     var tradeBar = (TradeBar)baseData;
                     chain.TradeBars[symbol] = tradeBar;
-                    contract.LastPrice = tradeBar.Close;
+                    UpdateContract(contract, tradeBar);
                     break;
 
                 case MarketDataType.QuoteBar:
@@ -416,6 +416,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 {
                     Time = baseData.EndTime,
                     LastPrice = security.Close,
+                    Volume = (long)security.Volume,
                     BidPrice = security.BidPrice,
                     BidSize = (long)security.BidSize,
                     AskPrice = security.AskPrice,
@@ -437,7 +438,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 case MarketDataType.TradeBar:
                     var tradeBar = (TradeBar)baseData;
                     chain.TradeBars[symbol] = tradeBar;
-                    contract.LastPrice = tradeBar.Close;
+                    UpdateContract(contract, tradeBar);
                     break;
 
                 case MarketDataType.QuoteBar:
@@ -495,6 +496,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
         }
 
+        private static void UpdateContract(OptionContract contract, TradeBar tradeBar)
+        {
+            if (tradeBar.Close == 0m) return;
+            contract.LastPrice = tradeBar.Close;
+            contract.Volume = (long)tradeBar.Volume;
+        }
+
         private static void UpdateContract(FuturesContract contract, QuoteBar quote)
         {
             if (quote.Ask != null && quote.Ask.Close != 0m)
@@ -535,6 +543,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     contract.OpenInterest = tick.Value;
                 }
             }
+        }
+
+        private static void UpdateContract(FuturesContract contract, TradeBar tradeBar)
+        {
+            if (tradeBar.Close == 0m) return;
+            contract.LastPrice = tradeBar.Close;
+            contract.Volume = (long)tradeBar.Volume;
         }
     }
 }

--- a/Tests/Engine/DataFeeds/TimeSliceTests.cs
+++ b/Tests/Engine/DataFeeds/TimeSliceTests.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Algorithm.CSharp;
 using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
@@ -165,5 +166,66 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.AreEqual("Item 2", ((DailyFx)data2).Title);
         }
 
+        [Test]
+        public void FutureDataHasVolume()
+        {
+            var initialVolume = 100;
+            var slices = GetSlices(Symbols.Fut_SPY_Mar19_2016, initialVolume).ToArray();
+
+            for (var i = 0; i < 10; i++)
+            {
+                var chain = slices[i].FutureChains.FirstOrDefault().Value;
+                var contract = chain.FirstOrDefault();
+                var expected = (i + 1) * initialVolume;
+                Assert.AreEqual(expected, contract.Volume);
+            }
+        }
+
+        [Test]
+        public void OptionsDataHasVolume()
+        {
+            var initialVolume = 150;
+            var slices = GetSlices(Symbols.SPY_C_192_Feb19_2016, initialVolume).ToArray();
+
+            for (var i = 0; i < 10; i++)
+            {
+                var chain = slices[i].OptionChains.FirstOrDefault().Value;
+                var contract = chain.FirstOrDefault();
+                var expected = (i + 1) * initialVolume;
+                Assert.AreEqual(expected, contract.Volume);
+            }
+        }
+
+        private IEnumerable<Slice> GetSlices(Symbol symbol, int initialVolume)
+        {
+            var subscriptionDataConfig = new SubscriptionDataConfig(typeof(ZipEntryName), symbol, Resolution.Second, TimeZones.Utc, TimeZones.Utc, true, true, false);
+            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), subscriptionDataConfig, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var refTime = DateTime.UtcNow;
+
+            return Enumerable
+                .Range(0, 10)
+                .Select(i =>
+                {
+                    var time = refTime.AddSeconds(i);
+                    var bid = new Bar(100, 100, 100, 100);
+                    var ask = new Bar(110, 110, 110, 110);
+                    var volume = (i + 1) * initialVolume;
+
+                    return TimeSlice.Create(
+                        time,
+                        TimeZones.Utc,
+                        new CashBook(),
+                        new List<DataFeedPacket>
+                        {
+                            new DataFeedPacket(security, subscriptionDataConfig, new List<BaseData>
+                            {
+                                new QuoteBar(time, symbol, bid, i*10, ask, (i + 1) * 11),
+                                new TradeBar(time, symbol, 100, 100, 110, 106, volume)
+                            }),
+                        },
+                        new SecurityChanges(Enumerable.Empty<Security>(), Enumerable.Empty<Security>()))
+                        .Slice;
+                });
+        }
     }
 }


### PR DESCRIPTION
#### Description
Adds `Volume` property to `FutureContract` and `OptionContract` objects.
Minor change in `OptionContract.ToString()` since it was getting a string that are already available in `Symbol.Value`.
Minor change in `TimeSlice` to update `FutureContract.Volume` and `OptionContract.Volume` with `TradeBar.Volume` value.

#### Related Issue
Closes #1453

#### Motivation and Context
Although QuantConnect has volume information for both futures and options, this information is not being passed to `FutureContract` and `OptionContract` objects respectively. Users have to look for this information in the `Slice` object.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
N/A

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`