### PR TITLE
Fix GDAXFeeModel.GetOrderFee for marketable limit orders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ install:
   - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
 script:
   - xbuild /p:Configuration=Release /p:VbcToolExe=vbnc.exe QuantConnect.Lean.sln
-  - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./Tests/bin/Release/QuantConnect.Tests.dll --exclude:TravisExclude
+  - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./Tests/bin/Release/QuantConnect.Tests.dll --exclude:TravisExclude --labels
 after_success:
   - coveralls

--- a/Common/Orders/Fees/GDAXFeeModel.cs
+++ b/Common/Orders/Fees/GDAXFeeModel.cs
@@ -42,10 +42,16 @@ namespace QuantConnect.Orders.Fees
         /// <returns>The cost of the order in units of the account currency</returns>
         public decimal GetOrderFee(Securities.Security security, Order order)
         {
-            //0% maker fee after reimbursement.
             if (order.Type == OrderType.Limit)
             {
-                return 0m;
+                // marketable limit orders are considered takers
+                var limitPrice = ((LimitOrder) order).LimitPrice;
+                if (order.Direction == OrderDirection.Buy && limitPrice < security.AskPrice ||
+                    order.Direction == OrderDirection.Sell && limitPrice > security.BidPrice)
+                {
+                    // limit order posted to the order book, 0% fee
+                    return 0m;
+                }
             }
 
             // currently we do not model daily rebates


### PR DESCRIPTION
#### Description
The fees returned for marketable limit orders have been updated to the correct values (using the taker fee percentages). This fix only affects backtesting and paper trading (in live trading, fees are already correct).

#### Related Issue
Fixes #1806

#### Motivation and Context
The fee returned for all limit orders was always zero.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Cloud testing with Paper brokerage + new unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`