### PR TITLE
Fix ArgumentOutOfRangeException in Option strike filtering

### DIFF
--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -240,13 +240,6 @@ namespace QuantConnect.Securities
                 }
 
                 index = ~index;
-
-                if (index >= _uniqueStrikes.Count)
-                {
-                    // should never happen, return empty
-                    _allSymbols = Enumerable.Empty<Symbol>();
-                    return this;
-                }
             }
 
             // compute the bounds, no need to worry about rounding and such


### PR DESCRIPTION

#### Description
The option strike range filtering in `OptionFilterUniverse.Strikes` has been updated to support edge cases such as the current underlying price being outside the strike range.

#### Related Issue
Fixes #1875

#### Motivation and Context
The method was throwing `ArgumentOutOfRangeException` in specific cases.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Tested manually with algorithm in #1875 and added the missing unit tests to cover the edge cases.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`