### PR TITLE
Fix exception throwing at OrderTicket.InvalidUpdateOrderId

### DIFF
--- a/Common/Orders/OrderTicket.cs
+++ b/Common/Orders/OrderTicket.cs
@@ -407,8 +407,9 @@ namespace QuantConnect.Orders
         /// </summary>
         public static OrderTicket InvalidCancelOrderId(SecurityTransactionManager transactionManager, CancelOrderRequest request)
         {
-            var submit = new SubmitOrderRequest(OrderType.Market, SecurityType.Base, Symbol.Empty, 0, 0, 0, DateTime.MaxValue, string.Empty);
+            var submit = new SubmitOrderRequest(OrderType.Market, SecurityType.Base, Symbol.Empty, 0, 0, 0, DateTime.MaxValue, request.Tag);
             submit.SetResponse(OrderResponse.UnableToFindOrder(request));
+            submit.SetOrderId(request.OrderId);
             var ticket = new OrderTicket(transactionManager, submit);
             request.SetResponse(OrderResponse.UnableToFindOrder(request));
             ticket.TrySetCancelRequest(request);
@@ -417,12 +418,13 @@ namespace QuantConnect.Orders
         }
 
         /// <summary>
-        /// Creates a new <see cref="OrderTicket"/> tht represents trying to update an order for which no ticket exists
+        /// Creates a new <see cref="OrderTicket"/> that represents trying to update an order for which no ticket exists
         /// </summary>
         public static OrderTicket InvalidUpdateOrderId(SecurityTransactionManager transactionManager, UpdateOrderRequest request)
         {
-            var submit = new SubmitOrderRequest(OrderType.Market, SecurityType.Base, Symbol.Empty, 0, 0, 0, DateTime.MaxValue, string.Empty);
+            var submit = new SubmitOrderRequest(OrderType.Market, SecurityType.Base, Symbol.Empty, 0, 0, 0, DateTime.MaxValue, request.Tag);
             submit.SetResponse(OrderResponse.UnableToFindOrder(request));
+            submit.SetOrderId(request.OrderId);
             var ticket = new OrderTicket(transactionManager, submit);
             request.SetResponse(OrderResponse.UnableToFindOrder(request));
             ticket.AddUpdateRequest(request);

--- a/Tests/Common/Orders/OrderTicketTests.cs
+++ b/Tests/Common/Orders/OrderTicketTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using NUnit.Framework;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Tests.Common.Orders
+{
+    [TestFixture]
+    public class OrderTicketTests
+    {
+        [Test]
+        public void TestInvalidUpdateOrderId()
+        {
+            var updateFields = new UpdateOrderFields { Quantity = 99, Tag = "Pepe", StopPrice = 77 , LimitPrice = 55 };
+            var updateRequest = new UpdateOrderRequest(DateTime.Now, 11, updateFields);
+            var ticket = OrderTicket.InvalidUpdateOrderId(null, updateRequest);
+            Assert.AreEqual(ticket.OrderId, 11);
+            Assert.AreEqual(ticket.Quantity, 0);
+            Assert.AreEqual(ticket.Tag, "Pepe");
+            Assert.AreEqual(ticket.Status, OrderStatus.Invalid);
+            Assert.AreEqual(ticket.UpdateRequests.Count, 1);
+            Assert.AreEqual(ticket.UpdateRequests[0].Status, OrderRequestStatus.Error);
+            Assert.AreEqual(ticket.UpdateRequests[0].Response.ErrorCode, OrderResponseErrorCode.UnableToFindOrder);
+            Assert.AreEqual(ticket.UpdateRequests[0].OrderId, 11);
+            Assert.AreEqual(ticket.UpdateRequests[0].Quantity, 99);
+            Assert.AreEqual(ticket.UpdateRequests[0].Tag, "Pepe");
+            Assert.AreEqual(ticket.UpdateRequests[0].StopPrice, 77);
+            Assert.AreEqual(ticket.UpdateRequests[0].LimitPrice, 55);
+        }
+        [Test]
+        public void TestInvalidCancelOrderId()
+        {
+            var cancelRequest = new CancelOrderRequest(DateTime.Now, 11, "Pepe");
+            var ticket = OrderTicket.InvalidCancelOrderId(null, cancelRequest);
+            Assert.AreEqual(ticket.OrderId, 11);
+            Assert.AreEqual(ticket.Quantity, 0);
+            Assert.AreEqual(ticket.Tag, "Pepe");
+            Assert.AreEqual(ticket.Status, OrderStatus.Invalid);
+            Assert.AreEqual(ticket.CancelRequest, cancelRequest);
+            Assert.AreEqual(ticket.CancelRequest.Status, OrderRequestStatus.Error);
+            Assert.AreEqual(ticket.CancelRequest.Response.ErrorCode, OrderResponseErrorCode.UnableToFindOrder);
+            Assert.AreEqual(ticket.CancelRequest.OrderId, 11);
+            Assert.AreEqual(ticket.CancelRequest.Tag, "Pepe");
+        }
+        [Test]
+        public void TestInvalidSubmitRequest()
+        {
+            var orderRequest = new SubmitOrderRequest(OrderType.Limit, SecurityType.Equity, Symbols.AAPL, 1000, 0, 1.11m, DateTime.Now, "Pepe");
+            var order = Order.CreateOrder(orderRequest);
+            orderRequest.SetOrderId(orderRequest.OrderId);
+            var orderResponse = OrderResponse.InvalidStatus(orderRequest, order);
+            var ticket = OrderTicket.InvalidSubmitRequest(null, orderRequest, orderResponse);
+            Assert.AreEqual(ticket.OrderId, orderRequest.OrderId);
+            Assert.AreEqual(ticket.Quantity, 1000);
+            Assert.AreEqual(ticket.Tag, "Pepe");
+            Assert.AreEqual(ticket.Status, OrderStatus.Invalid);
+            Assert.AreEqual(ticket.OrderType, OrderType.Limit);
+            Assert.AreEqual(ticket.SecurityType, SecurityType.Equity);
+            Assert.AreEqual(ticket.Symbol, Symbols.AAPL);
+            Assert.AreEqual(ticket.SubmitRequest, orderRequest);
+            Assert.AreEqual(ticket.SubmitRequest.Status, OrderRequestStatus.Error);
+            Assert.AreEqual(ticket.SubmitRequest.OrderId, orderRequest.OrderId);
+            Assert.AreEqual(ticket.SubmitRequest.Quantity, 1000);
+            Assert.AreEqual(ticket.SubmitRequest.Tag, "Pepe");
+        }
+        [Test]
+        public void TestInvalidWarmingUp()
+        {
+            var orderRequest = new SubmitOrderRequest(OrderType.Limit, SecurityType.Equity, Symbols.AAPL, 1000, 0, 1.11m, DateTime.Now, "Pepe");
+            orderRequest.SetOrderId(orderRequest.OrderId);
+            var ticket = OrderTicket.InvalidWarmingUp(null, orderRequest);
+            Assert.AreEqual(ticket.OrderId, orderRequest.OrderId);
+            Assert.AreEqual(ticket.Quantity, 1000);
+            Assert.AreEqual(ticket.Tag, "Pepe");
+            Assert.AreEqual(ticket.Status, OrderStatus.Invalid);
+            Assert.AreEqual(ticket.OrderType, OrderType.Limit);
+            Assert.AreEqual(ticket.SecurityType, SecurityType.Equity);
+            Assert.AreEqual(ticket.Symbol, Symbols.AAPL);
+            Assert.AreEqual(ticket.SubmitRequest, orderRequest);
+            Assert.AreEqual(ticket.SubmitRequest.Status, OrderRequestStatus.Error);
+            Assert.AreEqual(ticket.SubmitRequest.OrderId, orderRequest.OrderId);
+            Assert.AreEqual(ticket.SubmitRequest.Quantity, 1000);
+            Assert.AreEqual(ticket.SubmitRequest.Tag, "Pepe");
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Common\Exceptions\NullExceptionInterpreter.cs" />
     <Compile Include="Common\Exceptions\ScheduledEventExceptionInterpreterTests.cs" />
     <Compile Include="Common\Orders\Fills\LatestPriceFillModelTests.cs" />
+    <Compile Include="Common\Orders\OrderTicketTests.cs" />
     <Compile Include="Common\Orders\Slippage\SlippageModelsTests.cs" />
     <Compile Include="Common\Orders\TimeInForces\TimeInForceTests.cs" />
     <Compile Include="Common\Scheduling\ScheduleManagerTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Setting `orderId` and `tag` for the `SubmitOrderRequest` at `InvalidCancelOrderId` and `InvalidUpdateOrderId`
- Adding unit tests for `InvalidUpdateOrderId`, `InvalidCancelOrderId`, `InvalidSubmitRequest`, and `InvalidWarmingUp` 
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2209
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the request sent to `InvalidUpdateOrderId` and `InvalidCancelOrderId` has an order id != -10 it will throw an exception. 
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->