### PR TITLE
add y label and support for future tick quotebars

### DIFF
--- a/ToolBox/Visualizer/QuantConnect.Visualizer.py
+++ b/ToolBox/Visualizer/QuantConnect.Visualizer.py
@@ -24,6 +24,7 @@ import sys
 import uuid
 from clr import AddReference
 from pathlib import Path
+from numpy import NaN
 
 import matplotlib as mpl
 
@@ -139,12 +140,27 @@ class Visualizer:
         :param data: a pandas.DataFrame with the data to plot.
         :return: void
         """
+        is_future_tick = ('future' in self.arguments['DATAFILE'] and 'tick' in self.arguments['DATAFILE']
+                          and 'quote' in self.arguments['DATAFILE'])
+        if is_future_tick:
+            data = data.replace(0, NaN)
+
         plot = data.plot(grid=True, color=self.palette)
-        fig = plot.get_figure()
+
         is_low_resolution_data = 'hour' in self.arguments['DATAFILE'] or 'daily' in self.arguments['DATAFILE']
         if not is_low_resolution_data:
             plot.xaxis.set_major_formatter(DateFormatter("%H:%M"))
 
+        is_forex = 'forex' in self.arguments['DATAFILE']
+        is_open_interest = 'openinterest' in self.arguments['DATAFILE']
+        if is_forex:
+            plot.set_ylabel('exchange rate')
+        elif is_open_interest:
+            plot.set_ylabel('open contracts')
+        else:
+            plot.set_ylabel('price (USD)')
+
+        fig = plot.get_figure()
         size_px = [int(p) for p in self.arguments['--size'].split(',')]
         fig.set_size_inches(size_px[0] / fig.dpi, size_px[1] / fig.dpi)
         fig.savefig(self.plot_filename, transparent=True, dpi=fig.dpi)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR adds labels to the ´y´ axis and fixes futures tick quotebar data issues 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1983 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Plot all combinations of data type and resolutions.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->