### PR TITLE
Rename OrderDuration to TimeInForce

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.Util.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Util.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Brokerages.Fxcm
         private static TimeInForce ConvertTimeInForce(ITimeInForce timeInForce)
         {
             if (timeInForce == TimeInForceFactory.GOOD_TILL_CANCEL)
-                return TimeInForce.GTC;
+                return TimeInForce.GoodTilCancelled;
 
             if (timeInForce == TimeInForceFactory.DAY)
                 return (TimeInForce)1; //.Day;

--- a/Brokerages/Fxcm/FxcmBrokerage.Util.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Util.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -69,22 +69,22 @@ namespace QuantConnect.Brokerages.Fxcm
             order.Quantity = Convert.ToInt32(fxcmOrder.getOrderQty() * (fxcmOrder.getSide() == SideFactory.BUY ? +1 : -1));
             order.Status = ConvertOrderStatus(fxcmOrder.getFXCMOrdStatus());
             order.BrokerId.Add(fxcmOrder.getOrderID());
-            order.Duration = ConvertDuration(fxcmOrder.getTimeInForce());
+            order.TimeInForce = ConvertTimeInForce(fxcmOrder.getTimeInForce());
             order.Time = FromJavaDate(fxcmOrder.getTransactTime().toDate());
 
             return order;
         }
 
         /// <summary>
-        /// Converts an FXCM order duration to QuantConnect order duration
+        /// Converts an FXCM order time in force to QuantConnect order time in force
         /// </summary>
-        private static OrderDuration ConvertDuration(ITimeInForce timeInForce)
+        private static TimeInForce ConvertTimeInForce(ITimeInForce timeInForce)
         {
             if (timeInForce == TimeInForceFactory.GOOD_TILL_CANCEL)
-                return OrderDuration.GTC;
-            
+                return TimeInForce.GTC;
+
             if (timeInForce == TimeInForceFactory.DAY)
-                return (OrderDuration)1; //.Day;
+                return (TimeInForce)1; //.Day;
 
             throw new ArgumentOutOfRangeException();
         }
@@ -104,10 +104,10 @@ namespace QuantConnect.Brokerages.Fxcm
                 AveragePrice = Convert.ToDecimal(fxcmPosition.getSettlPrice()),
                 ConversionRate = 1.0m,
                 CurrencySymbol = "$",
-                Quantity = Convert.ToDecimal(fxcmPosition.getPositionQty().getLongQty() > 0 
-                    ? fxcmPosition.getPositionQty().getLongQty() 
+                Quantity = Convert.ToDecimal(fxcmPosition.getPositionQty().getLongQty() > 0
+                    ? fxcmPosition.getPositionQty().getLongQty()
                     : -fxcmPosition.getPositionQty().getShortQty())
-            };        
+            };
         }
 
         /// <summary>
@@ -244,9 +244,9 @@ namespace QuantConnect.Brokerages.Fxcm
 
         //
         // So it turns out that in order to properly load the QuantConnect.Brokerages
-        // dll we need the IKVM.OpenJdk.Jdbc referenced in other projects that use 
+        // dll we need the IKVM.OpenJdk.Jdbc referenced in other projects that use
         // this. By placing a hard reference to an IKVM.OpenJdk.Jdbc type, the compiler
-        // will properly copy the required dlls into other project bin directories. 
+        // will properly copy the required dlls into other project bin directories.
         // Without this, consuming projects would need to hard refernce the IKVM dlls,
         // which is less than perfect. This seems to be the better of two evils
         //

--- a/Brokerages/Oanda/OandaRestApiV1.cs
+++ b/Brokerages/Oanda/OandaRestApiV1.cs
@@ -770,7 +770,7 @@ namespace QuantConnect.Brokerages.Oanda
                 qcOrder.Id = orderByBrokerageId.Id;
             }
 
-            qcOrder.Duration = OrderDuration.Custom;
+            qcOrder.TimeInForce = TimeInForce.Custom;
             qcOrder.DurationValue = XmlConvert.ToDateTime(order.expiry, XmlDateTimeSerializationMode.Utc);
             qcOrder.Time = XmlConvert.ToDateTime(order.time, XmlDateTimeSerializationMode.Utc);
 

--- a/Brokerages/Oanda/OandaRestApiV20.cs
+++ b/Brokerages/Oanda/OandaRestApiV20.cs
@@ -37,6 +37,7 @@ using MarketOrder = QuantConnect.Orders.MarketOrder;
 using Order = QuantConnect.Orders.Order;
 using OandaLimitOrder = Oanda.RestV20.Model.LimitOrder;
 using OrderType = QuantConnect.Orders.OrderType;
+using TimeInForce = QuantConnect.Orders.TimeInForce;
 
 namespace QuantConnect.Brokerages.Oanda
 {
@@ -654,7 +655,7 @@ namespace QuantConnect.Brokerages.Oanda
             var gtdTime = order["gtdTime"];
             if (gtdTime != null)
             {
-                qcOrder.Duration = OrderDuration.Custom;
+                qcOrder.TimeInForce = TimeInForce.Custom;
                 qcOrder.DurationValue = GetTickDateTimeFromString(gtdTime.ToString());
             }
 

--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -1555,7 +1555,7 @@ namespace QuantConnect.Brokerages.Tradier
             switch (duration)
             {
                 case TradierOrderDuration.GTC:
-                    return TimeInForce.GTC;
+                    return TimeInForce.GoodTilCancelled;
                 case TradierOrderDuration.Day:
                     return (TimeInForce) 1; //.Day;
                 default:
@@ -1756,7 +1756,7 @@ namespace QuantConnect.Brokerages.Tradier
         {
             switch (duration)
             {
-                case TimeInForce.GTC:
+                case TimeInForce.GoodTilCancelled:
                     return TradierOrderDuration.GTC;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -948,7 +948,7 @@ namespace QuantConnect.Brokerages.Tradier
             // we only want to update the active order, and if successful, we'll update contingents as well in memory
 
             var orderType = ConvertOrderType(order.Type);
-            var orderDuration = GetOrderDuration(order.Duration);
+            var orderDuration = GetOrderDuration(order.TimeInForce);
             var limitPrice = GetLimitPrice(order);
             var stopPrice = GetStopPrice(order);
             var response = ChangeOrder(_accountID, activeOrder.Order.Id,
@@ -1513,7 +1513,7 @@ namespace QuantConnect.Brokerages.Tradier
             qcOrder.Status = ConvertStatus(order.Status);
             qcOrder.BrokerId.Add(order.Id.ToString());
             //qcOrder.ContingentId =
-            qcOrder.Duration = ConvertDuration(order.Duration);
+            qcOrder.TimeInForce = ConvertTimeInForce(order.Duration);
             var orderByBrokerageId = _orderProvider.GetOrderByBrokerageId(order.Id);
             if (orderByBrokerageId != null)
             {
@@ -1548,16 +1548,16 @@ namespace QuantConnect.Brokerages.Tradier
         }
 
         /// <summary>
-        /// Converts the tradier order duration into a qc order duration
+        /// Converts the tradier order duration into a qc order time in force
         /// </summary>
-        protected OrderDuration ConvertDuration(TradierOrderDuration duration)
+        protected TimeInForce ConvertTimeInForce(TradierOrderDuration duration)
         {
             switch (duration)
             {
                 case TradierOrderDuration.GTC:
-                    return OrderDuration.GTC;
+                    return TimeInForce.GTC;
                 case TradierOrderDuration.Day:
-                    return (OrderDuration) 1; //.Day;
+                    return (TimeInForce) 1; //.Day;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -1752,11 +1752,11 @@ namespace QuantConnect.Brokerages.Tradier
         /// <summary>
         /// Converts the qc order duration into a tradier order duration
         /// </summary>
-        protected static TradierOrderDuration GetOrderDuration(OrderDuration duration)
+        protected static TradierOrderDuration GetOrderDuration(TimeInForce duration)
         {
             switch (duration)
             {
-                case OrderDuration.GTC:
+                case TimeInForce.GTC:
                     return TradierOrderDuration.GTC;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -1892,7 +1892,7 @@ namespace QuantConnect.Brokerages.Tradier
                 Price = GetLimitPrice(order);
                 Stop = GetStopPrice(order);
                 Type = ConvertOrderType(order);
-                Duration = GetOrderDuration(order.Duration);
+                Duration = GetOrderDuration(order.TimeInForce);
             }
 
             public void ConvertStopOrderTypes()

--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 
@@ -86,9 +85,9 @@ namespace QuantConnect.Orders
         public OrderStatus Status { get; internal set; }
 
         /// <summary>
-        /// Order duration - GTC or Day. Day not supported in backtests.
+        /// Order Time In Force - GTC or Day. Day not supported in backtests.
         /// </summary>
-        public OrderDuration Duration { get; internal set; }
+        public TimeInForce TimeInForce { get; internal set; }
 
         /// <summary>
         /// Tag the order with some custom data
@@ -172,7 +171,7 @@ namespace QuantConnect.Orders
             Symbol = Symbol.Empty;
             Status = OrderStatus.None;
             Tag = "";
-            Duration = OrderDuration.GTC;
+            TimeInForce = TimeInForce.GTC;
             BrokerId = new List<string>();
             ContingentId = 0;
             DurationValue = DateTime.MaxValue;
@@ -196,7 +195,7 @@ namespace QuantConnect.Orders
             Symbol = symbol;
             Status = OrderStatus.None;
             Tag = tag;
-            Duration = OrderDuration.GTC;
+            TimeInForce = TimeInForce.GTC;
             BrokerId = new List<string>();
             ContingentId = 0;
             DurationValue = DateTime.MaxValue;
@@ -271,7 +270,7 @@ namespace QuantConnect.Orders
             order.Time = Time;
             order.BrokerId = BrokerId.ToList();
             order.ContingentId = ContingentId;
-            order.Duration = Duration;
+            order.TimeInForce = TimeInForce;
             order.Price = Price;
             order.PriceCurrency = PriceCurrency;
             order.Quantity = Quantity;

--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -171,7 +171,7 @@ namespace QuantConnect.Orders
             Symbol = Symbol.Empty;
             Status = OrderStatus.None;
             Tag = "";
-            TimeInForce = TimeInForce.GTC;
+            TimeInForce = TimeInForce.GoodTilCancelled;
             BrokerId = new List<string>();
             ContingentId = 0;
             DurationValue = DateTime.MaxValue;
@@ -195,7 +195,7 @@ namespace QuantConnect.Orders
             Symbol = symbol;
             Status = OrderStatus.None;
             Tag = tag;
-            TimeInForce = TimeInForce.GTC;
+            TimeInForce = TimeInForce.GoodTilCancelled;
             BrokerId = new List<string>();
             ContingentId = 0;
             DurationValue = DateTime.MaxValue;

--- a/Common/Orders/OrderJsonConverter.cs
+++ b/Common/Orders/OrderJsonConverter.cs
@@ -105,6 +105,12 @@ namespace QuantConnect.Orders
             order.BrokerId = jObject["BrokerId"].Select(x => x.Value<string>()).ToList();
             order.ContingentId = jObject["ContingentId"].Value<int>();
 
+            var timeInForce = jObject["TimeInForce"] ?? jObject["Duration"];
+            if (timeInForce != null)
+            {
+                order.TimeInForce = (TimeInForce)timeInForce.Value<int>();
+            }
+
             string market = Market.USA;
 
             //does data have market?
@@ -136,6 +142,7 @@ namespace QuantConnect.Orders
                 var tickerstring = jObject["Symbol"].Value<string>();
                 order.Symbol = Symbol.Create(tickerstring, securityType, market);
             }
+
             return order;
         }
 

--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -63,9 +63,14 @@ namespace QuantConnect.Orders
     public enum TimeInForce
     {
         /// <summary>
-        /// Order active until it is filled or cancelled (GTC).
+        /// Order active until it is filled or cancelled (same as GTC).
         /// </summary>
         GoodTilCancelled,
+
+        /// <summary>
+        /// Order active until it is filled or cancelled (same as GoodTilCancelled).
+        /// </summary>
+        GTC = GoodTilCancelled,
 
         /*
         /// <summary>

--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@ namespace QuantConnect.Orders
     /// <summary>
     /// Type of the order: market, limit or stop
     /// </summary>
-    public enum OrderType 
+    public enum OrderType
     {
         /// <summary>
         /// Market Order Type
@@ -58,9 +58,9 @@ namespace QuantConnect.Orders
 
 
     /// <summary>
-    /// Order duration in market
+    /// Time In Force - defines the length of time over which an order will continue working before it is canceled
     /// </summary>
-    public enum OrderDuration
+    public enum TimeInForce
     {
         /// <summary>
         /// Order good until its filled.
@@ -69,7 +69,7 @@ namespace QuantConnect.Orders
 
         /*
         /// <summary>
-        /// Order valid for today only: -- CURRENTLY ONLY GTC ORDER DURATION TYPE IN BACKTESTS.
+        /// Order valid for today only: -- CURRENTLY ONLY GTC ORDER TIME IN FORCE IN BACKTESTS.
         /// </summary>
         Day
         */
@@ -78,7 +78,7 @@ namespace QuantConnect.Orders
         /// Order valid until a custom set date time value.
         /// </summary>
         Custom
-        
+
     }
 
 
@@ -88,7 +88,7 @@ namespace QuantConnect.Orders
     public enum OrderDirection {
 
         /// <summary>
-        /// Buy Order 
+        /// Buy Order
         /// </summary>
         Buy,
 
@@ -112,7 +112,7 @@ namespace QuantConnect.Orders
     /// Fill status of the order class.
     /// </summary>
     public enum OrderStatus {
-        
+
         /// <summary>
         /// New order pre-submission to the order processor.
         /// </summary>

--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -58,14 +58,14 @@ namespace QuantConnect.Orders
 
 
     /// <summary>
-    /// Time In Force - defines the length of time over which an order will continue working before it is canceled
+    /// Time In Force - defines the length of time over which an order will continue working before it is cancelled
     /// </summary>
     public enum TimeInForce
     {
         /// <summary>
-        /// Order good until its filled.
+        /// Order active until it is filled or cancelled (GTC).
         /// </summary>
-        GTC,
+        GoodTilCancelled,
 
         /*
         /// <summary>

--- a/Tests/Common/Orders/OrderJsonConverterTests.cs
+++ b/Tests/Common/Orders/OrderJsonConverterTests.cs
@@ -192,7 +192,7 @@ namespace QuantConnect.Tests.Common.Orders
 'Time':'2010-03-04T14:31:00Z',
 'Quantity':999,
 'Status':3,
-'TimeInForce':0,
+'TimeInForce':1,
 'Tag':'',
 'SecurityType':1,
 'Direction':0,
@@ -201,7 +201,40 @@ namespace QuantConnect.Tests.Common.Orders
             var order = JsonConvert.DeserializeObject<Order>(json);
             Assert.IsInstanceOf<MarketOrder>(order);
             Assert.AreEqual(Market.USA, order.Symbol.ID.Market);
+            Assert.AreEqual(1, (int)order.TimeInForce);
+        }
 
+        [Test]
+        public void DeserializesOldDurationProperty()
+        {
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                Converters = { new OrderJsonConverter() }
+            };
+
+            // The Duration property has been renamed to TimeInForce,
+            // we still want to deserialize old JSON files containing Duration.
+            const string json = @"{'Type':0,
+'Value':99986.827413672,
+'Id':1,
+'ContingentId':0,
+'BrokerId':[1],
+'Symbol':{'Value':'SPY',
+'Permtick':'SPY'},
+'Price':100.086914328,
+'Time':'2010-03-04T14:31:00Z',
+'Quantity':999,
+'Status':3,
+'Duration':1,
+'Tag':'',
+'SecurityType':1,
+'Direction':0,
+'AbsoluteQuantity':999}";
+
+            var order = JsonConvert.DeserializeObject<Order>(json);
+            Assert.IsInstanceOf<MarketOrder>(order);
+            Assert.AreEqual(Market.USA, order.Symbol.ID.Market);
+            Assert.AreEqual(1, (int)order.TimeInForce);
         }
 
         [Test]

--- a/Tests/Common/Orders/OrderJsonConverterTests.cs
+++ b/Tests/Common/Orders/OrderJsonConverterTests.cs
@@ -159,7 +159,7 @@ namespace QuantConnect.Tests.Common.Orders
 'Time':'2010-03-04T14:31:00Z',
 'Quantity':999,
 'Status':3,
-'Duration':0,
+'TimeInForce':0,
 'Tag':'',
 'SecurityType':1,
 'Direction':0,
@@ -192,7 +192,7 @@ namespace QuantConnect.Tests.Common.Orders
 'Time':'2010-03-04T14:31:00Z',
 'Quantity':999,
 'Status':3,
-'Duration':0,
+'TimeInForce':0,
 'Tag':'',
 'SecurityType':1,
 'Direction':0,
@@ -223,7 +223,7 @@ namespace QuantConnect.Tests.Common.Orders
             CollectionAssert.AreEqual(expected.BrokerId, actual.BrokerId);
             Assert.AreEqual(expected.ContingentId, actual.ContingentId);
             Assert.AreEqual(expected.Direction, actual.Direction);
-            Assert.AreEqual(expected.Duration, actual.Duration);
+            Assert.AreEqual(expected.TimeInForce, actual.TimeInForce);
             Assert.AreEqual(expected.DurationValue, actual.DurationValue);
             Assert.AreEqual(expected.Id, actual.Id);
             Assert.AreEqual(expected.Price, actual.Price);


### PR DESCRIPTION

#### Description
This PR renames the following items:
- `OrderDuration` enum -> `TimeInForce`
- `Order.Duration` property -> `Order.TimeInForce`

#### Related Issue
#1093 

#### Motivation and Context
_"Time In Force"_ is the standard term used in trading platforms and APIs:
https://www.investopedia.com/terms/t/timeinforce.asp

#### Requires Documentation Change
No.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`