### PR TITLE
Add DuplicateSecurityWithBenchmarkRegressionAlgorithm

### DIFF
--- a/Algorithm.CSharp/DuplicateSecurityWithBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DuplicateSecurityWithBenchmarkRegressionAlgorithm.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+using QuantConnect.Securities.Equity;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This algorithm is a regression test case using consolidators with SetBenchmark and duplicate securities.
+    /// </summary>
+    public class DuplicateSecurityWithBenchmarkRegressionAlgorithm : QCAlgorithm
+    {
+        private SimpleMovingAverage _spyMovingAverage;
+        private Equity _spy1;
+        private Equity _spy2;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+            SetCash(100000);
+
+            _spy1 = AddEquity("SPY", Resolution.Daily);
+
+            // SetBenchmark call prevents SMA update
+            SetBenchmark("SPY");
+
+            _spy2 = AddEquity("SPY", Resolution.Daily);
+            _spyMovingAverage = SMA("SPY", 3, Resolution.Daily);
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            Log($"{Time} - {Securities["SPY"].Price}, {_spyMovingAverage}");
+        }
+
+        /// <summary>
+        /// End of algorithm run event handler. This method is called at the end of a backtest or live trading operation. Intended for closing out logs.
+        /// </summary>
+        public override void OnEndOfAlgorithm()
+        {
+            Log($"_spy1.Subscriptions.Count(): {_spy1.Subscriptions.Count()}");
+            Log($"_spy2.Subscriptions.Count(): {_spy2.Subscriptions.Count()}");
+            Log($"_spy1.Subscriptions.First().Consolidators.Count: {_spy1.Subscriptions.First().Consolidators.Count}");
+            Log($"_spy2.Subscriptions.First().Consolidators.Count: {_spy2.Subscriptions.First().Consolidators.Count}");
+
+            if (_spyMovingAverage == 0)
+            {
+                throw new Exception("SMA was not updated.");
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -84,6 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
+    <Compile Include="DuplicateSecurityWithBenchmarkRegressionAlgorithm.cs" />
     <Compile Include="BasicTemplateCryptoAlgorithm.cs" />
     <Compile Include="BasicTemplateCryptoFrameworkAlgorithm.cs" />
     <Compile Include="BasicTemplateIntrinioEconomicData.cs" />

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -814,6 +814,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("ForexInternalFeedOnDataSameResolutionRegressionAlgorithm", emptyStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm", emptyStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("BasicTemplateIntrinioEconomicData", basicTemplateIntrinioEconomicData, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("DuplicateSecurityWithBenchmarkRegressionAlgorithm", emptyStatistics, Language.CSharp),
 
                 // Python
                 // new AlgorithmStatisticsTestParameters("BasicTemplateFuturesAlgorithmDaily", basicTemplateFuturesAlgorithmDailyStatistics, Language.Python),


### PR DESCRIPTION

#### Description
This PR only adds a new regression algorithm, where consolidators were not being updated because of duplicate securities and calling `SetBenchmark`.

The bug has been fixed previously in #1682. 

#### Related Issue
Closes #1612

#### Requires Documentation Change
No.

#### How Has This Been Tested?
The included regression test was failing before and is passing since #1682 was merged.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`