### PR TITLE
Fixes RenkoConsolidator for python

### DIFF
--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -142,6 +142,7 @@
   <ItemGroup>
     <None Include="BasicTemplateCryptoAlgorithm.py" />
     <None Include="ScheduledUniverseSelectionModelRegressionAlgorithm.py" />
+    <None Include="RenkoConsolidatorAlgorithm.py" />
     <Content Include="MeanVarianceOptimizationAlgorithm.py" />
     <Content Include="BasicTemplateFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateLibrary.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -92,6 +92,7 @@
     <Compile Include="QuandlImporterAlgorithm.py" />
     <Compile Include="RegressionAlgorithm.py" />
     <Compile Include="RegressionChannelAlgorithm.py" />
+    <Compile Include="RenkoConsolidatorAlgorithm.py" />
     <Compile Include="RollingWindowAlgorithm.py" />
     <Compile Include="ScheduledEventsAlgorithm.py" />
     <Compile Include="ScheduledUniverseSelectionModelRegressionAlgorithm.py" />

--- a/Algorithm.Python/RenkoConsolidatorAlgorithm.py
+++ b/Algorithm.Python/RenkoConsolidatorAlgorithm.py
@@ -1,0 +1,63 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Data.Consolidators import *
+from datetime import timedelta
+
+### <summary>
+### Demonstration of how to initialize and use the RenkoConsolidator
+### </summary>
+### <meta name="tag" content="renko" />
+### <meta name="tag" content="indicators" />
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="consolidating data" />
+class RenkoConsolidatorAlgorithm(QCAlgorithm):
+    '''Demonstration of how to initialize and use the RenkoConsolidator'''
+
+    def Initialize(self):
+
+        self.SetStartDate(2012, 1, 1)
+        self.SetEndDate(2013, 1, 1)
+
+        self.AddEquity("SPY")
+
+        # this is the simple constructor that will perform the
+        # renko logic to the Value property of the data it receives.
+
+        # break SPY into $2.5 renko bricks and send that data to our 'OnRenkoBar' method
+        renkoClose = RenkoConsolidator(2.5)
+        renkoClose.DataConsolidated += self.HandleRenkoClose
+        self.SubscriptionManager.AddConsolidator("SPY", renkoClose)
+
+
+    # We're doing our analysis in the OnRenkoBar method, but the framework verifies that this method exists, so we define it.
+    def OnData(self, data):
+        pass
+
+
+    def HandleRenkoClose(self, sender, data):
+        '''This function is called by our renkoClose consolidator defined in Initialize()
+        Args:
+            data: The new renko bar produced by the consolidator'''
+        if not self.Portfolio.Invested:
+            self.SetHoldings(data.Symbol, 1)
+
+        self.Log("CLOSE - {0} - {1} {2}".format(data.Time, data.Open, data.Close))

--- a/Common/Data/Consolidators/RenkoConsolidator.cs
+++ b/Common/Data/Consolidators/RenkoConsolidator.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using Python.Runtime;
 using QuantConnect.Data.Market;
 
 namespace QuantConnect.Data.Consolidators
@@ -110,6 +111,32 @@ namespace QuantConnect.Data.Consolidators
             _volumeSelector = volumeSelector ?? (x => 0);
 
             Type = RenkoType.Classic;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RenkoConsolidator" /> class.
+        /// </summary>
+        /// <param name="barSize">The size of each bar in units of the value produced by <paramref name="selector"/></param>
+        /// <param name="selector">Extracts the value from a data instance to be formed into a <see cref="RenkoBar"/>. The default
+        /// value is (x => x.Value) the <see cref="IBaseData.Value"/> property on <see cref="IBaseData"/></param>
+        /// <param name="volumeSelector">Extracts the volume from a data instance. The default value is null which does
+        /// not aggregate volume per bar.</param>
+        /// <param name="evenBars">When true bar open/close will be a multiple of the barSize</param>
+        public RenkoConsolidator(decimal barSize, PyObject selector, PyObject volumeSelector = null, bool evenBars = true)
+            : this(barSize, evenBars)
+        {
+            if (barSize < Extensions.GetDecimalEpsilon())
+            {
+                throw new ArgumentOutOfRangeException("barSize", "RenkoConsolidator bar size must be positve and greater than 1e-28");
+            }
+
+            Func<IBaseData, decimal> selectorWrapper;
+            selector.TryConvertToDelegate(out selectorWrapper);
+            _selector = selectorWrapper ?? (x => x.Value);
+
+            Func<IBaseData, decimal> volumeSelectorWrapper;
+            volumeSelector.TryConvertToDelegate(out volumeSelectorWrapper);
+            _volumeSelector = volumeSelectorWrapper ?? (x => 0);
         }
 
         /// <summary>

--- a/Common/Data/Consolidators/RenkoConsolidator.cs
+++ b/Common/Data/Consolidators/RenkoConsolidator.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Data.Consolidators
         /// <summary>
         /// Event handler that fires when a new piece of data is produced
         /// </summary>
-        public EventHandler<RenkoBar> DataConsolidated;
+        public event EventHandler<RenkoBar> DataConsolidated;
 
         /// <summary>
         /// Event handler that fires when a new piece of data is produced
@@ -63,10 +63,11 @@ namespace QuantConnect.Data.Consolidators
         public RenkoConsolidator(decimal barSize, RenkoType type)
         {
             if (type != RenkoType.Wicked)
-                throw new ArgumentOutOfRangeException("type");
+            {
+                throw new ArgumentException($"RenkoConsolidator can only be initialized with RenkoType.Wicked. For RenkoType.Classic, please use the other constructor overloads.");
+            }
 
             _barSize = barSize;
-
             Type = type;
         }
 
@@ -119,62 +120,39 @@ namespace QuantConnect.Data.Consolidators
         /// <summary>
         /// Gets the bar size used by this consolidator
         /// </summary>
-        public decimal BarSize
-        {
-            get { return _barSize; }
-        }
+        public decimal BarSize => _barSize;
 
         /// <summary>
         /// Gets the most recently consolidated piece of data. This will be null if this consolidator
         /// has not produced any data yet.
         /// </summary>
-        public IBaseData Consolidated
-        {
-            get; private set;
-        }
+        public IBaseData Consolidated { get; private set; }
 
         /// <summary>
         /// Gets a clone of the data being currently consolidated
         /// </summary>
-        public IBaseData WorkingData
-        {
-            get { return _currentBar == null ? null : _currentBar.Clone(); }
-        }
+        public IBaseData WorkingData => _currentBar?.Clone();
 
         /// <summary>
         /// Gets the type consumed by this consolidator
         /// </summary>
-        public Type InputType
-        {
-            get { return typeof (IBaseData); }
-        }
+        public Type InputType => typeof(IBaseData);
 
         /// <summary>
         /// Gets <see cref="RenkoBar"/> which is the type emitted in the <see cref="IDataConsolidator.DataConsolidated"/> event.
         /// </summary>
-        public Type OutputType
-        {
-            get { return typeof(RenkoBar); }
-        }
+        public Type OutputType => typeof(RenkoBar);
 
         // Used for unit tests
-        internal RenkoBar OpenRenkoBar
-        {
-            get
-            {
-                return new RenkoBar(null, _openOn, _closeOn,
-                    BarSize, _openRate, _highRate, _lowRate, _closeRate);
-            }
-        }
+        internal RenkoBar OpenRenkoBar => new RenkoBar(null, _openOn, _closeOn, _barSize, _openRate, _highRate, _lowRate, _closeRate);
 
         private void Rising(IBaseData data)
         {
             decimal limit;
 
-            while (_closeRate > (limit = (_openRate + BarSize)))
+            while (_closeRate > (limit = _openRate + _barSize))
             {
-                var wicko = new RenkoBar(data.Symbol, _openOn, _closeOn,
-                    BarSize, _openRate, limit, _lowRate, limit);
+                var wicko = new RenkoBar(data.Symbol, _openOn, _closeOn, _barSize, _openRate, limit, _lowRate, limit);
 
                 _lastWicko = wicko;
 
@@ -190,10 +168,9 @@ namespace QuantConnect.Data.Consolidators
         {
             decimal limit;
 
-            while (_closeRate < (limit = (_openRate - BarSize)))
+            while (_closeRate < (limit = _openRate - _barSize))
             {
-                var wicko = new RenkoBar(data.Symbol, _openOn, _closeOn,
-                    BarSize, _openRate, _highRate, limit, limit);
+                var wicko = new RenkoBar(data.Symbol, _openOn, _closeOn, _barSize, _openRate, _highRate, limit, limit);
 
                 _lastWicko = wicko;
 
@@ -213,9 +190,13 @@ namespace QuantConnect.Data.Consolidators
         public void Update(IBaseData data)
         {
             if (Type == RenkoType.Classic)
+            {
                 UpdateClassic(data);
+            }
             else
+            {
                 UpdateWicked(data);
+            }
         }
 
         private void UpdateWicked(IBaseData data)
@@ -237,30 +218,25 @@ namespace QuantConnect.Data.Consolidators
             {
                 _closeOn = data.Time;
 
-                if (rate > _highRate)
-                    _highRate = rate;
+                if (rate > _highRate) _highRate = rate;
 
-                if (rate < _lowRate)
-                    _lowRate = rate;
+                if (rate < _lowRate) _lowRate = rate;
 
                 _closeRate = rate;
 
                 if (_closeRate > _openRate)
                 {
-                    if (_lastWicko == null ||
-                        (_lastWicko.Direction == BarDirection.Rising))
+                    if (_lastWicko == null || _lastWicko.Direction == BarDirection.Rising)
                     {
                         Rising(data);
-
                         return;
                     }
 
-                    var limit = (_lastWicko.Open + BarSize);
+                    var limit = _lastWicko.Open + _barSize;
 
                     if (_closeRate > limit)
                     {
-                        var wicko = new RenkoBar(data.Symbol, _openOn, _closeOn,
-                            BarSize, _lastWicko.Open, limit, _lowRate, limit);
+                        var wicko = new RenkoBar(data.Symbol, _openOn, _closeOn, _barSize, _lastWicko.Open, limit, _lowRate, limit);
 
                         _lastWicko = wicko;
 
@@ -275,20 +251,17 @@ namespace QuantConnect.Data.Consolidators
                 }
                 else if (_closeRate < _openRate)
                 {
-                    if (_lastWicko == null ||
-                        (_lastWicko.Direction == BarDirection.Falling))
+                    if (_lastWicko == null || _lastWicko.Direction == BarDirection.Falling)
                     {
                         Falling(data);
-
                         return;
                     }
 
-                    var limit = (_lastWicko.Open - BarSize);
+                    var limit = _lastWicko.Open - _barSize;
 
                     if (_closeRate < limit)
                     {
-                        var wicko = new RenkoBar(data.Symbol, _openOn, _closeOn,
-                            BarSize, _lastWicko.Open, _highRate, limit, limit);
+                        var wicko = new RenkoBar(data.Symbol, _openOn, _closeOn, _barSize, _lastWicko.Open, _highRate, limit, limit);
 
                         _lastWicko = wicko;
 
@@ -330,7 +303,7 @@ namespace QuantConnect.Data.Consolidators
                 var open = close ?? currentValue;
                 if (_evenBars && !close.HasValue)
                 {
-                    open = Math.Ceiling(open/_barSize)*_barSize;
+                    open = Math.Ceiling(open / _barSize) * _barSize;
                 }
                 _currentBar = new RenkoBar(data.Symbol, data.Time, _barSize, open, volume);
             }
@@ -351,21 +324,16 @@ namespace QuantConnect.Data.Consolidators
         /// <param name="consolidated">The newly consolidated data</param>
         protected virtual void OnDataConsolidated(RenkoBar consolidated)
         {
-            var handler = DataConsolidated;
-            if (handler != null) handler(this, consolidated);
+            DataConsolidated?.Invoke(this, consolidated);
 
-            var explicitHandler = _dataConsolidatedHandler;
-            if (explicitHandler != null) explicitHandler(this, consolidated);
+            _dataConsolidatedHandler?.Invoke(this, consolidated);
 
             Consolidated = consolidated;
         }
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
         /// <filterpriority>2</filterpriority>
-        public void Dispose()
-        {
-            _dataConsolidatedHandler = null;
-        }
+        public void Dispose() => _dataConsolidatedHandler = null;
     }
 
     /// <summary>

--- a/Common/Data/Consolidators/RenkoConsolidator.cs
+++ b/Common/Data/Consolidators/RenkoConsolidator.cs
@@ -130,13 +130,29 @@ namespace QuantConnect.Data.Consolidators
                 throw new ArgumentOutOfRangeException("barSize", "RenkoConsolidator bar size must be positve and greater than 1e-28");
             }
 
-            Func<IBaseData, decimal> selectorWrapper;
-            selector.TryConvertToDelegate(out selectorWrapper);
-            _selector = selectorWrapper ?? (x => x.Value);
+            if (selector != null)
+            {
+                if (!selector.TryConvertToDelegate(out _selector))
+                {
+                    throw new ArgumentException("Unable to convert parameter 'selector' to delegate type Func<IBaseData, decimal>");
+                }
+            }
+            else
+            {
+                _selector = (x => x.Value);
+            }
 
-            Func<IBaseData, decimal> volumeSelectorWrapper;
-            volumeSelector.TryConvertToDelegate(out volumeSelectorWrapper);
-            _volumeSelector = volumeSelectorWrapper ?? (x => 0);
+            if (volumeSelector != null)
+            {
+                if (!volumeSelector.TryConvertToDelegate(out _volumeSelector))
+                {
+                    throw new ArgumentException("Unable to convert parameter 'volumeSelector' to delegate type Func<IBaseData, decimal>");
+                }
+            }
+            else
+            {
+                _volumeSelector = (x => 0);
+            }
         }
 
         /// <summary>
@@ -360,7 +376,11 @@ namespace QuantConnect.Data.Consolidators
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
         /// <filterpriority>2</filterpriority>
-        public void Dispose() => _dataConsolidatedHandler = null;
+        public void Dispose()
+        {
+            DataConsolidated = null;
+            _dataConsolidatedHandler = null;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
#### Description
- Missing `event` keyword prevented pythonnet to recognize `DataConsolidated` as a event handler.
- Adds python version of `RenkoConsolidatorAlgorithm`.

#### Related Issue
Closes #1742

#### Motivation and Context
It was not possible to attach events to renko consolidators.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Existing tests and new algorithm.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`