### PR TITLE
Fix SetHoldings not taking into account pending market orders

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -909,8 +909,17 @@ namespace QuantConnect.Algorithm
                 }
             }
 
+            // calculate total unfilled quantity for open market orders
+            var marketOrdersQuantity =
+                (from order in Transactions.GetOpenOrders(symbol)
+                 where order.Type == OrderType.Market
+                 select Transactions.GetOrderTicket(order.Id)
+                 into ticket
+                 where ticket != null
+                 select ticket.Quantity - ticket.QuantityFilled).Sum();
+
             //Only place trade if we've got > 1 share to order.
-            var quantity = CalculateOrderQuantity(symbol, percentage);
+            var quantity = CalculateOrderQuantity(symbol, percentage) - marketOrdersQuantity;
             if (Math.Abs(quantity) > 0)
             {
                 MarketOrder(symbol, quantity, false, tag);

--- a/Tests/Algorithm/AlgorithmLiveTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmLiveTradingTests.cs
@@ -1,0 +1,93 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.Results;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmLiveTradingTests
+    {
+        [Test]
+        public void SetHoldingsTakesIntoAccountPendingMarketOrders()
+        {
+            var algorithm = new QCAlgorithm();
+            var security = algorithm.AddEquity("SPY");
+            security.Exchange = new SecurityExchange(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork));
+            security.SetMarketPrice(new Tick { Value = 270m });
+            algorithm.SetFinishedWarmingUp();
+
+            var brokerage = new NullBrokerage();
+            var transactionHandler = new BrokerageTransactionHandler();
+
+            transactionHandler.Initialize(algorithm, brokerage, new LiveTradingResultHandler());
+            new Thread(transactionHandler.Run) { IsBackground = true }.Start();
+            Thread.Sleep(2000);
+            algorithm.Transactions.SetOrderProcessor(transactionHandler);
+
+            var symbol = security.Symbol;
+
+            // this order should timeout (no fills received within 5 seconds)
+            algorithm.SetHoldings(symbol, 1m);
+            Thread.Sleep(2000);
+
+            var openOrders = algorithm.Transactions.GetOpenOrders();
+            Assert.AreEqual(1, openOrders.Count);
+
+            // this order should never be submitted because of the pending order
+            algorithm.SetHoldings(symbol, 1m);
+            Thread.Sleep(2000);
+
+            openOrders = algorithm.Transactions.GetOpenOrders();
+            Assert.AreEqual(1, openOrders.Count);
+
+            transactionHandler.Exit();
+        }
+
+        private class NullBrokerage : IBrokerage
+        {
+            public void Dispose() {}
+            public event EventHandler<OrderEvent> OrderStatusChanged;
+            public event EventHandler<OrderEvent> OptionPositionAssigned;
+            public event EventHandler<AccountEvent> AccountChanged;
+            public event EventHandler<BrokerageMessageEvent> Message;
+            public string Name => "NullBrokerage";
+            public bool IsConnected { get; } = true;
+            public List<Order> GetOpenOrders() { return new List<Order>(); }
+            public List<Holding> GetAccountHoldings() { return new List<Holding>(); }
+            public List<Cash> GetCashBalance() { return new List<Cash>(); }
+            public bool PlaceOrder(Order order) { return true; }
+            public bool UpdateOrder(Order order) { return true; }
+            public bool CancelOrder(Order order) { return true; }
+            public void Connect() {}
+            public void Disconnect() {}
+            public bool AccountInstantlyUpdated { get; } = true;
+            public IEnumerable<BaseData> GetHistory(HistoryRequest request) { return Enumerable.Empty<BaseData>(); }
+        }
+    }
+}

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -14,12 +14,15 @@
 */
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
 using QuantConnect.Brokerages;
 using Moq;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Orders;
 
 namespace QuantConnect.Tests.Algorithm
 {
@@ -1123,9 +1126,10 @@ namespace QuantConnect.Tests.Algorithm
 
             algo.Portfolio.SetCash(150000);
 
-            var mock = new Mock<IOrderProcessor>();
-            var request = new Mock<Orders.SubmitOrderRequest>(null, null, null, null, null, null, null, null, null);
-            mock.Setup(m => m.Process(It.IsAny<Orders.OrderRequest>())).Returns(new Orders.OrderTicket(null, request.Object));
+            var mock = new Mock<ITransactionHandler>();
+            var request = new Mock<SubmitOrderRequest>(null, null, null, null, null, null, null, null, null);
+            mock.Setup(m => m.Process(It.IsAny<OrderRequest>())).Returns(new OrderTicket(null, request.Object));
+            mock.Setup(m => m.GetOpenOrders(It.IsAny<Func<Order, bool>>())).Returns(new List<Order>());
             algo.Transactions.SetOrderProcessor(mock.Object);
 
             algo.Buy(Symbols.MSFT, 1);

--- a/Tests/Algorithm/CashModelAlgorithmTradingTests.cs
+++ b/Tests/Algorithm/CashModelAlgorithmTradingTests.cs
@@ -14,12 +14,15 @@
 */
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
 using Moq;
 using QuantConnect.Brokerages;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Orders;
 
 namespace QuantConnect.Tests.Algorithm
 {
@@ -536,9 +539,10 @@ namespace QuantConnect.Tests.Algorithm
 
             algo.Portfolio.SetCash(150000);
 
-            var mock = new Mock<IOrderProcessor>();
-            var request = new Mock<Orders.SubmitOrderRequest>(null, null, null, null, null, null, null, null, null);
-            mock.Setup(m => m.Process(It.IsAny<Orders.OrderRequest>())).Returns(new Orders.OrderTicket(null, request.Object));
+            var mock = new Mock<ITransactionHandler>();
+            var request = new Mock<SubmitOrderRequest>(null, null, null, null, null, null, null, null, null);
+            mock.Setup(m => m.Process(It.IsAny<OrderRequest>())).Returns(new OrderTicket(null, request.Object));
+            mock.Setup(m => m.GetOpenOrders(It.IsAny<Func<Order, bool>>())).Returns(new List<Order>());
             algo.Transactions.SetOrderProcessor(mock.Object);
 
             algo.Buy(_symbol, 1);

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="AlgorithmRunner.cs" />
     <Compile Include="Algorithm\AlgorithmAddDataTests.cs" />
     <Compile Include="Algorithm\AlgorithmInitializeTests.cs" />
+    <Compile Include="Algorithm\AlgorithmLiveTradingTests.cs" />
     <Compile Include="Algorithm\AlgorithmPlottingTests.cs" />
     <Compile Include="Algorithm\AlgorithmRegisterIndicatorTests.cs" />
     <Compile Include="Algorithm\AlgorithmResolveConsolidatorTests.cs" />


### PR DESCRIPTION

#### Description
`SetHoldings` now takes into account pending market orders.

#### Related Issue
Closes #2161 

#### Motivation and Context
If an existing market order is not filled immediately, the order is still pending and may be filled later.
A _subsequent_ call to `SetHoldings` would currently return a quantity that does not take the previous order into account.

#### How Has This Been Tested?
New unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`