### PR TITLE
Adds BasicCSharpQuantBookTemplate

### DIFF
--- a/Jupyter/BasicCSharpQuantBookTemplate.ipynb
+++ b/Jupyter/BasicCSharpQuantBookTemplate.ipynb
@@ -1,0 +1,149 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![QuantConnect Logo](https://cdn.quantconnect.com/web/i/logo-small.png)\n",
+    "## Welcome to The QuantConnect Research Page\n",
+    "#### Refer to this page for documentation https://www.quantconnect.com/docs#Introduction-to-Jupyter\n",
+    "#### Contribute to this template file https://github.com/QuantConnect/Lean/blob/master/Jupyter/BasicCSharpQuantBookTemplate.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## QuantBook Basics\n",
+    "\n",
+    "### Start QuantBook\n",
+    "- Load \"QuantConnect.csx\" with all the basic imports\n",
+    "- Create a QuantBook instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#load \"QuantConnect.csx\"\n",
+    "using QuantConnect.Data.Custom;\n",
+    "using QuantConnect.Data.Market;\n",
+    "var qb = new QuantBook();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Selecting Asset Data\n",
+    "Checkout the QuantConnect [docs](https://www.quantconnect.com/docs#Initializing-Algorithms-Selecting-Asset-Data) to learn how to select asset data."
+   ]
+  },
+  {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "var spy = qb.AddEquity(\"SPY\");\n",
+      "var eur = qb.AddForex(\"EURUSD\");\n",
+      "var btc = qb.AddCrypto(\"BTCUSD\");\n",
+      "var fxv = qb.AddData<FxcmVolume>(\"EURUSD_Vol\", Resolution.Hour);"
+    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Historical Data Requests\n",
+    "\n",
+    "We can use the QuantConnect API to make Historical Data Requests. The data will be presented as multi-index pandas.DataFrame where the first index is the Symbol.\n",
+    "\n",
+    "For more information, please follow the [link](https://www.quantconnect.com/docs#Historical-Data-Historical-Data-Requests)."
+   ]
+  },
+  {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "// Gets historical data from the subscribed assets, the last 360 datapoints with daily resolution\n",
+      "var h1 = qb.History(qb.Securities.Keys, 360, Resolution.Daily);"
+    ]
+  },
+  {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "// Gets historical data from the subscribed assets, from the last 30 days with daily resolution\n",
+      "var h2 = qb.History(qb.Securities.Keys, TimeSpan.FromDays(360), Resolution.Daily);"
+    ]
+  },
+  {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "// Gets historical data from the subscribed assets, between two dates with daily resolution\n",
+      "var h3 = qb.History(btc.Symbol, new DateTime(2014,1,1), DateTime.Now, Resolution.Daily);"
+    ]
+  },
+  {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "// Only fetchs historical data from a desired symbol\n",
+      "var h4 = qb.History(spy.Symbol, 360, Resolution.Daily);"
+    ]
+  },
+  {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "// Only fetchs historical data from a desired symbol\n",
+      "var h5 = qb.History<QuoteBar>(eur.Symbol, TimeSpan.FromDays(360), Resolution.Daily);"
+    ]
+  },
+  {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "// Fetchs custom data\n",
+      "var h6 = qb.History<FxcmVolume>(fxv.Symbol, TimeSpan.FromDays(360));"
+    ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "C#",
+   "language": "csharp",
+   "name": "csharp"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Jupyter/QuantConnect.Jupyter.csproj
+++ b/Jupyter/QuantConnect.Jupyter.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>QuantConnect.Jupyter</RootNamespace>
     <AssemblyName>QuantConnect.Jupyter</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <LangVersion>6</LangVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -97,6 +98,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="BasicCSharpQuantBookTemplate.ipynb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="BasicQuantBookTemplate.ipynb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
#### Description
Adds `BasicCSharpQuantBookTemplate.ipynb` that shows how to use `QuantBook` with C# kernel.

#### Related Issue
Closes #2123 

#### Motivation and Context
C# and python support for Research Enviro0nment.

#### Requires Documentation Change
Yes. Sections explaining C# features need to be included.

#### How Has This Been Tested?
Running the notebook in QuantConnect Research. 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`