### PR TITLE
Adds x axis label with timezone to images generated by the data Visualizer

### DIFF
--- a/ToolBox/LeanDataReader.cs
+++ b/ToolBox/LeanDataReader.cs
@@ -127,5 +127,14 @@ namespace QuantConnect.ToolBox
             }
             zipFile.Dispose();
         }
+
+        /// <summary>
+        /// Returns the data time zone
+        /// </summary>
+        /// <returns>String representing the data timezone</returns>
+        public string GetDataTimeZone()
+        {
+            return _config.DataTimeZone.Id;
+        }
     }
 }

--- a/ToolBox/Visualizer/QuantConnect.Visualizer.py
+++ b/ToolBox/Visualizer/QuantConnect.Visualizer.py
@@ -150,6 +150,7 @@ class Visualizer:
         is_low_resolution_data = 'hour' in self.arguments['DATAFILE'] or 'daily' in self.arguments['DATAFILE']
         if not is_low_resolution_data:
             plot.xaxis.set_major_formatter(DateFormatter("%H:%M"))
+            plot.set_xlabel(self.lean_data_reader.GetDataTimeZone())
 
         is_forex = 'forex' in self.arguments['DATAFILE']
         is_open_interest = 'openinterest' in self.arguments['DATAFILE']


### PR DESCRIPTION
#### Description
Implements `LeanDataReader.GetDataTimeZone` to enable `Visualizer` add a x label with the data time zone.

#### Related Issue
Closes #2009

#### Motivation and Context
The data is shown in the table using the data timezone, in turn the visualizer makes the plot using the exchange time zone for the x axis. The label would explain the difference to users.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Created new plots with local data that show the x axis label.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`