### PR TITLE
Set default population average score warmup period to zero

### DIFF
--- a/Engine/Alphas/StatisticsInsightManagerExtension.cs
+++ b/Engine/Alphas/StatisticsInsightManagerExtension.cs
@@ -28,6 +28,7 @@ namespace QuantConnect.Lean.Engine.Alphas
     {
         private readonly double _smoothingFactor;
         private readonly int _rollingAverageIsReadyCount;
+        private readonly bool _requireRollingAverageWarmup;
         private readonly decimal _tradablePercentOfVolume;
 
         /// <summary>
@@ -39,14 +40,15 @@ namespace QuantConnect.Lean.Engine.Alphas
         /// <summary>
         /// Gets whether or not the rolling average statistics is ready
         /// </summary>
-        public bool RollingAverageIsReady => Statistics.TotalInsightsAnalysisCompleted >= _rollingAverageIsReadyCount;
+        public bool RollingAverageIsReady => !_requireRollingAverageWarmup || Statistics.TotalInsightsAnalysisCompleted >= _rollingAverageIsReadyCount;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StatisticsInsightManagerExtension"/> class
         /// </summary>
         /// <param name="tradablePercentOfVolume">Percent of volume of first bar used to estimate the maximum number of tradable shares. Defaults to 1%</param>
-        /// <param name="period">The period used for exponential smoothing of scores - this is a number of insights. Defaults to 100 insight predictions</param>
-        public StatisticsInsightManagerExtension(decimal tradablePercentOfVolume = 0.01m, int period = 100)
+        /// <param name="period">The period used for exponential smoothing of scores - this is a number of insights. Defaults to 100 insight predictions.</param>
+        /// <param name="requireRollingAverageWarmup">Specify true to force the population average scoring to warmup before plotting.</param>
+        public StatisticsInsightManagerExtension(decimal tradablePercentOfVolume = 0.01m, int period = 100, bool requireRollingAverageWarmup = false)
         {
             Statistics = new AlphaRuntimeStatistics();
             _tradablePercentOfVolume = tradablePercentOfVolume;
@@ -54,6 +56,7 @@ namespace QuantConnect.Lean.Engine.Alphas
 
             // use normal ema warmup period
             _rollingAverageIsReadyCount = period;
+            _requireRollingAverageWarmup = requireRollingAverageWarmup;
         }
 
         /// <summary>

--- a/Tests/Engine/Alphas/StatisticsInsightManagerExtensionTests.cs
+++ b/Tests/Engine/Alphas/StatisticsInsightManagerExtensionTests.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Alphas.Analysis;
+using QuantConnect.Lean.Engine.Alphas;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Engine.Alphas
+{
+    [TestFixture]
+    public class StatisticsInsightManagerExtensionTests
+    {
+        [Test]
+        public void DefaultConstructorHasZeroWarmupPeriodForPopulationAverageScores()
+        {
+            var stats = new StatisticsInsightManagerExtension();
+            Assert.IsTrue(stats.RollingAverageIsReady);
+        }
+
+        [Test]
+        public void RecordsPopulationAverageScoresOnInsightAnalysisCompleted()
+        {
+            var time = new DateTime(2000, 01, 01);
+            var stats = new StatisticsInsightManagerExtension();
+            var insight = Insight.Price(Symbols.SPY, Time.OneDay, InsightDirection.Up);
+            var spySecurityValues = new SecurityValues(insight.Symbol, time, SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), 100m, 1m, 125000, 1m);
+            var context = new InsightAnalysisContext(insight, spySecurityValues, insight.Period);
+            context.Score.SetScore(InsightScoreType.Direction, .55, time);
+            context.Score.SetScore(InsightScoreType.Magnitude, .25, time);
+            stats.OnInsightAnalysisCompleted(context);
+            Assert.AreEqual(context.Score.Direction, stats.Statistics.RollingAveragedPopulationScore.Direction);
+            Assert.AreEqual(context.Score.Magnitude, stats.Statistics.RollingAveragedPopulationScore.Magnitude);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -265,6 +265,7 @@
     <Compile Include="Compression\CompressionTests.cs" />
     <Compile Include="Configuration\ConfigTests.cs" />
     <Compile Include="Engine\AlgorithmManagerTests.cs" />
+    <Compile Include="Engine\Alphas\StatisticsInsightManagerExtensionTests.cs" />
     <Compile Include="Engine\BasicOptionAssignmentSimulationTests.cs" />
     <Compile Include="Engine\BrokerageTransactionHandlerTests\BrokerageTransactionHandlerTests.cs" />
     <Compile Include="Engine\DataCacheProviders\SingleEntryDataCacheProviderTests.cs" />


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
In backtests with only a few insights (such as monthly), we end up never reaching the warmup period and so we never chart the direction/magnitude scores.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2187 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Framework algorithms should always produce direction/magnitude score charts. Everyone loves charts!

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added as well as confirmed in the cloud.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed. 
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->