### PR TITLE
Remove canonical symbols from manual universe model

### DIFF
--- a/Algorithm.Framework/Selection/ManualUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ManualUniverseSelectionModel.cs
@@ -66,7 +66,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
                 throw new ArgumentNullException(nameof(symbols));
             }
 
-            _symbols = symbols.ToList();
+            _symbols = symbols.Where(s => !s.IsCanonical()).ToList();
             _universeSettings = universeSettings;
             _securityInitializer = securityInitializer;
 

--- a/Tests/Algorithm/Framework/Selection/ManualUniverseSelectionModelTests.cs
+++ b/Tests/Algorithm/Framework/Selection/ManualUniverseSelectionModelTests.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Selection;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Selection
+{
+    [TestFixture]
+    public class ManualUniverseSelectionModelTests
+    {
+        [Test]
+        public void ExcludesCanonicalSymbols()
+        {
+            var symbols = new[]
+            {
+                Symbols.SPY,
+                Symbol.CreateOption(Symbols.SPY, Market.USA, default(OptionStyle), default(OptionRight), 0m, SecurityIdentifier.DefaultDate, "?SPY")
+            };
+
+            var model = new ManualUniverseSelectionModel(symbols);
+            var universe = model.CreateUniverses(new QCAlgorithmFramework()).Single();
+            var selectedSymbols = universe.SelectSymbols(default(DateTime), null).ToList();
+
+            Assert.AreEqual(1, selectedSymbols.Count);
+            Assert.AreEqual(Symbols.SPY, selectedSymbols[0]);
+            Assert.IsFalse(selectedSymbols.Any(s => s.IsCanonical()));
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Algorithm\Framework\Alphas\Serialization\InsightJsonConverterTests.cs" />
     <Compile Include="Algorithm\Framework\InsightTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
+    <Compile Include="Algorithm\Framework\Selection\ManualUniverseSelectionModelTests.cs" />
     <Compile Include="API\ApiTests.cs" />
     <Compile Include="Brokerages\BrokerageTests.cs" />
     <Compile Include="Brokerages\Fxcm\FxcmBrokerageHistoryProviderTests.cs" />


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Canonical securities were ending up in the SecurityChanges collection. This happens when users pass Securities.Keys into the manual model, causing the SecurityChanges object to have references to the canonical securities, thereby leading to indicators and other things being done to them unknowningly.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1886 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Canonical securities are confusing and really just an artifact of how LEAN manages derivative chains.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test added

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->