### PR TITLE
Fix OANDA fires duplicate market events

### DIFF
--- a/Brokerages/Oanda/OandaRestApiV20.cs
+++ b/Brokerages/Oanda/OandaRestApiV20.cs
@@ -52,7 +52,6 @@ namespace QuantConnect.Brokerages.Oanda
         private TransactionStreamSession _eventsSession;
         private PricingStreamSession _ratesSession;
         private readonly Dictionary<Symbol, DateTimeZone> _symbolExchangeTimeZones = new Dictionary<Symbol, DateTimeZone>();
-        private readonly object _locker = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OandaRestApiV20"/> class.
@@ -156,52 +155,57 @@ namespace QuantConnect.Brokerages.Oanda
         public override bool PlaceOrder(Order order)
         {
             const int orderFee = 0;
-            ApiResponse<InlineResponse201> response;
+            var marketOrderFillQuantity = 0;
+            var marketOrderFillPrice = 0m;
+            var marketOrderRemainingQuantity = 0;
+            var marketOrderStatus = OrderStatus.Filled;
+            var request = GenerateOrderRequest(order);
+            order.PriceCurrency = SecurityProvider.GetSecurity(order.Symbol).SymbolProperties.QuoteCurrency;
 
-            lock (_locker)
+            lock (Locker)
             {
-                var request = GenerateOrderRequest(order);
-                response = _apiRest.CreateOrder(Authorization, AccountId, request);
+                var response = _apiRest.CreateOrder(Authorization, AccountId, request);
                 order.BrokerId.Add(response.Data.OrderCreateTransaction.Id);
 
-                // send Submitted order event
-                order.PriceCurrency = SecurityProvider.GetSecurity(order.Symbol).SymbolProperties.QuoteCurrency;
-                OnOrderEvent(new OrderEvent(order, DateTime.UtcNow, orderFee) { Status = OrderStatus.Submitted });
+                // Market orders are special, due to the callback not being triggered always,
+                // if the order was Filled/PartiallyFilled, find fill quantity and price and inform the user
+                if (order.Type == OrderType.Market)
+                {
+                    var fill = response.Data.OrderFillTransaction;
+                    marketOrderFillPrice = Convert.ToDecimal(fill.Price);
+
+                    if (fill.TradeOpened != null && fill.TradeOpened.TradeID.Length > 0)
+                    {
+                        marketOrderFillQuantity = Convert.ToInt32(fill.TradeOpened.Units);
+                    }
+
+                    if (fill.TradeReduced != null && fill.TradeReduced.TradeID.Length > 0)
+                    {
+                        marketOrderFillQuantity = Convert.ToInt32(fill.TradeReduced.Units);
+                    }
+
+                    if (fill.TradesClosed != null && fill.TradesClosed.Count > 0)
+                    {
+                        marketOrderFillQuantity += fill.TradesClosed.Sum(trade => Convert.ToInt32(trade.Units));
+                    }
+
+                    marketOrderRemainingQuantity = Convert.ToInt32(order.AbsoluteQuantity - Math.Abs(marketOrderFillQuantity));
+                    if (marketOrderRemainingQuantity > 0)
+                    {
+                        marketOrderStatus = OrderStatus.PartiallyFilled;
+                        // The order was not fully filled lets save it so the callback can inform the user
+                        PendingFilledMarketOrders[order.Id] = marketOrderStatus;
+                    }
+                }
             }
+            OnOrderEvent(new OrderEvent(order, DateTime.UtcNow, orderFee) { Status = OrderStatus.Submitted });
 
-            // if market order, find fill quantity and price
-            var fill = response.Data.OrderFillTransaction;
-            var marketOrderFillPrice = 0m;
-            var marketOrderFillQuantity = 0;
-
-            if (order.Type == OrderType.Market)
+            // If 'marketOrderRemainingQuantity < order.AbsoluteQuantity' is false it means the order was not even PartiallyFilled, wait for callback
+            if (order.Type == OrderType.Market && marketOrderRemainingQuantity < order.AbsoluteQuantity)
             {
-                marketOrderFillPrice = Convert.ToDecimal(fill.Price);
-
-                if (fill.TradeOpened != null && fill.TradeOpened.TradeID.Length > 0)
-                {
-                    marketOrderFillQuantity = Convert.ToInt32(fill.TradeOpened.Units);
-                }
-
-                if (fill.TradeReduced != null && fill.TradeReduced.TradeID.Length > 0)
-                {
-                    marketOrderFillQuantity = Convert.ToInt32(fill.TradeReduced.Units);
-                }
-
-                if (fill.TradesClosed != null && fill.TradesClosed.Count > 0)
-                {
-                    marketOrderFillQuantity += fill.TradesClosed.Sum(trade => Convert.ToInt32(trade.Units));
-                }
-            }
-
-            if (order.Type == OrderType.Market && order.Status != OrderStatus.Filled)
-            {
-                order.Status = OrderStatus.Filled;
-
-                // if market order, also send Filled order event
                 OnOrderEvent(new OrderEvent(order, DateTime.UtcNow, orderFee, "Oanda Fill Event")
                 {
-                    Status = OrderStatus.Filled,
+                    Status = marketOrderStatus,
                     FillPrice = marketOrderFillPrice,
                     FillQuantity = marketOrderFillQuantity
                 });
@@ -349,16 +353,18 @@ namespace QuantConnect.Brokerages.Oanda
                     var transaction = obj.ToObject<OrderFillTransaction>();
 
                     Order order;
-                    lock (_locker)
+                    lock (Locker)
                     {
                         order = OrderProvider.GetOrderByBrokerageId(transaction.OrderID);
                     }
                     if (order != null)
                     {
-                        if (order.Type != OrderType.Market || order.Status != OrderStatus.Filled)
+                        OrderStatus status;
+                        // Market orders are special: if the order was not in 'PartiallyFilledMarketOrders', means
+                        // we already sent the fill event with OrderStatus.Filled, else it means we already informed the user
+                        // of a partiall fill, or didn't inform the user, so we need to do it now
+                        if (order.Type != OrderType.Market || PendingFilledMarketOrders.TryRemove(order.Id, out status))
                         {
-                            order.Status = OrderStatus.Filled;
-
                             order.PriceCurrency = SecurityProvider.GetSecurity(order.Symbol).SymbolProperties.QuoteCurrency;
 
                             const int orderFee = 0;

--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -484,6 +484,7 @@ namespace QuantConnect.Tests.Brokerages
             // pick a security with low, but some, volume
             var symbol = Symbols.EURUSD;
             var order = new MarketOrder(symbol, qty, DateTime.UtcNow) { Id = 1 };
+            OrderProvider.Add(order);
             Brokerage.PlaceOrder(order);
 
             // pause for a while to wait for fills to come in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding `Lock` to `OandaRestApiBase.cs` so both V1 and V20 api use it. To avoid depending on `order.Status` Oanda needs to keep track internally of the market orders and their status., adding new collection `ConcurrentDictionary<int, OrderStatus>` for this. Adding another test.
     - `PlaceOrder()` => Take lock, api.PlaceOrder(), add to dictionary only if order is Partially filled, release lock, inform user.
     - `Callback()` => Takes lock, get order, release lock. If order was not removed from the dictionary (means its already fully filled), pass, else inform user.
     - Moving ` OnOrderEvent(new OrderEvent(order, DateTime.UtcNow, orderFee) { Status = OrderStatus.Submitted });` outside lock scope.
- For both api V1 and V20, on `PlaceOrder()` will use `OrderStatus.PartiallyFilled` or `OrderStatus.Filled` based on `(order.AbsoluteQuantity - marketOrderFillQuantity)`
- On `OnTransactionDataReceived()` in api V20, removed line where we set order status directly.
- On `OandaBrokerageTests.cs` overwrote `OrderParameters` to avoid unsupported `StopLimitOrder` tests.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2204
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
OANDA Fires duplicate events
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Oanda brokerage tests using trial account
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->