### PR TITLE
Fix JSON deserialization for Split and Delisting

### DIFF
--- a/Common/Data/Market/Delisting.cs
+++ b/Common/Data/Market/Delisting.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using Newtonsoft.Json;
 using QuantConnect.Orders;
 
 namespace QuantConnect.Data.Market
@@ -28,6 +29,7 @@ namespace QuantConnect.Data.Market
         /// Gets the type of delisting, warning or delisted
         /// A <see cref="DelistingType.Warning"/> is sent
         /// </summary>
+        [JsonProperty]
         public DelistingType Type { get; private set; }
 
         /// <summary>

--- a/Common/Data/Market/Dividend.cs
+++ b/Common/Data/Market/Dividend.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -65,13 +65,13 @@ namespace QuantConnect.Data.Market
         /// </summary>
         public decimal Distribution
         {
-            get { return Value; } 
+            get { return Value; }
             set { Value = Math.Round(value, 2); }
         }
 
         /// <summary>
-        /// Reader converts each line of the data source into BaseData objects. Each data type creates its own factory method, and returns a new instance of the object 
-        /// each time it is called. 
+        /// Reader converts each line of the data source into BaseData objects. Each data type creates its own factory method, and returns a new instance of the object
+        /// each time it is called.
         /// </summary>
         /// <param name="config">Subscription data config setup object</param>
         /// <param name="line">Line of the source document</param>
@@ -85,7 +85,7 @@ namespace QuantConnect.Data.Market
         }
 
         /// <summary>
-        /// Return the URL string source of the file. This will be converted to a stream 
+        /// Return the URL string source of the file. This will be converted to a stream
         /// </summary>
         /// <param name="config">Configuration object</param>
         /// <param name="date">Date of this source file</param>

--- a/Common/Data/Market/Split.cs
+++ b/Common/Data/Market/Split.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using Newtonsoft.Json;
 
 namespace QuantConnect.Data.Market
 {
@@ -26,6 +27,7 @@ namespace QuantConnect.Data.Market
         /// <summary>
         ///Gets the type of split event, warning or split.
         /// </summary>
+        [JsonProperty]
         public SplitType Type
         {
             get; private set;
@@ -34,6 +36,7 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// Gets the split factor
         /// </summary>
+        [JsonProperty]
         public decimal SplitFactor
         {
             get; private set;

--- a/Tests/Common/Data/Auxiliary/AuxiliaryDataSerializationTests.cs
+++ b/Tests/Common/Data/Auxiliary/AuxiliaryDataSerializationTests.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Tests.Common.Data.Auxiliary
+{
+    [TestFixture]
+    public class AuxiliaryDataSerializationTests
+    {
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
+        [Test]
+        public void DeserializesSplitWarning()
+        {
+            var splitWarning = new Split(Symbols.AAPL, new DateTime(2014, 6, 9), 645.57m, 0.142857m, SplitType.Warning);
+
+            var json = JsonConvert.SerializeObject(splitWarning, _settings);
+            var deserialized = (Split)JsonConvert.DeserializeObject(json, _settings);
+
+            Assert.AreEqual(splitWarning.Symbol, deserialized.Symbol);
+            Assert.AreEqual(splitWarning.Time, deserialized.Time);
+            Assert.AreEqual(splitWarning.Type, deserialized.Type);
+            Assert.AreEqual(splitWarning.ReferencePrice, deserialized.ReferencePrice);
+            Assert.AreEqual(splitWarning.SplitFactor, deserialized.SplitFactor);
+        }
+
+        [Test]
+        public void DeserializesSplit()
+        {
+            var split = new Split(Symbols.AAPL, new DateTime(2014, 6, 9), 645.57m, 0.142857m, SplitType.SplitOccurred);
+
+            var json = JsonConvert.SerializeObject(split, _settings);
+            var deserialized = (Split)JsonConvert.DeserializeObject(json, _settings);
+
+            Assert.AreEqual(split.Symbol, deserialized.Symbol);
+            Assert.AreEqual(split.Time, deserialized.Time);
+            Assert.AreEqual(split.Type, deserialized.Type);
+            Assert.AreEqual(split.ReferencePrice, deserialized.ReferencePrice);
+            Assert.AreEqual(split.SplitFactor, deserialized.SplitFactor);
+        }
+
+        [Test]
+        public void DeserializesDividend()
+        {
+            var dividend = new Dividend(Symbols.AAPL, new DateTime(2014, 11, 6), 0.47m);
+
+            var json = JsonConvert.SerializeObject(dividend, _settings);
+            var deserialized = (Dividend)JsonConvert.DeserializeObject(json, _settings);
+
+            Assert.AreEqual(dividend.Symbol, deserialized.Symbol);
+            Assert.AreEqual(dividend.Time, deserialized.Time);
+            Assert.AreEqual(dividend.Distribution, deserialized.Distribution);
+        }
+
+        [Test]
+        public void DeserializesDelistingWarning()
+        {
+            var delistingWarning = new Delisting(Symbols.AAPL, new DateTime(2999, 12, 31), 100m, DelistingType.Warning);
+
+            var json = JsonConvert.SerializeObject(delistingWarning, _settings);
+            var deserialized = (Delisting)JsonConvert.DeserializeObject(json, _settings);
+
+            Assert.AreEqual(delistingWarning.Symbol, deserialized.Symbol);
+            Assert.AreEqual(delistingWarning.Time, deserialized.Time);
+            Assert.AreEqual(delistingWarning.Type, deserialized.Type);
+        }
+
+        [Test]
+        public void DeserializesDelisting()
+        {
+            var delisting = new Delisting(Symbols.AAPL, new DateTime(2999, 12, 31), 100m, DelistingType.Delisted);
+
+            var json = JsonConvert.SerializeObject(delisting, _settings);
+            var deserialized = (Delisting)JsonConvert.DeserializeObject(json, _settings);
+
+            Assert.AreEqual(delisting.Symbol, deserialized.Symbol);
+            Assert.AreEqual(delisting.Time, deserialized.Time);
+            Assert.AreEqual(delisting.Type, deserialized.Type);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Brokerages\Tradier\TradierBrokerageTests.cs" />
     <Compile Include="Common\BrokerageNameTests.cs" />
     <Compile Include="Common\CurrenciesTests.cs" />
+    <Compile Include="Common\Data\Auxiliary\AuxiliaryDataSerializationTests.cs" />
     <Compile Include="Common\Data\Market\QuoteBarTests.cs" />
     <Compile Include="Common\Data\SubscriptionManagerTests.cs" />
     <Compile Include="Common\Data\UniverseSelection\CoarseFundamentalTests.cs" />


### PR DESCRIPTION

#### Description
Add missing `[JsonProperty]` attributes to `Split` and `Delisting` properties

#### Related Issue
Closes #2084 

#### Motivation and Context
A few public properties are not being deserialized.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit tests included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`