### PR TITLE
Bug 2226 option contract not delisted if expiry date is a holiday

### DIFF
--- a/Algorithm.CSharp/OptionExpiryDateOnHolidayCase.cs
+++ b/Algorithm.CSharp/OptionExpiryDateOnHolidayCase.cs
@@ -1,0 +1,128 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class OptionExpiryDateOnHolidayCase : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private const string UnderlyingTicker = "SPY";
+        public readonly Symbol Underlying = QuantConnect.Symbol.Create(UnderlyingTicker, SecurityType.Equity, Market.USA);
+        public readonly Symbol OptionSymbol = QuantConnect.Symbol.Create(UnderlyingTicker, SecurityType.Option, Market.USA);
+        private OptionContract _optionContract;
+        private List<Delisting> _delistings = new List<Delisting>();
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 4, 15);
+            SetEndDate(2014, 4, 22);
+            SetCash(startingCash: 100000);
+
+            var equity = AddEquity(UnderlyingTicker);
+            equity.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            var option = AddOption(UnderlyingTicker);
+            option.SetFilter(f => f.Expiration(TimeSpan.Zero, TimeSpan.FromDays(30)));
+        }
+
+        public override void OnData(Slice slice)
+        {
+            OptionChain chain;
+            if (!Portfolio.Invested && IsMarketOpen(OptionSymbol))
+            {
+                if (slice.OptionChains.TryGetValue(OptionSymbol, out chain))
+                {
+                    _optionContract = chain.FirstOrDefault(c => c.Expiry.Date == new DateTime(2014, 04, 19) && c.OpenInterest > 0);
+                    if (_optionContract != null) MarketOrder(_optionContract.Symbol, 1);
+                }
+            }
+
+            Delisting delisting; 
+            if (slice.Delistings.TryGetValue(_optionContract.Symbol, out delisting))
+            {
+                Log(delisting.ToString());
+                _delistings.Add(delisting);
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!(_delistings.Count == 2 && 
+                  _delistings.Any(d => d.Type == DelistingType.Warning) && 
+                  _delistings.Any(d => d.Type == DelistingType.Delisted)))
+            {
+                throw new Exception($"Option contract {_optionContract.Symbol} was not correctly delisted.");
+            }
+
+            if (_delistings.FirstOrDefault(d => d.Type == DelistingType.Warning).EndTime.Date !=
+                new DateTime(2014, 04, 16))
+            {
+                throw new Exception($"Option contract {_optionContract.Symbol} delisting warning was not fired the right date.");
+            }
+
+            if (_delistings.FirstOrDefault(d => d.Type == DelistingType.Delisted).EndTime.Date !=
+                new DateTime(2014, 04, 17))
+            {
+                throw new Exception($"Option contract {_optionContract.Symbol} was not delisted the right date.");
+            }
+
+            if (Portfolio[_optionContract.Symbol].Invested)
+            {
+                throw new Exception($"Option contract {_optionContract.Symbol} was not wasn't liquidated as part of delisting.");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = false;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "-0.54%"},
+            {"Compounding Annual Return", "23.199%"},
+            {"Drawdown", "0.200%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "0.449%"},
+            {"Sharpe Ratio", "15.604"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0.172"},
+            {"Beta", "-0.683"},
+            {"Annual Standard Deviation", "0.01"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "13.984"},
+            {"Tracking Error", "0.01"},
+            {"Treynor Ratio", "-0.236"},
+            {"Total Fees", "$0.25"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -92,6 +92,7 @@
     <Compile Include="BlackLittermanPortfolioOptimizationFrameworkAlgorithm.cs" />
     <Compile Include="MeanVarianceOptimizationFrameworkAlgorithm.cs" />
     <Compile Include="TiingoDailyDataAlgorithm.cs" />
+    <Compile Include="OptionExpiryDateOnHolidayCase.cs" />
     <Compile Include="OptionDataNullReferenceRegressionAlgorithm.cs" />
     <Compile Include="CancelOpenOrdersRegressionAlgorithm.cs" />
     <Compile Include="ConvertToFrameworkAlgorithm.cs" />

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -27,6 +27,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Logging;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 using QuantConnect.Securities.Option;
 
@@ -91,6 +92,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private BaseData _lastInstanceBeforeAuxilliaryData;
         private readonly IDataProvider _dataProvider;
         private readonly IDataCacheProvider _dataCacheProvider;
+        private DateTime _delistingDate;
 
         /// <summary>
         /// Last read BaseData object from this type and source
@@ -245,6 +247,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
             }
 
+            // Estimate delisting date.
+            switch (_config.Symbol.ID.SecurityType)
+            {
+                case SecurityType.Future:
+                    _delistingDate = _config.Symbol.ID.Date;
+                    break;
+                case SecurityType.Option:
+                    _delistingDate = OptionSymbol.GetLastDayOfTrading(_config.Symbol);
+                    break;
+                default:
+                    _delistingDate = _mapFile.DelistingDate;
+                    break;
+            }
             _subscriptionFactoryEnumerator = ResolveDataEnumerator(true);
         }
 
@@ -671,33 +686,20 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         private void CheckForDelisting(DateTime date)
         {
-            DateTime delistingDate;
+            
 
-            switch (_config.Symbol.ID.SecurityType)
-            {
-                case SecurityType.Future:
-                    delistingDate = _config.Symbol.ID.Date;
-                    break;
-                case SecurityType.Option:
-                    delistingDate = OptionSymbol.GetLastDayOfTrading(_config.Symbol);
-                    break;
-                default:
-                    delistingDate = _mapFile.DelistingDate;
-                    break;
-            }
-
-            if (!_delistedWarning && date >= delistingDate)
+            if (!_delistedWarning && date >= _delistingDate)
             {
                 _delistedWarning = true;
                 var price = _previous != null ? _previous.Price : 0;
                 _auxiliaryData.Enqueue(new Delisting(_config.Symbol, date, price, DelistingType.Warning));
             }
-            else if (!_delisted && date > delistingDate)
+            else if (!_delisted && date > _delistingDate)
             {
                 _delisted = true;
                 var price = _previous != null ? _previous.Price : 0;
                 // delisted at EOD
-                _auxiliaryData.Enqueue(new Delisting(_config.Symbol, delistingDate.AddDays(1), price, DelistingType.Delisted));
+                _auxiliaryData.Enqueue(new Delisting(_config.Symbol, _delistingDate.AddDays(1), price, DelistingType.Delisted));
             }
         }
 

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -450,6 +450,15 @@ namespace QuantConnect.Tests.Common
             Assert.IsFalse(Symbols.SPY_C_192_Feb19_2016.HasUnderlyingSymbol(Symbols.AAPL));
         }
 
+        [Test]
+        public void TestIfFridayLastTradingDayIsHolidaysThenMoveToPreviousThursday()
+        {
+            var saturdayAfterGoodFriday = new DateTime(2014, 04, 19);
+            var thursdayBeforeGoodFriday = saturdayAfterGoodFriday.AddDays(-2);
+            var symbol = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 200, saturdayAfterGoodFriday);
+            Assert.AreEqual(thursdayBeforeGoodFriday, OptionSymbol.GetLastDayOfTrading(symbol));
+        }
+
         class OldSymbol
         {
             public string Value { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR, adds an additional check to `OptionSymbol.GetLastDayOfTrading` method, for the cases the expiry date is on holidays. 

Also the delisting date estimation was moved to the `SubscriptionDataReader` constructor, this means `OptionSymbol.GetLastDayOfTrading` will be called only once per each security instead of every day. This change was motivated by the fact that the new `OptionSymbol.GetLastDayOfTrading` method instantiate a `MarketHorsDataBase` and calling every day for every security erodes the engine's performance. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2226 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In some cases when the contract's last trading day is holiday, the engine assumes the contract is still active (and invested) after the expiration date.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All test were run and pass locally

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->