### PR TITLE
Refactors CompositeAlphaModel constructors

### DIFF
--- a/Algorithm.Framework/Alphas/CompositeAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/CompositeAlphaModel.cs
@@ -44,7 +44,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             _alphaModels = alphaModels;
         }
 
-        public CompositeAlphaModel(PyObject[] alphaModels)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositeAlphaModel"/> class
+        /// </summary>
+        /// <param name="alphaModels">The individual alpha models defining this composite model</param>
+        public CompositeAlphaModel(params PyObject[] alphaModels)
         {
             if (alphaModels.IsNullOrEmpty())
             {
@@ -60,6 +64,16 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                     _alphaModels[i] = new AlphaModelPythonWrapper(alphaModels[i]);
                 }
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositeAlphaModel"/> class
+        /// </summary>
+        /// <param name="alphaModel">The individual alpha model defining this composite model</param>
+        public CompositeAlphaModel(PyObject alphaModel)
+            : this(new[] { alphaModel} )
+        {
+
         }
 
         /// <summary>

--- a/Algorithm.Python/CompositeAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/CompositeAlphaModelFrameworkAlgorithm.py
@@ -55,7 +55,7 @@ class CompositeAlphaModelFrameworkAlgorithm(QCAlgorithmFramework):
         self.SetUniverseSelection(ManualUniverseSelectionModel(self.Securities.Keys))
 
         # define alpha model as a composite of the rsi and ema cross models
-        self.SetAlpha(CompositeAlphaModel([RsiAlphaModel(), EmaCrossAlphaModel()]))
+        self.SetAlpha(CompositeAlphaModel(RsiAlphaModel(), EmaCrossAlphaModel()))
 
         # default models for the rest
         self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())


### PR DESCRIPTION
#### Description
Changes the constructor that accepted an array to accept params array and adds a new constructor to deal with a single model addition.

#### Related Issue
Closes #1988 

#### Motivation and Context
In C# and python algorithm, we should be able to create an instance of `CompositeAlphaModel` with the same signature.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually by changing the parameters in `CompositeAlphaModelFrameworkAlgorithm`.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`