### PR TITLE
Fix SSL/TLS error in LiveOptionChainProvider

### DIFF
--- a/Engine/DataFeeds/LiveOptionChainProvider.cs
+++ b/Engine/DataFeeds/LiveOptionChainProvider.cs
@@ -28,9 +28,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     public class LiveOptionChainProvider : IOptionChainProvider
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LiveOptionChainProvider"/> class
+        /// Static constructor for the <see cref="LiveOptionChainProvider"/> class
         /// </summary>
-        public LiveOptionChainProvider()
+        static LiveOptionChainProvider()
         {
             // The OCC website now requires at least TLS 1.1 for API requests.
             // NET 4.5.2 and below does not enable these more secure protocols by default, so we add them in here

--- a/Engine/DataFeeds/LiveOptionChainProvider.cs
+++ b/Engine/DataFeeds/LiveOptionChainProvider.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +27,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     /// </summary>
     public class LiveOptionChainProvider : IOptionChainProvider
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiveOptionChainProvider"/> class
+        /// </summary>
+        public LiveOptionChainProvider()
+        {
+            // The OCC website now requires at least TLS 1.1 for API requests.
+            // NET 4.5.2 and below does not enable these more secure protocols by default, so we add them in here
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+        }
+
         /// <summary>
         /// Gets the list of option contracts for a given underlying symbol
         /// </summary>

--- a/Tests/Common/Securities/Options/OptionChainProviderTests.cs
+++ b/Tests/Common/Securities/Options/OptionChainProviderTests.cs
@@ -53,6 +53,15 @@ namespace QuantConnect.Tests.Common.Securities.Options
             Assert.GreaterOrEqual(stopwatch.ElapsedMilliseconds, 1000);
             Assert.AreEqual(2, symbols.Count());
         }
+
+        [Test]
+        public void LiveOptionChainProviderReturnsData()
+        {
+            var provider = new LiveOptionChainProvider();
+            var result = provider.GetOptionContractList(Symbols.AAPL, DateTime.Today);
+
+            Assert.IsTrue(result.Any());
+        }
     }
 
     internal class DelayedOptionChainProvider : IOptionChainProvider


### PR DESCRIPTION

#### Description
The `LiveOptionChainProvider` has been updated to enable the newer security protocols (`TLS 1.1` and `TLS 1.2`)

#### Related Issue
Closes #1952

#### Motivation and Context
The `GetOptionContractList` method is always throwing a security error.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`