### PR TITLE
Port C# demonstration algorithms to python

### DIFF
--- a/Algorithm.CSharp/CoarseFundamentalTop5Algorithm.cs
+++ b/Algorithm.CSharp/CoarseFundamentalTop5Algorithm.cs
@@ -66,7 +66,7 @@ namespace QuantConnect.Algorithm.CSharp
         //Data Event Handler: New data arrives here. "TradeBars" type is a dictionary of strings so you can access it by symbol.
         public void OnData(TradeBars data)
         {
-            Console.WriteLine($"OnData({UtcTime:o}): Keys: {string.Join(", ", data.Keys.OrderBy(x => x))}");
+            Log($"OnData({UtcTime:o}): Keys: {string.Join(", ", data.Keys.OrderBy(x => x))}");
 
             // if we have no changes, do nothing
             if (_changes == SecurityChanges.None) return;
@@ -97,7 +97,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void OnOrderEvent(OrderEvent fill)
         {
-            Console.WriteLine($"OnOrderEvent({UtcTime:o}):: {fill}");
+            Log($"OnOrderEvent({UtcTime:o}):: {fill}");
         }
     }
 }

--- a/Algorithm.CSharp/DisplacedMovingAverageRibbon.cs
+++ b/Algorithm.CSharp/DisplacedMovingAverageRibbon.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2009, 01, 01);
             SetEndDate(2015, 01, 01);
 
-            AddSecurity(SecurityType.Equity, "SPY", Resolution.Minute);
+            AddSecurity(SecurityType.Equity, "SPY", Resolution.Daily);
 
             const int count = 6;
             const int offset = 5;

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -134,7 +134,7 @@
     <Compile Include="BasicTemplateForexAlgorithm.cs" />
     <Compile Include="BasicTemplateAlgorithm.cs" />
     <Compile Include="BasicTemplateOptionsAlgorithm.cs" />
-    <Compile Include="CoarseUniverseTop5DollarVolumeAlgorithm.cs" />
+    <Compile Include="CoarseFundamentalTop5Algorithm.cs" />
     <Compile Include="CustomBenchmarkAlgorithm.cs" />
     <Compile Include="CustomBrokerageMessageHandlerAlgorithm.cs" />
     <Compile Include="FractionalQuantityRegressionAlgorithm.cs" />

--- a/Algorithm.CSharp/RenkoConsolidatorAlgorithm.cs
+++ b/Algorithm.CSharp/RenkoConsolidatorAlgorithm.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2012, 01, 01);
             SetEndDate(2013, 01, 01);
 
-            AddSecurity(SecurityType.Equity, "SPY");
+            AddEquity("SPY", Resolution.Daily);
 
             // this is the simple constructor that will perform the renko logic to the Value
             // property of the data it receives.
@@ -84,7 +84,7 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 SetHoldings(data.Symbol, 1.0);
             }
-            Console.WriteLine("CLOSE - {0} - {1} {2}", data.Time.ToString("o"), data.Open, data.Close);
+            Log($"CLOSE - {data.Time.ToString("o")} - {data.Open} {data.Close}");
         }
 
         /// <summary>
@@ -93,7 +93,11 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="data">The new renko bar produced by the consolidator</param>
         public void HandleRenko7Bar(RenkoBar data)
         {
-            Console.WriteLine("7BAR  - {0} - {1} {2}", data.Time.ToString("o"), data.Open, data.Close);
+            if (Portfolio.Invested)
+            {
+                Liquidate(data.Symbol);
+            }
+            Log($"7BAR - {data.Time.ToString("o")} - {data.Open} {data.Close}");
         }
     }
 }

--- a/Algorithm.Python/CoarseFundamentalTop5Algorithm.py
+++ b/Algorithm.Python/CoarseFundamentalTop5Algorithm.py
@@ -58,6 +58,9 @@ class CoarseFundamentalTop5Algorithm(QCAlgorithm):
 
 
     def OnData(self, data):
+
+        self.Log(f"OnData({self.UtcTime}): Keys: {', '.join([key.Value for key in data.Keys])}")
+
         # if we have no changes, do nothing
         if self._changes == None: return
 
@@ -76,3 +79,6 @@ class CoarseFundamentalTop5Algorithm(QCAlgorithm):
     # this event fires whenever we have changes to our universe
     def OnSecuritiesChanged(self, changes):
         self._changes = changes
+
+    def OnOrderEvent(self, fill):
+        self.Log(f"OnOrderEvent({self.UtcTime}):: {fill}")

--- a/Algorithm.Python/DisplacedMovingAverageRibbon.py
+++ b/Algorithm.Python/DisplacedMovingAverageRibbon.py
@@ -43,7 +43,7 @@ class DisplacedMovingAverageRibbon(QCAlgorithm):
     def Initialize(self):
         self.SetStartDate(2009, 1, 1)  #Set Start Date
         self.SetEndDate(2015, 1, 1)    #Set End Date
-        self.spy = self.AddEquity("SPY", Resolution.Minute).Symbol
+        self.spy = self.AddEquity("SPY", Resolution.Daily).Symbol
         count = 6
         offset = 5
         period = 15

--- a/Algorithm.Python/RenkoConsolidatorAlgorithm.py
+++ b/Algorithm.Python/RenkoConsolidatorAlgorithm.py
@@ -38,7 +38,7 @@ class RenkoConsolidatorAlgorithm(QCAlgorithm):
         self.SetStartDate(2012, 1, 1)
         self.SetEndDate(2013, 1, 1)
 
-        self.AddEquity("SPY")
+        self.AddEquity("SPY", Resolution.Daily)
 
         # this is the simple constructor that will perform the
         # renko logic to the Value property of the data it receives.
@@ -69,11 +69,13 @@ class RenkoConsolidatorAlgorithm(QCAlgorithm):
         if not self.Portfolio.Invested:
             self.SetHoldings(data.Symbol, 1)
 
-        self.Log("CLOSE - {0} - {1} {2}".format(data.Time, data.Open, data.Close))
+        self.Log(f"CLOSE - {data.Time} - {data.Open} {data.Close}")
 
 
     def HandleRenko7Bar(self, sender, data):
         '''This function is called by our renko7bar consolidator defined in Initialize()
         Args:
             data: The new renko bar produced by the consolidator'''
-        self.Log("7BAR - {0} - {1} {2}".format(data.Time, data.Open, data.Close))
+        if self.Portfolio.Invested:
+            self.Liquidate(data.Symbol)
+        self.Log(f"7BAR - {data.Time} - {data.Open} {data.Close}")

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -1086,6 +1086,29 @@ namespace QuantConnect.Tests
                 {"Total Fees", "$101.55"},
             };
 
+            var displacedMovingAverageRibbonStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "7"},
+                {"Average Win", "19.19%"},
+                {"Average Loss", "0%"},
+                {"Compounding Annual Return", "16.754%"},
+                {"Drawdown", "12.600%"},
+                {"Expectancy", "0"},
+                {"Net Profit", "153.401%"},
+                {"Sharpe Ratio", "1.27"},
+                {"Loss Rate", "0%"},
+                {"Win Rate", "100%"},
+                {"Profit-Loss Ratio", "0"},
+                {"Alpha", "0.073"},
+                {"Beta", "4.493"},
+                {"Annual Standard Deviation", "0.129"},
+                {"Annual Variance", "0.017"},
+                {"Information Ratio", "1.114"},
+                {"Tracking Error", "0.129"},
+                {"Treynor Ratio", "0.036"},
+                {"Total Fees", "$44.32"},
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -1133,6 +1156,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("SectorExposureRiskFrameworkAlgorithm", sectorExposureRiskFrameworkAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("DelistingEventsAlgorithm", delistingEventsAlgorithm, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("RenkoConsolidatorAlgorithm", renkoConsolidatorStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("DisplacedMovingAverageRibbon", displacedMovingAverageRibbonStatistics, Language.CSharp),
 
                 // Python
                 new AlgorithmStatisticsTestParameters("AddRemoveSecurityRegressionAlgorithm", addRemoveSecurityRegressionStatistics, Language.Python),
@@ -1172,7 +1196,8 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("SectorExposureRiskFrameworkAlgorithm", sectorExposureRiskFrameworkAlgorithmStatistics, Language.Python),
-                new AlgorithmStatisticsTestParameters("RenkoConsolidatorAlgorithm", renkoConsolidatorStatistics, Language.Python)
+                new AlgorithmStatisticsTestParameters("RenkoConsolidatorAlgorithm", renkoConsolidatorStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("DisplacedMovingAverageRibbon", displacedMovingAverageRibbonStatistics, Language.Python)
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -1063,6 +1063,29 @@ namespace QuantConnect.Tests
                 {"Total Fees", "$36.79"},
             };
 
+            var renkoConsolidatorStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "27"},
+                {"Average Win", "1.66%"},
+                {"Average Loss", "-2.50%"},
+                {"Compounding Annual Return", "-4.036%"},
+                {"Drawdown", "13.800%"},
+                {"Expectancy", "-0.104"},
+                {"Net Profit", "-4.047%"},
+                {"Sharpe Ratio", "-0.359"},
+                {"Loss Rate", "46%"},
+                {"Win Rate", "54%"},
+                {"Profit-Loss Ratio", "0.66"},
+                {"Alpha", "0.04"},
+                {"Beta", "-3.777"},
+                {"Annual Standard Deviation", "0.101"},
+                {"Annual Variance", "0.01"},
+                {"Information Ratio", "-0.558"},
+                {"Tracking Error", "0.101"},
+                {"Treynor Ratio", "0.01"},
+                {"Total Fees", "$101.55"},
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -1109,6 +1132,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("SectorExposureRiskFrameworkAlgorithm", sectorExposureRiskFrameworkAlgorithmStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("DelistingEventsAlgorithm", delistingEventsAlgorithm, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("RenkoConsolidatorAlgorithm", renkoConsolidatorStatistics, Language.CSharp),
 
                 // Python
                 new AlgorithmStatisticsTestParameters("AddRemoveSecurityRegressionAlgorithm", addRemoveSecurityRegressionStatistics, Language.Python),
@@ -1147,7 +1171,8 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("ScheduledUniverseSelectionModelRegressionAlgorithm", scheduledUniverseSelectionModelRegressionAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("PairsTradingAlphaModelFrameworkAlgorithm", pairsTradingAlphaModelFrameworkAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.Python),
-                new AlgorithmStatisticsTestParameters("SectorExposureRiskFrameworkAlgorithm", sectorExposureRiskFrameworkAlgorithmStatistics, Language.Python)
+                new AlgorithmStatisticsTestParameters("SectorExposureRiskFrameworkAlgorithm", sectorExposureRiskFrameworkAlgorithmStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("RenkoConsolidatorAlgorithm", renkoConsolidatorStatistics, Language.Python)
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION
#### Description
The following algorithms were ported but requested regression tests were missing.
- RenkoConsolidatorAlgorithm
- CoarseFundamentalTop5Algorithm
- DisplacedMovingAverageRibbon

#### Related Issue
Closes #1610 

#### Motivation and Context
Provide matching examples in C# and python.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added regression tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [c] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`