### PR TITLE
Fix SetSecurityInitializer when called after AddUniverse

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -611,6 +611,11 @@ namespace QuantConnect.Algorithm
         /// <param name="securityInitializer">The security initializer</param>
         public void SetSecurityInitializer(ISecurityInitializer securityInitializer)
         {
+            if (_locked)
+            {
+                throw new Exception("SetSecurityInitializer cannot be called after algorithm initialization.");
+            }
+
             // this flag will prevent calls to SetBrokerageModel from overwriting this initializer
             _userSetSecurityInitializer = true;
             SecurityInitializer = securityInitializer;

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -614,6 +614,11 @@ namespace QuantConnect.Algorithm
             // this flag will prevent calls to SetBrokerageModel from overwriting this initializer
             _userSetSecurityInitializer = true;
             SecurityInitializer = securityInitializer;
+
+            foreach (var universe in UniverseManager.Select(x => x.Value))
+            {
+                universe.SetSecurityInitializer(securityInitializer);
+            }
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -606,14 +606,21 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Sets the security initializer, used to initialize/configure securities after creation
+        /// Sets the security initializer, used to initialize/configure securities after creation.
+        /// The initializer will be applied to all universes and manually added securities.
         /// </summary>
         /// <param name="securityInitializer">The security initializer</param>
         public void SetSecurityInitializer(ISecurityInitializer securityInitializer)
         {
             if (_locked)
             {
-                throw new Exception("SetSecurityInitializer cannot be called after algorithm initialization.");
+                throw new Exception("SetSecurityInitializer() cannot be called after algorithm initialization. " +
+                                    "When you use the SetSecurityInitializer() method it will apply to all universes and manually added securities.");
+            }
+
+            if (_userSetSecurityInitializer)
+            {
+                Debug("Warning: SetSecurityInitializer() has already been called, existing security initializers in all universes will be overwritten.");
             }
 
             // this flag will prevent calls to SetBrokerageModel from overwriting this initializer
@@ -627,7 +634,8 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Sets the security initializer function, used to initialize/configure securities after creation
+        /// Sets the security initializer function, used to initialize/configure securities after creation.
+        /// The initializer will be applied to all universes and manually added securities.
         /// </summary>
         /// <param name="securityInitializer">The security initializer function</param>
         [Obsolete("This method is deprecated. Please use this overload: SetSecurityInitializer(Action<Security> securityInitializer)")]
@@ -637,7 +645,8 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Sets the security initializer function, used to initialize/configure securities after creation
+        /// Sets the security initializer function, used to initialize/configure securities after creation.
+        /// The initializer will be applied to all universes and manually added securities.
         /// </summary>
         /// <param name="securityInitializer">The security initializer function</param>
         public void SetSecurityInitializer(Action<Security> securityInitializer)

--- a/Common/Data/UniverseSelection/FineFundamentalFilteredUniverse.cs
+++ b/Common/Data/UniverseSelection/FineFundamentalFilteredUniverse.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using Python.Runtime;
 using QuantConnect.Data.Fundamental;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Data.UniverseSelection
 {
@@ -51,6 +52,17 @@ namespace QuantConnect.Data.UniverseSelection
         {
             var func = fineSelector.ConvertToDelegate<Func< IEnumerable<FineFundamental>, Symbol[]>>();
             FineFundamentalUniverse = new FineFundamentalUniverse(universe.UniverseSettings, universe.SecurityInitializer, func);
+        }
+
+        /// <summary>
+        /// Sets the security initializer, used to initialize/configure securities after creation
+        /// </summary>
+        /// <param name="securityInitializer">The security initializer</param>
+        public override void SetSecurityInitializer(ISecurityInitializer securityInitializer)
+        {
+            base.SetSecurityInitializer(securityInitializer);
+            Universe.SetSecurityInitializer(securityInitializer);
+            FineFundamentalUniverse.SetSecurityInitializer(securityInitializer);
         }
     }
 }

--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -280,6 +280,15 @@ namespace QuantConnect.Data.UniverseSelection
         }
 
         /// <summary>
+        /// Sets the security initializer, used to initialize/configure securities after creation
+        /// </summary>
+        /// <param name="securityInitializer">The security initializer</param>
+        public virtual void SetSecurityInitializer(ISecurityInitializer securityInitializer)
+        {
+            SecurityInitializer = securityInitializer;
+        }
+
+        /// <summary>
         /// Marks this universe as disposed and ready to remove all child subscriptions
         /// </summary>
         public void Dispose()


### PR DESCRIPTION

#### Description
`SetSecurityInitializer `now correctly updates the security initializer for universes added earlier in `Initialize`.

#### Related Issue
Closes #2062 

#### Motivation and Context
`SetSecurityInitializer` had no effect on universes added before.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Example algorithm in #2062

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`