### PR TITLE
Add UniverseManager.ActiveSecurities

### DIFF
--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -219,11 +219,13 @@ namespace QuantConnect.Data.UniverseSelection
         /// false if the security was already in the universe</returns>
         internal virtual bool AddMember(DateTime utcTime, Security security)
         {
-            if (Securities.ContainsKey(security.Symbol))
+            if (Securities.TryAdd(security.Symbol, new Member(utcTime, security)))
             {
-                return false;
+                security.AddUniverse(this);
+                return true;
             }
-            return Securities.TryAdd(security.Symbol, new Member(utcTime, security));
+
+            return false;
         }
 
         /// <summary>
@@ -240,7 +242,11 @@ namespace QuantConnect.Data.UniverseSelection
             if (CanRemoveMember(utcTime, security))
             {
                 Member member;
-                return Securities.TryRemove(security.Symbol, out member);
+                if (Securities.TryRemove(security.Symbol, out member))
+                {
+                    security.RemoveUniverse(this);
+                    return true;
+                }
             }
             return false;
         }

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -29,6 +29,7 @@ using QuantConnect.Python;
 using Python.Runtime;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Util;
 
 namespace QuantConnect.Securities
 {
@@ -44,6 +45,8 @@ namespace QuantConnect.Securities
         private LocalTimeKeeper _localTimeKeeper;
         // using concurrent bag to avoid list enumeration threading issues
         protected readonly ConcurrentBag<SubscriptionDataConfig> SubscriptionsBag;
+        // defines the universes this security is currently a member of
+        private readonly HashSet<Universe> _universes = new HashSet<Universe>();
 
         /// <summary>
         /// Gets all the subscriptions for this security
@@ -745,12 +748,46 @@ namespace QuantConnect.Securities
             UpdateSubscriptionProperties();
         }
 
+        /// <summary>
+        /// Adds the specified universe to the internal tracking of this security's universe memberships
+        /// </summary>
+        /// <param name="universe">The universe this security was just added to</param>
+        internal void AddUniverse(Universe universe)
+        {
+            if (_universes.Add(universe))
+            {
+                // securities are considered tradable
+                IsTradable = SecurityIsMemberOfUniverseWithNonInternalFeed();
+            }
+        }
+
+        /// <summary>
+        /// Removes the specified universe from the internal tracking of this security's universe memberships
+        /// </summary>
+        /// <param name="universe">The universe this security was just removed from</param>
+        internal void RemoveUniverse(Universe universe)
+        {
+            if (_universes.Remove(universe))
+            {
+                IsTradable = SecurityIsMemberOfUniverseWithNonInternalFeed();
+            }
+        }
+
         private void UpdateSubscriptionProperties()
         {
             Resolution = SubscriptionsBag.Select(x => x.Resolution).DefaultIfEmpty(Resolution.Daily).Min();
             IsFillDataForward = SubscriptionsBag.Any(x => x.FillDataForward);
             IsExtendedMarketHours = SubscriptionsBag.Any(x => x.ExtendedMarketHours);
             DataNormalizationMode = SubscriptionsBag.Select(x => x.DataNormalizationMode).DefaultIfEmpty(DataNormalizationMode.Adjusted).FirstOrDefault();
+        }
+
+        private bool SecurityIsMemberOfUniverseWithNonInternalFeed()
+        {
+            // security is member of universe producing non-internal feed subscriptions
+            return _universes.Where(u => u.ContainsMember(Symbol))
+                // the dates for this request are simply place holders, we really only need to check the internal feed flag on the generated subscription configuration
+                .SelectMany(u => u.GetSubscriptionRequests(this, new DateTime(2000, 01, 01), new DateTime(2001, 01, 01)))
+                .Any(sr => !sr.Configuration.IsInternalFeed);
         }
     }
 }

--- a/Common/Securities/UniverseManager.cs
+++ b/Common/Securities/UniverseManager.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Util;
 
 namespace QuantConnect.Securities
 {
@@ -34,6 +35,14 @@ namespace QuantConnect.Securities
         /// Event fired when a universe is added or removed
         /// </summary>
         public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        /// <summary>
+        /// Read-only dictionary containing all active securities. An active security is
+        /// a security that is currently selected by the universe or has holdings or open orders.
+        /// </summary>
+        public IReadOnlyDictionary<Symbol, Security> ActiveSecurities => this
+            .SelectMany(ukvp => ukvp.Value.Members.Select(mkvp => mkvp.Value))
+            .DistinctBy(s => s.Symbol).ToDictionary(s => s.Symbol);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UniverseManager"/> class


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fetches the unique set of securities that are currently members of at least one universe. This is the set of active/tradable securities that are currently receiving data. It does not guarantee that we've received pricing data, but does guarantee that the security is a member of the universe and we've minimally added a subscription for data and have not yet removed that subscription (although it is possible for the sub to end before the security is removed -- very rare/unlikely scenario though).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1945 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes the need to manually (and often buggily) keep track of active securities via security change events. Provides an easy mechanism for looping over the current set of active securities.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes. @jaredbroad @jingwu74 -- we should document this as many users have asked how to do this. Until now the answer was to manage the state via security changes, but it turns out that isn't exactly correct since it's possible to receive the removed event before we remove the data feed subscription (if security holds stock and/or has open orders this happens).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally w/ debug output to confirm the set of securities.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->