### PR TITLE
Add price and split factors to CoarseFundamental class

### DIFF
--- a/Algorithm.CSharp/EmaCrossUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/EmaCrossUniverseSelectionAlgorithm.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.Algorithm.CSharp
                         // grab th SelectionData instance for this symbol
                         let avg = _averages.GetOrAdd(cf.Symbol, sym => new SelectionData())
                         // Update returns true when the indicators are ready, so don't accept until they are
-                        where avg.Update(cf.EndTime, cf.Price)
+                        where avg.Update(cf.EndTime, cf.AdjustedPrice)
                         // only pick symbols who have their 50 day ema over their 100 day ema
                         where avg.Fast > avg.Slow*(1 + Tolerance)
                         // prefer symbols with a larger delta by percentage between the two averages

--- a/Algorithm.Framework/Selection/EmaCrossUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/EmaCrossUniverseSelectionModel.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
         private readonly int _fastPeriod;
         private readonly int _slowPeriod;
         private readonly int _universeCount;
-        
+
         // holds our coarse fundamental indicators by symbol
         private readonly ConcurrentDictionary<Symbol, SelectionData> _averages;
 
@@ -49,7 +49,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
             int fastPeriod = 100,
             int slowPeriod = 300,
             int universeCount = 500,
-            UniverseSettings universeSettings = null, 
+            UniverseSettings universeSettings = null,
             ISecurityInitializer securityInitializer = null)
             : base(false, universeSettings, securityInitializer)
         {
@@ -71,7 +71,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
                         // grab th SelectionData instance for this symbol
                         let avg = _averages.GetOrAdd(cf.Symbol, sym => new SelectionData(_fastPeriod, _slowPeriod))
                         // Update returns true when the indicators are ready, so don't accept until they are
-                        where avg.Update(cf.EndTime, cf.Price)
+                        where avg.Update(cf.EndTime, cf.AdjustedPrice)
                         // only pick symbols who have their _fastPeriod-day ema over their _slowPeriod-day ema
                         where avg.Fast > avg.Slow * (1 + _tolerance)
                         // prefer symbols with a larger delta by percentage between the two averages

--- a/Algorithm.Framework/Selection/EmaCrossUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/EmaCrossUniverseSelectionModel.py
@@ -29,7 +29,7 @@ class EmaCrossUniverseSelectionModel(FundamentalUniverseSelectionModel):
                  fastPeriod = 100,
                  slowPeriod = 300,
                  universeCount = 500,
-                 universeSettings = None, 
+                 universeSettings = None,
                  securityInitializer = None):
         '''Initializes a new instance of the EmaCrossUniverseSelectionModel class
         Args:
@@ -64,7 +64,7 @@ class EmaCrossUniverseSelectionModel(FundamentalUniverseSelectionModel):
 
             # Update returns true when the indicators are ready, so don't accept until they are
             # and only pick symbols who have their fastPeriod-day ema over their slowPeriod-day ema
-            if avg.Update(cf.EndTime, cf.Price) and avg.Fast > avg.Slow * (1 + self.tolerance):
+            if avg.Update(cf.EndTime, cf.AdjustedPrice) and avg.Fast > avg.Slow * (1 + self.tolerance):
                 filtered.append(avg)
 
         # prefer symbols with a larger delta by percentage between the two averages

--- a/Algorithm.Python/EmaCrossUniverseSelectionAlgorithm.py
+++ b/Algorithm.Python/EmaCrossUniverseSelectionAlgorithm.py
@@ -63,7 +63,7 @@ class EmaCrossUniverseSelectionAlgorithm(QCAlgorithm):
 
             # Updates the SymbolData object with current EOD price
             avg = self.averages[cf.Symbol]
-            avg.update(cf.EndTime, cf.Price)
+            avg.update(cf.EndTime, cf.AdjustedPrice)
 
         # Filter the values of the dict: we only want up-trending securities
         values = list(filter(lambda x: x.is_uptrend, self.averages.values()))
@@ -73,7 +73,7 @@ class EmaCrossUniverseSelectionAlgorithm(QCAlgorithm):
 
         for x in values[:self.coarse_count]:
             self.Log('symbol: ' + str(x.symbol.Value) + '  scale: ' + str(x.scale))
-        
+
         # we need to return only the symbol objects
         return [ x.symbol for x in values[:self.coarse_count] ]
 

--- a/Common/Data/Auxiliary/FactorFile.cs
+++ b/Common/Data/Auxiliary/FactorFile.cs
@@ -114,6 +114,23 @@ namespace QuantConnect.Data.Auxiliary
         }
 
         /// <summary>
+        /// Gets price and split factors to be applied at the specified date
+        /// </summary>
+        public FactorFileRow GetScalingFactors(DateTime searchDate)
+        {
+            var factors = new FactorFileRow(searchDate, 1m, 1m);
+
+            // Iterate backwards to find the most recent factors
+            foreach (var splitDate in SortedFactorFileData.Keys.Reverse())
+            {
+                if (splitDate.Date < searchDate.Date) break;
+                factors = SortedFactorFileData[splitDate];
+            }
+
+            return factors;
+        }
+
+        /// <summary>
         /// Checks whether or not a symbol has scaling factors
         /// </summary>
         public static bool HasScalingFactors(string permtick, string market)

--- a/Common/Data/UniverseSelection/CoarseFundamental.cs
+++ b/Common/Data/UniverseSelection/CoarseFundamental.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,6 +44,26 @@ namespace QuantConnect.Data.UniverseSelection
         public bool HasFundamentalData { get; set; }
 
         /// <summary>
+        /// Gets the price factor for the given date
+        /// </summary>
+        public decimal PriceFactor { get; set; } = 1m;
+
+        /// <summary>
+        /// Gets the split factor for the given date
+        /// </summary>
+        public decimal SplitFactor { get; set; } = 1m;
+
+        /// <summary>
+        /// Gets the combined factor used to create adjusted prices from raw prices
+        /// </summary>
+        public decimal PriceScaleFactor => PriceFactor * SplitFactor;
+
+        /// <summary>
+        /// Gets the split and dividend adjusted price
+        /// </summary>
+        public decimal AdjustedPrice => Price * PriceScaleFactor;
+
+        /// <summary>
         /// The end time of this data.
         /// </summary>
         public override DateTime EndTime
@@ -61,7 +81,7 @@ namespace QuantConnect.Data.UniverseSelection
         }
 
         /// <summary>
-        /// Return the URL string source of the file. This will be converted to a stream 
+        /// Return the URL string source of the file. This will be converted to a stream
         /// </summary>
         /// <param name="config">Configuration object</param>
         /// <param name="date">Date of this source file</param>
@@ -74,8 +94,8 @@ namespace QuantConnect.Data.UniverseSelection
         }
 
         /// <summary>
-        /// Reader converts each line of the data source into BaseData objects. Each data type creates its own factory method, and returns a new instance of the object 
-        /// each time it is called. 
+        /// Reader converts each line of the data source into BaseData objects. Each data type creates its own factory method, and returns a new instance of the object
+        /// each time it is called.
         /// </summary>
         /// <param name="config">Subscription data config setup object</param>
         /// <param name="line">Line of the source document</param>
@@ -102,6 +122,12 @@ namespace QuantConnect.Data.UniverseSelection
                     coarse.HasFundamentalData = Convert.ToBoolean(csv[5]);
                 }
 
+                if (csv.Length > 7)
+                {
+                    coarse.PriceFactor = csv[6].ToDecimal();
+                    coarse.SplitFactor = csv[7].ToDecimal();
+                }
+
                 return coarse;
             }
             catch (Exception)
@@ -125,7 +151,9 @@ namespace QuantConnect.Data.UniverseSelection
                 Value = Value,
                 Volume = Volume,
                 DataType = MarketDataType.Auxiliary,
-                HasFundamentalData = HasFundamentalData
+                HasFundamentalData = HasFundamentalData,
+                PriceFactor = PriceFactor,
+                SplitFactor = SplitFactor
             };
         }
 

--- a/Tests/Common/Data/UniverseSelection/CoarseFundamentalTests.cs
+++ b/Tests/Common/Data/UniverseSelection/CoarseFundamentalTests.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Tests.Common.Data.UniverseSelection
+{
+    [TestFixture]
+    public class CoarseFundamentalTests
+    {
+        [Test, TestCaseSource(nameof(TestParameters))]
+        public void ParsesCoarseCsvLine(string line, bool hasFundamentalData, decimal price, decimal priceFactor, decimal splitFactor, decimal adjustedPrice)
+        {
+            var cf = new CoarseFundamental();
+
+            var config = new SubscriptionDataConfig(typeof(TradeBar),
+                Symbols.AAPL,
+                Resolution.Second,
+                TimeZones.NewYork,
+                TimeZones.NewYork,
+                false,
+                false,
+                false,
+                false,
+                TickType.Trade,
+                false);
+
+            cf = (CoarseFundamental)cf.Reader(config, line, DateTime.MinValue, false);
+
+            Assert.AreEqual(hasFundamentalData, cf.HasFundamentalData);
+            Assert.AreEqual(price, cf.Price);
+            Assert.AreEqual(priceFactor, cf.PriceFactor);
+            Assert.AreEqual(splitFactor, cf.SplitFactor);
+            Assert.AreEqual(adjustedPrice, cf.AdjustedPrice);
+        }
+
+        public static object[] TestParameters =
+        {
+            new object[] { "AAPL R735QTJ8XC9X,AAPL,537.46,5483955,3490219402,True", true, 537.46m, 1m, 1m, 537.46m },
+            new object[] { "AAPL R735QTJ8XC9X,AAPL,645.57,7831583,5055835037,True,0.9304792,0.142857", true, 645.57m, 0.9304792m, 0.142857m, 85.812693779220408m },
+            new object[] { "AAPL R735QTJ8XC9X,AAPL,93.7,37807206,3542535202,True,0.9304792,1", true, 93.7m, 0.9304792m, 1m, 87.18590104m },
+        };
+
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Common\CurrenciesTests.cs" />
     <Compile Include="Common\Data\Market\QuoteBarTests.cs" />
     <Compile Include="Common\Data\SubscriptionManagerTests.cs" />
+    <Compile Include="Common\Data\UniverseSelection\CoarseFundamentalTests.cs" />
     <Compile Include="Common\Exceptions\DllNotFoundPythonExceptionInterpreterTests.cs" />
     <Compile Include="Common\Exceptions\InvalidTokenPythonExceptionInterpreterTests.cs" />
     <Compile Include="Common\Exceptions\FakeExceptionInterpreter.cs" />

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -36,7 +36,7 @@
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <StartupObject>QuantConnect.ToolBox.KaikoDataConverter.Program</StartupObject>
+    <StartupObject>QuantConnect.ToolBox.CoarseUniverseGenerator.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">


### PR DESCRIPTION

#### Description
- Updated Coarse Generator to save two extra columns in the output CSV files: 
`PriceFactor` and `SplitFactor`
- Added new properties to `CoarseFundamental`: 
`PriceFactor`, `SplitFactor`, `PriceScaleFactor` and `AdjustedPrice`
- Added new regression test algorithm: `CoarseUniverseSplitRegressionAlgorithm`

#### Related Issue
Closes #2055 

#### Motivation and Context
Currently only the raw (not adjusted for splits and dividends) price is included in coarse data, so it is impossible to handle splits and dividends properly in coarse universes.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Full run of Coarse generator with all daily data
- New regression test for AAPL split (June 2014)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`