### PR TITLE
Add VWAP and STD execution models

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -159,8 +159,10 @@
     <Compile Include="ParameterizedAlgorithm.cs" />
     <Compile Include="HourReverseSplitRegressionAlgorithm.cs" />
     <Compile Include="HourSplitRegressionAlgorithm.cs" />
+    <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.cs" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.cs" />
     <Compile Include="UserDefinedUniverseAlgorithm.cs" />
+    <Compile Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs" />
     <Compile Include="WarmupAlgorithm.cs" />
     <Compile Include="WarmupHistoryAlgorithm.cs" />
     <Compile Include="MACDTrendAlgorithm.cs" />

--- a/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm for the StandardDeviationExecutionModel.
+    /// This algorithm shows how the execution model works to split up orders and submit them only when
+    /// the price is 2 standard deviations from the 60min mean (default model settings).
+    /// </summary>
+    public class StandardDeviationExecutionModelRegressionAlgorithm : QCAlgorithmFramework
+    {
+        public override void Initialize()
+        {
+            UniverseSettings.Resolution = Resolution.Minute;
+
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+            SetCash(1000000);
+
+            UniverseSelection = new ManualUniverseSelectionModel(
+                QuantConnect.Symbol.Create("AIG", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("BAC", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)
+            );
+
+            // using hourly rsi to generate more insights
+            Alpha = new RsiAlphaModel(14, Resolution.Hour);
+            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
+            Execution = new StandardDeviationExecutionModel();
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Log($"{Time}: {orderEvent}");
+        }
+    }
+}

--- a/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm for the VolumeWeightedAveragePriceExecutionModel.
+    /// This algorithm shows how the execution model works to split up orders and submit them only when
+    /// the price is on the favorable side of the intraday VWAP.
+    /// </summary>
+    public class VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm : QCAlgorithmFramework
+    {
+        public override void Initialize()
+        {
+            UniverseSettings.Resolution = Resolution.Minute;
+
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+            SetCash(1000000);
+
+            UniverseSelection = new ManualUniverseSelectionModel(
+                QuantConnect.Symbol.Create("AIG", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("BAC", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)
+            );
+
+            // using hourly rsi to generate more insights
+            Alpha = new RsiAlphaModel(14, Resolution.Hour);
+            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
+            Execution = new VolumeWeightedAveragePriceExecutionModel();
+
+            InsightsGenerated += (algorithm, data) => Log($"{Time}: {string.Join(" | ", data.Insights)}");
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Log($"{Time}: {orderEvent}");
+        }
+    }
+}

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
     {
         private readonly int _fastPeriod;
         private readonly int _slowPeriod;
+        private readonly Resolution _resolution;
         private readonly int _predictionInterval;
         private readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol;
 
@@ -37,13 +38,16 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// </summary>
         /// <param name="fastPeriod">The fast EMA period</param>
         /// <param name="slowPeriod">The slow EMA period</param>
+        /// <param name="resolution">The resolution of data sent into the EMA indicators</param>
         public EmaCrossAlphaModel(
             int fastPeriod = 12,
-            int slowPeriod = 26
+            int slowPeriod = 26,
+            Resolution resolution = Resolution.Daily
             )
         {
             _fastPeriod = fastPeriod;
             _slowPeriod = slowPeriod;
+            _resolution = resolution;
             _predictionInterval = fastPeriod;
             _symbolDataBySymbol = new Dictionary<Symbol, SymbolData>();
         }
@@ -62,7 +66,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             {
                 if (symbolData.Fast.IsReady && symbolData.Slow.IsReady)
                 {
-                    var insightPeriod = symbolData.DataResolution.Multiply(_predictionInterval);
+                    var insightPeriod = _resolution.ToTimeSpan().Multiply(_predictionInterval);
                     if (symbolData.FastIsOverSlow)
                     {
                         if (symbolData.Slow > symbolData.Fast)
@@ -125,7 +129,6 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             public Symbol Symbol => Security.Symbol;
             public ExponentialMovingAverage Fast { get; set; }
             public ExponentialMovingAverage Slow { get; set; }
-            public TimeSpan DataResolution => Security.Resolution.ToTimeSpan();
 
             /// <summary>
             /// True if the fast is above the slow, otherwise false.

--- a/Algorithm.Framework/Alphas/MacdAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/MacdAlphaModel.cs
@@ -34,6 +34,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private readonly int _slowPeriod;
         private readonly int _signalPeriod;
         private readonly MovingAverageType _movingAverageType;
+        private readonly Resolution _resolution;
         private const decimal BounceThresholdPercent = 0.01m;
         private readonly Dictionary<Symbol, SymbolData> _symbolData;
 
@@ -44,17 +45,20 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="slowPeriod">The MACD slow period</param>
         /// <param name="signalPeriod">The smoothing period for the MACD signal</param>
         /// <param name="movingAverageType">The type of moving average to use in the MACD</param>
+        /// <param name="resolution">The resolution of data sent into the MACD indicator</param>
         public MacdAlphaModel(
             int fastPeriod = 12,
             int slowPeriod = 26,
             int signalPeriod = 9,
-            MovingAverageType movingAverageType = MovingAverageType.Exponential
+            MovingAverageType movingAverageType = MovingAverageType.Exponential,
+            Resolution resolution = Resolution.Daily
             )
         {
             _fastPeriod = fastPeriod;
             _slowPeriod = slowPeriod;
             _signalPeriod = signalPeriod;
             _movingAverageType = movingAverageType;
+            _resolution = resolution;
             _symbolData = new Dictionary<Symbol, SymbolData>();
         }
 
@@ -90,7 +94,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                     continue;
                 }
 
-                var insightPeriod = sd.DataResolution.Multiply(_fastPeriod);
+                var insightPeriod = _resolution.ToTimeSpan().Multiply(_fastPeriod);
                 var insight = new Insight(sd.Security.Symbol, InsightType.Price, direction, insightPeriod);
                 sd.PreviousDirection = insight.Direction;
                 yield return insight;
@@ -107,7 +111,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         {
             foreach (var added in changes.AddedSecurities)
             {
-                _symbolData.Add(added.Symbol, new SymbolData(algorithm, added, _fastPeriod, _slowPeriod, _signalPeriod, _movingAverageType));
+                _symbolData.Add(added.Symbol, new SymbolData(algorithm, added, _fastPeriod, _slowPeriod, _signalPeriod, _movingAverageType, _resolution));
             }
 
             foreach (var removed in changes.RemovedSecurities)
@@ -128,12 +132,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             public readonly Security Security;
             public readonly IDataConsolidator Consolidator;
             public readonly MovingAverageConvergenceDivergence MACD;
-            public TimeSpan DataResolution => Security.Resolution.ToTimeSpan();
 
-            public SymbolData(QCAlgorithmFramework algorithm, Security security, int fastPeriod, int slowPeriod, int signalPeriod, MovingAverageType movingAverageType)
+            public SymbolData(QCAlgorithmFramework algorithm, Security security, int fastPeriod, int slowPeriod, int signalPeriod, MovingAverageType movingAverageType, Resolution resolution)
             {
                 Security = security;
-                Consolidator = algorithm.ResolveConsolidator(security.Symbol, security.Resolution);
+                Consolidator = algorithm.ResolveConsolidator(security.Symbol, resolution);
                 algorithm.SubscriptionManager.AddConsolidator(security.Symbol, Consolidator);
 
                 MACD = algorithm.MACD(security.Symbol, fastPeriod, slowPeriod, signalPeriod, movingAverageType);

--- a/Algorithm.Framework/Execution/IExecutionModel.cs
+++ b/Algorithm.Framework/Execution/IExecutionModel.cs
@@ -28,7 +28,8 @@ namespace QuantConnect.Algorithm.Framework.Execution
         /// This model is free to delay or spread out these orders as it sees fit
         /// </summary>
         /// <param name="algorithm">The algorithm instance</param>
-        /// <param name="targets">The portfolio targets to be ordered</param>
+        /// <param name="targets">The portfolio targets just emitted by the portfolio construction model.
+        /// These are always just the new/updated targets and not a complete set of targets</param>
         void Execute(QCAlgorithmFramework algorithm, IEnumerable<IPortfolioTarget> targets);
     }
 }

--- a/Algorithm.Framework/Execution/OrderSizing.cs
+++ b/Algorithm.Framework/Execution/OrderSizing.cs
@@ -1,0 +1,100 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.Framework.Execution
+{
+    /// <summary>
+    /// Provides methods for computing a maximum order size.
+    /// </summary>
+    public static class OrderSizing
+    {
+        /// <summary>
+        /// Gets the maximum order size as a percentage of the current bar's volume.
+        /// </summary>
+        /// <param name="security">The security object</param>
+        /// <param name="maximumPercentCurrentVolume">The maximum percentage of the current bar's volume</param>
+        /// <returns>The fractional quantity of shares that equal the specified percentage of the current bar's volume</returns>
+        public static decimal PercentVolume(Security security, decimal maximumPercentCurrentVolume)
+        {
+            return maximumPercentCurrentVolume * security.Volume;
+        }
+
+        /// <summary>
+        /// Gets the maximum order size using a maximum order value in units of the account currency
+        /// </summary>
+        /// <param name="security">The security object</param>
+        /// <param name="maximumOrderValueInAccountCurrency">The maximum order value in units of the account currency</param>
+        /// <returns>The quantity of fractional of shares that yield the specified maximum order value</returns>
+        public static decimal Value(Security security, decimal maximumOrderValueInAccountCurrency)
+        {
+            var priceInAccountCurrency = security.Price * security.QuoteCurrency.ConversionRate;
+
+            if (priceInAccountCurrency == 0m)
+            {
+                return 0m;
+            }
+
+            return maximumOrderValueInAccountCurrency / priceInAccountCurrency;
+        }
+
+        /// <summary>
+        /// Gets the remaining quantity to be ordered to reach the specified target quantity
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="target">The portfolio target</param>
+        /// <returns>The remaining quantity to be ordered</returns>
+        public static decimal GetUnorderedQuantity(QCAlgorithmFramework algorithm, IPortfolioTarget target)
+        {
+            var security = algorithm.Securities[target.Symbol];
+            var baseCurrency = security as IBaseCurrencySymbol;
+            if (baseCurrency != null && algorithm.BrokerageModel.AccountType == AccountType.Cash)
+            {
+                // security represents a currency swap <base>/<quote>
+                var quoteC = security.QuoteCurrency;
+                var baseC = algorithm.Portfolio.CashBook[baseCurrency.BaseCurrencySymbol];
+
+                // resolve which way we need to exchange to reach the target
+                var source = target.Quantity > baseC.Amount ? quoteC : baseC;
+                var destination = source == quoteC ? baseC : quoteC;
+                var delta = target.Quantity - destination.Amount;
+
+                // check if we're below the lot size threshold
+                if (Math.Abs(delta) < security.SymbolProperties.LotSize)
+                {
+                    return 0m;
+                }
+
+                return delta;
+            }
+
+            var holdings = security.Holdings.Quantity;
+            var openOrderQuantity = algorithm.Transactions.GetOpenOrders(target.Symbol).Sum(o => o.Quantity);
+            var quantity = target.Quantity - holdings - openOrderQuantity;
+
+            // check if we're below the lot size threshold
+            if (Math.Abs(quantity) < security.SymbolProperties.LotSize)
+            {
+                return 0m;
+            }
+
+            return quantity;
+        }
+    }
+}

--- a/Algorithm.Framework/Execution/OrderSizing.cs
+++ b/Algorithm.Framework/Execution/OrderSizing.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Algorithm.Framework.Execution
         }
 
         /// <summary>
-        /// Gets the remaining quantity to be ordered to reach the specified target quantity
+        /// Gets the remaining quantity to be ordered to reach the specified target quantity.
         /// </summary>
         /// <param name="algorithm">The algorithm instance</param>
         /// <param name="target">The portfolio target</param>
@@ -63,27 +63,6 @@ namespace QuantConnect.Algorithm.Framework.Execution
         public static decimal GetUnorderedQuantity(QCAlgorithmFramework algorithm, IPortfolioTarget target)
         {
             var security = algorithm.Securities[target.Symbol];
-            var baseCurrency = security as IBaseCurrencySymbol;
-            if (baseCurrency != null && algorithm.BrokerageModel.AccountType == AccountType.Cash)
-            {
-                // security represents a currency swap <base>/<quote>
-                var quoteC = security.QuoteCurrency;
-                var baseC = algorithm.Portfolio.CashBook[baseCurrency.BaseCurrencySymbol];
-
-                // resolve which way we need to exchange to reach the target
-                var source = target.Quantity > baseC.Amount ? quoteC : baseC;
-                var destination = source == quoteC ? baseC : quoteC;
-                var delta = target.Quantity - destination.Amount;
-
-                // check if we're below the lot size threshold
-                if (Math.Abs(delta) < security.SymbolProperties.LotSize)
-                {
-                    return 0m;
-                }
-
-                return delta;
-            }
-
             var holdings = security.Holdings.Quantity;
             var openOrderQuantity = algorithm.Transactions.GetOpenOrders(target.Symbol).Sum(o => o.Quantity);
             var quantity = target.Quantity - holdings - openOrderQuantity;

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.cs
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.cs
@@ -1,0 +1,207 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Indicators;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.Framework.Execution
+{
+    /// <summary>
+    /// Execution model that submits orders while the current market prices is at least the configured number of standard
+    /// deviations away from the mean in the favorable direction (below/above for buy/sell respectively)
+    /// </summary>
+    public class StandardDeviationExecutionModel : IExecutionModel
+    {
+        private readonly int _period;
+        private readonly decimal _deviations;
+        private readonly Resolution _resolution;
+        private readonly PortfolioTargetCollection _targetsCollection;
+        private readonly Dictionary<Symbol, SymbolData> _symbolData;
+
+        /// <summary>
+        /// Gets or sets the maximum order value in units of the account currency.
+        /// This defaults to $20,000. For example, if purchasing a stock with a price
+        /// of $100, then the maximum order size would be 200 shares.
+        /// </summary>
+        public decimal MaximumOrderValue { get; set; } = 20 * 1000;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StandardDeviationExecutionModel"/> class
+        /// </summary>
+        /// <param name="period">Period of the standard deviation indicator</param>
+        /// <param name="deviations">The number of deviations away from the mean before submitting an order</param>
+        /// <param name="resolution">The resolution of the STD and SMA indicators</param>
+        public StandardDeviationExecutionModel(
+            int period = 60,
+            decimal deviations = 2m,
+            Resolution resolution = Resolution.Minute
+            )
+        {
+            _period = period;
+            _deviations = deviations;
+            _resolution = resolution;
+            _targetsCollection = new PortfolioTargetCollection();
+            _symbolData = new Dictionary<Symbol, SymbolData>();
+        }
+
+        /// <summary>
+        /// Executes market orders if the standard deviation of price is more than the configured number of deviations
+        /// in the favorable direction.
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="targets">The portfolio targets</param>
+        public void Execute(QCAlgorithmFramework algorithm, IEnumerable<IPortfolioTarget> targets)
+        {
+            _targetsCollection.AddRange(targets);
+
+            foreach (var target in _targetsCollection)
+            {
+                var symbol = target.Symbol;
+
+                // calculate remaining quantity to be ordered
+                var unorderedQuantity = OrderSizing.GetUnorderedQuantity(algorithm, target);
+
+                // fetch our symbol data containing our STD/SMA indicators
+                SymbolData data;
+                if (!_symbolData.TryGetValue(symbol, out data))
+                {
+                    continue;
+                }
+
+                // ensure we're receiving price data before submitting orders
+                if (data.Security.Price == 0m)
+                {
+                    continue;
+                }
+
+                // check order entry conditions
+                if (data.STD.IsReady && PriceIsFavorable(data, unorderedQuantity))
+                {
+                    // get the maximum order size based on total order value
+                    var maxOrderSize = OrderSizing.Value(data.Security, MaximumOrderValue);
+                    var orderSize = Math.Min(maxOrderSize, Math.Abs(unorderedQuantity));
+
+                    // round down to even lot size
+                    orderSize -= orderSize % data.Security.SymbolProperties.LotSize;
+                    if (orderSize != 0)
+                    {
+                        algorithm.MarketOrder(symbol, Math.Sign(unorderedQuantity) * orderSize);
+                    }
+                }
+
+                // check to see if we're done with this target
+                unorderedQuantity = OrderSizing.GetUnorderedQuantity(algorithm, target);
+                if (unorderedQuantity == 0m)
+                {
+                    _targetsCollection.Remove(target.Symbol);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
+        /// <param name="changes">The security additions and removals from the algorithm</param>
+        public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        {
+            foreach (var added in changes.AddedSecurities)
+            {
+                // initialize new securities
+                if (!_symbolData.ContainsKey(added.Symbol))
+                {
+                    _symbolData[added.Symbol] = new SymbolData(algorithm, added, _period, _resolution);
+                }
+            }
+
+            foreach (var removed in changes.RemovedSecurities)
+            {
+                // clean up data from removed securities
+                SymbolData data;
+                if (_symbolData.TryGetValue(removed.Symbol, out data))
+                {
+                    _symbolData.Remove(removed.Symbol);
+                    algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, data.Consolidator);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines if the current price is more than the configured number of standard deviations
+        /// away from the mean in the favorable direction.
+        /// </summary>
+        private bool PriceIsFavorable(SymbolData data, decimal unorderedQuantity)
+        {
+            if (unorderedQuantity > 0)
+            {
+                var price = data.Security.BidPrice == 0
+                    ? data.Security.Price
+                    : data.Security.BidPrice;
+
+                var threshold = data.SMA - _deviations * data.STD;
+
+                if (price < threshold)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                var price = data.Security.AskPrice == 0
+                    ? data.Security.AskPrice
+                    : data.Security.Price;
+
+                var threshold = data.SMA + _deviations * data.STD;
+
+                if (price > threshold)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        class SymbolData
+        {
+            public Security Security { get; }
+            public StandardDeviation STD { get; }
+            public SimpleMovingAverage SMA { get; }
+            public IDataConsolidator Consolidator { get; }
+
+            public SymbolData(QCAlgorithmFramework algorithm, Security security, int period, Resolution resolution)
+            {
+                Security = security;
+                Consolidator = algorithm.ResolveConsolidator(security.Symbol, resolution);
+                var smaName = algorithm.CreateIndicatorName(security.Symbol, "SMA" + period, resolution);
+                SMA = new SimpleMovingAverage(smaName, period);
+                var stdName = algorithm.CreateIndicatorName(security.Symbol, "STD" + period, resolution);
+                STD = new StandardDeviation(stdName, period);
+
+                algorithm.SubscriptionManager.AddConsolidator(security.Symbol, Consolidator);
+                Consolidator.DataConsolidated += (sender, consolidated) =>
+                {
+                    SMA.Update(consolidated.EndTime, consolidated.Value);
+                    STD.Update(consolidated.EndTime, consolidated.Value);
+                };
+            }
+        }
+    }
+}

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.cs
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.cs
@@ -149,17 +149,16 @@ namespace QuantConnect.Algorithm.Framework.Execution
         /// </summary>
         private bool PriceIsFavorable(SymbolData data, decimal unorderedQuantity)
         {
+            var deviations = _deviations * data.STD;
             if (unorderedQuantity > 0)
             {
                 var price = data.Security.BidPrice == 0
                     ? data.Security.Price
                     : data.Security.BidPrice;
 
-                var threshold = data.SMA - _deviations * data.STD;
-
-                if (price < threshold)
+                if (price < data.SMA - deviations)
                 {
-                    return false;
+                    return true;
                 }
             }
             else
@@ -168,15 +167,13 @@ namespace QuantConnect.Algorithm.Framework.Execution
                     ? data.Security.AskPrice
                     : data.Security.Price;
 
-                var threshold = data.SMA + _deviations * data.STD;
-
-                if (price > threshold)
+                if (price > data.SMA + deviations)
                 {
-                    return false;
+                    return true;
                 }
             }
 
-            return true;
+            return false;
         }
 
         class SymbolData

--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
@@ -1,0 +1,269 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Indicators;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.Framework.Execution
+{
+    /// <summary>
+    /// Execution model that submits orders while the current market price is more favorable that the current volume weighted average price.
+    /// </summary>
+    public class VolumeWeightedAveragePriceExecutionModel : IExecutionModel
+    {
+        private readonly PortfolioTargetCollection _targetsCollection = new PortfolioTargetCollection();
+        private readonly Dictionary<Symbol, SymbolData> _symbolData = new Dictionary<Symbol, SymbolData>();
+
+        /// <summary>
+        /// Gets or sets the maximum order quantity as a percentage of the current bar's volume.
+        /// This defaults to 0.01m = 1%. For example, if the current bar's volume is 100, then
+        /// the maximum order size would equal 1 share.
+        /// </summary>
+        public decimal MaximumOrderQuantityPercentVolume { get; set; } = 0.01m;
+
+        /// <summary>
+        /// Submit orders for the specified portolio targets.
+        /// This model is free to delay or spread out these orders as it sees fit
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="targets">The portfolio targets to be ordered</param>
+        public void Execute(QCAlgorithmFramework algorithm, IEnumerable<IPortfolioTarget> targets)
+        {
+            // update the complete set of portfolio targets with the new targets
+            _targetsCollection.AddRange(targets);
+
+            foreach (var target in _targetsCollection)
+            {
+                var symbol = target.Symbol;
+
+                // calculate remaining quantity to be ordered
+                var unorderedQuantity = OrderSizing.GetUnorderedQuantity(algorithm, target);
+
+                // fetch our symbol data containing our VWAP indicator
+                SymbolData data;
+                if (!_symbolData.TryGetValue(symbol, out data))
+                {
+                    continue;
+                }
+
+                // ensure we're receiving price data before submitting orders
+                if (data.Security.Price == 0m)
+                {
+                    continue;
+                }
+
+                // check order entry conditions
+                if (PriceIsFavorable(data, unorderedQuantity))
+                {
+                    // get the maximum order size based on a percentage of current volume
+                    var maxOrderSize = OrderSizing.PercentVolume(data.Security, MaximumOrderQuantityPercentVolume);
+                    var orderSize = Math.Min(maxOrderSize, Math.Abs(unorderedQuantity));
+
+                    // round down to even lot size
+                    orderSize -= orderSize % data.Security.SymbolProperties.LotSize;
+                    if (orderSize != 0)
+                    {
+                        algorithm.MarketOrder(data.Security.Symbol, Math.Sign(unorderedQuantity) * orderSize);
+                    }
+                }
+
+                // check to see if we're done with this target
+                unorderedQuantity = OrderSizing.GetUnorderedQuantity(algorithm, target);
+                if (unorderedQuantity == 0m)
+                {
+                    _targetsCollection.Remove(target.Symbol);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
+        /// <param name="changes">The security additions and removals from the algorithm</param>
+        public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        {
+            foreach (var added in changes.AddedSecurities)
+            {
+                if (!_symbolData.ContainsKey(added.Symbol))
+                {
+                    _symbolData[added.Symbol] = new SymbolData(algorithm, added);
+                }
+            }
+
+            foreach (var removed in changes.RemovedSecurities)
+            {
+                // clean up removed security data
+                SymbolData data;
+                if (_symbolData.TryGetValue(removed.Symbol, out data))
+                {
+                    _symbolData.Remove(removed.Symbol);
+                    algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, data.Consolidator);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines if the current price is better than VWAP
+        /// </summary>
+        private bool PriceIsFavorable(SymbolData data, decimal unorderedQuantity)
+        {
+            var vwap = data.VWAP;
+            if (unorderedQuantity > 0)
+            {
+                var price = data.Security.BidPrice == 0
+                    ? data.Security.Price
+                    : data.Security.BidPrice;
+
+                if (price > vwap)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                var price = data.Security.AskPrice == 0
+                    ? data.Security.AskPrice
+                    : data.Security.Price;
+
+                if (price < vwap)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private class SymbolData
+        {
+            public Security Security { get; }
+            public IntradayVwap VWAP { get; }
+            public IDataConsolidator Consolidator { get; }
+
+            public SymbolData(QCAlgorithmFramework algorithm, Security security)
+            {
+                Security = security;
+                Consolidator = algorithm.ResolveConsolidator(security.Symbol, security.Resolution);
+                var name = algorithm.CreateIndicatorName(security.Symbol, "VWAP", security.Resolution);
+                VWAP = new IntradayVwap(name);
+
+                algorithm.RegisterIndicator(security.Symbol, VWAP, Consolidator, bd => (BaseData) bd);
+            }
+        }
+
+        /// <summary>
+        /// Defines the canonical intraday VWAP indicator
+        /// </summary>
+        public class IntradayVwap : IndicatorBase<BaseData>
+        {
+            private DateTime _lastDate;
+            private decimal _sumOfVolume;
+            private decimal _sumOfPriceTimesVolume;
+
+            /// <summary>
+            /// Gets a flag indicating when this indicator is ready and fully initialized
+            /// </summary>
+            public override bool IsReady => _sumOfVolume > 0;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="IntradayVwap"/> class
+            /// </summary>
+            /// <param name="name">The name of the indicator</param>
+            public IntradayVwap(string name)
+                : base(name)
+            {
+            }
+
+            /// <summary>
+            /// Computes the new VWAP
+            /// </summary>
+            protected override IndicatorResult ValidateAndComputeNextValue(BaseData input)
+            {
+                decimal volume, averagePrice;
+                if (!TryGetVolumeAndAveragePrice(input, out volume, out averagePrice))
+                {
+                    return new IndicatorResult(0, IndicatorStatus.InvalidInput);
+                }
+
+                // reset vwap on daily boundaries
+                if (_lastDate != input.EndTime.Date)
+                {
+                    _sumOfVolume = 0m;
+                    _sumOfPriceTimesVolume = 0m;
+                    _lastDate = input.EndTime.Date;
+                }
+
+                // running totals for Σ PiVi / Σ Vi
+                _sumOfVolume += volume;
+                _sumOfPriceTimesVolume += averagePrice * volume;
+
+                if (_sumOfVolume == 0m)
+                {
+                    // if we have no trade volume then use the current price as VWAP
+                    return input.Value;
+                }
+
+                return _sumOfPriceTimesVolume / _sumOfVolume;
+            }
+
+            /// <summary>
+            /// Computes the next value of this indicator from the given state.
+            /// NOTE: This must be overriden since it's abstract in the base, but
+            /// will never be invoked since we've override the validate method above.
+            /// </summary>
+            /// <param name="input">The input given to the indicator</param>
+            /// <returns>A new value for this indicator</returns>
+            protected override decimal ComputeNextValue(BaseData input)
+            {
+                throw new NotImplementedException($"{nameof(IntradayVwap)}.{nameof(ComputeNextValue)} should never be invoked.");
+            }
+
+            /// <summary>
+            /// Determines the volume and price to be used for the current input in the VWAP computation
+            /// </summary>
+            protected bool TryGetVolumeAndAveragePrice(BaseData input, out decimal volume, out decimal averagePrice)
+            {
+                var tick = input as Tick;
+
+                if (tick?.TickType == TickType.Trade)
+                {
+                    volume = tick.Quantity;
+                    averagePrice = tick.LastPrice;
+                    return true;
+                }
+
+                var tradeBar = input as TradeBar;
+                if (tradeBar?.IsFillForward == false)
+                {
+                    volume = tradeBar.Volume;
+                    averagePrice = (tradeBar.High + tradeBar.Low + tradeBar.Close) / 3m;
+                    return true;
+                }
+
+                volume = 0;
+                averagePrice = 0;
+                return false;
+            }
+        }
+    }
+}

--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
@@ -134,9 +134,9 @@ namespace QuantConnect.Algorithm.Framework.Execution
                     ? data.Security.Price
                     : data.Security.BidPrice;
 
-                if (price > vwap)
+                if (price < vwap)
                 {
-                    return false;
+                    return true;
                 }
             }
             else
@@ -145,13 +145,13 @@ namespace QuantConnect.Algorithm.Framework.Execution
                     ? data.Security.AskPrice
                     : data.Security.Price;
 
-                if (price < vwap)
+                if (price > vwap)
                 {
-                    return false;
+                    return true;
                 }
             }
 
-            return true;
+            return false;
         }
 
         private class SymbolData

--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Data;
 using QuantConnect.Data.Consolidators;
@@ -116,10 +117,22 @@ namespace QuantConnect.Algorithm.Framework.Execution
                 SymbolData data;
                 if (_symbolData.TryGetValue(removed.Symbol, out data))
                 {
-                    _symbolData.Remove(removed.Symbol);
-                    algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, data.Consolidator);
+                    if (IsSafeToRemove(algorithm, removed.Symbol))
+                    {
+                        _symbolData.Remove(removed.Symbol);
+                        algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, data.Consolidator);
+                    }
                 }
             }
+        }
+
+        /// <summary>
+        /// Determines if it's safe to remove the associated symbol data
+        /// </summary>
+        private bool IsSafeToRemove(QCAlgorithmFramework algorithm, Symbol symbol)
+        {
+            // confirm the security isn't currently a member of any universe
+            return !algorithm.UniverseManager.Any(kvp => kvp.Value.ContainsMember(symbol));
         }
 
         /// <summary>

--- a/Algorithm.Framework/NotifiedSecurityChanges.cs
+++ b/Algorithm.Framework/NotifiedSecurityChanges.cs
@@ -98,7 +98,7 @@ namespace QuantConnect.Algorithm.Framework
             );
         }
 
-        private static void Update(SecurityChanges changes, Action<Security> add, Action<Security> remove)
+        public static void Update(SecurityChanges changes, Action<Security> add, Action<Security> remove)
         {
             foreach (var added in changes.AddedSecurities)
             {

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -43,6 +43,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             var targets = new List<IPortfolioTarget>();
             if (_removedSymbols != null)
             {
+                // zero out securities removes from the universe
                 targets.AddRange(_removedSymbols.Select(s => new PortfolioTarget(s, 0)));
                 _removedSymbols = null;
             }

--- a/Algorithm.Framework/QCAlgorithmFramework.cs
+++ b/Algorithm.Framework/QCAlgorithmFramework.cs
@@ -100,6 +100,14 @@ namespace QuantConnect.Algorithm.Framework
 
             InsightsGenerated += (algorithm, data) => Log($"{Time}: {string.Join(" | ", data.Insights.OrderBy(i => i.Symbol.ToString()))}");
 
+            // emit warning message about using the framework with cash modelling
+            if (BrokerageModel.AccountType == AccountType.Cash)
+            {
+                Error("These models are currently unsuitable for Cash Modeled brokerages (e.g. GDAX) and may result in unexpected trades."
+                    + " To prevent possible user error we've restricted them to Margin trading. You can select margin account types with"
+                    + " SetBrokerage( ... AccountType.Margin)");
+            }
+
             base.PostInitialize();
         }
 

--- a/Algorithm.Framework/QCAlgorithmFramework.cs
+++ b/Algorithm.Framework/QCAlgorithmFramework.cs
@@ -98,7 +98,10 @@ namespace QuantConnect.Algorithm.Framework
                 AddUniverse(universe);
             }
 
-            InsightsGenerated += (algorithm, data) => Log($"{Time}: {string.Join(" | ", data.Insights.OrderBy(i => i.Symbol.ToString()))}");
+            if (DebugMode)
+            {
+                InsightsGenerated += (algorithm, data) => Log($"{Time}: {string.Join(" | ", data.Insights.OrderBy(i => i.Symbol.ToString()))}");
+            }
 
             // emit warning message about using the framework with cash modelling
             if (BrokerageModel.AccountType == AccountType.Cash)

--- a/Algorithm.Framework/QCAlgorithmFramework.cs
+++ b/Algorithm.Framework/QCAlgorithmFramework.cs
@@ -97,6 +97,8 @@ namespace QuantConnect.Algorithm.Framework
                 AddUniverse(universe);
             }
 
+            InsightsGenerated += (algorithm, data) => Log($"{Time}: {string.Join(" | ", data.Insights.OrderBy(i => i.Symbol.ToString()))}");
+
             base.PostInitialize();
         }
 

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -60,6 +60,9 @@
     <Compile Include="Execution\ImmediateExecutionModel.cs" />
     <Compile Include="Execution\NullExecutionModel.cs" />
     <Compile Include="Execution\ExecutionModelPythonWrapper.cs" />
+    <Compile Include="Execution\OrderSizing.cs" />
+    <Compile Include="Execution\StandardDeviationExecutionModel.cs" />
+    <Compile Include="Execution\VolumeWeightedAveragePriceExecutionModel.cs" />
     <Compile Include="INotifiedSecurityChanges.cs" />
     <Compile Include="NotifiedSecurityChanges.cs" />
     <Compile Include="Portfolio\IPortfolioConstructionModel.cs" />

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1244,7 +1244,7 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Creates a WilderMovingAverage indicator for the symbol. 
+        /// Creates a WilderMovingAverage indicator for the symbol.
         /// The indicator will be automatically updated on the given resolution.
         /// </summary>
         /// <param name="symbol">The symbol whose WMA we want</param>

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1212,6 +1212,20 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Creates the canonical VWAP indicator that resets each day. The indicator will be automatically
+        /// updated on the security's configured resolution.
+        /// </summary>
+        /// <param name="symbol">The symbol whose VWAP we want</param>
+        /// <returns>The IntradayVWAP for the specified symbol</returns>
+        public IntradayVwap VWAP(Symbol symbol)
+        {
+            var name = CreateIndicatorName(symbol, "VWAP", null);
+            var vwap = new IntradayVwap(name);
+            RegisterIndicator(symbol, vwap);
+            return vwap;
+        }
+
+        /// <summary>
         /// Creates a new Williams %R indicator. This will compute the percentage change of
         /// the current closing price in relation to the high and low of the past N periods.
         /// The indicator will be automatically updated on the given resolution.

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
@@ -89,7 +89,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            return $"{Quantity.Normalize()} {Symbol}";
+            return $"{Symbol}: {Quantity.Normalize()}";
         }
     }
 }

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
@@ -89,7 +89,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            return $"{Quantity} {Symbol}";
+            return $"{Quantity.Normalize()} {Symbol}";
         }
     }
 }

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTargetCollection.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTargetCollection.cs
@@ -1,0 +1,277 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.Framework.Portfolio
+{
+    /// <summary>
+    /// Provides a collection for managing <see cref="IPortfolioTarget"/>s for each symbol
+    /// </summary>
+    public class PortfolioTargetCollection : ICollection<IPortfolioTarget>, IDictionary<Symbol, IPortfolioTarget>
+    {
+        private readonly ConcurrentDictionary<Symbol, IPortfolioTarget> _targets = new ConcurrentDictionary<Symbol, IPortfolioTarget>();
+
+        /// <summary>
+        /// Gets the number of targets in this collection
+        /// </summary>
+        public int Count => _targets.Count;
+
+        /// <summary>
+        /// Gets `false`. This collection is not read-only.
+        /// </summary>
+        public bool IsReadOnly => false;
+
+        /// <summary>
+        /// Gets the symbol keys for this collection
+        /// </summary>
+        public ICollection<Symbol> Keys => _targets.Keys;
+
+        /// <summary>
+        /// Gets all portfolio targets in this collection
+        /// </summary>
+        public ICollection<IPortfolioTarget> Values => _targets.Values;
+
+        /// <summary>
+        /// Adds the specified target to the collection. If a target for the same symbol
+        /// already exists it wil be overwritten.
+        /// </summary>
+        /// <param name="target">The portfolio target to add</param>
+        public void Add(IPortfolioTarget target)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            _targets[target.Symbol] = target;
+        }
+
+        /// <summary>
+        /// Adds the specified target to the collection. If a target for the same symbol
+        /// already exists it wil be overwritten.
+        /// </summary>
+        /// <param name="target">The portfolio target to add</param>
+        public void Add(KeyValuePair<Symbol, IPortfolioTarget> target)
+        {
+            WithDictionary(d => d.Add(target));
+        }
+
+        /// <summary>
+        /// Adds the specified target to the collection. If a target for the same symbol
+        /// already exists it wil be overwritten.
+        /// </summary>
+        /// <param name="symbol">The symbol key</param>
+        /// <param name="target">The portfolio target to add</param>
+        public void Add(Symbol symbol, IPortfolioTarget target)
+        {
+            WithDictionary(d => d.Add(symbol, target));
+        }
+
+        /// <summary>
+        /// Adds the specified targets to the collection. If a target for the same symbol
+        /// already exists it will be overwritten.
+        /// </summary>
+        /// <param name="targets">The portfolio targets to add</param>
+        public void AddRange(IEnumerable<IPortfolioTarget> targets)
+        {
+            foreach (var item in targets)
+            {
+                _targets[item.Symbol] = item;
+            }
+        }
+
+        /// <summary>
+        /// Removes all portfolio targets from this collection
+        /// </summary>
+        public void Clear()
+        {
+            _targets.Clear();
+        }
+
+        /// <summary>
+        /// Determines whether or not the specified target exists in this collection.
+        /// NOTE: This checks for the exact specified target, not by symbol. Use ContainsKey
+        /// to check by symbol.
+        /// </summary>
+        /// <param name="target">The portfolio target to check for existence.</param>
+        /// <returns>True if the target exists, false otherwise</returns>
+        public bool Contains(IPortfolioTarget target)
+        {
+            if (target == null)
+            {
+                return false;
+            }
+
+            return _targets.ContainsKey(target.Symbol);
+        }
+
+        /// <summary>
+        /// Determines whether the specified symbol/target pair exists in this collection
+        /// </summary>
+        /// <param name="target">The symbol/target pair</param>
+        /// <returns>True if the pair exists, false otherwise</returns>
+        public bool Contains(KeyValuePair<Symbol, IPortfolioTarget> target)
+        {
+            return WithDictionary(d => d.Contains(target));
+        }
+
+        /// <summary>
+        /// Determines whether the specified symbol exists as a key in this collection
+        /// </summary>
+        /// <param name="symbol">The symbol key</param>
+        /// <returns>True if the symbol exists in this collection, false otherwise</returns>
+        public bool ContainsKey(Symbol symbol)
+        {
+            return _targets.ContainsKey(symbol);
+        }
+
+        /// <summary>
+        /// Copies the targets in this collection to the specified array
+        /// </summary>
+        /// <param name="array">The destination array to copy to</param>
+        /// <param name="arrayIndex">The index in the array to start copying to</param>
+        public void CopyTo(IPortfolioTarget[] array, int arrayIndex)
+        {
+            _targets.Values.CopyTo(array, arrayIndex);
+        }
+
+        /// <summary>
+        /// Copies the targets in this collection to the specified array
+        /// </summary>
+        /// <param name="array">The destination array to copy to</param>
+        /// <param name="arrayIndex">The index in the array to start copying to</param>
+        public void CopyTo(KeyValuePair<Symbol, IPortfolioTarget>[] array, int arrayIndex)
+        {
+            WithDictionary(d => d.CopyTo(array, arrayIndex));
+        }
+
+        /// <summary>
+        /// Removes the target for the specified symbol if it exists in this collection.
+        /// </summary>
+        /// <param name="symbol">The symbol to remove</param>
+        /// <returns>True if the symbol's target was removed, false if it doesn't exist in the collection</returns>
+        public bool Remove(Symbol symbol)
+        {
+            return WithDictionary(d => d.Remove(symbol));
+        }
+
+        /// <summary>
+        /// Removes the target for the specified symbol/target pair if it exists in this collection.
+        /// </summary>
+        /// <param name="target">The symbol/target pair to remove</param>
+        /// <returns>True if the symbol's target was removed, false if it doesn't exist in the collection</returns>
+        public bool Remove(KeyValuePair<Symbol, IPortfolioTarget> target)
+        {
+            return WithDictionary(d => d.Remove(target));
+        }
+
+        /// <summary>
+        /// Removes the target if it exists in this collection.
+        /// </summary>
+        /// <param name="target">The target to remove</param>
+        /// <returns>True if the target was removed, false if it doesn't exist in the collection</returns>
+        public bool Remove(IPortfolioTarget target)
+        {
+            if (target == null)
+            {
+                return false;
+            }
+
+            IPortfolioTarget existing;
+            if (_targets.TryGetValue(target.Symbol, out existing))
+            {
+                // need to confirm that we're removing the requested target and not a different target w/ the same symbol key
+                if (existing.Equals(target))
+                {
+                    return Remove(target.Symbol);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the target for the specified symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="target">The portfolio target for the symbol, or null if not found</param>
+        /// <returns>True if the symbol's target was found, false if it does not exist in this collection</returns>
+        public bool TryGetValue(Symbol symbol, out IPortfolioTarget target)
+        {
+            return _targets.TryGetValue(symbol, out target);
+        }
+
+        /// <summary>
+        /// Gets or sets the portfolio target for the specified symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <returns>The symbol's portolio target if it exists in this collection, if not a <see cref="KeyNotFoundException"/> will be thrown.</returns>
+        public IPortfolioTarget this[Symbol symbol]
+        {
+            get { return _targets[symbol]; }
+            set { _targets[symbol] = value; }
+        }
+
+        /// <summary>
+        /// Gets an enumerator to iterator over the symbol/target key value pairs in this collection.
+        /// </summary>
+        /// <returns>Symbol/target key value pair enumerator</returns>
+        IEnumerator<KeyValuePair<Symbol, IPortfolioTarget>> IEnumerable<KeyValuePair<Symbol, IPortfolioTarget>>.GetEnumerator()
+        {
+            return _targets.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Gets an enumerator to iterator over all portfolio targets in this collection.
+        /// This is the default enumerator for this collection.
+        /// </summary>
+        /// <returns>Portfolio targets enumerator</returns>
+        public IEnumerator<IPortfolioTarget> GetEnumerator()
+        {
+            return _targets.Select(kvp => kvp.Value).GetEnumerator();
+        }
+
+        /// <summary>
+        /// Gets an enumerator to iterator over all portfolio targets in this collection.
+        /// This is the default enumerator for this collection.
+        /// </summary>
+        /// <returns>Portfolio targets enumerator</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Helper function to easily access explicitly implemented interface methods against concurrent dictionary
+        /// </summary>
+        private void WithDictionary(Action<IDictionary<Symbol, IPortfolioTarget>> action)
+        {
+            action(_targets);
+        }
+
+        /// <summary>
+        /// Helper function to easily access explicitly implemented interface methods against concurrent dictionary
+        /// </summary>
+        private T WithDictionary<T>(Func<IDictionary<Symbol, IPortfolioTarget>, T> func)
+        {
+            return func(_targets);
+        }
+    }
+}

--- a/Common/Data/SliceExtensions.cs
+++ b/Common/Data/SliceExtensions.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,8 +14,10 @@
 */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Util;
 
@@ -167,6 +169,59 @@ namespace QuantConnect.Data
         public static double[] ToDoubleArray(this IEnumerable<decimal> decimals)
         {
             return decimals.Select(x => (double) x).ToArray();
+        }
+
+        /// <summary>
+        /// Loops through the specified slices and pushes the data into the consolidators. This can be used to
+        /// easily warm up indicators from a history call that returns slice objects.
+        /// </summary>
+        /// <param name="slices">The data to send into the consolidators, likely result of a history request</param>
+        /// <param name="consolidatorsBySymbol">Dictionary of consolidators keyed by symbol</param>
+        public static void PushThroughConsolidators(this IEnumerable<Slice> slices, Dictionary<Symbol, IDataConsolidator> consolidatorsBySymbol)
+        {
+            PushThroughConsolidators(slices, symbol =>
+            {
+                IDataConsolidator consolidator;
+                consolidatorsBySymbol.TryGetValue(symbol, out consolidator);
+                return consolidator;
+            });
+        }
+
+        /// <summary>
+        /// Loops through the specified slices and pushes the data into the consolidators. This can be used to
+        /// easily warm up indicators from a history call that returns slice objects.
+        /// </summary>
+        /// <param name="slices">The data to send into the consolidators, likely result of a history request</param>
+        /// <param name="consolidatorsProvider">Delegate that fetches the consolidators by a symbol</param>
+        public static void PushThroughConsolidators(this IEnumerable<Slice> slices, Func<Symbol, IDataConsolidator> consolidatorsProvider)
+        {
+            slices.PushThrough(data => consolidatorsProvider(data?.Symbol)?.Update(data));
+        }
+
+        /// <summary>
+        /// Loops through the specified slices and pushes the data into the consolidators. This can be used to
+        /// easily warm up indicators from a history call that returns slice objects.
+        /// </summary>
+        /// <param name="slices">The data to send into the consolidators, likely result of a history request</param>
+        /// <param name="handler">Delegate handles each data piece from the slice</param>
+        public static void PushThrough(this IEnumerable<Slice> slices, Action<BaseData> handler)
+        {
+            foreach (var slice in slices)
+            {
+                foreach (var symbol in slice.Keys)
+                {
+                    dynamic value;
+                    if (!slice.TryGetValue(symbol, out value))
+                    {
+                        continue;
+                    }
+
+                    var list = value as IList;
+                    var data = (BaseData)(list != null ? list[list.Count - 1] : value);
+
+                    handler(data);
+                }
+            }
         }
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Algorithm\Framework\Alphas\Analysis\InsightManager.cs" />
     <Compile Include="Algorithm\Framework\Alphas\InsightScore.cs" />
     <Compile Include="Algorithm\Framework\Alphas\InsightScoreType.cs" />
+    <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollection.cs" />
     <Compile Include="AlphaRuntimeStatistics.cs" />
     <Compile Include="API\AuthenticationResponse.cs" />
     <Compile Include="API\Backtest.cs" />

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,9 +14,10 @@
 */
 
 using System;
+using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Orders;
 
-namespace QuantConnect.Securities 
+namespace QuantConnect.Securities
 {
     /// <summary>
     /// SecurityHolding is a base class for purchasing and holding a market item which manages the asset portfolio
@@ -71,6 +72,14 @@ namespace QuantConnect.Securities
             {
                 return _security;
             }
+        }
+
+        /// <summary>
+        /// Gets the current target holdings for this security
+        /// </summary>
+        public IPortfolioTarget Target
+        {
+            get; internal set;
         }
 
         /// <summary>
@@ -137,14 +146,14 @@ namespace QuantConnect.Securities
                 return _security.BuyingPowerModel.GetLeverage(_security);
             }
         }
-        
+
 
         /// <summary>
         /// Acquisition cost of the security total holdings.
         /// </summary>
-        public virtual decimal HoldingsCost 
+        public virtual decimal HoldingsCost
         {
-            get 
+            get
             {
                 return AveragePrice * Convert.ToDecimal(Quantity) * _security.QuoteCurrency.ConversionRate * _security.SymbolProperties.ContractMultiplier;
             }
@@ -177,9 +186,9 @@ namespace QuantConnect.Securities
         /// Absolute holdings cost for current holdings in units of the account's currency
         /// </summary>
         /// <seealso cref="HoldingsCost"/>
-        public virtual decimal AbsoluteHoldingsCost 
+        public virtual decimal AbsoluteHoldingsCost
         {
-            get 
+            get
             {
                 return Math.Abs(HoldingsCost);
             }
@@ -216,9 +225,9 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Boolean flat indicating if we hold any of the security
         /// </summary>
-        public virtual bool HoldStock 
+        public virtual bool HoldStock
         {
-            get 
+            get
             {
                 return (AbsoluteQuantity > 0);
             }
@@ -257,9 +266,9 @@ namespace QuantConnect.Securities
         /// Boolean flag indicating we have a net positive holding of the security.
         /// </summary>
         /// <seealso cref="IsShort"/>
-        public virtual bool IsLong 
+        public virtual bool IsLong
         {
-            get 
+            get
             {
                 return Quantity > 0;
             }
@@ -269,9 +278,9 @@ namespace QuantConnect.Securities
         /// BBoolean flag indicating we have a net negative holding of the security.
         /// </summary>
         /// <seealso cref="IsLong"/>
-        public virtual bool IsShort 
+        public virtual bool IsShort
         {
-            get 
+            get
             {
                 return Quantity < 0;
             }
@@ -281,9 +290,9 @@ namespace QuantConnect.Securities
         /// Absolute quantity of holdings of this security
         /// </summary>
         /// <seealso cref="Quantity"/>
-        public virtual decimal AbsoluteQuantity 
+        public virtual decimal AbsoluteQuantity
         {
-            get 
+            get
             {
                 return Math.Abs(Quantity);
             }
@@ -292,9 +301,9 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Record of the closing profit from the last trade conducted.
         /// </summary>
-        public virtual decimal LastTradeProfit 
+        public virtual decimal LastTradeProfit
         {
-            get 
+            get
             {
                 return _lastTradeProfit;
             }
@@ -314,9 +323,9 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <seealso cref="Profit"/>
         /// <seealso cref="TotalFees"/>
-        public virtual decimal NetProfit 
+        public virtual decimal NetProfit
         {
-            get 
+            get
             {
                 return Profit - TotalFees;
             }
@@ -346,7 +355,7 @@ namespace QuantConnect.Securities
         /// Adds a fee to the running total of total fees.
         /// </summary>
         /// <param name="newFee"></param>
-        public void AddNewFee(decimal newFee) 
+        public void AddNewFee(decimal newFee)
         {
             _totalFees += newFee;
         }
@@ -355,7 +364,7 @@ namespace QuantConnect.Securities
         /// Adds a profit record to the running total of profit.
         /// </summary>
         /// <param name="profitLoss">The cash change in portfolio from closing a position</param>
-        public void AddNewProfit(decimal profitLoss) 
+        public void AddNewProfit(decimal profitLoss)
         {
             _profit += profitLoss;
         }
@@ -373,15 +382,15 @@ namespace QuantConnect.Securities
         /// Set the last trade profit for this security from a Portfolio.ProcessFill call.
         /// </summary>
         /// <param name="lastTradeProfit">Value of the last trade profit</param>
-        public void SetLastTradeProfit(decimal lastTradeProfit) 
+        public void SetLastTradeProfit(decimal lastTradeProfit)
         {
             _lastTradeProfit = lastTradeProfit;
         }
-            
+
         /// <summary>
         /// Set the quantity of holdings and their average price after processing a portfolio fill.
         /// </summary>
-        public virtual void SetHoldings(decimal averagePrice, int quantity) 
+        public virtual void SetHoldings(decimal averagePrice, int quantity)
         {
             _averagePrice = averagePrice;
             _quantity = quantity;
@@ -409,7 +418,7 @@ namespace QuantConnect.Securities
         /// Profit if we closed the holdings right now including the approximate fees.
         /// </summary>
         /// <remarks>Does not use the transaction model for market fills but should.</remarks>
-        public virtual decimal TotalCloseProfit() 
+        public virtual decimal TotalCloseProfit()
         {
             if (AbsoluteQuantity == 0)
             {

--- a/Indicators/IntradayVwap.cs
+++ b/Indicators/IntradayVwap.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Indicators
+{
+    /// <summary>
+    /// Defines the canonical intraday VWAP indicator
+    /// </summary>
+    public class IntradayVwap : IndicatorBase<BaseData>
+    {
+        private DateTime _lastDate;
+        private decimal _sumOfVolume;
+        private decimal _sumOfPriceTimesVolume;
+
+        /// <summary>
+        /// Gets a flag indicating when this indicator is ready and fully initialized
+        /// </summary>
+        public override bool IsReady => _sumOfVolume > 0;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IntradayVwap"/> class
+        /// </summary>
+        /// <param name="name">The name of the indicator</param>
+        public IntradayVwap(string name)
+            : base(name)
+        {
+        }
+
+        /// <summary>
+        /// Computes the new VWAP
+        /// </summary>
+        protected override IndicatorResult ValidateAndComputeNextValue(BaseData input)
+        {
+            decimal volume, averagePrice;
+            if (!TryGetVolumeAndAveragePrice(input, out volume, out averagePrice))
+            {
+                return new IndicatorResult(0, IndicatorStatus.InvalidInput);
+            }
+
+            // reset vwap on daily boundaries
+            if (_lastDate != input.EndTime.Date)
+            {
+                _sumOfVolume = 0m;
+                _sumOfPriceTimesVolume = 0m;
+                _lastDate = input.EndTime.Date;
+            }
+
+            // running totals for Σ PiVi / Σ Vi
+            _sumOfVolume += volume;
+            _sumOfPriceTimesVolume += averagePrice * volume;
+
+            if (_sumOfVolume == 0m)
+            {
+                // if we have no trade volume then use the current price as VWAP
+                return input.Value;
+            }
+
+            return _sumOfPriceTimesVolume / _sumOfVolume;
+        }
+
+        /// <summary>
+        /// Computes the next value of this indicator from the given state.
+        /// NOTE: This must be overriden since it's abstract in the base, but
+        /// will never be invoked since we've override the validate method above.
+        /// </summary>
+        /// <param name="input">The input given to the indicator</param>
+        /// <returns>A new value for this indicator</returns>
+        protected override decimal ComputeNextValue(BaseData input)
+        {
+            throw new NotImplementedException($"{nameof(IntradayVwap)}.{nameof(ComputeNextValue)} should never be invoked.");
+        }
+
+        /// <summary>
+        /// Determines the volume and price to be used for the current input in the VWAP computation
+        /// </summary>
+        protected bool TryGetVolumeAndAveragePrice(BaseData input, out decimal volume, out decimal averagePrice)
+        {
+            var tick = input as Tick;
+
+            if (tick?.TickType == TickType.Trade)
+            {
+                volume = tick.Quantity;
+                averagePrice = tick.LastPrice;
+                return true;
+            }
+
+            var tradeBar = input as TradeBar;
+            if (tradeBar?.IsFillForward == false)
+            {
+                volume = tradeBar.Volume;
+                averagePrice = (tradeBar.High + tradeBar.Low + tradeBar.Close) / 3m;
+                return true;
+            }
+
+            volume = 0;
+            averagePrice = 0;
+            return false;
+        }
+    }
+}

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -130,6 +130,7 @@
     <Compile Include="DetrendedPriceOscillator.cs" />
     <Compile Include="DonchianChannel.cs" />
     <Compile Include="DoubleExponentialMovingAverage.cs" />
+    <Compile Include="IntradayVwap.cs" />
     <Compile Include="WilderMovingAverage.cs" />
     <Compile Include="FractalAdaptiveMovingAverage.cs" />
     <Compile Include="FilteredIdentity.cs" />

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,8 +51,8 @@ namespace QuantConnect.Indicators
         {
             _price = new Identity("Price");
             _volume = new Identity("Volume");
-            
-            // This class will be using WeightedBy indicator extension 
+
+            // This class will be using WeightedBy indicator extension
             _vwap = _price.WeightedBy(_volume, period);
         }
 
@@ -82,9 +82,19 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(TradeBar input)
         {
-            _price.Update(input.EndTime, (input.Open + input.High + input.Low + input.Value) / 4);
+            _price.Update(input.EndTime, GetTimeWeightedAveragePrice(input));
             _volume.Update(input.EndTime, input.Volume);
             return _vwap.Current.Value;
+        }
+
+        /// <summary>
+        /// Gets an estimated average price to use for the interval covered by the input trade bar.
+        /// </summary>
+        /// <param name="input">The current trade bar input</param>
+        /// <returns>An estimated average price over the trade bar's interval</returns>
+        protected virtual decimal GetTimeWeightedAveragePrice(TradeBar input)
+        {
+            return (input.Open + input.High + input.Low + input.Value) / 4;
         }
     }
 }

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -21,6 +21,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using NodaTime;
 using NUnit.Framework;
+using QuantConnect.Algorithm.Framework;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
@@ -171,6 +172,11 @@ namespace QuantConnect.Tests
             public override IAlgorithm CreateAlgorithmInstance(AlgorithmNodePacket algorithmNodePacket, string assemblyPath)
             {
                 Algorithm = base.CreateAlgorithmInstance(algorithmNodePacket, assemblyPath);
+                var framework = Algorithm as QCAlgorithmFramework;
+                if (framework != null)
+                {
+                    framework.DebugMode = true;
+                }
                 return Algorithm;
             }
         }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -527,6 +527,10 @@
       <Project>{39a81c16-a1e8-425e-a8f2-1433adb80228}</Project>
       <Name>QuantConnect.Algorithm.CSharp</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Algorithm.Framework\QuantConnect.Algorithm.Framework.csproj">
+      <Project>{75981418-7246-4B91-B136-482728E02901}</Project>
+      <Name>QuantConnect.Algorithm.Framework</Name>
+    </ProjectReference>
     <ProjectReference Include="..\AlgorithmFactory\QuantConnect.AlgorithmFactory.csproj">
       <Project>{e99d056a-b6fb-48d2-9f7c-683c54cebbf9}</Project>
       <Name>QuantConnect.AlgorithmFactory</Name>

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -778,6 +778,78 @@ namespace QuantConnect.Tests
                 {"Total Fees", "$100.58"}
             };
 
+            var volumeWeightedAveragePriceExecutionModelRegressionAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "61"},
+                {"Average Win", "0.10%"},
+                {"Average Loss", "0%"},
+                {"Compounding Annual Return", "585.503%"},
+                {"Drawdown", "0.600%"},
+                {"Expectancy", "0"},
+                {"Net Profit", "2.492%"},
+                {"Sharpe Ratio", "9.136"},
+                {"Loss Rate", "0%"},
+                {"Win Rate", "100%"},
+                {"Profit-Loss Ratio", "0"},
+                {"Alpha", "0"},
+                {"Beta", "113.313"},
+                {"Annual Standard Deviation", "0.137"},
+                {"Annual Variance", "0.019"},
+                {"Information Ratio", "9.063"},
+                {"Tracking Error", "0.137"},
+                {"Treynor Ratio", "0.011"},
+                {"Total Fees", "$96.79"},
+                {"Total Insights Generated", "5"},
+                {"Total Insights Closed", "3"},
+                {"Total Insights Analysis Completed", "0"},
+                {"Long Insight Count", "3"},
+                {"Short Insight Count", "2"},
+                {"Long/Short Ratio", "150.0%"},
+                {"Estimated Monthly Alpha Value", "$54250.3481"},
+                {"Total Accumulated Estimated Alpha Value", "$8740.3339"},
+                {"Mean Population Estimated Insight Value", "$2913.4446"},
+                {"Mean Population Direction", "0%"},
+                {"Mean Population Magnitude", "0%"},
+                {"Rolling Averaged Population Direction", "0%"},
+                {"Rolling Averaged Population Magnitude", "0%"},
+            };
+
+            var standardDeviationExecutionModelRegressionAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "63"},
+                {"Average Win", "0.06%"},
+                {"Average Loss", "0%"},
+                {"Compounding Annual Return", "793.499%"},
+                {"Drawdown", "0.400%"},
+                {"Expectancy", "0"},
+                {"Net Profit", "2.840%"},
+                {"Sharpe Ratio", "10.781"},
+                {"Loss Rate", "0%"},
+                {"Win Rate", "100%"},
+                {"Profit-Loss Ratio", "0"},
+                {"Alpha", "0"},
+                {"Beta", "128.815"},
+                {"Annual Standard Deviation", "0.132"},
+                {"Annual Variance", "0.017"},
+                {"Information Ratio", "10.71"},
+                {"Tracking Error", "0.132"},
+                {"Treynor Ratio", "0.011"},
+                {"Total Fees", "$76.61"},
+                {"Total Insights Generated", "5"},
+                {"Total Insights Closed", "3"},
+                {"Total Insights Analysis Completed", "0"},
+                {"Long Insight Count", "3"},
+                {"Short Insight Count", "2"},
+                {"Long/Short Ratio", "150.0%"},
+                {"Estimated Monthly Alpha Value", "$54250.3481"},
+                {"Total Accumulated Estimated Alpha Value", "$8740.3339"},
+                {"Mean Population Estimated Insight Value", "$2913.4446"},
+                {"Mean Population Direction", "0%"},
+                {"Mean Population Magnitude", "0%"},
+                {"Rolling Averaged Population Direction", "0%"},
+                {"Rolling Averaged Population Magnitude", "0%"},
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -815,6 +887,8 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm", emptyStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("BasicTemplateIntrinioEconomicData", basicTemplateIntrinioEconomicData, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("DuplicateSecurityWithBenchmarkRegressionAlgorithm", emptyStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm", volumeWeightedAveragePriceExecutionModelRegressionAlgorithmStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("StandardDeviationExecutionModelRegressionAlgorithm", standardDeviationExecutionModelRegressionAlgorithmStatistics, Language.CSharp),
 
                 // Python
                 // new AlgorithmStatisticsTestParameters("BasicTemplateFuturesAlgorithmDaily", basicTemplateFuturesAlgorithmDailyStatistics, Language.Python),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Creates two new execution models. First, `VolumeWeightedAveragePriceExecutionModel` will submit market orders while the price is more favorable than VWAP. Second, the `StandardDeviationExecutionModel` will submit market orders when the current price is at least the specified number of deviations away from the mean. Both models accept an implementation of `IOrderSizingStrategy` which is used to break up the order into multiple orders. Two implementations of `IOrderSizingStrategy` are also provided: `PercentVolumeOrderSizingStrategy` which defines a maximum order size as a specified percentage of volume from the current bar and the `TotalValueOrderSizingStrategy` which defines a maximum order size using a specified maximum order value.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1784 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Continuing to fill out the algorithm framework models namespace, providing some default models for users to use.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes! @jaredbroad -- please include these two models in the documentation.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Extensively tested in QC cloud in addition to a fair amount of local testing/debugging. The order sizing implementations are under unit test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) (`PortoflioTarget.Percent` bugfix)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover (**some**) my changes. <!--- If not applicable, please explain why --> 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

Models are not under automated test at this time.

>NOTE: Some features were left out following review comments from https://github.com/QuantConnect/Lean/pull/1781. If agreed, I can re-add those features, including the ability to plot the underlying indicator values (VWAP/(SMA ± n*STD) and configurable resolution support for the indicators (right now they use security configured resolution). I had also considered providing support for asymmetric thresholds for buy/sell, but this was not implemented.

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->