### PR TITLE
Add TimeInForce.Day support in backtesting and IB brokerage

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -166,6 +166,7 @@
     <Compile Include="HourSplitRegressionAlgorithm.cs" />
     <Compile Include="ScheduledUniverseSelectionModelRegressionAlgorithm.cs" />
     <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.cs" />
+    <Compile Include="TimeInForceAlgorithm.cs" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.cs" />
     <Compile Include="UserDefinedUniverseAlgorithm.cs" />
     <Compile Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs" />

--- a/Algorithm.CSharp/TimeInForceAlgorithm.cs
+++ b/Algorithm.CSharp/TimeInForceAlgorithm.cs
@@ -55,16 +55,17 @@ namespace QuantConnect.Algorithm.CSharp
         {
             if (_gtcOrderTicket == null)
             {
-                // This order has a default time in force of GoodTilCancelled,
-                // it will never expire and will not be cancelled automatically.
+                // This order has a default time in force of GoodTilCanceled,
+                // it will never expire and will not be canceled automatically.
 
+                DefaultOrderProperties.TimeInForce = TimeInForce.GoodTilCanceled;
                 _gtcOrderTicket = LimitOrder(_symbol, 10, 160m);
             }
 
             if (_dayOrderTicket == null)
             {
                 // This order will expire at market close,
-                // if not filled by then it will be cancelled automatically.
+                // if not filled by then it will be canceled automatically.
 
                 DefaultOrderProperties.TimeInForce = TimeInForce.Day;
                 _dayOrderTicket = LimitOrder(_symbol, 10, 160m);

--- a/Algorithm.CSharp/TimeInForceAlgorithm.cs
+++ b/Algorithm.CSharp/TimeInForceAlgorithm.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Demonstration algorithm of time in force order settings.
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="using quantconnect" />
+    /// <meta name="tag" content="trading and orders" />
+    public class TimeInForceAlgorithm : QCAlgorithm
+    {
+        private Symbol _symbol;
+        private OrderTicket _gtcOrderTicket;
+        private OrderTicket _dayOrderTicket;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+            SetCash(100000);
+
+            // The default time in force setting for all orders is GoodTilCancelled (GTC),
+            // uncomment this line to set a different time in force.
+            // We currently only support GTC and DAY.
+            // DefaultOrderProperties.TimeInForce = TimeInForce.Day;
+
+            _symbol = AddEquity("SPY", Resolution.Minute).Symbol;
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (_gtcOrderTicket == null)
+            {
+                // This order has a default time in force of GoodTilCancelled,
+                // it will never expire and will not be cancelled automatically.
+
+                _gtcOrderTicket = LimitOrder(_symbol, 10, 160m);
+            }
+
+            if (_dayOrderTicket == null)
+            {
+                // This order will expire at market close,
+                // if not filled by then it will be cancelled automatically.
+
+                DefaultOrderProperties.TimeInForce = TimeInForce.Day;
+                _dayOrderTicket = LimitOrder(_symbol, 10, 160m);
+            }
+        }
+
+        /// <summary>
+        /// Order event handler. This handler will be called for all order events, including submissions, fills, cancellations.
+        /// </summary>
+        /// <param name="orderEvent">Order event instance containing details of the event</param>
+        /// <remarks>This method can be called asynchronously, ensure you use proper locks on thread-unsafe objects</remarks>
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Debug($"{Time} {orderEvent}");
+        }
+
+    }
+}

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -140,6 +140,7 @@
     <None Include="CustomSecurityInitializerAlgorithm.py" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="TimeInForceAlgorithm.py" />
     <Content Include="PairsTradingAlphaModelFrameworkAlgorithm.py" />
     <Content Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
     <Content Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.py" />

--- a/Algorithm.Python/TimeInForceAlgorithm.py
+++ b/Algorithm.Python/TimeInForceAlgorithm.py
@@ -1,0 +1,70 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Orders import *
+
+### <summary>
+### Demonstration algorithm of time in force order settings.
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="using quantconnect" />
+### <meta name="tag" content="trading and orders" />
+class TimeInForceAlgorithm(QCAlgorithm):
+
+    # Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+    def Initialize(self):
+
+        self.SetStartDate(2013,10,7)
+        self.SetEndDate(2013,10,11)
+        self.SetCash(100000)
+
+        # The default time in force setting for all orders is GoodTilCancelled (GTC),
+        # uncomment this line to set a different time in force.
+        # We currently only support GTC and DAY.
+        # self.DefaultOrderProperties.TimeInForce = TimeInForce.Day;
+
+        self.symbol = self.AddEquity("SPY", Resolution.Second).Symbol
+
+        self.gtcOrderTicket = None
+        self.dayOrderTicket = None
+
+    # OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+    # Arguments:
+    #    data: Slice object keyed by symbol containing the stock data
+    def OnData(self, data):
+
+        if self.gtcOrderTicket is None:
+            # This order has a default time in force of GoodTilCancelled,
+            # it will never expire and will not be cancelled automatically.
+
+            self.gtcOrderTicket = self.LimitOrder(self.symbol, 10, 160)
+
+        if self.dayOrderTicket is None:
+            # This order will expire at market close,
+            # if not filled by then it will be cancelled automatically.
+
+            self.DefaultOrderProperties.TimeInForce = TimeInForce.Day
+            self.dayOrderTicket = self.LimitOrder(self.symbol, 10, 160)
+
+    # Order event handler. This handler will be called for all order events, including submissions, fills, cancellations.
+    # This method can be called asynchronously, ensure you use proper locks on thread-unsafe objects
+    def OnOrderEvent(self, orderEvent):
+        self.Debug(f"{self.Time} {orderEvent}")

--- a/Algorithm.Python/TimeInForceAlgorithm.py
+++ b/Algorithm.Python/TimeInForceAlgorithm.py
@@ -52,14 +52,15 @@ class TimeInForceAlgorithm(QCAlgorithm):
     def OnData(self, data):
 
         if self.gtcOrderTicket is None:
-            # This order has a default time in force of GoodTilCancelled,
-            # it will never expire and will not be cancelled automatically.
+            # This order has a default time in force of GoodTilCanceled,
+            # it will never expire and will not be canceled automatically.
 
+            self.DefaultOrderProperties.TimeInForce = TimeInForce.GoodTilCanceled
             self.gtcOrderTicket = self.LimitOrder(self.symbol, 10, 160)
 
         if self.dayOrderTicket is None:
             # This order will expire at market close,
-            # if not filled by then it will be cancelled automatically.
+            # if not filled by then it will be canceled automatically.
 
             self.DefaultOrderProperties.TimeInForce = TimeInForce.Day
             self.dayOrderTicket = self.LimitOrder(self.symbol, 10, 160)

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -116,6 +116,7 @@ namespace QuantConnect.Algorithm
             _localTimeKeeper = _timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork);
 
             Settings = new AlgorithmSettings();
+            DefaultOrderProperties = new OrderProperties();
 
             //Initialise Data Manager
             SubscriptionManager = new SubscriptionManager(Settings, _timeKeeper);

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -284,7 +284,11 @@ namespace QuantConnect.Brokerages.Backtesting
                     // check if the time in force handler allows fills
                     if (timeInForceHandler.HasOrderExpired(order))
                     {
-                        OnOrderEvent(new OrderEvent(order, Algorithm.UtcTime, 0m) { Status = OrderStatus.Canceled });
+                        OnOrderEvent(new OrderEvent(order, Algorithm.UtcTime, 0m)
+                        {
+                            Status = OrderStatus.Canceled,
+                            Message = "The order has expired."
+                        });
                         _pending.TryRemove(order.Id, out order);
                         continue;
                     }

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -289,7 +289,7 @@ namespace QuantConnect.Brokerages.Backtesting
                     var timeInForceHandler = _timeInForceHandlers[order.TimeInForce];
 
                     // check if the time in force handler allows fills
-                    if (timeInForceHandler.HasOrderExpired(security, order))
+                    if (timeInForceHandler.IsOrderExpired(security, order))
                     {
                         OnOrderEvent(new OrderEvent(order, Algorithm.UtcTime, 0m)
                         {

--- a/Brokerages/Fxcm/FxcmBrokerage.Util.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Util.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Brokerages.Fxcm
             order.Quantity = Convert.ToInt32(fxcmOrder.getOrderQty() * (fxcmOrder.getSide() == SideFactory.BUY ? +1 : -1));
             order.Status = ConvertOrderStatus(fxcmOrder.getFXCMOrdStatus());
             order.BrokerId.Add(fxcmOrder.getOrderID());
-            order.TimeInForce = ConvertTimeInForce(fxcmOrder.getTimeInForce());
+            order.Properties.TimeInForce = ConvertTimeInForce(fxcmOrder.getTimeInForce());
             order.Time = FromJavaDate(fxcmOrder.getTransactTime().toDate());
 
             return order;
@@ -84,7 +84,7 @@ namespace QuantConnect.Brokerages.Fxcm
                 return TimeInForce.GoodTilCancelled;
 
             if (timeInForce == TimeInForceFactory.DAY)
-                return (TimeInForce)1; //.Day;
+                return TimeInForce.Day;
 
             throw new ArgumentOutOfRangeException();
         }

--- a/Brokerages/Fxcm/FxcmBrokerage.Util.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Util.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Brokerages.Fxcm
         private static TimeInForce ConvertTimeInForce(ITimeInForce timeInForce)
         {
             if (timeInForce == TimeInForceFactory.GOOD_TILL_CANCEL)
-                return TimeInForce.GoodTilCancelled;
+                return TimeInForce.GoodTilCanceled;
 
             if (timeInForce == TimeInForceFactory.DAY)
                 return TimeInForce.Day;

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1750,7 +1750,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             order.BrokerId.Add(ibOrder.OrderId.ToString());
 
-            order.TimeInForce = ConvertTimeInForce(ibOrder.Tif);
+            order.Properties.TimeInForce = ConvertTimeInForce(ibOrder.Tif);
 
             return order;
         }

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1621,19 +1621,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 TotalQuantity = (int)Math.Abs(order.Quantity),
                 OrderType = ConvertOrderType(order.Type),
                 AllOrNone = false,
-                Tif = IB.TimeInForce.GoodTillCancel,
+                Tif = ConvertTimeInForce(order),
                 Transmit = true,
                 Rule80A = _agentDescription
             };
-
-            if (order.Type == OrderType.MarketOnOpen)
-            {
-                ibOrder.Tif = IB.TimeInForce.MarketOnOpen;
-            }
-            else if (order.Type == OrderType.MarketOnClose)
-            {
-                ibOrder.Tif = IB.TimeInForce.Day;
-            }
 
             var limitOrder = order as LimitOrder;
             var stopMarketOrder = order as StopMarketOrder;
@@ -1758,6 +1749,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
 
             order.BrokerId.Add(ibOrder.OrderId.ToString());
+
+            order.TimeInForce = ConvertTimeInForce(ibOrder.Tif);
 
             return order;
         }
@@ -1895,6 +1888,66 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 default:
                     throw new ArgumentException(order.OrderType, "order.OrderType");
+            }
+        }
+
+        /// <summary>
+        /// Maps TimeInForce from IB to LEAN
+        /// </summary>
+        private static TimeInForce ConvertTimeInForce(string timeInForce)
+        {
+            switch (timeInForce)
+            {
+                case IB.TimeInForce.Day:
+                    return TimeInForce.Day;
+
+                //case IB.TimeInForce.GoodTillDate:
+                //    return TimeInForce.GoodTilDate;
+
+                //case IB.TimeInForce.FillOrKill:
+                //    return TimeInForce.FillOrKill;
+
+                //case IB.TimeInForce.ImmediateOrCancel:
+                //    return TimeInForce.ImmediateOrCancel;
+
+                case IB.TimeInForce.MarketOnOpen:
+                case IB.TimeInForce.GoodTillCancel:
+                default:
+                    return TimeInForce.GoodTilCancelled;
+            }
+        }
+
+        /// <summary>
+        /// Maps TimeInForce from LEAN to IB
+        /// </summary>
+        private static string ConvertTimeInForce(Order order)
+        {
+            if (order.Type == OrderType.MarketOnOpen)
+            {
+                return IB.TimeInForce.MarketOnOpen;
+            }
+            if (order.Type == OrderType.MarketOnClose)
+            {
+                return IB.TimeInForce.Day;
+            }
+
+            switch (order.TimeInForce)
+            {
+                case TimeInForce.Day:
+                    return IB.TimeInForce.Day;
+
+                //case TimeInForce.GoodTilDate:
+                //    return IB.TimeInForce.GoodTillDate;
+
+                //case TimeInForce.FillOrKill:
+                //    return IB.TimeInForce.FillOrKill;
+
+                //case TimeInForce.ImmediateOrCancel:
+                //    return IB.TimeInForce.ImmediateOrCancel;
+
+                case TimeInForce.GoodTilCancelled:
+                default:
+                    return IB.TimeInForce.GoodTillCancel;
             }
         }
 

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1913,7 +1913,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 case IB.TimeInForce.MarketOnOpen:
                 case IB.TimeInForce.GoodTillCancel:
                 default:
-                    return TimeInForce.GoodTilCancelled;
+                    return TimeInForce.GoodTilCanceled;
             }
         }
 
@@ -1945,7 +1945,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 //case TimeInForce.ImmediateOrCancel:
                 //    return IB.TimeInForce.ImmediateOrCancel;
 
-                case TimeInForce.GoodTilCancelled:
+                case TimeInForce.GoodTilCanceled:
                 default:
                     return IB.TimeInForce.GoodTillCancel;
             }

--- a/Brokerages/Oanda/OandaRestApiV1.cs
+++ b/Brokerages/Oanda/OandaRestApiV1.cs
@@ -770,7 +770,7 @@ namespace QuantConnect.Brokerages.Oanda
                 qcOrder.Id = orderByBrokerageId.Id;
             }
 
-            qcOrder.TimeInForce = TimeInForce.Custom;
+            qcOrder.Properties.TimeInForce = TimeInForce.Custom;
             qcOrder.DurationValue = XmlConvert.ToDateTime(order.expiry, XmlDateTimeSerializationMode.Utc);
             qcOrder.Time = XmlConvert.ToDateTime(order.time, XmlDateTimeSerializationMode.Utc);
 

--- a/Brokerages/Oanda/OandaRestApiV20.cs
+++ b/Brokerages/Oanda/OandaRestApiV20.cs
@@ -655,7 +655,7 @@ namespace QuantConnect.Brokerages.Oanda
             var gtdTime = order["gtdTime"];
             if (gtdTime != null)
             {
-                qcOrder.TimeInForce = TimeInForce.Custom;
+                qcOrder.Properties.TimeInForce = TimeInForce.Custom;
                 qcOrder.DurationValue = GetTickDateTimeFromString(gtdTime.ToString());
             }
 

--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -1513,7 +1513,7 @@ namespace QuantConnect.Brokerages.Tradier
             qcOrder.Status = ConvertStatus(order.Status);
             qcOrder.BrokerId.Add(order.Id.ToString());
             //qcOrder.ContingentId =
-            qcOrder.TimeInForce = ConvertTimeInForce(order.Duration);
+            qcOrder.Properties.TimeInForce = ConvertTimeInForce(order.Duration);
             var orderByBrokerageId = _orderProvider.GetOrderByBrokerageId(order.Id);
             if (orderByBrokerageId != null)
             {

--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -1555,7 +1555,7 @@ namespace QuantConnect.Brokerages.Tradier
             switch (duration)
             {
                 case TradierOrderDuration.GTC:
-                    return TimeInForce.GoodTilCancelled;
+                    return TimeInForce.GoodTilCanceled;
                 case TradierOrderDuration.Day:
                     return (TimeInForce) 1; //.Day;
                 default:
@@ -1756,7 +1756,7 @@ namespace QuantConnect.Brokerages.Tradier
         {
             switch (duration)
             {
-                case TimeInForce.GoodTilCancelled:
+                case TimeInForce.GoodTilCanceled:
                     return TradierOrderDuration.GTC;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Common/Brokerages/FxcmBrokerageModel.cs
+++ b/Common/Brokerages/FxcmBrokerageModel.cs
@@ -123,7 +123,7 @@ namespace QuantConnect.Brokerages
             }
 
             // validate time in force
-            if (order.TimeInForce != TimeInForce.GoodTilCancelled)
+            if (order.TimeInForce != TimeInForce.GoodTilCanceled)
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     "This model does not support " + order.TimeInForce + " time in force."

--- a/Common/Brokerages/FxcmBrokerageModel.cs
+++ b/Common/Brokerages/FxcmBrokerageModel.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,7 +51,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to 
+        /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="QuantConnect.AccountType.Margin"/></param>
         public FxcmBrokerageModel(AccountType accountType = AccountType.Margin)
             : base(accountType)
@@ -122,6 +122,16 @@ namespace QuantConnect.Brokerages
                 return IsValidOrderPrices(security, OrderType.StopLimit, stopLimit.Direction, stopLimit.StopPrice, stopLimit.LimitPrice, ref message);
             }
 
+            // validate time in force
+            if (order.TimeInForce != TimeInForce.GoodTilCancelled)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    "This model does not support " + order.TimeInForce + " time in force."
+                );
+
+                return false;
+            }
+
             return true;
         }
 
@@ -146,7 +156,7 @@ namespace QuantConnect.Brokerages
 
                 return false;
             }
-            
+
             // determine direction via the new, updated quantity
             var newQuantity = request.Quantity ?? order.Quantity;
             var direction = newQuantity > 0 ? OrderDirection.Buy : OrderDirection.Sell;

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -145,7 +145,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (order.TimeInForce != TimeInForce.GoodTilCancelled)
+            if (order.TimeInForce != TimeInForce.GoodTilCanceled)
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     "This model does not support " + order.TimeInForce + " time in force."

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -145,6 +145,15 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
+            if (order.TimeInForce != TimeInForce.GoodTilCancelled)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    "This model does not support " + order.TimeInForce + " time in force."
+                );
+
+                return false;
+            }
+
             return base.CanSubmitOrder(security, order, out message);
         }
 

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Brokerages
             }
 
             // validate time in force
-            if (order.TimeInForce != TimeInForce.GoodTilCancelled && order.TimeInForce != TimeInForce.Day)
+            if (order.TimeInForce != TimeInForce.GoodTilCanceled && order.TimeInForce != TimeInForce.Day)
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     "This model does not support " + order.TimeInForce + " time in force."

--- a/Common/Brokerages/OandaBrokerageModel.cs
+++ b/Common/Brokerages/OandaBrokerageModel.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to 
+        /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="QuantConnect.AccountType.Margin"/></param>
         public OandaBrokerageModel(AccountType accountType = AccountType.Margin)
             : base(accountType)
@@ -94,12 +94,22 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
+            // validate time in force
+            if (order.TimeInForce != TimeInForce.GoodTilCancelled)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    "This model does not support " + order.TimeInForce + " time in force."
+                );
+
+                return false;
+            }
+
             return true;
         }
 
         /// <summary>
         /// Returns true if the brokerage would be able to execute this order at this time assuming
-        /// market prices are sufficient for the fill to take place. This is used to emulate the 
+        /// market prices are sufficient for the fill to take place. This is used to emulate the
         /// brokerage fills in backtesting and paper trading. For example some brokerages may not perform
         /// executions during extended market hours. This is not intended to be checking whether or not
         /// the exchange is open, that is handled in the Security.Exchange property.

--- a/Common/Brokerages/OandaBrokerageModel.cs
+++ b/Common/Brokerages/OandaBrokerageModel.cs
@@ -95,7 +95,7 @@ namespace QuantConnect.Brokerages
             }
 
             // validate time in force
-            if (order.TimeInForce != TimeInForce.GoodTilCancelled)
+            if (order.TimeInForce != TimeInForce.GoodTilCanceled)
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     "This model does not support " + order.TimeInForce + " time in force."

--- a/Common/Interfaces/IOrderProperties.cs
+++ b/Common/Interfaces/IOrderProperties.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using QuantConnect.Orders;
+
 namespace QuantConnect.Interfaces
 {
     /// <summary>
@@ -20,6 +22,11 @@ namespace QuantConnect.Interfaces
     /// </summary>
     public interface IOrderProperties
     {
+        /// <summary>
+        /// Defines the length of time over which an order will continue working before it is cancelled
+        /// </summary>
+        TimeInForce TimeInForce { get; set; }
+
         /// <summary>
         /// Returns a new instance clone of this object
         /// </summary>

--- a/Common/Interfaces/ITimeInForceHandler.cs
+++ b/Common/Interfaces/ITimeInForceHandler.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Orders;
+
+namespace QuantConnect.Interfaces
+{
+    /// <summary>
+    /// Handles the time in force for an order
+    /// </summary>
+    public interface ITimeInForceHandler
+    {
+        /// <summary>
+        /// Handles the time in force for an order before any order fill is generated
+        /// </summary>
+        /// <param name="order">The order to be handled</param>
+        /// <returns>Returns true if the order fills can be generated, false otherwise</returns>
+        bool HandleOrderPreFill(Order order);
+
+        /// <summary>
+        /// Handles the time in force for an order fill
+        /// </summary>
+        /// <param name="order">The order fill to be handled</param>
+        /// <param name="fill">The order fill to be handled</param>
+        /// <returns>Returns true if the order fill can be emitted, false otherwise</returns>
+        bool HandleOrderPostFill(Order order, OrderEvent fill);
+    }
+}

--- a/Common/Interfaces/ITimeInForceHandler.cs
+++ b/Common/Interfaces/ITimeInForceHandler.cs
@@ -14,6 +14,7 @@
 */
 
 using QuantConnect.Orders;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Interfaces
 {
@@ -25,16 +26,18 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Checks if an order has expired
         /// </summary>
+        /// <param name="security">The security matching the order</param>
         /// <param name="order">The order to be checked</param>
         /// <returns>Returns true if the order has expired, false otherwise</returns>
-        bool HasOrderExpired(Order order);
+        bool HasOrderExpired(Security security, Order order);
 
         /// <summary>
         /// Checks if an order fill is valid
         /// </summary>
+        /// <param name="security">The security matching the order</param>
         /// <param name="order">The order to be checked</param>
         /// <param name="fill">The order fill to be checked</param>
         /// <returns>Returns true if the order fill can be emitted, false otherwise</returns>
-        bool IsFillValid(Order order, OrderEvent fill);
+        bool IsFillValid(Security security, Order order, OrderEvent fill);
     }
 }

--- a/Common/Interfaces/ITimeInForceHandler.cs
+++ b/Common/Interfaces/ITimeInForceHandler.cs
@@ -24,12 +24,12 @@ namespace QuantConnect.Interfaces
     public interface ITimeInForceHandler
     {
         /// <summary>
-        /// Checks if an order has expired
+        /// Checks if an order is expired
         /// </summary>
         /// <param name="security">The security matching the order</param>
         /// <param name="order">The order to be checked</param>
         /// <returns>Returns true if the order has expired, false otherwise</returns>
-        bool HasOrderExpired(Security security, Order order);
+        bool IsOrderExpired(Security security, Order order);
 
         /// <summary>
         /// Checks if an order fill is valid

--- a/Common/Interfaces/ITimeInForceHandler.cs
+++ b/Common/Interfaces/ITimeInForceHandler.cs
@@ -23,18 +23,18 @@ namespace QuantConnect.Interfaces
     public interface ITimeInForceHandler
     {
         /// <summary>
-        /// Handles the time in force for an order before any order fill is generated
+        /// Checks if an order has expired
         /// </summary>
-        /// <param name="order">The order to be handled</param>
-        /// <returns>Returns true if the order fills can be generated, false otherwise</returns>
-        bool HandleOrderPreFill(Order order);
+        /// <param name="order">The order to be checked</param>
+        /// <returns>Returns true if the order has expired, false otherwise</returns>
+        bool HasOrderExpired(Order order);
 
         /// <summary>
-        /// Handles the time in force for an order fill
+        /// Checks if an order fill is valid
         /// </summary>
-        /// <param name="order">The order fill to be handled</param>
-        /// <param name="fill">The order fill to be handled</param>
+        /// <param name="order">The order to be checked</param>
+        /// <param name="fill">The order fill to be checked</param>
         /// <returns>Returns true if the order fill can be emitted, false otherwise</returns>
-        bool HandleOrderPostFill(Order order, OrderEvent fill);
+        bool IsFillValid(Order order, OrderEvent fill);
     }
 }

--- a/Common/Orders/InteractiveBrokersOrderProperties.cs
+++ b/Common/Orders/InteractiveBrokersOrderProperties.cs
@@ -20,7 +20,7 @@ namespace QuantConnect.Orders
     /// <summary>
     /// Contains additional properties and settings for an order submitted to Interactive Brokers
     /// </summary>
-    public class InteractiveBrokersOrderProperties : IOrderProperties
+    public class InteractiveBrokersOrderProperties : OrderProperties
     {
         /// <summary>
         /// The linked account for which to submit the order (only used by Financial Advisors)
@@ -51,7 +51,7 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Returns a new instance clone of this object
         /// </summary>
-        public IOrderProperties Clone()
+        public override IOrderProperties Clone()
         {
             return (InteractiveBrokersOrderProperties)MemberwiseClone();
         }

--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -87,7 +87,7 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Order Time In Force - GTC or Day. Day not supported in backtests.
         /// </summary>
-        public TimeInForce TimeInForce { get; internal set; }
+        public TimeInForce TimeInForce => Properties.TimeInForce;
 
         /// <summary>
         /// Tag the order with some custom data
@@ -171,11 +171,10 @@ namespace QuantConnect.Orders
             Symbol = Symbol.Empty;
             Status = OrderStatus.None;
             Tag = "";
-            TimeInForce = TimeInForce.GoodTilCancelled;
             BrokerId = new List<string>();
             ContingentId = 0;
             DurationValue = DateTime.MaxValue;
-            Properties = null;
+            Properties = new OrderProperties();
         }
 
         /// <summary>
@@ -195,11 +194,10 @@ namespace QuantConnect.Orders
             Symbol = symbol;
             Status = OrderStatus.None;
             Tag = tag;
-            TimeInForce = TimeInForce.GoodTilCancelled;
             BrokerId = new List<string>();
             ContingentId = 0;
             DurationValue = DateTime.MaxValue;
-            Properties = properties;
+            Properties = properties ?? new OrderProperties();
         }
 
         /// <summary>
@@ -270,14 +268,13 @@ namespace QuantConnect.Orders
             order.Time = Time;
             order.BrokerId = BrokerId.ToList();
             order.ContingentId = ContingentId;
-            order.TimeInForce = TimeInForce;
             order.Price = Price;
             order.PriceCurrency = PriceCurrency;
             order.Quantity = Quantity;
             order.Status = Status;
             order.Symbol = Symbol;
             order.Tag = Tag;
-            order.Properties = Properties?.Clone();
+            order.Properties = Properties.Clone();
             order.OrderSubmissionData = OrderSubmissionData?.Clone();
         }
 

--- a/Common/Orders/OrderJsonConverter.cs
+++ b/Common/Orders/OrderJsonConverter.cs
@@ -108,7 +108,7 @@ namespace QuantConnect.Orders
             var timeInForce = jObject["TimeInForce"] ?? jObject["Duration"];
             if (timeInForce != null)
             {
-                order.TimeInForce = (TimeInForce)timeInForce.Value<int>();
+                order.Properties.TimeInForce = (TimeInForce)timeInForce.Value<int>();
             }
 
             string market = Market.USA;

--- a/Common/Orders/OrderProperties.cs
+++ b/Common/Orders/OrderProperties.cs
@@ -18,24 +18,29 @@ using QuantConnect.Interfaces;
 namespace QuantConnect.Orders
 {
     /// <summary>
-    /// Contains additional properties and settings for an order submitted to GDAX brokerage
+    /// Contains additional properties and settings for an order
     /// </summary>
-    public class GDAXOrderProperties : OrderProperties
+    public class OrderProperties : IOrderProperties
     {
         /// <summary>
-        /// This flag will ensure the order executes only as a maker (no fee) order.
-        /// If part of the order results in taking liquidity rather than providing,
-        /// it will be rejected and no part of the order will execute.
-        /// Note: this flag is only applied to Limit orders.
+        /// Defines the length of time over which an order will continue working before it is cancelled
         /// </summary>
-        public bool PostOnly { get; set; }
+        public TimeInForce TimeInForce { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderProperties"/> class
+        /// </summary>
+        public OrderProperties()
+        {
+            TimeInForce = TimeInForce.GoodTilCancelled;
+        }
 
         /// <summary>
         /// Returns a new instance clone of this object
         /// </summary>
-        public override IOrderProperties Clone()
+        public virtual IOrderProperties Clone()
         {
-            return (GDAXOrderProperties)MemberwiseClone();
+            return (OrderProperties)MemberwiseClone();
         }
     }
 }

--- a/Common/Orders/OrderProperties.cs
+++ b/Common/Orders/OrderProperties.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Orders
         /// </summary>
         public OrderProperties()
         {
-            TimeInForce = TimeInForce.GoodTilCancelled;
+            TimeInForce = TimeInForce.GoodTilCanceled;
         }
 
         /// <summary>

--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -72,12 +72,11 @@ namespace QuantConnect.Orders
         /// </summary>
         GTC = GoodTilCancelled,
 
-        /*
         /// <summary>
-        /// Order valid for today only: -- CURRENTLY ONLY GTC ORDER TIME IN FORCE IN BACKTESTS.
+        /// Order valid only for the current day (DAY).
+        /// The order will be cancelled if not executed before the market close.
         /// </summary>
-        Day
-        */
+        Day,
 
         /// <summary>
         /// Order valid until a custom set date time value.

--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -58,19 +58,19 @@ namespace QuantConnect.Orders
 
 
     /// <summary>
-    /// Time In Force - defines the length of time over which an order will continue working before it is cancelled
+    /// Time In Force - defines the length of time over which an order will continue working before it is canceled
     /// </summary>
     public enum TimeInForce
     {
         /// <summary>
-        /// Order active until it is filled or cancelled (same as GTC).
+        /// Order active until it is filled or canceled (same as GTC).
         /// </summary>
-        GoodTilCancelled,
+        GoodTilCanceled,
 
         /// <summary>
-        /// Order active until it is filled or cancelled (same as GoodTilCancelled).
+        /// Order active until it is filled or canceled (same as GoodTilCanceled).
         /// </summary>
-        GTC = GoodTilCancelled,
+        GTC = GoodTilCanceled,
 
         /// <summary>
         /// Order valid only for the current day (DAY).
@@ -82,7 +82,6 @@ namespace QuantConnect.Orders
         /// Order valid until a custom set date time value.
         /// </summary>
         Custom
-
     }
 
 

--- a/Common/Orders/TimeInForces/DayTimeInForceHandler.cs
+++ b/Common/Orders/TimeInForces/DayTimeInForceHandler.cs
@@ -25,12 +25,12 @@ namespace QuantConnect.Orders.TimeInForces
     public class DayTimeInForceHandler : ITimeInForceHandler
     {
         /// <summary>
-        /// Checks if an order has expired
+        /// Checks if an order is expired
         /// </summary>
         /// <param name="security">The security matching the order</param>
         /// <param name="order">The order to be checked</param>
         /// <returns>Returns true if the order has expired, false otherwise</returns>
-        public bool HasOrderExpired(Security security, Order order)
+        public bool IsOrderExpired(Security security, Order order)
         {
             var exchangeHours = security.Exchange.Hours;
 

--- a/Common/Orders/TimeInForces/DayTimeInForceHandler.cs
+++ b/Common/Orders/TimeInForces/DayTimeInForceHandler.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Orders.TimeInForces
                 case SecurityType.Future:
                 default:
                     // expires at market close
-                    expired = time.Date > orderTime.Date || !exchangeHours.IsOpen(time, false);
+                    expired = time >= exchangeHours.GetNextMarketClose(orderTime, false);
                     break;
             }
 

--- a/Common/Orders/TimeInForces/DayTimeInForceHandler.cs
+++ b/Common/Orders/TimeInForces/DayTimeInForceHandler.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Orders.TimeInForces
+{
+    /// <summary>
+    /// Handles the Day time in force for an order (DAY)
+    /// </summary>
+    public class DayTimeInForceHandler : ITimeInForceHandler
+    {
+        private readonly IAlgorithm _algorithm;
+        private readonly IBrokerage _brokerage;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DayTimeInForceHandler"/> class
+        /// </summary>
+        /// <param name="algorithm">The instance of the algorithm</param>
+        /// <param name="brokerage">The instance of the backtesting brokerage</param>
+        public DayTimeInForceHandler(IAlgorithm algorithm, IBrokerage brokerage)
+        {
+            _algorithm = algorithm;
+            _brokerage = brokerage;
+        }
+
+        /// <summary>
+        /// Handles the time in force for an order before any order fill is generated
+        /// </summary>
+        /// <param name="order">The order to be handled</param>
+        /// <returns>Returns true if the order fills can be generated, false otherwise</returns>
+        public bool HandleOrderPreFill(Order order)
+        {
+            var exchangeHours = MarketHoursDatabase
+                .FromDataFolder()
+                .GetExchangeHours(order.Symbol.ID.Market, order.Symbol, order.Symbol.SecurityType);
+
+            var time = _algorithm.UtcTime.ConvertFromUtc(exchangeHours.TimeZone);
+
+            if (!exchangeHours.IsOpen(time, false))
+            {
+                _brokerage.CancelOrder(order);
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Handles the time in force for an order fill
+        /// </summary>
+        /// <param name="order">The order fill to be handled</param>
+        /// <param name="fill">The order fill to be handled</param>
+        /// <returns>Returns true if the order fill can be emitted, false otherwise</returns>
+        public bool HandleOrderPostFill(Order order, OrderEvent fill)
+        {
+            return true;
+        }
+    }
+}

--- a/Common/Orders/TimeInForces/DayTimeInForceHandler.cs
+++ b/Common/Orders/TimeInForces/DayTimeInForceHandler.cs
@@ -24,25 +24,22 @@ namespace QuantConnect.Orders.TimeInForces
     public class DayTimeInForceHandler : ITimeInForceHandler
     {
         private readonly IAlgorithm _algorithm;
-        private readonly IBrokerage _brokerage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DayTimeInForceHandler"/> class
         /// </summary>
         /// <param name="algorithm">The instance of the algorithm</param>
-        /// <param name="brokerage">The instance of the backtesting brokerage</param>
-        public DayTimeInForceHandler(IAlgorithm algorithm, IBrokerage brokerage)
+        public DayTimeInForceHandler(IAlgorithm algorithm)
         {
             _algorithm = algorithm;
-            _brokerage = brokerage;
         }
 
         /// <summary>
-        /// Handles the time in force for an order before any order fill is generated
+        /// Checks if an order has expired
         /// </summary>
-        /// <param name="order">The order to be handled</param>
-        /// <returns>Returns true if the order fills can be generated, false otherwise</returns>
-        public bool HandleOrderPreFill(Order order)
+        /// <param name="order">The order to be checked</param>
+        /// <returns>Returns true if the order has expired, false otherwise</returns>
+        public bool HasOrderExpired(Order order)
         {
             var exchangeHours = MarketHoursDatabase
                 .FromDataFolder()
@@ -50,22 +47,16 @@ namespace QuantConnect.Orders.TimeInForces
 
             var time = _algorithm.UtcTime.ConvertFromUtc(exchangeHours.TimeZone);
 
-            if (!exchangeHours.IsOpen(time, false))
-            {
-                _brokerage.CancelOrder(order);
-                return false;
-            }
-
-            return true;
+            return !exchangeHours.IsOpen(time, false);
         }
 
         /// <summary>
-        /// Handles the time in force for an order fill
+        /// Checks if an order fill is valid
         /// </summary>
-        /// <param name="order">The order fill to be handled</param>
-        /// <param name="fill">The order fill to be handled</param>
+        /// <param name="order">The order to be checked</param>
+        /// <param name="fill">The order fill to be checked</param>
         /// <returns>Returns true if the order fill can be emitted, false otherwise</returns>
-        public bool HandleOrderPostFill(Order order, OrderEvent fill)
+        public bool IsFillValid(Order order, OrderEvent fill)
         {
             return true;
         }

--- a/Common/Orders/TimeInForces/GoodTilCanceledTimeInForceHandler.cs
+++ b/Common/Orders/TimeInForces/GoodTilCanceledTimeInForceHandler.cs
@@ -14,20 +14,22 @@
 */
 
 using QuantConnect.Interfaces;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Orders.TimeInForces
 {
     /// <summary>
-    /// Handles the Good-Til-Cancelled time in force for an order (GTC)
+    /// Handles the Good-Til-Canceled time in force for an order (GTC)
     /// </summary>
-    public class GoodTilCancelledTimeInForceHandler : ITimeInForceHandler
+    public class GoodTilCanceledTimeInForceHandler : ITimeInForceHandler
     {
         /// <summary>
         /// Checks if an order has expired
         /// </summary>
+        /// <param name="security">The security matching the order</param>
         /// <param name="order">The order to be checked</param>
         /// <returns>Returns true if the order has expired, false otherwise</returns>
-        public bool HasOrderExpired(Order order)
+        public bool HasOrderExpired(Security security, Order order)
         {
             return false;
         }
@@ -35,10 +37,11 @@ namespace QuantConnect.Orders.TimeInForces
         /// <summary>
         /// Checks if an order fill is valid
         /// </summary>
+        /// <param name="security">The security matching the order</param>
         /// <param name="order">The order to be checked</param>
         /// <param name="fill">The order fill to be checked</param>
         /// <returns>Returns true if the order fill can be emitted, false otherwise</returns>
-        public bool IsFillValid(Order order, OrderEvent fill)
+        public bool IsFillValid(Security security, Order order, OrderEvent fill)
         {
             return true;
         }

--- a/Common/Orders/TimeInForces/GoodTilCanceledTimeInForceHandler.cs
+++ b/Common/Orders/TimeInForces/GoodTilCanceledTimeInForceHandler.cs
@@ -24,12 +24,12 @@ namespace QuantConnect.Orders.TimeInForces
     public class GoodTilCanceledTimeInForceHandler : ITimeInForceHandler
     {
         /// <summary>
-        /// Checks if an order has expired
+        /// Checks if an order is expired
         /// </summary>
         /// <param name="security">The security matching the order</param>
         /// <param name="order">The order to be checked</param>
         /// <returns>Returns true if the order has expired, false otherwise</returns>
-        public bool HasOrderExpired(Security security, Order order)
+        public bool IsOrderExpired(Security security, Order order)
         {
             return false;
         }

--- a/Common/Orders/TimeInForces/GoodTilCancelledTimeInForceModel.cs
+++ b/Common/Orders/TimeInForces/GoodTilCancelledTimeInForceModel.cs
@@ -23,22 +23,22 @@ namespace QuantConnect.Orders.TimeInForces
     public class GoodTilCancelledTimeInForceHandler : ITimeInForceHandler
     {
         /// <summary>
-        /// Handles the time in force for an order before any order fill is generated
+        /// Checks if an order has expired
         /// </summary>
-        /// <param name="order">The order to be handled</param>
-        /// <returns>Returns true if the order fills can be generated, false otherwise</returns>
-        public bool HandleOrderPreFill(Order order)
+        /// <param name="order">The order to be checked</param>
+        /// <returns>Returns true if the order has expired, false otherwise</returns>
+        public bool HasOrderExpired(Order order)
         {
-            return true;
+            return false;
         }
 
         /// <summary>
-        /// Handles the time in force for an order fill
+        /// Checks if an order fill is valid
         /// </summary>
-        /// <param name="order">The order fill to be handled</param>
-        /// <param name="fill">The order fill to be handled</param>
+        /// <param name="order">The order to be checked</param>
+        /// <param name="fill">The order fill to be checked</param>
         /// <returns>Returns true if the order fill can be emitted, false otherwise</returns>
-        public bool HandleOrderPostFill(Order order, OrderEvent fill)
+        public bool IsFillValid(Order order, OrderEvent fill)
         {
             return true;
         }

--- a/Common/Orders/TimeInForces/GoodTilCancelledTimeInForceModel.cs
+++ b/Common/Orders/TimeInForces/GoodTilCancelledTimeInForceModel.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Orders.TimeInForces
+{
+    /// <summary>
+    /// Handles the Good-Til-Cancelled time in force for an order (GTC)
+    /// </summary>
+    public class GoodTilCancelledTimeInForceHandler : ITimeInForceHandler
+    {
+        /// <summary>
+        /// Handles the time in force for an order before any order fill is generated
+        /// </summary>
+        /// <param name="order">The order to be handled</param>
+        /// <returns>Returns true if the order fills can be generated, false otherwise</returns>
+        public bool HandleOrderPreFill(Order order)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Handles the time in force for an order fill
+        /// </summary>
+        /// <param name="order">The order fill to be handled</param>
+        /// <param name="fill">The order fill to be handled</param>
+        /// <returns>Returns true if the order fill can be emitted, false otherwise</returns>
+        public bool HandleOrderPostFill(Order order, OrderEvent fill)
+        {
+            return true;
+        }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Orders\GDAXOrderProperties.cs" />
     <Compile Include="Orders\InteractiveBrokersOrderProperties.cs" />
     <Compile Include="Interfaces\IOrderProperties.cs" />
+    <Compile Include="Orders\OrderProperties.cs" />
     <Compile Include="Orders\OrderSubmissionData.cs" />
     <Compile Include="Orders\TimeInForces\DayTimeInForceHandler.cs" />
     <Compile Include="Orders\TimeInForces\GoodTilCancelledTimeInForceModel.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -196,7 +196,7 @@
     <Compile Include="Orders\OrderProperties.cs" />
     <Compile Include="Orders\OrderSubmissionData.cs" />
     <Compile Include="Orders\TimeInForces\DayTimeInForceHandler.cs" />
-    <Compile Include="Orders\TimeInForces\GoodTilCancelledTimeInForceModel.cs" />
+    <Compile Include="Orders\TimeInForces\GoodTilCanceledTimeInForceHandler.cs" />
     <Compile Include="Packets\AlphaNodePacket.cs" />
     <Compile Include="Packets\AlphaResultPacket.cs" />
     <Compile Include="Python\BrokerageModelPythonWrapper.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -188,11 +188,14 @@
     <Compile Include="Exceptions\ScheduledEventExceptionInterpreter.cs" />
     <Compile Include="Exceptions\UnsupportedOperandPythonExceptionInterpreter.cs" />
     <Compile Include="Interfaces\IFutureChainProvider.cs" />
+    <Compile Include="Interfaces\ITimeInForceHandler.cs" />
     <Compile Include="Orders\Fills\LatestPriceFillModel.cs" />
     <Compile Include="Orders\GDAXOrderProperties.cs" />
     <Compile Include="Orders\InteractiveBrokersOrderProperties.cs" />
     <Compile Include="Interfaces\IOrderProperties.cs" />
     <Compile Include="Orders\OrderSubmissionData.cs" />
+    <Compile Include="Orders\TimeInForces\DayTimeInForceHandler.cs" />
+    <Compile Include="Orders\TimeInForces\GoodTilCancelledTimeInForceModel.cs" />
     <Compile Include="Packets\AlphaNodePacket.cs" />
     <Compile Include="Packets\AlphaResultPacket.cs" />
     <Compile Include="Python\BrokerageModelPythonWrapper.cs" />

--- a/Tests/Common/Orders/TimeInForces/TimeInForceHandlerTests.cs
+++ b/Tests/Common/Orders/TimeInForces/TimeInForceHandlerTests.cs
@@ -91,11 +91,11 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
         public void DayTimeInForceForexOrderBefore5PMExpiresAt5PM()
         {
             // set time to 10:00:00 AM (NY time)
-            var utcTime = new DateTime(2018, 4, 27, 10, 0, 0).ConvertToUtc(TimeZones.NewYork);
+            var utcTime = new DateTime(2018, 4, 25, 10, 0, 0).ConvertToUtc(TimeZones.NewYork);
             var handler = new DayTimeInForceHandler();
 
             var security = new Forex(
-                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                SecurityExchangeHoursTests.CreateForexSecurityExchangeHours(),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
                 new SubscriptionDataConfig(typeof(QuoteBar), Symbols.EURUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
                 SymbolProperties.GetDefault(CashBook.AccountCurrency));
@@ -129,11 +129,11 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
         public void DayTimeInForceForexOrderAfter5PMExpiresAt5PMNextDay()
         {
             // set time to 6:00:00 PM (NY time)
-            var utcTime = new DateTime(2018, 4, 27, 18, 0, 0).ConvertToUtc(TimeZones.NewYork);
+            var utcTime = new DateTime(2018, 4, 25, 18, 0, 0).ConvertToUtc(TimeZones.NewYork);
             var handler = new DayTimeInForceHandler();
 
             var security = new Forex(
-                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                SecurityExchangeHoursTests.CreateForexSecurityExchangeHours(),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
                 new SubscriptionDataConfig(typeof(QuoteBar), Symbols.EURUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
                 SymbolProperties.GetDefault(CashBook.AccountCurrency));

--- a/Tests/Common/Orders/TimeInForces/TimeInForceHandlerTests.cs
+++ b/Tests/Common/Orders/TimeInForces/TimeInForceHandlerTests.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
 
             var order = new LimitOrder(Symbols.SPY, 10, 100, DateTime.UtcNow);
 
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             var fill1 = new OrderEvent(order.Id, order.Symbol, DateTime.UtcNow, OrderStatus.PartiallyFilled, OrderDirection.Buy, order.LimitPrice, 3, 0);
             Assert.IsTrue(handler.IsFillValid(security, order, fill1));
@@ -69,7 +69,7 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var orderProperties = new OrderProperties { TimeInForce = TimeInForce.Day };
             var order = new LimitOrder(Symbols.SPY, 10, 100, utcTime, "", orderProperties);
 
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             var fill1 = new OrderEvent(order.Id, order.Symbol, utcTime, OrderStatus.PartiallyFilled, OrderDirection.Buy, order.LimitPrice, 3, 0);
             Assert.IsTrue(handler.IsFillValid(security, order, fill1));
@@ -78,10 +78,10 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             Assert.IsTrue(handler.IsFillValid(security, order, fill2));
 
             localTimeKeeper.UpdateTime(utcTime.AddHours(6).AddSeconds(-1));
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             localTimeKeeper.UpdateTime(utcTime.AddHours(6));
-            Assert.IsTrue(handler.HasOrderExpired(security, order));
+            Assert.IsTrue(handler.IsOrderExpired(security, order));
 
             Assert.IsTrue(handler.IsFillValid(security, order, fill1));
             Assert.IsTrue(handler.IsFillValid(security, order, fill2));
@@ -105,7 +105,7 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var orderProperties = new OrderProperties { TimeInForce = TimeInForce.Day };
             var order = new LimitOrder(Symbols.EURUSD, 10, 100, utcTime, "", orderProperties);
 
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             var fill1 = new OrderEvent(order.Id, order.Symbol, utcTime, OrderStatus.PartiallyFilled, OrderDirection.Buy, order.LimitPrice, 3, 0);
             Assert.IsTrue(handler.IsFillValid(security, order, fill1));
@@ -115,11 +115,11 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
 
             // set time to 4:59:59 PM (NY time)
             localTimeKeeper.UpdateTime(utcTime.AddHours(7).AddSeconds(-1));
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             // set time to 5:00:00 PM (NY time)
             localTimeKeeper.UpdateTime(utcTime.AddHours(7));
-            Assert.IsTrue(handler.HasOrderExpired(security, order));
+            Assert.IsTrue(handler.IsOrderExpired(security, order));
 
             Assert.IsTrue(handler.IsFillValid(security, order, fill1));
             Assert.IsTrue(handler.IsFillValid(security, order, fill2));
@@ -143,7 +143,7 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var orderProperties = new OrderProperties { TimeInForce = TimeInForce.Day };
             var order = new LimitOrder(Symbols.EURUSD, 10, 100, utcTime, "", orderProperties);
 
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             var fill1 = new OrderEvent(order.Id, order.Symbol, utcTime, OrderStatus.PartiallyFilled, OrderDirection.Buy, order.LimitPrice, 3, 0);
             Assert.IsTrue(handler.IsFillValid(security, order, fill1));
@@ -153,15 +153,15 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
 
             // set time to midnight (NY time)
             localTimeKeeper.UpdateTime(utcTime.AddHours(6));
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             // set time to 4:59:59 PM next day (NY time)
             localTimeKeeper.UpdateTime(utcTime.AddHours(23).AddSeconds(-1));
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             // set time to 5:00:00 PM next day (NY time)
             localTimeKeeper.UpdateTime(utcTime.AddHours(23));
-            Assert.IsTrue(handler.HasOrderExpired(security, order));
+            Assert.IsTrue(handler.IsOrderExpired(security, order));
 
             Assert.IsTrue(handler.IsFillValid(security, order, fill1));
             Assert.IsTrue(handler.IsFillValid(security, order, fill2));
@@ -184,7 +184,7 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var orderProperties = new OrderProperties { TimeInForce = TimeInForce.Day };
             var order = new LimitOrder(Symbols.BTCUSD, 10, 100, utcTime, "", orderProperties);
 
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             var fill1 = new OrderEvent(order.Id, order.Symbol, utcTime, OrderStatus.PartiallyFilled, OrderDirection.Buy, order.LimitPrice, 3, 0);
             Assert.IsTrue(handler.IsFillValid(security, order, fill1));
@@ -193,10 +193,10 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             Assert.IsTrue(handler.IsFillValid(security, order, fill2));
 
             localTimeKeeper.UpdateTime(utcTime.AddHours(14).AddSeconds(-1));
-            Assert.IsFalse(handler.HasOrderExpired(security, order));
+            Assert.IsFalse(handler.IsOrderExpired(security, order));
 
             localTimeKeeper.UpdateTime(utcTime.AddHours(14));
-            Assert.IsTrue(handler.HasOrderExpired(security, order));
+            Assert.IsTrue(handler.IsOrderExpired(security, order));
 
             Assert.IsTrue(handler.IsFillValid(security, order, fill1));
             Assert.IsTrue(handler.IsFillValid(security, order, fill2));

--- a/Tests/Common/Orders/TimeInForces/TimeInForceHandlerTests.cs
+++ b/Tests/Common/Orders/TimeInForces/TimeInForceHandlerTests.cs
@@ -1,0 +1,74 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Orders;
+using QuantConnect.Orders.TimeInForces;
+
+namespace QuantConnect.Tests.Common.Orders.TimeInForces
+{
+    [TestFixture]
+    public class TimeInForceHandlerTests
+    {
+        [Test]
+        public void GtcTimeInForceOrderDoesNotExpire()
+        {
+            var handler = new GoodTilCancelledTimeInForceHandler();
+
+            var order = new LimitOrder(Symbols.SPY, 10, 100, DateTime.UtcNow);
+
+            Assert.IsFalse(handler.HasOrderExpired(order));
+
+            var fill1 = new OrderEvent(order.Id, order.Symbol, DateTime.UtcNow, OrderStatus.PartiallyFilled, OrderDirection.Buy, order.LimitPrice, 3, 0);
+            Assert.IsTrue(handler.IsFillValid(order, fill1));
+
+            var fill2 = new OrderEvent(order.Id, order.Symbol, DateTime.UtcNow, OrderStatus.Filled, OrderDirection.Buy, order.LimitPrice, 7, 0);
+            Assert.IsTrue(handler.IsFillValid(order, fill2));
+        }
+
+        [Test]
+        public void DayTimeInForceOrderExpiresAtMarketClose()
+        {
+            var utcTime = new DateTime(2018, 4, 27, 10, 0, 0).ConvertToUtc(TimeZones.NewYork);
+            var algorithm = new QCAlgorithm
+            {
+                DefaultOrderProperties = { TimeInForce = TimeInForce.Day }
+            };
+            var handler = new DayTimeInForceHandler(algorithm);
+
+            var order = new LimitOrder(Symbols.SPY, 10, 100, utcTime, "", algorithm.DefaultOrderProperties);
+
+            algorithm.SetDateTime(utcTime);
+
+            Assert.IsFalse(handler.HasOrderExpired(order));
+
+            var fill1 = new OrderEvent(order.Id, order.Symbol, utcTime, OrderStatus.PartiallyFilled, OrderDirection.Buy, order.LimitPrice, 3, 0);
+            Assert.IsTrue(handler.IsFillValid(order, fill1));
+
+            var fill2 = new OrderEvent(order.Id, order.Symbol, utcTime, OrderStatus.Filled, OrderDirection.Buy, order.LimitPrice, 7, 0);
+            Assert.IsTrue(handler.IsFillValid(order, fill2));
+
+            algorithm.SetDateTime(utcTime.AddHours(6));
+            Assert.IsTrue(handler.HasOrderExpired(order));
+
+            Assert.IsTrue(handler.IsFillValid(order, fill1));
+            Assert.IsTrue(handler.IsFillValid(order, fill2));
+        }
+
+
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Common\Exceptions\ScheduledEventExceptionInterpreterTests.cs" />
     <Compile Include="Common\Orders\Fills\LatestPriceFillModelTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />
+    <Compile Include="Common\Orders\TimeInForces\TimeInForceHandlerTests.cs" />
     <Compile Include="Common\Scheduling\ScheduleManagerTests.cs" />
     <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />
     <Compile Include="Common\Securities\CashBuyingPowerModelTests.cs" />

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -958,6 +958,29 @@ namespace QuantConnect.Tests
                 {"Rolling Averaged Population Magnitude", "0%"},
             };
 
+            var timeInForceAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "1"},
+                {"Average Win", "0%"},
+                {"Average Loss", "0%"},
+                {"Compounding Annual Return", "3.502%"},
+                {"Drawdown", "0.000%"},
+                {"Expectancy", "0"},
+                {"Net Profit", "0.044%"},
+                {"Sharpe Ratio", "9.199"},
+                {"Loss Rate", "0%"},
+                {"Win Rate", "0%"},
+                {"Profit-Loss Ratio", "0"},
+                {"Alpha", "0"},
+                {"Beta", "2.009"},
+                {"Annual Standard Deviation", "0.002"},
+                {"Annual Variance", "0"},
+                {"Information Ratio", "4.813"},
+                {"Tracking Error", "0.002"},
+                {"Treynor Ratio", "0.011"},
+                {"Total Fees", "$1.00"}
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -1000,6 +1023,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("CancelOpenOrdersRegressionAlgorithm", cancelOpenOrdersRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.CSharp),
 
                 // Python
                 new AlgorithmStatisticsTestParameters("AddRemoveSecurityRegressionAlgorithm", addRemoveSecurityRegressionStatistics, Language.Python),
@@ -1035,7 +1059,8 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm", volumeWeightedAveragePriceExecutionModelRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("StandardDeviationExecutionModelRegressionAlgorithm", standardDeviationExecutionModelRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.Python),
-                new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.Python)
+                new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.Python)
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION

#### Description
This PR includes some common changes to support `TimeInForce` types:
- New `ITimeInForceHandler` interface and `GoodTilCancelled` and `Day` implementations
- Base `OrderProperties` class, instantiated in `QCAlgorithm` constructor

Both unit tests and regression algorithms have been added.

This feature is currently supported only in backtesting and with Interactive Brokers brokerage.

#### Related Issue
#1093 

#### Motivation and Context
Previously we only supported `GTC` time in force.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests, new regression test and IB live testing.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`