### PR TITLE
Improves Exception Messaging For Loader

### DIFF
--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -256,8 +256,8 @@ namespace QuantConnect.AlgorithmFactory
 
                     if (string.IsNullOrEmpty(types[0]))
                     {
-                        errorMessage = "Please verify algorithm type name matches the algorithm name in the configuration file. Unable to resolve multiple algorithm types to a single type.";
-                        Log.Error("Loader.TryCreateILAlgorithm(): Failed resolving multiple algorithm types to a single type.");
+                        errorMessage = "Unable to resolve multiple algorithm types to a single type. Please verify algorithm type name matches the algorithm name in the configuration file and that there is one and only one class derived from QCAlgorithm.";
+                        Log.Error($"Loader.TryCreateILAlgorithm(): {errorMessage}");
                         return false;
                     }
                 }
@@ -278,8 +278,10 @@ namespace QuantConnect.AlgorithmFactory
             }
             catch (Exception err)
             {
-                Log.Error(err);
-                if (err.InnerException != null) errorMessage = err.InnerException.Message;
+                errorMessage = "Unable to resolve multiple algorithm types to a single type. Please verify algorithm type name matches the algorithm name in the configuration file and that there is one and only one class derived from QCAlgorithm. ";
+                errorMessage += err.InnerException == null ? err.Message : err.InnerException.Message;
+                Log.Error($"Loader.TryCreateILAlgorithm(): {errorMessage}");
+                return false;
             }
 
             return true;

--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -123,7 +123,7 @@ namespace QuantConnect.Lean.Engine.Setup
             // limit load times to 60 seconds and force the assembly to have exactly one derived type
             var loader = new Loader(algorithmNodePacket.Language, TimeSpan.FromSeconds(60), names => names.SingleOrAlgorithmTypeName(Config.Get("algorithm-type-name")));
             var complete = loader.TryCreateAlgorithmInstanceWithIsolator(assemblyPath, algorithmNodePacket.RamAllocation, out algorithm, out error);
-            if (!complete) throw new Exception(error + " Try re-building algorithm.");
+            if (!complete) throw new AlgorithmSetupException($"During the algorithm initialization, the following exception has occurred: {error}");
 
             return algorithm;
         }

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -94,7 +94,7 @@ namespace QuantConnect.Lean.Engine.Setup
             // limit load times to 10 seconds and force the assembly to have exactly one derived type
             var loader = new Loader(algorithmNodePacket.Language, TimeSpan.FromSeconds(15), names => names.SingleOrAlgorithmTypeName(Config.Get("algorithm-type-name")));
             var complete = loader.TryCreateAlgorithmInstanceWithIsolator(assemblyPath, algorithmNodePacket.RamAllocation, out algorithm, out error);
-            if (!complete) throw new Exception(error + " Try re-building algorithm and remove duplicate QCAlgorithm base classes.");
+            if (!complete) throw new AlgorithmSetupException($"During the algorithm initialization, the following exception has occurred: {error}");
 
             return algorithm;
         }

--- a/Engine/Setup/ConsoleSetupHandler.cs
+++ b/Engine/Setup/ConsoleSetupHandler.cs
@@ -89,7 +89,7 @@ namespace QuantConnect.Lean.Engine.Setup
             // and step through some code that may take us longer than the default 10 seconds
             var loader = new Loader(algorithmNodePacket.Language, TimeSpan.FromHours(1), names => names.SingleOrDefault(name => MatchTypeName(name, algorithmName)));
             var complete = loader.TryCreateAlgorithmInstanceWithIsolator(assemblyPath, algorithmNodePacket.RamAllocation, out algorithm, out error);
-            if (!complete) throw new Exception(error + ": try re-building algorithm.");
+            if (!complete) throw new AlgorithmSetupException($"During the algorithm initialization, the following exception has occurred: {error}");
 
             return algorithm;
         }


### PR DESCRIPTION
#### Description
Improves the message when the `Loader` cannot resolve the algorithm to load. It happens when the assemblies don't have a `QCAlgorithm` class that match the algorithm name or you have 2-of them so Lean doesn't know which one to backtest.

The possible Loader exceptions are thrown as `AlgorithmSetupException` to mach the pattern for exceptions during initialization.

#### Related Issue
Closes #1847 
If a user uploads two `QCAlgorithm` in the could, the new message is:
`Algorithm.Initialize() Error: During the algorithm initialization, the following exception has occurred: Unable to resolve multiple algorithm types to a single type. Please verify algorithm type name matches the algorithm name in the configuration file and that there is one and only one class derived from QCAlgorithm.`
If there is no `QCAlgorithm` type.
`Algorithm.Initialize() Error: During the algorithm initialization, the following exception has occurred: Algorithm type was not found.`

#### Motivation and Context
Improve error messaging.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Two QCAlgorithm in the same project in the cloud.
No QCAlgorithm in a project in the cloud. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`