### PR TITLE
Refactors OnFrameworkData in AlgorithmPythonWrapper

### DIFF
--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -537,13 +537,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// Used to send data updates to algorithm framework models
         /// </summary>
         /// <param name="slice">The current data slice</param>
-        public void OnFrameworkData(Slice slice)
-        {
-            using (Py.GIL())
-            {
-                _algorithm.OnFrameworkData(slice);
-            }
-        }
+        public void OnFrameworkData(Slice slice) => _baseAlgorithm.OnFrameworkData(slice);
 
         /// <summary>
         /// Call this event at the end of the algorithm running.


### PR DESCRIPTION
#### Description
`AlgorithmPythonWrapper.OnFrameworkData` should call the base class method (`QCAlgorithmFramework.OnFrameworkData`) directly instead of trying to call this method from the python script.

#### Related Issue
Closes #1796 

#### Motivation and Context
Since `QCAlgorithmFramework.OnFrameworkData` is a `sealed` method, python algorithms cannot inherit from it, therefore `AlgorithmPythonWrapper.OnFrameworkData` can call it directly from the base class.

#### Requires Documentation Change
No.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).  
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`