### PR TITLE
Add QCAlgorithm.ActiveSecurities

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -177,6 +177,12 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Read-only dictionary containing all active securities. An active security is
+        /// a security that is currently selected by the universe or has holdings or open orders.
+        /// </summary>
+        public IReadOnlyDictionary<Symbol, Security> ActiveSecurities => UniverseManager.ActiveSecurities;
+
+        /// <summary>
         /// Portfolio object provieds easy access to the underlying security-holding properties; summed together in a way to make them useful.
         /// This saves the user time by providing common portfolio requests in a single
         /// </summary>


### PR DESCRIPTION
#### Expected Behavior
It would be nice to have an `ActiveSecurities` property along with the existing `Securities` property in `QCAlgorithm`.

#### Actual Behavior
Currently `ActiveSecurities` is only accessible through `UniverseManager.ActiveSecurities`.

#### Potential Solution
Add a new get property in `QCAlgorithm`:
``` C#
/// <summary>
/// Read-only dictionary containing all active securities. An active security is
/// a security that is currently selected by the universe or has holdings or open orders.
/// </summary>
public IReadOnlyDictionary<Symbol, Security> ActiveSecurities => UniverseManager.ActiveSecurities;
```

#### Checklist
- [x] I have completely filled out this template
- [x] I have confirmed that this issue exists on the current `master` branch
- [x] I have confirmed that this is not a duplicate issue by searching [issues](https://github.com/QuantConnect/Lean/issues)