### PR TITLE
Fix RuntimeBinderException when enumerating Slice with tick data

### DIFF
--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -414,7 +414,24 @@ namespace QuantConnect.Data
         private IEnumerable<KeyValuePair<Symbol, BaseData>> GetKeyValuePairEnumerable()
         {
             // this will not enumerate auxilliary data!
-            return _data.Value.Select(kvp => new KeyValuePair<Symbol, BaseData>(kvp.Key, kvp.Value.GetData()));
+
+            foreach (var kvp in _data.Value)
+            {
+                var data = kvp.Value.GetData();
+
+                var ticks = data as List<Tick>;
+                if (ticks != null)
+                {
+                    foreach (var tick in ticks)
+                    {
+                        yield return new KeyValuePair<Symbol, BaseData>(kvp.Key, tick);
+                    }
+                }
+                else
+                {
+                    yield return new KeyValuePair<Symbol, BaseData>(kvp.Key, data);
+                }
+            }
         }
 
         private enum SubscriptionType { TradeBar, QuoteBar, Tick, Custom };

--- a/Tests/Common/Data/SliceTests.cs
+++ b/Tests/Common/Data/SliceTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Custom;
@@ -129,6 +130,20 @@ namespace QuantConnect.Tests.Common.Data
 
             Quandl quandlData = slice.Get<Quandl>(Symbols.SPY);
             Assert.AreEqual(quandlSpy, quandlData);
+        }
+
+        [Test]
+        public void EnumeratorDoesNotThrowWithTicks()
+        {
+            var slice = new Slice(DateTime.Now, new[]
+            {
+                new Tick(DateTime.Now, Symbols.SPY, 1, 2),
+                new Tick(DateTime.Now, Symbols.SPY, 1.1m, 2.1m),
+                new Tick(DateTime.Now, Symbols.AAPL, 1, 2),
+                new Tick(DateTime.Now, Symbols.AAPL, 1.1m, 2.1m)
+            });
+
+            Assert.AreEqual(4, slice.Count());
         }
     }
 }


### PR DESCRIPTION

#### Description
A bug in handling tick data in `Slice.GetKeyValuePairEnumerable` has been fixed.

#### Related Issue
Closes #1949

#### Motivation and Context
Enumerating a `Slice` containing tick data throws a `RuntimeBinderException`.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included + manual testing with algorithm included in #1949.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`