### PR TITLE
Add null check for subscriptions w/out universes

### DIFF
--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -257,7 +257,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
 
                 // if the security is no longer a member of the universe, then mark the subscription properly
-                if (!subscription.Universe.Members.ContainsKey(configuration.Symbol))
+                if (subscription.Universe != null && !subscription.Universe.Members.ContainsKey(configuration.Symbol))
                 {
                     subscription.MarkAsRemovedFromUniverse();
                 }

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -240,7 +240,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             // if the security is no longer a member of the universe, then mark the subscription properly
-            if (!subscription.Universe.Members.ContainsKey(configuration.Symbol))
+            if (subscription.Universe != null && !subscription.Universe.Members.ContainsKey(configuration.Symbol))
             {
                 subscription.MarkAsRemovedFromUniverse();
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Internal forex currency conversion feeds are currently added without a corresponding universe which leads to throwing a null reference exception when the subscription gets removed at the end of the backtest.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
The following algorithm was throwing null reference exceptions at the end of the backtest:
``` csharp
namespace QuantConnect.Algorithm.CSharp
{
    public class County : QCAlgorithm
    {
        public override void Initialize()
        {
            SetStartDate(2018, 5, 2);
            SetEndDate(2018, 5, 10);
            SetCash(10000);
            AddForex("GBPJPY");
        }
        public override void OnData (Slice data)
        {
        }
    }
}
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevent exceptions from being thrown in non-exceptional cases.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally ran the above algorithm and located the cause of the null reference exception. This check was recently added as part of resolving #1604 (via #1999) and didn't take into account that some data subscriptions, namely internal currency conversion feeds, aren't in a universe. While placing these subscriptions in a universe makes the most long-term sense, for now this simple fix should hold us over.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->