### PR TITLE
Fix GDAX fees for limit orders in backtesting

### DIFF
--- a/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
+++ b/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
@@ -26,15 +26,15 @@ namespace QuantConnect.Tests.Brokerages.GDAX
     {
         private static readonly Symbol Btcusd = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX);
 
-        public static Security GetSecurity(decimal price = 1m, SecurityType securityType = SecurityType.Crypto)
+        public static Security GetSecurity(decimal price = 1m, SecurityType securityType = SecurityType.Crypto, Resolution resolution = Resolution.Minute)
         {
-              return new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), CreateConfig(securityType), new Cash(CashBook.AccountCurrency, 1000, price),
-              new SymbolProperties("BTCUSD", CashBook.AccountCurrency, 1, 1, 0.01m));
+            return new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), CreateConfig(securityType, resolution), new Cash(CashBook.AccountCurrency, 1000, price),
+                new SymbolProperties("BTCUSD", CashBook.AccountCurrency, 1, 1, 0.01m));
         }
 
-        private static SubscriptionDataConfig CreateConfig(SecurityType securityType = SecurityType.Crypto)
+        private static SubscriptionDataConfig CreateConfig(SecurityType securityType = SecurityType.Crypto, Resolution resolution = Resolution.Minute)
         {
-            return new SubscriptionDataConfig(typeof(TradeBar), Symbol.Create("BTCUSD", securityType, Market.GDAX), Resolution.Minute, TimeZones.Utc, TimeZones.Utc,
+            return new SubscriptionDataConfig(typeof(TradeBar), Symbol.Create("BTCUSD", securityType, Market.GDAX), resolution, TimeZones.Utc, TimeZones.Utc,
             false, true, false);
         }
 


### PR DESCRIPTION

#### Description
The `GDAXFeeModel` has been updated to return the expected fees for limit orders. 
We now use bid/ask prices only with Tick resolution, in all other cases the time of the fill will be used to decide if a limit order is marketable or not.

#### Related Issue
Fixes #1852

#### Motivation and Context
GDAX fees in backtesting are incorrect.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manual testing + new included unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`