### PR TITLE
Add OnAlgorithmStart/End methods to ILeanManager

### DIFF
--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -208,6 +208,9 @@ namespace QuantConnect.Lean.Engine
                 //-> Using the job + initialization: load the designated handlers:
                 if (initializeComplete)
                 {
+                    // notify the LEAN manager that the algorithm is initialized and starting
+                    _systemHandlers.LeanManager.OnAlgorithmStart();
+
                     //-> Reset the backtest stopwatch; we're now running the algorithm.
                     var startTime = DateTime.Now;
 
@@ -301,6 +304,9 @@ namespace QuantConnect.Lean.Engine
                         //Error running the user algorithm: purge datafeed, send error messages, set algorithm status to failed.
                         HandleAlgorithmError(job, err);
                     }
+
+                    // notify the LEAN manager that the algorithm has finished
+                    _systemHandlers.LeanManager.OnAlgorithmEnd();
 
                     try
                     {

--- a/Engine/Server/ILeanManager.cs
+++ b/Engine/Server/ILeanManager.cs
@@ -1,16 +1,16 @@
-﻿/*		
- * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.		
- * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.		
- * 		
- * Licensed under the Apache License, Version 2.0 (the "License"); 		
- * you may not use this file except in compliance with the License.		
- * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0		
- * 		
- * Unless required by applicable law or agreed to in writing, software		
- * distributed under the License is distributed on an "AS IS" BASIS,		
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.		
- * See the License for the specific language governing permissions and		
- * limitations under the License.		
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
 */
 
 using System;
@@ -45,5 +45,15 @@ namespace QuantConnect.Lean.Engine.Server
         /// Update ILeanManager with the IAlgorithm instance
         /// </summary>
         void Update();
+
+        /// <summary>
+        /// This method is called after algorithm initialization
+        /// </summary>
+        void OnAlgorithmStart();
+
+        /// <summary>
+        /// This method is called before algorithm termination
+        /// </summary>
+        void OnAlgorithmEnd();
     }
 }

--- a/Engine/Server/LocalLeanManager.cs
+++ b/Engine/Server/LocalLeanManager.cs
@@ -1,4 +1,19 @@
-﻿using QuantConnect.Interfaces;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Interfaces;
 using QuantConnect.Packets;
 
 namespace QuantConnect.Lean.Engine.Server
@@ -37,7 +52,25 @@ namespace QuantConnect.Lean.Engine.Server
             // NOP
         }
 
-        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+        /// <summary>
+        /// This method is called after algorithm initialization
+        /// </summary>
+        public void OnAlgorithmStart()
+        {
+            // NOP
+        }
+
+        /// <summary>
+        /// This method is called before algorithm termination
+        /// </summary>
+        public void OnAlgorithmEnd()
+        {
+            // NOP
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
         public void Dispose()
         {
             // NOP

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -223,6 +223,14 @@ namespace QuantConnect.Tests.Engine
             public void Update()
             {
             }
+
+            public void OnAlgorithmStart()
+            {
+            }
+
+            public void OnAlgorithmEnd()
+            {
+            }
         }
 
         class NullResultHandler : IResultHandler


### PR DESCRIPTION

#### Description
Two new methods have been added to the `ILeanManager` interface:
- `OnAlgorithmStart`
- `OnAlgorithmEnd`

#### Motivation and Context
These methods are required for new API notifications in the cloud.

#### How Has This Been Tested?
Backtesting and Live testing in Beta environment.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.