### PR TITLE
Updates Framework example algorithms to use Set model methods

### DIFF
--- a/Algorithm.CSharp/BasicTemplateCryptoFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateCryptoFrameworkAlgorithm.cs
@@ -19,6 +19,7 @@ using QuantConnect.Algorithm.Framework;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Algorithm.Framework.Execution;
 using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
 using QuantConnect.Algorithm.Framework.Selection;
 using QuantConnect.Brokerages;
 using QuantConnect.Orders;
@@ -53,11 +54,11 @@ namespace QuantConnect.Algorithm.CSharp
             SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
 
             // set algorithm framework models
-            UniverseSelection = new ManualUniverseSelectionModel(QuantConnect.Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX));
-            Alpha = new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromMinutes(20), 0.025, null);
-            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
-            Execution = new ImmediateExecutionModel();
-            RiskManagement = new Algorithm.Framework.Risk.NullRiskManagementModel();
+            SetUniverseSelection(new ManualUniverseSelectionModel(QuantConnect.Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX)));
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromMinutes(20), 0.025, null));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetRiskManagement(new NullRiskManagementModel());
         }
 
         public override void OnOrderEvent(OrderEvent orderEvent)

--- a/Algorithm.CSharp/BasicTemplateFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFrameworkAlgorithm.cs
@@ -50,11 +50,11 @@ namespace QuantConnect.Algorithm.CSharp
             // Options Resolution: Minute Only.
 
             // set algorithm framework models
-            UniverseSelection = new ManualUniverseSelectionModel(QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA));
-            Alpha = new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromMinutes(20), 0.025, null);
-            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
-            Execution = new ImmediateExecutionModel();
-            RiskManagement = new MaximumDrawdownPercentPerSecurity(0.01m);
+            SetUniverseSelection(new ManualUniverseSelectionModel(QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)));
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromMinutes(20), 0.025, null));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetRiskManagement(new MaximumDrawdownPercentPerSecurity(0.01m));
         }
 
         public override void OnOrderEvent(OrderEvent orderEvent)

--- a/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
@@ -41,18 +41,18 @@ namespace QuantConnect.Algorithm.CSharp
             AddEquity("AIG");
 
             // define a manual universe of all the securities we manually registered
-            UniverseSelection = new ManualUniverseSelectionModel(Securities.Keys);
+            SetUniverseSelection(new ManualUniverseSelectionModel(Securities.Keys));
 
             // define alpha model as a composite of the rsi and ema cross models
-            Alpha = new CompositeAlphaModel(
+            SetAlpha(new CompositeAlphaModel(
                 new RsiAlphaModel(),
                 new EmaCrossAlphaModel()
-            );
+            ));
 
             // default models for the rest
-            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
-            Execution = new ImmediateExecutionModel();
-            RiskManagement = new NullRiskManagementModel();
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetRiskManagement(new NullRiskManagementModel());
         }
     }
 }

--- a/Algorithm.CSharp/CustomFrameworkModelsAlgorithm.cs
+++ b/Algorithm.CSharp/CustomFrameworkModelsAlgorithm.cs
@@ -42,14 +42,14 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 11);    //Set End Date
             SetCash(100000);             //Set Strategy Cash
 
-            UniverseSelection = new CustomFundamentalUniverseSelectionModel();
-            Alpha = new MacdAlphaModel(
+            SetUniverseSelection(new CustomFundamentalUniverseSelectionModel());
+            SetAlpha(new MacdAlphaModel(
                 fastPeriod: 10,
                 slowPeriod: 30,
                 signalPeriod: 12,
                 movingAverageType: MovingAverageType.Simple
-            );
-            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
+            ));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
         }
 
         public override void OnOrderEvent(OrderEvent orderEvent)

--- a/Algorithm.CSharp/PairsTradingAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/PairsTradingAlphaModelFrameworkAlgorithm.cs
@@ -37,11 +37,11 @@ namespace QuantConnect.Algorithm.CSharp
             var bac = AddEquity("BAC");
             var aig = AddEquity("AIG");
 
-            UniverseSelection = new ManualUniverseSelectionModel(Securities.Keys);
-            Alpha = new PairsTradingAlphaModel(bac.Symbol, aig.Symbol);
-            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
-            Execution = new ImmediateExecutionModel();
-            RiskManagement = new NullRiskManagementModel();
+            SetUniverseSelection(new ManualUniverseSelectionModel(Securities.Keys));
+            SetAlpha(new PairsTradingAlphaModel(bac.Symbol, aig.Symbol));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetRiskManagement(new NullRiskManagementModel());
         }
     }
 }

--- a/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
@@ -42,10 +42,10 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2014, 04, 07);
             SetCash(100000);
 
-            UniverseSelection = new FineFundamentalUniverseSelectionModel(SelectCoarse, SelectFine);
-            Alpha = new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, QuantConnect.Time.OneDay);
-            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
-            RiskManagement = new MaximumSectorExposureRiskManagementModel();
+            SetUniverseSelection(new FineFundamentalUniverseSelectionModel(SelectCoarse, SelectFine));
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, QuantConnect.Time.OneDay));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetRiskManagement(new MaximumSectorExposureRiskManagementModel());
         }
 
         public override void OnOrderEvent(OrderEvent orderEvent)

--- a/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
@@ -38,17 +38,17 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 11);
             SetCash(1000000);
 
-            UniverseSelection = new ManualUniverseSelectionModel(
+            SetUniverseSelection(new ManualUniverseSelectionModel(
                 QuantConnect.Symbol.Create("AIG", SecurityType.Equity, Market.USA),
                 QuantConnect.Symbol.Create("BAC", SecurityType.Equity, Market.USA),
                 QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA),
                 QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)
-            );
+            ));
 
             // using hourly rsi to generate more insights
-            Alpha = new RsiAlphaModel(14, Resolution.Hour);
-            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
-            Execution = new StandardDeviationExecutionModel();
+            SetAlpha(new RsiAlphaModel(14, Resolution.Hour));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new StandardDeviationExecutionModel());
         }
 
         public override void OnOrderEvent(OrderEvent orderEvent)

--- a/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
@@ -38,17 +38,17 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 11);
             SetCash(1000000);
 
-            UniverseSelection = new ManualUniverseSelectionModel(
+            SetUniverseSelection(new ManualUniverseSelectionModel(
                 QuantConnect.Symbol.Create("AIG", SecurityType.Equity, Market.USA),
                 QuantConnect.Symbol.Create("BAC", SecurityType.Equity, Market.USA),
                 QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA),
                 QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)
-            );
+            ));
 
             // using hourly rsi to generate more insights
-            Alpha = new RsiAlphaModel(14, Resolution.Hour);
-            PortfolioConstruction = new EqualWeightingPortfolioConstructionModel();
-            Execution = new VolumeWeightedAveragePriceExecutionModel();
+            SetAlpha(new RsiAlphaModel(14, Resolution.Hour));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new VolumeWeightedAveragePriceExecutionModel());
 
             InsightsGenerated += (algorithm, data) => Log($"{Time}: {string.Join(" | ", data.Insights)}");
         }

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -43,15 +43,17 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="BasicTemplateIntrinioEconomicData.py" />
-    <None Include="IndicatorSuiteAlgorithm.py" />
     <None Include="BasicTemplateAlgorithm.py" />
+    <None Include="BasicTemplateCryptoAlgorithm.py" />
     <None Include="BasicTemplateDailyAlgorithm.py" />
     <None Include="BasicTemplateFillForwardAlgorithm.py" />
     <None Include="BasicTemplateForexAlgorithm.py" />
+    <None Include="BasicTemplateFrameworkAlgorithm.py" />
     <None Include="BasicTemplateFuturesAlgorithm.py" />
     <None Include="BasicTemplateFuturesConsolidationAlgorithm.py" />
     <None Include="BasicTemplateFuturesHistoryAlgorithm.py" />
+    <None Include="BasicTemplateIntrinioEconomicData.py" />
+    <None Include="BasicTemplateLibrary.py" />
     <None Include="BasicTemplateOptionsAlgorithm.py" />
     <None Include="BasicTemplateOptionsFilterUniverseAlgorithm.py" />
     <None Include="BasicTemplateOptionsHistoryAlgorithm.py" />
@@ -64,17 +66,24 @@
     <None Include="CoarseFineFundamentalComboAlgorithm.py" />
     <None Include="CoarseFineFundamentalRegressionAlgorithm.py" />
     <None Include="CoarseFundamentalTop5Algorithm.py" />
+    <None Include="CompositeAlphaModelFrameworkAlgorithm.py" />
+    <None Include="ConstituentsQC500GeneratorAlgorithm.py" />
     <None Include="CustomBenchmarkAlgorithm.py" />
     <None Include="CustomChartingAlgorithm.py" />
     <None Include="CustomDataBitcoinAlgorithm.py" />
+    <None Include="CustomDataIndicatorExtensionsAlgorithm.py" />
     <None Include="CustomDataNIFTYAlgorithm.py" />
     <None Include="CustomDataRegressionAlgorithm.py" />
     <None Include="CustomDataUniverseAlgorithm.py" />
+    <None Include="CustomIndicatorAlgorithm.py" />
     <None Include="CustomModelsAlgorithm.py" />
+    <None Include="CustomSecurityInitializerAlgorithm.py" />
+    <None Include="CustomVolatilityModelAlgorithm.py" />
     <None Include="DailyAlgorithm.py" />
     <None Include="DailyFxAlgorithm.py" />
     <None Include="DataConsolidationAlgorithm.py" />
     <None Include="DelistingEventsAlgorithm.py" />
+    <None Include="DisplacedMovingAverageRibbon.py" />
     <None Include="DividendAlgorithm.py" />
     <None Include="DropboxBaseDataUniverseSelectionAlgorithm.py" />
     <None Include="DropboxUniverseSelectionAlgorithm.py" />
@@ -84,19 +93,28 @@
     <None Include="FinancialAdvisorDemoAlgorithm.py" />
     <None Include="FractionalQuantityRegressionAlgorithm.py" />
     <None Include="FuturesMomentumAlgorithm.py" />
+    <None Include="HistoryAlgorithm.py" />
     <None Include="HistoryAndWarmupRegressionAlgorithm.py" />
+    <None Include="HourReverseSplitRegressionAlgorithm.py" />
+    <None Include="HourSplitRegressionAlgorithm.py" />
+    <None Include="IndicatorSuiteAlgorithm.py" />
     <None Include="LimitFillRegressionAlgorithm.py" />
     <None Include="MACDTrendAlgorithm.py" />
     <None Include="main.py" />
     <None Include="MarginCallEventsAlgorithm.py" />
     <None Include="MarketOnOpenOnCloseAlgorithm.py" />
+    <None Include="MeanVarianceOptimizationAlgorithm.py" />
     <None Include="MovingAverageCrossAlgorithm.py" />
+    <None Include="MultipleSymbolConsolidationAlgorithm.py" />
+    <None Include="OptionChainConsistencyRegressionAlgorithm.py" />
     <None Include="OptionChainProviderAlgorithm.py" />
     <None Include="OptionExerciseAssignRegressionAlgorithm.py" />
     <None Include="OptionOpenInterestRegressionAlgorithm.py" />
     <None Include="OptionRenameRegressionAlgorithm.py" />
+    <None Include="OptionSplitRegressionAlgorithm.py" />
     <None Include="OrderTicketDemoAlgorithm.py" />
     <None Include="packages.config" />
+    <None Include="PairsTradingAlphaModelFrameworkAlgorithm.py" />
     <None Include="ParameterizedAlgorithm.py" />
     <None Include="PythonPackageTestAlgorithm.py" />
     <None Include="QCUWeatherBasedRebalancing.py" />
@@ -105,22 +123,21 @@
     <None Include="readme.md" />
     <None Include="RegressionAlgorithm.py" />
     <None Include="RegressionChannelAlgorithm.py" />
+    <None Include="RenkoConsolidatorAlgorithm.py" />
     <None Include="RollingWindowAlgorithm.py" />
     <None Include="ScheduledEventsAlgorithm.py" />
+    <None Include="ScheduledUniverseSelectionModelRegressionAlgorithm.py" />
+    <None Include="SectorExposureRiskFrameworkAlgorithm.py" />
+    <None Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
+    <None Include="TimeInForceAlgorithm.py" />
+    <None Include="UniverseSelectionDefinitionsAlgorithm.py" />
     <None Include="UniverseSelectionRegressionAlgorithm.py" />
     <None Include="UpdateOrderRegressionAlgorithm.py" />
     <None Include="UserDefinedUniverseAlgorithm.py" />
+    <None Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.py" />
     <None Include="WarmupAlgorithm.py" />
     <None Include="WarmupHistoryAlgorithm.py" />
     <None Include="WeeklyUniverseSelectionRegressionAlgorithm.py" />
-    <None Include="OptionSplitRegressionAlgorithm.py" />
-    <None Include="OptionChainConsistencyRegressionAlgorithm.py" />
-    <None Include="HourSplitRegressionAlgorithm.py" />
-    <None Include="HourReverseSplitRegressionAlgorithm.py" />
-    <None Include="MultipleSymbolConsolidationAlgorithm.py" />
-    <None Include="ConstituentsQC500GeneratorAlgorithm.py" />
-    <None Include="CustomDataIndicatorExtensionsAlgorithm.py" />
-    <None Include="DisplacedMovingAverageRibbon.py" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Algorithm\QuantConnect.Algorithm.csproj">
@@ -135,27 +152,6 @@
       <Project>{73fb2522-c3ed-4e47-8e3d-afad48a6b888}</Project>
       <Name>QuantConnect.Indicators</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="CustomSecurityInitializerAlgorithm.py" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="SectorExposureRiskFrameworkAlgorithm.py" />
-    <None Include="TimeInForceAlgorithm.py" />
-    <Content Include="PairsTradingAlphaModelFrameworkAlgorithm.py" />
-    <Content Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
-    <Content Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.py" />
-    <None Include="BasicTemplateCryptoAlgorithm.py" />
-    <None Include="ScheduledUniverseSelectionModelRegressionAlgorithm.py" />
-    <None Include="RenkoConsolidatorAlgorithm.py" />
-    <Content Include="CompositeAlphaModelFrameworkAlgorithm.py" />
-    <Content Include="MeanVarianceOptimizationAlgorithm.py" />
-    <Content Include="BasicTemplateFrameworkAlgorithm.py" />
-    <Content Include="BasicTemplateLibrary.py" />
-    <Content Include="CustomIndicatorAlgorithm.py" />
-    <Content Include="CustomVolatilityModelAlgorithm.py" />
-    <Content Include="HistoryAlgorithm.py" />
-    <Content Include="UniverseSelectionDefinitionsAlgorithm.py" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Python.Runtime, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -23,7 +23,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.py" />
+    <Compile Include="BasicTemplateCryptoAlgorithm.py" />
+    <Compile Include="BasicTemplateIntrinioEconomicData.py" />
     <Compile Include="CompositeAlphaModelFrameworkAlgorithm.py" />
+    <Compile Include="ConstituentsQC500GeneratorAlgorithm.py" />
+    <Compile Include="CustomDataIndicatorExtensionsAlgorithm.py" />
+    <Compile Include="CustomFrameworkModelsAlgorithm.py" />
     <Compile Include="CustomIndicatorAlgorithm.py" />
     <Compile Include="CustomVolatilityModelAlgorithm.py" />
     <Compile Include="BasicTemplateAlgorithm.py" />
@@ -57,6 +62,7 @@
     <Compile Include="DailyFxAlgorithm.py" />
     <Compile Include="DataConsolidationAlgorithm.py" />
     <Compile Include="DelistingEventsAlgorithm.py" />
+    <Compile Include="DisplacedMovingAverageRibbon.py" />
     <Compile Include="DividendAlgorithm.py" />
     <Compile Include="DropboxBaseDataUniverseSelectionAlgorithm.py" />
     <Compile Include="DropboxUniverseSelectionAlgorithm.py" />
@@ -100,6 +106,7 @@
     <Compile Include="ScheduledUniverseSelectionModelRegressionAlgorithm.py" />
     <Compile Include="SectorExposureRiskFrameworkAlgorithm.py" />
     <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
+    <Compile Include="TimeInForceAlgorithm.py" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.py" />
     <Compile Include="UniverseSelectionRegressionAlgorithm.py" />
     <Compile Include="UpdateOrderRegressionAlgorithm.py" />


### PR DESCRIPTION
#### Description
In algorithms that derive from `QCAlgorithmFramework` use `SetXXX` methods to assign a model to the property.

#### Related Issue
Closes #1965 

#### Motivation and Context
Standardize examples.

#### Requires Documentation Change
Yes. Use `SetXXX` methods  in documentation examples.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`