### PR TITLE
Adds overload to ScheduleManager.On method that accepts a PyObject parameter

### DIFF
--- a/Algorithm.Python/ScheduledEventsAlgorithm.py
+++ b/Algorithm.Python/ScheduledEventsAlgorithm.py
@@ -43,32 +43,28 @@ class ScheduledEventsAlgorithm(QCAlgorithm):
         # date rules specify on what dates and event will fire
         # time rules specify at what time on thos dates the event will fire
 
-        # Python note:
-        # Schedule.On third argument type is System.Action or System.Action[System.String,System.DateTime]
-        # we need to cast the callback function using Action(...) to make it work
-
         # schedule an event to fire at a specific date/time
-        self.Schedule.On(self.DateRules.On(2013, 10, 7), self.TimeRules.At(13, 0), Action(self.SpecificTime))
+        self.Schedule.On(self.DateRules.On(2013, 10, 7), self.TimeRules.At(13, 0), self.SpecificTime)
 
         # schedule an event to fire every trading day for a security the
         # time rule here tells it to fire 10 minutes after SPY's market open
-        self.Schedule.On(self.DateRules.EveryDay("SPY"), self.TimeRules.AfterMarketOpen("SPY", 10), Action(self.EveryDayAfterMarketOpen))
+        self.Schedule.On(self.DateRules.EveryDay("SPY"), self.TimeRules.AfterMarketOpen("SPY", 10), self.EveryDayAfterMarketOpen)
 
         # schedule an event to fire every trading day for a security the
         # time rule here tells it to fire 10 minutes before SPY's market close
-        self.Schedule.On(self.DateRules.EveryDay("SPY"), self.TimeRules.BeforeMarketClose("SPY", 10), Action(self.EveryDayAfterMarketClose))
+        self.Schedule.On(self.DateRules.EveryDay("SPY"), self.TimeRules.BeforeMarketClose("SPY", 10), self.EveryDayAfterMarketClose)
 
         # schedule an event to fire on certain days of the week
-        self.Schedule.On(self.DateRules.Every(DayOfWeek.Monday, DayOfWeek.Friday), self.TimeRules.At(12, 0), Action(self.EveryMonFriAtNoon))
+        self.Schedule.On(self.DateRules.Every(DayOfWeek.Monday, DayOfWeek.Friday), self.TimeRules.At(12, 0), self.EveryMonFriAtNoon)
 
         # the scheduling methods return the ScheduledEvent object which can be used for other things here I set
         # the event up to check the portfolio value every 10 minutes, and liquidate if we have too many losses
-        self.Schedule.On(self.DateRules.EveryDay(), self.TimeRules.Every(timedelta(minutes=10)), Action(self.LiquidateUnrealizedLosses))
+        self.Schedule.On(self.DateRules.EveryDay(), self.TimeRules.Every(timedelta(minutes=10)), self.LiquidateUnrealizedLosses)
 
         # schedule an event to fire at the beginning of the month, the symbol is optional
         # if specified, it will fire the first trading day for that symbol of the month,
         # if not specified it will fire on the first day of the month
-        self.Schedule.On(self.DateRules.MonthStart("SPY"), self.TimeRules.AfterMarketOpen("SPY"), Action(self.RebalancingCode))
+        self.Schedule.On(self.DateRules.MonthStart("SPY"), self.TimeRules.AfterMarketOpen("SPY"), self.RebalancingCode)
 
 
     def OnData(self, data):

--- a/Common/Scheduling/ScheduleManager.cs
+++ b/Common/Scheduling/ScheduleManager.cs
@@ -20,6 +20,7 @@ using NodaTime;
 using QuantConnect.Securities;
 using QuantConnect.Logging;
 using System.Linq;
+using Python.Runtime;
 
 namespace QuantConnect.Scheduling
 {
@@ -137,6 +138,17 @@ namespace QuantConnect.Scheduling
         /// <param name="dateRule">Specifies what dates the event should run</param>
         /// <param name="timeRule">Specifies the times on those dates the event should run</param>
         /// <param name="callback">The callback to be invoked</param>
+        public ScheduledEvent On(IDateRule dateRule, ITimeRule timeRule, PyObject callback)
+        {
+            return On(dateRule, timeRule, (name, time) => { using (Py.GIL()) callback.Invoke(); });
+        }
+
+        /// <summary>
+        /// Schedules the callback to run using the specified date and time rules
+        /// </summary>
+        /// <param name="dateRule">Specifies what dates the event should run</param>
+        /// <param name="timeRule">Specifies the times on those dates the event should run</param>
+        /// <param name="callback">The callback to be invoked</param>
         public ScheduledEvent On(IDateRule dateRule, ITimeRule timeRule, Action<string, DateTime> callback)
         {
             var name = dateRule.Name + ": " + timeRule.Name;
@@ -153,6 +165,18 @@ namespace QuantConnect.Scheduling
         public ScheduledEvent On(string name, IDateRule dateRule, ITimeRule timeRule, Action callback)
         {
             return On(name, dateRule, timeRule, (n, d) => callback());
+        }
+
+        /// <summary>
+        /// Schedules the callback to run using the specified date and time rules
+        /// </summary>
+        /// <param name="name">The event's unique name</param>
+        /// <param name="dateRule">Specifies what dates the event should run</param>
+        /// <param name="timeRule">Specifies the times on those dates the event should run</param>
+        /// <param name="callback">The callback to be invoked</param>
+        public ScheduledEvent On(string name, IDateRule dateRule, ITimeRule timeRule, PyObject callback)
+        {
+            return On(name, dateRule, timeRule, (n, d) => { using (Py.GIL()) callback.Invoke(); });
         }
 
         /// <summary>


### PR DESCRIPTION
**--- This change does not break current implementations using Action() ---**

#### Description
Adding an overload to `ScheduleManager.On` method that accepts a `PyObject` parameter enables python algorithm to pass a method as parameter directly.
- Fixes `ScheduleEventsAlgorithm` to show the new feature in action.

#### Related Issue
Closes #1962 

#### Motivation and Context
Standardize C# and python API.

#### Requires Documentation Change
Yes: [Scheduled Events DateTime Rules](https://www.quantconnect.com/docs/algorithm-reference/scheduled-events#Scheduled-Events-DateTime-Rules).

#### How Has This Been Tested?
Manually running  `ScheduleEventsAlgorithm` algorithm.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`