### PR TITLE
Prevent order status overwriting in BrokerageTransactionHandler.HandleSubmitOrderRequest

### DIFF
--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -744,7 +744,6 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 return response;
             }
 
-            order.Status = OrderStatus.Submitted;
             return OrderResponse.Success(request);
         }
 


### PR DESCRIPTION

#### Description
The order status is no longer set to `OrderStatus.Submitted` in the `HandleSubmitOrderRequest `method of `BrokerageTransactionHandler`. We assume that brokerage implementations are responsible for firing `Submitted` order events in `PlaceOrder`.

#### Related Issue
Fixes #1799

#### Motivation and Context
The order status should be set to `Submitted` only in `PlaceOrder` (for all brokerage implementations).

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually tested with the algorithm in #1799

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`