### PR TITLE
Implements Insight.Price helper method.

### DIFF
--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             {
                 if (ShouldEmitInsight(algorithm.UtcTime, security.Symbol))
                 {
-                    yield return new Insight(security.Symbol, _type, _direction, _period, _magnitude, _confidence);
+                    yield return new Insight(security.Symbol, _period, _type, _direction, _magnitude, _confidence);
                 }
             }
         }

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
@@ -71,14 +71,14 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                     {
                         if (symbolData.Slow > symbolData.Fast)
                         {
-                            insights.Add(new Insight(symbolData.Symbol, InsightType.Price, InsightDirection.Down, insightPeriod));
+                            insights.Add(Insight.Price(symbolData.Symbol, insightPeriod, InsightDirection.Down));
                         }
                     }
                     else if (symbolData.SlowIsOverFast)
                     {
                         if (symbolData.Fast > symbolData.Slow)
                         {
-                            insights.Add(new Insight(symbolData.Symbol, InsightType.Price, InsightDirection.Up, insightPeriod));
+                            insights.Add(Insight.Price(symbolData.Symbol, insightPeriod, InsightDirection.Up));
                         }
                     }
                 }

--- a/Algorithm.Framework/Alphas/MacdAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/MacdAlphaModel.cs
@@ -95,7 +95,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 }
 
                 var insightPeriod = _resolution.ToTimeSpan().Multiply(_fastPeriod);
-                var insight = new Insight(sd.Security.Symbol, InsightType.Price, direction, insightPeriod);
+                var insight = Insight.Price(sd.Security.Symbol, insightPeriod, direction);
                 sd.PreviousDirection = insight.Direction;
                 yield return insight;
             }

--- a/Algorithm.Framework/Alphas/RsiAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/RsiAlphaModel.cs
@@ -72,11 +72,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                     switch (state)
                     {
                         case State.TrippedLow:
-                            insights.Add(new Insight(symbol, InsightType.Price, InsightDirection.Up, insightPeriod));
+                            insights.Add(Insight.Price(symbol, insightPeriod, InsightDirection.Up));
                             break;
 
                         case State.TrippedHigh:
-                            insights.Add(new Insight(symbol, InsightType.Price, InsightDirection.Down, insightPeriod));
+                            insights.Add(Insight.Price(symbol, insightPeriod, InsightDirection.Down));
                             break;
                     }
                 }

--- a/Common/Algorithm/Framework/Alphas/Insight.cs
+++ b/Common/Algorithm/Framework/Alphas/Insight.cs
@@ -99,11 +99,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// Initializes a new instance of the <see cref="Insight"/> class
         /// </summary>
         /// <param name="symbol">The symbol this insight is for</param>
+        /// <param name="period">The period over which the prediction will come true</param>
         /// <param name="type">The type of insight, price/volatility</param>
         /// <param name="direction">The predicted direction</param>
-        /// <param name="period">The period over which the prediction will come true</param>
-        public Insight(Symbol symbol, InsightType type, InsightDirection direction, TimeSpan period)
-            : this(symbol, type, direction, period, null, null)
+        public Insight(Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction)
+            : this(symbol, period, type, direction, null, null)
         {
         }
 
@@ -111,12 +111,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// Initializes a new instance of the <see cref="Insight"/> class
         /// </summary>
         /// <param name="symbol">The symbol this insight is for</param>
+        /// <param name="period">The period over which the prediction will come true</param>
         /// <param name="type">The type of insight, price/volatility</param>
         /// <param name="direction">The predicted direction</param>
-        /// <param name="period">The period over which the prediction will come true</param>
         /// <param name="magnitude">The predicted magnitude as a percentage change</param>
         /// <param name="confidence">The confidence in this insight</param>
-        public Insight(Symbol symbol, InsightType type, InsightDirection direction, TimeSpan period, double? magnitude, double? confidence)
+        public Insight(Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence)
         {
             Id = Guid.NewGuid();
             Score = new InsightScore();
@@ -138,13 +138,13 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// </summary>
         /// <param name="generatedTimeUtc">The time this insight was generated in utc</param>
         /// <param name="symbol">The symbol this insight is for</param>
+        /// <param name="period">The period over which the prediction will come true</param>
         /// <param name="type">The type of insight, price/volatility</param>
         /// <param name="direction">The predicted direction</param>
-        /// <param name="period">The period over which the prediction will come true</param>
         /// <param name="magnitude">The predicted magnitude as a percentage change</param>
         /// <param name="confidence">The confidence in this insight</param>
-        public Insight(DateTime generatedTimeUtc, Symbol symbol, InsightType type, InsightDirection direction, TimeSpan period, double? magnitude, double? confidence)
-            : this(symbol,type, direction, period, magnitude, confidence)
+        public Insight(DateTime generatedTimeUtc, Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence)
+            : this(symbol, period, type, direction, magnitude, confidence)
         {
             GeneratedTimeUtc = generatedTimeUtc;
             CloseTimeUtc = generatedTimeUtc + period;
@@ -156,7 +156,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <returns>A new insight with identical values, but new instances</returns>
         public Insight Clone()
         {
-            return new Insight(Symbol, Type, Direction, Period, Magnitude, Confidence)
+            return new Insight(Symbol, Period, Type, Direction, Magnitude, Confidence)
             {
                 GeneratedTimeUtc = GeneratedTimeUtc,
                 CloseTimeUtc = CloseTimeUtc,
@@ -172,13 +172,13 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// </summary>
         /// <param name="symbol">The symbol this insight is for</param>
         /// <param name="period">The period over which the prediction will come true</param>
+        /// <param name="direction">The predicted direction</param>
         /// <param name="magnitude">The predicted magnitude as a percent change</param>
         /// <param name="confidence">The confidence in this insight</param>
         /// <returns>A new insight object for the specified parameters</returns>
-        public static Insight PriceMagnitude(Symbol symbol, double magnitude, TimeSpan period, double? confidence = null)
+        public static Insight Price(Symbol symbol, TimeSpan period, InsightDirection direction, double? magnitude = null, double? confidence = null)
         {
-            var direction = (InsightDirection) Math.Sign(magnitude);
-            return new Insight(symbol, InsightType.Price, direction, period, magnitude, confidence);
+            return new Insight(symbol, period, InsightType.Price, direction, magnitude, confidence);
         }
 
         /// <summary>
@@ -191,9 +191,9 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             var insight = new Insight(
                 Time.UnixTimeStampToDateTime(serializedInsight.GeneratedTime),
                 new Symbol(SecurityIdentifier.Parse(serializedInsight.Symbol), serializedInsight.Ticker),
+                TimeSpan.FromSeconds(serializedInsight.Period),
                 serializedInsight.Type,
                 serializedInsight.Direction,
-                TimeSpan.FromSeconds(serializedInsight.Period),
                 serializedInsight.Magnitude,
                 serializedInsight.Confidence
             )

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -27,8 +27,8 @@ namespace QuantConnect.Tests.Algorithm.Framework
         [Test]
         public void HasReferenceTypeEqualitySemantics()
         {
-            var one = new Insight(Symbols.SPY, InsightType.Price, InsightDirection.Up, Time.OneSecond);
-            var two = new Insight(Symbols.SPY, InsightType.Price, InsightDirection.Up, Time.OneSecond);
+            var one = Insight.Price(Symbols.SPY, Time.OneSecond, InsightDirection.Up);
+            var two = Insight.Price(Symbols.SPY, Time.OneSecond, InsightDirection.Up);
             Assert.AreNotEqual(one, two);
             Assert.AreEqual(one, one);
             Assert.AreEqual(two, two);
@@ -38,7 +38,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
         public void SurvivesRoundTripSerializationUsingJsonConvert()
         {
             var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);
-            var insight = new Insight(time, Symbols.SPY, InsightType.Volatility, InsightDirection.Up, Time.OneMinute, 1, 2);
+            var insight = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2);
             var serialized = JsonConvert.SerializeObject(insight);
             var deserialized = JsonConvert.DeserializeObject<Insight>(serialized);
 


### PR DESCRIPTION
#### Description
- Implements `Insight.Price` method to make it easier to create new instances of `Insight` of `InsightType.Price`.
- Standardize the parameter order to `Symbol`, `TimeSpan`, `InsightType`, `InsightDirection`, `Double`, `Double`.

#### Related Issue
Closes #1848 

#### Motivation and Context
Improve user-friendliness and standardize method/constructor parameter order.

#### Requires Documentation Change
Not yet, since docs on Algorithm Framework are WIP.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`