### PR TITLE
Update GDAX API endpoints after rebranding

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerageFactory.cs
+++ b/Brokerages/GDAX/GDAXBrokerageFactory.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// </summary>
         public override Dictionary<string, string> BrokerageData => new Dictionary<string, string>
         {
-            { "gdax-url" , Config.Get("gdax-url", "wss://ws-feed.gdax.com")},
+            { "gdax-url" , Config.Get("gdax-url", "wss://ws-feed.pro.coinbase.com")},
             { "gdax-api-secret", Config.Get("gdax-api-secret")},
             { "gdax-api-key", Config.Get("gdax-api-key")},
             { "gdax-passphrase", Config.Get("gdax-passphrase")}
@@ -73,7 +73,7 @@ namespace QuantConnect.Brokerages.GDAX
                     throw new Exception($"GDAXBrokerageFactory.CreateBrokerage: Missing {item} in config.json");
             }
 
-            var restClient = new RestClient("https://api.gdax.com");
+            var restClient = new RestClient("https://api.pro.coinbase.com");
             var webSocketClient = new WebSocketWrapper();
 
             IBrokerage brokerage;

--- a/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
@@ -55,9 +55,9 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
         private static GDAXBrokerage GetBrokerage()
         {
-            var wssUrl = Config.Get("gdax-url", "wss://ws-feed.gdax.com");
+            var wssUrl = Config.Get("gdax-url", "wss://ws-feed.pro.coinbase.com");
             var webSocketClient = new WebSocketWrapper();
-            var restClient = new RestClient("https://api.gdax.com");
+            var restClient = new RestClient("https://api.pro.coinbase.com");
             var apiKey = Config.Get("gdax-api-key");
             var apiSecret = Config.Get("gdax-api-secret");
             var passPhrase = Config.Get("gdax-passphrase");

--- a/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
@@ -1,15 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 using QuantConnect.Brokerages.GDAX;
 using NUnit.Framework;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 using QuantConnect.Configuration;
 using QuantConnect.Orders;
-using System.Reflection;
 using Moq;
 using QuantConnect.Brokerages;
 using RestSharp;
@@ -19,7 +28,6 @@ namespace QuantConnect.Tests.Brokerages.GDAX
     [TestFixture, Ignore("This test requires a configured and active account")]
     public class GDAXBrokerageIntegrationTests : BrokerageTests
     {
-
         #region Properties
         protected override Symbol Symbol
         {
@@ -58,13 +66,13 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
         protected override IBrokerage CreateBrokerage(IOrderProvider orderProvider, ISecurityProvider securityProvider)
         {
-            var restClient = new RestClient("https://api.gdax.com");
+            var restClient = new RestClient("https://api.pro.coinbase.com");
             var webSocketClient = new WebSocketWrapper();
 
             var algorithm = new Mock<IAlgorithm>();
             algorithm.Setup(a => a.BrokerageModel).Returns(new GDAXBrokerageModel(AccountType.Cash));
 
-            return new GDAXBrokerage(Config.Get("gdax-url", "wss://ws-feed.gdax.com"), webSocketClient, restClient, Config.Get("gdax-api-key"), Config.Get("gdax-api-secret"), 
+            return new GDAXBrokerage(Config.Get("gdax-url", "wss://ws-feed.pro.coinbase.com"), webSocketClient, restClient, Config.Get("gdax-api-key"), Config.Get("gdax-api-secret"),
                 Config.Get("gdax-passphrase"), algorithm.Object);
         }
 
@@ -80,18 +88,11 @@ namespace QuantConnect.Tests.Brokerages.GDAX
         }
 
         //no stop limit support
-        public override TestCaseData[] OrderParameters
+        public override TestCaseData[] OrderParameters => new[]
         {
-            get
-            {
-                return new[]
-                {
-                    new TestCaseData(new MarketOrderTestParameters(Symbol)).SetName("MarketOrder"),
-                    new TestCaseData(new LimitOrderTestParameters(Symbol, HighPrice, LowPrice)).SetName("LimitOrder"),
-                    new TestCaseData(new StopMarketOrderTestParameters(Symbol, HighPrice, LowPrice)).SetName("StopMarketOrder"),
-                };
-            }
-        }
-
+            new TestCaseData(new MarketOrderTestParameters(Symbol)).SetName("MarketOrder"),
+            new TestCaseData(new LimitOrderTestParameters(Symbol, HighPrice, LowPrice)).SetName("LimitOrder"),
+            new TestCaseData(new StopMarketOrderTestParameters(Symbol, HighPrice, LowPrice)).SetName("StopMarketOrder"),
+        };
     }
 }

--- a/ToolBox/GDAXDownloader/GDAXDownloader.cs
+++ b/ToolBox/GDAXDownloader/GDAXDownloader.cs
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,13 +28,13 @@ using QuantConnect.Logging;
 namespace QuantConnect.ToolBox.GDAXDownloader
 {
     /// <summary>
-    /// GDAX Data Downloader class 
+    /// GDAX Data Downloader class
     /// </summary>
     public class GDAXDownloader : IDataDownloader
     {
         const int MaxDatapointsPerRequest = 200;
         const int MaxRequestsPerSecond = 2;
-        const string HistoricCandlesUrl = "http://api.gdax.com/products/{0}/candles?start={1}&end={2}&granularity={3}";
+        const string HistoricCandlesUrl = "http://api.pro.coinbase.com/products/{0}/candles?start={1}&end={2}&granularity={3}";
 
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end times(in UTC).
@@ -110,7 +111,7 @@ namespace QuantConnect.ToolBox.GDAXDownloader
         /// <summary>
         /// Parse string response from web response
         /// </summary>
-        /// <param name="Symbol">Crypto security symbol.</param>
+        /// <param name="symbol">Crypto security symbol.</param>
         /// <param name="granularity">Resolution in seconds.</param>
         /// <param name="data">Web response as string.</param>
         /// <returns>web response as string</returns>


### PR DESCRIPTION

#### Description
Endpoints have been changed from `*.gdax.com` to `*.pro.coinbase.com`

#### Related Issue
Closes #2154 

#### Motivation and Context
The old endpoints will stop working on December 31, 2018.

#### How Has This Been Tested?
Local live testing.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`