### PR TITLE
Fix broken --config command-line argument

### DIFF
--- a/Configuration/Config.cs
+++ b/Configuration/Config.cs
@@ -57,6 +57,7 @@ namespace QuantConnect.Configuration
             if (cliArguments.ContainsKey("config"))
             {
                 SetConfigurationFile(cliArguments["config"] as string);
+                Reset();
             }
 
             var jsonArguments = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(cliArguments));

--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -52,8 +52,6 @@ namespace QuantConnect.Lean.Launcher
                 Config.MergeCommandLineArgumentsWithConfiguration(LeanArgumentParser.ParseArguments(args));
             }
 
-            Config.Reset();
-
             var environment = Config.Get("environment");
             var liveMode = Config.GetBool("live-mode");
             Log.DebuggingEnabled = Config.GetBool("debug-mode");

--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -52,6 +52,8 @@ namespace QuantConnect.Lean.Launcher
                 Config.MergeCommandLineArgumentsWithConfiguration(LeanArgumentParser.ParseArguments(args));
             }
 
+            Config.Reset();
+
             var environment = Config.Get("environment");
             var liveMode = Config.GetBool("live-mode");
             Log.DebuggingEnabled = Config.GetBool("debug-mode");


### PR DESCRIPTION
#### Description
Reset the configuration settings at the beginning of program
execution, so that, when passing a custom --config argument
to the program, values from that file are read instead of the
default config file.

#### Related Issue
https://github.com/QuantConnect/Lean/issues/2249

#### Motivation and Context
Config file argument was not used in the program.

#### How Has This Been Tested?
Reproduced the steps 1-7 described in https://github.com/QuantConnect/Lean/issues/2249, and confirmed that the value is now correctly read.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [N/A] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`