### PR TITLE
Fix locking bug in GDAXDataQueueHandler

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Brokerages.GDAX
     public partial class GDAXBrokerage
     {
         #region Declarations
-        private readonly object _tickLocker = new object();
+
         /// <summary>
         /// Collection of partial split messages
         /// </summary>
@@ -70,6 +70,11 @@ namespace QuantConnect.Brokerages.GDAX
         /// The list of websocket channels to subscribe
         /// </summary>
         protected virtual string[] ChannelNames { get; } = { "heartbeat", "user", "matches" };
+
+        /// <summary>
+        /// Locking object for the Ticks list in the data queue handler
+        /// </summary>
+        protected readonly object TickLocker = new object();
 
         /// <summary>
         /// Constructor for brokerage
@@ -457,7 +462,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// <param name="askSize">The ask price</param>
         private void EmitQuoteTick(Symbol symbol, decimal bidPrice, decimal bidSize, decimal askPrice, decimal askSize)
         {
-            lock (_tickLocker)
+            lock (TickLocker)
             {
                 Ticks.Add(new Tick
                 {
@@ -480,7 +485,7 @@ namespace QuantConnect.Brokerages.GDAX
         {
             var symbol = ConvertProductId(message.ProductId);
 
-            lock (_tickLocker)
+            lock (TickLocker)
             {
                 Ticks.Add(new Tick
                 {
@@ -565,7 +570,7 @@ namespace QuantConnect.Brokerages.GDAX
                 {
                     var rate = GetConversionRate(symbol.Value.Replace("USD", ""));
 
-                    lock (_tickLocker)
+                    lock (TickLocker)
                     {
                         var latest = new Tick
                         {

--- a/Brokerages/GDAX/GDAXDataQueueHandler.cs
+++ b/Brokerages/GDAX/GDAXDataQueueHandler.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// <returns>IEnumerable list of ticks since the last update.</returns>
         public IEnumerable<BaseData> GetNextTicks()
         {
-            lock (Ticks)
+            lock (TickLocker)
             {
                 var copy = Ticks.ToArray();
                 Ticks.Clear();


### PR DESCRIPTION

#### Description
The `Ticks` list in `GDAXDataQueueHandler` is now synchronized properly.

#### Related Issue
Closes #1990

#### Motivation and Context
The `GDAXDataQueueHandler` was not using the same locker object used in `GDAXBrokerage`, causing multi-threading issues.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Verified live GDAX algorithm receives ticks.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`