### PR TITLE
Framework Selection Python Support

### DIFF
--- a/Algorithm.Framework/Selection/CoarseFundamentalUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/CoarseFundamentalUniverseSelectionModel.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using Python.Runtime;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
 
@@ -40,6 +41,26 @@ namespace QuantConnect.Algorithm.Framework.Selection
             : base(false, universeSettings, securityInitializer)
         {
             _coarseSelector = coarseSelector;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CoarseFundamentalUniverseSelectionModel"/> class
+        /// </summary>
+        /// <param name="coarseSelector">Selects symbols from the provided coarse data set</param>
+        /// <param name="universeSettings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
+        /// <param name="securityInitializer">Performs extra initialization (such as setting models) after we create a new security object</param>
+        public CoarseFundamentalUniverseSelectionModel(
+            PyObject coarseSelector,
+            UniverseSettings universeSettings = null,
+            ISecurityInitializer securityInitializer = null
+            )
+            : base(false, universeSettings, securityInitializer)
+        {
+            Func<IEnumerable<CoarseFundamental>, Symbol[]> func;
+            if (coarseSelector.TryConvertToDelegate(out func))
+            {
+                _coarseSelector = func;
+            }
         }
 
         /// <inheritdoc />

--- a/Algorithm.Framework/Selection/FineFundamentalUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/FineFundamentalUniverseSelectionModel.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using Python.Runtime;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
@@ -46,6 +47,31 @@ namespace QuantConnect.Algorithm.Framework.Selection
         {
             _coarseSelector = coarseSelector;
             _fineSelector = fineSelector;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FineFundamentalUniverseSelectionModel"/> class
+        /// </summary>
+        /// <param name="coarseSelector">Selects symbols from the provided coarse data set</param>
+        /// <param name="fineSelector">Selects symbols from the provided fine data set (this set has already been filtered according to the coarse selection)</param>
+        /// <param name="universeSettings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
+        /// <param name="securityInitializer">Performs extra initialization (such as setting models) after we create a new security object</param>
+        public FineFundamentalUniverseSelectionModel(
+            PyObject coarseSelector,
+            PyObject fineSelector,
+            UniverseSettings universeSettings = null,
+            ISecurityInitializer securityInitializer = null
+            )
+            : base(true, universeSettings, securityInitializer)
+        {
+            Func<IEnumerable<FineFundamental>, Symbol[]> fineFunc;
+            Func<IEnumerable<CoarseFundamental>, Symbol[]> coarseFunc;
+            if (fineSelector.TryConvertToDelegate(out fineFunc) &&
+                coarseSelector.TryConvertToDelegate(out coarseFunc))
+            {
+                _fineSelector = fineFunc;
+                _coarseSelector = coarseFunc;
+            }
         }
 
         /// <inheritdoc />

--- a/Algorithm.Framework/Selection/ScheduledUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ScheduledUniverseSelectionModel.cs
@@ -16,8 +16,8 @@
 using System;
 using System.Collections.Generic;
 using NodaTime;
+using Python.Runtime;
 using QuantConnect.Data.UniverseSelection;
-using QuantConnect.Interfaces;
 using QuantConnect.Scheduling;
 using QuantConnect.Securities;
 
@@ -67,6 +67,46 @@ namespace QuantConnect.Algorithm.Framework.Selection
             _dateRule = dateRule;
             _timeRule = timeRule;
             _selector = selector;
+            _settings = settings;
+            _initializer = initializer;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScheduledUniverseSelectionModel"/> class using the algorithm's time zone
+        /// </summary>
+        /// <param name="dateRule">Date rule defines what days the universe selection function will be invoked</param>
+        /// <param name="timeRule">Time rule defines what times on each day selected by date rule the universe selection function will be invoked</param>
+        /// <param name="selector">Selector function accepting the date time firing time and returning the universe selected symbols</param>
+        /// <param name="settings">Universe settings for subscriptions added via this universe, null will default to algorithm's universe settings</param>
+        /// <param name="initializer">Security initializer for new securities created via this universe, null will default to algorithm's security initializer</param>
+        public ScheduledUniverseSelectionModel(IDateRule dateRule, ITimeRule timeRule, PyObject selector, UniverseSettings settings = null, ISecurityInitializer initializer = null)
+        {
+            Func<DateTime, Symbol[]> func;
+            selector.TryConvertToDelegate(out func);
+            _dateRule = dateRule;
+            _timeRule = timeRule;
+            _selector = func;
+            _settings = settings;
+            _initializer = initializer;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScheduledUniverseSelectionModel"/> class
+        /// </summary>
+        /// <param name="timeZone">The time zone the date/time rules are in</param>
+        /// <param name="dateRule">Date rule defines what days the universe selection function will be invoked</param>
+        /// <param name="timeRule">Time rule defines what times on each day selected by date rule the universe selection function will be invoked</param>
+        /// <param name="selector">Selector function accepting the date time firing time and returning the universe selected symbols</param>
+        /// <param name="settings">Universe settings for subscriptions added via this universe, null will default to algorithm's universe settings</param>
+        /// <param name="initializer">Security initializer for new securities created via this universe, null will default to algorithm's security initializer</param>
+        public ScheduledUniverseSelectionModel(DateTimeZone timeZone, IDateRule dateRule, ITimeRule timeRule, PyObject selector, UniverseSettings settings = null, ISecurityInitializer initializer = null)
+        {
+            Func<DateTime, Symbol[]> func;
+            selector.TryConvertToDelegate(out func);
+            _timeZone = timeZone;
+            _dateRule = dateRule;
+            _timeRule = timeRule;
+            _selector = func;
             _settings = settings;
             _initializer = initializer;
         }

--- a/Algorithm.Python/MeanVarianceOptimizationAlgorithm.py
+++ b/Algorithm.Python/MeanVarianceOptimizationAlgorithm.py
@@ -40,7 +40,6 @@ class MeanVarianceOptimizationAlgorithm(QCAlgorithmFramework):
     '''Mean Variance Optimization algorithm.'''
 
     def Initialize(self):
-        ''' Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
         # Set requested data resolution
         self.UniverseSettings.Resolution = Resolution.Minute
@@ -49,18 +48,17 @@ class MeanVarianceOptimizationAlgorithm(QCAlgorithmFramework):
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
 
-        selector = PythonUtil.ToCoarseFundamentalSelector(self.coarseSelector)
         self.symbols = [ Symbol.Create(x, SecurityType.Equity, Market.USA) for x in [ 'AIG', 'BAC', 'IBM', 'SPY' ] ]
 
         self.minimum_weight = -1
         self.maximum_weight = 1
 
         # set algorithm framework models
-        self.UniverseSelection = CoarseFundamentalUniverseSelectionModel(selector)
-        self.Alpha = HistoricalReturnsAlphaModel(resolution = Resolution.Daily)
-        self.PortfolioConstruction = MeanVarianceOptimizationPortfolioConstructionModel(optimization_method = self.maximum_sharpe_ratio)
-        self.Execution = ImmediateExecutionModel()
-        self.RiskManagement = NullRiskManagementModel()
+        self.SetUniverseSelection(CoarseFundamentalUniverseSelectionModel(self.coarseSelector))
+        self.SetAlpha(HistoricalReturnsAlphaModel(resolution = Resolution.Daily))
+        self.SetPortfolioConstruction(MeanVarianceOptimizationPortfolioConstructionModel(optimization_method = self.maximum_sharpe_ratio))
+        self.SetExecution(ImmediateExecutionModel())
+        self.SetRiskManagement(NullRiskManagementModel())
 
     def coarseSelector(self, coarse):
         # Drops SPY after the 8th

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -141,6 +141,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="BasicTemplateCryptoAlgorithm.py" />
+    <None Include="ScheduledUniverseSelectionModelRegressionAlgorithm.py" />
     <Content Include="MeanVarianceOptimizationAlgorithm.py" />
     <Content Include="BasicTemplateFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateLibrary.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -94,6 +94,7 @@
     <Compile Include="RegressionChannelAlgorithm.py" />
     <Compile Include="RollingWindowAlgorithm.py" />
     <Compile Include="ScheduledEventsAlgorithm.py" />
+    <Compile Include="ScheduledUniverseSelectionModelRegressionAlgorithm.py" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.py" />
     <Compile Include="UniverseSelectionRegressionAlgorithm.py" />
     <Compile Include="UpdateOrderRegressionAlgorithm.py" />

--- a/Algorithm.Python/ScheduledUniverseSelectionModelRegressionAlgorithm.py
+++ b/Algorithm.Python/ScheduledUniverseSelectionModelRegressionAlgorithm.py
@@ -1,0 +1,126 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from datetime import datetime, timedelta
+
+### <summary>
+### Regression algortihm for testing ScheduledUniverseSelectionModel scheduling functions.
+### </summary>
+class ScheduledUniverseSelectionModelRegressionAlgorithm(QCAlgorithmFramework):
+    '''Regression algortihm for testing ScheduledUniverseSelectionModel scheduling functions.'''
+
+    def Initialize(self):
+
+        self.UniverseSettings.Resolution = Resolution.Hour
+
+        self.SetStartDate(2017, 1, 1)
+        self.SetEndDate(2017, 2, 1)
+
+        # selection will run on mon/tues/thurs at 00:00/06:00/12:00/18:00
+        self.SetUniverseSelection(ScheduledUniverseSelectionModel(
+            self.DateRules.Every(DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Thursday),
+            self.TimeRules.Every(timedelta(hours = 12)),
+            self.SelectSymbols
+            ))
+
+        self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(1)))
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+
+        # some days of the week have different behavior the first time -- less securities to remove
+        self.seenDays = []
+
+    def SelectSymbols(self, dateTime):
+
+        symbols = []
+        weekday = dateTime.weekday()
+
+        if weekday == 0 or weekday == 1:
+            symbols.append(Symbol.Create('SPY', SecurityType.Equity, Market.USA))
+        elif weekday == 2:
+            # given the date/time rules specified in Initialize, this symbol will never be selected (not invoked on wednesdays)
+            symbols.append(Symbol.Create('AAPL', SecurityType.Equity, Market.USA))
+        else:
+            symbols.append(Symbol.Create('IBM', SecurityType.Equity, Market.USA))
+
+        if weekday == 1 or weekday == 3:
+            symbols.append(Symbol.Create('EURUSD', SecurityType.Forex, Market.FXCM))
+        elif weekday == 4:
+            # given the date/time rules specified in Initialize, this symbol will never be selected (every 6 hours never lands on hour==1)
+            symbols.append(Symbol.Create('EURGBP', SecurityType.Forex, Market.FXCM))
+        else:
+            symbols.append(Symbol.Create('NZDUSD', SecurityType.Forex, Market.FXCM))
+
+        return symbols
+
+    def OnSecuritiesChanged(self, changes):
+        self.Log("{}: {}".format(self.Time, changes))
+
+        weekday = self.Time.weekday()
+
+        if weekday == 0:
+            self.ExpectAdditions(changes, 'SPY', 'NZDUSD');
+            if weekday not in self.seenDays:
+                self.seenDays.append(weekday)
+                self.ExpectRemovals(changes, None)
+            else:
+                self.ExpectRemovals(changes, 'EURUSD', 'IBM')
+
+        if weekday == 1:
+            self.ExpectAdditions(changes, 'EURUSD');
+            if weekday not in self.seenDays:
+                self.seenDays.append(weekday)
+                self.ExpectRemovals(changes, 'NZDUSD')
+            else:
+                self.ExpectRemovals(changes, 'NZDUSD')
+
+        if weekday == 2 or weekday == 4:
+            # selection function not invoked on wednesdays (2) or friday (4)
+            self.ExpectAdditions(changes, None)
+            self.ExpectRemovals(changes, None)
+
+        if weekday == 3:
+            self.ExpectAdditions(changes, "IBM")
+            self.ExpectRemovals(changes, "SPY")
+
+
+    def OnOrderEvent(self, orderEvent):
+        self.Log("{}: {}".format(self.Time, orderEvent))
+
+    def ExpectAdditions(self, changes, *tickers):
+        if tickers is None and changes.AddedSecurities.Count > 0:
+            raise Exception("{}: Expected no additions: {}".format(self.Time, self.Time.weekday()))
+
+        for ticker in tickers:
+            if ticker is not None and ticker not in [s.Symbol.Value for s in changes.AddedSecurities]:
+                raise Exception("{}: Expected {} to be added: {}".format(self.Time, ticker, self.Time.weekday()));
+
+    def ExpectRemovals(self, changes, *tickers):
+        if tickers is None and changes.RemovedSecurities.Count > 0:
+            raise Exception("{}: Expected no removals: {}".format(self.Time, self.Time.weekday()))
+
+        for ticker in tickers:
+            if ticker is not None and ticker not in [s.Symbol.Value for s in changes.RemovedSecurities]:
+                raise Exception("{}: Expected {} to be removed: {}".format(self.Time, ticker, self.Time.weekday()));

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -982,6 +982,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("CustomIndicatorAlgorithm", basicTemplateStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("BasicTemplateCryptoAlgorithm", basicTemplateCryptoAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("IndicatorSuiteAlgorithm", indicatorSuiteAlgorithmStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.Python),
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION
#### Description
- Implements `TryConvertToDelegate` extension method
   Condenses three `PythonUtil` static methods that converts python objects in a multi delegate into one.
- Adds constructor overloads with `PyObject` parameter to UniverseSelectionModel
   The `PyObject` parameter is converted into selector function of `Func<T1,T2>` type so that the model can user universe selector methods defined in python algorithms.
- Adds python version of `ScheduledUniverseSelectionModelRegressionAlgorithm`


#### Related Issue
Closes #1846

#### Motivation and Context
QuantConnect has three universe selection models that can be used at `QCAlgorithmFramework` algorithms that covers most of common universe selection cases: Coarse Universe, Fine Universe and Scheduled Universe. In order to make it easy to use for python users, we just need to add a constructor overload that accepts a python method/lambda.

#### Requires Documentation Change
Yes. Universe Selection section in Framework docs should explain the input and output of selector method. 

#### How Has This Been Tested?
Unit and regression tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`