### PR TITLE
Refactor setting of insight close/generated times

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2038,7 +2038,7 @@ namespace QuantConnect.Algorithm
         /// Event invocator for the <see cref="InsightsGenerated"/> event
         /// </summary>
         /// <param name="insights">The collection of insights generaed at the current time step</param>
-        protected void OnInsightsGenerated(IEnumerable<Insight> insights)
+        protected virtual void OnInsightsGenerated(IEnumerable<Insight> insights)
         {
             InsightsGenerated?.Invoke(this, new GeneratedInsightsCollection(UtcTime, insights));
         }

--- a/Tests/Algorithm/Framework/QCAlgorithmFrameworkTests.cs
+++ b/Tests/Algorithm/Framework/QCAlgorithmFrameworkTests.cs
@@ -1,0 +1,87 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Tests.Common.Securities;
+
+namespace QuantConnect.Tests.Algorithm.Framework
+{
+    [TestFixture]
+    public class QCAlgorithmFrameworkTests
+    {
+        [Test]
+        public void SetsInsightGeneratedAndCloseTimes()
+        {
+            var eventFired = false;
+            var algo = new QCAlgorithmFramework();
+            algo.Transactions.SetOrderProcessor(new FakeOrderProcessor());
+            algo.InsightsGenerated += (algorithm, data) =>
+            {
+                eventFired = true;
+                var insights = data.Insights;
+                Assert.AreEqual(1, insights.Count);
+                Assert.IsTrue(insights.All(insight => insight.GeneratedTimeUtc != default(DateTime)));
+                Assert.IsTrue(insights.All(insight => insight.CloseTimeUtc != default(DateTime)));
+            };
+            algo.AddEquity("SPY");
+            algo.SetUniverseSelection(new ManualUniverseSelectionModel(algo.Securities.Keys));
+
+            var alpha = new FakeAlpha();
+            algo.SetAlpha(alpha);
+
+            var construction = new FakePortfolioConstruction();
+            algo.SetPortfolioConstruction(construction);
+
+            algo.OnFrameworkData(new Slice(new DateTime(2000, 01, 01), algo.Securities.Select(s => new Tick
+            {
+                Symbol = s.Key,
+                Value = 1,
+                Quantity = 2
+            })));
+
+            Assert.IsTrue(eventFired);
+            Assert.AreEqual(1, construction.Insights.Count);
+            Assert.IsTrue(construction.Insights.All(insight => insight.GeneratedTimeUtc != default(DateTime)));
+            Assert.IsTrue(construction.Insights.All(insight => insight.CloseTimeUtc != default(DateTime)));
+        }
+
+        class FakeAlpha : AlphaModel
+        {
+            public override IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data)
+            {
+                yield return Insight.Price(Symbols.SPY, TimeSpan.FromDays(1), InsightDirection.Up, .5, .75);
+            }
+        }
+
+        class FakePortfolioConstruction : PortfolioConstructionModel
+        {
+            public IReadOnlyCollection<Insight> Insights { get; private set; }
+            public override IEnumerable<IPortfolioTarget> CreateTargets(QCAlgorithmFramework algorithm, Insight[] insights)
+            {
+                Insights = insights;
+                return insights.Select(insight => PortfolioTarget.Percent(algorithm, insight.Symbol, 0.01m));
+            }
+        }
+    }
+}

--- a/Tests/Common/Securities/FakeOrderProcessor.cs
+++ b/Tests/Common/Securities/FakeOrderProcessor.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    /// <summary>
+    /// Provides a fake implementation of <see cref="IOrderProcessor"/> for tests
+    /// </summary>
+    public class FakeOrderProcessor : IOrderProcessor
+    {
+        private readonly ConcurrentDictionary<int, Order> _orders = new ConcurrentDictionary<int, Order>();
+        private readonly ConcurrentDictionary<int, OrderTicket> _tickets = new ConcurrentDictionary<int, OrderTicket>();
+        public void AddOrder(Order order)
+        {
+            _orders[order.Id] = order;
+        }
+
+        public void AddTicket(OrderTicket ticket)
+        {
+            _tickets[ticket.OrderId] = ticket;
+        }
+        public int OrdersCount { get; private set; }
+        public Order GetOrderById(int orderId)
+        {
+            Order order;
+            _orders.TryGetValue(orderId, out order);
+            return order;
+        }
+
+        public Order GetOrderByBrokerageId(string brokerageId)
+        {
+            return _orders.Values.FirstOrDefault(x => x.BrokerId.Contains(brokerageId));
+        }
+
+        public IEnumerable<OrderTicket> GetOrderTickets(Func<OrderTicket, bool> filter = null)
+        {
+            return _tickets.Values.Where(filter ?? (x => true));
+        }
+
+        public OrderTicket GetOrderTicket(int orderId)
+        {
+            OrderTicket ticket;
+            _tickets.TryGetValue(orderId, out ticket);
+            return ticket;
+        }
+
+        public IEnumerable<Order> GetOrders(Func<Order, bool> filter = null)
+        {
+            return _orders.Values.Where(filter ?? (x => true));
+        }
+
+        public OrderTicket Process(OrderRequest request)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -14,9 +14,6 @@
 */
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -104,7 +101,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             const int quantity = 1000;
             const decimal leverage = 2;
-            var orderProcessor = new OrderProcessor();
+            var orderProcessor = new FakeOrderProcessor();
             var portfolio = GetPortfolio(orderProcessor, quantity);
 
             var security = GetSecurity(Symbols.AAPL);
@@ -136,7 +133,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             const int quantity = 1000;
             const decimal leverage = 1m;
-            var orderProcessor = new OrderProcessor();
+            var orderProcessor = new FakeOrderProcessor();
             var portfolio = GetPortfolio(orderProcessor, quantity);
             portfolio.MarginCallModel = new DefaultMarginCallModel(portfolio, null);
 
@@ -240,55 +237,6 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
                 SymbolProperties.GetDefault(CashBook.AccountCurrency));
-        }
-
-        public class OrderProcessor : IOrderProcessor
-        {
-            private readonly ConcurrentDictionary<int, Order> _orders = new ConcurrentDictionary<int, Order>();
-            private readonly ConcurrentDictionary<int, OrderTicket> _tickets = new ConcurrentDictionary<int, OrderTicket>();
-            public void AddOrder(Order order)
-            {
-                _orders[order.Id] = order;
-            }
-
-            public void AddTicket(OrderTicket ticket)
-            {
-                _tickets[ticket.OrderId] = ticket;
-            }
-            public int OrdersCount { get; private set; }
-            public Order GetOrderById(int orderId)
-            {
-                Order order;
-                _orders.TryGetValue(orderId, out order);
-                return order;
-            }
-
-            public Order GetOrderByBrokerageId(string brokerageId)
-            {
-                return _orders.Values.FirstOrDefault(x => x.BrokerId.Contains(brokerageId));
-            }
-
-            public IEnumerable<OrderTicket> GetOrderTickets(Func<OrderTicket, bool> filter = null)
-            {
-                return _tickets.Values.Where(filter ?? (x => true));
-            }
-
-            public OrderTicket GetOrderTicket(int orderId)
-            {
-                OrderTicket ticket;
-                _tickets.TryGetValue(orderId, out ticket);
-                return ticket;
-            }
-
-            public IEnumerable<Order> GetOrders(Func<Order, bool> filter = null)
-            {
-                return _orders.Values.Where(filter ?? (x => true));
-            }
-
-            public OrderTicket Process(OrderRequest request)
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -212,7 +212,7 @@ namespace QuantConnect.Tests.Common.Securities
             var securityPrice = 100m;
             var quantity = 300;
 
-            var orderProcessor = new MarginCallModelTests.OrderProcessor();
+            var orderProcessor = new FakeOrderProcessor();
             var portfolio = GetPortfolio(orderProcessor, quantity);
             var model = new PatternDayTradingMarginModel();
 
@@ -243,7 +243,7 @@ namespace QuantConnect.Tests.Common.Securities
             var securityPrice = 100m;
             var quantity = -300;
 
-            var orderProcessor = new MarginCallModelTests.OrderProcessor();
+            var orderProcessor = new FakeOrderProcessor();
             var portfolio = GetPortfolio(orderProcessor, quantity);
             var model = new PatternDayTradingMarginModel();
 

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Algorithm\Framework\Alphas\Serialization\InsightJsonConverterTests.cs" />
     <Compile Include="Algorithm\Framework\InsightTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
+    <Compile Include="Algorithm\Framework\QCAlgorithmFrameworkTests.cs" />
     <Compile Include="Algorithm\Framework\Selection\ManualUniverseSelectionModelTests.cs" />
     <Compile Include="API\ApiTests.cs" />
     <Compile Include="Brokerages\BrokerageTests.cs" />
@@ -176,6 +177,7 @@
     <Compile Include="Common\Scheduling\ScheduleManagerTests.cs" />
     <Compile Include="Common\Securities\BrokerageModelSecurityInitializerTests.cs" />
     <Compile Include="Common\Securities\CashBuyingPowerModelTests.cs" />
+    <Compile Include="Common\Securities\FakeOrderProcessor.cs" />
     <Compile Include="Common\Securities\Forex\ForexHoldingTest.cs" />
     <Compile Include="Common\Securities\FutureFilterTests.cs" />
     <Compile Include="Common\Securities\Futures\FuturesExpiryFunctionsTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
These times were being set AFTER they were copied, so the insights sent into the portfolio construction model were the originals (uncopied) and then copies that are sent into the event are then piped to the insight manager/alpha handler for scoring, so interestingly, the scoring remained the same so regression tests continued to pass because no types were written with a dependency on that data other than the scoring, which as mentioned, got the copies with the correct times. A recent change made use of this time and showcases this heinous bug in all its glory.

This refactoring overrides the event invocator and seals the method to force derived types to use the event handler, thereby guaranteeing that the event is always invoked AFTER the generated/close times are properly set, also ensuring that the copy is performed after the times are set as well.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2058

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->