### PR TITLE
Multiple alpha models

### DIFF
--- a/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Algorithm.Framework.Selection;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Show cases how to use the <see cref="CompositeAlphaModel"/> to define
+    /// </summary>
+    public class CompositeAlphaModelFrameworkAlgorithm : QCAlgorithmFramework
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+
+            // even though we're using a framework algorithm, we can still add our securities
+            // using the AddEquity/Forex/Crypto/ect methods and then pass them into a manual
+            // universe selection model using Securities.Keys
+            AddEquity("SPY");
+            AddEquity("IBM");
+            AddEquity("BAC");
+            AddEquity("AIG");
+
+            // define a manual universe of all the securities we manually registered
+            UniverseSelection = new ManualUniverseSelectionModel(Securities.Keys);
+
+            // define alpha model as a composite of the rsi and ema cross models
+            Alpha = new CompositeAlphaModel(
+                new RsiAlphaModel(),
+                new EmaCrossAlphaModel()
+            );
+
+            // default models for the rest
+            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
+            Execution = new ImmediateExecutionModel();
+            RiskManagement = new NullRiskManagementModel();
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -88,6 +88,7 @@
     </Compile>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
     <Compile Include="CancelOpenOrdersRegressionAlgorithm.cs" />
+    <Compile Include="CompositeAlphaModelFrameworkAlgorithm.cs" />
     <Compile Include="DuplicateSecurityWithBenchmarkRegressionAlgorithm.cs" />
     <Compile Include="BasicTemplateCryptoAlgorithm.cs" />
     <Compile Include="BasicTemplateCryptoFrameworkAlgorithm.cs" />

--- a/Algorithm.Framework/Alphas/AlphaModelPythonWrapper.cs
+++ b/Algorithm.Framework/Alphas/AlphaModelPythonWrapper.cs
@@ -24,9 +24,27 @@ namespace QuantConnect.Algorithm.Framework.Alphas
     /// <summary>
     /// Provides an implementation of <see cref="IAlphaModel"/> that wraps a <see cref="PyObject"/> object
     /// </summary>
-    public class AlphaModelPythonWrapper : IAlphaModel
+    public class AlphaModelPythonWrapper : IAlphaModel, INamedModel
     {
         private readonly dynamic _model;
+
+        public string Name
+        {
+            get
+            {
+                using (Py.GIL())
+                {
+                    // if the model defines a Name property then use that
+                    if (_model.HasAttr("Name"))
+                    {
+                        return _model.Name;
+                    }
+
+                    // if the model does not define a name property, use the python type name
+                    return _model.GetPythonType();
+                }
+            }
+        }
 
         /// <summary>
         /// Constructor for initialising the <see cref="IAlphaModel"/> class with wrapped <see cref="PyObject"/> object

--- a/Algorithm.Framework/Alphas/CompositeAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/CompositeAlphaModel.cs
@@ -1,0 +1,86 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Util;
+
+namespace QuantConnect.Algorithm.Framework.Alphas
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IAlphaModel"/> that combines multiple alpha
+    /// models into a single alpha model and properly sets each insights 'SourceModel' property.
+    /// </summary>
+    public class CompositeAlphaModel : IAlphaModel
+    {
+        private readonly IAlphaModel[] _alphaModels;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositeAlphaModel"/> class
+        /// </summary>
+        /// <param name="alphaModels">The individual alpha models defining this composite model</param>
+        public CompositeAlphaModel(params IAlphaModel[] alphaModels)
+        {
+            if (alphaModels.IsNullOrEmpty())
+            {
+                throw new ArgumentException("Must specify at least 1 alpha model for the CompositeAlphaModel");
+            }
+
+            _alphaModels = alphaModels;
+        }
+
+        /// <summary>
+        /// Updates this alpha model with the latest data from the algorithm.
+        /// This is called each time the algorithm receives data for subscribed securities.
+        /// This method patches this call through the each of the wrapped models.
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="data">The new data available</param>
+        /// <returns>The new insights generated</returns>
+        public IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data)
+        {
+            foreach (var model in _alphaModels)
+            {
+                var name = model.GetModelName();
+                foreach (var insight in model.Update(algorithm, data))
+                {
+                    if (string.IsNullOrEmpty(insight.SourceModel))
+                    {
+                        // set the source model name if not already set
+                        insight.SourceModel = name;
+                    }
+
+                    yield return insight;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed.
+        /// This method patches this call through the each of the wrapped models.
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
+        /// <param name="changes">The security additions and removals from the algorithm</param>
+        public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        {
+            foreach (var model in _alphaModels)
+            {
+                model.OnSecuritiesChanged(algorithm, changes);
+            }
+        }
+    }
+}

--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
@@ -24,7 +24,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
     /// <summary>
     /// Provides an implementation of <see cref="IAlphaModel"/> that always returns the same insight for each security
     /// </summary>
-    public class ConstantAlphaModel : IAlphaModel
+    public class ConstantAlphaModel : IAlphaModel, INamedModel
     {
         private readonly InsightType _type;
         private readonly InsightDirection _direction;
@@ -33,6 +33,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private readonly double? _confidence;
         private readonly HashSet<Security> _securities;
         private readonly Dictionary<Symbol, DateTime> _insightsTimeBySymbol;
+
+        /// <summary>
+        /// Defines a name for a framework model
+        /// </summary>
+        public string Name { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstantAlphaModel"/> class
@@ -65,6 +70,19 @@ namespace QuantConnect.Algorithm.Framework.Alphas
 
             _securities = new HashSet<Security>();
             _insightsTimeBySymbol = new Dictionary<Symbol, DateTime>();
+
+            Name = $"{nameof(ConstantAlphaModel)}({type},{direction},{period}";
+            if (magnitude.HasValue)
+            {
+                Name += $",{magnitude.Value}";
+            }
+
+            if (confidence.HasValue)
+            {
+                Name += $",{confidence.Value}";
+            }
+
+            Name += ")";
         }
 
         /// <summary>

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
@@ -25,13 +24,18 @@ namespace QuantConnect.Algorithm.Framework.Alphas
     /// <summary>
     /// Alpha model that uses an EMA cross to create insights
     /// </summary>
-    public class EmaCrossAlphaModel : IAlphaModel
+    public class EmaCrossAlphaModel : IAlphaModel, INamedModel
     {
         private readonly int _fastPeriod;
         private readonly int _slowPeriod;
         private readonly Resolution _resolution;
         private readonly int _predictionInterval;
         private readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol;
+
+        /// <summary>
+        /// Defines a name for a framework model
+        /// </summary>
+        public string Name { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EmaCrossAlphaModel"/> class
@@ -50,6 +54,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             _resolution = resolution;
             _predictionInterval = fastPeriod;
             _symbolDataBySymbol = new Dictionary<Symbol, SymbolData>();
+            Name = $"{nameof(EmaCrossAlphaModel)}({fastPeriod},{slowPeriod},{resolution})";
         }
 
         /// <summary>

--- a/Algorithm.Framework/Alphas/IAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/IAlphaModel.cs
@@ -32,4 +32,24 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <returns>The new insights generated</returns>
         IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data);
     }
+
+    /// <summary>
+    /// Provides extension methods for alpha models
+    /// </summary>
+    public static class AlphaModel
+    {
+        /// <summary>
+        /// Gets the name of the alpha model
+        /// </summary>
+        public static string GetModelName(this IAlphaModel model)
+        {
+            var namedModel = model as INamedModel;
+            if (namedModel != null)
+            {
+                return namedModel.Name;
+            }
+
+            return model.GetType().Name;
+        }
+    }
 }

--- a/Algorithm.Framework/Alphas/INamedModel.cs
+++ b/Algorithm.Framework/Alphas/INamedModel.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Algorithm.Framework.Alphas
+{
+    /// <summary>
+    /// Provides a marker interface allowing models to define their own names.
+    /// If not specified, the framework will use the model's type name.
+    /// Implementation of this is not required unless you plan on running multiple models
+    /// of the same type w/ different parameters.
+    /// </summary>
+    public interface INamedModel
+    {
+        /// <summary>
+        /// Defines a name for a framework model
+        /// </summary>
+        string Name { get; }
+    }
+}

--- a/Algorithm.Framework/Alphas/MacdAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/MacdAlphaModel.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
     /// used to generate up/down insights if it's stronger than the bounce threshold.
     /// If the MACD signal is within the bounce threshold then a flat price insight is returned.
     /// </summary>
-    public class MacdAlphaModel : IAlphaModel
+    public class MacdAlphaModel : IAlphaModel, INamedModel
     {
         private readonly int _fastPeriod;
         private readonly int _slowPeriod;
@@ -37,6 +37,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private readonly Resolution _resolution;
         private const decimal BounceThresholdPercent = 0.01m;
         private readonly Dictionary<Symbol, SymbolData> _symbolData;
+
+        /// <summary>
+        /// Defines a name for a framework model
+        /// </summary>
+        public string Name { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MacdAlphaModel"/> class
@@ -60,6 +65,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             _movingAverageType = movingAverageType;
             _resolution = resolution;
             _symbolData = new Dictionary<Symbol, SymbolData>();
+            Name = $"{nameof(MacdAlphaModel)}({fastPeriod},{slowPeriod},{signalPeriod},{movingAverageType},{resolution})";
         }
 
         /// <summary>

--- a/Algorithm.Framework/Alphas/RsiAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/RsiAlphaModel.cs
@@ -27,12 +27,17 @@ namespace QuantConnect.Algorithm.Framework.Alphas
     /// Uses Wilder's RSI to create insights. Using default settings, a cross over below 30 or above 70 will
     /// trigger a new insight.
     /// </summary>
-    public class RsiAlphaModel : IAlphaModel
+    public class RsiAlphaModel : IAlphaModel, INamedModel
     {
         private readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol = new Dictionary<Symbol, SymbolData>();
 
         private readonly int _period;
         private readonly Resolution _resolution;
+
+        /// <summary>
+        /// Defines a name for a framework model
+        /// </summary>
+        public string Name { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RsiAlphaModel"/> class
@@ -46,6 +51,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         {
             _period = period;
             _resolution = resolution;
+            Name = $"{nameof(RsiAlphaModel)}({_period},{_resolution})";
         }
 
         /// <summary>

--- a/Algorithm.Framework/QCAlgorithmFramework.cs
+++ b/Algorithm.Framework/QCAlgorithmFramework.cs
@@ -176,9 +176,13 @@ namespace QuantConnect.Algorithm.Framework
             // execute on the targets, overriding targets for symbols w/ risk targets
             var riskAdjustedTargets = riskTargetOverrides.Concat(targets).DistinctBy(pt => pt.Symbol).ToArray();
 
-            if (DebugMode && riskAdjustedTargets.Length > 0)
+            if (DebugMode)
             {
-                Log($"{Time}: RISK ADJUSTED TARGETS: {string.Join(" | ", riskTargetOverrides.Select(t => t.ToString()).OrderBy(t => t))}");
+                // only log adjusted targets if we've performed an adjustment
+                if (riskTargetOverrides.Length > 0)
+                {
+                    Log($"{Time}: RISK ADJUSTED TARGETS: {string.Join(" | ", riskAdjustedTargets.Select(t => t.ToString()).OrderBy(t => t))}");
+                }
             }
 
             Execution.Execute(this, riskAdjustedTargets);

--- a/Algorithm.Framework/QCAlgorithmFramework.cs
+++ b/Algorithm.Framework/QCAlgorithmFramework.cs
@@ -250,6 +250,11 @@ namespace QuantConnect.Algorithm.Framework
         {
             insight.GeneratedTimeUtc = UtcTime;
             insight.ReferenceValue = _securityValuesProvider.GetValues(insight.Symbol).Get(insight.Type);
+            if (string.IsNullOrEmpty(insight.SourceModel))
+            {
+                // set the source model name if not already set
+                insight.SourceModel = Alpha.GetModelName();
+            }
 
             TimeSpan barSize;
             Security security;

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -55,6 +55,7 @@
     </Compile>
     <Compile Include="Alphas\AlphaModelPythonWrapper.cs" />
     <Compile Include="Alphas\EmaCrossAlphaModel.cs" />
+    <Compile Include="Alphas\INamedModel.cs" />
     <Compile Include="Alphas\RsiAlphaModel.cs" />
     <Compile Include="Execution\IExecutionModel.cs" />
     <Compile Include="Execution\ImmediateExecutionModel.cs" />

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -54,6 +54,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Alphas\AlphaModelPythonWrapper.cs" />
+    <Compile Include="Alphas\CompositeAlphaModel.cs" />
     <Compile Include="Alphas\EmaCrossAlphaModel.cs" />
     <Compile Include="Alphas\INamedModel.cs" />
     <Compile Include="Alphas\RsiAlphaModel.cs" />

--- a/Common/Algorithm/Framework/Alphas/Insight.cs
+++ b/Common/Algorithm/Framework/Alphas/Insight.cs
@@ -34,6 +34,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         public Guid Id { get; private set; }
 
         /// <summary>
+        /// Gets an identifier for the source model that generated this insight.
+        /// </summary>
+        public string SourceModel { get; internal set; }
+
+        /// <summary>
         /// Gets the utc time this insight was generated
         /// </summary>
         /// <remarks>
@@ -116,10 +121,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="direction">The predicted direction</param>
         /// <param name="magnitude">The predicted magnitude as a percentage change</param>
         /// <param name="confidence">The confidence in this insight</param>
-        public Insight(Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence)
+        /// <param name="sourceModel">An identifier defining the model that generated this insight</param>
+        public Insight(Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence, string sourceModel = null)
         {
             Id = Guid.NewGuid();
             Score = new InsightScore();
+            SourceModel = sourceModel;
 
             Symbol = symbol;
             Type = type;
@@ -143,8 +150,9 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="direction">The predicted direction</param>
         /// <param name="magnitude">The predicted magnitude as a percentage change</param>
         /// <param name="confidence">The confidence in this insight</param>
-        public Insight(DateTime generatedTimeUtc, Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence)
-            : this(symbol, period, type, direction, magnitude, confidence)
+        /// <param name="sourceModel">An identifier defining the model that generated this insight</param>
+        public Insight(DateTime generatedTimeUtc, Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence, string sourceModel = null)
+            : this(symbol, period, type, direction, magnitude, confidence, sourceModel)
         {
             GeneratedTimeUtc = generatedTimeUtc;
             CloseTimeUtc = generatedTimeUtc + period;
@@ -163,7 +171,8 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 Score = Score,
                 Id = Id,
                 EstimatedValue = EstimatedValue,
-                ReferenceValue = ReferenceValue
+                ReferenceValue = ReferenceValue,
+                SourceModel = SourceModel
             };
         }
 
@@ -175,10 +184,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="direction">The predicted direction</param>
         /// <param name="magnitude">The predicted magnitude as a percent change</param>
         /// <param name="confidence">The confidence in this insight</param>
+        /// <param name="sourceModel">The model generating this insight</param>
         /// <returns>A new insight object for the specified parameters</returns>
-        public static Insight Price(Symbol symbol, TimeSpan period, InsightDirection direction, double? magnitude = null, double? confidence = null)
+        public static Insight Price(Symbol symbol, TimeSpan period, InsightDirection direction, double? magnitude = null, double? confidence = null, string sourceModel = null)
         {
-            return new Insight(symbol, period, InsightType.Price, direction, magnitude, confidence);
+            return new Insight(symbol, period, InsightType.Price, direction, magnitude, confidence, sourceModel);
         }
 
         /// <summary>
@@ -195,7 +205,8 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 serializedInsight.Type,
                 serializedInsight.Direction,
                 serializedInsight.Magnitude,
-                serializedInsight.Confidence
+                serializedInsight.Confidence,
+                serializedInsight.SourceModel
             )
             {
                 Id = Guid.Parse(serializedInsight.Id),

--- a/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
+++ b/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
@@ -16,6 +16,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
         public string Id { get; set; }
 
         /// <summary>
+        /// See <see cref="Insight.SourceModel"/>
+        /// </summary>
+        [JsonProperty("source-model")]
+        public string SourceModel { get; set; }
+
+        /// <summary>
         /// See <see cref="Insight.GeneratedTimeUtc"/>
         /// </summary>
         [JsonProperty("generated-time")]
@@ -115,6 +121,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
         public SerializedInsight(Insight insight)
         {
             Id = insight.Id.ToString("N");
+            SourceModel = insight.SourceModel;
             GeneratedTime = Time.DateTimeToUnixTimeStamp(insight.GeneratedTimeUtc);
             CloseTime = Time.DateTimeToUnixTimeStamp(insight.CloseTimeUtc);
             Symbol = insight.Symbol.ID.ToString();

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -32,7 +32,7 @@ using System.Linq;
 namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 {
     /// <summary>
-    /// Provides a framework for testing alpha models. 
+    /// Provides a framework for testing alpha models.
     /// </summary>
     public abstract class CommonAlphaModelTests
     {
@@ -139,6 +139,22 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
             Assert.DoesNotThrow(() => model.OnSecuritiesChanged(_algorithm, changes));
         }
 
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void ModelNameTest(Language language)
+        {
+            IAlphaModel model;
+            if (!TryCreateModel(language, out model))
+            {
+                Assert.Ignore($"Ignore {GetType().Name}: Could not create {language} model.");
+            }
+
+            var actual = model.GetModelName();
+            var expected = GetExpectedModelName(model);
+            Assert.AreEqual(expected, actual);
+        }
+
         /// <summary>
         /// Returns a new instance of the alpha model to test
         /// </summary>
@@ -163,6 +179,14 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         /// List of securities to be removed to the model
         /// </summary>
         protected virtual IEnumerable<Security> RemovedSecurities => Enumerable.Empty<Security>();
+
+        /// <summary>
+        /// To be override for model types that implement <see cref="INamedModel"/>
+        /// </summary>
+        protected virtual string GetExpectedModelName(IAlphaModel model)
+        {
+            return model.GetType().Name;
+        }
 
         /// <summary>
         /// Creates an enumerable of Slice to update the alpha model

--- a/Tests/Algorithm/Framework/Alphas/ConstantAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/ConstantAlphaModelTests.cs
@@ -47,5 +47,10 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         {
             return Enumerable.Range(0, 360).Select(x => new Insight(Symbols.SPY, _period, _type, _direction, _magnitude, _confidence));
         }
+
+        protected override string GetExpectedModelName(IAlphaModel model)
+        {
+            return $"{nameof(ConstantAlphaModel)}({_type},{_direction},{_period},{_magnitude})";
+        }
     }
 }

--- a/Tests/Algorithm/Framework/Alphas/EmaCrossAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/EmaCrossAlphaModelTests.cs
@@ -46,5 +46,10 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
                 Insight.Price(Symbols.SPY, period, InsightDirection.Up)
             };
         }
+
+        protected override string GetExpectedModelName(IAlphaModel model)
+        {
+            return $"{nameof(EmaCrossAlphaModel)}(12,26,Daily)";
+        }
     }
 }

--- a/Tests/Algorithm/Framework/Alphas/MacdAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/MacdAlphaModelTests.cs
@@ -47,5 +47,10 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
                 Insight.Price(Symbols.SPY, period, InsightDirection.Up)
             };
         }
+
+        protected override string GetExpectedModelName(IAlphaModel model)
+        {
+            return $"{nameof(MacdAlphaModel)}(12,26,9,Exponential,Daily)";
+        }
     }
 }

--- a/Tests/Algorithm/Framework/Alphas/RsiAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/RsiAlphaModelTests.cs
@@ -44,5 +44,10 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
                 yield return Insight.Price(Symbols.SPY, period, direction);
             }
         }
+
+        protected override string GetExpectedModelName(IAlphaModel model)
+        {
+            return $"{nameof(RsiAlphaModel)}(14,Daily)";
+        }
     }
 }

--- a/Tests/Algorithm/Framework/Alphas/Serialization/InsightJsonConverterTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/Serialization/InsightJsonConverterTests.cs
@@ -31,6 +31,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
             var jObject = JObject.Parse(jsonNoScore);
             var result = JsonConvert.DeserializeObject<Insight>(jsonNoScore);
             Assert.AreEqual(jObject["id"].Value<string>(), result.Id.ToString("N"));
+            Assert.AreEqual(jObject["source-model"].Value<string>(), result.SourceModel);
             Assert.AreEqual(jObject["generated-time"].Value<double>(), Time.DateTimeToUnixTimeStamp(result.GeneratedTimeUtc), 5e-4);
             Assert.AreEqual(jObject["close-time"].Value<double>(), Time.DateTimeToUnixTimeStamp(result.CloseTimeUtc), 5e-4);
             Assert.AreEqual(jObject["symbol"].Value<string>(), result.Symbol.ID.ToString());
@@ -54,6 +55,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
             var jObject = JObject.Parse(jsonWithScore);
             var result = JsonConvert.DeserializeObject<Insight>(jsonWithScore);
             Assert.AreEqual(jObject["id"].Value<string>(), result.Id.ToString("N"));
+            Assert.AreEqual(jObject["source-model"].Value<string>(), result.SourceModel);
             Assert.AreEqual(jObject["generated-time"].Value<double>(), Time.DateTimeToUnixTimeStamp(result.GeneratedTimeUtc), 5e-4);
             Assert.AreEqual(jObject["close-time"].Value<double>(), Time.DateTimeToUnixTimeStamp(result.CloseTimeUtc), 5e-4);
             Assert.AreEqual(jObject["symbol"].Value<string>(), result.Symbol.ID.ToString());
@@ -76,6 +78,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
             var insight = Insight.FromSerializedInsight(new SerializedInsight
             {
                 Id = jObject["id"].Value<string>(),
+                SourceModel = jObject["source-model"].Value<string>(),
                 GeneratedTime = jObject["generated-time"].Value<double>(),
                 CloseTime = jObject["close-time"].Value<double>(),
                 Symbol = jObject["symbol"].Value<string>(),
@@ -97,6 +100,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
             var insight = Insight.FromSerializedInsight(new SerializedInsight
             {
                 Id = jObject["id"].Value<string>(),
+                SourceModel = jObject["source-model"].Value<string>(),
                 GeneratedTime = jObject["generated-time"].Value<double>(),
                 CloseTime = jObject["close-time"].Value<double>(),
                 Symbol = jObject["symbol"].Value<string>(),
@@ -118,6 +122,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
         private const string jsonNoScore =
 @"{
   ""id"": ""e02be50f56a8496b9ba995d19a904ada"",
+  ""source-model"": ""mySourceModel-1"",
   ""generated-time"": 1520711961.00055,
   ""close-time"": 1520711961.00055,
   ""symbol"": ""BTCUSD XJ"",
@@ -132,6 +137,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
         private const string jsonWithScore =
 @"{
   ""id"": ""e02be50f56a8496b9ba995d19a904ada"",
+  ""source-model"": ""mySourceModel-1"",
   ""generated-time"": 1520711961.00055,
   ""close-time"": 1520711961.00055,
   ""symbol"": ""BTCUSD XJ"",

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -50,12 +50,37 @@ namespace QuantConnect.Tests.Algorithm.Framework
             Assert.AreEqual(insight.Id, deserialized.Id);
             Assert.AreEqual(insight.Magnitude, deserialized.Magnitude);
             Assert.AreEqual(insight.Period, deserialized.Period);
+            Assert.AreEqual(insight.SourceModel, deserialized.SourceModel);
             Assert.AreEqual(insight.Score.Direction, deserialized.Score.Direction);
             Assert.AreEqual(insight.Score.Magnitude, deserialized.Score.Magnitude);
             Assert.AreEqual(insight.Score.UpdatedTimeUtc, deserialized.Score.UpdatedTimeUtc);
             Assert.AreEqual(insight.Score.IsFinalScore, deserialized.Score.IsFinalScore);
             Assert.AreEqual(insight.Symbol, deserialized.Symbol);
             Assert.AreEqual(insight.Type, deserialized.Type);
+        }
+
+        [Test]
+        public void SurvivesRoundTripCopy()
+        {
+            var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);
+            var original = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2);
+            var copy = original.Clone();
+
+            Assert.AreEqual(original.CloseTimeUtc, copy.CloseTimeUtc);
+            Assert.AreEqual(original.Confidence, copy.Confidence);
+            Assert.AreEqual(original.Direction, copy.Direction);
+            Assert.AreEqual(original.EstimatedValue, copy.EstimatedValue);
+            Assert.AreEqual(original.GeneratedTimeUtc, copy.GeneratedTimeUtc);
+            Assert.AreEqual(original.Id, copy.Id);
+            Assert.AreEqual(original.Magnitude, copy.Magnitude);
+            Assert.AreEqual(original.Period, copy.Period);
+            Assert.AreEqual(original.SourceModel, copy.SourceModel);
+            Assert.AreEqual(original.Score.Direction, copy.Score.Direction);
+            Assert.AreEqual(original.Score.Magnitude, copy.Score.Magnitude);
+            Assert.AreEqual(original.Score.UpdatedTimeUtc, copy.Score.UpdatedTimeUtc);
+            Assert.AreEqual(original.Score.IsFinalScore, copy.Score.IsFinalScore);
+            Assert.AreEqual(original.Symbol, copy.Symbol);
+            Assert.AreEqual(original.Type, copy.Type);
         }
     }
 }

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -886,6 +886,41 @@ namespace QuantConnect.Tests
                 {"Rolling Averaged Population Magnitude", "0%"},
             };
 
+            var compositeAlphaModelFrameworkAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "288"},
+                {"Average Win", "0.07%"},
+                {"Average Loss", "-0.05%"},
+                {"Compounding Annual Return", "-95.659%"},
+                {"Drawdown", "4.100%"},
+                {"Expectancy", "-0.467"},
+                {"Net Profit", "-3.932%"},
+                {"Sharpe Ratio", "-23.357"},
+                {"Loss Rate", "79%"},
+                {"Win Rate", "21%"},
+                {"Profit-Loss Ratio", "1.51"},
+                {"Alpha", "-1.167"},
+                {"Beta", "-76.443"},
+                {"Annual Standard Deviation", "0.086"},
+                {"Annual Variance", "0.007"},
+                {"Information Ratio", "-23.448"},
+                {"Tracking Error", "0.086"},
+                {"Treynor Ratio", "0.026"},
+                {"Total Fees", "$1899.95"},
+                {"Total Insights Generated", "289"},
+                {"Total Insights Closed", "0"},
+                {"Total Insights Analysis Completed", "0"},
+                {"Long Insight Count", "146"},
+                {"Short Insight Count", "143"},
+                {"Long/Short Ratio", "102.10%"},
+                {"Estimated Monthly Alpha Value", "$0"},
+                {"Total Accumulated Estimated Alpha Value", "$0"},
+                {"Mean Population Estimated Insight Value", "$0"},
+                {"Mean Population Direction", "0%"},
+                {"Mean Population Magnitude", "0%"},
+                {"Rolling Averaged Population Direction", "0%"},
+                {"Rolling Averaged Population Magnitude", "0%"},
+            };
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -894,6 +929,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("BasicTemplateFrameworkAlgorithm", basicTemplateFrameworkStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("BasicTemplateOptionsAlgorithm", basicTemplateOptionsStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("CustomDataRegressionAlgorithm", customDataRegressionStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("CompositeAlphaModelFrameworkAlgorithm", compositeAlphaModelFrameworkAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("DropboxBaseDataUniverseSelectionAlgorithm", dropboxBaseDataUniverseSelectionStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("DropboxUniverseSelectionAlgorithm", dropboxUniverseSelectionStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("LimitFillRegressionAlgorithm", limitFillRegressionStatistics, Language.CSharp),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Adds `Insight.SourceModel` to track where each insight object was generated. This can be set manually via constructor and/or `Insight.Price` helper, but if left null, the framework will properly resolve the correct model name. Also, a `CompositeAlphaModel` was created to support multiple alpha models running within the same framework algorithm. The composite alpha model will properly tag each generated insight with the source model's name.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1862 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes - @jaredbroad - we should document this new type and the `Insight.SourceModel` property. Also important to note, that users can override the 'source model' at anytime, thereby not *requiring* them to use the composite model if they don't want to, for example, multiple models inside a single alpha model implementation.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->