### PR TITLE
Fix duplicate order event logging in LiveTradingResultHandler

### DIFF
--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -950,9 +950,6 @@ namespace QuantConnect.Lean.Engine.Results
 
             var message = "New Order Event: " + newEvent;
             DebugMessage(message);
-
-            //Add the order event message to the log:
-            LogMessage(message);
         }
 
         /// <summary>


### PR DESCRIPTION

#### Description
Remove the extra `LogMessage` call in `LiveTradingResultHandler.OrderEvent` method.

#### Related Issue
Closes #1992

#### Motivation and Context
This call was causing duplicate logging of order events.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Ran this algorithm live on GDAX (both locally and in the cloud) and verified the order event is no longer duplicated in the log:
``` C#
public class TestDuplicateLiveOrderEvents : QCAlgorithm
    {
        public override void Initialize()
        {
            SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
            DefaultOrderProperties = new GDAXOrderProperties { PostOnly = true };
            AddCrypto("LTCBTC", Resolution.Tick);
        }

        private bool _done;
        public override void OnData(Slice data)
        {
            if (!_done)
            {
                LimitOrder("LTCBTC", -1, 0.02m);
                Debug($"Limit order submitted");
                _done = true;
            }
        }
    }
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`