### PR TITLE
Fix non-deterministic enumeration in SubscriptionCollection

### DIFF
--- a/Engine/DataFeeds/SubscriptionCollection.cs
+++ b/Engine/DataFeeds/SubscriptionCollection.cs
@@ -126,6 +126,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 .Select(x => x.Value)
                 .OrderBy(x => x.Configuration.SecurityType)
                 .ThenBy(x => x.Configuration.TickType)
+                .ThenBy(x => x.Configuration.Symbol)
                 .ToList();
         }
     }


### PR DESCRIPTION

#### Description
The `SubscriptionCollection` enumerator is now sorted by `SecurityType + TickType + Symbol`.

#### Related Issue
Closes #2135 

#### Motivation and Context
Besides the regression test in #2135 failing, we **want** to have deterministic results in enumerators.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
The regression test in #2135 is now always passing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`