### PR TITLE
Fixes ambigous call bug for Download method

### DIFF
--- a/Algorithm.Python/DropboxUniverseSelectionAlgorithm.py
+++ b/Algorithm.Python/DropboxUniverseSelectionAlgorithm.py
@@ -21,6 +21,7 @@ from QuantConnect import *
 from QuantConnect.Algorithm import QCAlgorithm
 from QuantConnect.Data.UniverseSelection import *
 import decimal as d
+import base64
 
 ### <summary>
 ### In this algortihm we show how you can easily use the universe selection feature to fetch symbols
@@ -53,7 +54,13 @@ class DropboxUniverseSelectionAlgorithm(QCAlgorithm):
 
         # backtest - first cache the entire file
         if len(self.backtestSymbolsPerDay) == 0:
-            str = self.Download("https://www.dropbox.com/s/rmiiktz0ntpff3a/daily-stock-picker-backtest.csv?dl=1")
+
+            # No need for headers for authorization with dropbox, these two lines are for example purposes 
+            byteKey = base64.b64encode("UserName:Password".encode('ASCII'))
+            # The headers must be passed to the Download method as dictionary
+            headers = { 'Authorization' : f'Basic ({byteKey.decode("ASCII")})' }
+
+            str = self.Download("https://www.dropbox.com/s/rmiiktz0ntpff3a/daily-stock-picker-backtest.csv?dl=1", headers)
             for line in str.splitlines():
                 data = line.split(',')
                 self.backtestSymbolsPerDay[data[0]] = data[1:]

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -753,10 +753,19 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="address">A string containing the URI to download</param>
         /// <param name="headers">Defines header values to add to the request</param>
+        /// <returns>The requested resource as a <see cref="string"/></returns>
+        public string Download(string address, PyObject headers) => Download(address, headers, null, null);
+
+        /// <summary>
+        /// Downloads the requested resource as a <see cref="string"/>.
+        /// The resource to download is specified as a <see cref="string"/> containing the URI.
+        /// </summary>
+        /// <param name="address">A string containing the URI to download</param>
+        /// <param name="headers">Defines header values to add to the request</param>
         /// <param name="userName">The user name associated with the credentials</param>
         /// <param name="password">The password for the user name associated with the credentials</param>
         /// <returns>The requested resource as a <see cref="string"/></returns>
-        public string Download(string address, PyObject headers = null, string userName = null, string password = null)
+        public string Download(string address, PyObject headers, string userName, string password)
         {
             var dict = new Dictionary<string, string>();
 

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2056,11 +2056,28 @@ namespace QuantConnect.Algorithm
         /// The resource to download is specified as a <see cref="string"/> containing the URI.
         /// </summary>
         /// <param name="address">A string containing the URI to download</param>
+        /// <returns>The requested resource as a <see cref="string"/></returns>
+        public string Download(string address) => Download(address, Enumerable.Empty<KeyValuePair<string, string>>());
+
+        /// <summary>
+        /// Downloads the requested resource as a <see cref="string"/>.
+        /// The resource to download is specified as a <see cref="string"/> containing the URI.
+        /// </summary>
+        /// <param name="address">A string containing the URI to download</param>
+        /// <param name="headers">Defines header values to add to the request</param>
+        /// <returns>The requested resource as a <see cref="string"/></returns>
+        public string Download(string address, IEnumerable<KeyValuePair<string, string>> headers) => Download(address, headers, null, null);
+
+        /// <summary>
+        /// Downloads the requested resource as a <see cref="string"/>.
+        /// The resource to download is specified as a <see cref="string"/> containing the URI.
+        /// </summary>
+        /// <param name="address">A string containing the URI to download</param>
         /// <param name="headers">Defines header values to add to the request</param>
         /// <param name="userName">The user name associated with the credentials</param>
         /// <param name="password">The password for the user name associated with the credentials</param>
         /// <returns>The requested resource as a <see cref="string"/></returns>
-        public string Download(string address, IEnumerable<KeyValuePair<string, string>> headers = null, string userName = null, string password = null)
+        public string Download(string address, IEnumerable<KeyValuePair<string, string>> headers, string userName, string password)
         {
             using (var client = new WebClient { Credentials = new NetworkCredential(userName, password) })
             {

--- a/Tests/Algorithm/AlgorithmDownloadTests.cs
+++ b/Tests/Algorithm/AlgorithmDownloadTests.cs
@@ -1,0 +1,57 @@
+﻿using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmDownloadTests
+    {
+        [Test]
+        public void Download_Without_Parameters_Successfully()
+        {
+            var algo = new QCAlgorithm();
+            var content = string.Empty;
+            Assert.DoesNotThrow(() => content = algo.Download("https://www.quantconnect.com/"));
+            Assert.IsNotEmpty(content);
+        }
+
+        [Test]
+        public void Download_With_CSharp_Parameter_Successfully()
+        {
+            var algo = new QCAlgorithm();
+
+            var byteKey = Encoding.ASCII.GetBytes($"UserName:Password");
+            var headers = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("Authorization", $"Basic ({Convert.ToBase64String(byteKey)})")
+            };
+
+            var content = string.Empty;
+            Assert.DoesNotThrow(() => content = algo.Download("https://www.quantconnect.com/", headers));
+            Assert.IsNotEmpty(content);
+        }
+
+        [Test, Category("TravisExclude")]
+        public void Download_With_Python_Parameter_Successfully()
+        {
+            var algo = new QCAlgorithm();
+
+            var byteKey = Encoding.ASCII.GetBytes($"UserName:Password");
+            var value = $"Basic ({Convert.ToBase64String(byteKey)})";
+
+            var headers = new PyDict();
+            using (Py.GIL())
+            {
+                headers.SetItem("Authorization".ToPython(), value.ToPython());
+            }
+
+            var content = string.Empty;
+            Assert.DoesNotThrow(() => content = algo.Download("https://www.quantconnect.com/", headers));
+            Assert.IsNotEmpty(content);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -106,6 +106,7 @@
     </Compile>
     <Compile Include="AlgorithmFactory\LoaderTests.cs" />
     <Compile Include="AlgorithmRunner.cs" />
+    <Compile Include="Algorithm\AlgorithmDownloadTests.cs" />
     <Compile Include="Algorithm\AlgorithmAddDataTests.cs" />
     <Compile Include="Algorithm\AlgorithmInitializeTests.cs" />
     <Compile Include="Algorithm\AlgorithmPlottingTests.cs" />


### PR DESCRIPTION
#### Description
Removes the `QCAlgorithm.Download` method that accepts a `PyObject` and modify the remaining overload to accept a string. With this setup, this method can be called by both languages.

#### Related Issue
Closes #2030 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Before this change, C# QCAlgorithm would not compile if this method was included.
Test manually the method win C# and python with and without setting the second argument.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`