### PR TITLE
Improves Extensions.TryConvert to avoid test by exception

### DIFF
--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Tests.Algorithm
             }
         }
 
-        [Test, Ignore]
+        [Test, Category("TravisExclude")]
         public void RegistersIndicatorProperlyPython()
         {
             var expected = 0;
@@ -117,7 +117,7 @@ namespace QuantConnect.Tests.Algorithm
             }
         }
 
-        [Test, Ignore]
+        [Test, Category("TravisExclude")]
         public void RegisterPythonCustomIndicatorProperly()
         {
             using (Py.GIL())
@@ -142,6 +142,31 @@ namespace QuantConnect.Tests.Algorithm
 
                 var badIndicator = module.GetAttr("BadCustomIndicator").Invoke();
                 Assert.Throws<ArgumentException>(() => _algorithm.RegisterIndicator(_spy, badIndicator, Resolution.Minute));
+            }
+        }
+
+        [Test, Category("TravisExclude")]
+        public void RegistersIndicatorProperlyPythonScript()
+        {
+            var code = @"from clr import AddReference
+AddReference('System')
+AddReference('QuantConnect.Algorithm')
+AddReference('QuantConnect.Indicators')
+AddReference('QuantConnect.Common')
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Indicators import *
+
+algo = QCAlgorithm()
+forex = algo.AddForex('EURUSD', Resolution.Daily)
+indicator = IchimokuKinkoHyo('EURUSD', 9, 26, 26, 52, 26, 26)
+algo.RegisterIndicator(forex.Symbol, indicator, Resolution.Daily)";
+
+            using (Py.GIL())
+            {
+                Assert.DoesNotThrow(() => PythonEngine.ModuleFromString("RegistersIndicatorProperlyPythonScript", code));
             }
         }
     }

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -385,7 +385,23 @@ namespace QuantConnect.Tests.Common.Util
             Assert.IsTrue(canConvert);
             Assert.IsNotNull(indicatorBaseTradeBar);
             Assert.IsAssignableFrom<AccumulationDistribution>(indicatorBaseTradeBar);
+        }
 
+        [Test, Category("TravisExclude")]
+        public void PyObjectTryConvertSymbolArray()
+        {
+            PyObject value;
+            using (Py.GIL())
+            {
+                // Wrap a Symbol Array around a PyObject and convert it back
+                value = new PyList(new[] { Symbols.SPY.ToPython(), Symbols.AAPL.ToPython() });
+            }
+
+            Symbol[] symbols;
+            var canConvert = value.TryConvert(out symbols);
+            Assert.IsTrue(canConvert);
+            Assert.IsNotNull(symbols);
+            Assert.IsAssignableFrom<Symbol[]>(symbols);
         }
 
         [Test, Category("TravisExclude")]


### PR DESCRIPTION
#### Description
Instead of letting `PyObject.AsManagedObject` throw an exception because the types do not match, we check whether the target type is assignable from the python object type.

#### Related Issue
This PR fixes PR #2102 that caused a bug in Symbol[] convertion.
Closes #2091 and fixes #2102

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit tests were added to test all changes.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`