### PR TITLE
Improves Extensions.TryConvert to avoid test by exception

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1050,9 +1050,23 @@ namespace QuantConnect
             {
                 try
                 {
+                    if (typeof(T) == typeof(Type))
+                    {
+                        result = pyObject.As<Type>() as T;
+                        return true;
+                    }
+
+                    var pythonType = pyObject.GetPythonType();
+                    var csharpType = pythonType.As<Type>();
+
+                    if (!typeof(T).IsAssignableFrom(csharpType))
+                    {
+                        return false;
+                    }
+
                     result = pyObject.AsManagedObject(typeof(T)) as T;
 
-                    if (typeof(T) == typeof(Type) || result is IEnumerable)
+                    if (result is IEnumerable)
                     {
                         return true;
                     }
@@ -1060,7 +1074,7 @@ namespace QuantConnect
                     // If the PyObject type and the managed object names are the same,
                     // pyObject is a C# object wrapped in PyObject, in this case return true
                     // Otherwise, pyObject is a python object that subclass a C# class.
-                    string name = (pyObject.GetPythonType() as dynamic).__name__;
+                    string name = (pythonType as dynamic).__name__;
                     return name == result.GetType().Name;
                 }
                 catch


### PR DESCRIPTION
#### Description
Instead of letting `PyObject.AsManagedObject` throw an exception because the types do not match, we check whether the target type is assignable from the python object type.

#### Related Issue
Closes #2091 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Algorithm provided in #2091.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`