### PR TITLE
Adds Reset method override in WilderMovingAverage

### DIFF
--- a/Indicators/WilderMovingAverage.cs
+++ b/Indicators/WilderMovingAverage.cs
@@ -53,6 +53,15 @@ namespace QuantConnect.Indicators
         public override bool IsReady => Samples >= _period;
 
         /// <summary>
+        ///     Resets this indicator to its initial state
+        /// </summary>
+        public override void Reset()
+        {
+            _sma.Reset();
+            base.Reset();
+        }
+
+        /// <summary>
         ///     Computes the next value of this indicator from the given state
         /// </summary>
         /// <param name="input">The input given to the indicator</param>


### PR DESCRIPTION
#### Description
Adds `Reset` method override in `WilderMovingAverage`.

#### Related Issue
Closes #1787 

#### Motivation and Context
Without this method override, the indicator is not properly reset since it has a internal `SimpleMovingAverage`.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Run script described in issue #1787.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`