### PR TITLE
Adds API related keys to config.json of Jupyter project

### DIFF
--- a/Jupyter/config.json
+++ b/Jupyter/config.json
@@ -1,7 +1,14 @@
 {
     // In this configuration file, the data folder and the plugin directory are defined
     // We use absolute paths to be able to load notebooks across different folders
-
     "data-folder": "/root/Lean/Data/",
-    "plugin-directory": "/opt/miniconda3/Lean/"
+    "plugin-directory": "/opt/miniconda3/Lean/",
+
+    // To get your api access token go to quantconnect.com/account
+    "job-user-id": "0",
+    "api-access-token": "",
+
+    // Required to access data from Quandl
+    // To get your access token go to https://www.quandl.com/account/api
+    "quandl-auth-token": ""
 }


### PR DESCRIPTION
#### Description
Adds API related keys to config.json of Jupyter project

#### Related Issue
Closes #1776 

#### Motivation and Context
In order to access data from QuantConnect and Quandl, we need API credentials keys for both services in the config.json file. 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
N/A

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`