### PR TITLE
Bug 2205 - Fix loader error message when algo type name not found

### DIFF
--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -262,7 +262,7 @@ namespace QuantConnect.AlgorithmFactory
 
                     if (string.IsNullOrEmpty(types[0]))
                     {
-                        errorMessage = "Unable to resolve multiple algorithm types to a single type. Please verify algorithm type name matches the algorithm name in the configuration file and that there is one and only one class derived from QCAlgorithm.";
+                        errorMessage = "Algorithm type name not found, or unable to resolve multiple algorithm types to a single type. Please verify algorithm type name matches the algorithm name in the configuration file and that there is one and only one class derived from QCAlgorithm.";
                         Log.Error($"Loader.TryCreateILAlgorithm(): {errorMessage}");
                         return false;
                     }
@@ -284,7 +284,7 @@ namespace QuantConnect.AlgorithmFactory
             }
             catch (Exception err)
             {
-                errorMessage = "Unable to resolve multiple algorithm types to a single type. Please verify algorithm type name matches the algorithm name in the configuration file and that there is one and only one class derived from QCAlgorithm. ";
+                errorMessage = "Algorithm type name not found, or unable to resolve multiple algorithm types to a single type. Please verify algorithm type name matches the algorithm name in the configuration file and that there is one and only one class derived from QCAlgorithm.";
                 errorMessage += err.InnerException == null ? err.Message : err.InnerException.Message;
                 Log.Error($"Loader.TryCreateILAlgorithm(): {errorMessage}");
                 return false;


### PR DESCRIPTION
#### Description
To make the error message clearer, changed it 
from:
"Unable to resolve multiple algorithm types to a single type. Please verify algorithm type name matches the algorithm name in the configuration file and that there is one and only one class derived from QCAlgorithm.";
to:
"Algorithm type name not found, or unable to resolve multiple algorithm types to a single type. Please verify algorithm type name matches the algorithm name in the configuration file and that there is one and only one class derived from QCAlgorithm.";

#### Related Issue
https://github.com/QuantConnect/Lean/issues/2205

#### Motivation and Context
This change makes the error message clearer when the specified algorithm name is not found.

#### How Has This Been Tested?
Ran the algorithm with a bad algorithm name. Log message is now clearer.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [N/A] I have added tests to cover my changes. (Not applicable. Only a log message change.)
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`