### PR TITLE
Add UniverseManager.GetSecurities

### DIFF
--- a/Common/Securities/UniverseManager.cs
+++ b/Common/Securities/UniverseManager.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Util;
 
 namespace QuantConnect.Securities
 {
@@ -41,6 +42,16 @@ namespace QuantConnect.Securities
         public UniverseManager()
         {
             _universes = new ConcurrentDictionary<Symbol, Universe>();
+        }
+
+        /// <summary>
+        /// Gets the unique set of securities that are currently members of at least one universe
+        /// </summary>
+        /// <returns>Enumerable containing all securities that are currently members of a universe</returns>
+        public IEnumerable<Security> GetSecurities()
+        {
+            return _universes.SelectMany(ukvp => ukvp.Value.Securities.Select(skvp => skvp.Value.Security))
+                .DistinctBy(s => s.Symbol);
         }
 
         #region IDictionary implementation


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fetches the unique set of securities that are currently members of at least one universe. This is the set of active/tradable securities that are currently receiving data. It does not guarantee that we've received pricing data, but does guarantee that the security is a member of the universe and we've minimally added a subscription for data and have not yet removed that subscription (although it is possible for the sub to end before the security is removed -- very rare/unlikely scenario though).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1945 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes the need to manually (and often buggily) keep track of active securities via security change events. Provides an easy mechanism for looping over the current set of active securities.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes. @jaredbroad @jingwu74 -- we should document this as many users have asked how to do this. Until now the answer was to manage the state via security changes, but it turns out that isn't exactly correct since it's possible to receive the removed event before we remove the data feed subscription (if security holds stock and/or has open orders this happens).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally w/ debug output to confirm the set of securities.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->