### PR TITLE
Update TickConsolidator to process only TickType.Trade ticks

### DIFF
--- a/Common/Data/Consolidators/TickConsolidator.cs
+++ b/Common/Data/Consolidators/TickConsolidator.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@ using System;
 using QuantConnect.Data.Market;
 
 namespace QuantConnect.Data.Consolidators
-{    
+{
     /// <summary>
     /// A data consolidator that can make bigger bars from ticks over a given
     /// time span or a count of pieces of data.
@@ -50,6 +50,16 @@ namespace QuantConnect.Data.Consolidators
         public TickConsolidator(int maxCount, TimeSpan period)
             : base(maxCount, period)
         {
+        }
+
+        /// <summary>
+        /// Determines whether or not the specified data should be processd
+        /// </summary>
+        /// <param name="data">The data to check</param>
+        /// <returns>True if the consolidator should process this data, false otherwise</returns>
+        protected override bool ShouldProcess(Tick data)
+        {
+            return data.TickType == TickType.Trade;
         }
 
         /// <summary>

--- a/Tests/Common/Data/TickConsolidatorTests.cs
+++ b/Tests/Common/Data/TickConsolidatorTests.cs
@@ -281,10 +281,20 @@ namespace QuantConnect.Tests.Common.Data
             var tick3 = new Tick
             {
                 Symbol = Symbols.SPY,
+                Time = reference.AddSeconds(10),
+                Value = 10000m,
+                TickType = TickType.Quote
+            };
+            consolidator.Update(tick3);
+            Assert.IsNull(consolidated);
+
+            var tick4 = new Tick
+            {
+                Symbol = Symbols.SPY,
                 Time = reference.AddSeconds(61),
                 Value = 250m
             };
-            consolidator.Update(tick3);
+            consolidator.Update(tick4);
             Assert.IsNotNull(consolidated);
 
             Assert.AreEqual(consolidated.Time, reference);

--- a/Tests/Common/Data/TickConsolidatorTests.cs
+++ b/Tests/Common/Data/TickConsolidatorTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -99,8 +99,8 @@ namespace QuantConnect.Tests.Common.Data
 
             consolidator.Update(new Tick { Time = reference.AddMilliseconds(1)});
             Assert.IsNotNull(consolidated);
- 
-            // sadly the first emit will be off by the data resolution since we 'swallow' a point, so to 
+
+            // sadly the first emit will be off by the data resolution since we 'swallow' a point, so to
             Assert.AreEqual(TimeSpan.FromMilliseconds(1), consolidated.Period);
             consolidated = null;
 
@@ -246,6 +246,50 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(consolidated.Time, reference.AddSeconds(60));
             Assert.AreEqual(consolidated.Open, tick3.Value);
             Assert.AreEqual(consolidated.Close, tick5.Value);
+        }
+
+        [Test]
+        public void ProcessesTradeTicksOnly()
+        {
+            TradeBar consolidated = null;
+            var consolidator = new TickConsolidator(TimeSpan.FromMinutes(1));
+            consolidator.DataConsolidated += (sender, bar) =>
+            {
+                consolidated = bar;
+            };
+
+            var reference = new DateTime(2015, 06, 02);
+            var tick1 = new Tick
+            {
+                Symbol = Symbols.SPY,
+                Time = reference.AddSeconds(3),
+                Value = 200m
+            };
+            consolidator.Update(tick1);
+            Assert.IsNull(consolidated);
+
+            var tick2 = new Tick
+            {
+                Symbol = Symbols.SPY,
+                Time = reference.AddSeconds(10),
+                Value = 20000m,
+                TickType = TickType.OpenInterest
+            };
+            consolidator.Update(tick2);
+            Assert.IsNull(consolidated);
+
+            var tick3 = new Tick
+            {
+                Symbol = Symbols.SPY,
+                Time = reference.AddSeconds(61),
+                Value = 250m
+            };
+            consolidator.Update(tick3);
+            Assert.IsNotNull(consolidated);
+
+            Assert.AreEqual(consolidated.Time, reference);
+            Assert.AreEqual(consolidated.Open, tick1.Value);
+            Assert.AreEqual(consolidated.Close, tick1.Value);
         }
 
     }


### PR DESCRIPTION

#### Description
The `TickConsolidator` has been updated to process `TickType.Trade` ticks only

#### Related Issue
Fixes #1818 

#### Motivation and Context
The `TickConsolidator` was considering open interest values as prices.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test included + tested with a live IB futures algorithm

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`