### PR TITLE
Remove disposed security data from TimeSlice

### DIFF
--- a/Engine/DataFeeds/DataFeedPacket.cs
+++ b/Engine/DataFeeds/DataFeedPacket.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Securities;
+using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -25,7 +26,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     /// </summary>
     public class DataFeedPacket
     {
-        private readonly List<BaseData> _data;
+        private readonly IReadOnlyRef<bool> _isRemoved;
 
         /// <summary>
         /// The security
@@ -46,29 +47,27 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// Gets the number of data points held within this packet
         /// </summary>
-        public int Count
-        {
-            get { return _data.Count; }
-        }
+        public int Count => Data.Count;
 
         /// <summary>
         /// The data for the security
         /// </summary>
-        public List<BaseData> Data
-        {
-            get { return _data; }
-        }
+        public List<BaseData> Data { get; }
+
+        /// <summary>
+        /// Gets whether or not this packet should be filtered out due to the subscription being removed
+        /// </summary>
+        public bool IsSubscriptionRemoved => _isRemoved.Value;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataFeedPacket"/> class
         /// </summary>
         /// <param name="security">The security whose data is held in this packet</param>
         /// <param name="configuration">The subscription configuration that produced this data</param>
-        public DataFeedPacket(Security security, SubscriptionDataConfig configuration)
+        /// <param name="isSubscriptionRemoved">Reference to whether or not the subscription has since been removed, defaults to false</param>
+        public DataFeedPacket(Security security, SubscriptionDataConfig configuration, IReadOnlyRef<bool> isSubscriptionRemoved = null)
+            : this(security, configuration, new List<BaseData>(), isSubscriptionRemoved)
         {
-            Security = security;
-            Configuration = configuration;
-            _data = new List<BaseData>();
         }
 
         /// <summary>
@@ -78,11 +77,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="configuration">The subscription configuration that produced this data</param>
         /// <param name="data">The data to add to this packet. The list reference is reused
         /// internally and NOT copied.</param>
-        public DataFeedPacket(Security security, SubscriptionDataConfig configuration, List<BaseData> data)
+        /// <param name="isSubscriptionRemoved">Reference to whether or not the subscription has since been removed, defaults to false</param>
+        public DataFeedPacket(Security security, SubscriptionDataConfig configuration, List<BaseData> data, IReadOnlyRef<bool> isSubscriptionRemoved = null)
         {
             Security = security;
             Configuration = configuration;
-            _data = data;
+            Data = data;
+            _isRemoved = isSubscriptionRemoved ?? Ref.Create(false);
         }
 
         /// <summary>
@@ -91,7 +92,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="data">The data to be added to this packet</param>
         public void Add(BaseData data)
         {
-            _data.Add(data);
+            Data.Add(data);
         }
     }
 }

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -256,6 +256,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     return false;
                 }
 
+                // if the security is no longer a member of the universe, then mark the subscription properly
+                if (!subscription.Universe.Members.ContainsKey(configuration.Symbol))
+                {
+                    subscription.MarkAsRemovedFromUniverse();
+                }
                 subscription.Dispose();
                 Log.Debug("FileSystemDataFeed.RemoveSubscription(): Removed " + configuration);
 
@@ -464,7 +469,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             syncer.SubscriptionFinished += (sender, subscription) =>
             {
                 RemoveSubscription(subscription.Configuration);
-                Log.Debug(string.Format("FileSystemDataFeed.GetEnumerator(): Finished subscription: {0} at {1} UTC", subscription.Configuration, _algorithm.UtcTime));
+                Log.Debug($"FileSystemDataFeed.GetEnumerator(): Finished subscription: {subscription.Configuration} at {_algorithm.UtcTime} UTC");
             };
 
             while (!_cancellationTokenSource.IsCancellationRequested)

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -239,6 +239,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 _exchange.RemoveDataHandler(security.Symbol);
             }
 
+            // if the security is no longer a member of the universe, then mark the subscription properly
+            if (!subscription.Universe.Members.ContainsKey(configuration.Symbol))
+            {
+                subscription.MarkAsRemovedFromUniverse();
+            }
             subscription.Dispose();
 
             // keep track of security changes, we emit these to the algorithm
@@ -281,7 +286,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     foreach (var subscription in Subscriptions)
                     {
                         var config = subscription.Configuration;
-                        var packet = new DataFeedPacket(subscription.Security, config);
+                        var packet = new DataFeedPacket(subscription.Security, config, subscription.RemovedFromUniverse);
 
                         // dequeue data that is time stamped at or before this frontier
                         while (subscription.MoveNext() && subscription.Current != null)

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using NodaTime;
-using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
 
@@ -94,7 +93,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         }
                     }
 
-                    var packet = new DataFeedPacket(subscription.Security, subscription.Configuration);
+                    var packet = new DataFeedPacket(subscription.Security, subscription.Configuration, subscription.RemovedFromUniverse);
 
                     while (subscription.Current.EmitTimeUtc <= _frontier)
                     {
@@ -170,7 +169,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     universeDataForTimeSliceCreate[universe] = baseDataCollection;
                     newChanges += _universeSelection.ApplyUniverseSelection(universe, _frontier, baseDataCollection);
                 }
-                universeData.Clear();;
+                universeData.Clear();
 
                 changes += newChanges;
             }

--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -158,6 +158,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // ensure we read equity data before option data, so we can set the current underlying price
             foreach (var packet in data)
             {
+                // filter out packets for removed subscriptions
+                if (packet.IsSubscriptionRemoved)
+                {
+                    continue;
+                }
+
                 var list = packet.Data;
                 var symbol = packet.Security.Symbol;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
If we pull data and on the same time step that security gets removed,
we can still get that data in OnData(Slice) even though it was removed.
This change filters out removed securities by tracking a reference to
the subscription's disposed flag. Another change was made to wait until
the end of the time step to dispose of subscriptions.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1604 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a security is removed from a universe we should stop receiving data for that security.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Regression tests updated to confirm slice data matches active securities.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed. (those that pass on master)
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->