### PR TITLE
Show warning when defaulting to Equity in SetBenchmark

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1060,9 +1060,16 @@ namespace QuantConnect.Algorithm
             // check existence
             symbol = symbol.ToUpper();
             var security = Securities.FirstOrDefault(x => x.Key.Value == symbol).Value;
-            _benchmarkSymbol = security == null
-                ? QuantConnect.Symbol.Create(symbol, SecurityType.Equity, Market.USA)
-                : security.Symbol;
+            if (security == null)
+            {
+                Debug($"Warning: SetBenchmark({symbol}): no existing security found, benchmark security will be added with {SecurityType.Equity} type.");
+
+                _benchmarkSymbol = QuantConnect.Symbol.Create(symbol, SecurityType.Equity, Market.USA);
+            }
+            else
+            {
+                _benchmarkSymbol = security.Symbol;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION

#### Description
A warning message has been added in `SetBenchmark(string symbol)` when no existing security is found and the new benchmark security is being added with `SecurityType.Equity`.

#### Related Issue
Closes #2153

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`