### PR TITLE
Convert to exchange tz and reverse a day when reading fine data

### DIFF
--- a/Algorithm.CSharp/CoarseFineFundamentalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseFineFundamentalRegressionAlgorithm.cs
@@ -58,17 +58,17 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 return new List<Symbol>
                 {
-                    QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, "usa"),
-                    QuantConnect.Symbol.Create("AIG", SecurityType.Equity, "usa"),
-                    QuantConnect.Symbol.Create("IBM", SecurityType.Equity, "usa")
+                    QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA),
+                    QuantConnect.Symbol.Create("AIG", SecurityType.Equity, Market.USA),
+                    QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA)
                 };
             }
 
             return new List<Symbol>
             {
-                QuantConnect.Symbol.Create("BAC", SecurityType.Equity, "usa"),
-                QuantConnect.Symbol.Create("GOOG", SecurityType.Equity, "usa"),
-                QuantConnect.Symbol.Create("SPY", SecurityType.Equity, "usa")
+                QuantConnect.Symbol.Create("BAC", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("GOOG", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)
             };
         }
 

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -170,6 +170,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     universeDataForTimeSliceCreate[universe] = baseDataCollection;
                     newChanges += _universeSelection.ApplyUniverseSelection(universe, _frontier, baseDataCollection);
                 }
+                universeData.Clear();;
 
                 changes += newChanges;
             }

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -83,7 +83,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     foreach (var symbol in selectSymbolsResult)
                     {
-                        var factory = new FineFundamentalSubscriptionEnumeratorFactory(_algorithm.LiveMode, x => new[] { dateTimeUtc });
                         var config = FineFundamentalUniverse.CreateConfiguration(symbol);
 
                         var exchangeHours = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType).ExchangeHours;
@@ -92,7 +91,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                         var security = new Equity(symbol, exchangeHours, quoteCash, symbolProperties);
 
-                        var request = new SubscriptionRequest(true, universe, security, new SubscriptionDataConfig(config), dateTimeUtc, dateTimeUtc);
+                        var localStartTime = dateTimeUtc.ConvertFromUtc(exchangeHours.TimeZone).AddDays(-1);
+                        var factory = new FineFundamentalSubscriptionEnumeratorFactory(_algorithm.LiveMode, x => new[] { localStartTime });
+                        var request = new SubscriptionRequest(true, universe, security, new SubscriptionDataConfig(config), localStartTime, localStartTime);
                         using (var enumerator = factory.CreateEnumerator(request, dataProvider))
                         {
                             if (enumerator.MoveNext())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The fine enumerator factor accepts a 'date'. This date is that day that the data is produced, so the emit time on that data is midnight the following day. When we go to read the fine data we can't use the
current time because that's the 'emit time' -- instead we need to back the time up a full day to find the correct start time. In addition, the fine data was being read using UTC time stamps which led to even
more confusion here -- this change resolves both issues.

In addition to the above, the security.Fundamentals property wasn't being properly set for the first time step when a security is selected due to a bug in the subscription synchronizer not clearing out the `universeData` in preparation for another loop (in the event changes != None).

Initially I was under the impression that coarse's price data should come after the security price data, but that isn't the case. Consider universe selection running at midnight on the 25th -- it's pulling data from 24->25 (date=24). When we add a security, say `AAPL`, we'll pull data from 24->25 as well and pipe it into the algorithm, then when submitting an order you'll get an execution at market open on the 25th -> no look-ahead bias confirmed.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #1905 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and confirmed changes with `CoarseFineFundamentalRegressionAlgorithm`.

Turns out the coarse data wasn't at fault -- the main issue here was that when reading the fine data we didn't convert from UTC->NewYork *and also* we didn't back up a day, since the 'date' parameter for the enumerator factor reads on the interval [date, date+1day] -- introducing look-ahead bias. This has been updated to properly convert to exchange time and reverse a full day so we read data for the corrct date. Manually inspected timestamps on data and ensured they're good.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->