### PR TITLE
Changes Insight.Group return type to IEnumerable<Insight> from Guid

### DIFF
--- a/Common/Algorithm/Framework/Alphas/Insight.cs
+++ b/Common/Algorithm/Framework/Alphas/Insight.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using QuantConnect.Algorithm.Framework.Alphas.Serialization;
 
@@ -201,7 +202,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// Creates a new, unique group id and sets it on each insight
         /// </summary>
         /// <param name="insights">The insights to be grouped</param>
-        public static Guid Group(params Insight[] insights)
+        public static IEnumerable<Insight> Group(params Insight[] insights)
         {
             if (insights == null)
             {
@@ -217,9 +218,9 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 }
 
                 insight.GroupId = groupId;
-            }
 
-            return groupId;
+                yield return insight;
+            }
         }
 
         /// <summary>

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Algorithm.Framework.Alphas;
@@ -93,17 +94,24 @@ namespace QuantConnect.Tests.Algorithm.Framework
         {
             var insight1 = Insight.Price(Symbols.SPY, Time.OneMinute, InsightDirection.Up);
             var insight2 = Insight.Price(Symbols.SPY, Time.OneMinute, InsightDirection.Up);
-            var groupId = Insight.Group(insight1, insight2);
-            Assert.AreEqual(groupId, insight1.GroupId);
-            Assert.AreEqual(groupId, insight2.GroupId);
+            var group = Insight.Group(insight1, insight2).ToList();
+            foreach (var member in group)
+            {
+                Assert.IsTrue(member.GroupId.HasValue);
+            }
+            var groupId = insight1.GroupId.Value;
+            foreach (var member in group)
+            {
+                Assert.AreEqual(groupId, member.GroupId);
+            }
         }
 
         [Test]
         public void GroupThrowsExceptionIfInsightAlreadyHasGroupId()
         {
             var insight1 = Insight.Price(Symbols.SPY, Time.OneMinute, InsightDirection.Up);
-            Insight.Group(insight1);
-            Assert.That(() => Insight.Group(insight1), Throws.InvalidOperationException);
+            Insight.Group(insight1).ToList();
+            Assert.That(() => Insight.Group(insight1).ToList(), Throws.InvalidOperationException);
         }
     }
 }


### PR DESCRIPTION
#### Description
Changes `Insight.Group` return type to `IEnumerable<Insight>` from `Guid`.

#### Related Issue
Closes #1981

#### How Has This Been Tested?
Unit test.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`