### PR TITLE
Add more contract filter helpers

### DIFF
--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="algorithm">The algorithm instance</param>
         /// <param name="data">The new data available</param>
         /// <returns>The new insights generated</returns>
-        public IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data)
+        public virtual IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data)
         {
             foreach (var security in _securities)
             {
@@ -107,7 +107,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// </summary>
         /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
         /// <param name="changes">The security additions and removals from the algorithm</param>
-        public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        public virtual void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
         {
             NotifiedSecurityChanges.UpdateCollection(_securities, changes);
 

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -101,9 +101,18 @@ namespace QuantConnect.Securities.Future
             SetFilter(TimeSpan.Zero, TimeSpan.FromDays(35));
         }
 
-
         // save off a strongly typed version of symbol properties
         private readonly SymbolProperties _symbolProperties;
+
+        /// <summary>
+        /// Returns true if this is the future chain security, false if it is a specific future contract
+        /// </summary>
+        public bool IsFutureChain => Symbol.IsCanonical();
+
+        /// <summary>
+        /// Returns true if this is a specific future contract security, false if it is the future chain security
+        /// </summary>
+        public bool IsFutureContract => !Symbol.IsCanonical();
 
         /// <summary>
         /// Gets the expiration date
@@ -149,7 +158,6 @@ namespace QuantConnect.Securities.Future
         {
             SetFilter(universe => universe.Expiration(minExpiry, maxExpiry));
         }
-
 
         /// <summary>
         /// Sets the <see cref="ContractFilter"/> to a new universe selection function

--- a/Common/Securities/Future/FutureFilterUniverse.cs
+++ b/Common/Securities/Future/FutureFilterUniverse.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,7 @@ namespace QuantConnect.Securities
 {
     /// <summary>
     /// Represents futures symbols universe used in filtering.
-    /// </summary> 
+    /// </summary>
     public class FutureFilterUniverse : IDerivativeSecurityFilterUniverse
     {
         internal IEnumerable<Symbol> _allSymbols;
@@ -102,7 +102,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Applies filter selecting futures contracts based on a range of expiration dates relative to the current day 
+        /// Applies filter selecting futures contracts based on a range of expiration dates relative to the current day
         /// </summary>
         /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
         /// would exclude contracts expiring in less than 10 days</param>
@@ -133,7 +133,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Applies filter selecting futures contracts based on expiration cycles. See <see cref="FutureExpirationCycles"/> for details 
+        /// Applies filter selecting futures contracts based on expiration cycles. See <see cref="FutureExpirationCycles"/> for details
         /// </summary>
         /// <param name="months"></param>
         /// <returns></returns>
@@ -141,6 +141,29 @@ namespace QuantConnect.Securities
         {
             var monthHashSet = months.ToHashSet();
             return this.Where(x => monthHashSet.Contains(x.ID.Date.Month));
+        }
+
+        /// <summary>
+        /// Explicitly sets the selected contract symbols for this universe.
+        /// This overrides and and all other methods of selecting symbols assuming it is called last.
+        /// </summary>
+        /// <param name="contracts">The future contract symbol objects to select</param>
+        public FutureFilterUniverse Contracts(IEnumerable<Symbol> contracts)
+        {
+            _allSymbols = contracts.ToList();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a function used to filter the set of available contract filters. The input to the 'contractSelector'
+        /// function will be the already filtered list if any other filters have already been applied.
+        /// </summary>
+        /// <param name="contractSelector">The future contract symbol objects to select</param>
+        public FutureFilterUniverse Contracts(Func<IEnumerable<Symbol>, IEnumerable<Symbol>> contractSelector)
+        {
+            // force materialization using ToList
+            _allSymbols = contractSelector(_allSymbols).ToList();
+            return this;
         }
 
         /// <summary>
@@ -166,7 +189,7 @@ namespace QuantConnect.Securities
     public static class FutureFilterUniverseEx
     {
         /// <summary>
-        /// Filters universe 
+        /// Filters universe
         /// </summary>
         /// <param name="universe"></param>
         /// <param name="predicate"></param>
@@ -179,7 +202,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Maps universe 
+        /// Maps universe
         /// </summary>
         public static FutureFilterUniverse Select(this FutureFilterUniverse universe, Func<Symbol, Symbol> mapFunc)
         {
@@ -189,7 +212,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Binds universe 
+        /// Binds universe
         /// </summary>
         public static FutureFilterUniverse SelectMany(this FutureFilterUniverse universe, Func<Symbol, IEnumerable<Symbol>> mapFunc)
         {

--- a/Common/Securities/Future/FutureFilterUniverse.cs
+++ b/Common/Securities/Future/FutureFilterUniverse.cs
@@ -77,7 +77,6 @@ namespace QuantConnect.Securities
             return this;
         }
 
-
         /// <summary>
         /// Returns a list of back month contracts
         /// </summary>

--- a/Common/Securities/Future/FutureFilterUniverse.cs
+++ b/Common/Securities/Future/FutureFilterUniverse.cs
@@ -166,6 +166,15 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Instructs the engine to only filter options contracts on the first time step of each market day.
+        /// </summary>
+        public FutureFilterUniverse OnlyApplyFilterAtMarketOpen()
+        {
+            _isDynamic = false;
+            return this;
+        }
+
+        /// <summary>
         /// IEnumerable interface method implementation
         /// </summary>
         public IEnumerator<Symbol> GetEnumerator()

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -106,9 +106,18 @@ namespace QuantConnect.Securities.Option
             SetFilter(-1, 1, TimeSpan.Zero, TimeSpan.FromDays(35));
         }
 
-
         // save off a strongly typed version of symbol properties
         private readonly OptionSymbolProperties _symbolProperties;
+
+        /// <summary>
+        /// Returns true if this is the option chain security, false if it is a specific option contract
+        /// </summary>
+        public bool IsOptionChain => Symbol.IsCanonical();
+
+        /// <summary>
+        /// Returns true if this is a specific option contract security, false if it is the option chain security
+        /// </summary>
+        public bool IsOptionContract => !Symbol.IsCanonical();
 
         /// <summary>
         /// Gets the strike price

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -312,6 +312,19 @@ namespace QuantConnect.Securities.Option
         /// Sets the <see cref="ContractFilter"/> to a new instance of the filter
         /// using the specified min and max strike and expiration range values
         /// </summary>
+        /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
+        /// would exclude contracts expiring in less than 10 days</param>
+        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
+        /// would exclude contracts expiring in more than 10 days</param>
+        public void SetFilter(TimeSpan minExpiry, TimeSpan maxExpiry)
+        {
+            SetFilter(universe => universe.Expiration(minExpiry, maxExpiry));
+        }
+
+        /// <summary>
+        /// Sets the <see cref="ContractFilter"/> to a new instance of the filter
+        /// using the specified min and max strike and expiration range values
+        /// </summary>
         /// <param name="minStrike">The min strike rank relative to market price, for example, -1 would put
         /// a lower bound of one strike under market price, where a +1 would put a lower bound of one strike
         /// over market price</param>
@@ -325,8 +338,8 @@ namespace QuantConnect.Securities.Option
         public void SetFilter(int minStrike, int maxStrike, TimeSpan minExpiry, TimeSpan maxExpiry)
         {
             SetFilter(universe => universe
-                                .Strikes(minStrike, maxStrike)
-                                .Expiration(minExpiry, maxExpiry));
+                .Strikes(minStrike, maxStrike)
+                .Expiration(minExpiry, maxExpiry));
         }
 
         /// <summary>

--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -349,6 +349,15 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Instructs the engine to only filter options contracts on the first time step of each market day.
+        /// </summary>
+        public OptionFilterUniverse OnlyApplyFilterAtMarketOpen()
+        {
+            _isDynamic = false;
+            return this;
+        }
+
+        /// <summary>
         /// IEnumerable interface method implementation
         /// </summary>
         public IEnumerator<Symbol> GetEnumerator()

--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -112,7 +112,6 @@ namespace QuantConnect.Securities
             return this;
         }
 
-
         /// <summary>
         /// Returns universe, filtered by option type
         /// </summary>
@@ -166,7 +165,6 @@ namespace QuantConnect.Securities
             _allSymbols = frontMonth.ToList();
             return this;
         }
-
 
         /// <summary>
         /// Returns a list of back month contracts
@@ -324,6 +322,29 @@ namespace QuantConnect.Securities
 
             _allSymbols = filtered.ToList();
 
+            return this;
+        }
+
+        /// <summary>
+        /// Explicitly sets the selected contract symbols for this universe.
+        /// This overrides and and all other methods of selecting symbols assuming it is called last.
+        /// </summary>
+        /// <param name="contracts">The option contract symbol objects to select</param>
+        public OptionFilterUniverse Contracts(IEnumerable<Symbol> contracts)
+        {
+            _allSymbols = contracts.ToList();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a function used to filter the set of available contract filters. The input to the 'contractSelector'
+        /// function will be the already filtered list if any other filters have already been applied.
+        /// </summary>
+        /// <param name="contractSelector">The option contract symbol objects to select</param>
+        public OptionFilterUniverse Contracts(Func<IEnumerable<Symbol>, IEnumerable<Symbol>> contractSelector)
+        {
+            // force materialization using ToList
+            _allSymbols = contractSelector(_allSymbols).ToList();
             return this;
         }
 

--- a/Common/Util/LinqExtensions.cs
+++ b/Common/Util/LinqExtensions.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,6 +83,19 @@ namespace QuantConnect.Util
         public static HashSet<TResult> ToHashSet<T, TResult>(this IEnumerable<T> enumerable, Func<T, TResult> selector)
         {
             return new HashSet<TResult>(enumerable.Select(selector));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="IList{T}"/> from the projected elements in the specified enumerable
+        /// </summary>
+        /// <typeparam name="T">The item type of the source enumerable</typeparam>
+        /// <typeparam name="TResult">The type of the items in the output <see cref="List{T}"/></typeparam>
+        /// <param name="enumerable">The items to be placed into the enumerable</param>
+        /// <param name="selector">Selects items from the enumerable to be placed into the <see cref="List{T}"/></param>
+        /// <returns>A new <see cref="List{T}"/> containing the items in the enumerable</returns>
+        public static List<TResult> ToList<T, TResult>(this IEnumerable<T> enumerable, Func<T, TResult> selector)
+        {
+            return enumerable.Select(selector).ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Adds flags to option/future security objects to determine if the security represents the chain or a specific contract. Without these flags, users would need to know to call `Symbol.IsCanonical()` to make the determination. Also added are functions to allow algorithms to explicitly set the contracts to be selected. Without the addition `OptionFilterUniverse.Contracts(...)` and `FutureFilterUniverse.Contracts(...)`, users would need to use the other helper methods, but they fall short in providing full LINQ support (orderby clauses not supported via the extension methods).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #1967 (this PR does *not* close the issue).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To improve usage of derivative security universes and provide a means of explicitly setting the set of contracts to be selected.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Not required, but potentially useful to use in the documentation.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I'm in the middle of producing a `BasicTemplateOptionsFrameworkAlgorithm` and a `BasicTemplateFuturesFrameworkAlgorithm` -- these two will be added to the regression test suite, for now these functions remain without automated tests, but have been tested locally during the development of the aforementioned regression algorithms.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->