### PR TITLE
Adding default return value for GetMappedSymbol()

### DIFF
--- a/Common/Data/Auxiliary/MapFile.cs
+++ b/Common/Data/Auxiliary/MapFile.cs
@@ -65,10 +65,11 @@ namespace QuantConnect.Data.Auxiliary
         /// Memory overload search method for finding the mapped symbol for this date.
         /// </summary>
         /// <param name="searchDate">date for symbol we need to find.</param>
+        /// <param name="defaultReturnValue">Default return value if search was got no result.</param>
         /// <returns>Symbol on this date.</returns>
-        public string GetMappedSymbol(DateTime searchDate)
+        public string GetMappedSymbol(DateTime searchDate, string defaultReturnValue = "")
         {
-            var mappedSymbol = "";
+            var mappedSymbol = defaultReturnValue;
             //Iterate backwards to find the most recent factor:
             foreach (var splitDate in _data.Keys)
             {

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
@@ -75,10 +75,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             {
                 foreach (var date in _tradableDaysProvider(request))
                 {
-                    var currentSymbol = request.Configuration.MappedSymbol;
                     request.Configuration.MappedSymbol = GetMappedSymbol(request, date);
                     var source = sourceFactory.GetSource(request.Configuration, date, _isLiveMode);
-                    request.Configuration.MappedSymbol = currentSymbol;
                     var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, request.Configuration, date, _isLiveMode);
                     var entriesForDate = factory.Read(source);
                     foreach (var entry in entriesForDate)
@@ -99,12 +97,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                         _mapFileResolver.ResolveMapFile(config.Symbol.Underlying.ID.Symbol, config.Symbol.Underlying.ID.Date) :
                         _mapFileResolver.ResolveMapFile(config.Symbol.ID.Symbol, config.Symbol.ID.Date);
 
-                return mapFile.GetMappedSymbol(date);
+                return mapFile.GetMappedSymbol(date, config.MappedSymbol);
             }
-            else
-            {
-                return config.MappedSymbol;
-            }
+            return config.MappedSymbol;
         }
     }
 }

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -50,9 +50,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// true if we can find a scale factor file for the security of the form: ..\Lean\Data\equity\market\factor_files\{SYMBOL}.csv
         private readonly bool _hasScaleFactors;
 
-        // Symbol Mapping:
-        private string _mappedSymbol = "";
-
         // Location of the datafeed - the type of this data.
 
         // Create a single instance to invoke all Type Methods:
@@ -563,15 +560,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
 
                 // check to see if the symbol was remapped
-                var newSymbol = _mapFile.GetMappedSymbol(date);
-                if (newSymbol != _mappedSymbol)
+                var newSymbol = _mapFile.GetMappedSymbol(date, _config.MappedSymbol);
+                if (newSymbol != _config.MappedSymbol)
                 {
-                    if (_mappedSymbol != "")
-                    {
-                        var changed = new SymbolChangedEvent(_config.Symbol, date, _mappedSymbol, newSymbol);
-                        _auxiliaryData.Enqueue(changed);
-                    }
-                    _config.MappedSymbol = _mappedSymbol = newSymbol;
+                    var changed = new SymbolChangedEvent(_config.Symbol, date, _config.MappedSymbol, newSymbol);
+                    _auxiliaryData.Enqueue(changed);
+                    _config.MappedSymbol = newSymbol;
                 }
 
                 // we've passed initial checks,now go get data for this date!

--- a/Tests/Engine/DataFeeds/Auxiliary/MapFileResolverTests.cs
+++ b/Tests/Engine/DataFeeds/Auxiliary/MapFileResolverTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,6 +32,14 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Auxiliary
             var spyMapFile = _resolver.ResolveMapFile("SPY", new DateTime(2015, 08, 23));
             Assert.IsNotNull(spyMapFile);
             Assert.AreEqual("SPY", spyMapFile.GetMappedSymbol(new DateTime(2015, 08, 23)));
+        }
+
+        [Test]
+        public void MapFileReturnDefaultValueCorrectly()
+        {
+            var spyMapFile = _resolver.ResolveMapFile("PEPE", new DateTime(2015, 08, 23));
+            Assert.IsNotNull(spyMapFile);
+            Assert.AreEqual("Pepito", spyMapFile.GetMappedSymbol(new DateTime(2015, 08, 23), "Pepito"));
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding default return value for `GetMappedSymbol()`. Adding unit test.
- Removing unnecessary `_mappedSymbol` at `Engine/DataFeeds/SubscriptionDataReader.cs`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2223
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The algorithm could not run successfully due to this error
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->