### PR TITLE
Perform insight scoring synchronously/remove messaging/persistence updates

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1061,5 +1061,41 @@ namespace QuantConnect
 
             return false;
         }
+
+        /// <summary>
+        /// Performs on-line batching of the specified enumerator, emitting chunks of the requested batch size
+        /// </summary>
+        /// <typeparam name="T">The enumerable item type</typeparam>
+        /// <param name="enumerable">The enumerable to be batched</param>
+        /// <param name="batchSize">The number of items per batch</param>
+        /// <returns>An enumerable of lists</returns>
+        public static IEnumerable<List<T>> BatchBy<T>(this IEnumerable<T> enumerable, int batchSize)
+        {
+            using (var enumerator = enumerable.GetEnumerator())
+            {
+                List<T> list = null;
+                while (enumerator.MoveNext())
+                {
+                    if (list == null)
+                    {
+                        list = new List<T> {enumerator.Current};
+                    }
+                    else if (list.Count < batchSize)
+                    {
+                        list.Add(enumerator.Current);
+                    }
+                    else
+                    {
+                        yield return list;
+                        list = new List<T> {enumerator.Current};
+                    }
+                }
+
+                if (list?.Count > 0)
+                {
+                    yield return list;
+                }
+            }
+        }
     }
 }

--- a/Engine/Alphas/DefaultAlphaHandler.cs
+++ b/Engine/Alphas/DefaultAlphaHandler.cs
@@ -262,8 +262,9 @@ namespace QuantConnect.Lean.Engine.Alphas
             var insights = InsightManager.AllInsights.OrderBy(insight => insight.GeneratedTimeUtc).ToList();
             if (insights.Count > 0)
             {
-                var path = Path.Combine(Directory.GetCurrentDirectory(), AlgorithmId, "alpha-results.json");
-                Directory.CreateDirectory(new FileInfo(path).DirectoryName);
+                var directory = Path.Combine(Directory.GetCurrentDirectory(), AlgorithmId);
+                var path = Path.Combine(directory, "alpha-results.json");
+                Directory.CreateDirectory(directory);
                 File.WriteAllText(path, JsonConvert.SerializeObject(insights, Formatting.Indented));
             }
         }

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Python.Runtime;
@@ -412,6 +413,18 @@ namespace QuantConnect.Tests.Common.Util
                 Assert.IsFalse(canConvert);
                 Assert.IsNull(indicatorBaseTradeBar);
             }
+        }
+
+        [Test]
+        public void BatchByDoesNotDropItems()
+        {
+            var list = new List<int> {1, 2, 3, 4, 5};
+            var by2 = list.BatchBy(2).ToList();
+            Assert.AreEqual(3, by2.Count);
+            Assert.AreEqual(2, by2[0].Count);
+            Assert.AreEqual(2, by2[1].Count);
+            Assert.AreEqual(1, by2[2].Count);
+            CollectionAssert.AreEqual(list, by2.SelectMany(x => x));
         }
 
         private PyObject ConvertToPyObject(object value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Slims down the `DefaultAlphaHandler` and runs insight scoring synchronously with the algorithm manager. This ensures that we never fall behind. All data is persisted at the end of the backtest. A forthcoming PR will re-add messaging support in a limited fashion.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1737 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Running a framework algorithm with second resolution and many insights caused the final results to not be persisted when running in the cloud. Furthermore, since scoring was performed asynchronously, we weren't guaranteed to send the final alpha runtime statistics in the result handler's final result packet. This change addresses these issues.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing had to be performed in the cloud since it was not reproducible locally. See the snippet from #1737 for algorithm details.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

Tests not added because it was not reproducible locally, so our regression test system wouldn't detect it. I suppose we could supply mock implementations for messaging and api that do `Thread.Sleep(50)` or similar to simulate external communication.

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->