### PR TITLE
Add IDataConsolidator.Dispose to remove event handlers

### DIFF
--- a/Common/Data/Consolidators/DataConsolidator.cs
+++ b/Common/Data/Consolidators/DataConsolidator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -104,6 +104,13 @@ namespace QuantConnect.Data.Consolidators
             // this allows the event handlers to look at the new consolidated data
             // and the previous consolidated data at the same time without extra bookkeeping
             Consolidated = consolidated;
+        }
+
+        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+        /// <filterpriority>2</filterpriority>
+        public void Dispose()
+        {
+            DataConsolidated = null;
         }
     }
 }

--- a/Common/Data/Consolidators/IDataConsolidator.cs
+++ b/Common/Data/Consolidators/IDataConsolidator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@ namespace QuantConnect.Data.Consolidators
     /// transform the data before being sent to another component. The most common usage of these
     /// types is with indicators.
     /// </summary>
-    public interface IDataConsolidator
+    public interface IDataConsolidator : IDisposable
     {
         /// <summary>
         /// Gets the most recently consolidated piece of data. This will be null if this consolidator

--- a/Common/Data/Consolidators/RenkoConsolidator.cs
+++ b/Common/Data/Consolidators/RenkoConsolidator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -93,7 +93,7 @@ namespace QuantConnect.Data.Consolidators
         /// <param name="barSize">The size of each bar in units of the value produced by <paramref name="selector"/></param>
         /// <param name="selector">Extracts the value from a data instance to be formed into a <see cref="RenkoBar"/>. The default
         /// value is (x => x.Value) the <see cref="IBaseData.Value"/> property on <see cref="IBaseData"/></param>
-        /// <param name="volumeSelector">Extracts the volume from a data instance. The default value is null which does 
+        /// <param name="volumeSelector">Extracts the volume from a data instance. The default value is null which does
         /// not aggregate volume per bar.</param>
         /// <param name="evenBars">When true bar open/close will be a multiple of the barSize</param>
         public RenkoConsolidator(decimal barSize, Func<IBaseData, decimal> selector, Func<IBaseData, decimal> volumeSelector = null, bool evenBars = true)
@@ -310,7 +310,7 @@ namespace QuantConnect.Data.Consolidators
             var volume = _volumeSelector(data);
 
             decimal? close = null;
-            
+
             // if we're already in a bar then update it
             if (_currentBar != null)
             {
@@ -359,6 +359,13 @@ namespace QuantConnect.Data.Consolidators
 
             Consolidated = consolidated;
         }
+
+        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+        /// <filterpriority>2</filterpriority>
+        public void Dispose()
+        {
+            _dataConsolidatedHandler = null;
+        }
     }
 
     /// <summary>
@@ -374,7 +381,7 @@ namespace QuantConnect.Data.Consolidators
         /// <param name="barSize">The size of each bar in units of the value produced by <paramref name="selector"/></param>
         /// <param name="selector">Extracts the value from a data instance to be formed into a <see cref="RenkoBar"/>. The default
         /// value is (x => x.Value) the <see cref="IBaseData.Value"/> property on <see cref="IBaseData"/></param>
-        /// <param name="volumeSelector">Extracts the volume from a data instance. The default value is null which does 
+        /// <param name="volumeSelector">Extracts the volume from a data instance. The default value is null which does
         /// not aggregate volume per bar.</param>
         /// <param name="evenBars">When true bar open/close will be a multiple of the barSize</param>
         public RenkoConsolidator(decimal barSize, Func<TInput, decimal> selector, Func<TInput, decimal> volumeSelector = null, bool evenBars = true)

--- a/Common/Data/Consolidators/SequentialConsolidator.cs
+++ b/Common/Data/Consolidators/SequentialConsolidator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,7 +44,7 @@ namespace QuantConnect.Data.Consolidators
         /// <summary>
         /// Gets the most recently consolidated piece of data. This will be null if this consolidator
         /// has not produced any data yet.
-        /// 
+        ///
         /// For a SequentialConsolidator, this is the output from the 'Second' consolidator.
         /// </summary>
         public IBaseData Consolidated
@@ -116,7 +116,7 @@ namespace QuantConnect.Data.Consolidators
 
             // wire up the second one to get data from the first
             first.DataConsolidated += (sender, consolidated) => second.Update(consolidated);
-            
+
             // wire up the second one's events to also fire this consolidator's event so consumers
             // can attach
             second.DataConsolidated += (sender, consolidated) => OnDataConsolidated(consolidated);
@@ -131,6 +131,15 @@ namespace QuantConnect.Data.Consolidators
         {
             var handler = DataConsolidated;
             if (handler != null) handler(this, consolidated);
+        }
+
+        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+        /// <filterpriority>2</filterpriority>
+        public void Dispose()
+        {
+            First.Dispose();
+            Second.Dispose();
+            DataConsolidated = null;
         }
     }
 }

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -207,6 +207,9 @@ namespace QuantConnect.Data
             {
                 subscription.Consolidators.Remove(consolidator);
             }
+
+            // dispose of the consolidator to remove any remaining event handlers
+            consolidator.DisposeSafely();
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmSubscriptionManagerRemoveConsolidatorTests.cs
+++ b/Tests/Algorithm/AlgorithmSubscriptionManagerRemoveConsolidatorTests.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmSubscriptionManagerRemoveConsolidatorTests
+    {
+        [Test]
+        public void RemoveConsolidatorClearsEventHandlers()
+        {
+            bool eventHandlerFired = false;
+            var algorithm = new QCAlgorithm();
+            var security = algorithm.AddEquity("SPY");
+            var consolidator = new IdentityDataConsolidator<BaseData>();
+            consolidator.DataConsolidated += (sender, consolidated) => eventHandlerFired = true;
+            security.Subscriptions.First().Consolidators.Add(consolidator);
+
+            algorithm.SubscriptionManager.RemoveConsolidator(security.Symbol, consolidator);
+
+            consolidator.Update(new Tick());
+            Assert.IsFalse(eventHandlerFired);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Algorithm\AlgorithmResolveConsolidatorTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetBrokerageTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetHoldingsTests.cs" />
+    <Compile Include="Algorithm\AlgorithmSubscriptionManagerRemoveConsolidatorTests.cs" />
     <Compile Include="Algorithm\CashModelAlgorithmTradingTests.cs" />
     <Compile Include="Algorithm\AlgorithmTradingTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\Serialization\InsightJsonConverterTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
All consolidators now clear the event handlers list when being disposed. In addition, SubscriptionManager.RemoveConsolidator will now dispose of the consolidator before returning. This ensures the consolidator and any downstream indicators that were attached to it can be properly cleaned by garbage collection.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1824 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change enables garbage collection to free memory associated with removed consolidators and indicator, otherwise users would need to manually remove their event handlers when they're finished with a consolidator (such as the security being removed from the universe).

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test added to ensure we're clearing `IDataConsolidator.DataConsolidated` event handlers after call to `SubscriptionManager.RemoveConsolidator`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)
It's *kind of* a bug fix, but really more of an enhancement of existing functionality. We're just doing a better job of cleaning up so the algorithm/user doesn't have to worry about it as much.

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->