### PR TITLE
Add Guaranteed VWAP Order Type

### DIFF
--- a/Algorithm.CSharp/GuaranteedVwapRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/GuaranteedVwapRegressionAlgorithm.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Brokerages;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm for guaranteed Volume Weighted Average Price orders.
+    /// This algorithm shows how to submit VWAP orders.
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="using quantconnect" />
+    /// <meta name="tag" content="trading and orders" />
+    public class GuaranteedVwapRegressionAlgorithm : QCAlgorithm
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 08);
+            SetEndDate(2013, 10, 11);
+            SetCash(100000);
+
+            SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage);
+            AddEquity("SPY", Resolution.Minute);
+
+            // The guaranteed VWAP order will be submitted in pre-market,
+            // so we warmup one day to ensure we have a price for the security
+            // when the first order is submitted.
+            SetWarmUp(TimeSpan.FromDays(1));
+
+            // IB will only accept Guaranteed VWAP orders at or before 9.29 AM,
+            // so LEAN requires them to be submitted at least one minute earlier.
+
+            // Guaranteed VWAP orders must be submitted at or before 9:28 AM
+            Schedule.On(DateRules.EveryDay(), TimeRules.At(9, 15), EveryDayBeforeMarketOpen);
+        }
+
+        private void EveryDayBeforeMarketOpen()
+        {
+            Debug($"Submitting VWAP order at: {Time}");
+
+            // Submit the VWAP order
+            VwapOrder("SPY", 100);
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Debug($"OnOrderEvent(): {Time}: {orderEvent}");
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -89,6 +89,7 @@
     <Compile Include="AddRemoveOptionUniverseRegressionAlgorithm.cs" />
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
     <Compile Include="OptionDataNullReferenceRegressionAlgorithm.cs" />
+    <Compile Include="GuaranteedVwapRegressionAlgorithm.cs" />
     <Compile Include="CancelOpenOrdersRegressionAlgorithm.cs" />
     <Compile Include="ConvertToFrameworkAlgorithm.cs" />
     <Compile Include="RawPricesCoarseUniverseAlgorithm.cs" />

--- a/Algorithm.Python/GuaranteedVwapRegressionAlgorithm.py
+++ b/Algorithm.Python/GuaranteedVwapRegressionAlgorithm.py
@@ -1,0 +1,60 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Brokerages import *
+from datetime import timedelta
+
+### <summary>
+### Regression algorithm for guaranteed Volume Weighted Average Price orders.
+### This algorithm shows how to submit VWAP orders.
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="using quantconnect" />
+### <meta name="tag" content="trading and orders" />
+class GuaranteedVwapRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 8)
+        self.SetEndDate(2013, 10, 11)
+        self.SetCash(100000)
+
+        self.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage)
+        self.AddEquity("SPY", Resolution.Minute)
+
+        # The guaranteed VWAP order will be submitted in pre-market,
+        # so we warmup one day to ensure we have a price for the security
+        # when the first order is submitted.
+        self.SetWarmUp(timedelta(days=1))
+
+        # IB will only accept Guaranteed VWAP orders at or before 9.29 AM,
+        # so LEAN requires them to be submitted at least one minute earlier.
+
+        # Guaranteed VWAP orders must be submitted at or before 9:29 AM
+        self.Schedule.On(self.DateRules.EveryDay(), self.TimeRules.At(9, 15), self.EveryDayBeforeMarketOpen)
+
+    def EveryDayBeforeMarketOpen(self):
+        self.Debug(f"Submitting VWAP order at: {self.Time}")
+
+        # Submit the VWAP order
+        self.VwapOrder("SPY", 100)
+
+    def OnOrderEvent(self, orderEvent):
+        self.Debug(f"{self.Time} {orderEvent}")

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -176,6 +176,9 @@
   <ItemGroup>
     <None Include="OptionDataNullReferenceRegressionAlgorithm.py" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="GuaranteedVwapRegressionAlgorithm.py" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent Condition="'$(OS)' == 'Windows_NT' ">

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -473,6 +473,51 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Send a guaranteed VWAP order to the transaction handler
+        /// </summary>
+        /// <param name="symbol">String symbol for the asset</param>
+        /// <param name="quantity">Quantity of shares for VWAP order</param>
+        /// <param name="tag">String tag for the order (optional)</param>
+        /// <returns>Order id</returns>
+        public OrderTicket VwapOrder(Symbol symbol, int quantity, string tag = "")
+        {
+            return VwapOrder(symbol, (decimal)quantity, tag);
+        }
+
+        /// <summary>
+        /// Send a guaranteed VWAP order to the transaction handler
+        /// </summary>
+        /// <param name="symbol">String symbol for the asset</param>
+        /// <param name="quantity">Quantity of shares for VWAP order</param>
+        /// <param name="tag">String tag for the order (optional)</param>
+        /// <returns>Order id</returns>
+        public OrderTicket VwapOrder(Symbol symbol, double quantity, string tag = "")
+        {
+            return VwapOrder(symbol, (decimal)quantity, tag);
+        }
+
+        /// <summary>
+        /// Send a guaranteed VWAP order to the transaction handler
+        /// </summary>
+        /// <param name="symbol">String symbol for the asset</param>
+        /// <param name="quantity">Quantity of shares for VWAP order</param>
+        /// <param name="tag">String tag for the order (optional)</param>
+        /// <returns>Order id</returns>
+        public OrderTicket VwapOrder(Symbol symbol, decimal quantity, string tag = "")
+        {
+            var security = Securities[symbol];
+            var request = CreateSubmitOrderRequest(OrderType.Vwap, security, quantity, tag, properties: DefaultOrderProperties?.Clone());
+            var response = PreOrderChecks(request);
+            if (response.IsError)
+            {
+                return OrderTicket.InvalidSubmitRequest(Transactions, request, response);
+            }
+
+            //Add the order and create a new order Id.
+            return Transactions.AddOrder(request);
+        }
+
+        /// <summary>
         /// Send an exercise order to the transaction handler
         /// </summary>
         /// <param name="optionSymbol">String symbol for the option position</param>

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -352,6 +352,10 @@ namespace QuantConnect.Brokerages.Backtesting
                                     var option = (Option)security;
                                     fills = option.OptionExerciseModel.OptionExercise(option, order as OptionExerciseOrder).ToArray();
                                     break;
+
+                                case OrderType.Vwap:
+                                    fills = new[] { model.VwapFill(security, order as VwapOrder) };
+                                    break;
                             }
                         }
                         catch (Exception err)

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -785,6 +785,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 exchange = Market.CBOE.ToUpper();
             }
 
+            if (order.Type == OrderType.Vwap)
+            {
+                exchange = "VWAP";
+            }
+
             var contract = CreateContract(order.Symbol, exchange);
 
             int ibOrderId;
@@ -1769,6 +1774,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                         );
                     break;
 
+                case OrderType.Vwap:
+                    order = new VwapOrder(mappedSymbol,
+                        Convert.ToInt32(ibOrder.TotalQuantity) * quantitySign,
+                        new DateTime()
+                    );
+                    break;
+
                 default:
                     throw new InvalidEnumArgumentException("orderType", (int) orderType, typeof (OrderType));
             }
@@ -1855,7 +1867,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 case IB.ActionSide.Sell: return OrderDirection.Sell;
                 case IB.ActionSide.Undefined: return OrderDirection.Hold;
                 default:
-                    throw new ArgumentException(direction, "direction");
+                    throw new ArgumentException(direction, nameof(direction));
             }
         }
 
@@ -1870,7 +1882,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 case OrderDirection.Sell: return IB.ActionSide.Sell;
                 case OrderDirection.Hold: return IB.ActionSide.Undefined;
                 default:
-                    throw new InvalidEnumArgumentException("direction", (int) direction, typeof (OrderDirection));
+                    throw new InvalidEnumArgumentException(nameof(direction), (int) direction, typeof (OrderDirection));
             }
         }
 
@@ -1881,14 +1893,29 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             switch (type)
             {
-                case OrderType.Market:          return IB.OrderType.Market;
-                case OrderType.Limit:           return IB.OrderType.Limit;
-                case OrderType.StopMarket:      return IB.OrderType.Stop;
-                case OrderType.StopLimit:       return IB.OrderType.StopLimit;
-                case OrderType.MarketOnOpen:    return IB.OrderType.Market;
-                case OrderType.MarketOnClose:   return IB.OrderType.MarketOnClose;
+                case OrderType.Market:
+                    return IB.OrderType.Market;
+
+                case OrderType.Limit:
+                    return IB.OrderType.Limit;
+
+                case OrderType.StopMarket:
+                    return IB.OrderType.Stop;
+
+                case OrderType.StopLimit:
+                    return IB.OrderType.StopLimit;
+
+                case OrderType.MarketOnOpen:
+                    return IB.OrderType.Market;
+
+                case OrderType.MarketOnClose:
+                    return IB.OrderType.MarketOnClose;
+
+                case OrderType.Vwap:
+                    return IB.OrderType.VolumeWeightedAveragePrice;
+
                 default:
-                    throw new InvalidEnumArgumentException("type", (int)type, typeof(OrderType));
+                    throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(OrderType));
             }
         }
 
@@ -1899,10 +1926,20 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             switch (order.OrderType)
             {
-                case IB.OrderType.Limit:            return OrderType.Limit;
-                case IB.OrderType.Stop:             return OrderType.StopMarket;
-                case IB.OrderType.StopLimit:        return OrderType.StopLimit;
-                case IB.OrderType.MarketOnClose:    return OrderType.MarketOnClose;
+                case IB.OrderType.Limit:
+                    return OrderType.Limit;
+
+                case IB.OrderType.Stop:
+                    return OrderType.StopMarket;
+
+                case IB.OrderType.StopLimit:
+                    return OrderType.StopLimit;
+
+                case IB.OrderType.MarketOnClose:
+                    return OrderType.MarketOnClose;
+
+                case IB.OrderType.VolumeWeightedAveragePrice:
+                    return OrderType.Vwap;
 
                 case IB.OrderType.Market:
                     if (order.Tif == IB.TimeInForce.MarketOnOpen)
@@ -2041,7 +2078,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 // not sure how to map these guys
                 default:
-                    throw new ArgumentException(status, "status");
+                    throw new ArgumentException(status, nameof(status));
             }
         }
 
@@ -2071,7 +2108,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     throw new ArgumentException("InteractiveBrokers does not support SecurityType.Base");
 
                 default:
-                    throw new InvalidEnumArgumentException("type", (int)type, typeof(SecurityType));
+                    throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(SecurityType));
             }
         }
 
@@ -2108,7 +2145,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     return SecurityType.Base;
 
                 default:
-                    throw new ArgumentOutOfRangeException("type");
+                    throw new ArgumentOutOfRangeException(nameof(type));
             }
         }
 

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2007,7 +2007,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 return IB.TimeInForce.MarketOnOpen;
             }
-            if (order.Type == OrderType.MarketOnClose)
+
+            if (order.Type == OrderType.MarketOnClose || order.Type == OrderType.Vwap)
             {
                 return IB.TimeInForce.Day;
             }

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -785,11 +785,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 exchange = Market.CBOE.ToUpper();
             }
 
-            if (order.Type == OrderType.Vwap)
-            {
-                exchange = "VWAP";
-            }
-
             var contract = CreateContract(order.Symbol, exchange);
 
             int ibOrderId;

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -50,19 +50,12 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Gets or sets the account type used by this model
         /// </summary>
-        public virtual AccountType AccountType
-        {
-            get;
-            private set;
-        }
+        public virtual AccountType AccountType { get; }
 
         /// <summary>
         /// Gets a map of the default markets to be used for each security type
         /// </summary>
-        public virtual IReadOnlyDictionary<SecurityType, string> DefaultMarkets
-        {
-            get { return DefaultMarketMap; }
-        }
+        public virtual IReadOnlyDictionary<SecurityType, string> DefaultMarkets => DefaultMarketMap;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
@@ -88,6 +81,19 @@ namespace QuantConnect.Brokerages
         public virtual bool CanSubmitOrder(Security security, Order order, out BrokerageMessageEvent message)
         {
             message = null;
+
+            // validate order type
+            if (order.Type == OrderType.Vwap)
+            {
+                // not supported
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    "This model does not support " + order.Type + " order type. " +
+                    "Please use the IB brokerage model: SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage)."
+                );
+
+                return false;
+            }
+
             return true;
         }
 
@@ -100,6 +106,20 @@ namespace QuantConnect.Brokerages
         /// <param name="message">If this function returns false, a brokerage message detailing why the order may not be updated</param>
         /// <returns>True if the brokerage would allow updating the order, false otherwise</returns>
         public virtual bool CanUpdateOrder(Security security, Order order, UpdateOrderRequest request, out BrokerageMessageEvent message)
+        {
+            message = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if the brokerage would allow canceling the order as specified by the request
+        /// </summary>
+        /// <param name="security">The security of the order</param>
+        /// <param name="order">The order to be cancelled</param>
+        /// <param name="request">The order cancellation request</param>
+        /// <param name="message">If this function returns false, a brokerage message detailing why the order may not be cancelled</param>
+        /// <returns>True if the brokerage would allow updating the order, false otherwise</returns>
+        public virtual bool CanCancelOrder(Security security, Order order, CancelOrderRequest request, out BrokerageMessageEvent message)
         {
             message = null;
             return true;

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -67,6 +67,16 @@ namespace QuantConnect.Brokerages
         bool CanUpdateOrder(Security security, Order order, UpdateOrderRequest request, out BrokerageMessageEvent message);
 
         /// <summary>
+        /// Returns true if the brokerage would allow canceling the order as specified by the request
+        /// </summary>
+        /// <param name="security">The security of the order</param>
+        /// <param name="order">The order to be cancelled</param>
+        /// <param name="request">The order cancellation request</param>
+        /// <param name="message">If this function returns false, a brokerage message detailing why the order may not be cancelled</param>
+        /// <returns>True if the brokerage would allow updating the order, false otherwise</returns>
+        bool CanCancelOrder(Security security, Order order, CancelOrderRequest request, out BrokerageMessageEvent message);
+
+        /// <summary>
         /// Returns true if the brokerage would be able to execute this order at this time assuming
         /// market prices are sufficient for the fill to take place. This is used to emulate the
         /// brokerage fills in backtesting and paper trading. For example some brokerages may not perform

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -29,7 +29,6 @@ using NodaTime;
 using Python.Runtime;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
-using QuantConnect.Util;
 using Timer = System.Timers.Timer;
 
 namespace QuantConnect
@@ -951,22 +950,27 @@ namespace QuantConnect
                     var limitOrder = order as LimitOrder;
                     limitPrice = limitOrder.LimitPrice;
                     break;
+
                 case OrderType.StopMarket:
                     var stopMarketOrder = order as StopMarketOrder;
                     stopPrice = stopMarketOrder.StopPrice;
                     break;
+
                 case OrderType.StopLimit:
                     var stopLimitOrder = order as StopLimitOrder;
                     stopPrice = stopLimitOrder.StopPrice;
                     limitPrice = stopLimitOrder.LimitPrice;
                     break;
+
                 case OrderType.OptionExercise:
                 case OrderType.Market:
                 case OrderType.MarketOnOpen:
                 case OrderType.MarketOnClose:
+                case OrderType.Vwap:
                     limitPrice = order.Price;
                     stopPrice = order.Price;
                     break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Common/Orders/Fills/IFillModel.cs
+++ b/Common/Orders/Fills/IFillModel.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -69,5 +69,13 @@ namespace QuantConnect.Orders.Fills
         /// <param name="order">Order to be filled</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
         OrderEvent MarketOnCloseFill(Security asset, MarketOnCloseOrder order);
+
+        /// <summary>
+        /// Volume Weighted Average Price Fill Model. Return an order event with the fill details
+        /// </summary>
+        /// <param name="asset">Asset we're trading with this order</param>
+        /// <param name="order">Order to be filled</param>
+        /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        OrderEvent VwapFill(Security asset, VwapOrder order);
     }
 }

--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -340,9 +340,14 @@ namespace QuantConnect.Orders
                     order = new OptionExerciseOrder(request.Symbol, request.Quantity, request.Time, request.Tag, request.OrderProperties);
                     break;
 
+                case OrderType.Vwap:
+                    order = new VwapOrder(request.Symbol, request.Quantity, request.Time, request.Tag, request.OrderProperties);
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+
             order.Status = OrderStatus.New;
             order.Id = request.OrderId;
             if (request.Tag != null)

--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -53,7 +53,12 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Option Exercise Order Type
         /// </summary>
-        OptionExercise
+        OptionExercise,
+
+        /// <summary>
+        /// Volume Weighted Average Price order type - guaranteed VWAP fill at market close
+        /// </summary>
+        Vwap
     }
 
     /// <summary>

--- a/Common/Orders/VwapOrder.cs
+++ b/Common/Orders/VwapOrder.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Orders
+{
+    /// <summary>
+    /// Guaranteed Volume Weighted Average Price (VWAP) order type
+    /// </summary>
+    public class VwapOrder : Order
+    {
+        /// <summary>
+        /// Guaranteed VWAP Order Type
+        /// </summary>
+        public override OrderType Type => OrderType.Vwap;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VwapOrder"/> class.
+        /// </summary>
+        public VwapOrder()
+        {
+        }
+
+        /// <summary>
+        /// Intiializes a new instance of the <see cref="VwapOrder"/> class.
+        /// </summary>
+        /// <param name="symbol">The security's symbol being ordered</param>
+        /// <param name="quantity">The number of units to order</param>
+        /// <param name="time">The current time</param>
+        /// <param name="tag">A user defined tag for the order</param>
+        /// <param name="properties">The order properties for this order</param>
+        public VwapOrder(Symbol symbol, decimal quantity, DateTime time, string tag = "", IOrderProperties properties = null)
+            : base(symbol, quantity, time, tag, properties)
+        {
+        }
+
+        /// <summary>
+        /// Gets the order value in units of the security's quote currency
+        /// </summary>
+        /// <param name="security">The security matching this order's symbol</param>
+        protected override decimal GetValueImpl(Security security)
+        {
+            return Quantity * security.Price;
+        }
+
+        /// <summary>
+        /// Creates a deep-copy clone of this order
+        /// </summary>
+        /// <returns>A copy of this order</returns>
+        public override Order Clone()
+        {
+            var order = new VwapOrder();
+            CopyTo(order);
+            return order;
+        }
+    }
+}

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -136,6 +136,22 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
+        /// Returns true if the brokerage would allow canceling the order as specified by the request
+        /// </summary>
+        /// <param name="security">The security of the order</param>
+        /// <param name="order">The order to be cancelled</param>
+        /// <param name="request">The order cancellation request</param>
+        /// <param name="message">If this function returns false, a brokerage message detailing why the order may not be cancelled</param>
+        /// <returns>True if the brokerage would allow updating the order, false otherwise</returns>
+        public bool CanCancelOrder(Security security, Order order, CancelOrderRequest request, out BrokerageMessageEvent message)
+        {
+            using (Py.GIL())
+            {
+                return _model.CanCancelOrder(security, order, out message);
+            }
+        }
+
+        /// <summary>
         /// Gets a new fee model that represents this brokerage's fee structure
         /// </summary>
         /// <param name="security">The security to get a fee model for</param>

--- a/Common/Python/FillModelPythonWrapper.cs
+++ b/Common/Python/FillModelPythonWrapper.cs
@@ -119,5 +119,19 @@ namespace QuantConnect.Python
                 return _model.StopMarketFill(asset, order);
             }
         }
+
+        /// <summary>
+        /// Volume Weighted Average Price Fill Model. Return an order event with the fill details
+        /// </summary>
+        /// <param name="asset">Asset we're trading with this order</param>
+        /// <param name="order">Order to be filled</param>
+        /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        public OrderEvent VwapFill(Security asset, VwapOrder order)
+        {
+            using (Py.GIL())
+            {
+                return _model.VwapFill(asset, order);
+            }
+        }
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Orders\TimeInForces\GoodTilDateTimeInForce.cs" />
     <Compile Include="Orders\InteractiveBrokersOrderProperties.cs" />
     <Compile Include="Interfaces\IOrderProperties.cs" />
+    <Compile Include="Orders\VwapOrder.cs" />
     <Compile Include="Orders\OrderProperties.cs" />
     <Compile Include="Orders\OrderSubmissionData.cs" />
     <Compile Include="Orders\TimeInForce.cs" />

--- a/Common/Securities/SecurityTransactionModel.cs
+++ b/Common/Securities/SecurityTransactionModel.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Slippage;
 using QuantConnect.Securities.Interfaces;
 
-namespace QuantConnect.Securities 
+namespace QuantConnect.Securities
 {
     /// <summary>
     /// Default security transaction model for user defined securities.
@@ -90,9 +90,9 @@ namespace QuantConnect.Securities
         /// <seealso cref="StopMarketFill(Security, StopMarketOrder)"/>
         /// <seealso cref="LimitFill(Security, LimitOrder)"/>
         /// <remarks>
-        ///     There is no good way to model limit orders with OHLC because we never know whether the market has 
+        ///     There is no good way to model limit orders with OHLC because we never know whether the market has
         ///     gapped past our fill price. We have to make the assumption of a fluid, high volume market.
-        /// 
+        ///
         ///     Stop limit orders we also can't be sure of the order of the H - L values for the limit fill. The assumption
         ///     was made the limit fill will be done with closing price of the bar after the stop has been triggered..
         /// </remarks>
@@ -134,6 +134,17 @@ namespace QuantConnect.Securities
         public OrderEvent MarketOnCloseFill(Security asset, MarketOnCloseOrder order)
         {
             return _fillModel.MarketOnCloseFill(asset, order);
+        }
+
+        /// <summary>
+        /// Volume Weighted Average Price Fill Model. Return an order event with the fill details
+        /// </summary>
+        /// <param name="asset">Asset we're trading with this order</param>
+        /// <param name="order">Order to be filled</param>
+        /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        public OrderEvent VwapFill(Security asset, VwapOrder order)
+        {
+            return _fillModel.VwapFill(asset, order);
         }
 
         /// <summary>

--- a/Indicators/IntradayVwap.cs
+++ b/Indicators/IntradayVwap.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -1168,6 +1168,29 @@ namespace QuantConnect.Tests
                 {"Total Fees", "$1.50"},
             };
 
+            var guaranteedVwapRegressionAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "4"},
+                {"Average Win", "0%"},
+                {"Average Loss", "0%"},
+                {"Compounding Annual Return", "146.262%"},
+                {"Drawdown", "0.200%"},
+                {"Expectancy", "0"},
+                {"Net Profit", "1.060%"},
+                {"Sharpe Ratio", "9.392"},
+                {"Loss Rate", "0%"},
+                {"Win Rate", "0%"},
+                {"Profit-Loss Ratio", "0"},
+                {"Alpha", "0"},
+                {"Beta", "48.301"},
+                {"Annual Standard Deviation", "0.057"},
+                {"Annual Variance", "0.003"},
+                {"Information Ratio", "9.218"},
+                {"Tracking Error", "0.057"},
+                {"Treynor Ratio", "0.011"},
+                {"Total Fees", "$8.00"}
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp
@@ -1219,6 +1242,7 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("DelistingEventsAlgorithm", delistingEventsAlgorithm, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("RenkoConsolidatorAlgorithm", renkoConsolidatorStatistics, Language.CSharp),
                 new AlgorithmStatisticsTestParameters("DisplacedMovingAverageRibbon", displacedMovingAverageRibbonStatistics, Language.CSharp),
+                new AlgorithmStatisticsTestParameters("GuaranteedVwapRegressionAlgorithm", guaranteedVwapRegressionAlgorithmStatistics, Language.CSharp),
 
                 // Python
                 new AlgorithmStatisticsTestParameters("AddRemoveSecurityRegressionAlgorithm", addRemoveSecurityRegressionStatistics, Language.Python),
@@ -1260,7 +1284,8 @@ namespace QuantConnect.Tests
                 new AlgorithmStatisticsTestParameters("TimeInForceAlgorithm", timeInForceAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("SectorExposureRiskFrameworkAlgorithm", sectorExposureRiskFrameworkAlgorithmStatistics, Language.Python),
                 new AlgorithmStatisticsTestParameters("RenkoConsolidatorAlgorithm", renkoConsolidatorStatistics, Language.Python),
-                new AlgorithmStatisticsTestParameters("DisplacedMovingAverageRibbon", displacedMovingAverageRibbonStatistics, Language.Python)
+                new AlgorithmStatisticsTestParameters("DisplacedMovingAverageRibbon", displacedMovingAverageRibbonStatistics, Language.Python),
+                new AlgorithmStatisticsTestParameters("GuaranteedVwapRegressionAlgorithm", guaranteedVwapRegressionAlgorithmStatistics, Language.Python)
 
                 // FSharp
                 // new AlgorithmStatisticsTestParameters("BasicTemplateAlgorithm", basicTemplateStatistics, Language.FSharp),


### PR DESCRIPTION

#### Description
This PR adds support for a new order type only supported by Interactive Brokers, the **guaranteed** Volume Weighted Average Price (VWAP) order type:
https://www.interactivebrokers.com/en/index.php?f=603

#### Related Issue
#1093

#### Requires Documentation Change
Yes, this section will have to be updated to include the new order type:
https://www.quantconnect.com/docs/algorithm-reference/trading-and-orders

#### How Has This Been Tested?
New regression test, checking that VWAP orders are filled at market close.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`