### PR TITLE
Update Python regression tests to match C# equivalents

### DIFF
--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
@@ -57,7 +57,7 @@ class EmaCrossAlphaModel(AlphaModel):
                 if symbolData.FastIsOverSlow:
                     if symbolData.Slow > symbolData.Fast:
                         insights.append(Insight.Price(symbolData.Symbol, self.predictionInterval, InsightDirection.Down))
-                
+
                 elif symbolData.SlowIsOverFast:
                     if symbolData.Fast > symbolData.Slow:
                         insights.append(Insight.Price(symbolData.Symbol, self.predictionInterval, InsightDirection.Up))
@@ -76,8 +76,8 @@ class EmaCrossAlphaModel(AlphaModel):
             if symbolData is None:
                 # create fast/slow EMAs
                 symbolData = SymbolData(added)
-                symbolData.Fast = algorithm.EMA(added.Symbol, self.fastPeriod)
-                symbolData.Slow = algorithm.EMA(added.Symbol, self.slowPeriod)
+                symbolData.Fast = algorithm.EMA(added.Symbol, self.fastPeriod, self.resolution)
+                symbolData.Slow = algorithm.EMA(added.Symbol, self.slowPeriod, self.resolution)
                 self.symbolDataBySymbol[added.Symbol] = symbolData
             else:
                 # a security that was already initialized was re-added, reset the indicators

--- a/Algorithm.Python/AddRemoveSecurityRegressionAlgorithm.py
+++ b/Algorithm.Python/AddRemoveSecurityRegressionAlgorithm.py
@@ -18,7 +18,7 @@ AddReference("QuantConnect.Algorithm")
 
 from System import *
 from QuantConnect import *
-from QuantConnect.Orders import OrderStatus
+from QuantConnect.Orders import *
 from QuantConnect.Algorithm import QCAlgorithm
 
 ### <summary>

--- a/Algorithm.Python/BasicTemplateDailyAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateDailyAlgorithm.py
@@ -35,8 +35,8 @@ class BasicTemplateDailyAlgorithm(QCAlgorithm):
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
-        self.SetStartDate(2013,10,7)   #Set Start Date
-        self.SetEndDate(2013,10,18)    #Set End Date
+        self.SetStartDate(2013,10,8)   #Set Start Date
+        self.SetEndDate(2013,10,17)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
         self.AddEquity("SPY", Resolution.Daily)

--- a/Algorithm.Python/BasicTemplateIntrinioEconomicData.py
+++ b/Algorithm.Python/BasicTemplateIntrinioEconomicData.py
@@ -10,14 +10,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
- 
+
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Indicators")
- 
- 
+
+
 from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import *
@@ -25,42 +25,42 @@ from QuantConnect.Indicators import *
 from QuantConnect.Data.Custom import *
 from QuantConnect.Data.Custom.Intrinio import *
 from numpy import sign
- 
+
 class BasicTemplateIntrinioEconomicData(QCAlgorithm):
- 
+
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
-        
-        self.SetStartDate(2013, 1, 1)  #Set Start Date
-        self.SetEndDate(2014, 12, 31)    #Set End Date
-        self.SetCash(25000)           #Set Strategy Cash
-        
+
+        self.SetStartDate(2010, 1, 1)  #Set Start Date
+        self.SetEndDate(2013, 12, 31)  #Set End Date
+        self.SetCash(100000)           #Set Strategy Cash
+
         # Set your Intrinino user and password.
         IntrinioConfig.SetUserAndPassword(self.GetParameter("intrinio-username"), self.GetParameter("intrinio-password"))
         # The Intrinio user and password can be also defined in the config.json file for local backtest.
-        
+
         # United States Oil Fund LP
-        self.uso = self.AddEquity("USO", Resolution.Daily).Symbol 
+        self.uso = self.AddEquity("USO", Resolution.Daily).Symbol
         self.Securities[self.uso].SetLeverage(2)
         # United States Brent Oil Fund LP
         self.bno = self.AddEquity("BNO", Resolution.Daily).Symbol
-        self.Securities[self.bno].SetLeverage(2)        
+        self.Securities[self.bno].SetLeverage(2)
 
         self.AddData(IntrinioEconomicData, "$DCOILWTICO", Resolution.Daily)
         self.AddData(IntrinioEconomicData, "$DCOILBRENTEU", Resolution.Daily)
-        
+
 
     def OnData(self, slice):
         '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
         Arguments:
             data: Slice object keyed by symbol containing the stock data
-        '''        
+        '''
         if (slice.ContainsKey("$DCOILBRENTEU") or slice.ContainsKey("$DCOILWTICO")):
             spread = slice["$DCOILBRENTEU"].Value - slice["$DCOILWTICO"].Value
         else:
-            return 
+            return
 
         if ((spread > 0 and not self.Portfolio[self.bno].IsLong) or
             (spread < 0 and not self.Portfolio[self.uso].IsShort)):
             self.SetHoldings(self.bno, 0.25 * sign(spread))
-            self.SetHoldings(self.uso, -0.25 * sign(spread))        
+            self.SetHoldings(self.uso, -0.25 * sign(spread))

--- a/Algorithm.Python/Benchmarks/CoarseFineUniverseSelectionBenchmark.py
+++ b/Algorithm.Python/Benchmarks/CoarseFineUniverseSelectionBenchmark.py
@@ -59,7 +59,7 @@ class CoarseFineUniverseSelectionBenchmark(QCAlgorithm):
 
     def OnData(self, data):
         # if we have no changes, do nothing
-        if self._changes == None: return
+        if self._changes is None: return
 
         # liquidate removed securities
         for security in self._changes.RemovedSecurities:

--- a/Algorithm.Python/CoarseFineFundamentalComboAlgorithm.py
+++ b/Algorithm.Python/CoarseFineFundamentalComboAlgorithm.py
@@ -70,7 +70,7 @@ class CoarseFineFundamentalComboAlgorithm(QCAlgorithm):
 
     def OnData(self, data):
         # if we have no changes, do nothing
-        if self._changes == None: return
+        if self._changes is None: return
 
         # liquidate removed securities
         for security in self._changes.RemovedSecurities:

--- a/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
+++ b/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
@@ -67,7 +67,7 @@ class CoarseFineFundamentalRegressionAlgorithm(QCAlgorithm):
 
     def OnData(self, data):
         # if we have no changes, do nothing
-        if self.changes == None: return
+        if self.changes is None: return
 
         # liquidate removed securities
         for security in self.changes.RemovedSecurities:

--- a/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
+++ b/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
@@ -20,7 +20,7 @@ from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import QCAlgorithm
 from QuantConnect.Data.UniverseSelection import *
-from datetime import datetime
+from datetime import date
 
 ### <summary>
 ### Demonstration of how to define a universe as a combination of use the coarse fundamental data and fine fundamental data
@@ -50,8 +50,7 @@ class CoarseFineFundamentalRegressionAlgorithm(QCAlgorithm):
     def CoarseSelectionFunction(self, coarse):
         tickers = [ "GOOG", "BAC", "SPY" ]
 
-        dt = datetime(self.Time.year, self.Time.month, self.Time.day)
-        if dt < datetime(2014, 4, 1):
+        if self.Time.date() < date(2014, 4, 1):
             tickers = [ "AAPL", "AIG", "IBM" ]
 
         return [ Symbol.Create(x, SecurityType.Equity, Market.USA) for x in tickers ]

--- a/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
+++ b/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
@@ -32,8 +32,8 @@ from datetime import datetime
 class CoarseFineFundamentalRegressionAlgorithm(QCAlgorithm):
 
     def Initialize(self):
-        self.SetStartDate(2014,4,1)    #Set Start Date
-        self.SetEndDate(2014,4,30)     #Set End Date
+        self.SetStartDate(2014,3,24)   #Set Start Date
+        self.SetEndDate(2014,4,7)      #Set End Date
         self.SetCash(50000)            #Set Strategy Cash
 
         self.UniverseSettings.Resolution = Resolution.Daily
@@ -47,14 +47,15 @@ class CoarseFineFundamentalRegressionAlgorithm(QCAlgorithm):
         self.numberOfSymbolsFine = 2
 
     # return a list of three fixed symbol objects
-    def CoarseSelectionFunction(self, coarse):        
+    def CoarseSelectionFunction(self, coarse):
         tickers = [ "GOOG", "BAC", "SPY" ]
 
-        if self.Time < datetime(2014, 4, 5):
+        dt = datetime(self.Time.year, self.Time.month, self.Time.day)
+        if dt < datetime(2014, 4, 1):
             tickers = [ "AAPL", "AIG", "IBM" ]
-        
+
         return [ Symbol.Create(x, SecurityType.Equity, Market.USA) for x in tickers ]
-        
+
 
     # sort the data by P/E ratio and take the top 'NumberOfSymbolsFine'
     def FineSelectionFunction(self, fine):
@@ -76,11 +77,11 @@ class CoarseFineFundamentalRegressionAlgorithm(QCAlgorithm):
 
         # we want 50% allocation in each security in our universe
         for security in self.changes.AddedSecurities:
-            self.SetHoldings(security.Symbol, 0.5)
-            self.Debug("Purchased Stock: " + str(security.Symbol.Value))
+            if (security.Fundamentals.EarningRatios.EquityPerShareGrowth.OneYear > 0.25):
+                self.SetHoldings(security.Symbol, 0.5)
+                self.Debug("Purchased Stock: " + str(security.Symbol.Value))
 
         self.changes = None
-
 
     # this event fires whenever we have changes to our universe
     def OnSecuritiesChanged(self, changes):

--- a/Algorithm.Python/CoarseFundamentalTop5Algorithm.py
+++ b/Algorithm.Python/CoarseFundamentalTop5Algorithm.py
@@ -62,7 +62,7 @@ class CoarseFundamentalTop5Algorithm(QCAlgorithm):
         self.Log(f"OnData({self.UtcTime}): Keys: {', '.join([key.Value for key in data.Keys])}")
 
         # if we have no changes, do nothing
-        if self._changes == None: return
+        if self._changes is None: return
 
         # liquidate removed securities
         for security in self._changes.RemovedSecurities:

--- a/Algorithm.Python/CustomDataRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataRegressionAlgorithm.py
@@ -99,11 +99,6 @@ class Bitcoin(PythonData):
 
         try:
             data = line.split(',')
-
-            # If value is zero, return None
-            value = decimal.Decimal(data[4])
-            if value == 0: return None
-
             coin.Time = datetime.strptime(data[0], "%Y-%m-%d")
             coin.Value = value
             coin["Open"] = float(data[1])

--- a/Algorithm.Python/CustomDataRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataRegressionAlgorithm.py
@@ -100,7 +100,7 @@ class Bitcoin(PythonData):
         try:
             data = line.split(',')
             coin.Time = datetime.strptime(data[0], "%Y-%m-%d")
-            coin.Value = value
+            coin.Value = float(data[4])
             coin["Open"] = float(data[1])
             coin["High"] = float(data[2])
             coin["Low"] = float(data[3])

--- a/Algorithm.Python/DelistingEventsAlgorithm.py
+++ b/Algorithm.Python/DelistingEventsAlgorithm.py
@@ -63,10 +63,10 @@ class DelistingEventsAlgorithm(QCAlgorithm):
 
         aaa = self.Securities["AAA"];
         if aaa.IsDelisted and aaa.IsTradable:
-            raise Exception("Delisted security must NOT be tradable");
+            raise Exception("Delisted security must NOT be tradable")
 
         if not aaa.IsDelisted and not aaa.IsTradable:
-            raise Exception("Securities must be marked as tradable until they're delisted or removed from the universe");
+            raise Exception("Securities must be marked as tradable until they're delisted or removed from the universe")
 
         for kvp in data.Delistings:
             symbol = kvp.Key
@@ -76,13 +76,13 @@ class DelistingEventsAlgorithm(QCAlgorithm):
                 self.Log("OnData(Delistings): {0}: {1} will be delisted at end of day today.".format(self.Time, symbol))
 
                 # liquidate on delisting warning
-                self.SetHoldings(symbol, 0);
+                self.SetHoldings(symbol, 0)
 
             if value.Type == DelistingType.Delisted:
                 self.Log("OnData(Delistings): {0}: {1} has been delisted.".format(self.Time, symbol))
 
                 # fails because the security has already been delisted and is no longer tradable
-                self.SetHoldings(symbol, 1);
+                self.SetHoldings(symbol, 1)
 
 
     def OnOrderEvent(self, orderEvent):

--- a/Algorithm.Python/DisplacedMovingAverageRibbon.py
+++ b/Algorithm.Python/DisplacedMovingAverageRibbon.py
@@ -87,7 +87,7 @@ class DisplacedMovingAverageRibbon(QCAlgorithm):
     def IsAscending(self, values):
         last = None
         for val in values:
-            if last == None:
+            if last is None:
                 last = val
                 continue
             if last < val:
@@ -99,7 +99,7 @@ class DisplacedMovingAverageRibbon(QCAlgorithm):
     def IsDescending(self, values):
         last = None
         for val in values:
-            if last == None:
+            if last is None:
                 last = val
                 continue
             if last > val:

--- a/Algorithm.Python/DropboxBaseDataUniverseSelectionAlgorithm.py
+++ b/Algorithm.Python/DropboxBaseDataUniverseSelectionAlgorithm.py
@@ -59,7 +59,7 @@ class DropboxBaseDataUniverseSelectionAlgorithm(QCAlgorithm):
     def OnData(self, slice):
 
         if slice.Bars.Count == 0: return
-        if self._changes == None: return
+        if self._changes is None: return
         
         # start fresh
         self.Liquidate()

--- a/Algorithm.Python/DropboxUniverseSelectionAlgorithm.py
+++ b/Algorithm.Python/DropboxUniverseSelectionAlgorithm.py
@@ -73,7 +73,7 @@ class DropboxUniverseSelectionAlgorithm(QCAlgorithm):
     def OnData(self, slice):
 
         if slice.Bars.Count == 0: return
-        if self.changes == None: return
+        if self.changes is None: return
 
         # start fresh
         self.Liquidate()

--- a/Algorithm.Python/OptionSplitRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionSplitRegressionAlgorithm.py
@@ -31,11 +31,11 @@ class OptionSplitRegressionAlgorithm(QCAlgorithm):
 
     def Initialize(self):
 
-        # this test opens position in the first day of trading, lives through stock split (7 for 1), 
+        # this test opens position in the first day of trading, lives through stock split (7 for 1),
         # and closes adjusted position on the second day
 
         self.SetCash(1000000)
-        self.SetStartDate(2014,6,6)
+        self.SetStartDate(2014,6,5)
         self.SetEndDate(2014,6,9)
 
         option = self.AddOption("AAPL")
@@ -52,9 +52,9 @@ class OptionSplitRegressionAlgorithm(QCAlgorithm):
             if self.Time.hour > 9 and self.Time.minute > 0:
                 for kvp in slice.OptionChains:
                     chain = kvp.Value
-                    contracts = filter(lambda x: x.Strike == 650 and x.Right ==  OptionRight.Call, chain) 
+                    contracts = filter(lambda x: x.Strike == 650 and x.Right ==  OptionRight.Call, chain)
                     sorted_contracts = sorted(contracts, key = lambda x: x.Expiry)
-                
+
                 if len(sorted_contracts) > 1:
                     self.contract = sorted_contracts[1]
                     self.Buy(self.contract.Symbol, 1)
@@ -62,7 +62,7 @@ class OptionSplitRegressionAlgorithm(QCAlgorithm):
         elif self.Time.day > 6 and self.Time.hour > 14 and self.Time.minute > 0:
             self.Liquidate()
 
-        if self.Portfolio.Invested: 
+        if self.Portfolio.Invested:
             options_hold = [x for x in self.Portfolio.Securities if x.Value.Holdings.AbsoluteQuantity != 0]
             holdings = options_hold[0].Value.Holdings.AbsoluteQuantity
             if self.Time.day == 6 and holdings != 1:

--- a/Algorithm.Python/PairsTradingAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/PairsTradingAlphaModelFrameworkAlgorithm.py
@@ -20,11 +20,15 @@ from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
 from QuantConnect.Algorithm.Framework.Execution import *
 from QuantConnect.Algorithm.Framework.Portfolio import *
 from QuantConnect.Algorithm.Framework.Risk import *
 from QuantConnect.Algorithm.Framework.Selection import *
+from Portfolio.EqualWeightingPortfolioConstructionModel import EqualWeightingPortfolioConstructionModel
 from Alphas.PairsTradingAlphaModel import PairsTradingAlphaModel
+from Execution.ImmediateExecutionModel import ImmediateExecutionModel
+from Risk.NullRiskManagementModel import NullRiskManagementModel
 
 ### <summary>
 ### Framework algorithm that uses the PairsTradingAlphaModel to detect

--- a/Algorithm.Python/RegressionAlgorithm.py
+++ b/Algorithm.Python/RegressionAlgorithm.py
@@ -71,7 +71,7 @@ class RegressionAlgorithm(QCAlgorithm):
         dt : datetime object, default now.
         roundTo : Closest number of seconds to round to, default 1 minute.
         """
-        if dt == None : dt = datetime.now()
+        if dt is None : dt = datetime.now()
         seconds = (dt - dt.min).seconds
         # // is a floor division, not a comment on following line:
         rounding = (seconds+roundTo/2) // roundTo * roundTo

--- a/Algorithm.Python/UniverseSelectionDefinitionsAlgorithm.py
+++ b/Algorithm.Python/UniverseSelectionDefinitionsAlgorithm.py
@@ -56,7 +56,7 @@ class UniverseSelectionDefinitionsAlgorithm(QCAlgorithm):
         self.changes = None
 
     def OnData(self, data):
-        if self.changes == None: return
+        if self.changes is None: return
 
         # liquidate securities that fell out of our universe
         for security in self.changes.RemovedSecurities:

--- a/Algorithm.Python/UpdateOrderRegressionAlgorithm.py
+++ b/Algorithm.Python/UpdateOrderRegressionAlgorithm.py
@@ -117,18 +117,19 @@ class UpdateOrderRegressionAlgorithm(QCAlgorithm):
 
     def OnOrderEvent(self, orderEvent):
         order = self.Transactions.GetOrderById(orderEvent.OrderId)
+        ticket = self.Transactions.GetOrderTicket(orderEvent.OrderId);
 
         #order cancelations update CanceledTime
-        if order.Status == OrderStatus.Canceled and orderEvent.CanceledTime != orderEvent.UtcTime:
+        if order.Status == OrderStatus.Canceled and order.CanceledTime != orderEvent.UtcTime:
             raise ValueError("Expected canceled order CanceledTime to equal canceled order event time.")
-        
+
         #fills update LastFillTime
         if (order.Status == OrderStatus.Filled or order.Status == OrderStatus.PartiallyFilled) and order.LastFillTime != orderEvent.UtcTime:
             raise ValueError("Expected filled order LastFillTime to equal fill order event time.")
 
-        #updates have a status of submitted and the created time will be different from the event time
-        if order.Status == OrderStatus.Submitted and order.Time != orderEvent.UtcTime and order.LastUpdateTime != orderEvent.UtcTime:
-            raise ValueError("Expected updated order LastUpdateTime to equal submitted update order event time")
+        # check the ticket to see if the update was successfully processed
+        if len([ur for ur in ticket.UpdateRequests if ur.Response is not None and ur.Response.IsSuccess]) > 0 and order.CreatedTime != self.UtcTime and order.LastUpdateTime == None:
+            raise ValueError("Expected updated order LastUpdateTime to equal submitted update order event time");
 
         if orderEvent.Status == OrderStatus.Filled:
             self.Log("FILLED:: {0} FILL PRICE:: {1}".format(self.Transactions.GetOrderById(orderEvent.OrderId), orderEvent.FillPrice))

--- a/Algorithm.Python/UpdateOrderRegressionAlgorithm.py
+++ b/Algorithm.Python/UpdateOrderRegressionAlgorithm.py
@@ -128,7 +128,7 @@ class UpdateOrderRegressionAlgorithm(QCAlgorithm):
             raise ValueError("Expected filled order LastFillTime to equal fill order event time.")
 
         # check the ticket to see if the update was successfully processed
-        if len([ur for ur in ticket.UpdateRequests if ur.Response is not None and ur.Response.IsSuccess]) > 0 and order.CreatedTime != self.UtcTime and order.LastUpdateTime == None:
+        if len([ur for ur in ticket.UpdateRequests if ur.Response is not None and ur.Response.IsSuccess]) > 0 and order.CreatedTime != self.UtcTime and order.LastUpdateTime is None:
             raise ValueError("Expected updated order LastUpdateTime to equal submitted update order event time");
 
         if orderEvent.Status == OrderStatus.Filled:

--- a/Algorithm.Python/UpdateOrderRegressionAlgorithm.py
+++ b/Algorithm.Python/UpdateOrderRegressionAlgorithm.py
@@ -117,7 +117,7 @@ class UpdateOrderRegressionAlgorithm(QCAlgorithm):
 
     def OnOrderEvent(self, orderEvent):
         order = self.Transactions.GetOrderById(orderEvent.OrderId)
-        ticket = self.Transactions.GetOrderTicket(orderEvent.OrderId);
+        ticket = self.Transactions.GetOrderTicket(orderEvent.OrderId)
 
         #order cancelations update CanceledTime
         if order.Status == OrderStatus.Canceled and order.CanceledTime != orderEvent.UtcTime:
@@ -129,7 +129,7 @@ class UpdateOrderRegressionAlgorithm(QCAlgorithm):
 
         # check the ticket to see if the update was successfully processed
         if len([ur for ur in ticket.UpdateRequests if ur.Response is not None and ur.Response.IsSuccess]) > 0 and order.CreatedTime != self.UtcTime and order.LastUpdateTime is None:
-            raise ValueError("Expected updated order LastUpdateTime to equal submitted update order event time");
+            raise ValueError("Expected updated order LastUpdateTime to equal submitted update order event time")
 
         if orderEvent.Status == OrderStatus.Filled:
             self.Log("FILLED:: {0} FILL PRICE:: {1}".format(self.Transactions.GetOrderById(orderEvent.OrderId), orderEvent.FillPrice))

--- a/Algorithm.Python/WeeklyUniverseSelectionRegressionAlgorithm.py
+++ b/Algorithm.Python/WeeklyUniverseSelectionRegressionAlgorithm.py
@@ -38,7 +38,7 @@ class WeeklyUniverseSelectionRegressionAlgorithm(QCAlgorithm):
         self.AddUniverse("my-custom-universe", lambda dt: ["IBM"] if dt.day % 7 == 0 else [])
 
     def OnData(self, slice):
-        if self.changes == None: return
+        if self.changes is None: return
 
         # liquidate removed securities
         for security in self.changes.RemovedSecurities:

--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,6 @@ using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using Python.Runtime;
 using QuantConnect.AlgorithmFactory.Python.Wrappers;
-using QuantConnect.Util;
 
 namespace QuantConnect.AlgorithmFactory
 {
@@ -42,6 +41,9 @@ namespace QuantConnect.AlgorithmFactory
 
         // Defines how we resolve a list of type names into a single type name to be instantiated
         private readonly Func<List<string>, string> _multipleTypeNameResolverFunction;
+
+        // Used to allow multiple Python regression tests
+        private static bool _isBeginAllowThreadsCalled;
 
         /// <summary>
         /// Memory space of the user algorithm
@@ -80,7 +82,7 @@ namespace QuantConnect.AlgorithmFactory
         /// </param>
         /// <param name="multipleTypeNameResolverFunction">
         /// Used to resolve multiple type names found in assembly to a single type name, if null, defaults to names => names.SingleOrDefault()
-        /// 
+        ///
         /// When we search an assembly for derived types of IAlgorithm, sometimes the assembly will contain multiple matching types. This is the case
         /// for the QuantConnect.Algorithm assembly in this solution.  In order to pick the correct type, consumers must specify how to pick the type,
         /// that's what this function does, it picks the correct type from the list of types found within the assembly.
@@ -105,15 +107,15 @@ namespace QuantConnect.AlgorithmFactory
         /// <param name="assemblyPath">Location of the DLL</param>
         /// <param name="algorithmInstance">Output algorithm instance</param>
         /// <param name="errorMessage">Output error message on failure</param>
-        /// <returns>Bool true on successfully loading the class.</returns>        
-        public bool TryCreateAlgorithmInstance(string assemblyPath, out IAlgorithm algorithmInstance, out string errorMessage) 
+        /// <returns>Bool true on successfully loading the class.</returns>
+        public bool TryCreateAlgorithmInstance(string assemblyPath, out IAlgorithm algorithmInstance, out string errorMessage)
         {
             //Default initialisation of Assembly.
             algorithmInstance = null;
             errorMessage = "";
 
             //First most basic check:
-            if (!File.Exists(assemblyPath)) 
+            if (!File.Exists(assemblyPath))
             {
                 return false;
             }
@@ -169,7 +171,11 @@ namespace QuantConnect.AlgorithmFactory
             {
                 algorithmInstance = new AlgorithmPythonWrapper(moduleName);
 
-                PythonEngine.BeginAllowThreads();
+                if (!_isBeginAllowThreadsCalled)
+                {
+                    PythonEngine.BeginAllowThreads();
+                    _isBeginAllowThreadsCalled = true;
+                }
             }
             catch (Exception e)
             {
@@ -183,7 +189,7 @@ namespace QuantConnect.AlgorithmFactory
         }
 
         /// <summary>
-        /// Create a generic IL algorithm 
+        /// Create a generic IL algorithm
         /// </summary>
         /// <param name="assemblyPath"></param>
         /// <param name="algorithmInstance"></param>
@@ -197,7 +203,7 @@ namespace QuantConnect.AlgorithmFactory
             try
             {
                 byte[] debugInformationBytes = null;
-                
+
                 // if the assembly is located in the base directory then don't bother loading the pdbs
                 // manually, they'll be loaded automatically by the .NET runtime.
                 var directoryName = new FileInfo(assemblyPath).DirectoryName;
@@ -237,7 +243,7 @@ namespace QuantConnect.AlgorithmFactory
                     return false;
                 }
 
-                //Get the list of extention classes in the library: 
+                //Get the list of extention classes in the library:
                 var types = GetExtendedTypeNames(assembly);
                 Log.Debug("Loader.TryCreateILAlgorithm(): Assembly types: " + string.Join(",", types));
 
@@ -292,7 +298,7 @@ namespace QuantConnect.AlgorithmFactory
         /// </summary>
         /// <param name="assembly">Assembly dll we're loading.</param>
         /// <returns>String list of types available.</returns>
-        public static List<string> GetExtendedTypeNames(Assembly assembly) 
+        public static List<string> GetExtendedTypeNames(Assembly assembly)
         {
             var types = new List<string>();
             try
@@ -338,7 +344,7 @@ namespace QuantConnect.AlgorithmFactory
         /// <param name="ramLimit">Limit of the RAM for this process</param>
         /// <param name="algorithmInstance">Output algorithm instance</param>
         /// <param name="errorMessage">Output error message on failure</param>
-        /// <returns>bool success</returns>     
+        /// <returns>bool success</returns>
         public bool TryCreateAlgorithmInstanceWithIsolator(string assemblyPath, int ramLimit, out IAlgorithm algorithmInstance, out string errorMessage)
         {
             IAlgorithm instance = null;
@@ -349,7 +355,7 @@ namespace QuantConnect.AlgorithmFactory
             var complete = isolator.ExecuteWithTimeLimit(_loaderTimeLimit, () =>
             {
                 success = TryCreateAlgorithmInstance(assemblyPath, out instance, out error);
-            }, ramLimit); 
+            }, ramLimit);
 
             algorithmInstance = instance;
             errorMessage = error;
@@ -370,7 +376,7 @@ namespace QuantConnect.AlgorithmFactory
         /// <remarks>Not used in lean engine. Running the library in an app domain is 10x slower.</remarks>
         /// <seealso cref="AppDomain.CreateDomain(string, Evidence, string, string, bool, AppDomainInitializer, string[])"/>
         public void Unload() {
-            if (appDomain != null) 
+            if (appDomain != null)
             {
                 AppDomain.Unload(appDomain);
                 appDomain = null;

--- a/Engine/Results/RegressionResultHandler.cs
+++ b/Engine/Results/RegressionResultHandler.cs
@@ -28,14 +28,13 @@ namespace QuantConnect.Lean.Engine.Results
     /// </summary>
     public class RegressionResultHandler : BacktestingResultHandler
     {
-        private string AlgorithmTypeName => Algorithm.GetType().Name;
         private Language Language => Config.GetValue<Language>("algorithm-language");
         private readonly Lazy<StreamWriter> OrdersLogStreamWriter;
 
         /// <summary>
         /// Gets the path used for logging all order events
         /// </summary>
-        public string OrdersLogFilePath => $"./regression/{AlgorithmTypeName}.{Language.ToLower()}.orders.log";
+        public string OrdersLogFilePath => $"./regression/{Algorithm.AlgorithmId}.{Language.ToLower()}.orders.log";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RegressionResultHandler"/> class

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,8 +39,8 @@ namespace QuantConnect.Queues
         private static readonly string AccessToken = Config.Get("api-access-token");
         private static readonly int UserId = Config.GetInt("job-user-id", 0);
         private static readonly int ProjectId = Config.GetInt("job-project-id", 0);
-        private static readonly string AlgorithmTypeName = Config.Get("algorithm-type-name");
-        private static readonly string AlgorithmPathPython = Config.Get("algorithm-path-python", "../../../Algorithm.Python/");
+        private readonly string AlgorithmTypeName = Config.Get("algorithm-type-name");
+        private readonly string AlgorithmPathPython = Config.Get("algorithm-path-python", "../../../Algorithm.Python/");
         private readonly Language Language = (Language)Enum.Parse(typeof(Language), Config.Get("algorithm-language"));
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace QuantConnect.Queues
             get
             {
                 // we expect this dll to be copied into the output directory
-                return Config.Get("algorithm-location", "QuantConnect.Algorithm.CSharp.dll"); 
+                return Config.Get("algorithm-location", "QuantConnect.Algorithm.CSharp.dll");
             }
         }
 
@@ -62,7 +62,7 @@ namespace QuantConnect.Queues
         {
             //
         }
-        
+
         /// <summary>
         /// Desktop/Local Get Next Task - Get task from the Algorithm folder of VS Solution.
         /// </summary>
@@ -70,11 +70,11 @@ namespace QuantConnect.Queues
         public AlgorithmNodePacket NextJob(out string location)
         {
             location = GetAlgorithmLocation();
-                
+
             Log.Trace("JobQueue.NextJob(): Selected " + location);
 
             // check for parameters in the config
-            var parameters = new Dictionary<string, string>();            
+            var parameters = new Dictionary<string, string>();
 
             var parametersConfigString = Config.Get("parameters");
             if (parametersConfigString != string.Empty)
@@ -111,7 +111,7 @@ namespace QuantConnect.Queues
                 };
 
                 try
-                { 
+                {
                     // import the brokerage data for the configured brokerage
                     var brokerageFactory = Composer.Instance.Single<IBrokerageFactory>(factory => factory.BrokerageType.MatchesTypeName(liveJob.Brokerage));
                     liveJob.BrokerageData = brokerageFactory.BrokerageData;

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -91,12 +91,19 @@ namespace QuantConnect.Tests
                     var engine = new Lean.Engine.Engine(systemHandlers, algorithmHandlers, false);
                     Task.Factory.StartNew(() =>
                     {
-                        string algorithmPath;
-                        var job = systemHandlers.JobQueue.NextJob(out algorithmPath);
-                        ((BacktestNodePacket)job).BacktestId = algorithm;
-                        var algorithmManager = new AlgorithmManager(false);
-                        engine.Run(job, algorithmManager, algorithmPath);
-                        ordersLogFile = ((RegressionResultHandler) algorithmHandlers.Results).OrdersLogFilePath;
+                        try
+                        {
+                            string algorithmPath;
+                            var job = systemHandlers.JobQueue.NextJob(out algorithmPath);
+                            ((BacktestNodePacket)job).BacktestId = algorithm;
+                            var algorithmManager = new AlgorithmManager(false);
+                            engine.Run(job, algorithmManager, algorithmPath);
+                            ordersLogFile = ((RegressionResultHandler)algorithmHandlers.Results).OrdersLogFilePath;
+                        }
+                        catch (Exception e)
+                        {
+                            Log.LogHandler.Trace($"Error in AlgorithmRunner task: {e}");
+                        }
                     }).Wait();
 
                     var backtestingResultHandler = (BacktestingResultHandler) algorithmHandlers.Results;


### PR DESCRIPTION
#### Description
- Some Python regression tests have been updated to match their C# equivalents.
- A resolution bug was fixed in the Python version of `EmaCrossAlphaModel`.
- The regression order log file name now includes the algorithm name.
- The `PythonEngine.BeginAllowThreads()` method is now called only once per process launch, because it was causing a Python Fatal Error with multiple Python regression tests.
- A few `import` statements were fixed in a couple of Python algorithms.
- Added missing `try...catch` with logging in `AlgorithmRunner` task.
- Fixed `static` variable bug in `JobQueue`, causing Python regression algorithms to fail if ran after `AddRemoveOptionUniverseRegressionAlgorithm` (which does not have a Python version).

All regression tests (C# and Python) are finally passing, also when running the full suite.

#### Related Issue
Closes #2192 

#### Motivation and Context
8 Python regression tests were failing.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Regression test runs.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/ect)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`