### PR TITLE
Add live brokerage DataQueueHandler support to PaperBrokerage

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.cs
@@ -37,6 +37,7 @@ namespace QuantConnect.Brokerages.Fxcm
     /// <summary>
     /// FXCM brokerage - implementation of IBrokerage interface
     /// </summary>
+    [BrokerageFactory(typeof(FxcmBrokerageFactory))]
     public partial class FxcmBrokerage : Brokerage, IDataQueueHandler, IGenericMessageListener, IStatusMessageListener
     {
         private readonly IOrderProvider _orderProvider;

--- a/Brokerages/GDAX/GDAXDataQueueHandler.cs
+++ b/Brokerages/GDAX/GDAXDataQueueHandler.cs
@@ -24,6 +24,7 @@ namespace QuantConnect.Brokerages.GDAX
     /// <summary>
     /// An implementation of <see cref="IDataQueueHandler"/> for GDAX
     /// </summary>
+    [BrokerageFactory(typeof(GDAXBrokerageFactory))]
     public class GDAXDataQueueHandler : GDAXBrokerage, IDataQueueHandler
     {
         /// <summary>

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -44,6 +44,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
     /// <summary>
     /// The Interactive Brokers brokerage
     /// </summary>
+    [BrokerageFactory(typeof(InteractiveBrokersBrokerageFactory))]
     public sealed class InteractiveBrokersBrokerage : Brokerage, IDataQueueHandler, IDataQueueUniverseProvider
     {
         // next valid order id for this client

--- a/Brokerages/Oanda/OandaBrokerage.cs
+++ b/Brokerages/Oanda/OandaBrokerage.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,6 +32,7 @@ namespace QuantConnect.Brokerages.Oanda
     /// <summary>
     /// Oanda Brokerage implementation
     /// </summary>
+    [BrokerageFactory(typeof(OandaBrokerageFactory))]
     public class OandaBrokerage : Brokerage, IDataQueueHandler
     {
         private readonly OandaSymbolMapper _symbolMapper = new OandaSymbolMapper();
@@ -98,7 +99,7 @@ namespace QuantConnect.Brokerages.Oanda
         }
 
         /// <summary>
-        /// Gets all open orders on the account. 
+        /// Gets all open orders on the account.
         /// NOTE: The order objects returned do not have QC order IDs.
         /// </summary>
         /// <returns>The open orders returned from Oanda</returns>

--- a/Brokerages/Paper/PaperBrokerageFactory.cs
+++ b/Brokerages/Paper/PaperBrokerageFactory.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
@@ -32,18 +31,12 @@ namespace QuantConnect.Brokerages.Paper
         /// The implementation of this property will create the brokerage data dictionary required for
         /// running live jobs. See <see cref="IJobQueueHandler.NextJob"/>
         /// </remarks>
-        public override Dictionary<string, string> BrokerageData
-        {
-            get { return new Dictionary<string, string>(); }
-        }
+        public override Dictionary<string, string> BrokerageData => new Dictionary<string, string>();
 
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
-        {
-            get { return new DefaultBrokerageModel(); }
-        }
+        public override IBrokerageModel BrokerageModel => new DefaultBrokerageModel();
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Common/Brokerages/BrokerageFactoryAttribute.cs
+++ b/Common/Brokerages/BrokerageFactoryAttribute.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Brokerages
+{
+    /// <summary>
+    /// Represents the brokerage factory type required to load a data queue handler
+    /// </summary>
+    public class BrokerageFactoryAttribute : Attribute
+    {
+        /// <summary>
+        /// The type of the brokerage factory
+        /// </summary>
+        public Type Type { get; set; }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="BrokerageFactoryAttribute"/> class
+        /// </summary>
+        /// <param name="type">The brokerage factory type</param>
+        public BrokerageFactoryAttribute(Type type)
+        {
+            Type = type;
+        }
+    }
+}

--- a/Common/Brokerages/BrokerageFactoryAttribute.cs
+++ b/Common/Brokerages/BrokerageFactoryAttribute.cs
@@ -20,6 +20,7 @@ namespace QuantConnect.Brokerages
     /// <summary>
     /// Represents the brokerage factory type required to load a data queue handler
     /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
     public class BrokerageFactoryAttribute : Attribute
     {
         /// <summary>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Benchmarks\FuncBenchmark.cs" />
     <Compile Include="Benchmarks\IBenchmark.cs" />
     <Compile Include="Benchmarks\SecurityBenchmark.cs" />
+    <Compile Include="Brokerages\BrokerageFactoryAttribute.cs" />
     <Compile Include="Brokerages\BrokerageName.cs" />
     <Compile Include="Brokerages\DefaultBrokerageMessageHandler.cs" />
     <Compile Include="Brokerages\DefaultBrokerageModel.cs" />

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -118,39 +118,7 @@ namespace QuantConnect.Lean.Engine.Setup
             _factory = Composer.Instance.Single<IBrokerageFactory>(brokerageFactory => brokerageFactory.BrokerageType.MatchesTypeName(liveJob.Brokerage));
             factory = _factory;
 
-            // preload the data queue handler using custom BrokerageFactory attribute
-            var dataQueueHandlerType = Assembly.GetAssembly(typeof(Brokerage))
-                .GetTypes()
-                .FirstOrDefault(x =>
-                    x.FullName != null &&
-                    x.FullName.EndsWith(liveJob.DataQueueHandler) &&
-                    x.HasAttribute(typeof(BrokerageFactoryAttribute)));
-
-            if (dataQueueHandlerType != null)
-            {
-                var attribute = dataQueueHandlerType.GetCustomAttribute<BrokerageFactoryAttribute>();
-
-                // only load the data queue handler if the factory is different from our brokerage factory
-                if (attribute.Type != factory.GetType())
-                {
-                    var brokerageFactory = (BrokerageFactory) Activator.CreateInstance(attribute.Type);
-
-                    // copy the brokerage data (usually credentials)
-                    foreach (var kvp in brokerageFactory.BrokerageData)
-                    {
-                        if (!liveJob.BrokerageData.ContainsKey(kvp.Key))
-                        {
-                            liveJob.BrokerageData.Add(kvp.Key, kvp.Value);
-                        }
-                    }
-
-                    // create the data queue handler and add it to composer
-                    _dataQueueHandlerBrokerage = brokerageFactory.CreateBrokerage(liveJob, uninitializedAlgorithm);
-
-                    // open connection for subscriptions
-                    _dataQueueHandlerBrokerage.Connect();
-                }
-            }
+            PreloadDataQueueHandler(liveJob, uninitializedAlgorithm, factory);
 
             // initialize the correct brokerage using the resolved factory
             var brokerage = _factory.CreateBrokerage(liveJob, uninitializedAlgorithm);
@@ -478,6 +446,43 @@ namespace QuantConnect.Lean.Engine.Setup
                     _dataQueueHandlerBrokerage.Disconnect();
                 }
                 _dataQueueHandlerBrokerage.DisposeSafely();
+            }
+        }
+
+        private void PreloadDataQueueHandler(LiveNodePacket liveJob, IAlgorithm algorithm, IBrokerageFactory factory)
+        {
+            // preload the data queue handler using custom BrokerageFactory attribute
+            var dataQueueHandlerType = Assembly.GetAssembly(typeof(Brokerage))
+                .GetTypes()
+                .FirstOrDefault(x =>
+                    x.FullName != null &&
+                    x.FullName.EndsWith(liveJob.DataQueueHandler) &&
+                    x.HasAttribute(typeof(BrokerageFactoryAttribute)));
+
+            if (dataQueueHandlerType != null)
+            {
+                var attribute = dataQueueHandlerType.GetCustomAttribute<BrokerageFactoryAttribute>();
+
+                // only load the data queue handler if the factory is different from our brokerage factory
+                if (attribute.Type != factory.GetType())
+                {
+                    var brokerageFactory = (BrokerageFactory)Activator.CreateInstance(attribute.Type);
+
+                    // copy the brokerage data (usually credentials)
+                    foreach (var kvp in brokerageFactory.BrokerageData)
+                    {
+                        if (!liveJob.BrokerageData.ContainsKey(kvp.Key))
+                        {
+                            liveJob.BrokerageData.Add(kvp.Key, kvp.Value);
+                        }
+                    }
+
+                    // create the data queue handler and add it to composer
+                    _dataQueueHandlerBrokerage = brokerageFactory.CreateBrokerage(liveJob, algorithm);
+
+                    // open connection for subscriptions
+                    _dataQueueHandlerBrokerage.Connect();
+                }
             }
         }
     }

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -16,6 +16,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using Fasterflect;
 using Newtonsoft.Json;
 using QuantConnect.AlgorithmFactory;
 using QuantConnect.Brokerages;
@@ -66,6 +68,7 @@ namespace QuantConnect.Lean.Engine.Setup
 
         // saves ref to algo so we can call quit if runtime error encountered
         private IBrokerageFactory _factory;
+        private IBrokerage _dataQueueHandlerBrokerage;
 
         /// <summary>
         /// Initializes a new BrokerageSetupHandler
@@ -114,6 +117,40 @@ namespace QuantConnect.Lean.Engine.Setup
             // find the correct brokerage factory based on the specified brokerage in the live job packet
             _factory = Composer.Instance.Single<IBrokerageFactory>(brokerageFactory => brokerageFactory.BrokerageType.MatchesTypeName(liveJob.Brokerage));
             factory = _factory;
+
+            // preload the data queue handler using custom BrokerageFactory attribute
+            var dataQueueHandlerType = Assembly.GetAssembly(typeof(Brokerage))
+                .GetTypes()
+                .FirstOrDefault(x =>
+                    x.FullName != null &&
+                    x.FullName.EndsWith(liveJob.DataQueueHandler) &&
+                    x.HasAttribute(typeof(BrokerageFactoryAttribute)));
+
+            if (dataQueueHandlerType != null)
+            {
+                var attribute = dataQueueHandlerType.GetCustomAttribute<BrokerageFactoryAttribute>();
+
+                // only load the data queue handler if the factory is different from our brokerage factory
+                if (attribute.Type != factory.GetType())
+                {
+                    var brokerageFactory = (BrokerageFactory) Activator.CreateInstance(attribute.Type);
+
+                    // copy the brokerage data (usually credentials)
+                    foreach (var kvp in brokerageFactory.BrokerageData)
+                    {
+                        if (!liveJob.BrokerageData.ContainsKey(kvp.Key))
+                        {
+                            liveJob.BrokerageData.Add(kvp.Key, kvp.Value);
+                        }
+                    }
+
+                    // create the data queue handler and add it to composer
+                    _dataQueueHandlerBrokerage = brokerageFactory.CreateBrokerage(liveJob, uninitializedAlgorithm);
+
+                    // open connection for subscriptions
+                    _dataQueueHandlerBrokerage.Connect();
+                }
+            }
 
             // initialize the correct brokerage using the resolved factory
             var brokerage = _factory.CreateBrokerage(liveJob, uninitializedAlgorithm);
@@ -432,9 +469,15 @@ namespace QuantConnect.Lean.Engine.Setup
         /// <filterpriority>2</filterpriority>
         public void Dispose()
         {
-            if (_factory != null)
+            _factory?.DisposeSafely();
+
+            if (_dataQueueHandlerBrokerage != null)
             {
-                _factory.Dispose();
+                if (_dataQueueHandlerBrokerage.IsConnected)
+                {
+                    _dataQueueHandlerBrokerage.Disconnect();
+                }
+                _dataQueueHandlerBrokerage.DisposeSafely();
             }
         }
     }


### PR DESCRIPTION

#### Description
This change allows local LEAN users to use the `GDAXDataQueueHandler` with the `PaperBrokerage`.

#### Related Issue
Closes #2103 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local testing with the `paper-gdax` configuration in #2103 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`