### PR TITLE
Fix currency conversion in CashBook.Convert

### DIFF
--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -104,8 +104,19 @@ namespace QuantConnect.Securities
         {
             var source = this[sourceCurrency];
             var destination = this[destinationCurrency];
-            var conversionRate = source.ConversionRate*destination.ConversionRate;
-            return sourceQuantity*conversionRate;
+
+            if (source.ConversionRate == 0)
+            {
+                throw new Exception($"The conversion rate for {sourceCurrency} is not available.");
+            }
+
+            if (destination.ConversionRate == 0)
+            {
+                throw new Exception($"The conversion rate for {destinationCurrency} is not available.");
+            }
+
+            var conversionRate = source.ConversionRate / destination.ConversionRate;
+            return sourceQuantity * conversionRate;
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -947,6 +947,7 @@ namespace QuantConnect.Tests.Algorithm
             var algo = new QCAlgorithm();
             algo.AddSecurity(SecurityType.Forex, "EURUSD");
             algo.SetCash(100000);
+            algo.SetCash("BTC", 0, 8000);
             algo.SetBrokerageModel(BrokerageName.FxcmBrokerage);
             algo.Securities[Symbols.EURUSD].TransactionModel = new ConstantFeeTransactionModel(0);
             Security eurusd = algo.Securities[Symbols.EURUSD];

--- a/Tests/Common/Securities/CashBookTests.cs
+++ b/Tests/Common/Securities/CashBookTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,7 @@ namespace QuantConnect.Tests.Common.Securities
             book.Add("EUR", 0, 1.10m);
             book.Add("GBP", 0, 0.71m);
 
-            var expected = 781m;
+            var expected = 1549.2957746478873239436619718m;
             var actual = book.Convert(1000, "EUR", "GBP");
             Assert.AreEqual(expected, actual);
         }
@@ -65,6 +65,28 @@ namespace QuantConnect.Tests.Common.Securities
 
             var expected = 1100m;
             var actual = book.ConvertToAccountCurrency(1000, "EUR");
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ConvertsToEurFromAccountCurrencyProperly()
+        {
+            var book = new CashBook();
+            book.Add("EUR", 0, 1.20m);
+
+            var expected = 1000m;
+            var actual = book.Convert(1200, CashBook.AccountCurrency, "EUR");
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ConvertsToJpyFromAccountCurrencyProperly()
+        {
+            var book = new CashBook();
+            book.Add("JPY", 0, 1/100m);
+
+            var expected = 100000m;
+            var actual = book.Convert(1000, CashBook.AccountCurrency, "JPY");
             Assert.AreEqual(expected, actual);
         }
     }


### PR DESCRIPTION

#### Description
The currency conversion was multiplying conversion rates instead of dividing.

#### Related Issue
Fixes #1813

#### Motivation and Context
This method is currently used by the `CashBuyingPowerModel` and in some cases was causing incorrect order quantity calculations.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit tests included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`