### PR TITLE
Update GDAXBrokerage endpoint for EURUSD and GBPUSD exchange rates

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.Brokerages.GDAX
             FillSplit = new ConcurrentDictionary<long, GDAXFill>();
             _passPhrase = passPhrase;
             _algorithm = algorithm;
-            RateClient = new RestClient("http://api.fixer.io/latest?base=usd");
+            RateClient = new RestClient("http://data.fixer.io/api/latest?base=usd&access_key=26a2eb9f13db3f14b6df6ec2379f9261");
 
             WebSocket.Open += (sender, args) =>
             {


### PR DESCRIPTION

#### Description
The endpoint used by the GDAX brokerage to fetch exchange rates for EURUSD and GBPUSD has been updated because the previous endpoint has been deprecated today.

#### Related Issue
Closes #2072 

#### Motivation and Context
GDAX users with EUR or GBP accounts were unable to deploy live algorithms.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Deployed a GDAX live algorithm both locally and in the cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`