### PR TITLE
Implements MaximumSectorExposureRiskManagementModel

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -89,6 +89,7 @@
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
     <Compile Include="CancelOpenOrdersRegressionAlgorithm.cs" />
     <Compile Include="CompositeAlphaModelFrameworkAlgorithm.cs" />
+    <Compile Include="SectorExposureRiskFrameworkAlgorithm.cs" />
     <Compile Include="DuplicateSecurityWithBenchmarkRegressionAlgorithm.cs" />
     <Compile Include="BasicTemplateCryptoAlgorithm.cs" />
     <Compile Include="BasicTemplateCryptoFrameworkAlgorithm.cs" />

--- a/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Orders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This example algorithm defines its own custom coarse/fine fundamental selection model
+    /// with equally weighted portfolio and a maximum sector exposure 
+    /// </summary>
+    public class SectorExposureRiskFrameworkAlgorithm : QCAlgorithmFramework
+    {
+        public override void Initialize()
+        {
+            // Set requested data resolution
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            SetStartDate(2014, 03, 24);
+            SetEndDate(2014, 04, 07);
+            SetCash(100000);
+
+            UniverseSelection = new FineFundamentalUniverseSelectionModel(SelectCoarse, SelectFine);
+            Alpha = new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, QuantConnect.Time.OneDay);
+            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
+            RiskManagement = new MaximumSectorExposureRiskManagementModel();
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status.IsFill())
+            {
+                Debug($"Order event: {orderEvent}. Holding value: {Securities[orderEvent.Symbol].Holdings.AbsoluteHoldingsValue}");
+            }
+        }
+
+        private IEnumerable<Symbol> SelectCoarse(IEnumerable<CoarseFundamental> coarse)
+        {
+            var tickers = Time.Date < new DateTime(2014, 4, 1)
+                ? new[] { "AAPL", "AIG", "IBM" }
+                : new[] { "GOOG", "BAC", "SPY" };
+
+            return tickers.Select(x => QuantConnect.Symbol.Create(x, SecurityType.Equity, Market.USA));
+        }
+
+        private IEnumerable<Symbol> SelectFine(IEnumerable<FineFundamental> fine) => fine.Select(f => f.Symbol);
+    }
+}

--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.py
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.py
@@ -22,7 +22,7 @@ from QuantConnect.Algorithm.Framework.Alphas import Insight, InsightType, Insigh
 class ConstantAlphaModel:
     ''' Provides an implementation of IAlphaModel that always returns the same insight for each security'''
 
-    def __init__(self, type, direction, period, magnitude, confidence):
+    def __init__(self, type, direction, period, magnitude = None, confidence = None):
         '''Initializes a new instance of the ConstantAlphaModel class
         Args:
             type: The type of insight

--- a/Algorithm.Framework/Portfolio/BlackLittermanPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanPortfolioConstructionModel.py
@@ -81,7 +81,7 @@ class BlackLittermanPortfolioConstructionModel:
         for symbol, data in self.symbolDataDict.items():
             price[str(symbol)] = data.PriceSeries()
         df_price = pd.DataFrame(price)[::-1]
-        algorithm.Log(str(df_price))
+
         returns = df_price.pct_change().dropna()
 
         # get view vectors

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
@@ -1,0 +1,66 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("QuantConnect.Algorithm.Framework")
+from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget
+
+
+class EqualWeightingPortfolioConstructionModel:
+    '''Provides an implementation of IPortfolioConstructionModel that gives equal weighting to all securities.
+    The target percent holdings of each security is 1/N where N is the number of securities. 
+    For insights of direction InsightDirection.Up, long targets are returned and
+    for insights of direction InsightDirection.Down, short targets are returned.'''
+    def __init__(self):
+        self.securities = []
+        self.removedSymbols = []
+
+    def CreateTargets(self, algorithm, insights):
+        '''Create portfolio targets from the specified insights
+        Args:
+            algorithm: The algorithm instance
+            insights: The insights to create portoflio targets from
+        Returns:
+            An enumerable of portoflio targets to be sent to the execution model'''
+        targets = []
+
+        if self.removedSymbols is not None:
+            # zero out securities removes from the universe
+            for symbol in self.removedSymbols:
+                targets.append(PortfolioTarget(symbol, 0))
+                self.removedSymbols = None
+
+        if len(self.securities) == 0:
+            return []
+
+        # give equal weighting to each security
+        percent = 1.0 / len(self.securities)
+        for insight in insights:
+            targets.append(PortfolioTarget.Percent(algorithm, insight.Symbol, insight.Direction * percent))
+
+        return targets
+
+    def OnSecuritiesChanged(self, algorithm, changes):
+        '''Event fired each time the we add/remove securities from the data feed
+        Args:
+            algorithm: The algorithm instance that experienced the change in securities
+            changes: The security additions and removals from the algorithm'''
+
+        # save securities removed so we can zero out our holdings
+        self.removedSymbols = [x.Symbol for x in changes.RemovedSecurities]
+
+        for added in changes.AddedSecurities:
+            self.securities.append(added)
+        for removed in changes.RemovedSecurities:
+            if removed in self.securities:
+                self.securities.remove(removed)

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -131,6 +131,9 @@
     <Content Include="Execution\ImmediateExecutionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Portfolio\EqualWeightingPortfolioConstructionModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Risk\MaximumDrawdownPercentPerSecurity.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -77,6 +77,7 @@
     <Compile Include="QCAlgorithmFramework.cs" />
     <Compile Include="Risk\IRiskManagementModel.cs" />
     <Compile Include="Risk\MaximumDrawdownPercentPerSecurity.cs" />
+    <Compile Include="Risk\MaximumSectorExposureRiskManagementModel.cs" />
     <Compile Include="Risk\NullRiskManagementModel.cs" />
     <Compile Include="Risk\RiskManagementModelPythonWrapper.cs" />
     <Compile Include="Selection\CoarseFundamentalUniverseSelectionModel.cs" />
@@ -135,6 +136,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Risk\MaximumDrawdownPercentPerSecurity.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Risk\MaximumSectorExposureRiskManagementModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.cs
+++ b/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.cs
@@ -1,0 +1,118 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Algorithm.Framework.Risk
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IRiskManagementModel"/> that limits
+    /// the sector exposure to the specified percentage
+    /// </summary>
+    public class MaximumSectorExposureRiskManagementModel : IRiskManagementModel
+    {
+        private readonly decimal _maximumSectorExposure;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaximumSectorExposureRiskManagementModel"/> class
+        /// </summary>
+        /// <param name="maximumSectorExposure">The maximum exposure for any sector, defaults to 20% sector exposure.</param>
+        public MaximumSectorExposureRiskManagementModel(
+            decimal maximumSectorExposure = 0.20m
+            )
+        {
+            _maximumSectorExposure = Math.Abs(maximumSectorExposure);
+        }
+
+        /// <summary>
+        /// Manages the algorithm's risk at each time step
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="targets">The current portfolio targets to be assessed for risk</param>
+        public IEnumerable<IPortfolioTarget> ManageRisk(QCAlgorithmFramework algorithm, IPortfolioTarget[] targets)
+        {
+            var maximumSectorExposureValue = algorithm.Portfolio.TotalPortfolioValue * _maximumSectorExposure;
+
+            var targetCollection = new PortfolioTargetCollection();
+            targetCollection.AddRange(targets);
+
+            // Group the securities by their sector
+            var groupBySector = algorithm.Securities
+                .Where(x => x.Value.Fundamentals.HasFundamentalData)
+                .GroupBy(x => x.Value.Fundamentals.CompanyReference.IndustryTemplateCode);
+
+            foreach (var securities in groupBySector)
+            {
+                // Compute the sector absolute holdings value
+                // If the construction model has created a target, we consider that
+                // value to calculate the security absolute holding value
+                var sectorAbsoluteHoldingsValue = 0m;
+
+                foreach (var security in securities)
+                {
+                    var absoluteHoldingsValue = security.Value.Holdings.AbsoluteHoldingsValue;
+
+                    IPortfolioTarget target;
+                    if (targetCollection.TryGetValue(security.Value.Symbol, out target))
+                    {
+                        absoluteHoldingsValue = security.Value.Price * Math.Abs(target.Quantity) *
+                            security.Value.SymbolProperties.ContractMultiplier *
+                            security.Value.QuoteCurrency.ConversionRate;
+                    }
+
+                    sectorAbsoluteHoldingsValue += absoluteHoldingsValue;
+                }
+
+                // If the ratio between the sector absolute holdings value and the maximum sector exposure value
+                // exceeds the unity, it means we need to reduce each security of that sector by that ratio
+                // Otherwise, it means that the sector exposure is below the maximum and there is nothing to do.
+                var ratio = sectorAbsoluteHoldingsValue / maximumSectorExposureValue;
+                if (ratio > 1)
+                {
+                    foreach (var security in securities)
+                    {
+                        var quantity = security.Value.Holdings.Quantity;
+                        var symbol = security.Value.Symbol;
+
+                        IPortfolioTarget target;
+                        if (targetCollection.TryGetValue(symbol, out target))
+                        {
+                            quantity = target.Quantity;
+                        }
+
+                        if (quantity != 0)
+                        {
+                            yield return new PortfolioTarget(symbol, quantity / ratio);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
+        /// <param name="changes">The security additions and removals from the algorithm</param>
+        public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        {
+        }
+    }
+}

--- a/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.py
+++ b/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.py
@@ -1,0 +1,86 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm.Framework")
+
+from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget, PortfolioTargetCollection
+from itertools import groupby
+
+class MaximumSectorExposureRiskManagementModel():
+    '''Provides an implementation of IRiskManagementModel that that limits the sector exposure to the specified percentage'''
+
+    def __init__(self, maximumSectorExposure = 0.20):
+        '''Initializes a new instance of the MaximumSectorExposureRiskManagementModel class
+        Args:
+            maximumDrawdownPercent: The maximum exposure for any sector, defaults to 20% sector exposure.'''
+        self.maximumSectorExposure = abs(maximumSectorExposure)
+
+    def ManageRisk(self, algorithm, targets):
+        '''Manages the algorithm's risk at each time step
+        Args:
+            algorithm: The algorithm instance'''
+        maximumSectorExposureValue = float(algorithm.Portfolio.TotalPortfolioValue) * self.maximumSectorExposure
+
+        targetCollection = PortfolioTargetCollection()
+        targetCollection.AddRange(targets)
+
+        risk_targets = list()
+
+        # Group the securities by their sector
+        filtered = list(filter(lambda x: x.Value.Fundamentals.HasFundamentalData, algorithm.Securities))
+        filtered.sort(key = lambda x: x.Value.Fundamentals.CompanyReference.IndustryTemplateCode)
+        groupBySector = groupby(filtered, lambda x: x.Value.Fundamentals.CompanyReference.IndustryTemplateCode)
+
+        for code, securities in groupBySector:
+            # Compute the sector absolute holdings value
+            # If the construction model has created a target, we consider that
+            # value to calculate the security absolute holding value
+            quantities = {}
+            sectorAbsoluteHoldingsValue = 0
+
+            for security in securities:
+                symbol = security.Value.Symbol
+                quantities[symbol] = security.Value.Holdings.Quantity
+                absoluteHoldingsValue = security.Value.Holdings.AbsoluteHoldingsValue
+
+                if targetCollection.ContainsKey(symbol):
+                    quantities[symbol] = targetCollection[symbol].Quantity
+
+                    absoluteHoldingsValue = (security.Value.Price * abs(quantities[symbol]) *
+                        security.Value.SymbolProperties.ContractMultiplier *
+                        security.Value.QuoteCurrency.ConversionRate)
+
+                sectorAbsoluteHoldingsValue += absoluteHoldingsValue
+
+            # If the ratio between the sector absolute holdings value and the maximum sector exposure value
+            # exceeds the unity, it means we need to reduce each security of that sector by that ratio
+            # Otherwise, it means that the sector exposure is below the maximum and there is nothing to do.
+            ratio = float(sectorAbsoluteHoldingsValue) / maximumSectorExposureValue
+
+            if ratio > 1:
+                for symbol, quantity in quantities.items():
+                    if quantity != 0:
+                        risk_targets.append(PortfolioTarget(symbol, float(quantity) / ratio))
+
+        return risk_targets
+
+
+    def OnSecuritiesChanged(self, algorithm, changes):
+        '''Event fired each time the we add/remove securities from the data feed
+        Args:
+            algorithm: The algorithm instance that experienced the change in securities
+            changes: The security additions and removals from the algorithm'''
+        pass

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -140,6 +140,7 @@
     <None Include="CustomSecurityInitializerAlgorithm.py" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="SectorExposureRiskFrameworkAlgorithm.py" />
     <None Include="TimeInForceAlgorithm.py" />
     <Content Include="PairsTradingAlphaModelFrameworkAlgorithm.py" />
     <Content Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -98,6 +98,7 @@
     <Compile Include="RollingWindowAlgorithm.py" />
     <Compile Include="ScheduledEventsAlgorithm.py" />
     <Compile Include="ScheduledUniverseSelectionModelRegressionAlgorithm.py" />
+    <Compile Include="SectorExposureRiskFrameworkAlgorithm.py" />
     <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.py" />
     <Compile Include="UniverseSelectionRegressionAlgorithm.py" />

--- a/Algorithm.Python/SectorExposureRiskFrameworkAlgorithm.py
+++ b/Algorithm.Python/SectorExposureRiskFrameworkAlgorithm.py
@@ -1,0 +1,65 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from Portfolio.EqualWeightingPortfolioConstructionModel import EqualWeightingPortfolioConstructionModel
+from Alphas.ConstantAlphaModel import ConstantAlphaModel
+from Execution.ImmediateExecutionModel import ImmediateExecutionModel
+from Risk.MaximumSectorExposureRiskManagementModel import MaximumSectorExposureRiskManagementModel
+from datetime import date, timedelta
+
+### <summary>
+### This example algorithm defines its own custom coarse/fine fundamental selection model
+### with equally weighted portfolio and a maximum sector exposure.
+### </summary>
+class SectorExposureRiskFrameworkAlgorithm(QCAlgorithmFramework):
+    '''This example algorithm defines its own custom coarse/fine fundamental selection model
+### with equally weighted portfolio and a maximum sector exposure.'''
+
+    def Initialize(self):
+
+        # Set requested data resolution
+        self.UniverseSettings.Resolution = Resolution.Daily
+
+        self.SetStartDate(2014, 3, 24)
+        self.SetEndDate(2014, 4, 7)
+        self.SetCash(100000)
+
+        # set algorithm framework models
+        self.SetUniverseSelection(FineFundamentalUniverseSelectionModel(self.SelectCoarse, self.SelectFine))
+        self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(1)))
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+        self.SetRiskManagement(MaximumSectorExposureRiskManagementModel())
+
+    def OnOrderEvent(self, orderEvent):
+        if orderEvent.Status == OrderStatus.Filled:
+            self.Debug(f"Order event: {orderEvent}. Holding value: {self.Securities[orderEvent.Symbol].Holdings.AbsoluteHoldingsValue}")
+
+    def SelectCoarse(self, coarse):
+        tickers = ["AAPL", "AIG", "IBM"] if self.Time.date() < date(2014, 4, 1) else [ "GOOG", "BAC", "SPY" ]
+        return [Symbol.Create(x, SecurityType.Equity, Market.USA) for x in tickers]
+
+    def SelectFine(self, fine):
+        return [f.Symbol for f in fine]

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -981,6 +981,42 @@ namespace QuantConnect.Tests
                 {"Rolling Averaged Population Magnitude", "0%"},
             };
 
+            var sectorExposureRiskFrameworkAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "18"},
+                {"Average Win", "0.16%"},
+                {"Average Loss", "-0.03%"},
+                {"Compounding Annual Return", "-47.626%"},
+                {"Drawdown", "3.000%"},
+                {"Expectancy", "2.197"},
+                {"Net Profit", "-2.623%"},
+                {"Sharpe Ratio", "-6.139"},
+                {"Loss Rate", "50%"},
+                {"Win Rate", "50%"},
+                {"Profit-Loss Ratio", "5.39"},
+                {"Alpha", "-0.209"},
+                {"Beta", "-19.996"},
+                {"Annual Standard Deviation", "0.09"},
+                {"Annual Variance", "0.008"},
+                {"Information Ratio", "-6.321"},
+                {"Tracking Error", "0.09"},
+                {"Treynor Ratio", "0.028"},
+                {"Total Fees", "$24.90"},
+                {"Total Insights Generated", "33"},
+                {"Total Insights Closed", "30"},
+                {"Total Insights Analysis Completed", "27"},
+                {"Long Insight Count", "33"},
+                {"Short Insight Count", "0"},
+                {"Long/Short Ratio", "100%"},
+                {"Estimated Monthly Alpha Value", "$-8788163"},
+                {"Total Accumulated Estimated Alpha Value", "$-4442904"},
+                {"Mean Population Estimated Insight Value", "$-148096.8"},
+                {"Mean Population Direction", "51.8519%"},
+                {"Mean Population Magnitude", "0%"},
+                {"Rolling Averaged Population Direction", "78.9332%"},
+                {"Rolling Averaged Population Magnitude", "0%"},
+            };
+
             var timeInForceAlgorithmStatistics = new Dictionary<string, string>
             {
                 {"Total Trades", "1"},
@@ -1047,7 +1083,6 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("CancelOpenOrdersRegressionAlgorithm", cancelOpenOrdersRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.CSharp),
-                new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.CSharp),
 
                 // Python
                 new AlgorithmStatisticsTestParameters("AddRemoveSecurityRegressionAlgorithm", addRemoveSecurityRegressionStatistics, Language.Python),
@@ -1084,8 +1119,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm", volumeWeightedAveragePriceExecutionModelRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("StandardDeviationExecutionModelRegressionAlgorithm", standardDeviationExecutionModelRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.Python),
-                new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.Python),
-                new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.Python)
+                new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.Python)
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -1083,6 +1083,8 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("CancelOpenOrdersRegressionAlgorithm", cancelOpenOrdersRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("SectorExposureRiskFrameworkAlgorithm", sectorExposureRiskFrameworkAlgorithmStatistics, Language.CSharp),
 
                 // Python
                 new AlgorithmStatisticsTestParameters("AddRemoveSecurityRegressionAlgorithm", addRemoveSecurityRegressionStatistics, Language.Python),
@@ -1119,7 +1121,9 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm", volumeWeightedAveragePriceExecutionModelRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("StandardDeviationExecutionModelRegressionAlgorithm", standardDeviationExecutionModelRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.Python),
-                new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.Python)
+                new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("SectorExposureRiskFrameworkAlgorithm", sectorExposureRiskFrameworkAlgorithmStatistics, Language.Python)
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION
#### Description
- Minor models fixes:
  - ConstantAlphaModel.py: sets default value `None` for magnitude and confidence;
  - BlackLittermanPortfolioConstructionModel.py: removes logging.
- Implements python version of EqualWeightingPortfolioConstructionModel;
- Implements MaximumSectorExposureRiskManagementModel:
  Provides an implementation of `IRiskManagementModel` that limits the sector exposure to the specified percentage;
- Implements SectorExposureRiskFrameworkAlgorithm:
  This algorithm and its regression test are meant to test the `MaximumSectorExposureRiskManagementModel`.

#### Related Issue
Closes #1942 

#### Motivation and Context
Provide examples of framework models

#### Requires Documentation Change
Yes. 

#### How Has This Been Tested?
Regression test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`