### PR TITLE
Fix threading bug in EnqueueableEnumerator.MoveNext

### DIFF
--- a/Algorithm.CSharp/OptionDataNullReferenceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionDataNullReferenceRegressionAlgorithm.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This algorithm is a regression test for issue #2018 and PR #2038.
+    /// </summary>
+    public class OptionDataNullReferenceRegressionAlgorithm : QCAlgorithm
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2016, 12, 1);
+            SetEndDate(2017, 1, 1);
+            SetCash(500000);
+
+            AddEquity("DUST");
+
+            var option = AddOption("DUST");
+
+            option.SetFilter(u => u.IncludeWeeklys()
+                                   .Strikes(-1, +1)
+                                   .Expiration(TimeSpan.FromDays(25), TimeSpan.FromDays(100)));
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -87,6 +87,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
+    <Compile Include="OptionDataNullReferenceRegressionAlgorithm.cs" />
     <Compile Include="CancelOpenOrdersRegressionAlgorithm.cs" />
     <Compile Include="RawPricesCoarseUniverseAlgorithm.cs" />
     <Compile Include="CompositeAlphaModelFrameworkAlgorithm.cs" />

--- a/Algorithm.Python/OptionDataNullReferenceRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionDataNullReferenceRegressionAlgorithm.py
@@ -1,0 +1,41 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from datetime import timedelta
+
+### <summary>
+### This algorithm is a regression test for issue #2018 and PR #2038.
+### </summary>
+class OptionDataNullReferenceRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2016, 12, 1)
+        self.SetEndDate(2017, 1, 1)
+        self.SetCash(500000)
+
+        self.AddEquity("DUST")
+
+        option = self.AddOption("DUST")
+
+        option.SetFilter(self.UniverseFunc)
+
+    def UniverseFunc(self, universe):
+        return universe.IncludeWeeklys().Strikes(-1, +1).Expiration(timedelta(25), timedelta(100))

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -166,6 +166,9 @@
   <ItemGroup>
     <Folder Include="Benchmarks\" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="OptionDataNullReferenceRegressionAlgorithm.py" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent Condition="'$(OS)' == 'Windows_NT' ">

--- a/Engine/DataFeeds/Enumerators/EnqueueableEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/EnqueueableEnumerator.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,6 +35,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         private volatile bool _end;
         private volatile bool _disposed;
 
+        private readonly bool _isBlocking;
         private readonly int _timeout;
         private readonly object _lock = new object();
         private readonly BlockingCollection<T> _blockingCollection;
@@ -77,6 +78,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         public EnqueueableEnumerator(bool blocking = false)
         {
             _blockingCollection = new BlockingCollection<T>();
+            _isBlocking = blocking;
             _timeout = blocking ? Timeout.Infinite : 0;
         }
 
@@ -122,6 +124,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             if (!_blockingCollection.TryTake(out current, _timeout))
             {
                 _current = default(T);
+
+                // if the enumerator has blocking behavior and there is no more data, it has ended
+                if (_isBlocking)
+                {
+                    lock (_lock)
+                    {
+                        _end = true;
+                    }
+                }
+
                 return !_end;
             }
 

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -91,6 +91,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             OnSubscriptionFinished(subscription);
                             continue;
                         }
+
+                        if (subscription.Current == null)
+                        {
+                            throw new Exception($"SubscriptionSynchronizer.Sync(): subscription.Current is null, configuration: {subscription}");
+                        }
                     }
 
                     var packet = new DataFeedPacket(subscription.Security, subscription.Configuration, subscription.RemovedFromUniverse);


### PR DESCRIPTION

#### Description
With the enumerator in blocking mode (backtesting), `MoveNext` was returning `true` while `Current` was being set to `null`.

#### Related Issue
Closes #2018

#### Motivation and Context
This was causing a `NullReferenceException` in `SubscriptionSynchronizer.Sync`.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local and cloud backtests with the algorithm included in #2018

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`