### PR TITLE
Fix ParameterizedAlgorithm regression failure

### DIFF
--- a/Configuration/Config.cs
+++ b/Configuration/Config.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using QuantConnect.Logging;
@@ -61,14 +60,26 @@ namespace QuantConnect.Configuration
             }
 
             var jsonArguments = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(cliArguments));
-            
+
             Settings.Value.Merge(jsonArguments, new JsonMergeSettings
             {
                 MergeArrayHandling = MergeArrayHandling.Union
             });
         }
 
-        private static readonly Lazy<JObject> Settings = new Lazy<JObject>(() =>
+        /// <summary>
+        /// Resets the config settings to their default values.
+        /// Called in regression tests where multiple algorithms are run sequentially,
+        /// and we need to guarantee that every test starts with the same configuration.
+        /// </summary>
+        public static void Reset()
+        {
+            Settings = new Lazy<JObject>(ConfigFactory);
+        }
+
+        private static Lazy<JObject> Settings = new Lazy<JObject>(ConfigFactory);
+
+        private static JObject ConfigFactory()
         {
             // initialize settings inside a lazy for free thread-safe, one-time initialization
             if (!File.Exists(ConfigurationFileName))
@@ -90,7 +101,7 @@ namespace QuantConnect.Configuration
             }
 
             return JObject.Parse(File.ReadAllText(ConfigurationFileName));
-        });
+        }
 
         /// <summary>
         /// Gets the currently selected environment. If sub-environments are defined,
@@ -117,7 +128,7 @@ namespace QuantConnect.Configuration
             }
             return string.Join(".", environments);
         }
-        
+
         /// <summary>
         /// Get the matching config setting from the file searching for this key.
         /// </summary>

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 using System.Linq;
 using Newtonsoft.Json;
 using QuantConnect.Algorithm.CSharp;
+using QuantConnect.Configuration;
 
 namespace QuantConnect.Tests
 {
@@ -28,25 +29,28 @@ namespace QuantConnect.Tests
         [Test, TestCaseSource(nameof(GetRegressionTestParameters))]
         public void AlgorithmStatisticsRegression(AlgorithmStatisticsTestParameters parameters)
         {
-            QuantConnect.Configuration.Config.Set("quandl-auth-token", "WyAazVXnq7ATy_fefTqm");
-            QuantConnect.Configuration.Config.Set("forward-console-messages", "false");
+            Config.Set("quandl-auth-token", "WyAazVXnq7ATy_fefTqm");
+            Config.Set("forward-console-messages", "false");
 
             if (parameters.Algorithm == "OptionChainConsistencyRegressionAlgorithm")
             {
                 // special arrangement for consistency test - we check if limits work fine
-                QuantConnect.Configuration.Config.Set("symbol-minute-limit", "100");
-                QuantConnect.Configuration.Config.Set("symbol-second-limit", "100");
-                QuantConnect.Configuration.Config.Set("symbol-tick-limit", "100");
+                Config.Set("symbol-minute-limit", "100");
+                Config.Set("symbol-second-limit", "100");
+                Config.Set("symbol-tick-limit", "100");
             }
 
             if (parameters.Algorithm == "BasicTemplateIntrinioEconomicData")
             {
-                var intrinioCredentials = new Dictionary<string, string>
-                {
-                    {"intrinio-username", "121078c02c20a09aa5d9c541087e7fa4"},
-                    {"intrinio-password", "65be35238b14de4cd0afc0edf364efc3" }
-                };
-                QuantConnect.Configuration.Config.Set("parameters", JsonConvert.SerializeObject(intrinioCredentials));
+                var parametersConfigString = Config.Get("parameters");
+                var algorithmParameters = parametersConfigString != string.Empty
+                    ? JsonConvert.DeserializeObject<Dictionary<string, string>>(parametersConfigString)
+                    : new Dictionary<string, string>();
+
+                algorithmParameters["intrinio-username"] = "121078c02c20a09aa5d9c541087e7fa4";
+                algorithmParameters["intrinio-password"] = "65be35238b14de4cd0afc0edf364efc3";
+
+                Config.Set("parameters", JsonConvert.SerializeObject(algorithmParameters));
             }
 
             AlgorithmRunner.RunLocalBacktest(parameters.Algorithm, parameters.Statistics, parameters.AlphaStatistics, parameters.Language);

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -29,6 +29,9 @@ namespace QuantConnect.Tests
         [Test, TestCaseSource(nameof(GetRegressionTestParameters))]
         public void AlgorithmStatisticsRegression(AlgorithmStatisticsTestParameters parameters)
         {
+            // ensure we start with a fresh config every time when running multiple tests
+            Config.Reset();
+
             Config.Set("quandl-auth-token", "WyAazVXnq7ATy_fefTqm");
             Config.Set("forward-console-messages", "false");
 


### PR DESCRIPTION

#### Description
The `AlgorithmStatisticsRegression` method, when called for the `BasicTemplateIntrinioEconomicData` regression, was overwriting all existing algorithm parameters in `config.json` (in this case the two ema periods for `ParameterizedAlgorithm`). 

#### Related Issue
Closes #2140 

#### Motivation and Context
Failing `ParameterizedAlgorithm` regression test.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Run the full regression test suite.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`