### PR TITLE
Fixes CreateUniverses method modifier

### DIFF
--- a/Algorithm.Framework/Selection/UniverseSelectionModelPythonWrapper.cs
+++ b/Algorithm.Framework/Selection/UniverseSelectionModelPythonWrapper.cs
@@ -17,7 +17,6 @@ using Python.Runtime;
 using QuantConnect.Data.UniverseSelection;
 using System;
 using System.Collections.Generic;
-using QuantConnect.Interfaces;
 
 namespace QuantConnect.Algorithm.Framework.Selection
 {
@@ -52,7 +51,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// </summary>
         /// <param name="algorithm">The algorithm instance to create universes for</param>
         /// <returns>The universes to be used by the algorithm</returns>
-        public virtual IEnumerable<Universe> CreateUniverses(QCAlgorithmFramework algorithm)
+        public override IEnumerable<Universe> CreateUniverses(QCAlgorithmFramework algorithm)
         {
             using (Py.GIL())
             {


### PR DESCRIPTION
#### Description
`UniverseSelectionModelPythonWrapper.CreateUniverses` method modifier should be `override` instead of `virtual`, since that class inherit from `UniverseSelectionModel`.

#### Related Issue
Closes #2053 

#### How Has This Been Tested?
Running `EmaCrossUniverseSelectionFrameworkAlgorithm.py`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`