### PR TITLE
Decompressing AlgoSeek's OPRA files with SharpZipLib

### DIFF
--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -45,6 +45,9 @@
     <Reference Include="EngineIoClientDotNet, Version=0.9.22.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EngineIoClientDotNet.0.9.22\lib\net45\EngineIoClientDotNet.dll</HintPath>
     </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.85.4.369, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\ICSharpCode.SharpZipLib.dll.0.85.4.369\lib\net20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
     <Reference Include="IKVM.AWT.WinForms">
       <HintPath>..\packages\IKVM-WithExes.7.3.4830.1\tools\IKVM.AWT.WinForms.dll</HintPath>
     </Reference>

--- a/ToolBox/packages.config
+++ b/ToolBox/packages.config
@@ -3,10 +3,12 @@
   <package id="DotNetZip" version="1.10.1" targetFramework="net452" />
   <package id="EngineIoClientDotNet" version="0.9.22" targetFramework="net45" />
   <package id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" targetFramework="net452" />
+  <package id="ICSharpCode.SharpZipLib.dll" version="0.85.4.369" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
   <package id="QuantConnect.pythonnet" version="1.0.5.7" targetFramework="net452" />
   <package id="SevenZipSharp" version="0.64" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />
   <package id="SocketIoClientDotNet" version="0.9.13" targetFramework="net45" />
   <package id="WebSocket4Net" version="0.14.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR implements a thread safe decompression of the huge AlgoSeek's opra files using SharpZipLib.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2163 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As it was stated in the issue #2163, the wide range in opra files sizes plus some other not managed errors made the 7zip implementation unreliable.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was used successfully to convert several days without any error. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->