### PR TITLE
Fixes PythonExceptionStackParser

### DIFF
--- a/Common/Util/PythonUtil.cs
+++ b/Common/Util/PythonUtil.cs
@@ -159,7 +159,7 @@ namespace QuantConnect.Util
                     line = $" in {line}:{info[1].Trim()}";
 
                     info = info[2].Split(new[] { "\\n" }, StringSplitOptions.RemoveEmptyEntries);
-                    line = $" {info[0].Replace("in", "at")}{line}";
+                    line = $" {info[0].Replace(" in ", " at ")}{line}";
 
                     // If we have the exact statement, add it to the error line
                     if (info.Length > 2) line += $" :: {info[1].Trim()}";


### PR DESCRIPTION
#### Description
`PythonExceptionStackParser` was wrongly replacing all `in` string for `at` where it should only replace the first occurence.

#### Related Issue
Closes #1867 

#### Motivation and Context
Improve exception information.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Simple algorithm from issue #1867.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`