### PR TITLE
Calls python destructor to trigger exceptions

### DIFF
--- a/Algorithm.Framework/Alphas/AlphaModelPythonWrapper.cs
+++ b/Algorithm.Framework/Alphas/AlphaModelPythonWrapper.cs
@@ -81,6 +81,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 {
                     yield return insight.AsManagedObject(typeof(Insight)) as Insight;
                 }
+                insights.Destroy();
             }
         }
 

--- a/Algorithm.Framework/Portfolio/PortfolioConstructionModelPythonWrapper.cs
+++ b/Algorithm.Framework/Portfolio/PortfolioConstructionModelPythonWrapper.cs
@@ -62,6 +62,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 {
                     yield return target.AsManagedObject(typeof(IPortfolioTarget)) as IPortfolioTarget;
                 }
+                targets.Destroy();
             }
         }
 

--- a/Algorithm.Framework/Risk/RiskManagementModelPythonWrapper.cs
+++ b/Algorithm.Framework/Risk/RiskManagementModelPythonWrapper.cs
@@ -61,6 +61,7 @@ namespace QuantConnect.Algorithm.Framework.Risk
                 {
                     yield return target.AsManagedObject(typeof(IPortfolioTarget)) as IPortfolioTarget;
                 }
+                riskTargetOverrides.Destroy();
             }
         }
 

--- a/Algorithm.Framework/Selection/UniverseSelectionModelPythonWrapper.cs
+++ b/Algorithm.Framework/Selection/UniverseSelectionModelPythonWrapper.cs
@@ -60,6 +60,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
                 {
                     yield return universe.AsManagedObject(typeof(Universe)) as Universe;
                 }
+                universers.Destroy();
             }
         }
     }

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1137,6 +1137,33 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Destroys a PyObject
+        /// https://docs.python.org/2/reference/datamodel.html#object.__del__
+        /// </summary>
+        /// <param name="pyObject">PyObject to be destroyed</param>
+        public static void Destroy(this PyObject pyObject)
+        {
+            try
+            {
+                if (pyObject.HasAttr("__del__"))
+                {
+                    pyObject.InvokeMethod("__del__");
+                }
+            }
+            catch (PythonException e)
+            {
+                if (string.IsNullOrWhiteSpace(e.StackTrace))
+                {
+                    throw new Exception($"{(pyObject as dynamic).__qualname__} returned a result with an undefined error set.");
+                }
+                else
+                {
+                    throw e;
+                }
+            }
+        }
+
+        /// <summary>
         /// Performs on-line batching of the specified enumerator, emitting chunks of the requested batch size
         /// </summary>
         /// <typeparam name="T">The enumerable item type</typeparam>


### PR DESCRIPTION
#### Description
The exception in ignored because the python generator isn't closed until it is being deleted (automatically in this case, when Python exits); the generator `__del__` handler closes the generator, which triggers an exception of there is one.
See more [here](https://stackoverflow.com/questions/18637048/avoid-exception-ignored-in-python-enhanced-generator?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa)

#### Related Issue
Closes #1914

#### Motivation and Context
Avoid silent exceptions.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Algorithm provided in issue #1914.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`