### PR TITLE
Python version of framework models to subclass C# base classes

### DIFF
--- a/Algorithm.Framework/Alphas/AlphaModel.cs
+++ b/Algorithm.Framework/Alphas/AlphaModel.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
@@ -27,7 +28,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <summary>
         /// Defines a name for a framework model
         /// </summary>
-        public virtual string Name => GetType().Name;
+        public virtual string Name { get; set; }
+
+        public AlphaModel()
+        {
+            Name = Guid.NewGuid().ToString();
+        }
 
         /// <summary>
         /// Updates this alpha model with the latest data from the algorithm.

--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
@@ -35,11 +35,6 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private readonly Dictionary<Symbol, DateTime> _insightsTimeBySymbol;
 
         /// <summary>
-        /// Defines a name for a framework model
-        /// </summary>
-        public override string Name { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="ConstantAlphaModel"/> class
         /// </summary>
         /// <param name="type">The type of insight</param>

--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.py
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.py
@@ -16,10 +16,10 @@ AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Common")
 
 from QuantConnect import *
-from QuantConnect.Algorithm.Framework.Alphas import Insight, InsightType, InsightDirection
+from QuantConnect.Algorithm.Framework.Alphas import AlphaModel, Insight, InsightType, InsightDirection
 
 
-class ConstantAlphaModel:
+class ConstantAlphaModel(AlphaModel):
     ''' Provides an implementation of IAlphaModel that always returns the same insight for each security'''
 
     def __init__(self, type, direction, period, magnitude = None, confidence = None):

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
@@ -33,11 +33,6 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol;
 
         /// <summary>
-        /// Defines a name for a framework model
-        /// </summary>
-        public override string Name { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="EmaCrossAlphaModel"/> class
         /// </summary>
         /// <param name="fastPeriod">The fast EMA period</param>

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
@@ -21,7 +21,7 @@ from QuantConnect.Indicators import *
 from QuantConnect.Algorithm.Framework.Alphas import *
 
 
-class EmaCrossAlphaModel:
+class EmaCrossAlphaModel(AlphaModel):
     '''Alpha model that uses an EMA cross to create insights'''
 
     def __init__(self,

--- a/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.cs
@@ -26,17 +26,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas
     /// <summary>
     /// Alpha model that uses historical returns to create insights
     /// </summary>
-    public class HistoricalReturnsAlphaModel : IAlphaModel, INamedModel
+    public class HistoricalReturnsAlphaModel : AlphaModel
     {
         private readonly int _lookback;
         private readonly Resolution _resolution;
         private readonly TimeSpan _predictionInterval;
         private readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol;
-
-        /// <summary>
-        /// Defines a name for a framework model
-        /// </summary>
-        public string Name { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HistoricalReturnsAlphaModel"/> class

--- a/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.py
+++ b/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.py
@@ -21,7 +21,7 @@ from QuantConnect.Indicators import *
 from QuantConnect.Algorithm.Framework.Alphas import *
 from datetime import timedelta
 
-class HistoricalReturnsAlphaModel:
+class HistoricalReturnsAlphaModel(AlphaModel):
     '''Uses Historical returns to create insights.'''
 
     def __init__(self, *args, **kwargs):

--- a/Algorithm.Framework/Alphas/MacdAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/MacdAlphaModel.cs
@@ -38,11 +38,6 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private readonly Dictionary<Symbol, SymbolData> _symbolData;
 
         /// <summary>
-        /// Defines a name for a framework model
-        /// </summary>
-        public override string Name { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="MacdAlphaModel"/> class
         /// </summary>
         /// <param name="fastPeriod">The MACD fast period</param>

--- a/Algorithm.Framework/Alphas/MacdAlphaModel.py
+++ b/Algorithm.Framework/Alphas/MacdAlphaModel.py
@@ -21,7 +21,7 @@ from QuantConnect.Indicators import *
 from QuantConnect.Algorithm.Framework.Alphas import *
 
 
-class MacdAlphaModel:
+class MacdAlphaModel(AlphaModel):
     '''Defines a custom alpha model that uses MACD crossovers. The MACD signal line
     is used to generate up/down insights if it's stronger than the bounce threshold.
     If the MACD signal is within the bounce threshold then a flat price insight is returned.'''

--- a/Algorithm.Framework/Alphas/PairsTradingAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/PairsTradingAlphaModel.cs
@@ -33,11 +33,6 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private IndicatorBase<IndicatorDataPoint> _lowerThreshold;
 
         /// <summary>
-        /// Defines a name for a framework model
-        /// </summary>
-        public override string Name => $"{nameof(PairsTradingAlphaModel)}({_asset1},{_asset2},{_threshold.Normalize()})";
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PairsTradingAlphaModel"/> class
         /// </summary>
         /// <param name="asset1">The first asset's symbol in the pair</param>
@@ -48,6 +43,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             _asset1 = asset1;
             _asset2 = asset2;
             _threshold = threshold;
+            Name = $"{nameof(PairsTradingAlphaModel)}({_asset1},{_asset2},{_threshold.Normalize()})";
         }
 
         /// <summary>

--- a/Algorithm.Framework/Alphas/PairsTradingAlphaModel.py
+++ b/Algorithm.Framework/Alphas/PairsTradingAlphaModel.py
@@ -22,7 +22,7 @@ from QuantConnect.Algorithm.Framework.Alphas import *
 from datetime import timedelta
 from enum import Enum
 
-class PairsTradingAlphaModel:
+class PairsTradingAlphaModel(AlphaModel):
     '''This alpha model is designed to work against a single, predefined pair.
     This model generates alternating long ratio/short ratio insights emitted as a group'''
 

--- a/Algorithm.Framework/Alphas/RsiAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/RsiAlphaModel.cs
@@ -33,11 +33,6 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private readonly Resolution _resolution;
 
         /// <summary>
-        /// Defines a name for a framework model
-        /// </summary>
-        public override string Name { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="RsiAlphaModel"/> class
         /// </summary>
         /// <param name="period">The RSI indicator period</param>

--- a/Algorithm.Framework/Alphas/RsiAlphaModel.py
+++ b/Algorithm.Framework/Alphas/RsiAlphaModel.py
@@ -22,7 +22,7 @@ from QuantConnect.Algorithm.Framework.Alphas import *
 from datetime import timedelta
 from enum import Enum
 
-class RsiAlphaModel:
+class RsiAlphaModel(AlphaModel):
     '''Uses Wilder's RSI to create insights. 
     Using default settings, a cross over below 30 or above 70 will trigger a new insight.'''
 

--- a/Algorithm.Framework/Execution/ImmediateExecutionModel.py
+++ b/Algorithm.Framework/Execution/ImmediateExecutionModel.py
@@ -14,13 +14,14 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm.Framework")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Orders import *
+from QuantConnect.Algorithm.Framework.Execution import ExecutionModel
 
-
-class ImmediateExecutionModel:
+class ImmediateExecutionModel(ExecutionModel):
     '''Provides an implementation of IExecutionModel that immediately submits market orders to achieve the desired portfolio targets'''
 
     def Execute(self, algorithm, targets):
@@ -34,10 +35,3 @@ class ImmediateExecutionModel:
             quantity = target.Quantity - existing
             if quantity != 0:
                 algorithm.MarketOrder(target.Symbol, quantity)
-
-    def OnSecuritiesChanged(self, algorithm, changes):
-        '''Event fired each time the we add/remove securities from the data feed
-        Args:
-            algorithm: The algorithm instance that experienced the change in securities
-            changes: The security additions and removals from the algorithm'''
-        pass

--- a/Algorithm.Framework/Execution/NullExecutionModel.py
+++ b/Algorithm.Framework/Execution/NullExecutionModel.py
@@ -1,0 +1,21 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("QuantConnect.Algorithm.Framework")
+from QuantConnect.Algorithm.Framework.Execution import ExecutionModel
+
+class NullExecutionModel(ExecutionModel):
+    '''Provides an implementation of IExecutionModel that does nothing'''
+    def Execute(self, algorithm, targets):
+        return []

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
@@ -22,12 +22,12 @@ from QuantConnect import *
 from QuantConnect.Indicators import *
 from QuantConnect.Data.Market import TradeBar
 from QuantConnect.Orders import *
-from QuantConnect.Algorithm.Framework.Execution import OrderSizing
+from QuantConnect.Algorithm.Framework.Execution import ExecutionModel, OrderSizing
 from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTargetCollection
 import numpy as np
 
 
-class StandardDeviationExecutionModel:
+class StandardDeviationExecutionModel(ExecutionModel):
     '''Execution model that submits orders while the current market prices is at least the configured number of standard
      deviations away from the mean in the favorable direction (below/above for buy/sell respectively)'''
 

--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.py
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.py
@@ -22,13 +22,13 @@ from QuantConnect import *
 from QuantConnect.Indicators import *
 from QuantConnect.Data.Market import Tick, TradeBar
 from QuantConnect.Orders import *
-from QuantConnect.Algorithm.Framework.Execution import OrderSizing
+from QuantConnect.Algorithm.Framework.Execution import ExecutionModel, OrderSizing
 from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTargetCollection
 import numpy as np
 from datetime import datetime
 
 
-class VolumeWeightedAveragePriceExecutionModel:
+class VolumeWeightedAveragePriceExecutionModel(ExecutionModel):
     '''Execution model that submits orders while the current market price is more favorable that the current volume weighted average price.'''
 
     def __init__(self):

--- a/Algorithm.Framework/Portfolio/BlackLittermanPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanPortfolioConstructionModel.py
@@ -23,7 +23,7 @@ from QuantConnect.Indicators import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import *
-from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget
+from QuantConnect.Algorithm.Framework.Portfolio import PortfolioConstructionModel, PortfolioTarget
 from datetime import timedelta
 import numpy as np
 import pandas as pd
@@ -41,7 +41,7 @@ from numpy.linalg import inv
 ### The default model uses the 0.0025 as weight-on-views scalar parameter tau. The optimization method 
 ### maximizes the Sharpe ratio with the weight range from -1 to 1.
 ### </summary>
-class BlackLittermanPortfolioConstructionModel:
+class BlackLittermanPortfolioConstructionModel(PortfolioConstructionModel):
     def __init__(self, *args, **kwargs):
         """Initialize the model
         Args:

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
@@ -13,10 +13,10 @@
 
 from clr import AddReference
 AddReference("QuantConnect.Algorithm.Framework")
-from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget
+from QuantConnect.Algorithm.Framework.Portfolio import PortfolioConstructionModel, PortfolioTarget
 
 
-class EqualWeightingPortfolioConstructionModel:
+class EqualWeightingPortfolioConstructionModel(PortfolioConstructionModel):
     '''Provides an implementation of IPortfolioConstructionModel that gives equal weighting to all securities.
     The target percent holdings of each security is 1/N where N is the number of securities. 
     For insights of direction InsightDirection.Up, long targets are returned and

--- a/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
@@ -23,7 +23,7 @@ from QuantConnect.Indicators import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import *
-from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget
+from QuantConnect.Algorithm.Framework.Portfolio import PortfolioConstructionModel, PortfolioTarget
 from datetime import timedelta
 import numpy as np
 import pandas as pd
@@ -35,7 +35,7 @@ from scipy.optimize import minimize
 ### The default model uses the last three months daily price to calculate the optimal weight 
 ### with the weight range from -1 to 1 and minimize the portfolio variance with a target return of 2%
 ### </summary>
-class MeanVarianceOptimizationPortfolioConstructionModel:
+class MeanVarianceOptimizationPortfolioConstructionModel(PortfolioConstructionModel):
     def __init__(self, *args, **kwargs):
         """Initialize the model
         Args:

--- a/Algorithm.Framework/Portfolio/NullPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/NullPortfolioConstructionModel.py
@@ -15,11 +15,7 @@ from clr import AddReference
 AddReference("QuantConnect.Algorithm.Framework")
 from QuantConnect.Algorithm.Framework.Portfolio import PortfolioConstructionModel
 
-
-class NullPortfolioConstructionModel:
+class NullPortfolioConstructionModel(PortfolioConstructionModel):
     '''Provides an implementation of IPortfolioConstructionModel that does nothing'''
     def CreateTargets(self, algorithm, insights):
         return []
-
-    def OnSecuritiesChanged(self, algorithm, changes):
-        pass

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -155,6 +155,9 @@
     <Content Include="Risk\MaximumSectorExposureRiskManagementModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Risk\NullRiskManagementModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Selection\EmaCrossUniverseSelectionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -131,6 +131,9 @@
     <Content Include="Alphas\PairsTradingAlphaModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Execution\NullExecutionModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Execution\VolumeWeightedAveragePriceExecutionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.py
+++ b/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.py
@@ -17,8 +17,9 @@ AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Algorithm.Framework")
 
 from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget
+from QuantConnect.Algorithm.Framework.Risk import RiskManagementModel
 
-class MaximumDrawdownPercentPerSecurity():
+class MaximumDrawdownPercentPerSecurity(RiskManagementModel):
     '''Provides an implementation of IRiskManagementModel that limits the drawdown per holding to the specified percentage'''
 
     def __init__(self, maximumDrawdownPercent = 0.05):
@@ -44,10 +45,3 @@ class MaximumDrawdownPercentPerSecurity():
                 targets.append(PortfolioTarget(security.Symbol, 0))
 
         return targets
-
-    def OnSecuritiesChanged(self, algorithm, changes):
-        '''Event fired each time the we add/remove securities from the data feed
-        Args:
-            algorithm: The algorithm instance that experienced the change in securities
-            changes: The security additions and removals from the algorithm'''
-        pass

--- a/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.py
+++ b/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.py
@@ -17,9 +17,10 @@ AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Algorithm.Framework")
 
 from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget, PortfolioTargetCollection
+from QuantConnect.Algorithm.Framework.Risk import RiskManagementModel
 from itertools import groupby
 
-class MaximumSectorExposureRiskManagementModel():
+class MaximumSectorExposureRiskManagementModel(RiskManagementModel):
     '''Provides an implementation of IRiskManagementModel that that limits the sector exposure to the specified percentage'''
 
     def __init__(self, maximumSectorExposure = 0.20):
@@ -76,11 +77,3 @@ class MaximumSectorExposureRiskManagementModel():
                         risk_targets.append(PortfolioTarget(symbol, float(quantity) / ratio))
 
         return risk_targets
-
-
-    def OnSecuritiesChanged(self, algorithm, changes):
-        '''Event fired each time the we add/remove securities from the data feed
-        Args:
-            algorithm: The algorithm instance that experienced the change in securities
-            changes: The security additions and removals from the algorithm'''
-        pass

--- a/Algorithm.Framework/Risk/NullRiskManagementModel.py
+++ b/Algorithm.Framework/Risk/NullRiskManagementModel.py
@@ -1,0 +1,21 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("QuantConnect.Algorithm.Framework")
+from QuantConnect.Algorithm.Framework.Risk import RiskManagementModel
+
+class NullRiskManagementModel(RiskManagementModel):
+    '''Provides an implementation of IRiskManagementModel that does nothing'''
+    def ManageRisk(self, algorithm, targets):
+        return []

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -1051,7 +1052,7 @@ namespace QuantConnect
                 {
                     result = pyObject.AsManagedObject(typeof(T)) as T;
 
-                    if (typeof(T) == typeof(Type))
+                    if (typeof(T) == typeof(Type) || result is IEnumerable)
                     {
                         return true;
                     }

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1044,13 +1044,23 @@ namespace QuantConnect
             {
                 return true;
             }
-
+            
             using (Py.GIL())
             {
                 try
                 {
                     result = pyObject.AsManagedObject(typeof(T)) as T;
-                    return true;
+
+                    if (typeof(T) == typeof(Type))
+                    {
+                        return true;
+                    }
+
+                    // If the PyObject type and the managed object names are the same,
+                    // pyObject is a C# object wrapped in PyObject, in this case return true
+                    // Otherwise, pyObject is a python object that subclass a C# class.
+                    string name = (pyObject.GetPythonType() as dynamic).__name__;
+                    return name == result.GetType().Name;
                 }
                 catch
                 {

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -189,10 +189,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         /// <summary>
         /// To be override for model types that implement <see cref="INamedModel"/>
         /// </summary>
-        protected virtual string GetExpectedModelName(IAlphaModel model)
-        {
-            return model.GetType().Name;
-        }
+        protected abstract string GetExpectedModelName(IAlphaModel model);
 
         /// <summary>
         /// Provides derived types a chance to initialize anything special they require


### PR DESCRIPTION
#### Description
- Fixes Extensions.TryConvert:
  When a python class is a subclass of a C# class, `Extensions.TryConvert` should return `false`. Currenty it was returning true and the result was reduced to the parent class.
- Python execution models subclass C# ExecutionModel
- Python risk management models subclass C# RiskManagementModel 
- Python portfolio construction models subclass C# PortfolioConstructionModel

#### Related Issue
Address python component of #1991 

#### Motivation and Context
See #1996 

#### Requires Documentation Change
See #1996 

#### How Has This Been Tested?
Manually plugging each module in `BasicTemplateFrameworkAlgorithm`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`