### PR TITLE
Improve performance of backtests with a large amount of orders

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -721,8 +721,8 @@ namespace QuantConnect.Algorithm
                 return OrderResponse.Error(request, OrderResponseErrorCode.SecurityHasNoData, "There is no data for this symbol yet, please check the security.HasData flag to ensure there is at least one data point.");
             }
 
-            //We've already processed too many orders: max 100 per day or the memory usage explodes
-            if (Transactions.OrdersCount > _maxOrders)
+            // We've already processed too many orders: max 10k
+            if (!LiveMode && Transactions.OrdersCount > _maxOrders)
             {
                 Status = AlgorithmStatus.Stopped;
                 return OrderResponse.Error(request, OrderResponseErrorCode.ExceededMaximumOrders, string.Format("You have exceeded maximum number of orders ({0}), for unlimited orders upgrade your account.", _maxOrders));

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -94,7 +94,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <returns>The open orders returned from IB</returns>
         public override List<Order> GetOpenOrders()
         {
-            return Algorithm.Transactions.GetOpenOrders();
+            return Algorithm.Transactions.GetOpenOrders().ToList();
         }
 
         /// <summary>

--- a/Common/Securities/IOrderProvider.cs
+++ b/Common/Securities/IOrderProvider.cs
@@ -51,6 +51,13 @@ namespace QuantConnect.Securities
         IEnumerable<OrderTicket> GetOrderTickets(Func<OrderTicket, bool> filter = null);
 
         /// <summary>
+        /// Gets and enumerable of opened <see cref="OrderTicket"/> matching the specified <paramref name="filter"/>
+        /// </summary>
+        /// <param name="filter">The filter predicate used to find the required order tickets. If null is specified then all tickets are returned</param>
+        /// <returns>An enumerable of opened <see cref="OrderTicket"/> matching the specified <paramref name="filter"/></returns>
+        IEnumerable<OrderTicket> GetOpenOrderTickets(Func<OrderTicket, bool> filter = null);
+
+        /// <summary>
         /// Gets the order ticket for the specified order id. Returns null if not found
         /// </summary>
         /// <param name="orderId">The order's id</param>
@@ -62,8 +69,16 @@ namespace QuantConnect.Securities
         /// of all orders.
         /// </summary>
         /// <param name="filter">Delegate used to filter the orders</param>
-        /// <returns>All open orders this order provider currently holds</returns>
+        /// <returns>All orders this order provider currently holds by the specified filter</returns>
         IEnumerable<Order> GetOrders(Func<Order, bool> filter = null);
+
+        /// <summary>
+        /// Gets open orders matching the specified filter. Specifying null will return an enumerable
+        /// of all open orders.
+        /// </summary>
+        /// <param name="filter">Delegate used to filter the orders</param>
+        /// <returns>All filtered open orders this order provider currently holds</returns>
+        List<Order> GetOpenOrders(Func<Order, bool> filter = null);
     }
 
     /// <summary>

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -303,7 +303,7 @@ namespace QuantConnect.Lean.Engine
                     foreach (var symbol in timeSlice.Slice.SymbolChangedEvents.Keys)
                     {
                         // cancel all orders for the old symbol
-                        foreach (var ticket in transactions.GetOrderTickets(x => x.Status.IsOpen() && x.Symbol == symbol))
+                        foreach (var ticket in transactions.GetOpenOrderTickets(x => x.Symbol == symbol))
                         {
                             ticket.Cancel("Open order cancelled on symbol changed event");
                         }
@@ -500,7 +500,7 @@ namespace QuantConnect.Lean.Engine
                         if (_liveMode || algorithm.Securities[split.Symbol].DataNormalizationMode == DataNormalizationMode.Raw)
                         {
                             // in live mode we always want to have our order match the order at the brokerage, so apply the split to the orders
-                            var openOrders = transactions.GetOrderTickets(ticket => ticket.Status.IsOpen() && ticket.Symbol == split.Symbol);
+                            var openOrders = transactions.GetOpenOrderTickets(ticket => ticket.Symbol == split.Symbol);
                             algorithm.BrokerageModel.ApplySplit(openOrders.ToList(), split);
                         }
                     }

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -319,7 +319,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private bool IsSafeToRemove(Security member)
         {
             // but don't physically remove it from the algorithm if we hold stock or have open orders against it or an open target
-            var openOrders = _algorithm.Transactions.GetOrders(x => x.Status.IsOpen() && x.Symbol == member.Symbol);
+            var openOrders = _algorithm.Transactions.GetOpenOrders(x => x.Symbol == member.Symbol);
             if (!member.HoldStock && !openOrders.Any() && (member.Holdings.Target == null || member.Holdings.Target.Quantity == 0))
             {
                 return true;

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -393,8 +393,7 @@ namespace QuantConnect.Lean.Engine.Setup
                 Log.Trace("BrokerageSetupHandler.Setup(): Has open order: " + order.Symbol.Value + " - " + order.Quantity);
                 resultHandler.DebugMessage($"BrokerageSetupHandler.Setup(): Open order detected.  Creating order tickets for open order {order.Symbol.Value} with quantity {order.Quantity}. Beware that this order ticket may not accurately reflect the quantity of the order if the open order is partially filled.");
                 order.Id = algorithm.Transactions.GetIncrementOrderId();
-                transactionHandler.Orders.AddOrUpdate(order.Id, order, (i, o) => order);
-                transactionHandler.OrderTickets.AddOrUpdate(order.Id, order.ToOrderTicket(algorithm.Transactions));
+                transactionHandler.AddOpenOrder(order);
             }
         }
 

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -38,6 +38,9 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         private IBrokerage _brokerage;
         private bool _syncedLiveBrokerageCashToday;
 
+        // Counter to keep track of total amount of processed orders
+        private int _totalOrderCount;
+
         // this bool is used to check if the warning message for the rounding of order quantity has been displayed for the first time
         private bool _firstRoundOffMessage = false;
 
@@ -57,17 +60,30 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
         /// <summary>
-        /// The orders dictionary holds orders which are sent to exchange, partially filled, completely filled or cancelled.
+        /// The _completeOrders dictionary holds all orders.
         /// Once the transaction thread has worked on them they get put here while witing for fill updates.
         /// </summary>
-        private readonly ConcurrentDictionary<int, Order> _orders = new ConcurrentDictionary<int, Order>();
+        private readonly ConcurrentDictionary<int, Order> _completeOrders = new ConcurrentDictionary<int, Order>();
 
         /// <summary>
-        /// The orders tickets dictionary holds order tickets that the algorithm can use to reference a specific order. This
+        /// The orders dictionary holds orders which are open. Status: New, Submitted, PartiallyFilled, None, CancelPending
+        /// Once the transaction thread has worked on them they get put here while witing for fill updates.
+        /// </summary>
+        private readonly ConcurrentDictionary<int, Order> _openOrders = new ConcurrentDictionary<int, Order>();
+
+        /// <summary>
+        /// The _openOrderTickets dictionary holds open order tickets that the algorithm can use to reference a specific order. This
         /// includes invoking update and cancel commands. In the future, we can add more features to the ticket, such as events
         /// and async events (such as run this code when this order fills)
         /// </summary>
-        private readonly ConcurrentDictionary<int, OrderTicket> _orderTickets = new ConcurrentDictionary<int, OrderTicket>();
+        private readonly ConcurrentDictionary<int, OrderTicket> _openOrderTickets = new ConcurrentDictionary<int, OrderTicket>();
+
+        /// <summary>
+        /// The _completeOrderTickets dictionary holds all order tickets that the algorithm can use to reference a specific order. This
+        /// includes invoking update and cancel commands. In the future, we can add more features to the ticket, such as events
+        /// and async events (such as run this code when this order fills)
+        /// </summary>
+        private readonly ConcurrentDictionary<int, OrderTicket> _completeOrderTickets = new ConcurrentDictionary<int, OrderTicket>();
 
         private IResultHandler _resultHandler;
 
@@ -76,7 +92,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// </summary>
         public ConcurrentDictionary<int, Order> Orders
         {
-            get { return _orders; }
+            get
+            {
+                return _completeOrders;
+            }
         }
 
         /// <summary>
@@ -84,16 +103,16 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// </summary>
         public ConcurrentDictionary<int, OrderTicket> OrderTickets
         {
-            get { return _orderTickets; }
+            get
+            {
+                return _completeOrderTickets;
+            }
         }
 
         /// <summary>
         /// Gets the current number of orders that have been processed
         /// </summary>
-        public int OrdersCount
-        {
-            get { return _orders.Count; }
-        }
+        public int OrdersCount => _totalOrderCount;
 
         /// <summary>
         /// Creates a new BrokerageTransactionHandler to process orders using the specified brokerage implementation
@@ -191,11 +210,13 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
             request.SetResponse(response);
             var ticket = new OrderTicket(_algorithm.Transactions, request);
-            _orderTickets.TryAdd(ticket.OrderId, ticket);
 
+            Interlocked.Increment(ref _totalOrderCount);
             // send the order to be processed after creating the ticket
             if (response.IsSuccess)
             {
+                _openOrderTickets.TryAdd(ticket.OrderId, ticket);
+                _completeOrderTickets.TryAdd(ticket.OrderId, ticket);
                 _orderRequestQueue.Add(request);
             }
             else
@@ -210,7 +231,8 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 order.Status = OrderStatus.Invalid;
                 order.Tag = "Algorithm warming up.";
                 ticket.SetOrder(order);
-                _orders.TryAdd(request.OrderId, order);
+                _completeOrderTickets.TryAdd(ticket.OrderId, ticket);
+                _completeOrders.TryAdd(order.Id, order);
             }
             return ticket;
         }
@@ -223,7 +245,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         public OrderTicket UpdateOrder(UpdateOrderRequest request)
         {
             OrderTicket ticket;
-            if (!_orderTickets.TryGetValue(request.OrderId, out ticket))
+            if (!_completeOrderTickets.TryGetValue(request.OrderId, out ticket))
             {
                 return OrderTicket.InvalidUpdateOrderId(_algorithm.Transactions, request);
             }
@@ -274,7 +296,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         public OrderTicket CancelOrder(CancelOrderRequest request)
         {
             OrderTicket ticket;
-            if (!_orderTickets.TryGetValue(request.OrderId, out ticket))
+            if (!_completeOrderTickets.TryGetValue(request.OrderId, out ticket))
             {
                 Log.Error("BrokerageTransactionHandler.CancelOrder(): Unable to locate ticket for order.");
                 return OrderTicket.InvalidCancelOrderId(_algorithm.Transactions, request);
@@ -340,7 +362,17 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// <returns>An enumerable of <see cref="OrderTicket"/> matching the specified <paramref name="filter"/></returns>
         public IEnumerable<OrderTicket> GetOrderTickets(Func<OrderTicket, bool> filter = null)
         {
-            return _orderTickets.Select(x => x.Value).Where(filter ?? (x => true));
+            return _completeOrderTickets.Select(x => x.Value).Where(filter ?? (x => true));
+        }
+
+        /// <summary>
+        /// Gets and enumerable of opened <see cref="OrderTicket"/> matching the specified <paramref name="filter"/>
+        /// </summary>
+        /// <param name="filter">The filter predicate used to find the required order tickets</param>
+        /// <returns>An enumerable of opened <see cref="OrderTicket"/> matching the specified <paramref name="filter"/></returns>
+        public IEnumerable<OrderTicket> GetOpenOrderTickets(Func<OrderTicket, bool> filter = null)
+        {
+            return _openOrderTickets.Select(x => x.Value).Where(filter ?? (x => true));
         }
 
         /// <summary>
@@ -351,7 +383,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         public OrderTicket GetOrderTicket(int orderId)
         {
             OrderTicket ticket;
-            _orderTickets.TryGetValue(orderId, out ticket);
+            _completeOrderTickets.TryGetValue(orderId, out ticket);
             return ticket;
         }
 
@@ -371,10 +403,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         private Order GetOrderByIdInternal(int orderId)
         {
             // this function can be invoked by brokerages when getting open orders, guard against null ref
-            if (_orders == null) return null;
+            if (_completeOrders == null) return null;
 
             Order order;
-            return _orders.TryGetValue(orderId, out order) ? order : null;
+            return _completeOrders.TryGetValue(orderId, out order) ? order : null;
         }
 
         /// <summary>
@@ -385,32 +417,55 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         public Order GetOrderByBrokerageId(string brokerageId)
         {
             // this function can be invoked by brokerages when getting open orders, guard against null ref
-            if (_orders == null) return null;
+            if (_completeOrders == null || _openOrders == null) return null;
 
-            var order = _orders.FirstOrDefault(x => x.Value.BrokerId.Contains(brokerageId)).Value;
-            return order != null ? order.Clone() : null;
+            var order = _openOrders.FirstOrDefault(x => x.Value.BrokerId.Contains(brokerageId)).Value
+                        ?? _completeOrders.FirstOrDefault(x => x.Value.BrokerId.Contains(brokerageId)).Value;
+            return order?.Clone();
         }
 
         /// <summary>
-        /// Gets all orders matching the specified filter
+        /// Gets all orders matching the specified filter. Specifying null will return an enumerable
+        /// of all orders.
         /// </summary>
         /// <param name="filter">Delegate used to filter the orders</param>
-        /// <returns>All open orders this order provider currently holds</returns>
+        /// <returns>All orders this order provider currently holds by the specified filter</returns>
         public IEnumerable<Order> GetOrders(Func<Order, bool> filter = null)
         {
-            if (_orders == null)
+            if (_completeOrders == null)
             {
                 // this is the case when we haven't initialize yet, backtesting brokerage
                 // will end up calling this through the transaction manager
                 return Enumerable.Empty<Order>();
             }
+            if (filter != null)
+            {
+                // return a clone to prevent object reference shenanigans, you must submit a request to change the order
+                return _completeOrders.Select(x => x.Value).Where(filter).Select(x => x.Clone());
+            }
+            return _completeOrders.Select(x => x.Value).Select(x => x.Clone());
+        }
+
+        /// <summary>
+        /// Gets open orders matching the specified filter
+        /// </summary>
+        /// <param name="filter">Delegate used to filter the orders</param>
+        /// <returns>All open orders this order provider currently holds</returns>
+        public List<Order> GetOpenOrders(Func<Order, bool> filter = null)
+        {
+            if (_openOrders == null)
+            {
+                // this is the case when we haven't initialize yet, backtesting brokerage
+                // will end up calling this through the transaction manager
+                return new List<Order>();
+            }
 
             if (filter != null)
             {
                 // return a clone to prevent object reference shenanigans, you must submit a request to change the order
-                return _orders.Select(x => x.Value).Where(filter).Select(x => x.Clone());
+                return _openOrders.Select(x => x.Value).Where(filter).Select(x => x.Clone()).ToList();
             }
-            return _orders.Select(x => x.Value).Select(x => x.Clone());
+            return _openOrders.Select(x => x.Value).Select(x => x.Clone()).ToList();
         }
 
         /// <summary>
@@ -491,23 +546,35 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
             // we want to remove orders older than 10k records, but only in live mode
             const int maxOrdersToKeep = 10000;
-            if (_orders.Count < maxOrdersToKeep + 1)
+            if (_completeOrders.Count < maxOrdersToKeep + 1)
             {
                 Log.Debug("BrokerageTransactionHandler.ProcessSynchronousEvents(): Exit");
                 return;
             }
 
-            int max = _orders.Max(x => x.Key);
+            int max = _completeOrders.Max(x => x.Key);
             int lowestOrderIdToKeep = max - maxOrdersToKeep;
-            foreach (var item in _orders.Where(x => x.Key <= lowestOrderIdToKeep))
+            foreach (var item in _completeOrders.Where(x => x.Key <= lowestOrderIdToKeep))
             {
                 Order value;
                 OrderTicket ticket;
-                _orders.TryRemove(item.Key, out value);
-                _orderTickets.TryRemove(item.Key, out ticket);
+                _completeOrders.TryRemove(item.Key, out value);
+                _completeOrderTickets.TryRemove(item.Key, out ticket);
             }
 
             Log.Debug("BrokerageTransactionHandler.ProcessSynchronousEvents(): Exit");
+        }
+
+        /// <summary>
+        /// Register an already open Order
+        /// </summary>
+        public void AddOpenOrder(Order order)
+        {
+            _openOrders.AddOrUpdate(order.Id, order, (i, o) => order);
+            _completeOrders.AddOrUpdate(order.Id, order, (i, o) => order);
+            var ticket = order.ToOrderTicket(_algorithm.Transactions);
+            _openOrderTickets.AddOrUpdate(order.Id, ticket);
+            _completeOrderTickets.AddOrUpdate(order.Id, ticket);
         }
 
         /// <summary>
@@ -658,12 +725,12 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             // rounds off the order towards 0 to the nearest multiple of lot size
             order.Quantity = RoundOffOrder(order, security);
 
-            if (!_orders.TryAdd(order.Id, order))
+            if (!_openOrders.TryAdd(order.Id, order) || !_completeOrders.TryAdd(order.Id, order))
             {
                 Log.Error("BrokerageTransactionHandler.HandleSubmitOrderRequest(): Unable to add new order, order not processed.");
                 return OrderResponse.Error(request, OrderResponseErrorCode.OrderAlreadyExists, "Cannot process submit request because order with id {0} already exists");
             }
-            if (!_orderTickets.TryGetValue(order.Id, out ticket))
+            if (!_completeOrderTickets.TryGetValue(order.Id, out ticket))
             {
                 Log.Error("BrokerageTransactionHandler.HandleSubmitOrderRequest(): Unable to retrieve order ticket, order not processed.");
                 return OrderResponse.UnableToFindOrder(request);
@@ -757,7 +824,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         {
             Order order;
             OrderTicket ticket;
-            if (!_orders.TryGetValue(request.OrderId, out order) || !_orderTickets.TryGetValue(request.OrderId, out ticket))
+            if (!_completeOrders.TryGetValue(request.OrderId, out order) || !_completeOrderTickets.TryGetValue(request.OrderId, out ticket))
             {
                 Log.Error("BrokerageTransactionHandler.HandleUpdateOrderRequest(): Unable to update order with ID " + request.OrderId);
                 return OrderResponse.UnableToFindOrder(request);
@@ -836,7 +903,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         {
             Order order;
             OrderTicket ticket;
-            if (!_orders.TryGetValue(request.OrderId, out order) || !_orderTickets.TryGetValue(request.OrderId, out ticket))
+            if (!_completeOrders.TryGetValue(request.OrderId, out order) || !_completeOrderTickets.TryGetValue(request.OrderId, out ticket))
             {
                 Log.Error("BrokerageTransactionHandler.HandleCancelOrderRequest(): Unable to cancel order with ID " + request.OrderId + ".");
                 return OrderResponse.UnableToFindOrder(request);
@@ -883,23 +950,30 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
         private void HandleOrderEvent(OrderEvent fill)
         {
-            // update the order status
-            var order = GetOrderByIdInternal(fill.OrderId);
-            if (order == null)
+            Order order;
+            OrderTicket ticket;
+            if(fill.Status.IsClosed() && _openOrders.TryRemove(fill.OrderId, out order))
             {
-                Log.Error("BrokerageTransactionHandler.HandleOrderEvent(): Unable to locate Order with id " + fill.OrderId);
+                _completeOrders[fill.OrderId] = order;
+            }
+            else if(!_completeOrders.TryGetValue(fill.OrderId, out order))
+            {
+                Log.Error("BrokerageTransactionHandler.HandleOrderEvent(): Unable to locate open Order with id " + fill.OrderId);
                 return;
             }
 
+            if (fill.Status.IsClosed() && _openOrderTickets.TryRemove(fill.OrderId, out ticket))
+            {
+                _completeOrderTickets[fill.OrderId] = ticket;
+            }
+            else if (!_completeOrderTickets.TryGetValue(fill.OrderId, out ticket))
+            {
+                Log.Error("BrokerageTransactionHandler.HandleOrderEvent(): Unable to resolve open ticket: " + fill.OrderId);
+                return;
+            }
             // set the status of our order object based on the fill event
             order.Status = fill.Status;
 
-            OrderTicket ticket;
-            if (!_orderTickets.TryGetValue(fill.OrderId, out ticket))
-            {
-                Log.Error("BrokerageTransactionHandler.HandleOrderEvent(): Unable to resolve ticket: " + fill.OrderId);
-                return;
-            }
 
             // set the modified time of the order to the fill's timestamp
             switch (fill.Status)

--- a/Engine/TransactionHandlers/ITransactionHandler.cs
+++ b/Engine/TransactionHandlers/ITransactionHandler.cs
@@ -74,5 +74,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// Process any synchronous events from the primary algorithm thread.
         /// </summary>
         void ProcessSynchronousEvents();
+
+        /// <summary>
+        /// Register an already open Order
+        /// </summary>
+        void AddOpenOrder(Order order);
     }
 }

--- a/Tests/Brokerages/OrderProvider.cs
+++ b/Tests/Brokerages/OrderProvider.cs
@@ -66,6 +66,11 @@ namespace QuantConnect.Tests.Brokerages
             throw new NotImplementedException("This method has not been implemented");
         }
 
+        public IEnumerable<OrderTicket> GetOpenOrderTickets(Func<OrderTicket, bool> filter = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public OrderTicket GetOrderTicket(int orderId)
         {
             throw new NotImplementedException("This method has not been implemented");
@@ -74,6 +79,11 @@ namespace QuantConnect.Tests.Brokerages
         public IEnumerable<Order> GetOrders(Func<Order, bool> filter)
         {
             return _orders.Where(filter);
+        }
+
+        public List<Order> GetOpenOrders(Func<Order, bool> filter = null)
+        {
+            return _orders.Where(x => x.Status.IsOpen() && (filter == null || filter(x))).ToList();
         }
     }
 }

--- a/Tests/Common/Securities/FakeOrderProcessor.cs
+++ b/Tests/Common/Securities/FakeOrderProcessor.cs
@@ -56,6 +56,11 @@ namespace QuantConnect.Tests.Common.Securities
             return _tickets.Values.Where(filter ?? (x => true));
         }
 
+        public IEnumerable<OrderTicket> GetOpenOrderTickets(Func<OrderTicket, bool> filter = null)
+        {
+            return _tickets.Values.Where(x => x.Status.IsOpen() && (filter == null || filter(x)));
+        }
+
         public OrderTicket GetOrderTicket(int orderId)
         {
             OrderTicket ticket;
@@ -66,6 +71,11 @@ namespace QuantConnect.Tests.Common.Securities
         public IEnumerable<Order> GetOrders(Func<Order, bool> filter = null)
         {
             return _orders.Values.Where(filter ?? (x => true));
+        }
+
+        public List<Order> GetOpenOrders(Func<Order, bool> filter = null)
+        {
+            return _orders.Values.Where(x => x.Status.IsOpen() && (filter == null || filter(x))).ToList();
         }
 
         public OrderTicket Process(OrderRequest request)

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -1540,6 +1540,11 @@ namespace QuantConnect.Tests.Common.Securities
                 return _tickets.Values.Where(filter ?? (x => true));
             }
 
+            public IEnumerable<OrderTicket> GetOpenOrderTickets(Func<OrderTicket, bool> filter = null)
+            {
+                return _tickets.Values.Where(x => x.Status.IsOpen() && (filter == null || filter(x)));
+            }
+
             public OrderTicket GetOrderTicket(int orderId)
             {
                 OrderTicket ticket;
@@ -1550,6 +1555,11 @@ namespace QuantConnect.Tests.Common.Securities
             public IEnumerable<Order> GetOrders(Func<Order, bool> filter = null)
             {
                 return _orders.Values.Where(filter ?? (x => true));
+            }
+
+            public List<Order> GetOpenOrders(Func<Order, bool> filter = null)
+            {
+                return _orders.Values.Where(x => x.Status.IsOpen() && (filter == null || filter(x))).ToList();
             }
 
             public OrderTicket Process(OrderRequest request)

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -404,6 +404,11 @@ namespace QuantConnect.Tests.Engine
                 throw new NotImplementedException();
             }
 
+            public IEnumerable<OrderTicket> GetOpenOrderTickets(Func<OrderTicket, bool> filter = null)
+            {
+                return OrderTickets.Values.Where(x => x.Status.IsOpen() && (filter == null || filter(x)));
+            }
+
             public OrderTicket GetOrderTicket(int orderId)
             {
                 throw new NotImplementedException();
@@ -417,6 +422,11 @@ namespace QuantConnect.Tests.Engine
             public OrderTicket Process(OrderRequest request)
             {
                 throw new NotImplementedException();
+            }
+
+            public List<Order> GetOpenOrders(Func<Order, bool> filter = null)
+            {
+                return Orders.Values.Where(x => x.Status.IsOpen() && (filter == null || filter(x))).ToList();
             }
 
             public bool IsActive { get; }
@@ -436,6 +446,11 @@ namespace QuantConnect.Tests.Engine
 
             public void ProcessSynchronousEvents()
             {
+            }
+
+            public void AddOpenOrder(Order order)
+            {
+                throw new NotImplementedException();
             }
         }
     }

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -40,6 +40,7 @@ namespace QuantConnect.Tests.Engine.Setup
             _brokerage = new TestBrokerage();
 
             _brokerageSetupHandler = new TestableBrokerageSetupHandler();
+            _transactionHandler.Initialize(_algorithm, _brokerage, _resultHanlder);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Modified max number of orders check:
   - Replaced `Transactions.OrdersCount` implemenation to return `_totalOrderCount`, a new internal counter of `BrokerageTransactionHandler` since Count is expensive in concurrent dictionaries
   - Removed the check for live mode
- Split `ConcurrentDictionary<int, Order> _orders` into `_openOrders` and `_completeOrders` and `ConcurrentDictionary<int, Order> _orderTickets` into `_openOrderTickets` and `_completeOrderTickets`.
  - Added `GetOpenOrderTickets()` and `GetOpenOrders()`. This allows a great performance improvement on operations that want to be applied only on open Orders or Tickets like `Liquidate()` and `CancelOpenOrders()`.
- Added `void AddOpenOrder(Order order);` to avoid direct operations on the Orders and Tickets containers

 <details><summary>Algorithm used for performance tests</summary>
<p>

```
  /*
 * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
 * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
*/

using System.Collections.Generic;
using QuantConnect.Data;
using QuantConnect.Orders;

namespace QuantConnect.Algorithm.CSharp
{
    /// <summary>
    /// Basic template algorithm simply initializes the date range and cash. This is a skeleton
    /// framework you can use for designing an algorithm.
    /// </summary>
    /// <meta name="tag" content="using data" />
    /// <meta name="tag" content="using quantconnect" />
    /// <meta name="tag" content="trading and orders" />
    public class BasicTemplateAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
    {

        private Symbol _spy = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
        private int _numberTrades;
        private bool _liquidate;
        private System.Diagnostics.Stopwatch watch;
        int _numberOfOrdersPerIteration = 1000;

        /// <summary>
        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
        /// </summary>
        public override void Initialize()
        {
            SetStartDate(2013, 10, 07);  //Set Start Date
            SetEndDate(2013, 10, 15);    //Set End Date
            SetCash(10000000);             //Set Strategy Cash
            // Find more symbols here: http://quantconnect.com/data
            // Forex, CFD, Equities Resolutions: Tick, Second, Minute, Hour, Daily.
            // Futures Resolution: Tick, Second, Minute
            // Options Resolution: Minute Only.
            AddEquity("SPY", Resolution.Minute);

            // There are other assets with similar methods. See "Selecting Options" etc for more details.
            // AddFuture, AddForex, AddCfd, AddOption
        }

        /// <summary>
        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
        /// </summary>
        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
        public override void OnData(Slice data)
        {
            if (Portfolio.Invested && _liquidate)
            {
                _liquidate = false;

                var watch2 = System.Diagnostics.Stopwatch.StartNew();
                Liquidate(_spy);
                watch2.Stop();
                if (_numberTrades % (_numberOfOrdersPerIteration * 100) == 0)
                {
                    Log("Liquidate() took: " + watch2.ElapsedTicks + "[ticks] " + watch2.ElapsedMilliseconds + "[ms]. Number of unique orders: " + _numberTrades);
                }

                watch2.Restart();
                Transactions.CancelOpenOrders(_spy);
                watch2.Stop();
                if (_numberTrades % (_numberOfOrdersPerIteration * 100) == 0)
                {
                    Log("CancelOpenOrders() took: " + watch2.ElapsedTicks + "[ticks] " + watch2.ElapsedMilliseconds + "[ms]. Number of unique orders: " + _numberTrades);
                }
            }
            else
            {
                var watch2 = System.Diagnostics.Stopwatch.StartNew();
                for (int i = 0; i < _numberOfOrdersPerIteration; ++i)
                {
                    var order = MarketOrder(_spy, 1);
                    if (order.Status.Equals(OrderStatus.Invalid))
                    {
                        return;
                    }
                }
                _numberTrades += _numberOfOrdersPerIteration;
                watch2.Stop();
                if (_numberTrades % (_numberOfOrdersPerIteration * 100) == 0)
                {
                    Log("On avg last MarketOrder() took: " + watch2.ElapsedTicks / _numberOfOrdersPerIteration + "[ticks] " + watch2.ElapsedMilliseconds + "[ms]. Number of unique orders: " + _numberTrades);
                }
            }
        }

        public override void OnOrderEvent(OrderEvent orderEvent)
        {
            if (orderEvent.Status == OrderStatus.Filled || orderEvent.Status == OrderStatus.PartiallyFilled
                || orderEvent.Status == OrderStatus.Invalid || orderEvent.Status == OrderStatus.Canceled)
            {
                _liquidate = true;
            }
        }
    }
}
```

</p>
</details>

   - Results:
<kbd> ![capture](https://user-images.githubusercontent.com/18473240/41733830-8101b134-755b-11e8-97db-651b8dc38ef3.PNG) <kbd>

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2128

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The number of closed trades was impacting backtest speed.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, unit and regression tests.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->