### PR TITLE
Fix cancelled order status setting location

### DIFF
--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -241,6 +241,7 @@
     <Compile Include="Alphas\IAlphaHandler.cs" />
     <Compile Include="TransactionHandlers\BacktestingTransactionHandler.cs" />
     <Compile Include="TransactionHandlers\BrokerageTransactionHandler.cs" />
+    <Compile Include="TransactionHandlers\CancelPendingOrders.cs" />
     <Compile Include="TransactionHandlers\ITransactionHandler.cs" />
     <Compile Include="DataFeeds\IDataFeed.cs" />
     <Compile Include="Results\LiveTradingResultHandler.cs" />

--- a/Engine/TransactionHandlers/CancelPendingOrders.cs
+++ b/Engine/TransactionHandlers/CancelPendingOrders.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+using System.Collections.Concurrent;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Lean.Engine.TransactionHandlers
+{
+    /// <summary>
+    /// Class used to keep track of CancelPending orders and their original or updated status
+    /// </summary>
+    public class CancelPendingOrders
+    {
+        private readonly ConcurrentDictionary<int, CancelPendingOrder> _cancelPendingOrders = new ConcurrentDictionary<int, CancelPendingOrder>();
+
+        /// <summary>
+        /// Amount of CancelPending Orders
+        /// </summary>
+        public int GetCancelPendingOrdersSize => _cancelPendingOrders.Count;
+
+        /// <summary>
+        /// Adds an order which will be canceled and we want to keep track of it Status in case of fallback
+        /// </summary>
+        /// <param name="orderId">The order id</param>
+        /// <param name="status">The order Status, before the cancel request</param>
+        public void Set(int orderId, OrderStatus status)
+        {
+            _cancelPendingOrders[orderId] = new CancelPendingOrder { Status = status };
+        }
+
+        /// <summary>
+        /// Updates an order that is pending to be canceled.
+        /// </summary>
+        /// <param name="newStatus">The new status of the order. If its OrderStatus.Canceled or OrderStatus.Filled it will be removed</param>
+        /// <param name="orderId">The id of the order</param>
+        public void UpdateOrRemove(int orderId, OrderStatus newStatus)
+        {
+            CancelPendingOrder cancelPendingOrder;
+            if (_cancelPendingOrders.TryGetValue(orderId, out cancelPendingOrder))
+            {
+                // The purpose of this pattern 'trygetvalue/lock/if containskey' is to guarantee that threads working on the same order will be correctly synchronized
+                // Thread 1 at HandleCancelOrderRequest() processing a failed cancel request will call RemoveAndFallback() and revert order status
+                // Thread 2 at HandleOrderEvent() with a filled order event will call UpdateOrRemove() and remove the order, ignoring its 'saved' status.
+                lock (cancelPendingOrder)
+                {
+                    if (newStatus.IsClosed())
+                    {
+                        RemoveOrderFromCollection(orderId);
+                    }
+                    else if (newStatus != OrderStatus.CancelPending)
+                    {
+                        // check again because it might of been removed by the failed to cancel event
+                        if (_cancelPendingOrders.ContainsKey(orderId))
+                        {
+                            _cancelPendingOrders[orderId].Status = newStatus;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes an order which we failed to cancel and falls back the order Status to previous value
+        /// </summary>
+        /// <param name="order">The order that failed to be canceled</param>
+        public void RemoveAndFallback(Order order)
+        {
+            CancelPendingOrder cancelPendingOrder;
+            if (_cancelPendingOrders.TryGetValue(order.Id, out cancelPendingOrder))
+            {
+                // The purpose of this pattern 'trygetvalue/lock/if containskey' is to guarantee that threads working on the same order will be correctly synchronized
+                // Thread 1 at HandleCancelOrderRequest() processing a failed cancel request will call RemoveAndFallback() and revert order status
+                // Thread 2 at HandleOrderEvent() with a filled order event will call UpdateOrRemove() and remove the order, ignoring its 'saved' status.
+                lock (cancelPendingOrder)
+                {
+                    if (_cancelPendingOrders.ContainsKey(order.Id))
+                    {
+                        // update Status before removing from _cancelPendingOrders
+                        order.Status = _cancelPendingOrders[order.Id].Status;
+                        RemoveOrderFromCollection(order.Id);
+                    }
+                }
+            }
+        }
+
+        private void RemoveOrderFromCollection(int orderId)
+        {
+            CancelPendingOrder cancelPendingOrderTrash;
+            _cancelPendingOrders.TryRemove(orderId, out cancelPendingOrderTrash);
+        }
+
+        private class CancelPendingOrder
+        {
+            public OrderStatus Status { get; set; }
+        }
+    }
+}

--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,8 +24,6 @@ using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
-using QuantConnect.Brokerages;
-using QuantConnect.Brokerages.GDAX;
 
 namespace QuantConnect.Tests.Brokerages
 {
@@ -269,6 +267,11 @@ namespace QuantConnect.Tests.Brokerages
         protected abstract decimal LowPrice { get; }
 
         /// <summary>
+        /// Returns wether or not the brokers order methods implementation are async
+        /// </summary>
+        protected abstract bool IsAsync();
+
+        /// <summary>
         /// Gets the current market price of the specified security
         /// </summary>
         protected abstract decimal GetAskPrice(Symbol symbol);
@@ -285,6 +288,65 @@ namespace QuantConnect.Tests.Brokerages
         public void IsConnected()
         {
             Assert.IsTrue(Brokerage.IsConnected);
+        }
+
+        [Test, TestCaseSource("OrderParameters")]
+        public void CancelOrders(OrderTestParameters parameters)
+        {
+            const int secondsTimeout = 20;
+            Log.Trace("");
+            Log.Trace("CANCEL ORDERS");
+            Log.Trace("");
+
+            var order = PlaceOrderWaitForStatus(parameters.CreateLongOrder(GetDefaultQuantity()), parameters.ExpectedStatus);
+
+            var canceledOrderStatusEvent = new ManualResetEvent(false);
+            EventHandler<OrderEvent> orderStatusCallback = (sender, fill) =>
+            {
+                if (fill.Status == OrderStatus.Canceled)
+                {
+                    canceledOrderStatusEvent.Set();
+                }
+            };
+            Brokerage.OrderStatusChanged += orderStatusCallback;
+            var cancelResult = false;
+            try
+            {
+                cancelResult = Brokerage.CancelOrder(order);
+            }
+            catch (Exception exception)
+            {
+                Log.Error(exception);
+            }
+
+            Assert.AreEqual(IsAsync() || parameters.ExpectedCancellationResult, cancelResult);
+
+            if (parameters.ExpectedCancellationResult)
+            {
+                // We expect the OrderStatus.Canceled event
+                canceledOrderStatusEvent.WaitOneAssertFail(1000 * secondsTimeout, "Order timedout to cancel");
+            }
+
+            var openOrders = Brokerage.GetOpenOrders();
+            var cancelledOrder = openOrders.FirstOrDefault(x => x.Id == order.Id);
+            Assert.IsNull(cancelledOrder);
+
+            canceledOrderStatusEvent.Reset();
+
+            var cancelResultSecondTime = false;
+            try
+            {
+                cancelResultSecondTime = Brokerage.CancelOrder(order);
+            }
+            catch (Exception exception)
+            {
+                Log.Error(exception);
+            }
+            Assert.AreEqual(IsAsync(), cancelResultSecondTime);
+            // We do NOT expect the OrderStatus.Canceled event
+            Assert.IsFalse(canceledOrderStatusEvent.WaitOne(new TimeSpan(0, 0, 10)));
+
+            Brokerage.OrderStatusChanged -= orderStatusCallback;
         }
 
         [Test, TestCaseSource("OrderParameters")]
@@ -497,8 +559,10 @@ namespace QuantConnect.Tests.Brokerages
         /// <param name="order">The order to be submitted</param>
         /// <param name="expectedStatus">The status to wait for</param>
         /// <param name="secondsTimeout">Maximum amount of time to wait for <paramref name="expectedStatus"/></param>
+        /// <param name="allowFailedSubmission">Allow failed order submission</param>
         /// <returns>The same order that was submitted.</returns>
-        protected Order PlaceOrderWaitForStatus(Order order, OrderStatus expectedStatus = OrderStatus.Filled, double secondsTimeout = 10.0, bool allowFailedSubmission = false)
+        protected Order PlaceOrderWaitForStatus(Order order, OrderStatus expectedStatus = OrderStatus.Filled,
+                                                double secondsTimeout = 10.0, bool allowFailedSubmission = false)
         {
             var requiredStatusEvent = new ManualResetEvent(false);
             var desiredStatusEvent = new ManualResetEvent(false);
@@ -529,8 +593,20 @@ namespace QuantConnect.Tests.Brokerages
             {
                 Assert.Fail("Brokerage failed to place the order: " + order);
             }
-            requiredStatusEvent.WaitOneAssertFail((int)(1000 * secondsTimeout), "Expected every order to fire a submitted or invalid status event");
-            desiredStatusEvent.WaitOneAssertFail((int)(1000 * secondsTimeout), "OrderStatus " + expectedStatus + " was not encountered within the timeout. Order Id:" + order.Id);
+
+            // This is due to IB simulating stop orders https://www.interactivebrokers.com/en/trading/orders/stop.php
+            // which causes the Status.Submitted order event to never be set
+            bool assertOrderEventStatus = !(Brokerage.Name == "Interactive Brokers Brokerage"
+                                            && new[] { OrderType.StopMarket, OrderType.StopLimit }.Contains(order.Type));
+            if (assertOrderEventStatus)
+            {
+                requiredStatusEvent.WaitOneAssertFail((int)(1000 * secondsTimeout), "Expected every order to fire a submitted or invalid status event");
+                desiredStatusEvent.WaitOneAssertFail((int)(1000 * secondsTimeout), "OrderStatus " + expectedStatus + " was not encountered within the timeout. Order Id:" + order.Id);
+            }
+            else
+            {
+                requiredStatusEvent.WaitOne((int)(1000 * secondsTimeout));
+            }
 
             Brokerage.OrderStatusChanged -= brokerageOnOrderStatusChanged;
 

--- a/Tests/Brokerages/Fxcm/FxcmBrokerageTests.cs
+++ b/Tests/Brokerages/Fxcm/FxcmBrokerageTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -99,6 +99,14 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
         {
             // FXCM requires order prices to be not more than 5600 pips from the market price (at least for EURUSD)
             get { return 0.7m; }
+        }
+
+        /// <summary>
+        /// Returns wether or not the brokers order methods implementation are async
+        /// </summary>
+        protected override bool IsAsync()
+        {
+            return false;
         }
 
         /// <summary>

--- a/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
@@ -76,6 +76,14 @@ namespace QuantConnect.Tests.Brokerages.GDAX
                 Config.Get("gdax-passphrase"), algorithm.Object);
         }
 
+        /// <summary>
+        /// Returns wether or not the brokers order methods implementation are async
+        /// </summary>
+        protected override bool IsAsync()
+        {
+            return false;
+        }
+
         protected override decimal GetAskPrice(Symbol symbol)
         {
             var tick = ((GDAXBrokerage)this.Brokerage).GetTick(symbol);

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersOrderTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersOrderTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         // set to true to disable launch of gateway from tests
         private const bool _manualGatewayControl = false;
         private static bool _gatewayLaunched;
-     
+
         [TestFixtureSetUp]
         public void InitializeBrokerage()
         {
@@ -59,6 +59,14 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         protected override decimal LowPrice
         {
             get { return 0.01m; }
+        }
+
+        /// <summary>
+        /// Returns wether or not the brokers order methods implementation are async
+        /// </summary>
+        protected override bool IsAsync()
+        {
+            return true;
         }
 
         protected override decimal GetAskPrice(Symbol symbol)

--- a/Tests/Brokerages/LimitOrderTestParameters.cs
+++ b/Tests/Brokerages/LimitOrderTestParameters.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -64,5 +64,7 @@ namespace QuantConnect.Tests.Brokerages
             // default limit orders will only be submitted, not filled
             get { return OrderStatus.Submitted; }
         }
+
+        public override bool ExpectedCancellationResult => true;
     }
 }

--- a/Tests/Brokerages/MarketOrderTestParameters.cs
+++ b/Tests/Brokerages/MarketOrderTestParameters.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,5 +48,7 @@ namespace QuantConnect.Tests.Brokerages
             // all market orders should fill
             get { return OrderStatus.Filled; }
         }
+
+        public override bool ExpectedCancellationResult => false;
     }
 }

--- a/Tests/Brokerages/Oanda/OandaBrokerageTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,6 +72,14 @@ namespace QuantConnect.Tests.Brokerages.Oanda
         protected override decimal LowPrice
         {
             get { return 0.32m; }
+        }
+
+        /// <summary>
+        /// Returns wether or not the brokers order methods implementation are async
+        /// </summary>
+        protected override bool IsAsync()
+        {
+            return false;
         }
 
         /// <summary>

--- a/Tests/Brokerages/OrderTestParameters.cs
+++ b/Tests/Brokerages/OrderTestParameters.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -59,6 +59,10 @@ namespace QuantConnect.Tests.Brokerages
         /// unless market order, then Filled
         /// </summary>
         public abstract OrderStatus ExpectedStatus { get; }
+        /// <summary>
+        /// The status to expect when cancelling this order
+        /// </summary>
+        public abstract bool ExpectedCancellationResult { get; }
 
         /// <summary>
         /// True to continue modifying the order until it is filled, false otherwise

--- a/Tests/Brokerages/StopLimitOrderTestParameters.cs
+++ b/Tests/Brokerages/StopLimitOrderTestParameters.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ namespace QuantConnect.Tests.Brokerages
             {
                 // for stop buys we need to decrease the stop price
                 stop.StopPrice = Math.Min(stop.StopPrice, Math.Max(stop.StopPrice/2, Math.Round(lastMarketPrice, 2, MidpointRounding.AwayFromZero)));
-                
+
                 //change behaviour for forex type unit tests
                 if(order.SecurityType == SecurityType.Forex || order.SecurityType == SecurityType.Crypto)
                 {
@@ -77,5 +77,7 @@ namespace QuantConnect.Tests.Brokerages
             // default limit orders will only be submitted, not filled
             get { return OrderStatus.Submitted; }
         }
+
+        public override bool ExpectedCancellationResult => true;
     }
 }

--- a/Tests/Brokerages/StopMarketOrderTestParameters.cs
+++ b/Tests/Brokerages/StopMarketOrderTestParameters.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,5 +63,7 @@ namespace QuantConnect.Tests.Brokerages
             // default limit orders will only be submitted, not filled
             get { return OrderStatus.Submitted; }
         }
+
+        public override bool ExpectedCancellationResult => true;
     }
 }

--- a/Tests/Brokerages/Tradier/TradierBrokerageTests.cs
+++ b/Tests/Brokerages/Tradier/TradierBrokerageTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -82,6 +82,14 @@ namespace QuantConnect.Tests.Brokerages.Tradier
         protected override decimal LowPrice
         {
             get { return 0.01m; }
+        }
+
+        /// <summary>
+        /// Returns wether or not the brokers order methods implementation are async
+        /// </summary>
+        protected override bool IsAsync()
+        {
+            return false;
         }
 
         /// <summary>

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,37 +30,21 @@ using QuantConnect.Securities;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
+using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 {
-    internal class EmptyHistoryProvider : IHistoryProvider
-    {
-        public int DataPointCount
-        {
-            get { return 0; }
-        }
-
-        public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
-        {
-        }
-
-        public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
-        {
-            return Enumerable.Empty<Slice>();
-        }
-    }
-
     [TestFixture]
     class BrokerageTransactionHandlerTests
     {
         private const string Ticker = "EURUSD";
-        private QCAlgorithm _algorithm;
+        private TestAlgorithm _algorithm;
 
         [SetUp]
         public void Initialize()
         {
-            _algorithm = new QCAlgorithm { HistoryProvider = new EmptyHistoryProvider() };
+            _algorithm = new TestAlgorithm { HistoryProvider = new EmptyHistoryProvider() };
             _algorithm.SetBrokerageModel(BrokerageName.FxcmBrokerage);
             _algorithm.SetCash(100000);
             _algorithm.AddSecurity(SecurityType.Forex, Ticker);
@@ -222,7 +206,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         public void OrderCancellationTransitionsThroughCancelPendingStatus()
         {
             // Initializes the transaction handler
-            var transactionHandler = new BrokerageTransactionHandler();
+            var transactionHandler = new TestBrokerageTransactionHandler();
             transactionHandler.Initialize(_algorithm, new BacktestingBrokerage(_algorithm), new BacktestingResultHandler());
 
             // Creates a limit order
@@ -250,12 +234,20 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.IsTrue(cancelRequest.Response.IsSuccess);
             Assert.IsTrue(cancelRequest.Status == OrderRequestStatus.Processing);
             Assert.IsTrue(orderTicket.Status == OrderStatus.CancelPending);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 1);
 
             transactionHandler.HandleOrderRequest(cancelRequest);
             Assert.IsTrue(cancelRequest.Response.IsProcessed);
             Assert.IsTrue(cancelRequest.Response.IsSuccess);
             Assert.IsTrue(cancelRequest.Status == OrderRequestStatus.Processed);
             Assert.IsTrue(orderTicket.Status == OrderStatus.Canceled);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 0);
+
+            // Check CancelPending was sent
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 3);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Submitted), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.CancelPending), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Canceled), 1);
         }
 
         [Test]
@@ -326,5 +318,489 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             Assert.AreEqual(0, actual);
         }
+
+        [Test]
+        public void InvalidUpdateOrderRequestShouldNotInvalidateOrder()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new BrokerageTransactionHandler();
+            transactionHandler.Initialize(_algorithm, new BacktestingBrokerage(_algorithm), new BacktestingResultHandler());
+            _algorithm.SetBrokerageModel(new TestBrokerageModel());
+            // Creates a limit order
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Limit, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            // Submit and process a limit order
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.IsTrue(orderRequest.Response.IsProcessed);
+            Assert.IsTrue(orderRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            var updateRequest = new UpdateOrderRequest(DateTime.Now, orderTicket.OrderId, new UpdateOrderFields());
+            transactionHandler.Process(updateRequest);
+            Assert.AreEqual(updateRequest.Status, OrderRequestStatus.Processing);
+            Assert.IsTrue(updateRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            transactionHandler.HandleOrderRequest(updateRequest);
+            Assert.IsFalse(updateRequest.Response.ErrorMessage.IsNullOrEmpty());
+            Assert.IsTrue(updateRequest.Response.IsError);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 2);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Message.Contains("unable to update order")), 1);
+            Assert.IsTrue(_algorithm.OrderEvents.TrueForAll(orderEvent => orderEvent.Status == OrderStatus.Submitted));
+        }
+
+        [Test]
+        public void UpdateOrderRequestShouldWork()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new BrokerageTransactionHandler();
+            transactionHandler.Initialize(_algorithm, new BacktestingBrokerage(_algorithm), new BacktestingResultHandler());
+
+            // Creates a limit order
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Limit, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            // Submit and process a limit order
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.IsTrue(orderRequest.Response.IsProcessed);
+            Assert.IsTrue(orderRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            var updateRequest = new UpdateOrderRequest(DateTime.Now, orderTicket.OrderId, new UpdateOrderFields());
+            transactionHandler.Process(updateRequest);
+            Assert.AreEqual(updateRequest.Status, OrderRequestStatus.Processing);
+            Assert.IsTrue(updateRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            transactionHandler.HandleOrderRequest(updateRequest);
+            Assert.IsTrue(updateRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 2);
+            Assert.IsTrue(_algorithm.OrderEvents.TrueForAll(orderEvent => orderEvent.Status == OrderStatus.Submitted));
+        }
+
+        [Test]
+        public void UpdateOrderRequestShouldFailForFilledOrder()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new BrokerageTransactionHandler();
+            var broker = new BacktestingBrokerage(_algorithm);
+            transactionHandler.Initialize(_algorithm, broker, new BacktestingResultHandler());
+
+            // Creates a limit order
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            // Submit and process a limit order
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.IsTrue(orderRequest.Response.IsProcessed);
+            Assert.IsTrue(orderRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            broker.Scan();
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+
+            var updateRequest = new UpdateOrderRequest(DateTime.Now, orderTicket.OrderId, new UpdateOrderFields());
+            transactionHandler.Process(updateRequest);
+            Assert.AreEqual(updateRequest.Status, OrderRequestStatus.Error);
+            Assert.IsTrue(updateRequest.Response.IsError);
+            Assert.AreEqual(updateRequest.Response.ErrorCode, OrderResponseErrorCode.InvalidOrderStatus);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 2);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Submitted), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Filled), 1);
+        }
+
+        [Test]
+        public void CancelOrderRequestShouldFailForFilledOrder()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new BrokerageTransactionHandler();
+            var broker = new BacktestingBrokerage(_algorithm);
+            transactionHandler.Initialize(_algorithm, broker, new BacktestingResultHandler());
+
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            broker.Scan();
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+
+            var cancelRequest = new CancelOrderRequest(DateTime.Now, orderTicket.OrderId, "");
+            transactionHandler.Process(cancelRequest);
+            Assert.AreEqual(cancelRequest.Status, OrderRequestStatus.Error);
+            Assert.IsTrue(cancelRequest.Response.IsError);
+            Assert.AreEqual(cancelRequest.Response.ErrorCode, OrderResponseErrorCode.InvalidOrderStatus);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 2);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Submitted), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Filled), 1);
+        }
+
+        [Test]
+        public void SyncFailedCancelOrderRequestShouldUpdateOrderStatusCorrectly()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new TestBrokerageTransactionHandler();
+            var broker = new TestBroker(_algorithm, false);
+            transactionHandler.Initialize(_algorithm, broker, new BacktestingResultHandler());
+
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            var cancelRequest = new CancelOrderRequest(DateTime.Now, orderTicket.OrderId, "");
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 0);
+            transactionHandler.Process(cancelRequest);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 1);
+            Assert.AreEqual(cancelRequest.Status, OrderRequestStatus.Processing);
+            Assert.IsTrue(cancelRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.CancelPending);
+
+            transactionHandler.HandleOrderRequest(cancelRequest);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+            Assert.AreEqual(cancelRequest.Status, OrderRequestStatus.Error);
+            Assert.IsTrue(cancelRequest.Response.IsProcessed);
+            Assert.IsTrue(cancelRequest.Response.IsError);
+            Assert.IsTrue(cancelRequest.Response.ErrorMessage.Contains("Brokerage failed to cancel order"));
+
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 0);
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 2);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.CancelPending), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Submitted), 1);
+        }
+
+        [Test]
+        public void AsyncFailedCancelOrderRequestShouldUpdateOrderStatusCorrectly()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new TestBrokerageTransactionHandler();
+            var broker = new TestBroker(_algorithm, true);
+            transactionHandler.Initialize(_algorithm, broker, new BacktestingResultHandler());
+
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            var cancelRequest = new CancelOrderRequest(DateTime.Now, orderTicket.OrderId, "");
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 0);
+            transactionHandler.Process(cancelRequest);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 1);
+            Assert.AreEqual(cancelRequest.Status, OrderRequestStatus.Processing);
+            Assert.IsTrue(cancelRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.CancelPending);
+
+            transactionHandler.HandleOrderRequest(cancelRequest);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.CancelPending);
+            Assert.AreEqual(cancelRequest.Status, OrderRequestStatus.Processed);
+            Assert.IsTrue(cancelRequest.Response.IsProcessed);
+            Assert.IsFalse(cancelRequest.Response.IsError);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 1);
+
+            broker.Scan();
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 0);
+
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 3);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.CancelPending), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Submitted), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Filled), 1);
+        }
+
+        [Test]
+        public void AsyncFailedCancelOrderRequestShouldUpdateOrderStatusCorrectlyWithIntermediateUpdate()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new TestBrokerageTransactionHandler();
+            var broker = new TestBroker(_algorithm, true);
+            transactionHandler.Initialize(_algorithm, broker, new BacktestingResultHandler());
+
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            var cancelRequest = new CancelOrderRequest(DateTime.Now, orderTicket.OrderId, "");
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 0);
+            transactionHandler.Process(cancelRequest);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 1);
+            Assert.AreEqual(cancelRequest.Status, OrderRequestStatus.Processing);
+            Assert.IsTrue(cancelRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.CancelPending);
+
+            broker.Scan();
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+
+            transactionHandler.HandleOrderRequest(cancelRequest);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 0);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+            Assert.AreEqual(cancelRequest.Status, OrderRequestStatus.Error);
+            Assert.IsTrue(cancelRequest.Response.IsProcessed);
+            Assert.IsTrue(cancelRequest.Response.IsError);
+            Assert.AreEqual(cancelRequest.Response.ErrorCode, OrderResponseErrorCode.InvalidOrderStatus);
+
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 3);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.CancelPending), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Submitted), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Filled), 1);
+        }
+
+        [Test]
+        public void SyncFailedCancelOrderRequestShouldUpdateOrderStatusCorrectlyWithIntermediateUpdate()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new TestBrokerageTransactionHandler();
+            var broker = new TestBroker(_algorithm, false);
+            transactionHandler.Initialize(_algorithm, broker, new BacktestingResultHandler());
+
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+
+            var cancelRequest = new CancelOrderRequest(DateTime.Now, orderTicket.OrderId, "");
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 0);
+            transactionHandler.Process(cancelRequest);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 1);
+            Assert.AreEqual(cancelRequest.Status, OrderRequestStatus.Processing);
+            Assert.IsTrue(cancelRequest.Response.IsSuccess);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.CancelPending);
+
+            broker.Scan();
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+
+            transactionHandler.HandleOrderRequest(cancelRequest);
+            Assert.AreEqual(transactionHandler.CancelPendingOrdersSize, 0);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+            Assert.AreEqual(cancelRequest.Status, OrderRequestStatus.Error);
+            Assert.IsTrue(cancelRequest.Response.IsProcessed);
+            Assert.IsTrue(cancelRequest.Response.IsError);
+            Assert.AreEqual(cancelRequest.Response.ErrorCode, OrderResponseErrorCode.InvalidOrderStatus);
+
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 3);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.CancelPending), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Submitted), 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Filled), 1);
+        }
+
+        [Test]
+        public void UpdateOrderRequestShouldFailForInvalidOrderId()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new BrokerageTransactionHandler();
+            transactionHandler.Initialize(_algorithm, new BacktestingBrokerage(_algorithm), new BacktestingResultHandler());
+
+            var updateRequest = new UpdateOrderRequest(DateTime.Now, -10, new UpdateOrderFields());
+            transactionHandler.Process(updateRequest);
+            Assert.AreEqual(updateRequest.Status, OrderRequestStatus.Error);
+            Assert.IsTrue(updateRequest.Response.IsError);
+
+            Assert.IsTrue(_algorithm.OrderEvents.IsNullOrEmpty());
+        }
+
+        [Test]
+        public void GetOpenOrdersWorksForSubmittedFilledStatus()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new BrokerageTransactionHandler();
+            var broker = new BacktestingBrokerage(_algorithm);
+            transactionHandler.Initialize(_algorithm, broker, new BacktestingResultHandler());
+
+            // Creates a limit order
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            Assert.AreEqual(transactionHandler.GetOpenOrders().Count, 0);
+
+            // Submit and process a limit order
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Submitted);
+            var openOrders = transactionHandler.GetOpenOrders();
+            Assert.AreEqual(openOrders.Count, 1);
+            Assert.AreEqual(openOrders[0].Id, orderTicket.OrderId);
+            broker.Scan();
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Filled);
+            Assert.AreEqual(transactionHandler.GetOpenOrders().Count, 0);
+        }
+
+        [Test]
+        public void GetOpenOrdersWorksForCancelPendingCanceledStatus()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new BrokerageTransactionHandler();
+            transactionHandler.Initialize(_algorithm, new BacktestingBrokerage(_algorithm), new BacktestingResultHandler());
+
+            // Creates a limit order
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Limit, security.Type, security.Symbol, 1000, 0, 1.11m, DateTime.Now, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            Assert.AreEqual(transactionHandler.GetOpenOrders().Count, 0);
+            // Submit and process a limit order
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.IsTrue(orderTicket.Status == OrderStatus.Submitted);
+            var openOrders = transactionHandler.GetOpenOrders();
+            Assert.AreEqual(openOrders.Count, 1);
+            Assert.AreEqual(openOrders[0].Id, orderTicket.OrderId);
+
+            // Cancel the order
+            var cancelRequest = new CancelOrderRequest(DateTime.Now, orderTicket.OrderId, "");
+            transactionHandler.Process(cancelRequest);
+            Assert.IsTrue(orderTicket.Status == OrderStatus.CancelPending);
+            openOrders = transactionHandler.GetOpenOrders();
+            Assert.AreEqual(openOrders.Count, 1);
+            Assert.AreEqual(openOrders[0].Id, orderTicket.OrderId);
+
+            transactionHandler.HandleOrderRequest(cancelRequest);
+            Assert.IsTrue(orderTicket.Status == OrderStatus.Canceled);
+            Assert.AreEqual(transactionHandler.GetOpenOrders().Count, 0);
+        }
+
+        internal class EmptyHistoryProvider : IHistoryProvider
+        {
+            public int DataPointCount
+            {
+                get { return 0; }
+            }
+
+            public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+            {
+            }
+
+            public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+            {
+                return Enumerable.Empty<Slice>();
+            }
+        }
+
+        internal class TestBrokerageModel : DefaultBrokerageModel
+        {
+            public override bool CanUpdateOrder(Security security, Order order, UpdateOrderRequest request, out BrokerageMessageEvent message)
+            {
+                message = new BrokerageMessageEvent(0, 0, "");
+                return false;
+            }
+        }
+
+        internal class TestAlgorithm : QCAlgorithm
+        {
+            public List<OrderEvent> OrderEvents = new List<OrderEvent>();
+            public override void OnOrderEvent(OrderEvent orderEvent)
+            {
+                OrderEvents.Add(orderEvent);
+            }
+        }
+
+        internal class TestBroker : BacktestingBrokerage
+        {
+            private readonly bool _cancelOrderResult;
+            public TestBroker(IAlgorithm algorithm, bool cancelOrderResult) : base(algorithm)
+            {
+                _cancelOrderResult = cancelOrderResult;
+            }
+            public override bool CancelOrder(Order order)
+            {
+                return _cancelOrderResult;
+            }
+        }
+
+        internal class TestBrokerageTransactionHandler : BrokerageTransactionHandler
+        {
+            public int CancelPendingOrdersSize => _cancelPendingOrders.GetCancelPendingOrdersSize;
+        }
+
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix an issue where we invalidated the entire order even though only the order request was invalid. Added unit test.
- Removing `order.Status = OrderStatus.Canceled` from `BrokerageTransactionHandler`, since the `brokerage.CancelOrder` returning true only means we were successful in submitting a request to cancel the order and not that the order was actually canceled. Setting the order status to Canceled is the responsibility of the brokers implementation, and is done through the call to `OnOrderEvent()`. Adding unit tests and brokers test
- Implementing a fallback logic for when the cancellation request fails. Currently, the order status will remain as `CancelPending`. Added unit tests and helper class `CancelPendingOrders`. **There is still a case missing to be covered**: for a broker which implements async operations (IB), and after the failure, there is no further order update, the order status will remain as `CancelPending`. We are missing to capture the failure message and forward it to the `BrokerageTransactionHandler` so it can execute the fallback.
- Removing unnecessary null checks in `BrokerageTransactionHandler`.
- Adding unit tests for `BrokerageTransactionHandler.GetOpenOrders()`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2143
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve cancel orders and request handling
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, regression tests. Using paper/trail accounts for Oanda, IB, FXCM
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->