### PR TITLE
Add refresh to IUniverseSelectionModel to support dynamic universes

### DIFF
--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -1,0 +1,151 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Basic template options framework algorithm uses framework components to define an algorithm
+    /// that trades options.
+    /// </summary>
+    public class BasicTemplateOptionsFrameworkAlgorithm : QCAlgorithmFramework
+    {
+        public override void Initialize()
+        {
+            UniverseSettings.Resolution = Resolution.Minute;
+
+            SetStartDate(2014, 06, 05);
+            SetEndDate(2014, 06, 06);
+            SetCash(100000);
+
+            // set framework models
+            SetUniverseSelection(new EarliestExpiringWeeklyAtTheMoneyPutOptionUniverseSelectionModel(SelectOptionChainSymbols));
+            SetAlpha(new ConstantOptionContractAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromHours(0.5)));
+            SetPortfolioConstruction(new SingleSharePortofioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetRiskManagement(new NullRiskManagementModel());
+        }
+
+        public override void OnOrderEvent(OrderEvent fill)
+        {
+            Log($"{UtcTime}:: {fill}");
+        }
+
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            Log($"{UtcTime}:: {changes}");
+        }
+
+        // option symbol universe selection function
+        private static IEnumerable<Symbol> SelectOptionChainSymbols(DateTime utcTime)
+        {
+            var newYorkTime = utcTime.ConvertFromUtc(TimeZones.NewYork);
+            if (newYorkTime.Date < new DateTime(2014, 06, 06))
+            {
+                yield return QuantConnect.Symbol.Create("TWX", SecurityType.Option, Market.USA, "?TWX");
+            }
+
+            if (newYorkTime.Date >= new DateTime(2014, 06, 06))
+            {
+                yield return QuantConnect.Symbol.Create("AAPL", SecurityType.Option, Market.USA, "?AAPL");
+            }
+        }
+
+        /// <summary>
+        /// Creates option chain universes that select only the earliest expiry ATM weekly put contract
+        /// and runs a user defined optionChainSymbolSelector every day to enable choosing different option chains
+        /// </summary>
+        class EarliestExpiringWeeklyAtTheMoneyPutOptionUniverseSelectionModel : OptionUniverseSelectionModel
+        {
+            public EarliestExpiringWeeklyAtTheMoneyPutOptionUniverseSelectionModel(Func<DateTime, IEnumerable<Symbol>> optionChainSymbolSelector)
+                : base(TimeSpan.FromDays(1), optionChainSymbolSelector)
+            {
+            }
+
+            /// <summary>
+            /// Configure generated securities
+            /// </summary>
+            /// <param name="optionChain"></param>
+            protected override void ConfigureOptionChainSecurity(Option optionChain)
+            {
+                // configure option chain filter to desired limit contracts
+                optionChain.SetFilter(filter =>
+                {
+                    return filter
+                        // limit options contracts to a maximum of 180 days in the future
+                        .Strikes(+1, +1)
+                        .Expiration(TimeSpan.Zero, TimeSpan.FromDays(7))
+                        .WeeklysOnly()
+                        .Contracts(contracts => contracts.Where(x => x.ID.OptionRight == OptionRight.Put))
+                        .OnlyApplyFilterAtMarketOpen();
+                });
+            }
+        }
+
+        /// <summary>
+        /// Implementation of a constant alpha model that only emits insights for option symbols
+        /// </summary>
+        class ConstantOptionContractAlphaModel : ConstantAlphaModel
+        {
+            public ConstantOptionContractAlphaModel(InsightType type, InsightDirection direction, TimeSpan period)
+                : base(type, direction, period)
+            {
+            }
+
+            protected override bool ShouldEmitInsight(DateTime utcTime, Symbol symbol)
+            {
+                // only emit alpha for option symbols and not underlying equity symbols
+                if (symbol.SecurityType != SecurityType.Option)
+                {
+                    return false;
+                }
+
+                return base.ShouldEmitInsight(utcTime, symbol);
+            }
+        }
+
+        /// <summary>
+        /// Portoflio construction model that sets target quantities to 1 for up insights and -1 for down insights
+        /// </summary>
+        class SingleSharePortofioConstructionModel : IPortfolioConstructionModel
+        {
+            public IEnumerable<IPortfolioTarget> CreateTargets(QCAlgorithmFramework algorithm, Insight[] insights)
+            {
+                foreach (var insight in insights)
+                {
+                    yield return new PortfolioTarget(insight.Symbol, (int) insight.Direction);
+                }
+            }
+
+            public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+            {
+                // no need to track anything here
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -25,7 +25,6 @@ using QuantConnect.Algorithm.Framework.Selection;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
-using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -88,22 +87,16 @@ namespace QuantConnect.Algorithm.CSharp
             }
 
             /// <summary>
-            /// Configure generated securities
+            /// Defines the option chain universe filter
             /// </summary>
-            /// <param name="optionChain"></param>
-            protected override void ConfigureOptionChainSecurity(Option optionChain)
+            protected override OptionFilterUniverse Filter(OptionFilterUniverse filter)
             {
-                // configure option chain filter to desired limit contracts
-                optionChain.SetFilter(filter =>
-                {
-                    return filter
-                        // limit options contracts to a maximum of 180 days in the future
-                        .Strikes(+1, +1)
-                        .Expiration(TimeSpan.Zero, TimeSpan.FromDays(7))
-                        .WeeklysOnly()
-                        .Contracts(contracts => contracts.Where(x => x.ID.OptionRight == OptionRight.Put))
-                        .OnlyApplyFilterAtMarketOpen();
-                });
+                return filter
+                    .Strikes(+1, +1)
+                    .Expiration(TimeSpan.Zero, TimeSpan.FromDays(7))
+                    .WeeklysOnly()
+                    .Contracts(contracts => contracts.Where(x => x.ID.OptionRight == OptionRight.Put))
+                    .OnlyApplyFilterAtMarketOpen();
             }
         }
 

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -88,6 +88,7 @@
     </Compile>
     <Compile Include="AddRemoveOptionUniverseRegressionAlgorithm.cs" />
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
+    <Compile Include="BasicTemplateOptionsFrameworkAlgorithm.cs" />
     <Compile Include="OptionDataNullReferenceRegressionAlgorithm.cs" />
     <Compile Include="CancelOpenOrdersRegressionAlgorithm.cs" />
     <Compile Include="ConvertToFrameworkAlgorithm.cs" />

--- a/Algorithm.Framework/QCAlgorithmFramework.cs
+++ b/Algorithm.Framework/QCAlgorithmFramework.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Algorithm.Framework
         /// <param name="slice">The current data slice</param>
         public sealed override void OnFrameworkData(Slice slice)
         {
-            if (UtcTime >= UniverseSelection.NextRefreshTimeUtc)
+            if (UtcTime >= UniverseSelection.GetNextRefreshTimeUtc())
             {
                 var universes = UniverseSelection.CreateUniverses(this).ToDictionary(u => u.Configuration.Symbol);
 

--- a/Algorithm.Framework/QCAlgorithmFramework.cs
+++ b/Algorithm.Framework/QCAlgorithmFramework.cs
@@ -128,6 +128,48 @@ namespace QuantConnect.Algorithm.Framework
         /// <param name="slice">The current data slice</param>
         public sealed override void OnFrameworkData(Slice slice)
         {
+            if (UtcTime >= UniverseSelection.NextRefreshTimeUtc)
+            {
+                var universes = UniverseSelection.CreateUniverses(this).ToDictionary(u => u.Configuration.Symbol);
+
+                // remove deselected universes by symbol
+                foreach (var ukvp in UniverseManager)
+                {
+                    var universeSymbol = ukvp.Key;
+                    var qcUserDefined = UserDefinedUniverse.CreateSymbol(ukvp.Value.SecurityType, ukvp.Value.Market);
+                    if (universeSymbol.Equals(qcUserDefined))
+                    {
+                        // prevent removal of qc algorithm created user defined universes
+                        continue;
+                    }
+
+                    Universe universe;
+                    if (!universes.TryGetValue(universeSymbol, out universe))
+                    {
+                        if (ukvp.Value.DisposeRequested)
+                        {
+                            UniverseManager.Remove(universeSymbol);
+                        }
+
+                        // mark this universe as disposed to remove all child subscriptions
+                        ukvp.Value.Dispose();
+                    }
+                }
+
+                // add newly selected universes
+                foreach (var ukvp in universes)
+                {
+                    // note: UniverseManager.Add uses TryAdd, so don't need to worry about duplicates here
+                    UniverseManager.Add(ukvp);
+                }
+            }
+
+            // we only want to run universe selection if there's no data available in the slice
+            if (!slice.HasData)
+            {
+                return;
+            }
+
             // insight timestamping handled via InsightsGenerated event handler
             var insights = Alpha.Update(this, slice).ToArray();
 

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Alphas\ConstantAlphaModel.cs" />
     <Compile Include="Alphas\MacdAlphaModel.cs" />
     <Compile Include="Alphas\IAlphaModel.cs" />
+    <Compile Include="Selection\OptionUniverseSelectionModel.cs" />
     <Compile Include="Selection\ScheduledUniverseSelectionModel.cs" />
     <Compile Include="Selection\UniverseSelectionModel.cs" />
     <Compile Include="Selection\UniverseSelectionModelPythonWrapper.cs" />

--- a/Algorithm.Framework/Selection/IUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/IUniverseSelectionModel.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <summary>
         /// Gets the next time the framework should invoke the `CreateUniverses` method to refresh the set of universes.
         /// </summary>
-        DateTime NextRefreshTimeUtc { get; }
+        DateTime GetNextRefreshTimeUtc();
 
         /// <summary>
         /// Creates the universes for this algorithm. Called once after <see cref="IAlgorithm.Initialize"/>

--- a/Algorithm.Framework/Selection/IUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/IUniverseSelectionModel.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
@@ -24,6 +25,11 @@ namespace QuantConnect.Algorithm.Framework.Selection
     /// </summary>
     public interface IUniverseSelectionModel
     {
+        /// <summary>
+        /// Gets the next time the framework should invoke the `CreateUniverses` method to refresh the set of universes.
+        /// </summary>
+        DateTime NextRefreshTimeUtc { get; }
+
         /// <summary>
         /// Creates the universes for this algorithm. Called once after <see cref="IAlgorithm.Initialize"/>
         /// </summary>

--- a/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
@@ -1,0 +1,151 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.Framework.Selection
+{
+    public class OptionUniverseSelectionModel : UniverseSelectionModel
+    {
+        private DateTime _nextRefreshTimeUtc;
+
+        private readonly TimeSpan _refreshInterval;
+        private readonly UniverseSettings _universeSettings;
+        private readonly ISecurityInitializer _securityInitializer;
+        private readonly Func<DateTime, IEnumerable<Symbol>> _optionChainSymbolSelector;
+
+        public override DateTime NextRefreshTimeUtc => _nextRefreshTimeUtc;
+
+        public OptionUniverseSelectionModel(TimeSpan refreshInterval, Func<DateTime, IEnumerable<Symbol>> optionChainSymbolSelector)
+            : this(refreshInterval, optionChainSymbolSelector, null, null)
+        {
+        }
+
+        public OptionUniverseSelectionModel(TimeSpan refreshInterval,
+            Func<DateTime, IEnumerable<Symbol>> optionChainSymbolSelector,
+            UniverseSettings universeSettings,
+            ISecurityInitializer securityInitializer
+        )
+        {
+            _nextRefreshTimeUtc = DateTime.MinValue;
+
+            _refreshInterval = refreshInterval;
+            _universeSettings = universeSettings;
+            _securityInitializer = securityInitializer;
+            _optionChainSymbolSelector = optionChainSymbolSelector;
+        }
+
+        public override IEnumerable<Universe> CreateUniverses(QCAlgorithmFramework algorithm)
+        {
+            _nextRefreshTimeUtc = algorithm.UtcTime + _refreshInterval;
+
+            algorithm.Log($"OptionUniverseSelectionModel.CreateUniverse({algorithm.UtcTime}): Refreshing Universes");
+
+            var uniqueUnderlyingSymbols = new HashSet<Symbol>();
+            foreach (var optionSymbol in _optionChainSymbolSelector(algorithm.UtcTime))
+            {
+                if (optionSymbol.SecurityType != SecurityType.Option)
+                {
+                    throw new ArgumentException("optionChainSymbolSelector must return option symbols.");
+                }
+
+                // prevent creating duplicate option chains -- one per underlying
+                if (uniqueUnderlyingSymbols.Add(optionSymbol.Underlying))
+                {
+                    yield return CreateOptionChain(algorithm, optionSymbol);
+                }
+            }
+        }
+
+        protected virtual Option CreateOptionChainSecurity(QCAlgorithmFramework algorithm, Symbol symbol, UniverseSettings settings, ISecurityInitializer initializer)
+        {
+            algorithm.Log($"OptionUniverseSelectionModel.CreateOptionChainSecurity({algorithm.UtcTime}, {symbol}): Creating Option Chain Security");
+
+            var market = symbol.ID.Market;
+            var underlying = symbol.Underlying;
+
+            var marketHoursEntry = MarketHoursDatabase.FromDataFolder()
+                .GetEntry(market, underlying, SecurityType.Option);
+
+            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder()
+                .GetSymbolProperties(market, underlying, SecurityType.Option, CashBook.AccountCurrency);
+
+            var optionChain = (Option)SecurityManager.CreateSecurity(typeof(ZipEntryName), algorithm.Portfolio,
+                algorithm.SubscriptionManager, marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties,
+                initializer, symbol, settings.Resolution, settings.FillForward, settings.Leverage, settings.ExtendedMarketHours,
+                false, false, algorithm.LiveMode, false, false);
+
+            return optionChain;
+        }
+
+        /// <summary>
+        /// Configure the created option security, this can include setting filters or other custom set up actions against the security object
+        /// </summary>
+        /// <param name="optionChain">The option chain's security object</param>
+        protected virtual void ConfigureOptionChainSecurity(Option optionChain)
+        {
+            // NOP
+        }
+
+        private OptionChainUniverse CreateOptionChain(QCAlgorithmFramework algorithm, Symbol symbol)
+        {
+            if (symbol.SecurityType != SecurityType.Option)
+            {
+                throw new ArgumentException("CreateOptionChain requires an option symbol.");
+            }
+
+            algorithm.Log($"OptionUniverseSelectionModel.CreateOptionChain({algorithm.UtcTime}, {symbol}): Creating Option Chain");
+
+            // rewrite non-canonical symbols to be canonical
+            var market = symbol.ID.Market;
+            var underlying = symbol.Underlying;
+            if (!symbol.IsCanonical())
+            {
+                var alias = $"?{underlying.Value}";
+                symbol = Symbol.Create(underlying.Value, SecurityType.Option, market, alias);
+            }
+
+            // resolve defaults if not specified
+            var settings = _universeSettings ?? algorithm.UniverseSettings;
+            var initializer = _securityInitializer ?? algorithm.SecurityInitializer;
+
+            // create canonical security object, but don't duplicate if it already exists
+            Security security;
+            Option optionChain;
+            if (!algorithm.Securities.TryGetValue(symbol, out security))
+            {
+                optionChain = CreateOptionChainSecurity(algorithm, symbol, settings, initializer);
+            }
+            else
+            {
+                optionChain = (Option)security;
+
+                algorithm.Log($"OptionUniverseSelectionModel.CreateOptionChain({algorithm.UtcTime}, {symbol}): Resolved existing Option Chain Security");
+            }
+
+            ConfigureOptionChainSecurity(optionChain);
+
+            // force option chain security to not be directly tradable AFTER it's configured to ensure it's not overwritten
+            optionChain.IsTradable = false;
+
+            return new OptionChainUniverse(optionChain, settings, initializer, algorithm.LiveMode);
+        }
+    }
+}

--- a/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
@@ -96,12 +96,12 @@ namespace QuantConnect.Algorithm.Framework.Selection
         }
 
         /// <summary>
-        /// Configure the created option security, this can include setting filters or other custom set up actions against the security object
+        /// Defines the option chain universe filter
         /// </summary>
-        /// <param name="optionChain">The option chain's security object</param>
-        protected virtual void ConfigureOptionChainSecurity(Option optionChain)
+        protected virtual OptionFilterUniverse Filter(OptionFilterUniverse filter)
         {
             // NOP
+            return filter;
         }
 
         private OptionChainUniverse CreateOptionChain(QCAlgorithmFramework algorithm, Symbol symbol)
@@ -140,7 +140,8 @@ namespace QuantConnect.Algorithm.Framework.Selection
                 algorithm.Log($"OptionUniverseSelectionModel.CreateOptionChain({algorithm.UtcTime}, {symbol}): Resolved existing Option Chain Security");
             }
 
-            ConfigureOptionChainSecurity(optionChain);
+            // set the option chain contract filter function
+            optionChain.SetFilter(Filter);
 
             // force option chain security to not be directly tradable AFTER it's configured to ensure it's not overwritten
             optionChain.IsTradable = false;

--- a/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
         private readonly ISecurityInitializer _securityInitializer;
         private readonly Func<DateTime, IEnumerable<Symbol>> _optionChainSymbolSelector;
 
-        public override DateTime NextRefreshTimeUtc => _nextRefreshTimeUtc;
+        public override DateTime GetNextRefreshTimeUtc() => _nextRefreshTimeUtc;
 
         public OptionUniverseSelectionModel(TimeSpan refreshInterval, Func<DateTime, IEnumerable<Symbol>> optionChainSymbolSelector)
             : this(refreshInterval, optionChainSymbolSelector, null, null)

--- a/Algorithm.Framework/Selection/UniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/UniverseSelectionModel.cs
@@ -28,7 +28,10 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <summary>
         /// Gets the next time the framework should invoke the `CreateUniverses` method to refresh the set of universes.
         /// </summary>
-        public virtual DateTime NextRefreshTimeUtc => DateTime.MaxValue;
+        public virtual DateTime GetNextRefreshTimeUtc()
+        {
+            return DateTime.MaxValue;
+        }
 
         /// <summary>
         /// Creates the universes for this algorithm. Called once after <see cref="IAlgorithm.Initialize"/>

--- a/Algorithm.Framework/Selection/UniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/UniverseSelectionModel.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
@@ -24,6 +25,11 @@ namespace QuantConnect.Algorithm.Framework.Selection
     /// </summary>
     public class UniverseSelectionModel : IUniverseSelectionModel
     {
+        /// <summary>
+        /// Gets the next time the framework should invoke the `CreateUniverses` method to refresh the set of universes.
+        /// </summary>
+        public virtual DateTime NextRefreshTimeUtc => DateTime.MaxValue;
+
         /// <summary>
         /// Creates the universes for this algorithm. Called once after <see cref="IAlgorithm.Initialize"/>
         /// </summary>

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -631,8 +631,10 @@ namespace QuantConnect.Lean.Engine
                     {
                         // EVENT HANDLER v3.0 -- all data in a single event
                         algorithm.OnData(timeSlice.Slice);
-                        algorithm.OnFrameworkData(timeSlice.Slice);
                     }
+
+                    // always turn the crank on this method to ensure universe selection models function properly on day changes w/out data
+                    algorithm.OnFrameworkData(timeSlice.Slice);
                 }
                 catch (Exception err)
                 {

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -63,6 +63,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             // Set the alpha model
             _algorithm.SetAlpha(model);
+            _algorithm.SetUniverseSelection(new ManualUniverseSelectionModel(_algorithm.Securities.Keys));
 
             var changes = new SecurityChanges(AddedSecurities, RemovedSecurities);
             _algorithm.OnFrameworkSecuritiesChanged(changes);

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -1168,6 +1168,42 @@ namespace QuantConnect.Tests
                 {"Total Fees", "$1.50"},
             };
 
+            var basicTemplateOptionsFrameworkAlgorithmStatistics = new Dictionary<string, string>
+            {
+                {"Total Trades", "4"},
+                {"Average Win", "0.14%"},
+                {"Average Loss", "0%"},
+                {"Compounding Annual Return", "74.140%"},
+                {"Drawdown", "0.700%"},
+                {"Expectancy", "0"},
+                {"Net Profit", "0.279%"},
+                {"Sharpe Ratio", "9.165"},
+                {"Loss Rate", "0%"},
+                {"Win Rate", "100%"},
+                {"Profit-Loss Ratio", "0"},
+                {"Alpha", "0"},
+                {"Beta", "25.476"},
+                {"Annual Standard Deviation", "0.026"},
+                {"Annual Variance", "0.001"},
+                {"Information Ratio", "8.891"},
+                {"Tracking Error", "0.025"},
+                {"Treynor Ratio", "0.009"},
+                {"Total Fees", "$1.00"},
+                {"Total Insights Generated", "26"},
+                {"Total Insights Closed", "24"},
+                {"Total Insights Analysis Completed", "6"},
+                {"Long Insight Count", "26"},
+                {"Short Insight Count", "0"},
+                {"Long/Short Ratio", "100%"},
+                {"Estimated Monthly Alpha Value", "$22.79625"},
+                {"Total Accumulated Estimated Alpha Value", "$1.51975"},
+                {"Mean Population Estimated Insight Value", "$0.06332292"},
+                {"Mean Population Direction", "33.3333%"},
+                {"Mean Population Magnitude", "0%"},
+                {"Rolling Averaged Population Direction", "92.3114%"},
+                {"Rolling Averaged Population Magnitude", "0%"},
+            };
+
             return new List<AlgorithmStatisticsTestParameters>
             {
                 // CSharp


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This change allows the universe selection model to select different universe definitions as time proceeds. This enables the definition of a universe model that, for example, could add option chains for securities selected by a different universe model.

The BasicTemplateOptionsFrameworkAlgorithm was added to showcase and provide regression for a universe model that selects different universes.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1977 -- also see #1967

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support of using derivative securities (options/futures) in the algorithm framework.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes, will need to showcase how to use the refresh time properly.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Regression tests updated to cover changes.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed. (all that were)
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->