### PR TITLE
Fixes missing inner exception information in ScheduledEventException

### DIFF
--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -157,7 +157,7 @@ namespace QuantConnect.Lean.Engine.RealTime
 
                         // Errors in scheduled event should be treated as runtime error
                         // Runtime errors should end Lean execution
-                        _algorithm.RunTimeError = new Exception(errorMessage);
+                        _algorithm.RunTimeError = scheduledEventException;
                     }
                 }
             }


### PR DESCRIPTION
#### Description
When a `ScheduledEventException` was thrown, `IAlgorithm.RunTimeError` was not set as `ScheduledEventException` , but as `Exception` with the orginal exception message and no inner exception.

#### Related Issue
Closes #1870 

#### Motivation and Context
Improve exception information.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Simple algorithm from issue #1870. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`