### PR TITLE
Fixes security.Volume for options/futures

### DIFF
--- a/Tests/TestExtensions.cs
+++ b/Tests/TestExtensions.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,6 +14,7 @@
 */
 
 using System.Threading;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace QuantConnect.Tests
@@ -36,6 +37,19 @@ namespace QuantConnect.Tests
             {
                 Assert.Fail(message);
             }
+        }
+
+        /// <summary>
+        /// Asserts that the two JObject instances are equal. This uses <see cref="JToken.DeepEquals"/> wrapped w/ better failure messages
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The actual value</param>
+        /// <param name="property">The property to assert</param>
+        public static void IsEqualTo(this JObject expected, JObject actual, string property)
+        {
+            var e = expected.SelectToken(property);
+            var a = actual.SelectToken(property);
+            Assert.IsTrue(JToken.DeepEquals(e, a), $"{property}: Expected {e}. Actual {a}");
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This change aims to keep the quote bar preference for values in the cache while also ensuring that the volume data is properly being updated. Tests were added to provide coverage around expected property changes from different starting configurations (last data type) and a data update.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1794 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Options/futures securities weren't properly having their volumes recorded in the security cache, leading to all sorts of unexpected behavior in algorithms (especially if you're testing VWAP :P )

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Extensive unit tests added to cover recent changes as well as this change.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->