### PR TITLE
Add Insight.GroupId to support grouping of insights

### DIFF
--- a/Algorithm.CSharp/PairsTradingAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/PairsTradingAlphaModelFrameworkAlgorithm.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Algorithm.Framework.Selection;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Framework algorithm that uses the <see cref="PairsTradingAlphaModel"/> to detect
+    /// divergences between correllated assets. Detection of asset correlation is not
+    /// performed and is expected to be handled outside of the alpha model.
+    /// </summary>
+    public class PairsTradingAlphaModelFrameworkAlgorithm : QCAlgorithmFramework
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+
+            var bac = AddEquity("BAC");
+            var aig = AddEquity("AIG");
+
+            UniverseSelection = new ManualUniverseSelectionModel(Securities.Keys);
+            Alpha = new PairsTradingAlphaModel(bac.Symbol, aig.Symbol);
+            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
+            Execution = new ImmediateExecutionModel();
+            RiskManagement = new NullRiskManagementModel();
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -102,6 +102,7 @@
     <Compile Include="FinancialAdvisorDemoAlgorithm.cs" />
     <Compile Include="ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm.cs" />
     <Compile Include="ForexInternalFeedOnDataSameResolutionRegressionAlgorithm.cs" />
+    <Compile Include="PairsTradingAlphaModelFrameworkAlgorithm.cs" />
     <Compile Include="RollingWindowAlgorithm.cs" />
     <Compile Include="BasicTemplateDailyAlgorithm.cs" />
     <Compile Include="BasicTemplateFxcmVolumeAlgorithm.cs" />

--- a/Algorithm.Framework/Alphas/PairsTradingAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/PairsTradingAlphaModel.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Algorithm.Framework.Alphas
+{
+    /// <summary>
+    /// This alpha model is designed to work against a single, predefined pair.
+    /// This model generates alternating long ratio/short ratio insights emitted as a group
+    /// </summary>
+    public class PairsTradingAlphaModel : IAlphaModel, INamedModel
+    {
+        private enum State
+        {
+            ShortRatio,
+            FlatRatio,
+            LongRatio
+        };
+
+        private readonly Symbol _asset1;
+        private readonly Symbol _asset2;
+        private readonly decimal _threshold;
+        private State _state = State.FlatRatio;
+
+        private IndicatorBase<IndicatorDataPoint> _asset1Price;
+        private IndicatorBase<IndicatorDataPoint> _asset2Price;
+        private IndicatorBase<IndicatorDataPoint> _ratio;
+        private IndicatorBase<IndicatorDataPoint> _mean;
+        private IndicatorBase<IndicatorDataPoint> _upperThreshold;
+        private IndicatorBase<IndicatorDataPoint> _lowerThreshold;
+
+        /// <summary>
+        /// Defines a name for a framework model
+        /// </summary>
+        public string Name => $"{nameof(PairsTradingAlphaModel)}({_asset1},{_asset2},{_threshold.Normalize()})";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PairsTradingAlphaModel"/> class
+        /// </summary>
+        /// <param name="asset1">The first asset's symbol in the pair</param>
+        /// <param name="asset2">The second asset's symbol in the pair</param>
+        /// <param name="threshold">The percent [0, 100] deviation of the ratio from the mean before emitting an insight</param>
+        public PairsTradingAlphaModel(Symbol asset1, Symbol asset2, decimal threshold = 1m)
+        {
+            _asset1 = asset1;
+            _asset2 = asset2;
+            _threshold = threshold;
+        }
+
+        /// <summary>
+        /// Updates this alpha model with the latest data from the algorithm.
+        /// This is called each time the algorithm receives data for subscribed securities
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="data">The new data available</param>
+        /// <returns>The new insights generated</returns>
+        public IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data)
+        {
+            if (_mean?.IsReady != true)
+            {
+                return Enumerable.Empty<Insight>();
+            }
+
+            // don't re-emit the same direction
+            if (_state != State.LongRatio && _ratio > _upperThreshold)
+            {
+                _state = State.LongRatio;
+
+                // asset1/asset2 is more than 2 std away from mean, short asset1, long asset2
+                var shortAsset1 = Insight.Price(_asset1, TimeSpan.FromMinutes(15), InsightDirection.Down);
+                var longAsset2 = Insight.Price(_asset2, TimeSpan.FromMinutes(15), InsightDirection.Up);
+
+                // creates a group id and set the GroupId property on each insight object
+                Insight.Group(shortAsset1, longAsset2);
+                return new[] {shortAsset1, longAsset2};
+            }
+
+            // don't re-emit the same direction
+            if (_state != State.ShortRatio && _ratio < _lowerThreshold)
+            {
+                _state = State.ShortRatio;
+
+                // asset1/asset2 is less than 2 std away from mean, long asset1, short asset2
+                var longAsset1 = Insight.Price(_asset1, TimeSpan.FromMinutes(15), InsightDirection.Up);
+                var shortAsset2 = Insight.Price(_asset2, TimeSpan.FromMinutes(15), InsightDirection.Down);
+
+                // creates a group id and set the GroupId property on each insight object
+                Insight.Group(longAsset1, shortAsset2);
+                return new[] {longAsset1, shortAsset2};
+            }
+
+            return Enumerable.Empty<Insight>();
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
+        /// <param name="changes">The security additions and removals from the algorithm</param>
+        public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        {
+            foreach (var added in changes.AddedSecurities)
+            {
+                // this model is limitted to looking at a single pair of assets
+                if (added.Symbol != _asset1 && added.Symbol != _asset2)
+                {
+                    continue;
+                }
+
+                if (added.Symbol == _asset1)
+                {
+                    _asset1Price = algorithm.Identity(added.Symbol);
+                }
+                else
+                {
+                    _asset2Price = algorithm.Identity(added.Symbol);
+                }
+            }
+
+            if (_ratio == null)
+            {
+                // initialize indicators dependent on both assets
+                if (_asset1Price != null && _asset2Price != null)
+                {
+                    _ratio = _asset1Price.Over(_asset2Price);
+                    _mean = new ExponentialMovingAverage(500).Of(_ratio);
+
+                    var upper = new ConstantIndicator<IndicatorDataPoint>("ct", 1 + _threshold / 100m);
+                    _upperThreshold = _mean.Times(upper, "UpperThreshold");
+
+                    var lower = new ConstantIndicator<IndicatorDataPoint>("ct", 1 - _threshold / 100m);
+                    _lowerThreshold = _mean.Times(lower, "LowerThreshold");
+                }
+            }
+        }
+    }
+}

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Alphas\CompositeAlphaModel.cs" />
     <Compile Include="Alphas\EmaCrossAlphaModel.cs" />
     <Compile Include="Alphas\INamedModel.cs" />
+    <Compile Include="Alphas\PairsTradingAlphaModel.cs" />
     <Compile Include="Alphas\RsiAlphaModel.cs" />
     <Compile Include="Execution\IExecutionModel.cs" />
     <Compile Include="Execution\ImmediateExecutionModel.cs" />

--- a/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
+++ b/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
@@ -1,4 +1,20 @@
-﻿using Newtonsoft.Json;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using Newtonsoft.Json;
 
 namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
 {
@@ -14,6 +30,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
+
+        /// <summary>
+        /// See <see cref="Insight.GroupId"/>
+        /// </summary>
+        [JsonProperty("group-id")]
+        public string GroupId { get; set; }
 
         /// <summary>
         /// See <see cref="Insight.SourceModel"/>
@@ -122,6 +144,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
         {
             Id = insight.Id.ToString("N");
             SourceModel = insight.SourceModel;
+            GroupId = insight.GroupId?.ToString("N");
             GeneratedTime = Time.DateTimeToUnixTimeStamp(insight.GeneratedTimeUtc);
             CloseTime = Time.DateTimeToUnixTimeStamp(insight.CloseTimeUtc);
             Symbol = insight.Symbol.ID.ToString();

--- a/Tests/Algorithm/Framework/Alphas/PairsTradingAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/PairsTradingAlphaModelTests.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Alphas
+{
+    [TestFixture]
+    public class PairsTradingAlphaModelTests : CommonAlphaModelTests
+    {
+        protected override int MaxSliceCount => 1500;
+
+        protected override IAlphaModel CreateCSharpAlphaModel()
+        {
+            return new PairsTradingAlphaModel(
+                Symbol.Create("BAC", SecurityType.Equity, Market.USA),
+                Symbol.Create("AIG", SecurityType.Equity, Market.USA)
+            );
+        }
+
+        protected override void InitializeAlgorithm(QCAlgorithmFramework algorithm)
+        {
+            algorithm.AddEquity("BAC");
+            algorithm.AddEquity("AIG");
+        }
+
+        protected override string GetExpectedModelName(IAlphaModel model)
+        {
+            return $"{nameof(PairsTradingAlphaModel)}(BAC,AIG,1)";
+        }
+
+        protected override IAlphaModel CreatePythonAlphaModel()
+        {
+            throw new NotImplementedException($"{nameof(PairsTradingAlphaModel)} has not been implemented in python yet.");
+        }
+
+        protected override IEnumerable<Insight> ExpectedInsights()
+        {
+            Assert.Ignore("The CommonAlphaModelTests need to be refactored to support multiple securities with different prices for each security");
+            return null;
+        }
+    }
+}

--- a/Tests/Algorithm/Framework/Alphas/Serialization/InsightJsonConverterTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/Serialization/InsightJsonConverterTests.cs
@@ -32,6 +32,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
             var result = JsonConvert.DeserializeObject<Insight>(jsonNoScore);
             Assert.AreEqual(jObject["id"].Value<string>(), result.Id.ToString("N"));
             Assert.AreEqual(jObject["source-model"].Value<string>(), result.SourceModel);
+            Assert.AreEqual(jObject["group-id"].Value<string>(), result.GroupId?.ToString("N"));
             Assert.AreEqual(jObject["generated-time"].Value<double>(), Time.DateTimeToUnixTimeStamp(result.GeneratedTimeUtc), 5e-4);
             Assert.AreEqual(jObject["close-time"].Value<double>(), Time.DateTimeToUnixTimeStamp(result.CloseTimeUtc), 5e-4);
             Assert.AreEqual(jObject["symbol"].Value<string>(), result.Symbol.ID.ToString());
@@ -56,6 +57,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
             var result = JsonConvert.DeserializeObject<Insight>(jsonWithScore);
             Assert.AreEqual(jObject["id"].Value<string>(), result.Id.ToString("N"));
             Assert.AreEqual(jObject["source-model"].Value<string>(), result.SourceModel);
+            Assert.AreEqual(jObject["group-id"].Value<string>(), result.GroupId?.ToString("N"));
             Assert.AreEqual(jObject["generated-time"].Value<double>(), Time.DateTimeToUnixTimeStamp(result.GeneratedTimeUtc), 5e-4);
             Assert.AreEqual(jObject["close-time"].Value<double>(), Time.DateTimeToUnixTimeStamp(result.CloseTimeUtc), 5e-4);
             Assert.AreEqual(jObject["symbol"].Value<string>(), result.Symbol.ID.ToString());
@@ -79,6 +81,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
             {
                 Id = jObject["id"].Value<string>(),
                 SourceModel = jObject["source-model"].Value<string>(),
+                GroupId = jObject["group-id"].Value<string>(),
                 GeneratedTime = jObject["generated-time"].Value<double>(),
                 CloseTime = jObject["close-time"].Value<double>(),
                 Symbol = jObject["symbol"].Value<string>(),
@@ -101,6 +104,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
             {
                 Id = jObject["id"].Value<string>(),
                 SourceModel = jObject["source-model"].Value<string>(),
+                GroupId = jObject["group-id"].Value<string>(),
                 GeneratedTime = jObject["generated-time"].Value<double>(),
                 CloseTime = jObject["close-time"].Value<double>(),
                 Symbol = jObject["symbol"].Value<string>(),
@@ -122,6 +126,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
         private const string jsonNoScore =
 @"{
   ""id"": ""e02be50f56a8496b9ba995d19a904ada"",
+  ""group-id"": ""a02be50f56a8496b9ba995d19a904ada"",
   ""source-model"": ""mySourceModel-1"",
   ""generated-time"": 1520711961.00055,
   ""close-time"": 1520711961.00055,
@@ -137,6 +142,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
         private const string jsonWithScore =
 @"{
   ""id"": ""e02be50f56a8496b9ba995d19a904ada"",
+  ""group-id"": ""a02be50f56a8496b9ba995d19a904ada"",
   ""source-model"": ""mySourceModel-1"",
   ""generated-time"": 1520711961.00055,
   ""close-time"": 1520711961.00055,

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -38,7 +38,8 @@ namespace QuantConnect.Tests.Algorithm.Framework
         public void SurvivesRoundTripSerializationUsingJsonConvert()
         {
             var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);
-            var insight = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2);
+            var insight = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2, "source-model");
+            Insight.Group(insight);
             var serialized = JsonConvert.SerializeObject(insight);
             var deserialized = JsonConvert.DeserializeObject<Insight>(serialized);
 
@@ -47,6 +48,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
             Assert.AreEqual(insight.Direction, deserialized.Direction);
             Assert.AreEqual(insight.EstimatedValue, deserialized.EstimatedValue);
             Assert.AreEqual(insight.GeneratedTimeUtc, deserialized.GeneratedTimeUtc);
+            Assert.AreEqual(insight.GroupId, deserialized.GroupId);
             Assert.AreEqual(insight.Id, deserialized.Id);
             Assert.AreEqual(insight.Magnitude, deserialized.Magnitude);
             Assert.AreEqual(insight.Period, deserialized.Period);
@@ -63,7 +65,9 @@ namespace QuantConnect.Tests.Algorithm.Framework
         public void SurvivesRoundTripCopy()
         {
             var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);
-            var original = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2);
+            var original = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2, "source-model");
+            Insight.Group(original);
+
             var copy = original.Clone();
 
             Assert.AreEqual(original.CloseTimeUtc, copy.CloseTimeUtc);
@@ -71,6 +75,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
             Assert.AreEqual(original.Direction, copy.Direction);
             Assert.AreEqual(original.EstimatedValue, copy.EstimatedValue);
             Assert.AreEqual(original.GeneratedTimeUtc, copy.GeneratedTimeUtc);
+            Assert.AreEqual(original.GroupId, copy.GroupId);
             Assert.AreEqual(original.Id, copy.Id);
             Assert.AreEqual(original.Magnitude, copy.Magnitude);
             Assert.AreEqual(original.Period, copy.Period);
@@ -81,6 +86,24 @@ namespace QuantConnect.Tests.Algorithm.Framework
             Assert.AreEqual(original.Score.IsFinalScore, copy.Score.IsFinalScore);
             Assert.AreEqual(original.Symbol, copy.Symbol);
             Assert.AreEqual(original.Type, copy.Type);
+        }
+
+        [Test]
+        public void GroupAssignsGroupId()
+        {
+            var insight1 = Insight.Price(Symbols.SPY, Time.OneMinute, InsightDirection.Up);
+            var insight2 = Insight.Price(Symbols.SPY, Time.OneMinute, InsightDirection.Up);
+            var groupId = Insight.Group(insight1, insight2);
+            Assert.AreEqual(groupId, insight1.GroupId);
+            Assert.AreEqual(groupId, insight2.GroupId);
+        }
+
+        [Test]
+        public void GroupThrowsExceptionIfInsightAlreadyHasGroupId()
+        {
+            var insight1 = Insight.Price(Symbols.SPY, Time.OneMinute, InsightDirection.Up);
+            Insight.Group(insight1);
+            Assert.That(() => Insight.Group(insight1), Throws.InvalidOperationException);
         }
     }
 }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Algorithm\Framework\Alphas\ConstantAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\EmaCrossAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\MacdAlphaModelTests.cs" />
+    <Compile Include="Algorithm\Framework\Alphas\PairsTradingAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\RsiAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\Serialization\InsightJsonConverterTests.cs" />
     <Compile Include="Algorithm\Framework\InsightTests.cs" />

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -921,6 +921,43 @@ namespace QuantConnect.Tests
                 {"Rolling Averaged Population Direction", "0%"},
                 {"Rolling Averaged Population Magnitude", "0%"},
             };
+
+            var pairsTradingAlphaModelFrameworkAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "4"},
+                {"Average Win", "2.18%"},
+                {"Average Loss", "-1.38%"},
+                {"Compounding Annual Return", "75.646%"},
+                {"Drawdown", "0.600%"},
+                {"Expectancy", "0.290"},
+                {"Net Profit", "0.723%"},
+                {"Sharpe Ratio", "7.017"},
+                {"Loss Rate", "50%"},
+                {"Win Rate", "50%"},
+                {"Profit-Loss Ratio", "1.58"},
+                {"Alpha", "0"},
+                {"Beta", "33.003"},
+                {"Annual Standard Deviation", "0.052"},
+                {"Annual Variance", "0.003"},
+                {"Information Ratio", "6.816"},
+                {"Tracking Error", "0.052"},
+                {"Treynor Ratio", "0.011"},
+                {"Total Fees", "$70.58"},
+                {"Total Insights Generated", "4"},
+                {"Total Insights Closed", "4"},
+                {"Total Insights Analysis Completed", "4"},
+                {"Long Insight Count", "2"},
+                {"Short Insight Count", "2"},
+                {"Long/Short Ratio", "100%"},
+                {"Estimated Monthly Alpha Value", "$-1201.722"},
+                {"Total Accumulated Estimated Alpha Value", "$-193.6107"},
+                {"Mean Population Estimated Insight Value", "$-48.40268"},
+                {"Mean Population Direction", "50%"},
+                {"Mean Population Magnitude", "0%"},
+                {"Rolling Averaged Population Direction", "3.8827%"},
+                {"Rolling Averaged Population Magnitude", "0%"},
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -962,6 +999,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("StandardDeviationExecutionModelRegressionAlgorithm", standardDeviationExecutionModelRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("CancelOpenOrdersRegressionAlgorithm", cancelOpenOrdersRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.CSharp),
 
                 // Python
                 new AlgorithmStatisticsTestParameters("AddRemoveSecurityRegressionAlgorithm", addRemoveSecurityRegressionStatistics, Language.Python),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Add `Insight.GroupId` and `Insight.Group`. The purpose here is to allow an alpha model to group some insights together because the alpha exists within the group and not within the individual members of the group. Calling `Insight.Group( insights )` will assign the specified `insights` with a new, unique group id.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1863 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This provides a mechanism for alpha models to group insights, for example, to support pairs trading or straddles, ect....

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes - we'll want to add `Insight.GroupId` and the `Insight.Group` function to the documentation for users.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added and regression test added. The alpha model was visually validated in QC cloud by plotting the various indicators and marking times when insights were generated.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->