### PR TITLE
Fix GDAX WebSocketSharp always logging errors to console

### DIFF
--- a/Brokerages/WebSocketWrapper.cs
+++ b/Brokerages/WebSocketWrapper.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using QuantConnect.Logging;
 using WebSocketSharp;
 
 namespace QuantConnect.Brokerages
@@ -38,7 +39,10 @@ namespace QuantConnect.Brokerages
             }
 
             _url = url;
-            _wrapped = new WebSocket(url);
+            _wrapped = new WebSocket(url)
+            {
+                Log = { Output = (data, file) => { Log.Trace(data.Message); } }
+            };
 
             _wrapped.OnOpen += (sender, args) => OnOpen();
             _wrapped.OnMessage += (sender, args) => OnMessage(new WebSocketMessage(args.Data));
@@ -108,7 +112,7 @@ namespace QuantConnect.Brokerages
         /// <param name="e"></param>
         protected virtual void OnError(WebSocketError e)
         {
-            Logging.Log.Error(e.Exception, "WebSocketWrapper.OnError(): " + e.Message);
+            Log.Error(e.Exception, "WebSocketWrapper.OnError(): " + e.Message);
             Error?.Invoke(this, e);
         }
 
@@ -117,7 +121,7 @@ namespace QuantConnect.Brokerages
         /// </summary>
         protected virtual void OnOpen()
         {
-            Logging.Log.Trace($"WebSocketWrapper.OnOpen(): Connection opened({IsOpen}): {_url}");
+            Log.Trace($"WebSocketWrapper.OnOpen(): Connection opened({IsOpen}): {_url}");
             Open?.Invoke(this, EventArgs.Empty);
         }
     }


### PR DESCRIPTION

#### Description
The `WebSocketSharp` library used in the `GDAXBrokerage` was defaulting to console output.
Now we use a custom log handler which calls `Log.Trace()` instead.

#### Related Issue
Closes #2126

#### Motivation and Context
All WebSocket errors were being logged to the console.

#### How Has This Been Tested?
Local GDAX live testing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`