### PR TITLE
Fix CustomDataRegressionAlgorithm failing test

### DIFF
--- a/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
+++ b/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
@@ -142,7 +142,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             //return "http://my-ftp-server.com/futures-data-" + date.ToString("Ymd") + ".zip";
             // OR simply return a fixed small data file. Large files will slow down your backtest
-            return new SubscriptionDataSource("http://www.quandl.com/api/v1/datasets/BCHARTS/BITSTAMPUSD.csv?sort_order=asc", SubscriptionTransportMedium.RemoteFile);
+            return new SubscriptionDataSource("https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc", SubscriptionTransportMedium.RemoteFile);
         }
 
         /// <summary>

--- a/Algorithm.Python/CustomDataBitcoinAlgorithm.py
+++ b/Algorithm.Python/CustomDataBitcoinAlgorithm.py
@@ -68,7 +68,7 @@ class Bitcoin(PythonData):
 
         #return "http://my-ftp-server.com/futures-data-" + date.ToString("Ymd") + ".zip";
         # OR simply return a fixed small data file. Large files will slow down your backtest
-        return SubscriptionDataSource("http://www.quandl.com/api/v1/datasets/BCHARTS/BITSTAMPUSD.csv?sort_order=asc", SubscriptionTransportMedium.RemoteFile);
+        return SubscriptionDataSource("https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc", SubscriptionTransportMedium.RemoteFile);
 
 
     def Reader(self, config, line, date, isLiveMode):

--- a/Algorithm.Python/CustomDataRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataRegressionAlgorithm.py
@@ -60,7 +60,7 @@ class Bitcoin(PythonData):
 
         #return "http://my-ftp-server.com/futures-data-" + date.ToString("Ymd") + ".zip";
         # OR simply return a fixed small data file. Large files will slow down your backtest
-        return SubscriptionDataSource("http://www.quandl.com/api/v1/datasets/BCHARTS/BITSTAMPUSD.csv?sort_order=asc", SubscriptionTransportMedium.RemoteFile);
+        return SubscriptionDataSource("https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc", SubscriptionTransportMedium.RemoteFile);
 
 
     def Reader(self, config, line, date, isLiveMode):

--- a/Tests/RegressionAlgorithms/Test_LiveAlgorithm.cs
+++ b/Tests/RegressionAlgorithms/Test_LiveAlgorithm.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -98,7 +98,7 @@ namespace QuantConnect
             {
                 //Historical backtesting data:
                 case DataFeedEndpoint.Backtesting:
-                    source = "http://www.quandl.com/api/v1/datasets/BITCOIN/BITSTAMPUSD.csv?sort_order=asc";
+                    source = "https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc";
                     break;
 
                 //Live socket for bitcoin prices:
@@ -179,7 +179,7 @@ namespace QuantConnect
                     catch { /* Do nothing, possible error in json decoding */ }
                     break;
             }
-            
+
             return coin;
         }
     }

--- a/Tests/RegressionAlgorithms/Test_MixedAssets.cs
+++ b/Tests/RegressionAlgorithms/Test_MixedAssets.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -68,7 +68,7 @@ namespace QuantConnect
             }
         }
 
-        // 
+        //
         public void OnData(VIX vix)
         {
             _vix = vix.Close;
@@ -91,7 +91,7 @@ namespace QuantConnect
 
         public override string GetSource(SubscriptionDataConfig config, DateTime date, DataFeedEndpoint datafeed)
         {
-            return "https://www.quandl.com/api/v1/datasets/YAHOO/INDEX_VIX.csv?trim_start=2000-01-01&trim_end=2014-10-31&sort_order=asc&exclude_headers=true";
+            return "https://www.quandl.com/api/v3/datasets/YAHOO/INDEX_VIX.csv?trim_start=2000-01-01&trim_end=2014-10-31&order=asc&exclude_headers=true";
         }
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, DataFeedEndpoint datafeed)
         {
@@ -102,13 +102,13 @@ namespace QuantConnect
             //10/27/2014    17.24    17.87    16    16.04    0         16.04
             string[] data = line.Split(',');
             fear.Time = DateTime.ParseExact(data[0], "yyyy-MM-dd", CultureInfo.InvariantCulture);
-            fear.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture); 
+            fear.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
             fear.High = Convert.ToDecimal(data[2], CultureInfo.InvariantCulture);
-            fear.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture); 
+            fear.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture);
             fear.Close = Convert.ToDecimal(data[4], CultureInfo.InvariantCulture);
             fear.Symbol = "VIX"; fear.Value = fear.Close;
             //}
-            //catch 
+            //catch
             //{ }
             return fear;
         }


### PR DESCRIPTION

#### Description
All Quandl API calls in regression and example algorithms have been updated to match the current documentation here: https://docs.quandl.com/docs/in-depth-usage

#### Related Issue
Closes #2117 

#### Motivation and Context
The CustomDataRegressionAlgorithm test was failing.
This regression test and some example algorithms for custom data were using the deprecated Quandl `v1` API URL and the `sort_order=asc` is no longer working.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually tested Quandl API calls.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`