### PR TITLE
Fix non-deterministic query in QCAlgorithm.GetSubscription

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1332,12 +1332,15 @@ namespace QuantConnect.Algorithm
             SubscriptionDataConfig subscription;
             try
             {
+                // deterministic ordering is required here
+                var subscriptions = SubscriptionManager.Subscriptions.OrderBy(x => x.TickType);
+
                 // find our subscription to this symbol
-                subscription = SubscriptionManager.Subscriptions.FirstOrDefault(x => x.Symbol == symbol && (tickType == null || tickType == x.TickType));
+                subscription = subscriptions.FirstOrDefault(x => x.Symbol == symbol && (tickType == null || tickType == x.TickType));
                 if (subscription == null)
                 {
                     // if we can't locate the exact subscription by tick type just grab the first one we find
-                    subscription = SubscriptionManager.Subscriptions.First(x => x.Symbol == symbol);
+                    subscription = subscriptions.First(x => x.Symbol == symbol);
                 }
             }
             catch (InvalidOperationException)


### PR DESCRIPTION

#### Description
`QCAlgorithm.GetSubscription` now searches for the first matching subscription in an enumerable sorted by `Symbol` and `TickType`.

#### Related Issue
Closes #2119 

#### Motivation and Context
`BasicTemplateCryptoAlgorithm` is returning different results for a backtest with the Test runner vs LEAN launcher.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
`BasicTemplateCryptoAlgorithm` is now consistently returning the same results.
Previously, when running in the test runner, the last 5 orders were never submitted because the EMA values were always zero (due to the wrong consolidators being selected).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`