### PR TITLE
Adds setup.py script that handles pythonnet installation in Lean

### DIFF
--- a/Algorithm.Python/readme.md
+++ b/Algorithm.Python/readme.md
@@ -3,63 +3,25 @@ QuantConnect Python Algorithm Project:
 
 Before we enable python support, follow the [installation instructions](https://github.com/QuantConnect/Lean#installation-instructions) to get LEAN running C# algorithms in your machine. 
 
-### [Windows](https://github.com/QuantConnect/Lean#windows)
-**1. Install Python 3.6:**
-   1. Use the Windows x86-64 MSI installer from [https://www.python.org/downloads/release/python-364/](https://www.python.org/downloads/release/python-364/).
-  2. When asked to select the features to be installed, make sure you select "Add python.exe to Path"
-   3. Skip the next step if `python36.dll` can be found at `C:\Windows\System32`.
-   4. Add `python36.dll` location to the system path:
-      1. Right mouse button on My Computer. Click Properties.
-      2. Click Advanced System Settings -> Environment Variables -> System Variables
-      3. On the "Path" section click New and enter the `python36.dll` path, in our example this was `C:\Windows\System32`
-      4. Create two new system variables: `PYTHONHOME` and `PYTHONPATH` which values must be, respectively, the location of your python installation (e.g. `C:\Python36amd64`) and its Lib folder (e.g. `C:\Python36amd64\Lib`).
- 5. Install [pandas](https://pandas.pydata.org/) and its [dependencies](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies).
+### Install Python 3.6:
+#### [Windows](https://github.com/QuantConnect/Lean#windows)
+1. Use the Windows x86-64 MSI installer from [python.org](https://www.python.org/downloads/release/python-365/) or [Anaconda](https://www.anaconda.com/download/) for Windows installer
+2. When asked to select the features to be installed, make sure you select "Add python.exe to Path"
+4. Create `PYTHONHOME` system variables which value must be the location of your python installation (e.g. `C:\Python36amd64` or `C:\Anaconda3`):
+   1. Right mouse button on My Computer. Click Properties.
+   2. Click Advanced System Settings -> Environment Variables -> System Variables
+   3. Click **New**. 
+        - Name of the variable: `PYTHONHOME`. 
+        - Value of the variable: python installation path.
+5. Install [pandas](https://pandas.pydata.org/) and its [dependencies](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies).
+6. Install [**Visual C++ for Python 2.7**](https://www.microsoft.com/en-us/download/details.aspx?id=44266)
 
-**2. Run python algorithm:**
-   1. Prepare `Python.Runtime.dll`. This is needed to run Python algorithms in LEAN.
-      1. Delete the existing files in `\Lean\packages\QuantConnect.pythonnet.1.0.5.7\lib`
-      2. Using windows you'll need to copy the `\Lean\packages\QuantConnect.pythonnet.1.0.5.7\build\Python.Runtime.win` file into the `..\lib\` directory and rename it to `Python.Runtime.dll`.
-  2. Update the [config](https://github.com/QuantConnect/Lean/blob/master/Launcher/config.json) to run the python algorithm:
-```json
-"algorithm-type-name": "BasicTemplateAlgorithm",
-"algorithm-language": "Python",
-"algorithm-location": "../../../Algorithm.Python/BasicTemplateAlgorithm.py",
-```
- 3. Rebuild LEAN. This step will ensure that the `Python.Runtime.dll` you set in 2.1 will be used.
-      Note: You should do a complete/clean build to recompile the whole solution from scratch, ignoring anything it's done before.
- 4. Run LEAN. You should see the same result of the C# algorithm you tested earlier.
-      Note: If you have multiple Python versions, confirm the default environtment in Visual Studio using Python Evironments
+#### [macOS](https://github.com/QuantConnect/Lean#macos)
+1. Follow "[Installing on macOS](https://docs.anaconda.com/anaconda/install/mac-os)" instructions from Anaconda documentation page.
+2. Install [pandas](https://pandas.pydata.org/) and its [dependencies](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies).
+3. Install [**pkg-config**](http://macappstore.org/pkg-config/)
 
-### [macOS](https://github.com/QuantConnect/Lean#macos)
-**1. Install Python 3.6 with Anaconda:**
-   1. Follow "[Installing on macOS](https://docs.anaconda.com/anaconda/install/mac-os)" instructions from Anaconda documentation page.
-   2. Prepend the Anaconda install location to `DYLD_FALLBACK_LIBRARY_PATH`.
-```
-$ export DYLD_FALLBACK_LIBRARY_PATH="/<path to anaconda>/lib:$DYLD_FALLBACK_LIBRARY_PATH"
-```
-   3. For [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/) users: add symbolic links to python's dynamic-link libraries in `/usr/local/lib`
-```
-$ sudo mkdir /usr/local/lib
-$ sudo ln -s /<path to anaconda>/lib/libpython* /usr/local/lib
-```
-   4. Install [pandas](https://pandas.pydata.org/) and its [dependencies](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies).
-
-**2. Run python algorithm:**
-   1. Prepare `Python.Runtime.dll`. This is needed to run Python algorithms in LEAN.
-      1. Delete the existing files in `\Lean\packages\QuantConnect.pythonnet.1.0.5.7\lib`
-      2. Using windows you'll need to copy the `\Lean\packages\QuantConnect.pythonnet.1.0.5.7\build\Python.Runtime.mac` file into the `..\lib\` directory and rename it to `Python.Runtime.dll`.
-  2. Update the [config](https://github.com/QuantConnect/Lean/blob/master/Launcher/config.json) to run the python algorithm:
-```json
-"algorithm-type-name": "BasicTemplateAlgorithm",
-"algorithm-language": "Python",
-"algorithm-location": "../../../Algorithm.Python/BasicTemplateAlgorithm.py",
-```
- 3. Rebuild LEAN. This step will ensure that the `Python.Runtime.dll` you set in 2.1 will be used.
-      Note: You should do a complete/clean build to recompile the whole solution from scratch, ignoring anything it's done before.
- 4. Run LEAN. You should see the same result of the C# algorithm you tested earlier.
-
-### [Linux](https://github.com/QuantConnect/Lean#linux-debian-ubuntu)
-**1. Install Python 3.6 with Miniconda:**
+#### [Linux](https://github.com/QuantConnect/Lean#linux-debian-ubuntu)
 By default, **miniconda** is installed in the users home directory (`$HOME`):
 ```
 export PATH="$HOME/miniconda3/bin:$PATH"
@@ -70,14 +32,29 @@ sudo ln -s $HOME/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6m.so
 conda update -y python conda pip
 conda install -y cython pandas
 ```
-**2 Run python algorithm:**
- 1. Update the [config](https://github.com/QuantConnect/Lean/blob/master/Launcher/config.json) to run the python algorithm:
+
+*Note:* There is a [known issue](https://github.com/pythonnet/pythonnet/issues/609) with python 3.6.5 that prevents pythonnet installation, please downgrade python to version 3.6.4:
+```
+conda install -y python=3.6.4
+``` 
+
+
+### Run python algorithm
+1. At Lean root directory, run the setup script:
+```
+python setup.py
+```
+It will install QuantConnect's version of [pythonnet](https://github.com/QuantConnect/pythonnet/) in your system.
+
+2. Update the [config](https://github.com/QuantConnect/Lean/blob/master/Launcher/config.json) to run the python algorithm:
 ```json
 "algorithm-type-name": "BasicTemplateAlgorithm",
 "algorithm-language": "Python",
 "algorithm-location": "../../../Algorithm.Python/BasicTemplateAlgorithm.py",
 ```
- 2. Run LEAN. You should see the same result of the C# algorithm you tested earlier.
+ 3. Rebuild LEAN.
+ 4. Run LEAN. You should see the same result of the C# algorithm you tested earlier.
+
 ___
 #### Python.Runtime.dll compilation
 LEAN users do **not** need to compile `Python.Runtime.dll`. The information below is targeted to developers who wish to improve it. 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+from shutil import which, copyfile
+from subprocess import check_output, CalledProcessError
+
+MACOS = sys.platform == "darwin"
+WIN32 = sys.platform == "win32"
+LINUX = not MACOS and not WIN32
+LINK = 'https://www.microsoft.com/en-us/download/details.aspx?id=44266'
+if MACOS: LINK = 'http://macappstore.org/pkg-config/'
+
+ARCH = 'x64'
+VERSION = f"3.6{'.4' if LINUX else ''}"
+README = 'https://github.com/QuantConnect/Lean#installation-instructions'
+PYTHONNET = 'https://github.com/QuantConnect/pythonnet'
+PACKAGES = ['conda', 'pip', 'wheel', 'setuptools', 'pandas']
+
+def _check_output(cmd):
+    try:
+        output = check_output(cmd)
+        output = os.linesep.join([str(x)[2:-1] for x in output.splitlines()])
+        cmd.append(output)
+    except CalledProcessError as e:
+        exit(os.linesep.join([str(x)[2:-1] for x in e.output.splitlines()]))
+    return cmd
+
+def check_requirements():
+    extra = ''''''
+    if WIN32:
+        extra = f'''
+        - Visual C++ for Python: {LINK}'''
+    if MACOS:
+        extra = f'''
+        - pkg-config: {LINK}'''
+
+    print(f'''
+    Python support in Lean with pythonnet
+    =====================================
+
+    Prerequisites:
+        - Python {VERSION} {ARCH} with pip
+        - LEAN: {README}{extra}
+        - git
+
+    It will update {', '.join(PACKAGES)} packages.
+    ''')
+
+    version = sys.version[0:(5 if LINUX else 3)]
+    arch = "x64" if sys.maxsize > 2**32 else "x86"
+    if version != VERSION or arch != ARCH:
+        conda_in_linux = LINUX and which('conda') is not None
+        print(f'Python {VERSION} {ARCH} is required: version {version} {arch} found.')
+        exit(f'Please use "conda install -y python={VERSION}"' if conda_in_linux else '')
+
+    if which('git') is None:
+        exit('Git is required and not found in the path. Link to install: https://git-scm.com/downloads')
+
+    if which('pip') is None:
+        exit('pip is required and not found in the path.')
+
+    if LINUX:
+        path = '/usr/lib/libpython3.6m.so'
+        if not os.path.exists(path):
+            print('Add symbolic link to python library in /usr/lib')
+            exit(f'sudo ln -s /path/to/miniconda3/lib/libpython3.6m.so {path}')
+
+def install_packages():
+
+    def get_pkgs(cmd):
+        cmd.append('list')
+        pkgs = _check_output(cmd)[-1]
+        pkgs = [pkg[:pkg.find(' ')].strip() for pkg in pkgs.splitlines()]
+        return set(PACKAGES) & set(pkgs)
+
+    print('''
+    Install/updates required packages
+    ---------------------------------
+    ''')
+    conda = which('conda')
+    if conda is not None:
+        pkgs = get_pkgs([conda])
+        for pkg in PACKAGES:
+            cmd = 'update' if pkg in pkgs else 'install'
+            _check_output([conda, cmd, '-y', pkg])
+        print(f'[conda] Successfully installed/updated: {", ".join(get_pkgs([conda]))}')
+    else:
+        cmd = [sys.executable, '-m', 'pip', 'install', '-U'] + PACKAGES[1:]
+        _check_output(cmd)
+        print(f'[ pip ] Successfully installed/updated: {", ".join(get_pkgs(cmd[0:3]))}')
+
+def install_pythonnet():
+    print('''
+    Install/updates pythonnet
+    -------------------------
+    ''')
+    cmd = [sys.executable, '-m', 'pip', 'install', '-U', 'git+' + PYTHONNET]
+    return _check_output(cmd)
+
+def get_enable_shared():
+
+    if WIN32:
+        return True
+
+    from sysconfig import get_config_var
+
+    if LINUX:
+        return get_config_var('Py_ENABLE_SHARED')
+
+    if which('pkg-config') is None:
+        exit(f'pkg-config is required and not found in path. Link to install: {LINK}')
+
+    lib = '/Library/Frameworks/Mono.framework/Versions/Current/lib'
+
+    # Create a symlink of framework lib/mono to python lib/mono
+    dst = os.path.join(os.path.dirname(sys.executable)[:-3] + 'lib', 'mono')
+    if os.path.exists(dst): os.remove(dst)
+    os.symlink(os.path.join(lib, 'mono'), dst)
+
+    paths = [path for path, dirs, files in os.walk(lib) if 'mono-2.pc' in files]
+    os.environ['PKG_CONFIG_PATH'] = ':'.join(paths)
+
+    if len(paths) == 0:
+       exit(f'Could not find "mono-2.pc" in "{lib}" tree.')
+
+    return get_config_var('Py_ENABLE_SHARED')
+
+def get_target_path():
+
+    for path, dirs, files in os.walk('packages'):
+        if 'Python.Runtime.dll' in files:
+            path = os.path.join(os.getcwd(), path, 'Python.Runtime.dll')
+            ori = path[0:-4] + '.ori'
+
+            # Save the original file
+            if not os.path.exists(ori):
+                os.rename(path, ori)
+                copyfile(ori, path)
+
+            return path
+
+    exit(f'Python.Runtime.dll not found in packages tree.{os.linesep}Please restore Nuget packages ({README})')
+
+def update_package_dll(shared, target):
+
+    try:
+        if shared:
+            import clr
+            path = os.path.dirname(clr.__file__)
+            file = os.path.join(path, 'Python.Runtime.dll')
+        else:
+            suffix = 'mac' if MACOS else 'nux'  
+            path = os.path.dirname(os.path.dirname(target))
+            file = os.path.join(path, 'build', f'Python.Runtime.{suffix}')
+
+        copyfile(file, target)
+
+        exit('Please REBUILD Lean solution to complete pythonnet setup.')
+
+    except Exception as e:
+        exit(f'Python.Runtime.dll not found in site-packages directories. Reason: {e}')
+
+def main():
+    check_requirements()
+
+    # Installs/updates packages required for pythonnet and Lean
+    install_packages()
+
+    shared = get_enable_shared()
+    target = get_target_path()
+
+    # Installs/updates pythonnet
+    result = install_pythonnet()
+
+    # If pythonnet is installed, copy the file to Lean packages folder
+    if result is not None:
+        update_package_dll(shared, target)
+    elif WIN32:
+        exit(f'Failed to install pythonnet. Please install Visual C++ for Python: {LINK}')
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
#### Description
Adds setup.py script that handles pythonnet installation in Lean.

This script will install QuantConnect's pythonnet and move the `Python.Runtime.dll` to the `packages/QuantConnect.pythonnet.x.x.x.x/lib` folder. `In macOS` and `Linux`, `Python.Runtime.dll` comes from the `packages/QuantConnect.pythonnet.x.x.x.x/build` folder created and from `Anaconda3\Lib\site-packages` in Windows.

#### Related Issue
Closes #2134 

#### Motivation and Context
Make pythonnet installation simpler for local development.

#### Requires Documentation Change
No. 

#### How Has This Been Tested?
Ran the script in Windows, macOS and Linux and verify the pythonnet installation.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`