### PR TITLE
Implements ReadBacktestReport method in the API

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -566,6 +566,23 @@ namespace QuantConnect.Api
         }
 
         /// <summary>
+        /// Read out the report of a backtest in the project id specified.
+        /// </summary>
+        /// <param name="projectId">Project id to read</param>
+        /// <param name="backtestId">Specific backtest id to read</param>
+        /// <returns><see cref="BacktestReport"/></returns>
+        public BacktestReport ReadBacktestReport(int projectId, string backtestId)
+        {
+            var request = new RestRequest("backtests/read/report", Method.POST);
+            request.AddParameter("backtestId", backtestId);
+            request.AddParameter("projectId", projectId);
+
+            BacktestReport report;
+            ApiConnection.TryRequest(request, out report);
+            return report;
+        }
+
+        /// <summary>
         /// Method to download and save the data purchased through QuantConnect
         /// </summary>
         /// <param name="symbol">Symbol of security of which data will be requested.</param>

--- a/Common/API/BacktestReport.cs
+++ b/Common/API/BacktestReport.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Api
     public class BacktestReport : RestResponse
     {
         /// <summary>
-        /// Link to the data
+        /// HTML data of the report with embedded base64 images
         /// </summary>
         [JsonProperty(PropertyName = "report")]
         public string Report { get; set; }

--- a/Common/API/BacktestReport.cs
+++ b/Common/API/BacktestReport.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json;
 namespace QuantConnect.Api
 {
     /// <summary>
-    /// Response from reading purchased data
+    /// Backtest Report Response wrapper
     /// </summary>
     public class BacktestReport : RestResponse
     {

--- a/Common/API/BacktestReport.cs
+++ b/Common/API/BacktestReport.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+using Newtonsoft.Json;
+
+namespace QuantConnect.Api
+{
+    /// <summary>
+    /// Response from reading purchased data
+    /// </summary>
+    public class BacktestReport : RestResponse
+    {
+        /// <summary>
+        /// Link to the data
+        /// </summary>
+        [JsonProperty(PropertyName = "report")]
+        public string Report { get; set; }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -155,6 +155,7 @@
     <Compile Include="API\Backtest.cs" />
     <Compile Include="API\Compile.cs" />
     <Compile Include="API\CompileState.cs" />
+    <Compile Include="API\BacktestReport.cs" />
     <Compile Include="API\Link.cs" />
     <Compile Include="API\LiveAlgorithm.cs" />
     <Compile Include="API\LiveAlgorithmResults.cs" />

--- a/PythonToolbox/README.rst
+++ b/PythonToolbox/README.rst
@@ -56,7 +56,7 @@ Instruction on running the program
 (3) Update the "user_data.json" accordingly.
 
 2. Generate report
-""""""""""""""""""""""
+""""""""""""""""""
 Execute the following command to generate your strategy report:
 
    $ python CreateLeanReport.py --backtest=./json/sample.json --output=./outputs/Report.html --user=user_data.json
@@ -66,6 +66,16 @@ Execute the following command to generate your strategy report:
 (1) Lean report HTML file defined by "--output"
 
 (2) Individual images in the same directory of the report (remove the `lrc.clean()` statement in "CreateLeanReport.py")
+
+4. Display report from QuantConnect
+"""""""""""""""""""""""""""""""""""
+For backtests that were executed in QuantConnect, use the API to get the report:
+
+   >>> from IPython.core.display import display, HTML
+   >>> from quantconnect.api import Api
+   >>> api = Api(your-user-id, your-token)
+   >>> lean_report = api.read_backtest_report(project-id, backtest-id)
+   >>> display(HTML(lean_report['report']))
 
 Explanation on the meaning of the charts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/PythonToolbox/quantconnect/api.py
+++ b/PythonToolbox/quantconnect/api.py
@@ -432,6 +432,23 @@ class Api:
 
         return self.api_connection.try_request(request)
 
+    def read_backtest_report(self, projectId, backtestId):
+        """Read out the report of a backtest in the project id specified.
+        Args:
+            projectId(int): Project id to read.
+            backtestId(str): Specific backtest id to read.
+        Returns:
+            BacktestReport report
+        """
+        request = Request('POST', "backtests/read/report",
+            params =
+            {
+                "backtestId": backtestId, 
+                "projectId": projectId
+            })
+
+        return self.api_connection.try_request(request)
+
     def download_data(self, symbol, securityType, market, resolution, date, fileName):
         """Method to download and save the data purchased through QuantConnect
         Args:


### PR DESCRIPTION
#### Description
Implements `ReadBacktestReport` method in the API.

#### Related Issue
Closes #1097

#### Motivation and Context
Users can fetch the backtest reports with the Api. This is particularly interesting for QC Reseach environment, since the user won't need to generate the report in the jupyter environment. 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually fetch backtest reports using `jupyter lab`.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`