### PR TITLE
Multiple alpha models for python

### DIFF
--- a/Algorithm.Framework/Alphas/AlphaModelPythonWrapper.cs
+++ b/Algorithm.Framework/Alphas/AlphaModelPythonWrapper.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                     }
 
                     // if the model does not define a name property, use the python type name
-                    return _model.GetPythonType();
+                    return _model.__class__.__name__;
                 }
             }
         }

--- a/Algorithm.Framework/Alphas/CompositeAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/CompositeAlphaModel.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Util;
@@ -41,6 +42,24 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             }
 
             _alphaModels = alphaModels;
+        }
+
+        public CompositeAlphaModel(PyObject[] alphaModels)
+        {
+            if (alphaModels.IsNullOrEmpty())
+            {
+                throw new ArgumentException("Must specify at least 1 alpha model for the CompositeAlphaModel");
+            }
+
+            _alphaModels = new IAlphaModel[alphaModels.Length];
+
+            for (var i = 0; i < alphaModels.Length; i++)
+            {
+                if (!alphaModels[i].TryConvert(out _alphaModels[i]))
+                {
+                    _alphaModels[i] = new AlphaModelPythonWrapper(alphaModels[i]);
+                }
+            }
         }
 
         /// <summary>

--- a/Algorithm.Framework/Alphas/RsiAlphaModel.py
+++ b/Algorithm.Framework/Alphas/RsiAlphaModel.py
@@ -53,9 +53,9 @@ class RsiAlphaModel:
 
             if state != previous_state and rsi.IsReady:
                 if state == State.TrippedLow:
-                    insights.append(Insight(symbol, self.insightPeriod, InsightDirection.Up))
+                    insights.append(Insight.Price(symbol, self.insightPeriod, InsightDirection.Up))
                 if state == State.TrippedHigh:
-                    insights.append(Insight(symbol, self.insightPeriod, InsightDirection.Down))
+                    insights.append(Insight.Price(symbol, self.insightPeriod, InsightDirection.Down))
 
             symbolData.State = state
 

--- a/Algorithm.Python/CompositeAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/CompositeAlphaModelFrameworkAlgorithm.py
@@ -1,0 +1,63 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from Alphas.RsiAlphaModel import RsiAlphaModel
+from Alphas.EmaCrossAlphaModel import EmaCrossAlphaModel
+from datetime import timedelta
+import numpy as np
+
+### <summary>
+### Show cases how to use the CompositeAlphaModel to define.
+### </summary>
+class CompositeAlphaModelFrameworkAlgorithm(QCAlgorithmFramework):
+    '''Show cases how to use the CompositeAlphaModel to define.'''
+
+    def Initialize(self):
+
+        self.SetStartDate(2013,10,7)   #Set Start Date
+        self.SetEndDate(2013,10,11)    #Set End Date
+        self.SetCash(100000)           #Set Strategy Cash
+        
+        # even though we're using a framework algorithm, we can still add our securities
+        # using the AddEquity/Forex/Crypto/ect methods and then pass them into a manual
+        # universe selection model using Securities.Keys
+        self.AddEquity("SPY")
+        self.AddEquity("IBM")
+        self.AddEquity("BAC")
+        self.AddEquity("AIG")
+
+        # define a manual universe of all the securities we manually registered
+        self.SetUniverseSelection(ManualUniverseSelectionModel(self.Securities.Keys))
+
+        # define alpha model as a composite of the rsi and ema cross models
+        self.SetAlpha(CompositeAlphaModel([RsiAlphaModel(), EmaCrossAlphaModel()]))
+
+        # default models for the rest
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+        self.SetRiskManagement(NullRiskManagementModel())

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -143,6 +143,7 @@
     <None Include="BasicTemplateCryptoAlgorithm.py" />
     <None Include="ScheduledUniverseSelectionModelRegressionAlgorithm.py" />
     <None Include="RenkoConsolidatorAlgorithm.py" />
+    <Content Include="CompositeAlphaModelFrameworkAlgorithm.py" />
     <Content Include="MeanVarianceOptimizationAlgorithm.py" />
     <Content Include="BasicTemplateFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateLibrary.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.py" />
+    <Compile Include="CompositeAlphaModelFrameworkAlgorithm.py" />
     <Compile Include="CustomIndicatorAlgorithm.py" />
     <Compile Include="CustomVolatilityModelAlgorithm.py" />
     <Compile Include="BasicTemplateAlgorithm.py" />

--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -158,8 +158,8 @@ namespace QuantConnect.AlgorithmFactory
             // Set the python path for loading python algorithms.
             var pythonPath = new[]
             {
-                new DirectoryInfo(Environment.CurrentDirectory).FullName,
                 pythonFile.Directory.FullName,
+                new DirectoryInfo(Environment.CurrentDirectory).FullName,
                 Environment.GetEnvironmentVariable("PYTHONPATH")
             };
 

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -151,7 +151,10 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
             }
 
             var actual = model.GetModelName();
-            var expected = GetExpectedModelName(model);
+            var expected = language == Language.CSharp
+                ? GetExpectedModelName(model)
+                : (model as AlphaModelPythonWrapper).Name;
+
             Assert.AreEqual(expected, actual);
         }
 

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -969,6 +969,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("BasicTemplateFrameworkAlgorithm", basicTemplateFrameworkStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("BasicTemplateOptionsAlgorithm", basicTemplateOptionsStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("CustomDataRegressionAlgorithm", customDataRegressionStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("CompositeAlphaModelFrameworkAlgorithm", compositeAlphaModelFrameworkAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("DropboxBaseDataUniverseSelectionAlgorithm", dropboxBaseDataUniverseSelectionStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("DropboxUniverseSelectionAlgorithm", dropboxUniverseSelectionStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("LimitFillRegressionAlgorithm", limitFillRegressionStatistics, Language.Python),


### PR DESCRIPTION
#### Description
- Fixes `RsiAlphaModel.py` typo
  In the static method `Insight.Price`, `.Price` was missing.
- Refactors AlphaModelPythonWrapper.Name
  The cleanest way to get a python type name, when we know it is an instance of a class, is getting the value of the  `__class__.__name__` attribute.
- Adds constructor overload to `CompositeAlphaModel` that accepts python objects.
- Adds python version of `CompositeAlphaModelFrameworkAlgorithm`.
- Fixes python path order
  The first place python should look for scripts is not the current directory, but the directory defined at "algorithm-location".

#### Related Issue
Closes #1887 

#### Motivation and Context
Python and C# users should be able to use all the features.

#### Requires Documentation Change
See #1879.

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`