### PR TITLE
Fix for delisted subscription data being sent

### DIFF
--- a/Algorithm.CSharp/OptionDelistedDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionDelistedDataRegressionAlgorithm.cs
@@ -1,0 +1,121 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class OptionDelistedDataRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private const string UnderlyingTicker = "GOOG";
+        public readonly Symbol OptionSymbol = QuantConnect.Symbol.Create(UnderlyingTicker, SecurityType.Option, Market.USA);
+        private readonly List<Symbol> _delisted = new List<Symbol>();
+        private readonly List<Symbol> _toBeDelisted = new List<Symbol>();
+        private bool _executed;
+        public override void Initialize()
+        {
+            SetStartDate(2016, 01, 15);  //Set Start Date
+            SetEndDate(2016, 01, 19);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+            AddOption(UnderlyingTicker);
+        }
+
+        public override void OnData(Slice data)
+        {
+            _executed = true;
+            if (Time.Minute == 0)
+            {
+                foreach (var d in data)
+                {
+                    if (_delisted.Contains(d.Key))
+                    {
+                        throw new Exception("We shouldn't be recieving data from an already delisted symbol");
+                    }
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_executed)
+            {
+                Debug("CUSTOM OnEndOfAlgorithm");
+                if (_delisted.Count != 20)
+                {
+                    throw new Exception("Expecting exactly 20 delisted events");
+                }
+                if (_toBeDelisted.Count != 20)
+                {
+                    throw new Exception("Expecting exactly 20 to be delisted warning events");
+                }
+            }
+            base.OnEndOfAlgorithm();
+        }
+
+        public void OnData(Delistings data)
+        {
+            foreach (var kvp in data)
+            {
+                var symbol = kvp.Key;
+                var delisting = kvp.Value;
+                if (delisting.Type == DelistingType.Warning)
+                {
+                    _toBeDelisted.Add(symbol);
+                    Debug($"OnData(Delistings): {Time}: {symbol} will be delisted at end of day today.");
+                }
+                if (delisting.Type == DelistingType.Delisted)
+                {
+                    _delisted.Add(symbol);
+                    Debug($"OnData(Delistings): {Time}: {symbol} has been delisted.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -92,6 +92,7 @@
     <Compile Include="OptionDataNullReferenceRegressionAlgorithm.cs" />
     <Compile Include="CancelOpenOrdersRegressionAlgorithm.cs" />
     <Compile Include="ConvertToFrameworkAlgorithm.cs" />
+    <Compile Include="OptionDelistedDataRegressionAlgorithm.cs" />
     <Compile Include="PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs" />
     <Compile Include="RawPricesCoarseUniverseAlgorithm.cs" />
     <Compile Include="CompositeAlphaModelFrameworkAlgorithm.cs" />

--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -427,7 +427,7 @@ namespace QuantConnect.Data
                         yield return new KeyValuePair<Symbol, BaseData>(kvp.Key, dataPoint);
                     }
                 }
-                else
+                else if (data != null)
                 {
                     yield return new KeyValuePair<Symbol, BaseData>(kvp.Key, data);
                 }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -718,6 +718,7 @@ namespace QuantConnect.Lean.Engine
 
             //Algorithm finished, send regardless of commands:
             results.SendStatusUpdate(AlgorithmStatus.Completed);
+            SetStatus(AlgorithmStatus.Completed);
 
             //Take final samples:
             results.SampleRange(algorithm.GetChartUpdates());

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -293,6 +293,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     return true;
                 }
 
+                if (_delisted)
+                {
+                    break;
+                }
+
                 // keep enumerating until we find something that is within our time frame
                 while (_subscriptionFactoryEnumerator.MoveNext())
                 {
@@ -386,11 +391,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     return true;
                 }
 
-                if (_delisted)
-                {
-                    break;
-                }
-
                 // we've ended the enumerator, time to refresh
                 _subscriptionFactoryEnumerator = ResolveDataEnumerator(true);
             }
@@ -439,10 +439,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 if (sourceChanged || liveRemoteFile)
                 {
                     // dispose of the current enumerator before creating a new one
-                    if (_subscriptionFactoryEnumerator != null)
-                    {
-                        _subscriptionFactoryEnumerator.Dispose();
-                    }
+                    Dispose();
 
                     // save off for comparison next time
                     _source = newSource;

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -46,6 +46,7 @@ namespace QuantConnect.Tests
         {
             var statistics = new Dictionary<string, string>();
             var alphaStatistics = new AlphaRuntimeStatistics();
+            var algorithmManager = new AlgorithmManager(false);
 
             Composer.Instance.Reset();
             var ordersLogFile = string.Empty;
@@ -96,7 +97,6 @@ namespace QuantConnect.Tests
                             string algorithmPath;
                             var job = systemHandlers.JobQueue.NextJob(out algorithmPath);
                             ((BacktestNodePacket)job).BacktestId = algorithm;
-                            var algorithmManager = new AlgorithmManager(false);
                             engine.Run(job, algorithmManager, algorithmPath);
                             ordersLogFile = ((RegressionResultHandler)algorithmHandlers.Results).OrdersLogFilePath;
                         }
@@ -118,6 +118,10 @@ namespace QuantConnect.Tests
             catch (Exception ex)
             {
                 Log.LogHandler.Error("{0} {1}", ex.Message, ex.StackTrace);
+            }
+            if (algorithmManager.State != AlgorithmStatus.Completed)
+            {
+                Assert.Fail($"Algorithm state should be completed and is: {algorithmManager.State}");
             }
 
             foreach (var stat in expectedStatistics)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Moving the `if (_delisted) { break; }` above the `while (_subscriptionFactoryEnumerator.MoveNext())` loop. Why? The `_subscriptionFactoryEnumerator` isn't useful, when created, we detect that the subscription is delisted through `CheckForDelisting()` cause `date > delistingDate`. But we still need to loop once more to send the `new Delisting` event, but after we send it we are done and we can break (not going through `_subscriptionFactoryEnumerator.MoveNext()`, since it will start reading a New zip file that's after the delisting date). We still need to create the `_subscriptionFactoryEnumerator` since that's the way we detect that the subscription has to be delisted.
- Replacing a couple of lines with an already defined method with the same behavior. Method: https://github.com/QuantConnect/Lean/blob/master/Engine/DataFeeds/SubscriptionDataReader.cs#L740
- Modified `Common/Data/Slice.cs` so that the enumerator does not send null data to the algorithm
- Adding a regression test. It will throw an exception if we receive any delisted data (fails on master). It will also throw if we didn't recieve the warning and delisted events. ***requires data not present in the open source repository and will pass in that case**.
     - Modified `Engine/AlgorithmManager.cs` to set the algorithms state to `completed`, it was being left as `running`
     - Modified `Tests/AlgorithmRunner.cs` to assert the state of the algorithm and if not `completed` fail.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2197
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Delisted symbol should not be sent through OnData(Slice) after it has been delisted and user informed.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests. Test algorithm at https://github.com/QuantConnect/Lean/issues/2197
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->