### PR TITLE
Update LiveOptionChainProvider to use QC proxy url

### DIFF
--- a/Engine/DataFeeds/LiveOptionChainProvider.cs
+++ b/Engine/DataFeeds/LiveOptionChainProvider.cs
@@ -62,8 +62,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             using (var client = new WebClient())
             {
+                // use QC url to bypass TLS issues with Mono pre-4.8 version
+                var url = "https://www.quantconnect.com/api/v2/theocc/series-search?symbolType=U&symbol=" + underlyingSymbol;
+
                 // download the text file
-                var url = "https://www.theocc.com/webapps/series-search?symbolType=U&symbol=" + underlyingSymbol;
                 var fileContent = client.DownloadString(url);
 
                 // read the lines, skipping the headers


### PR DESCRIPTION

#### Description
This change bypasses the TLS provider restrictions with older versions of Mono.

#### Related Issue
#1952

#### Motivation and Context
Fixes this runtime error in algorithms trading options:
```
System.Net.WebException: Error: SecureChannelFailure (The authentication or decryption has failed.)
```

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually deployed in the cloud an algorithm calling the `LiveOptionChainProvider`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`