### PR TITLE
Fixes "object isn't callable" bug in Universe Selection in python algorithms

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -110,13 +110,13 @@ namespace QuantConnect.Algorithm
             Func<IEnumerable<CoarseFundamental>, object[]> coarse;
             Universe universe;
 
-            if (pyObject.TryConvertToDelegate(out coarse))
-            {
-                AddUniverse(c => coarse(c.ToList()).Select(x => (Symbol)x));
-            }
-            else if (pyObject.TryConvert(out universe))
+            if (pyObject.TryConvert(out universe))
             {
                 AddUniverse(universe);
+            }
+            else if (pyObject.TryConvertToDelegate(out coarse))
+            {
+                AddUniverse(c => coarse(c.ToList()).Select(x => (Symbol)x));
             }
             else
             {


### PR DESCRIPTION
#### Description
Reverse the order that a `PyObject` is attempt to be converted into a `Universe` object and a `Func`.

#### Related Issue
Closes #2198 

#### Motivation and Context
Bug fix: "Object isn't callable" error when `Universe` object is passed to `AddUniverse` method.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Write an algorithm with the `self.AddUniverse(Universe.DollarVolume.Top(50))` statement in `Initialize` method and run it locally and in the cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`