### PR TITLE
Fix GDAX fee calculation with partial fills

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -291,40 +291,6 @@ namespace QuantConnect.Brokerages.GDAX
         #endregion
 
         /// <summary>
-        /// Retrieves the fee for a given order
-        /// </summary>
-        /// <param name="order"></param>
-        /// <returns></returns>
-        public decimal GetFee(Order order)
-        {
-            var gdaxOrderProperties = order.Properties as GDAXOrderProperties;
-            if (order.Type == OrderType.Limit && gdaxOrderProperties?.PostOnly == true)
-            {
-                return 0m;
-            }
-
-            var totalFee = 0m;
-
-            foreach (var item in order.BrokerId)
-            {
-                var req = new RestRequest("/orders/" + item, Method.GET);
-                GetAuthenticationToken(req);
-                var response = ExecuteRestRequest(req, GdaxEndpointType.Private);
-
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    throw new Exception($"GDAXBrokerage.GetFee: request failed: [{(int)response.StatusCode}] {response.StatusDescription}, Content: {response.Content}, ErrorMessage: {response.ErrorMessage}");
-                }
-
-                var fill = JsonConvert.DeserializeObject<dynamic>(response.Content);
-
-                totalFee += (decimal)fill.fill_fees;
-            }
-
-            return totalFee;
-        }
-
-        /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public override void Dispose()

--- a/Common/Orders/Fees/GDAXFeeModel.cs
+++ b/Common/Orders/Fees/GDAXFeeModel.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Orders.Fees
         /// Tier 1 maker fees
         /// https://www.gdax.com/fees/BTC-USD
         /// </summary>
-        private static readonly Dictionary<string, decimal> Fees = new Dictionary<string, decimal>
+        public static readonly Dictionary<string, decimal> Fees = new Dictionary<string, decimal>
         {
             { "BTCUSD", 0.0025m }, { "BTCEUR", 0.0025m }, { "BTCGBP", 0.0025m },
             { "BCHBTC", 0.003m  }, { "BCHEUR", 0.003m  }, { "BCHUSD", 0.003m  },

--- a/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
@@ -153,10 +153,10 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
                 Assert.AreEqual(actualQuantity != orderQuantity ? Orders.OrderStatus.PartiallyFilled : Orders.OrderStatus.Filled, e.Status);
                 Assert.AreEqual(expectedQuantity, e.FillQuantity);
-                // order fees are pro-rated for partial fills
-                // total order fee = 0.01
-                // partial order fee = (0.01 * 5.23512 / 6.1) = 0.0085821639344262295081967213
-                Assert.AreEqual(0.00858216m, Math.Round(actualFee, 8));
+                // fill quantity = 5.23512
+                // fill price = 400.23
+                // partial order fee = (400.23 * 5.23512 * 0.0025) = 5.238130194
+                Assert.AreEqual(5.238130194m, actualFee);
                 raised.Set();
             };
 


### PR DESCRIPTION

#### Description
The calculation of GDAX live fees is now calculated exactly on each (partial or total) fill as a percentage of `FilledQuantity * FillPrice` reusing the percentages already defined and used in the `GDAXFeeModel`.

#### Related Issue
Fixes #1745

#### Motivation and Context
The fees were calculated incorrectly when receiving partial fills.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Manually tested with algorithm submitting market orders on real live account.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`