### PR TITLE
Refactors FractalAdaptiveMovingAverage

### DIFF
--- a/Indicators/FractalAdaptiveMovingAverage.cs
+++ b/Indicators/FractalAdaptiveMovingAverage.cs
@@ -26,8 +26,8 @@ namespace QuantConnect.Indicators
     {
         private readonly int _n = 16;
         private readonly double _w = -4.6;
-        private RollingWindow<double> _high;
-        private RollingWindow<double> _low;
+        private readonly RollingWindow<double> _high;
+        private readonly RollingWindow<double> _low;
 
         /// <summary>
         /// Initializes a new instance of the average class

--- a/Tests/Indicators/FractalAdaptiveMovingAverageTests.cs
+++ b/Tests/Indicators/FractalAdaptiveMovingAverageTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,12 +23,10 @@ namespace QuantConnect.Tests.Indicators
     [TestFixture]
     public class FractalAdaptiveMovingAverageTests
     {
-
         [Test]
         public void ResetsProperly()
         {
-
-            FractalAdaptiveMovingAverage frama = new FractalAdaptiveMovingAverage("", 6, 198);
+            var frama = new FractalAdaptiveMovingAverage(6, 198);
 
             foreach (var data in TestHelper.GetDataStream(7))
             {
@@ -46,7 +44,7 @@ namespace QuantConnect.Tests.Indicators
         [Test]
         public void ComparesAgainstExternalData()
         {
-            var indicator = new FractalAdaptiveMovingAverage("", 16, 198);
+            var indicator = new FractalAdaptiveMovingAverage(16, 198);
             RunTestIndicator(indicator);
         }
 
@@ -59,6 +57,5 @@ namespace QuantConnect.Tests.Indicators
         {
             Assert.IsTrue(Math.Abs((decimal)expected - actual) < 0.006m);
         }
-
     }
 }


### PR DESCRIPTION
#### Description
A constructor overload was missing in the previsous version. In the indicators' pattern they have constructors that don't need a string as the first parameter.
Refactored the code to implement QuantConnect's code style.

#### Related Issue
Closes #1786 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Existing unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`