### PR TITLE
Change SecurityDatabaseKey operators to be case Insensitive

### DIFF
--- a/Common/Securities/SecurityDatabaseKey.cs
+++ b/Common/Securities/SecurityDatabaseKey.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -89,7 +89,9 @@ namespace QuantConnect.Securities
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return string.Equals(Market, other.Market) && Equals(Symbol, other.Symbol) && SecurityType == other.SecurityType;
+            return Market.Equals(other.Market, StringComparison.OrdinalIgnoreCase)
+                   && Symbol.Equals(other.Symbol, StringComparison.OrdinalIgnoreCase)
+                   && SecurityType == other.SecurityType;
         }
 
         /// <summary>
@@ -108,7 +110,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Serves as the default hash function. 
+        /// Serves as the default hash function.
         /// </summary>
         /// <returns>
         /// A hash code for the current object.
@@ -117,8 +119,8 @@ namespace QuantConnect.Securities
         {
             unchecked
             {
-                var hashCode = (Market != null ? Market.GetHashCode() : 0);
-                hashCode = (hashCode*397) ^ (Symbol != null ? Symbol.GetHashCode() : 0);
+                var hashCode = StringComparer.OrdinalIgnoreCase.GetHashCode(Market);
+                hashCode = (hashCode*397) ^ StringComparer.OrdinalIgnoreCase.GetHashCode(Symbol);
                 hashCode = (hashCode*397) ^ (int) SecurityType;
                 return hashCode;
             }
@@ -144,7 +146,7 @@ namespace QuantConnect.Securities
         /// </returns>
         public override string ToString()
         {
-            return string.Format("{0}-{1}-{2}", SecurityType, Market ?? Wildcard, Symbol ?? Wildcard);
+            return string.Format("{0}-{1}-{2}", SecurityType, Market, Symbol);
         }
     }
 }

--- a/Tests/Common/Securities/SecurityDatabaseKeyTests.cs
+++ b/Tests/Common/Securities/SecurityDatabaseKeyTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -95,6 +95,16 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(SecurityType.Equity, key.SecurityType);
             Assert.AreEqual("[*]", key.Market);
             Assert.AreEqual("SPY", key.Symbol);
+        }
+
+        [Test]
+        public void EqualityMembersAreCaseInsensitive()
+        {
+            var key = new SecurityDatabaseKey("uSa", "SPY", SecurityType.Equity);
+            var key2 = new SecurityDatabaseKey("UsA", "spy", SecurityType.Equity);
+
+            Assert.AreEqual(key, key2);
+            Assert.AreEqual(key.GetHashCode(), key2.GetHashCode());
         }
 
         [Test, ExpectedException(typeof(ArgumentException), MatchType = MessageMatch.Contains, ExpectedMessage = "as a SecurityType")]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Modifying SecurityDatabaseKey Equals() and GetHashCode() to be case insensitive
- Added unit test
- Removing unnecessary null checks
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2170
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Key was added as `Base-usa-FFRate` and was searching for `Base-usa-FFRATE`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, unittest
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->