### PR TITLE
ToOrderTicket now correctly sets order field

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -982,8 +982,9 @@ namespace QuantConnect
                 order.Properties);
 
             submitOrderRequest.SetOrderId(order.Id);
-
-            return new OrderTicket(transactionManager, submitOrderRequest);
+            var orderTicket = new OrderTicket(transactionManager, submitOrderRequest);
+            orderTicket.SetOrder(order);
+            return orderTicket;
         }
 
         public static void ProcessUntilEmpty<T>(this IProducerConsumerCollection<T> collection, Action<T> handler)

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -23,6 +23,7 @@ using Python.Runtime;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Indicators;
+using QuantConnect.Orders;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Util
@@ -534,6 +535,24 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(2, by2[1].Count);
             Assert.AreEqual(1, by2[2].Count);
             CollectionAssert.AreEqual(list, by2.SelectMany(x => x));
+        }
+
+        [Test]
+        public void ToOrderTicketCreatesCorrectTicket()
+        {
+            var orderRequest = new SubmitOrderRequest(OrderType.Limit, SecurityType.Equity, Symbols.USDJPY, 1000, 0, 1.11m, DateTime.Now, "Pepe");
+            var order = Order.CreateOrder(orderRequest);
+            order.Status = OrderStatus.Submitted;
+            order.Id = 11;
+            var orderTicket = order.ToOrderTicket(null);
+            Assert.AreEqual(order.Id, orderTicket.OrderId);
+            Assert.AreEqual(order.Quantity, orderTicket.Quantity);
+            Assert.AreEqual(order.Status, orderTicket.Status);
+            Assert.AreEqual(order.Type, orderTicket.OrderType);
+            Assert.AreEqual(order.Symbol, orderTicket.Symbol);
+            Assert.AreEqual(order.Tag, orderTicket.Tag);
+            Assert.AreEqual(order.Time, orderTicket.Time);
+            Assert.AreEqual(order.SecurityType, orderTicket.SecurityType);
         }
 
         private PyObject ConvertToPyObject(object value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `ToOrderTicket` will now set order field. Adding unit test
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2207
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`ToOrderTicket()` isn't setting the order field in the new OrderTicket. This causes `newOrderTicket.Status != order.Status`, due to `newOrderTicket.Status` being `OrderStatus.New`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->