### PR TITLE
Removes History method overloads in QuantBook

### DIFF
--- a/Jupyter/BasicQuantBookTemplate.ipynb
+++ b/Jupyter/BasicQuantBookTemplate.ipynb
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "# Gets historical data from the subscribed assets, the last 360 datapoints with daily resolution\n",
-    "h1 = qb.History(360, Resolution.Daily)"
+    "h1 = qb.History(qb.Securities.Keys, 360, Resolution.Daily)"
    ]
   },
   {
@@ -112,7 +112,7 @@
    "outputs": [],
    "source": [
     "# Gets historical data from the subscribed assets, from the last 30 days with daily resolution\n",
-    "h2 = qb.History(timedelta(30), Resolution.Daily)"
+    "h2 = qb.History(qb.Securities.Keys, timedelta(360), Resolution.Daily)"
    ]
   },
   {
@@ -134,7 +134,7 @@
    "outputs": [],
    "source": [
     "# Gets historical data from the subscribed assets, between two dates with daily resolution\n",
-    "h3 = qb.History(btc.Symbol, datetime(2014,1,1), datetime.now(), Resolution.Daily)"
+    "h3 = qb.History([btc.Symbol], datetime(2014,1,1), datetime.now(), Resolution.Daily)"
    ]
   },
   {
@@ -154,8 +154,8 @@
    "outputs": [],
    "source": [
     "# Only fetchs historical data from a desired symbol\n",
-    "h4 = qb.History(spy.Symbol, 360, Resolution.Daily)\n",
-    "# or qb.History(\"SPY\", 360, Resolution.Daily)"
+    "h4 = qb.History([spy.Symbol], 360, Resolution.Daily)\n",
+    "# or qb.History([\"SPY\"], 360, Resolution.Daily)"
    ]
   },
   {
@@ -165,9 +165,8 @@
    "outputs": [],
    "source": [
     "# Only fetchs historical data from a desired symbol\n",
-    "# When we are not dealing with equity, we must use the generic method\n",
-    "h5 = qb.History[QuoteBar](eur.Symbol, timedelta(30), Resolution.Daily)\n",
-    "# or qb.History[QuoteBar](\"EURUSD\", timedelta(30), Resolution.Daily)"
+    "h5 = qb.History([eur.Symbol], timedelta(360), Resolution.Daily)\n",
+    "# or qb.History([\"EURUSD\"], timedelta(30), Resolution.Daily)"
    ]
   },
   {
@@ -177,9 +176,8 @@
    "outputs": [],
    "source": [
     "# Fetchs custom data\n",
-    "# When we are not dealing with custom data, we must use the generic method\n",
-    "h6 = qb.History[FxcmVolume](fxv.Symbol, timedelta(30))\n",
-    "h6.loc[fxv.Symbol.Value][\"Volume\"].plot()"
+    "h6 = qb.History([fxv.Symbol], timedelta(360))\n",
+    "h6.loc[fxv.Symbol.Value][\"volume\"].plot()"
    ]
   },
   {
@@ -209,8 +207,8 @@
    "outputs": [],
    "source": [
     "option_history = qb.GetOptionHistory(goog.Symbol, datetime(2017, 1, 4))\n",
-    "print option_history.GetStrikes()\n",
-    "print option_history.GetExpiryDates()\n",
+    "print (option_history.GetStrikes())\n",
+    "print (option_history.GetExpiryDates())\n",
     "h7 = option_history.GetAllData()"
    ]
   },
@@ -243,7 +241,7 @@
    "outputs": [],
    "source": [
     "future_history = qb.GetFutureHistory(es.Symbol, datetime(2017, 1, 4))\n",
-    "print future_history.GetExpiryDates()\n",
+    "print (future_history.GetExpiryDates())\n",
     "h7 = future_history.GetAllData()"
    ]
   },
@@ -367,7 +365,7 @@
     "# SMA cross:\n",
     "symbol = \"EURUSD\"\n",
     "# Get History \n",
-    "hist = qb.History[QuoteBar](symbol, 500, Resolution.Daily)\n",
+    "hist = qb.History([symbol], 500, Resolution.Daily)\n",
     "# Get the fast moving average\n",
     "fast = qb.Indicator(SimpleMovingAverage(50), symbol, 500, Resolution.Daily)\n",
     "# Get the fast moving average\n",
@@ -417,21 +415,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -83,69 +83,6 @@ namespace QuantConnect.Jupyter
         }
 
         /// <summary>
-        /// Gets the historical data for the specified symbols between the specified dates. The symbols must exist in the Securities collection.
-        /// </summary>
-        /// <param name="span">The span over which to retrieve recent historical data</param>
-        /// <param name="resolution">The resolution to request</param>
-        /// <returns>A pandas.DataFrame containing the requested historical data</returns>
-        public new PyObject History(TimeSpan span, Resolution? resolution = null)
-        {
-            return History(Securities.Keys.ToPython(), span, resolution);
-        }
-
-        /// <summary>
-        /// Get the history for all configured securities over the requested span.
-        /// This will use the resolution and other subscription settings for each security.
-        /// The symbols must exist in the Securities collection.
-        /// </summary>
-        /// <param name="periods">The number of bars to request</param>
-        /// <param name="resolution">The resolution to request</param>
-        /// <returns>A pandas.DataFrame containing the requested historical data</returns>
-        public new PyObject History(int periods, Resolution? resolution = null)
-        {
-            return History(Securities.Keys.ToPython(), periods, resolution);
-        }
-
-        /// <summary>
-        /// Gets the historical data for the specified symbol over the request span. The symbol must exist in the Securities collection.
-        /// </summary>
-        /// <typeparam name="T">The data type of the symbol</typeparam>
-        /// <param name="symbol">The symbol to retrieve historical data for</param>
-        /// <param name="span">The span over which to retrieve recent historical data</param>
-        /// <param name="resolution">The resolution to request</param>
-        /// <returns>An enumerable of slice containing the requested historical data</returns>
-        public new PyObject History(Symbol symbol, TimeSpan span, Resolution? resolution = null)
-        {
-            return History(symbol.ToPython(), span, resolution);
-        }
-
-        /// <summary>
-        /// Gets the historical data for the specified symbol. The exact number of bars will be returned. 
-        /// The symbol must exist in the Securities collection.
-        /// </summary>
-        /// <param name="symbol">The symbol to retrieve historical data for</param>
-        /// <param name="periods">The number of bars to request</param>
-        /// <param name="resolution">The resolution to request</param>
-        /// <returns>An enumerable of slice containing the requested historical data</returns>
-        public new PyObject History(Symbol symbol, int periods, Resolution? resolution = null)
-        {
-            return History(symbol.ToPython(), periods, resolution);
-        }
-
-        /// <summary>
-        /// Gets the historical data for the specified symbol between the specified dates. The symbol must exist in the Securities collection.
-        /// </summary>
-        /// <param name="symbol">The symbol to retrieve historical data for</param>
-        /// <param name="start">The start time in the algorithm's time zone</param>
-        /// <param name="end">The end time in the algorithm's time zone</param>
-        /// <param name="resolution">The resolution to request</param>
-        /// <returns>An enumerable of slice containing the requested historical data</returns>
-        public new PyObject History(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null)
-        {
-            return History(symbol.ToPython(), start, end, resolution);
-        }
-        
-        /// <summary>
         /// Get fundamental data from given symbols
         /// </summary>
         /// <param name="pyObject">The symbols to retrieve fundamental data for</param>

--- a/Tests/Jupyter/QuantBookHistoryTests.cs
+++ b/Tests/Jupyter/QuantBookHistoryTests.cs
@@ -21,7 +21,7 @@ using System.IO;
 
 namespace QuantConnect.Tests.Jupyter
 {
-    [TestFixture, Ignore]
+    [TestFixture, Category("TravisExclude")]
     public class QuantBookHistoryTests
     {
         dynamic _module;

--- a/Tests/Jupyter/RegressionScripts/Test_QuantBookHistory.py
+++ b/Tests/Jupyter/RegressionScripts/Test_QuantBookHistory.py
@@ -35,12 +35,12 @@ class SecurityHistoryTest():
         return "{} on {}".format(self.symbol.ID, self.qb.StartDate)
 
     def test_period_overload(self, period):
-        history = self.qb.History(self.symbol, period)
+        history = self.qb.History([self.symbol], period)
         return history[self.column].unstack(level=0)
 
     def test_daterange_overload(self, end):
         start = end - timedelta(1)
-        history = self.qb.History(self.symbol, start, end)
+        history = self.qb.History([self.symbol], start, end)
         return history[self.column].unstack(level=0)
 
 class OptionHistoryTest(SecurityHistoryTest):
@@ -80,5 +80,5 @@ class MultipleSecuritiesHistoryTest(SecurityHistoryTest):
         self.qb.AddCrypto('BTCUSD', Resolution.Daily)
 
     def test_period_overload(self, period):
-        history = self.qb.History(period)
+        history = self.qb.History(self.qb.Securities.Keys, period)
         return history['close'].unstack(level=0)


### PR DESCRIPTION
#### Description
Removed `History` method overloads in `QuantBook` and made changes in `BasicQuantBookTemplate.ipynb`.

#### Related Issue
Closes #1782 

#### Motivation and Context
`History` method overload should be defined only in `QCAlgorithm` to assure that method class from in an algorithm and in research match. We have defined some `History` method overloads in `QuantBook` that may cause confusion in users that may copy code from research to algorithm lab.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Running `BasicQuantBookTemplate.ipynb`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`