### PR TITLE
Add entries to SymbolCache for ManualPortoflioSelectionModel symbols

### DIFF
--- a/Algorithm.Framework/Selection/ManualPortfolioSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ManualPortfolioSelectionModel.cs
@@ -49,13 +49,8 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// </summary>
         /// <param name="symbols">The symbols to subscribe to</param>
         public ManualPortfolioSelectionModel(params Symbol[] symbols)
+            : this (symbols?.AsEnumerable(), null, null)
         {
-            if (symbols == null)
-            {
-                throw new ArgumentNullException(nameof(symbols));
-            }
-
-            _symbols = symbols.ToList();
         }
 
         /// <summary>
@@ -66,9 +61,19 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="securityInitializer">Optional security initializer invoked when creating new securities, specify null to use algorithm.SecurityInitializer</param>
         public ManualPortfolioSelectionModel(IEnumerable<Symbol> symbols, UniverseSettings universeSettings, ISecurityInitializer securityInitializer)
         {
+            if (symbols == null)
+            {
+                throw new ArgumentNullException(nameof(symbols));
+            }
+
             _symbols = symbols.ToList();
             _universeSettings = universeSettings;
             _securityInitializer = securityInitializer;
+
+            foreach (var symbol in _symbols)
+            {
+                SymbolCache.Set(symbol.Value, symbol);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Entries are added to the `SymbolCache` in `ManualPortoflioSelectionModel`'s constructor. This ensure consistent behavior between the manual model and using `AddSecurity` directly.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1762 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is expected to be a common issue and arguably, should behave similarly to `AddSecurity` since we're specifying a specific set of symbols *and* we're defining the alias for those symbol as the 'ticker today'.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with code provided in #1762 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->