### PR TITLE
Adds python examples for Insight.GroupId feature

### DIFF
--- a/Algorithm.Framework/Alphas/PairsTradingAlphaModel.py
+++ b/Algorithm.Framework/Alphas/PairsTradingAlphaModel.py
@@ -1,0 +1,116 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Indicators")
+
+from QuantConnect import *
+from QuantConnect.Indicators import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from datetime import timedelta
+from enum import Enum
+
+class PairsTradingAlphaModel:
+    '''This alpha model is designed to work against a single, predefined pair.
+    This model generates alternating long ratio/short ratio insights emitted as a group'''
+
+    class State(Enum):
+        ShortRatio = -1
+        FlatRatio = 0
+        LongRatio = 1
+
+    def __init__(self, asset1, asset2, threshold = 1):
+        ''' Initializes a new instance of the PairsTradingAlphaModel class
+        Args:
+            asset1: The first asset's symbol in the pair
+            asset2: The second asset's symbol in the pair
+            threshold: The percent [0, 100] deviation of the ratio from the mean before emitting an insight'''
+        self.asset1 = asset1
+        self.asset2 = asset2
+        self.threshold = threshold
+        self.state = self.State.FlatRatio
+        self.asset1Price = None
+        self.asset2Price = None
+        self.ratio = None
+        self.mean = None
+        self.upperThreshold = None;
+        self.lowerThreshold = None;
+
+        self.Name = '{}({},{},{})'.format(self.__class__.__name__, asset1, asset2, Extensions.Normalize(threshold))
+
+
+    def Update(self, algorithm, data):
+        ''' Updates this alpha model with the latest data from the algorithm.
+        This is called each time the algorithm receives data for subscribed securities
+        Args:
+            algorithm: The algorithm instance
+            data: The new data available
+        Returns:
+            The new insights generated'''
+        if self.mean is None or not self.mean.IsReady:
+            return []
+
+        # don't re-emit the same direction
+        if self.state is not self.State.LongRatio and self.ratio > self.upperThreshold:
+            self.state = self.State.LongRatio
+
+            # asset1/asset2 is more than 2 std away from mean, short asset1, long asset2
+            shortAsset1 = Insight.Price(self.asset1, timedelta(minutes = 15), InsightDirection.Down)
+            longAsset2 = Insight.Price(self.asset2, timedelta(minutes = 15), InsightDirection.Up)
+
+            # creates a group id and set the GroupId property on each insight object
+            Insight.Group(shortAsset1, longAsset2)
+            return [shortAsset1, longAsset2]
+        
+        # don't re-emit the same direction
+        if self.state is not self.State.ShortRatio and self.ratio < self.lowerThreshold:
+            self.state = self.State.ShortRatio
+
+            # asset1/asset2 is less than 2 std away from mean, long asset1, short asset2
+            longAsset1 = Insight.Price(self.asset1, timedelta(minutes = 15), InsightDirection.Up)
+            shortAsset2 = Insight.Price(self.asset2, timedelta(minutes = 15), InsightDirection.Down)
+
+            # creates a group id and set the GroupId property on each insight object
+            Insight.Group(longAsset1, shortAsset2)
+            return [longAsset1, shortAsset2]
+
+        return []
+
+    def OnSecuritiesChanged(self, algorithm, changes):
+        '''Event fired each time the we add/remove securities from the data feed.
+        Args:
+            algorithm: The algorithm instance that experienced the change in securities
+            changes: The security additions and removals from the algorithm'''
+        for added in changes.AddedSecurities:
+            # this model is limitted to looking at a single pair of assets
+            if added.Symbol != self.asset1 and added.Symbol != self.asset2:
+                continue
+
+            if added.Symbol == self.asset1:
+                self.asset1Price = algorithm.Identity(added.Symbol)
+            else:
+                self.asset2Price = algorithm.Identity(added.Symbol)
+
+        if self.ratio is None:
+            # initialize indicators dependent on both assets
+            if self.asset1Price is not None and self.asset2Price is not None:
+                self.ratio = IndicatorExtensions.Over(self.asset1Price, self.asset2Price)
+                self.mean = IndicatorExtensions.Of(ExponentialMovingAverage(500), self.ratio)
+                
+                upper = ConstantIndicator[IndicatorDataPoint]("ct", 1 + self.threshold / 100)
+                self.upperThreshold = IndicatorExtensions.Times(self.mean, upper)
+
+                lower = ConstantIndicator[IndicatorDataPoint]("ct", 1 - self.threshold / 100)
+                self.lowerThreshold = IndicatorExtensions.Times(self.mean, lower)

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -116,6 +116,9 @@
     <Content Include="Alphas\HistoricalReturnsAlphaModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Alphas\PairsTradingAlphaModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Execution\VolumeWeightedAveragePriceExecutionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Algorithm.Python/PairsTradingAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/PairsTradingAlphaModelFrameworkAlgorithm.py
@@ -1,0 +1,51 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from Alphas.PairsTradingAlphaModel import PairsTradingAlphaModel
+
+### <summary>
+### Framework algorithm that uses the PairsTradingAlphaModel to detect
+### divergences between correllated assets. Detection of asset correlation is not
+### performed and is expected to be handled outside of the alpha model.
+### </summary>
+class PairsTradingAlphaModelFrameworkAlgorithm(QCAlgorithmFramework):
+    '''Framework algorithm that uses the PairsTradingAlphaModel to detect
+    divergences between correllated assets. Detection of asset correlation is not
+    performed and is expected to be handled outside of the alpha model.'''
+
+    def Initialize(self):
+
+        self.SetStartDate(2013,10,7)
+        self.SetEndDate(2013,10,11)
+
+        bac = self.AddEquity("BAC")
+        aig = self.AddEquity("AIG")
+
+        self.SetUniverseSelection(ManualUniverseSelectionModel(self.Securities.Keys))
+        self.SetAlpha(PairsTradingAlphaModel(bac.Symbol, aig.Symbol))
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+        self.SetRiskManagement(NullRiskManagementModel())

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -140,6 +140,7 @@
     <None Include="CustomSecurityInitializerAlgorithm.py" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="PairsTradingAlphaModelFrameworkAlgorithm.py" />
     <Content Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
     <Content Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.py" />
     <None Include="BasicTemplateCryptoAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -86,6 +86,7 @@
     <Compile Include="OptionRenameRegressionAlgorithm.py" />
     <Compile Include="OptionSplitRegressionAlgorithm.py" />
     <Compile Include="OrderTicketDemoAlgorithm.py" />
+    <Compile Include="PairsTradingAlphaModelFrameworkAlgorithm.py" />
     <Compile Include="ParameterizedAlgorithm.py" />
     <Compile Include="PythonPackageTestAlgorithm.py" />
     <Compile Include="QCUWeatherBasedRebalancing.py" />

--- a/Tests/Algorithm/Framework/Alphas/PairsTradingAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/PairsTradingAlphaModelTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Algorithm.Framework;
 using QuantConnect.Algorithm.Framework.Alphas;
 
@@ -47,7 +48,14 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
         protected override IAlphaModel CreatePythonAlphaModel()
         {
-            throw new NotImplementedException($"{nameof(PairsTradingAlphaModel)} has not been implemented in python yet.");
+            using (Py.GIL())
+            {
+                dynamic model = Py.Import("PairsTradingAlphaModel").GetAttr("PairsTradingAlphaModel");
+                var instance = model(
+                    Symbol.Create("BAC", SecurityType.Equity, Market.USA),
+                    Symbol.Create("AIG", SecurityType.Equity, Market.USA));
+                return new AlphaModelPythonWrapper(instance);
+            }
         }
 
         protected override IEnumerable<Insight> ExpectedInsights()

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -1035,6 +1035,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm", volumeWeightedAveragePriceExecutionModelRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("StandardDeviationExecutionModelRegressionAlgorithm", standardDeviationExecutionModelRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.Python)
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION
#### Description
- Adds python version of `PairsTradingAlphaModel`;
- Adds python version of `PairsTradingAlphaModelFrameworkAlgorithm`.

#### Related Issue
Closes #1896

#### Motivation and Context
Aiming to have python and C# version of every feature example.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test and regression tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`