### PR TITLE
Fix IEXDataQueueHandler data feed

### DIFF
--- a/Tests/app.config
+++ b/Tests/app.config
@@ -18,6 +18,10 @@
         <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebSocket4Net" publicKeyToken="eb4e154b696bf72a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.14.1.0" newVersion="0.14.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/ToolBox/GzipStreamProvider.cs
+++ b/ToolBox/GzipStreamProvider.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
 using System.IO;
 using Ionic.BZip2;
 using Ionic.Zlib;
-using Quobject.Collections.Immutable;
 
 namespace QuantConnect.ToolBox
 {

--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.ToolBox.IEX
                     new IO.Options()
                     {
                         // default is 1000, default attempts is int.MaxValue
-                        ReconnectionDelay = 250
+                        ReconnectionDelay = 1000
                     });
                 _socket.On(Socket.EVENT_CONNECT, () =>
                 {
@@ -80,7 +80,7 @@ namespace QuantConnect.ToolBox.IEX
                     Log.Trace("IEXDataQueueHandler.Reconnect(): IEX Real-Time Price");
                 });
 
-                _socket.On("message", message => ProcessJsonObject((JObject)message));
+                _socket.On("message", message => ProcessJsonObject(JObject.Parse((string)message)));
                 _manager = _socket.Io();
             }
             catch (Exception err)

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -42,8 +42,8 @@
     <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
     </Reference>
-    <Reference Include="EngineIoClientDotNet, Version=0.9.22.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EngineIoClientDotNet.0.9.22\lib\net45\EngineIoClientDotNet.dll</HintPath>
+    <Reference Include="EngineIoClientDotNet, Version=1.0.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EngineIoClientDotNet.1.0.7\lib\net45\EngineIoClientDotNet.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.85.4.369, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\packages\ICSharpCode.SharpZipLib.dll.0.85.4.369\lib\net20\ICSharpCode.SharpZipLib.dll</HintPath>
@@ -144,10 +144,16 @@
     <Reference Include="SevenZipSharp">
       <HintPath>..\packages\SevenZipSharp.0.64\lib\SevenZipSharp.dll</HintPath>
     </Reference>
-    <Reference Include="SocketIoClientDotNet, Version=0.9.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SocketIoClientDotNet.0.9.13\lib\net45\SocketIoClientDotNet.dll</HintPath>
+    <Reference Include="SocketIoClientDotNet, Version=1.0.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SocketIoClientDotNet.1.0.7.1\lib\net45\SocketIoClientDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="SuperSocket.ClientEngine, Version=0.10.0.0, Culture=neutral, PublicKeyToken=ee9af13f57f00acc, processorArchitecture=MSIL">
+      <HintPath>..\packages\SuperSocket.ClientEngine.Core.0.10.0\lib\net45\SuperSocket.ClientEngine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.4.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
@@ -157,8 +163,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebSocket4Net, Version=0.14.1.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebSocket4Net.0.14.1\lib\net45\WebSocket4Net.dll</HintPath>
+    <Reference Include="WebSocket4Net, Version=0.15.2.11, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocket4Net.0.15.2\lib\net45\WebSocket4Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ToolBox/packages.config
+++ b/ToolBox/packages.config
@@ -1,14 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DotNetZip" version="1.10.1" targetFramework="net452" />
-  <package id="EngineIoClientDotNet" version="0.9.22" targetFramework="net45" />
-  <package id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" targetFramework="net452" />
+  <package id="EngineIoClientDotNet" version="1.0.7" targetFramework="net452" />
   <package id="ICSharpCode.SharpZipLib.dll" version="0.85.4.369" targetFramework="net452" />
+  <package id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
   <package id="QuantConnect.pythonnet" version="1.0.5.7" targetFramework="net452" />
   <package id="SevenZipSharp" version="0.64" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />
-  <package id="SocketIoClientDotNet" version="0.9.13" targetFramework="net45" />
-  <package id="WebSocket4Net" version="0.14.1" targetFramework="net45" />
+  <package id="SocketIoClientDotNet" version="1.0.7.1" targetFramework="net452" />
+  <package id="SuperSocket.ClientEngine.Core" version="0.10.0" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net452" />
+  <package id="WebSocket4Net" version="0.15.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
#### Description
When selecting IEXDataQueueHandler as a data source for live trading,
it would not connect. The following fixed the issue:

- Updated Socket IO NuGet package (and its dependencies) to latest;

- In GzipStreamProvider, removed obsolete "using" statement refering
to deprecated Socket IO API (using statement was not used anyways);

- Increased the reconnection delay value to its recommended
value (1000ms), this was necessary for the feed to connect;

- Minor change in IEXDataQueueHandler to parse Json message.
"(JObject)message" would compile, but threw a runtime error, as this
formulation could not implicitly convert string to JObject. Used
the cleaner "JObject.Parse()" method instead.

#### Related Issue
https://github.com/QuantConnect/Lean/issues/2220

#### Motivation and Context
Required to use IEX as a data handler.

#### How Has This Been Tested?
- Tested by running live. Correctly connects, and confirmed that data is fed to the OnData() 
method, using debug logs.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes: N/A: Bugfix on existing functionality.
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`