### PR TITLE
Keep directory structure in Compression.UnzipToFolder

### DIFF
--- a/Compression/Compression.cs
+++ b/Compression/Compression.cs
@@ -718,15 +718,17 @@ namespace QuantConnect
                     //Ignore Directories
                     if (!zipEntry.IsFile) continue;
 
-                    //Remove the folder from the entry
-                    var entryFileName = Path.GetFileName(zipEntry.Name);
-                    if (entryFileName == null) continue;
-
                     var buffer = new byte[4096];     // 4K is optimum
                     var zipStream = zf.GetInputStream(zipEntry);
 
                     // Manipulate the output filename here as desired.
-                    var fullZipToPath = Path.Combine(outFolder, entryFileName);
+                    var fullZipToPath = Path.Combine(outFolder, zipEntry.Name);
+
+                    var targetFile = new FileInfo(fullZipToPath);
+                    if (targetFile.Directory != null && !targetFile.Directory.Exists)
+                    {
+                        targetFile.Directory.Create();
+                    }
 
                     //Save the file name for later:
                     files.Add(fullZipToPath);

--- a/Tests/Compression/CompressionTests.cs
+++ b/Tests/Compression/CompressionTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -81,6 +83,35 @@ namespace QuantConnect.Tests.Compression
             for (var i = 0; i < entryFileNames.Count; i++)
             {
                 Assert.AreEqual(expectedFileNames[i], entryFileNames[i]);
+            }
+        }
+
+        [Test]
+        public void UnzipToFolderDoesNotStripSubDirectories()
+        {
+            var name = nameof(UnzipToFolderDoesNotStripSubDirectories);
+            var root = new DirectoryInfo(name);
+            var testPath = Path.Combine(root.FullName, "test.txt");
+            var test2Path = Path.Combine(Path.Combine(root.FullName, "sub"), "test2.txt");
+            var zipFile = $"./{name}.zip";
+            var files = new List<string>();
+            try
+            {
+                root.Create();
+                File.WriteAllText(testPath, "string contents");
+                var sub = root.CreateSubdirectory("sub");
+                File.WriteAllText(test2Path, "string contents 2");
+                QuantConnect.Compression.ZipDirectory(root.FullName, zipFile);
+                Directory.Delete(root.FullName, true);
+                files = QuantConnect.Compression.UnzipToFolder(zipFile);
+
+                Assert.IsTrue(File.Exists(testPath));
+                Assert.IsTrue(File.Exists(test2Path));
+            }
+            finally
+            {
+                File.Delete(zipFile);
+                files.ForEach(File.Delete);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The implementation here was stripping out the directories and unzipping to a flat structure. This is not required and was breaking python algorithms by messing up their folder based imports. Also, all consumers currently utilize the return value which is a full list of the unzipped files including the sub directories, so no changes were needed elsewhere.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Final step in supporting python projects with folders in the web IDE.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
If our current documentation states that we don't support folders than this should be updated.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested used the cloud branching system as well as an accompanying unit test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->