### PR TITLE
Add null check for subscriptions w/out universes

### DIFF
--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -257,7 +257,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
 
                 // if the security is no longer a member of the universe, then mark the subscription properly
-                if (!subscription.Universe.Members.ContainsKey(configuration.Symbol))
+                if (subscription.Universe != null && !subscription.Universe.Members.ContainsKey(configuration.Symbol))
                 {
                     subscription.MarkAsRemovedFromUniverse();
                 }

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -240,7 +240,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             // if the security is no longer a member of the universe, then mark the subscription properly
-            if (!subscription.Universe.Members.ContainsKey(configuration.Symbol))
+            if (subscription.Universe != null && !subscription.Universe.Members.ContainsKey(configuration.Symbol))
             {
                 subscription.MarkAsRemovedFromUniverse();
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Adds null check on `subscription.Universe` in data feed `RemoveSubscription` implementations.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2045 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Algorithm should not throw errors in this case.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally tested the changes with the attached algorithm (see #2045).

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->