### PR TITLE
Update LiveTradingDataFeed to handle equity auxiliary data

### DIFF
--- a/Engine/DataFeeds/Enumerators/LiveBaseDataSynchronizingEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/LiveBaseDataSynchronizingEnumerator.cs
@@ -1,0 +1,140 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NodaTime;
+using QuantConnect.Data;
+using QuantConnect.Util;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
+{
+    /// <summary>
+    /// Represents an enumerator capable of synchronizing live base data enumerators in time.
+    /// This assumes that all enumerators have data time stamped in the same time zone.
+    /// </summary>
+    public class LiveBaseDataSynchronizingEnumerator : IEnumerator<BaseData>
+    {
+        private readonly ITimeProvider _timeProvider;
+        private readonly DateTimeZone _exchangeTimeZone;
+        private readonly List<IEnumerator<BaseData>> _enumerators;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiveBaseDataSynchronizingEnumerator"/> class
+        /// </summary>
+        /// <param name="timeProvider">The source of time used to gauge when this enumerator should emit extra bars when null data is returned from the source enumerator</param>
+        /// <param name="exchangeTimeZone">The time zone the raw data is time stamped in</param>
+        /// <param name="enumerators">The enumerators to be synchronized. NOTE: Assumes the same time zone for all data</param>
+        public LiveBaseDataSynchronizingEnumerator(ITimeProvider timeProvider, DateTimeZone exchangeTimeZone, params IEnumerator<BaseData>[] enumerators)
+        {
+            _timeProvider = timeProvider;
+            _exchangeTimeZone = exchangeTimeZone;
+            _enumerators = enumerators.ToList();
+
+            // prime enumerators
+            _enumerators.ForEach(x => x.MoveNext());
+        }
+
+        /// <summary>
+        /// Advances the enumerator to the next element of the collection.
+        /// </summary>
+        /// <returns> true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.</returns>
+        /// <exception cref="T:System.InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+        public bool MoveNext()
+        {
+            // use manual time provider from LiveTradingDataFeed
+            var frontier = _timeProvider.GetUtcNow().ConvertFromUtc(_exchangeTimeZone);
+
+            // check if any enumerator is ready to emit
+            if (DataPointEmitted(_enumerators, frontier))
+                return true;
+
+            // advance enumerators with no current data
+            var enumeratorsAdvanced = new List<IEnumerator<BaseData>>();
+            _enumerators.ForEach(x =>
+            {
+                if (x.Current == null)
+                {
+                    x.MoveNext();
+
+                    enumeratorsAdvanced.Add(x);
+                }
+            });
+
+            // check if any enumerator is ready to emit
+            if (DataPointEmitted(enumeratorsAdvanced, frontier))
+                return true;
+
+            Current = null;
+
+            // IEnumerator contract dictates that we return true unless we're actually
+            // finished with the 'collection' and since this is live, we're never finished
+            return true;
+        }
+
+        /// <summary>
+        /// Sets the enumerator to its initial position, which is before the first element in the collection.
+        /// </summary>
+        /// <exception cref="T:System.InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+        public void Reset()
+        {
+            _enumerators.ForEach(x => Reset());
+        }
+
+        /// <summary>
+        /// Gets the element in the collection at the current position of the enumerator.
+        /// </summary>
+        /// <returns>The element in the collection at the current position of the enumerator.</returns>
+        public BaseData Current { get; private set; }
+
+        /// <summary>
+        /// Gets the current element in the collection.
+        /// </summary>
+        /// <returns>The current element in the collection.</returns>
+        object IEnumerator.Current => Current;
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            _enumerators.ForEach(x => x.DisposeSafely());
+        }
+
+        private bool DataPointEmitted(IEnumerable<IEnumerator<BaseData>> enumerators, DateTime frontier)
+        {
+            // check if any enumerator is ready to emit
+            var enumerator = enumerators
+                .Where(x => x.Current != null && x.Current.EndTime <= frontier)
+                .OrderBy(x => x.Current?.EndTime)
+                .FirstOrDefault();
+
+            if (enumerator != null)
+            {
+                // emit new data point
+                Current = enumerator.Current;
+
+                // advance enumerator
+                enumerator.MoveNext();
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Engine/DataFeeds/Enumerators/LiveBaseDataSynchronizingEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/LiveBaseDataSynchronizingEnumerator.cs
@@ -67,10 +67,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             var enumeratorsAdvanced = new List<IEnumerator<BaseData>>();
             _enumerators.ForEach(x =>
             {
-                if (x.Current == null)
+                if (x.Current == null && x.MoveNext())
                 {
-                    x.MoveNext();
-
                     enumeratorsAdvanced.Add(x);
                 }
             });

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -150,6 +150,7 @@
     <Compile Include="DataFeeds\CachingFutureChainProvider.cs" />
     <Compile Include="DataFeeds\CachingOptionChainProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\Factories\LiveCustomDataSubscriptionEnumeratorFactory.cs" />
+    <Compile Include="DataFeeds\Enumerators\LiveBaseDataSynchronizingEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\QuoteBarFillForwardEnumerator.cs" />
     <Compile Include="DataFeeds\ISubscriptionSynchronizer.cs" />
     <Compile Include="DataFeeds\LiveFutureChainProvider.cs" />

--- a/Tests/Engine/DataFeeds/Enumerators/LiveBaseDataSynchronizingEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveBaseDataSynchronizingEnumeratorTests.cs
@@ -34,9 +34,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var end = start.AddSeconds(15);
 
             var time = start;
-            var stream1 = Enumerable.Range(0, 10).Select(x => new Tick { Time = time.AddSeconds(1) }).GetEnumerator();
-            var stream2 = Enumerable.Range(0, 5).Select(x => new Tick { Time = time.AddSeconds(2) }).GetEnumerator();
-            var stream3 = Enumerable.Range(0, 20).Select(x => new Tick { Time = time.AddSeconds(0.5) }).GetEnumerator();
+            var stream1 = Enumerable.Range(0, 10).Select(x => new Tick { Time = time.AddSeconds(x * 1) }).GetEnumerator();
+            var stream2 = Enumerable.Range(0, 5).Select(x => new Tick { Time = time.AddSeconds(x * 2) }).GetEnumerator();
+            var stream3 = Enumerable.Range(0, 20).Select(x => new Tick { Time = time.AddSeconds(x * 0.5) }).GetEnumerator();
 
             var previous = DateTime.MinValue;
             var synchronizer = new LiveBaseDataSynchronizingEnumerator(new RealTimeProvider(), DateTimeZone.Utc, stream1, stream2, stream3);

--- a/Tests/Engine/DataFeeds/Enumerators/LiveBaseDataSynchronizingEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveBaseDataSynchronizingEnumeratorTests.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+
+namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
+{
+    [TestFixture]
+    public class LiveBaseDataSynchronizingEnumeratorTests
+    {
+        [Test]
+        public void SynchronizesData()
+        {
+            var start = DateTime.UtcNow;
+            var end = start.AddSeconds(15);
+
+            var time = start;
+            var stream1 = Enumerable.Range(0, 10).Select(x => new Tick { Time = time.AddSeconds(1) }).GetEnumerator();
+            var stream2 = Enumerable.Range(0, 5).Select(x => new Tick { Time = time.AddSeconds(2) }).GetEnumerator();
+            var stream3 = Enumerable.Range(0, 20).Select(x => new Tick { Time = time.AddSeconds(0.5) }).GetEnumerator();
+
+            var previous = DateTime.MinValue;
+            var synchronizer = new LiveBaseDataSynchronizingEnumerator(new RealTimeProvider(), DateTimeZone.Utc, stream1, stream2, stream3);
+            while (synchronizer.MoveNext() && DateTime.UtcNow < end)
+            {
+                if (synchronizer.Current != null)
+                {
+                    Assert.That(synchronizer.Current.EndTime, Is.GreaterThanOrEqualTo(previous));
+                    previous = synchronizer.Current.EndTime;
+                }
+            }
+        }
+    }
+}

--- a/Tests/Engine/DataFeeds/Enumerators/SynchronizingEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/SynchronizingEnumeratorTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,9 +29,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
         public void SynchronizesData()
         {
             var time = new DateTime(2016, 03, 03, 12, 05, 00);
-            var stream1 = Enumerable.Range(0, 10).Select(x => new Tick {Time = time.AddSeconds(1)}).GetEnumerator();
-            var stream2 = Enumerable.Range(0, 5).Select(x => new Tick {Time = time.AddSeconds(2)}).GetEnumerator();
-            var stream3 = Enumerable.Range(0, 20).Select(x => new Tick {Time = time.AddSeconds(0.5)}).GetEnumerator();
+            var stream1 = Enumerable.Range(0, 10).Select(x => new Tick {Time = time.AddSeconds(x * 1)}).GetEnumerator();
+            var stream2 = Enumerable.Range(0, 5).Select(x => new Tick {Time = time.AddSeconds(x * 2)}).GetEnumerator();
+            var stream3 = Enumerable.Range(0, 20).Select(x => new Tick {Time = time.AddSeconds(x * 0.5)}).GetEnumerator();
 
             var previous = DateTime.MinValue;
             var synchronizer = new SynchronizingEnumerator(stream1, stream2, stream3);

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Engine\DataFeeds\Enumerators\Factories\LiveCustomDataSubscriptionEnumeratorFactoryTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\FastForwardEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\FrontierAwareEnumeratorTests.cs" />
+    <Compile Include="Engine\DataFeeds\Enumerators\LiveBaseDataSynchronizingEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\LiveFillForwardEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\OptionChainUniverseDataCollectionAggregatorEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\QuoteBarFillForwardEnumeratorTests.cs" />


### PR DESCRIPTION

#### Description
This is the first step required to support live equity splits, dividends and delistings.
The new `LiveBaseDataSynchronizingEnumerator` has been added to the live equity enumerator stack.

#### Related Issue
Closes #2104 

#### Motivation and Context
Currently we do not support live equity auxiliary data.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test included for the new enumerator + local and cloud testing with IB.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`