### PR TITLE
Update regression stats for BasicTemplateCryptoAlgorithm

### DIFF
--- a/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
@@ -83,10 +83,6 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="data">Slice object keyed by symbol containing the stock data</param>
         public override void OnData(Slice data)
         {
-            // Note: all limit orders in this algorithm will be paying taker fees,
-            // they shouldn't, but they do (for now) because of this issue:
-            // https://github.com/QuantConnect/Lean/issues/1852
-
             if (Time.Hour == 1 && Time.Minute == 0)
             {
                 // Sell all ETH holdings with a limit order at 1% above the current price
@@ -118,8 +114,7 @@ namespace QuantConnect.Algorithm.CSharp
                 // use all of our available USD
                 var quantity = usdAvailable / limitPrice;
 
-                // this order will be rejected (for now) because of this issue:
-                // https://github.com/QuantConnect/Lean/issues/1852
+                // this order will be rejected for insufficient funds
                 LimitOrder("ETHUSD", quantity, limitPrice);
 
                 // use only half of our available USD

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -691,22 +691,22 @@ namespace QuantConnect.Tests
                 {"Total Trades", "10"},
                 {"Average Win", "0%"},
                 {"Average Loss", "-0.17%"},
-                {"Compounding Annual Return", "-99.993%"},
-                {"Drawdown", "3.800%"},
+                {"Compounding Annual Return", "-99.991%"},
+                {"Drawdown", "3.700%"},
                 {"Expectancy", "-1"},
-                {"Net Profit", "-2.577%"},
-                {"Sharpe Ratio", "-15.89"},
+                {"Net Profit", "-2.511%"},
+                {"Sharpe Ratio", "-16.062"},
                 {"Loss Rate", "100%"},
                 {"Win Rate", "0%"},
                 {"Profit-Loss Ratio", "0"},
-                {"Alpha", "-5.559"},
-                {"Beta", "333.506"},
-                {"Annual Standard Deviation", "0.205"},
-                {"Annual Variance", "0.042"},
-                {"Information Ratio", "-15.972"},
-                {"Tracking Error", "0.204"},
+                {"Alpha", "-5.392"},
+                {"Beta", "321.486"},
+                {"Annual Standard Deviation", "0.198"},
+                {"Annual Variance", "0.039"},
+                {"Information Ratio", "-16.147"},
+                {"Tracking Error", "0.197"},
                 {"Treynor Ratio", "-0.01"},
-                {"Total Fees", "$96.51"}
+                {"Total Fees", "$75.48"}
             };
 
             var indicatorSuiteAlgorithmStatistics = new Dictionary<string, string>


### PR DESCRIPTION

#### Description
Regression stats have been updated to match the change made in #1857.

#### Related Issue
#1852

#### Motivation and Context
The regression test was failing, because of the GDAX order fees bug fix in PR #1857.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
`BasicTemplateCryptoAlgorithm` regression test.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`