### PR TITLE
Set TickType to Trade for Crypto internal currency feeds

### DIFF
--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -226,6 +226,13 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsTrue(symbols.Contains(Symbols.EURUSD));
             Assert.IsTrue(symbols.Contains(Symbols.XAGUSD));
             Assert.IsTrue(symbols.Contains(Symbols.XAUUSD));
+
+            foreach (var subscription in subscriptions.Subscriptions)
+            {
+                Assert.AreEqual(
+                    subscription.Symbol.SecurityType == SecurityType.Crypto ? TickType.Trade : TickType.Quote,
+                    subscription.TickType);
+            }
         }
 
         [Test]


### PR DESCRIPTION

#### Description
In `Cash.EnsureCurrencyDataFeed` the `TickType` for the added subscription was hardcoded to `TickType.Quote`. Since we don't have quote data for Crypto assets in backtesting, we now use `TickType.Trade` (only for Crypto).

#### Related Issue
Closes #1922

#### Motivation and Context
Conversion rates are zero for Crypto internal currency feeds.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually verified algorithm in #1922 and added tick type asserts in existing unit test for `Cash`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`