### PR TITLE
Improve subscription sorting, FillForwardResolution, mechanism to improve performance

### DIFF
--- a/Engine/DataFeeds/IDataFeed.cs
+++ b/Engine/DataFeeds/IDataFeed.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/Engine/DataFeeds/SubscriptionCollection.cs
+++ b/Engine/DataFeeds/SubscriptionCollection.cs
@@ -14,11 +14,13 @@
  *
 */
 
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
+using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -28,6 +30,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     public class SubscriptionCollection : IEnumerable<Subscription>
     {
         private readonly ConcurrentDictionary<SubscriptionDataConfig, Subscription> _subscriptions;
+        private bool _sortingSubscriptionRequired;
+        private readonly Ref<TimeSpan> _fillForwardResolution;
 
         // some asset types (options, futures, crypto) have multiple subscriptions for different tick types,
         // we keep a sorted list of subscriptions so we can return them in a deterministic order
@@ -40,6 +44,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             _subscriptions = new ConcurrentDictionary<SubscriptionDataConfig, Subscription>();
             _subscriptionsByTickType = new List<Subscription>();
+            var ffres = Time.OneMinute;
+            _fillForwardResolution = Ref.Create(() => ffres, res => ffres = res);
         }
 
         /// <summary>
@@ -60,12 +66,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>True if the subscription is successfully added, false otherwise</returns>
         public bool TryAdd(Subscription subscription)
         {
-            if (!_subscriptions.TryAdd(subscription.Configuration, subscription))
-                return false;
-
-            SortSubscriptions();
-
-            return true;
+            if (_subscriptions.TryAdd(subscription.Configuration, subscription))
+            {
+                UpdateFillForwardResolution(FillForwardResolutionOperation.AfterAdd, subscription.Configuration);
+                _sortingSubscriptionRequired = true;
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -87,12 +94,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>True if the subscription is successfully removed, false otherwise</returns>
         public bool TryRemove(SubscriptionDataConfig configuration, out Subscription subscription)
         {
-            if (!_subscriptions.TryRemove(configuration, out subscription))
-                return false;
-
-            SortSubscriptions();
-
-            return true;
+            if (_subscriptions.TryRemove(configuration, out subscription))
+            {
+                UpdateFillForwardResolution(FillForwardResolutionOperation.AfterRemove, configuration);
+                _sortingSubscriptionRequired = true;
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -103,6 +111,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </returns>
         public IEnumerator<Subscription> GetEnumerator()
         {
+            SortSubscriptions();
             return _subscriptionsByTickType.GetEnumerator();
         }
 
@@ -117,17 +126,80 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             return GetEnumerator();
         }
 
+        /// <summary>
+        /// Gets and updates the fill forward resolution by checking specified subscription configurations and
+        /// selecting the smallest resoluton not equal to tick
+        /// </summary>
+        public Ref<TimeSpan> UpdateAndGetFillForwardResolution(SubscriptionDataConfig configuration = null)
+        {
+            if (configuration != null)
+            {
+                UpdateFillForwardResolution(FillForwardResolutionOperation.BeforeAdd, configuration);
+            }
+            return _fillForwardResolution;
+        }
+
+        /// <summary>
+        /// Helper method to validate a configuration to be included in the fill forward calculation
+        /// </summary>
+        private static bool ValidateFillForwardResolution(SubscriptionDataConfig configuration)
+        {
+            return !configuration.IsInternalFeed && configuration.Resolution != Resolution.Tick;
+        }
+        /// <summary>
+        /// Gets and updates the fill forward resolution by checking specified subscription configurations and
+        /// selecting the smallest resoluton not equal to tick
+        /// </summary>
+        private void UpdateFillForwardResolution(FillForwardResolutionOperation operation, SubscriptionDataConfig configuration)
+        {
+            // Due to performance implications let's be jealous in updating the _fillForwardResolution
+            if (ValidateFillForwardResolution(configuration) &&
+                (
+                    (new[] { FillForwardResolutionOperation.BeforeAdd, FillForwardResolutionOperation.AfterAdd }.Contains(operation)
+                     && configuration.Increment != _fillForwardResolution.Value) // check if the new Increment is different
+                ||
+                    (operation == FillForwardResolutionOperation.AfterRemove // We are removing
+                    && configuration.Increment == _fillForwardResolution.Value // True: We are removing the resolution we were using
+                    && _subscriptions.All(x => x.Key.Resolution != configuration.Resolution))) // False: there is at least another one equal, no need to update
+                )
+            {
+                var configurations = (operation == FillForwardResolutionOperation.BeforeAdd)
+                    ? _subscriptions.Keys.Concat(new[] { configuration }) : _subscriptions.Keys;
+
+                _fillForwardResolution.Value = configurations.Where(ValidateFillForwardResolution)
+                                                             .Select(x => x.Resolution)
+                                                             .Distinct()
+                                                             .DefaultIfEmpty(Resolution.Minute)
+                                                             .Min().ToTimeSpan();
+            }
+        }
+
+        /// <summary>
+        /// Sorts subscriptions so that equity subscriptions are enumerated before option
+        /// securities to ensure the underlying data is available when we process the options data
+        /// </summary>
         private void SortSubscriptions()
         {
-            // it's important that we enumerate underlying securities before derivatives to this end,
-            // we order by security type so that equity subscriptions are enumerated before option
-            // securities to ensure the underlying data is available when we process the options data
-            _subscriptionsByTickType = _subscriptions
-                .Select(x => x.Value)
-                .OrderBy(x => x.Configuration.SecurityType)
-                .ThenBy(x => x.Configuration.TickType)
-                .ThenBy(x => x.Configuration.Symbol)
-                .ToList();
+            if (_sortingSubscriptionRequired)
+            {
+                _sortingSubscriptionRequired = false;
+                // it's important that we enumerate underlying securities before derivatives to this end,
+                // we order by security type so that equity subscriptions are enumerated before option
+                // securities to ensure the underlying data is available when we process the options data
+                _subscriptionsByTickType = _subscriptions
+                    .Select(x => x.Value)
+                    .OrderBy(x => x.Configuration.SecurityType)
+                    .ThenBy(x => x.Configuration.TickType)
+                    .ThenBy(x => x.Configuration.Symbol)
+                    .ToList();
+            }
+        }
+
+        private enum FillForwardResolutionOperation
+        {
+            AfterRemove,
+            BeforeAdd,
+            AfterAdd
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Moving `_fillForwardResolution` field, from both `FileSystemDataFeed.cs` and `LiveTradingDataFeed.cs` into `SubscriptionCollection.cs`. This avoids duplication and more importantly adds control on how many times the `_fillForwardResolution` is calculated. Also, **this avoids having to sort each time we calculate** the `_fillForwardResolution`, since now we will use the ConcurrentDictionaries keys. Adding new unit tests
- Adding a new flied `_sortingSubscriptionRequired` to `SubscriptionCollection`, which allows a jealous approach for calls on `SortSubscriptions()`. The sorting will only happen if there were subscriptions changes and when the `public IEnumerator<Subscription> GetEnumerator()` is called. Adding new unit tests

- Both changes above generate a **230% time improvement** in the execution of the test algorithm (using SSD and 6 symbols), at 43k data points per second, versus 19k data points per second on master. Performance improvement should be bigger when using more symbols. New algorithm thread runner performance call tree follows, master call tree at https://github.com/QuantConnect/Lean/issues/2240
![imagen](https://user-images.githubusercontent.com/18473240/42704308-ba9f9ec8-86a5-11e8-8aad-5de51064fc10.png)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2240
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve performance
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test algorithm, unit and regression tests.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->