### PR TITLE
Implements python version of BasicTemplateOptionsFrameworkAlgorithm

### DIFF
--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -22,6 +22,7 @@ using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Algorithm.Framework.Risk;
 using QuantConnect.Algorithm.Framework.Selection;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 
@@ -31,7 +32,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// Basic template options framework algorithm uses framework components to define an algorithm
     /// that trades options.
     /// </summary>
-    public class BasicTemplateOptionsFrameworkAlgorithm : QCAlgorithmFramework
+    public class BasicTemplateOptionsFrameworkAlgorithm : QCAlgorithmFramework, IRegressionAlgorithmDefinition
     {
         public override void Initialize()
         {
@@ -134,5 +135,49 @@ namespace QuantConnect.Algorithm.CSharp
                 }
             }
         }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "4"},
+            {"Average Win", "0.14%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "74.140%"},
+            {"Drawdown", "0.700%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0.279%"},
+            {"Sharpe Ratio", "9.165"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "100%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "25.476"},
+            {"Annual Standard Deviation", "0.026"},
+            {"Annual Variance", "0.001"},
+            {"Information Ratio", "8.891"},
+            {"Tracking Error", "0.025"},
+            {"Treynor Ratio", "0.009"},
+            {"Total Fees", "$1.00"},
+            {"Total Insights Generated", "26"},
+            {"Total Insights Closed", "24"},
+            {"Total Insights Analysis Completed", "6"},
+            {"Long Insight Count", "26"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$22.79625"},
+            {"Total Accumulated Estimated Alpha Value", "$1.51975"},
+            {"Mean Population Estimated Insight Value", "$0.06332292"},
+            {"Mean Population Direction", "33.3333%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "92.3114%"},
+            {"Rolling Averaged Population Magnitude", "0%"}
+        };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using QuantConnect.Algorithm.Framework;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Algorithm.Framework.Execution;
@@ -45,7 +44,7 @@ namespace QuantConnect.Algorithm.CSharp
             // set framework models
             SetUniverseSelection(new EarliestExpiringWeeklyAtTheMoneyPutOptionUniverseSelectionModel(SelectOptionChainSymbols));
             SetAlpha(new ConstantOptionContractAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromHours(0.5)));
-            SetPortfolioConstruction(new SingleSharePortofioConstructionModel());
+            SetPortfolioConstruction(new SingleSharePortfolioConstructionModel());
             SetExecution(new ImmediateExecutionModel());
             SetRiskManagement(new NullRiskManagementModel());
         }
@@ -95,7 +94,7 @@ namespace QuantConnect.Algorithm.CSharp
                     .Strikes(+1, +1)
                     .Expiration(TimeSpan.Zero, TimeSpan.FromDays(7))
                     .WeeklysOnly()
-                    .Contracts(contracts => contracts.Where(x => x.ID.OptionRight == OptionRight.Put))
+                    .PutsOnly()
                     .OnlyApplyFilterAtMarketOpen();
             }
         }
@@ -123,21 +122,16 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
-        /// Portoflio construction model that sets target quantities to 1 for up insights and -1 for down insights
+        /// Portfolio construction model that sets target quantities to 1 for up insights and -1 for down insights
         /// </summary>
-        class SingleSharePortofioConstructionModel : IPortfolioConstructionModel
+        class SingleSharePortfolioConstructionModel : PortfolioConstructionModel
         {
-            public IEnumerable<IPortfolioTarget> CreateTargets(QCAlgorithmFramework algorithm, Insight[] insights)
+            public override IEnumerable<IPortfolioTarget> CreateTargets(QCAlgorithmFramework algorithm, Insight[] insights)
             {
                 foreach (var insight in insights)
                 {
                     yield return new PortfolioTarget(insight.Symbol, (int) insight.Direction);
                 }
-            }
-
-            public void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
-            {
-                // no need to track anything here
             }
         }
     }

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -169,6 +169,12 @@
     <Content Include="Selection\EmaCrossUniverseSelectionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Selection\OptionUniverseSelectionModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Selection\UniverseSelectionModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Selection\QC500UniverseSelectionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Algorithm.Framework/Selection/OptionUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/OptionUniverseSelectionModel.py
@@ -1,0 +1,111 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+from clr import GetClrType as typeof
+AddReference("System")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm.Framework")
+
+from QuantConnect import *
+from QuantConnect.Securities import *
+from QuantConnect.Data.Auxiliary import ZipEntryName
+from QuantConnect.Data.UniverseSelection import OptionChainUniverse
+from Selection.UniverseSelectionModel import UniverseSelectionModel
+from datetime import datetime
+
+class OptionUniverseSelectionModel(UniverseSelectionModel):
+
+    def __init__(self,
+                 refreshInterval,
+                 optionChainSymbolSelector,
+                 universeSettings = None, 
+                 securityInitializer = None):
+
+        self.nextRefreshTimeUtc = datetime.min
+
+        self.refreshInterval = refreshInterval
+        self.optionChainSymbolSelector = optionChainSymbolSelector
+        self.universeSettings = universeSettings
+        self.securityInitializer = securityInitializer
+
+    def GetNextRefreshTimeUtc(self):
+        return self.nextRefreshTimeUtc
+
+    def CreateUniverses(self, algorithm):
+        self.nextRefreshTimeUtc = (algorithm.UtcTime + self.refreshInterval).date()
+
+        algorithm.Log(f"OptionUniverseSelectionModel.CreateUniverse({algorithm.UtcTime}): Refreshing Universes")
+
+        uniqueUnderlyingSymbols = set()
+        for optionSymbol in self.optionChainSymbolSelector(algorithm.UtcTime):
+            if optionSymbol.SecurityType != SecurityType.Option:
+                raise ValueError("optionChainSymbolSelector must return option symbols.")
+
+            # prevent creating duplicate option chains -- one per underlying
+            if optionSymbol.Underlying not in uniqueUnderlyingSymbols:
+                uniqueUnderlyingSymbols.add(optionSymbol.Underlying)
+                yield self.CreateOptionChain(algorithm, optionSymbol)
+
+    def CreateOptionChain(self, algorithm, symbol):
+        if symbol.SecurityType != SecurityType.Option:
+            raise ValueError("CreateOptionChain requires an option symbol.")
+
+        algorithm.Log(f"OptionUniverseSelectionModel.CreateOptionChain({algorithm.UtcTime}, {symbol}): Creating Option Chain")
+
+        # rewrite non-canonical symbols to be canonical
+        market = symbol.ID.Market
+        underlying = symbol.Underlying
+        if not symbol.IsCanonical():
+            alias = f"?{underlying.Value}"
+            symbol = Symbol.Create(underlying.Value, SecurityType.Option, market, alias)
+
+        # resolve defaults if not specified
+        settings = self.universeSettings if self.universeSettings is not None else algorithm.UniverseSettings
+        initializer = self.securityInitializer if self.securityInitializer is not None else algorithm.SecurityInitializer
+        # create canonical security object, but don't duplicate if it already exists
+        securities = [s for s in algorithm.Securities if s.Key == symbol]
+        if len(securities) == 0:
+            optionChain = self.CreateOptionChainSecurity(algorithm, symbol, settings, initializer)
+        else:
+            optionChain = securities[0]
+
+            algorithm.Log(f"OptionUniverseSelectionModel.CreateOptionChain({algorithm.UtcTime}, {symbol}): Resolved existing Option Chain Security")
+
+        # set the option chain contract filter function
+        optionChain.SetFilter(self.Filter)
+
+        # force option chain security to not be directly tradable AFTER it's configured to ensure it's not overwritten
+        optionChain.IsTradable = False
+
+        return OptionChainUniverse(optionChain, settings, initializer, algorithm.LiveMode)
+
+    def CreateOptionChainSecurity(self, algorithm, symbol, settings, initializer):
+
+        algorithm.Log(f"OptionUniverseSelectionModel.CreateOptionChainSecurity({algorithm.UtcTime}, {symbol}): Creating Option Chain Security")
+
+        market = symbol.ID.Market
+        underlying = symbol.Underlying
+
+        marketHoursEntry = MarketHoursDatabase.FromDataFolder().GetEntry(market, underlying, SecurityType.Option)
+        symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(market, underlying, SecurityType.Option, CashBook.AccountCurrency)
+
+        return SecurityManager.CreateSecurity(typeof(ZipEntryName), algorithm.Portfolio,
+                algorithm.SubscriptionManager, marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties,
+                initializer, symbol, settings.Resolution, settings.FillForward, settings.Leverage, settings.ExtendedMarketHours,
+                False, False, algorithm.LiveMode, False, False)
+
+    def Filter(self, filter):
+        '''Defines the option chain universe filter'''
+        # NOP
+        return filter

--- a/Algorithm.Framework/Selection/UniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/UniverseSelectionModel.py
@@ -1,0 +1,29 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+
+class UniverseSelectionModel:
+    '''Provides a base class for universe selection models.'''
+
+    def GetNextRefreshTimeUtc(self):
+        '''Gets the next time the framework should invoke the `CreateUniverses` method to refresh the set of universes.'''
+        return datetime.max
+
+    def CreateUniverses(self, algorithm):
+        '''Creates the universes for this algorithm. Called once after <see cref="IAlgorithm.Initialize"/>
+        Args:
+            algorithm: The algorithm instance to create universes for</param>
+        Returns:
+            The universes to be used by the algorithm'''
+        raise NotImplementedError("Types deriving from 'UniverseSelectionModel' must implement the 'def CreateUniverses(QCAlgorithmFramework) method.")

--- a/Algorithm.Framework/Selection/UniverseSelectionModelPythonWrapper.cs
+++ b/Algorithm.Framework/Selection/UniverseSelectionModelPythonWrapper.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
 
             using (Py.GIL())
             {
-                return _model.GetNextRefreshTime();
+                return _model.GetNextRefreshTimeUtc();
             }
         }
 
@@ -52,10 +52,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
         {
             using (Py.GIL())
             {
-                if (!model.HasAttr(nameof(IUniverseSelectionModel.GetNextRefreshTimeUtc)))
-                {
-                    _modelHasGetNextRefreshTime = false;
-                }
+                _modelHasGetNextRefreshTime = model.HasAttr(nameof(IUniverseSelectionModel.GetNextRefreshTimeUtc));
 
                 foreach (var attributeName in new[] { "CreateUniverses" })
                 {

--- a/Algorithm.Python/BasicTemplateOptionsFrameworkAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsFrameworkAlgorithm.py
@@ -1,0 +1,99 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from Alphas.ConstantAlphaModel import ConstantAlphaModel
+from Selection.OptionUniverseSelectionModel import OptionUniverseSelectionModel
+from Execution.ImmediateExecutionModel import ImmediateExecutionModel
+from Risk.NullRiskManagementModel import NullRiskManagementModel
+from datetime import date, timedelta
+
+### <summary>
+### Basic template options framework algorithm uses framework components
+### to define an algorithm that trades options.
+### </summary>
+class BasicTemplateOptionsFrameworkAlgorithm(QCAlgorithmFramework):
+
+    def Initialize(self):
+
+        self.UniverseSettings.Resolution = Resolution.Minute
+
+        self.SetStartDate(2014, 6, 5)
+        self.SetEndDate(2014, 6, 6)
+        self.SetCash(100000)
+
+        # set framework models
+        self.SetUniverseSelection(EarliestExpiringWeeklyAtTheMoneyPutOptionUniverseSelectionModel(self.SelectOptionChainSymbols))
+        self.SetAlpha(ConstantOptionContractAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(hours = 0.5)))
+        self.SetPortfolioConstruction(SingleSharePortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+        self.SetRiskManagement(NullRiskManagementModel())
+
+
+    def OnOrderEvent(self, fill):
+        self.Log(f"{self.UtcTime}:: {fill}")
+
+    def OnSecuritiesChanged(self, changes):
+        self.Log(f"{self.UtcTime}:: {changes}")
+
+    def SelectOptionChainSymbols(self, utcTime):
+        newYorkTime = Extensions.ConvertFromUtc(utcTime, TimeZones.NewYork)
+        ticker = "TWX" if newYorkTime.date() < date(2014, 6, 6) else "AAPL";
+        return [ Symbol.Create(ticker, SecurityType.Option, Market.USA, f"?{ticker}") ]
+
+class EarliestExpiringWeeklyAtTheMoneyPutOptionUniverseSelectionModel(OptionUniverseSelectionModel):
+    '''Creates option chain universes that select only the earliest expiry ATM weekly put contract
+    and runs a user defined optionChainSymbolSelector every day to enable choosing different option chains'''
+    def __init__(self, select_option_chain_symbols):
+        super().__init__(timedelta(1), select_option_chain_symbols)
+
+    def Filter(self, filter):
+        '''Defines the option chain universe filter'''
+        return (filter.Strikes(+1, +1)
+                      .Expiration(timedelta(0), timedelta(7))
+                      .WeeklysOnly()
+                      .PutsOnly()
+                      .OnlyApplyFilterAtMarketOpen())
+
+class ConstantOptionContractAlphaModel(ConstantAlphaModel):
+    '''Implementation of a constant alpha model that only emits insights for option symbols'''
+    def __init__(self, type, direction, period):
+        super().__init__(type, direction, period)
+
+    def ShouldEmitInsight(self, utcTime, symbol):
+        # only emit alpha for option symbols and not underlying equity symbols
+        if symbol.SecurityType != SecurityType.Option:
+            return False
+
+        return super().ShouldEmitInsight(utcTime, symbol)
+
+class SingleSharePortfolioConstructionModel(PortfolioConstructionModel):
+    '''Portoflio construction model that sets target quantities to 1 for up insights and -1 for down insights'''
+    def CreateTargets(self, algorithm, insights):
+        targets = []
+        for insight in insights:
+            targets.append(PortfolioTarget(insight.Symbol, insight.Direction))
+        return targets

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -36,6 +36,7 @@
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="BasicTemplateOptionsFrameworkAlgorithm.py" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -25,6 +25,7 @@
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.py" />
     <Compile Include="BasicTemplateCryptoAlgorithm.py" />
     <Compile Include="BasicTemplateIntrinioEconomicData.py" />
+    <Compile Include="BasicTemplateOptionsFrameworkAlgorithm.py" />
     <Compile Include="CompositeAlphaModelFrameworkAlgorithm.py" />
     <Compile Include="ConstituentsQC500GeneratorAlgorithm.py" />
     <Compile Include="ConvertToFrameworkAlgorithm.py" />
@@ -79,6 +80,7 @@
     <Compile Include="HourReverseSplitRegressionAlgorithm.py" />
     <Compile Include="HourSplitRegressionAlgorithm.py" />
     <Compile Include="IndicatorSuiteAlgorithm.py" />
+    <Compile Include="IndicatorWarmupAlgorithm.py" />
     <Compile Include="LimitFillRegressionAlgorithm.py" />
     <Compile Include="MACDTrendAlgorithm.py" />
     <Compile Include="main.py" />
@@ -89,6 +91,7 @@
     <Compile Include="MultipleSymbolConsolidationAlgorithm.py" />
     <Compile Include="OptionChainConsistencyRegressionAlgorithm.py" />
     <Compile Include="OptionChainProviderAlgorithm.py" />
+    <Compile Include="OptionDataNullReferenceRegressionAlgorithm.py" />
     <Compile Include="OptionExerciseAssignRegressionAlgorithm.py" />
     <Compile Include="OptionOpenInterestRegressionAlgorithm.py" />
     <Compile Include="OptionRenameRegressionAlgorithm.py" />

--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -349,6 +349,22 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Sets universe of call options (if any) as a selection
+        /// </summary>
+        public OptionFilterUniverse CallsOnly()
+        {
+            return Contracts(contracts => contracts.Where(x => x.ID.OptionRight == OptionRight.Call));
+        }
+
+        /// <summary>
+        /// Sets universe of put options (if any) as a selection
+        /// </summary>
+        public OptionFilterUniverse PutsOnly()
+        {
+            return Contracts(contracts => contracts.Where(x => x.ID.OptionRight == OptionRight.Put));
+        }
+
+        /// <summary>
         /// Instructs the engine to only filter options contracts on the first time step of each market day.
         /// </summary>
         public OptionFilterUniverse OnlyApplyFilterAtMarketOpen()


### PR DESCRIPTION
#### Description
- Implements `CallsOnly` and `PutsOnly` methods in `OptionFilterUniverse`;
  These two helper methods makes it simpler to select options with a specific right. This selection could be done with a Linq expression, but there is no equivalent for python. It is more user friendly to add those helper than adding a `PyObject` overload to `Contracts` method.
  Use `PutsOnly` method in `BasicTemplateOptionsFrameworkAlgorithm`.
- Fixes `UniverseSelectionModelPythonWrapper`:
  - Typo in `GetNextRefreshTimeUtc` method.
  - Logics bug in constructor.
- Implements python version of OptionUniverseSelectionModel  …
  Since `OptionUniverseSelectionModel` derives from `UniverseSelectionModel`, a python version of this class was also implemented.

#### Related Issue
Closes #1967 

#### Motivation and Context
Provide python version of examples that have been implemented only in C#.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manual comparison between C# and python algorithms outputs.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`