### PR TITLE
Update GDAX fill handling for market orders

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -56,6 +56,10 @@ namespace QuantConnect.Brokerages.GDAX
         private readonly RateGate _publicEndpointRateLimiter = new RateGate(6, TimeSpan.FromSeconds(1));
         private readonly RateGate _privateEndpointRateLimiter = new RateGate(10, TimeSpan.FromSeconds(1));
 
+        // market order fill tracking
+        private string _lastBrokerMarketOrderId;
+        private int _lastMarketOrderId;
+
         /// <summary>
         /// Rest client used to call missing conversion rates
         /// </summary>
@@ -185,18 +189,12 @@ namespace QuantConnect.Brokerages.GDAX
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, -1, $"GDAXBrokerage.OnMessage: {error.Message} {error.Reason}"));
                     return;
                 }
-                else if (raw.Type == "done")
-                {
-                    // TODO: this message type is only received when subscribing to the "full" channel, we don't need it and will be removed in a forthcoming PR
-                    OrderDone(e.Message);
-                    return;
-                }
                 else if (raw.Type == "match")
                 {
                     OrderMatch(e.Message);
                     return;
                 }
-                else if (raw.Type == "open" || raw.Type == "change" || raw.Type == "received" || raw.Type == "subscriptions" || raw.Type == "last_match")
+                else if (raw.Type == "open" || raw.Type == "change" || raw.Type == "done" || raw.Type == "received" || raw.Type == "subscriptions" || raw.Type == "last_match")
                 {
                     //known messages we don't need to handle or log
                     return;
@@ -323,31 +321,75 @@ namespace QuantConnect.Brokerages.GDAX
             }
 
             var cached = CachedOrderIDs
-                .Where(o => o.Value.BrokerId.Contains(message.MakerOrderId) || o.Value.BrokerId.Contains(message.TakerOrderId))
-                .ToList();
+                .FirstOrDefault(o => o.Value.BrokerId.Contains(message.MakerOrderId) || o.Value.BrokerId.Contains(message.TakerOrderId));
 
-            var symbol = ConvertProductId(message.ProductId);
+            if (_lastBrokerMarketOrderId != null &&
+                // order fill for other users
+                (cached.Value == null ||
+                // order fill for other order of ours (less likely but may happen)
+                cached.Value.BrokerId[0] != _lastBrokerMarketOrderId))
+            {
+                // process all fills for our previous market order
+                var fills = FillSplit[_lastMarketOrderId];
+                var fillMessages = fills.Messages;
 
-            if (cached.Count == 0)
+                for (var i = 0; i < fillMessages.Count; i++)
+                {
+                    var fillMessage = fillMessages[i];
+                    var isFinalFill = i == fillMessages.Count - 1;
+
+                    EmitFillOrderEvent(fillMessage, fills.Order.Symbol, fills, isFinalFill);
+                }
+
+                // clear the previous market order
+                _lastBrokerMarketOrderId = null;
+                _lastMarketOrderId = 0;
+            }
+
+            if (cached.Value == null)
             {
                 return;
             }
 
             Log.Trace($"GDAXBrokerage.OrderMatch(): Match: {message.ProductId} {data}");
-            var orderId = cached[0].Key;
-            var order = cached[0].Value;
 
-            if (!FillSplit.ContainsKey(orderId))
+            var order = cached.Value;
+
+            if (order.Type == OrderType.Market)
             {
-                FillSplit[orderId] = new GDAXFill(order);
+                // Fill events for this order will be delayed until we receive messages for a different order,
+                // so we can know which is the last fill.
+                // The market order total filled quantity can be less than the total order quantity,
+                // details here: https://github.com/QuantConnect/Lean/issues/1751
+
+                _lastBrokerMarketOrderId = order.BrokerId[0];
+                _lastMarketOrderId = order.Id;
             }
 
-            var split = FillSplit[orderId];
+            if (!FillSplit.ContainsKey(order.Id))
+            {
+                FillSplit[order.Id] = new GDAXFill(order);
+            }
+
+            var split = FillSplit[order.Id];
             split.Add(message);
 
-            //is this the total order at once? Is this the last split fill?
-            var status = Math.Abs(message.Size) == Math.Abs(order.Quantity) || Math.Abs(split.OrderQuantity) == Math.Abs(split.TotalQuantity())
-                ? OrderStatus.Filled : OrderStatus.PartiallyFilled;
+            if (order.Type != OrderType.Market)
+            {
+                var symbol = ConvertProductId(message.ProductId);
+
+                // is this the total order at once? Is this the last split fill?
+                var isFinalFill = Math.Abs(message.Size) == Math.Abs(order.Quantity) || Math.Abs(split.OrderQuantity) == Math.Abs(split.TotalQuantity);
+
+                EmitFillOrderEvent(message, symbol, split, isFinalFill);
+            }
+        }
+
+        private void EmitFillOrderEvent(Messages.Matched message, Symbol symbol, GDAXFill split, bool isFinalFill)
+        {
+            var order = split.Order;
+
+            var status = isFinalFill ? OrderStatus.Filled : OrderStatus.PartiallyFilled;
 
             OrderDirection direction;
             // Messages are always from the perspective of the market maker. Flip direction if executed as a taker.
@@ -367,7 +409,7 @@ namespace QuantConnect.Brokerages.GDAX
 
             var orderEvent = new OrderEvent
             (
-                orderId, symbol, message.Time, status,
+                order.Id, symbol, message.Time, status,
                 direction, fillPrice, fillQuantity,
                 orderFee, $"GDAX Match Event {direction}"
             );
@@ -376,56 +418,8 @@ namespace QuantConnect.Brokerages.GDAX
             if (orderEvent.Status == OrderStatus.Filled)
             {
                 Order outOrder;
-                CachedOrderIDs.TryRemove(orderId, out outOrder);
+                CachedOrderIDs.TryRemove(order.Id, out outOrder);
             }
-
-            OnOrderEvent(orderEvent);
-        }
-
-        private void OrderDone(string data)
-        {
-            Log.Trace($"GDAXBrokerage.Messaging.OrderDone(): Order completed with data {data}");
-            var message = JsonConvert.DeserializeObject<Messages.Done>(data, JsonSettings);
-
-            //if we don't exit now, will result in fill message
-            if (message.Reason == "canceled" || message.RemainingSize > 0)
-            {
-                Log.Trace($"GDAXBrokerage.Messaging.OrderDone(): Order cancelled. Remaining {message.RemainingSize}");
-                return;
-            }
-
-            //is this our order?
-            var cached = CachedOrderIDs.Where(o => o.Value.BrokerId.Contains(message.OrderId)).ToList();
-
-            if (cached.Count == 0 || cached[0].Value.Status == OrderStatus.Filled)
-            {
-                Log.Trace($"GDAXBrokerage.Messaging.OrderDone(): Order could not locate order in cache with order id {message.OrderId}");
-                return;
-            }
-
-            var orderId = cached[0].Key;
-
-            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Information, -1,
-                $"GDAXWebsocketsBrokerage.OrderDone: Encountered done message prior to match filling order brokerId: {message.OrderId} orderId: {orderId}"));
-
-            var split = FillSplit[orderId];
-
-            var symbol = ConvertProductId(message.ProductId);
-            var fillPrice = message.Price;
-            var fillQuantity = message.Side == "sell" ? -split.TotalQuantity() : split.TotalQuantity();
-            var orderFee = GetFillFee(symbol, fillPrice, fillQuantity, true);
-
-            //should have already been filled but match message may have been missed. Let's say we've filled now
-            var orderEvent = new OrderEvent
-            (
-                orderId, symbol, message.Time, OrderStatus.Filled,
-                message.Side == "sell" ? OrderDirection.Sell : OrderDirection.Buy,
-                fillPrice, fillQuantity,
-                orderFee, "GDAX Fill Event"
-            );
-
-            Order outOrder;
-            CachedOrderIDs.TryRemove(orderId, out outOrder);
 
             OnOrderEvent(orderEvent);
         }

--- a/Brokerages/GDAX/GDAXFill.cs
+++ b/Brokerages/GDAX/GDAXFill.cs
@@ -1,47 +1,56 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
 using QuantConnect.Brokerages.GDAX.Messages;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace QuantConnect.Brokerages.GDAX
 {
-
     /// <summary>
     /// Tracks fill messages
     /// </summary>
     public class GDAXFill
     {
+        private readonly List<Matched> _messages = new List<Matched>();
 
-        Orders.Order _order;
+        /// <summary>
+        /// The Lean order
+        /// </summary>
+        public Orders.Order Order { get; }
 
         /// <summary>
         /// Lean orderId
         /// </summary>
-        public int OrderId
-        {
-            get
-            {
-                return _order.Id;
-            }
-        }
+        public int OrderId => Order.Id;
 
-        private List<Matched> _messages = new List<Matched>();
+        /// <summary>
+        /// The list of match messages
+        /// </summary>
+        public List<Matched> Messages => _messages.ToList();
+
+        /// <summary>
+        /// Total amount executed across all fills
+        /// </summary>
+        /// <returns></returns>
+        public decimal TotalQuantity => _messages.Sum(m => m.Size);
+
+        /// <summary>
+        /// Original order quantity
+        /// </summary>
+        public decimal OrderQuantity => Order.Quantity;
 
         /// <summary>
         /// Creates instance of GDAXFill
@@ -49,45 +58,16 @@ namespace QuantConnect.Brokerages.GDAX
         /// <param name="order"></param>
         public GDAXFill(Orders.Order order)
         {
-            _order = order;
+            Order = order;
         }
 
         /// <summary>
         /// Adds a trade message
         /// </summary>
         /// <param name="msg"></param>
-        /// <returns></returns>
         public void Add(Matched msg)
         {
             _messages.Add(msg);
         }
-
-        /// <summary>
-        /// Compares fill amouns to determine if fill is complete
-        /// </summary>
-        /// <returns></returns>
-        public bool IsCompleted()
-        {
-            decimal quantity = Math.Abs(_messages.Sum(m => m.Size));
-            return quantity >= Math.Abs(_order.Quantity);
-        }
-
-        /// <summary>
-        /// Total amount executed across all fills
-        /// </summary>
-        /// <returns></returns>
-        public decimal TotalQuantity()
-        {
-            return _messages.Sum(m => m.Size);
-        }
-
-        /// <summary>
-        /// Original order quantity
-        /// </summary>
-        public decimal OrderQuantity
-        {
-            get { return _order.Quantity; }
-        }
-
     }
 }

--- a/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
@@ -151,7 +151,8 @@ namespace QuantConnect.Tests.Brokerages.GDAX
                 actualFee += e.OrderFee;
                 actualQuantity += e.AbsoluteFillQuantity;
 
-                Assert.AreEqual(actualQuantity != orderQuantity ? Orders.OrderStatus.PartiallyFilled : Orders.OrderStatus.Filled, e.Status);
+                Assert.IsTrue(actualQuantity != orderQuantity);
+                Assert.AreEqual(OrderStatus.Filled, e.Status);
                 Assert.AreEqual(expectedQuantity, e.FillQuantity);
                 // fill quantity = 5.23512
                 // fill price = 400.23
@@ -160,6 +161,10 @@ namespace QuantConnect.Tests.Brokerages.GDAX
                 raised.Set();
             };
 
+            _unit.OnMessage(_unit, GDAXTestsHelpers.GetArgs(json));
+
+            // not our order, market order is completed even if not totally filled
+            json = json.Replace(id, Guid.NewGuid().ToString());
             _unit.OnMessage(_unit, GDAXTestsHelpers.GetArgs(json));
 
             //if not our order should get no event

--- a/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
+++ b/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
@@ -1,3 +1,18 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 using QuantConnect.Brokerages.GDAX;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -9,6 +24,7 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 {
     public class GDAXTestsHelpers
     {
+        private static readonly Symbol Btcusd = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX);
 
         public static Security GetSecurity(decimal price = 1m, SecurityType securityType = SecurityType.Crypto)
         {
@@ -18,15 +34,13 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
         private static SubscriptionDataConfig CreateConfig(SecurityType securityType = SecurityType.Crypto)
         {
-                return new SubscriptionDataConfig(typeof(TradeBar), Symbol.Create("BTCUSD", securityType, Market.GDAX), Resolution.Minute, TimeZones.Utc, TimeZones.Utc,
-                false, true, false);
+            return new SubscriptionDataConfig(typeof(TradeBar), Symbol.Create("BTCUSD", securityType, Market.GDAX), Resolution.Minute, TimeZones.Utc, TimeZones.Utc,
+            false, true, false);
         }
-
-
 
         public static void AddOrder(GDAXBrokerage unit, int id, string brokerId, decimal quantity)
         {
-            var order = new Orders.MarketOrder { BrokerId = new List<string> { brokerId }, Quantity = quantity, Id = id };
+            var order = new Orders.MarketOrder { BrokerId = new List<string> { brokerId }, Symbol = Btcusd, Quantity = quantity, Id = id };
             unit.CachedOrderIDs.TryAdd(1, order);
             unit.FillSplit.TryAdd(id, new GDAXFill(order));
         }


### PR DESCRIPTION

#### Description
Partially filled GDAX market orders are now guaranteed to transition to the final state of `Filled`, even if the total quantity filled is less than the order quantity.
Now we are (slightly) delaying market order fill events until messages for a different order are received.
Order fill event handling is performed entirely in the `"match"` message event handler.

The `"done"` message event handler was also removed since it was unused (these messages were never received because we are not subscribing to the `"full"` channel).

#### Related Issue
Fixes #1751

#### Motivation and Context
If a previous market buy order was not filled completely because of insufficient funds, the market order was never being set to status `Filled`, causing an _"Insufficient buying power"_ error when calling `Liquidate` later on.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manual testing as described in #1751.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`