### PR TITLE
Adds more locations to PYTHONPATH

### DIFF
--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -156,10 +156,14 @@ namespace QuantConnect.AlgorithmFactory
             var moduleName = pythonFile.Name.Replace(".pyc", "").Replace(".py", "");
 
             // Set the python path for loading python algorithms.
-            // For Unix systems (PlatformID 4 and 6), separator is ":" while it is ";" for Windows
-            var separator = (int)Environment.OSVersion.Platform > 3 ? ":" : ";";
-            var pythonPath = new[] { Environment.CurrentDirectory, pythonFile.DirectoryName, Environment.GetEnvironmentVariable("PYTHONPATH") };
-            Environment.SetEnvironmentVariable("PYTHONPATH", string.Join(separator, pythonPath));
+            var pythonPath = new[]
+            {
+                new DirectoryInfo(Environment.CurrentDirectory).FullName,
+                pythonFile.Directory.FullName,
+                Environment.GetEnvironmentVariable("PYTHONPATH")
+            };
+
+            Environment.SetEnvironmentVariable("PYTHONPATH", string.Join(OS.IsLinux ? ":" : ";", pythonPath));
 
             try
             {

--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -96,9 +96,6 @@ namespace QuantConnect.AlgorithmFactory
 
             _loaderTimeLimit = loaderTimeLimit;
             _multipleTypeNameResolverFunction = multipleTypeNameResolverFunction;
-
-            //Set the python path for loading python algorithms.
-            Environment.SetEnvironmentVariable("PYTHONPATH", Environment.CurrentDirectory);
         }
 
 
@@ -158,8 +155,11 @@ namespace QuantConnect.AlgorithmFactory
             var pythonFile = new FileInfo(assemblyPath);
             var moduleName = pythonFile.Name.Replace(".pyc", "").Replace(".py", "");
 
-            //Help python find the module
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonFile.DirectoryName);
+            // Set the python path for loading python algorithms.
+            // For Unix systems (PlatformID 4 and 6), separator is ":" while it is ";" for Windows
+            var separator = (int)Environment.OSVersion.Platform > 3 ? ":" : ";";
+            var pythonPath = new[] { Environment.CurrentDirectory, pythonFile.DirectoryName, Environment.GetEnvironmentVariable("PYTHONPATH") };
+            Environment.SetEnvironmentVariable("PYTHONPATH", string.Join(separator, pythonPath));
 
             try
             {


### PR DESCRIPTION
#### Description
Before loading python algorithms, set `PYTHONPATH` with `CurrentDirectory`, algorithm location and current/environment `PYTHONPATH`.

#### Related Issue
Closes #1878 

#### Motivation and Context
Without that change it is not possible to make unit tests with algorithm framework modules written in python.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Regression tests that were not passing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`