### PR TITLE
Adds universe selection algorithm with custom security initilizer

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -88,6 +88,7 @@
     </Compile>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
     <Compile Include="CancelOpenOrdersRegressionAlgorithm.cs" />
+    <Compile Include="RawPricesCoarseUniverseAlgorithm.cs" />
     <Compile Include="CompositeAlphaModelFrameworkAlgorithm.cs" />
     <Compile Include="SectorExposureRiskFrameworkAlgorithm.cs" />
     <Compile Include="DuplicateSecurityWithBenchmarkRegressionAlgorithm.cs" />

--- a/Algorithm.CSharp/RawPricesCoarseUniverseAlgorithm.cs
+++ b/Algorithm.CSharp/RawPricesCoarseUniverseAlgorithm.cs
@@ -37,12 +37,12 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void Initialize()
         {
+            // what resolution should the data *added* to the universe be?
+            UniverseSettings.Resolution = Resolution.Daily;
+
             SetStartDate(2014, 01, 01);
             SetEndDate(2015, 01, 01);
             SetCash(50000);
-
-            // what resolution should the data *added* to the universe be?
-            UniverseSettings.Resolution = Resolution.Daily;
 
             // Set the security initializer with the characteristics defined in CustomSecurityInitializer
             SetSecurityInitializer(CustomSecurityInitializer);

--- a/Algorithm.CSharp/RawPricesCoarseUniverseAlgorithm.cs
+++ b/Algorithm.CSharp/RawPricesCoarseUniverseAlgorithm.cs
@@ -1,0 +1,94 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// In this algorithm we demonstrate how to use the coarse fundamental data to
+    /// define a universe as the top dollar volume and set the algorithm to use
+    /// raw prices
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="universes" />
+    /// <meta name="tag" content="coarse universes" />
+    /// <meta name="tag" content="regression test" />
+    public class RawPricesCoarseUniverseAlgorithm : QCAlgorithm
+    {
+        private const int NumberOfSymbols = 5;
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 01, 01);
+            SetEndDate(2015, 01, 01);
+            SetCash(50000);
+
+            // what resolution should the data *added* to the universe be?
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            // Set the security initializer to set the data normalization mode to raw
+            SetSecurityInitializer(x => x.SetDataNormalizationMode(DataNormalizationMode.Raw));
+
+            // this add universe method accepts a single parameter that is a function that
+            // accepts an IEnumerable<CoarseFundamental> and returns IEnumerable<Symbol>
+            AddUniverse(CoarseSelectionFunction);
+        }
+
+        // sort the data by daily dollar volume and take the top 'NumberOfSymbols'
+        public static IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
+        {
+            // sort descending by daily dollar volume
+            var sortedByDollarVolume = coarse.OrderByDescending(x => x.DollarVolume);
+
+            // take the top entries from our sorted collection
+            var top5 = sortedByDollarVolume.Take(NumberOfSymbols);
+
+            // we need to return only the symbol objects
+            return top5.Select(x => x.Symbol);
+        }
+
+        // this event fires whenever we have changes to our universe
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            foreach (var security in changes.RemovedSecurities)
+            {
+                if (security.Invested)
+                {
+                    Liquidate(security.Symbol);
+                }
+            }
+
+            // we want 20% allocation in each security in our universe
+            foreach (var security in changes.AddedSecurities)
+            {
+                SetHoldings(security.Symbol, 0.2m);
+            }
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status == OrderStatus.Filled)
+            {
+                Log($"OnOrderEvent({UtcTime:o}):: {orderEvent}");
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/RawPricesCoarseUniverseAlgorithm.cs
+++ b/Algorithm.CSharp/RawPricesCoarseUniverseAlgorithm.cs
@@ -13,12 +13,12 @@
  * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -44,12 +44,22 @@ namespace QuantConnect.Algorithm.CSharp
             // what resolution should the data *added* to the universe be?
             UniverseSettings.Resolution = Resolution.Daily;
 
-            // Set the security initializer to set the data normalization mode to raw
-            SetSecurityInitializer(x => x.SetDataNormalizationMode(DataNormalizationMode.Raw));
+            // Set the security initializer with the characteristics defined in CustomSecurityInitializer
+            SetSecurityInitializer(CustomSecurityInitializer);
 
             // this add universe method accepts a single parameter that is a function that
             // accepts an IEnumerable<CoarseFundamental> and returns IEnumerable<Symbol>
             AddUniverse(CoarseSelectionFunction);
+        }
+
+        /// <summary>
+        /// Initialize the security with raw prices and zero fees 
+        /// </summary>
+        /// <param name="security">Security which characteristics we want to change</param>
+        private void CustomSecurityInitializer(Security security)
+        {
+            security.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            security.SetFeeModel(new ConstantFeeModel(0));
         }
 
         // sort the data by daily dollar volume and take the top 'NumberOfSymbols'

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -122,6 +122,7 @@
     <None Include="QuandlFuturesDataAlgorithm.py" />
     <None Include="QuandlImporterAlgorithm.py" />
     <None Include="readme.md" />
+    <None Include="RawPricesCoarseUniverseAlgorithm.py" />
     <None Include="RegressionAlgorithm.py" />
     <None Include="RegressionChannelAlgorithm.py" />
     <None Include="RenkoConsolidatorAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -99,6 +99,7 @@
     <Compile Include="QCUWeatherBasedRebalancing.py" />
     <Compile Include="QuandlFuturesDataAlgorithm.py" />
     <Compile Include="QuandlImporterAlgorithm.py" />
+    <Compile Include="RawPricesCoarseUniverseAlgorithm.py" />
     <Compile Include="RegressionAlgorithm.py" />
     <Compile Include="RegressionChannelAlgorithm.py" />
     <Compile Include="RenkoConsolidatorAlgorithm.py" />

--- a/Algorithm.Python/RawPricesCoarseUniverseAlgorithm.py
+++ b/Algorithm.Python/RawPricesCoarseUniverseAlgorithm.py
@@ -35,12 +35,12 @@ class RawPricesCoarseUniverseAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
+        # what resolution should the data *added* to the universe be?
+        self.UniverseSettings.Resolution = Resolution.Daily
+
         self.SetStartDate(2014,1,1)    #Set Start Date
         self.SetEndDate(2015,1,1)      #Set End Date
         self.SetCash(50000)            #Set Strategy Cash
-
-        # what resolution should the data *added* to the universe be?
-        self.UniverseSettings.Resolution = Resolution.Daily
 
         # Set the security initializer with the characteristics defined in CustomSecurityInitializer
         self.SetSecurityInitializer(self.CustomSecurityInitializer)

--- a/Algorithm.Python/RawPricesCoarseUniverseAlgorithm.py
+++ b/Algorithm.Python/RawPricesCoarseUniverseAlgorithm.py
@@ -1,0 +1,76 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System.Core")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import QCAlgorithm
+from QuantConnect.Data.UniverseSelection import *
+from QuantConnect.Orders import OrderStatus
+
+### <summary>
+### In this algorithm we demonstrate how to use the coarse fundamental data to define a universe as the top dollar volume and set the algorithm to use raw prices
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="universes" />
+### <meta name="tag" content="coarse universes" />
+### <meta name="tag" content="fine universes" />
+class RawPricesCoarseUniverseAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        self.SetStartDate(2014,1,1)    #Set Start Date
+        self.SetEndDate(2015,1,1)      #Set End Date
+        self.SetCash(50000)            #Set Strategy Cash
+
+        # what resolution should the data *added* to the universe be?
+        self.UniverseSettings.Resolution = Resolution.Daily
+
+        # Set the security initializer to set the data normalization mode to raw
+        self.SetSecurityInitializer(lambda x: x.SetDataNormalizationMode(DataNormalizationMode.Raw))
+
+        # this add universe method accepts a single parameter that is a function that
+        # accepts an IEnumerable<CoarseFundamental> and returns IEnumerable<Symbol>
+        self.AddUniverse(self.CoarseSelectionFunction)
+
+        self.__numberOfSymbols = 5
+
+
+    # sort the data by daily dollar volume and take the top 'NumberOfSymbols'
+    def CoarseSelectionFunction(self, coarse):
+        # sort descending by daily dollar volume
+        sortedByDollarVolume = sorted(coarse, key=lambda x: x.DollarVolume, reverse=True)
+
+        # return the symbol objects of the top entries from our sorted collection
+        return [ x.Symbol for x in sortedByDollarVolume[:self.__numberOfSymbols] ]
+
+
+    # this event fires whenever we have changes to our universe
+    def OnSecuritiesChanged(self, changes):
+        # liquidate removed securities
+        for security in changes.RemovedSecurities:
+            if security.Invested:
+                self.Liquidate(security.Symbol)
+
+        # we want 20% allocation in each security in our universe
+        for security in changes.AddedSecurities:
+            self.SetHoldings(security.Symbol, 0.2)
+
+    def OnOrderEvent(self, orderEvent):
+        if orderEvent.Status == OrderStatus.Filled:
+            self.Log(f"OnOrderEvent({self.UtcTime}):: {orderEvent}")

--- a/Algorithm.Python/RawPricesCoarseUniverseAlgorithm.py
+++ b/Algorithm.Python/RawPricesCoarseUniverseAlgorithm.py
@@ -21,6 +21,7 @@ from QuantConnect import *
 from QuantConnect.Algorithm import QCAlgorithm
 from QuantConnect.Data.UniverseSelection import *
 from QuantConnect.Orders import OrderStatus
+from QuantConnect.Orders.Fees import ConstantFeeModel
 
 ### <summary>
 ### In this algorithm we demonstrate how to use the coarse fundamental data to define a universe as the top dollar volume and set the algorithm to use raw prices
@@ -41,8 +42,8 @@ class RawPricesCoarseUniverseAlgorithm(QCAlgorithm):
         # what resolution should the data *added* to the universe be?
         self.UniverseSettings.Resolution = Resolution.Daily
 
-        # Set the security initializer to set the data normalization mode to raw
-        self.SetSecurityInitializer(lambda x: x.SetDataNormalizationMode(DataNormalizationMode.Raw))
+        # Set the security initializer with the characteristics defined in CustomSecurityInitializer
+        self.SetSecurityInitializer(self.CustomSecurityInitializer)
 
         # this add universe method accepts a single parameter that is a function that
         # accepts an IEnumerable<CoarseFundamental> and returns IEnumerable<Symbol>
@@ -50,6 +51,12 @@ class RawPricesCoarseUniverseAlgorithm(QCAlgorithm):
 
         self.__numberOfSymbols = 5
 
+    def CustomSecurityInitializer(self, security):
+        '''Initialize the security with raw prices and zero fees 
+        Args:
+            security: Security which characteristics we want to change'''
+        security.SetDataNormalizationMode(DataNormalizationMode.Raw)
+        security.SetFeeModel(ConstantFeeModel(0))
 
     # sort the data by daily dollar volume and take the top 'NumberOfSymbols'
     def CoarseSelectionFunction(self, coarse):


### PR DESCRIPTION
#### Description
Adds `RawPricesCoarseUniverseAlgorithm` algorithm.

#### Related Issue
Closes #1985 

#### Motivation and Context
`SetSecurityInitializer` is method in the API that is tailored to change the security settings of a collection of securities. Yet, we didn't have a example associated with universe selection.

#### Requires Documentation Change
Yes. Documentation should mention `SetSecurityInitializer`.

#### How Has This Been Tested?
Manually but watching the prices that orders are filled.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`