### PR TITLE
Fixes benchmark performance tests

### DIFF
--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -62,6 +62,8 @@ namespace QuantConnect.Tests.Engine
             var token = new CancellationToken();
 
             algorithm.Initialize();
+            algorithm.PostInitialize();
+
             results.Initialize(job, new QuantConnect.Messaging.Messaging(), new Api.Api(), feed, new BacktestingSetupHandler(), transactions);
             results.SetAlgorithm(algorithm);
             transactions.Initialize(algorithm, new BacktestingBrokerage(algorithm), results);

--- a/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
@@ -45,6 +45,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             feed.Initialize(algorithm, job, resultHandler, mapFileProvider, factorFileProvider, dataProvider);
             algorithm.Initialize();
+            algorithm.PostInitialize();
 
             var feedThreadStarted = new ManualResetEvent(false);
             var dataFeedThread = new Thread(() =>
@@ -80,6 +81,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         {
             var algorithm = PerformanceBenchmarkAlgorithms.SingleSecurity_Second;
             algorithm.Initialize();
+            algorithm.PostInitialize();
 
             var dataProvider = new DefaultDataProvider();
             var resultHandler = new BacktestingResultHandler();

--- a/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
@@ -50,6 +50,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         private void TestSubscriptionSynchronizerSpeed(QCAlgorithm algorithm)
         {
             algorithm.Initialize();
+            algorithm.PostInitialize();
 
             // set exchanges to be always open
             foreach (var kvp in algorithm.Securities)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
A recent change requires that we call `IAlgorithm.PostInitialize` for universe objects to end up in the `UniverseManager` and some tests weren't properly updated.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1774 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes failing unit tests.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the previously failing tests and noted that they now pass.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

Exiting tests cover these changes.

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->