### PR TITLE
Make the current Slice available to the algorithm

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -485,6 +485,11 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Returns the latest Slice object received
+        /// </summary>
+        public Slice LatestSlice { get; private set; }
+
+        /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
         /// </summary>
         /// <seealso cref="SetStartDate(DateTime)"/>
@@ -2041,6 +2046,15 @@ namespace QuantConnect.Algorithm
         protected virtual void OnInsightsGenerated(IEnumerable<Insight> insights)
         {
             InsightsGenerated?.Invoke(this, new GeneratedInsightsCollection(UtcTime, insights));
+        }
+
+        /// <summary>
+        /// Set the latest slice received
+        /// </summary>
+        /// <param name="slice">The Slice object</param>
+        public void SetLatestSlice(Slice slice)
+        {
+            LatestSlice = slice;
         }
     }
 }

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -485,9 +485,9 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Returns the latest Slice object received
+        /// Returns the current Slice object
         /// </summary>
-        public Slice LatestSlice { get; private set; }
+        public Slice CurrentSlice { get; private set; }
 
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
@@ -2049,12 +2049,12 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Set the latest slice received
+        /// Sets the current slice
         /// </summary>
         /// <param name="slice">The Slice object</param>
-        public void SetLatestSlice(Slice slice)
+        public void SetCurrentSlice(Slice slice)
         {
-            LatestSlice = slice;
+            CurrentSlice = slice;
         }
     }
 }

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -855,5 +855,11 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// </summary>
         /// <returns></returns>
         public override string ToString() => _algorithm == null ? base.ToString() : _algorithm.Repr();
+
+        /// <summary>
+        /// Set the latest slice received
+        /// </summary>
+        /// <param name="slice">The Slice object</param>
+        public void SetLatestSlice(Slice slice) => _baseAlgorithm.SetLatestSlice(slice);
     }
 }

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -857,9 +857,9 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         public override string ToString() => _algorithm == null ? base.ToString() : _algorithm.Repr();
 
         /// <summary>
-        /// Set the latest slice received
+        /// Sets the current slice
         /// </summary>
         /// <param name="slice">The Slice object</param>
-        public void SetLatestSlice(Slice slice) => _baseAlgorithm.SetLatestSlice(slice);
+        public void SetCurrentSlice(Slice slice) => _baseAlgorithm.SetCurrentSlice(slice);
     }
 }

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -650,5 +650,11 @@ namespace QuantConnect.Interfaces
         /// </summary>
         /// <param name="futureChainProvider">The future chain provider</param>
         void SetFutureChainProvider(IFutureChainProvider futureChainProvider);
+
+        /// <summary>
+        /// Set the latest slice received
+        /// </summary>
+        /// <param name="slice">The Slice object</param>
+        void SetLatestSlice(Slice slice);
     }
 }

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -652,9 +652,9 @@ namespace QuantConnect.Interfaces
         void SetFutureChainProvider(IFutureChainProvider futureChainProvider);
 
         /// <summary>
-        /// Set the latest slice received
+        /// Sets the current slice
         /// </summary>
         /// <param name="slice">The Slice object</param>
-        void SetLatestSlice(Slice slice);
+        void SetCurrentSlice(Slice slice);
     }
 }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -291,6 +291,9 @@ namespace QuantConnect.Lean.Engine
                 //Set the algorithm and real time handler's time
                 algorithm.SetDateTime(time);
 
+                // Update the latest slice before firing scheduled events or any other task
+                algorithm.SetLatestSlice(timeSlice.Slice);
+
                 if (timeSlice.Slice.SymbolChangedEvents.Count != 0)
                 {
                     if (hasOnDataSymbolChangedEvents)

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -291,8 +291,8 @@ namespace QuantConnect.Lean.Engine
                 //Set the algorithm and real time handler's time
                 algorithm.SetDateTime(time);
 
-                // Update the latest slice before firing scheduled events or any other task
-                algorithm.SetLatestSlice(timeSlice.Slice);
+                // Update the current slice before firing scheduled events or any other task
+                algorithm.SetCurrentSlice(timeSlice.Slice);
 
                 if (timeSlice.Slice.SymbolChangedEvents.Count != 0)
                 {


### PR DESCRIPTION
#### Description
A new property has been added to `QCAlgorithm`: `CurrentSlice`

#### Related Issue
Closes #2061 

#### Motivation and Context
Algorithms can now access the current slice object from any algorithm method, including scheduled events.

#### Requires Documentation Change
No.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`