### PR TITLE
Fixes the exception message handling to return the python dll name

### DIFF
--- a/Common/Exceptions/DllNotFoundPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/DllNotFoundPythonExceptionInterpreter.cs
@@ -48,8 +48,17 @@ namespace QuantConnect.Exceptions
         public Exception Interpret(Exception exception, IExceptionInterpreter innerInterpreter)
         {
             var dnfe = (DllNotFoundException)exception;
+            
+            var startIndex = dnfe.Message.IndexOf("python");
+            var length = Math.Min(dnfe.Message.Length - startIndex, 10);
+            var dllName = dnfe.Message.Substring(startIndex, length);
 
-            var dllName = dnfe.Message.GetStringBetweenChars('\'', '\'');
+            length = dllName.IndexOf('\'');
+            if (length > 0)
+            {
+                dllName = dllName.Substring(0, length);
+            }
+
             var platform = Environment.OSVersion.Platform.ToString();
             var message = $"The dynamic-link library for {dllName} could not be found. Please visit https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/readme.md for instructions on how to enable python support in {platform}";
             return new DllNotFoundException(message, dnfe);


### PR DESCRIPTION
#### Description
Do not rely on `string.GetStringBetweenChars` to get the python dll name, because it is not bound by the same chars in Windows and Unix systems. Instead use 'python' string and limits the dll name to 10 characters.

#### Related Issue
Closes #2164 

#### Motivation and Context
Improve error messages.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Running Lean in both Windows and Linux (docker).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`