### PR TITLE
Add QCAlgorithm.GetParameters helper method

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -568,6 +568,14 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Gets a read-only dictionary with all current parameters
+        /// </summary>
+        public IReadOnlyDictionary<string, string> GetParameters()
+        {
+            return _parameters.ToReadOnlyDictionary();
+        }
+
+        /// <summary>
         /// Sets the parameters from the dictionary
         /// </summary>
         /// <param name="parameters">Dictionary containing the parameter names to values</param>


### PR DESCRIPTION

#### Description
The new `GetParameters` method has been added to `QCAlgorithm`.

#### Related Issue
Closes #2006 

#### Motivation and Context
If you don't know the name of a parameter you can't access it.

#### Requires Documentation Change
This is a new method in `QCAlgorithm` and will have to be added to the documentation.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`