### PR TITLE
Integration with Tiingo daily data

### DIFF
--- a/Common/Data/Custom/Tiingo/Tiingo.cs
+++ b/Common/Data/Custom/Tiingo/Tiingo.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Data.Custom.Tiingo
+{
+    /// <summary>
+    /// Helper class for Tiingo configuration
+    /// </summary>
+    public static class Tiingo
+    {
+        /// <summary>
+        /// Gets the Tiingo API token.
+        /// </summary>
+        public static string AuthCode { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Returns true if the Tiingo API token has been set.
+        /// </summary>
+        public static bool IsAuthCodeSet { get; private set; }
+
+        /// <summary>
+        /// Sets the Tiingo API token.
+        /// </summary>
+        /// <param name="authCode">The Tiingo API token</param>
+        public static void SetAuthCode(string authCode)
+        {
+            if (string.IsNullOrWhiteSpace(authCode)) return;
+
+            AuthCode = authCode;
+            IsAuthCodeSet = true;
+        }
+    }
+}

--- a/Common/Data/Custom/Tiingo/TiingoDailyData.cs
+++ b/Common/Data/Custom/Tiingo/TiingoDailyData.cs
@@ -1,0 +1,172 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Data.Custom.Tiingo
+{
+    /// <summary>
+    /// Tiingo daily price data
+    /// https://api.tiingo.com/docs/tiingo/daily
+    /// </summary>
+    public class TiingoDailyData : TradeBar
+    {
+        private readonly ConcurrentDictionary<string, DateTime> _startDates = new ConcurrentDictionary<string, DateTime>();
+
+        /// <summary>
+        /// The end time of this data. Some data covers spans (trade bars) and as such we want
+        /// to know the entire time span covered
+        /// </summary>
+        public override DateTime EndTime
+        {
+            get { return Time + Period; }
+            set { Time = value - Period; }
+        }
+
+        /// <summary>
+        /// The period of this trade bar, (second, minute, daily, ect...)
+        /// </summary>
+        public override TimeSpan Period => QuantConnect.Time.OneDay;
+
+        /// <summary>
+        /// The date this data pertains to
+        /// </summary>
+        [JsonProperty("date")]
+        public DateTime Date { get; set; }
+
+        /// <summary>
+        /// The actual (not adjusted) open price of the asset on the specific date
+        /// </summary>
+        [JsonProperty("open")]
+        public override decimal Open { get; set; }
+
+        /// <summary>
+        /// The actual (not adjusted) high price of the asset on the specific date
+        /// </summary>
+        [JsonProperty("high")]
+        public override decimal High { get; set; }
+
+        /// <summary>
+        /// The actual (not adjusted) low price of the asset on the specific date
+        /// </summary>
+        [JsonProperty("low")]
+        public override decimal Low { get; set; }
+
+        /// <summary>
+        /// The actual (not adjusted) closing price of the asset on the specific date
+        /// </summary>
+        [JsonProperty("close")]
+        public override decimal Close { get; set; }
+
+        /// <summary>
+        /// The actual (not adjusted) number of shares traded during the day
+        /// </summary>
+        [JsonProperty("volume")]
+        public override decimal Volume { get; set; }
+
+        /// <summary>
+        /// The adjusted opening price of the asset on the specific date. Returns null if not available.
+        /// </summary>
+        [JsonProperty("adjOpen")]
+        public decimal AdjustedOpen { get; set; }
+
+        /// <summary>
+        /// The adjusted high price of the asset on the specific date. Returns null if not available.
+        /// </summary>
+        [JsonProperty("adjHigh")]
+        public decimal AdjustedHigh { get; set; }
+
+        /// <summary>
+        /// The adjusted low price of the asset on the specific date. Returns null if not available.
+        /// </summary>
+        [JsonProperty("adjLow")]
+        public decimal AdjustedLow { get; set; }
+
+        /// <summary>
+        /// The adjusted close price of the asset on the specific date. Returns null if not available.
+        /// </summary>
+        [JsonProperty("adjClose")]
+        public decimal AdjustedClose { get; set; }
+
+        /// <summary>
+        /// The adjusted number of shares traded during the day - adjusted for splits. Returns null if not available
+        /// </summary>
+        [JsonProperty("adjVolume")]
+        public long AdjustedVolume { get; set; }
+
+        /// <summary>
+        /// The dividend paid out on "date" (note that "date" will be the "exDate" for the dividend)
+        /// </summary>
+        [JsonProperty("divCash")]
+        public decimal Dividend { get; set; }
+
+        /// <summary>
+        /// A factor used when a company splits or reverse splits. On days where there is ONLY a split (no dividend payment),
+        /// you can calculate the adjusted close as follows: adjClose = "Previous Close"/splitFactor
+        /// </summary>
+        [JsonProperty("splitFactor")]
+        public decimal SplitFactor { get; set; }
+
+        /// <summary>
+        /// Return the URL string source of the file. This will be converted to a stream
+        /// </summary>
+        /// <param name="config">Configuration object</param>
+        /// <param name="date">Date of this source file</param>
+        /// <param name="isLiveMode">true if we're in live mode, false for backtesting mode</param>
+        /// <returns>String URL of source file.</returns>
+        public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+        {
+            DateTime startDate;
+            if (!_startDates.TryGetValue(config.Symbol.Value, out startDate))
+            {
+                startDate = date;
+                _startDates.TryAdd(config.Symbol.Value, startDate);
+            }
+
+            var source = $"https://api.tiingo.com/tiingo/daily/{config.Symbol.Value}/prices?startDate={startDate:yyyy-MM-dd}&token={Tiingo.AuthCode}";
+            return new SubscriptionDataSource(source, SubscriptionTransportMedium.RemoteFile, FileFormat.Collection);
+        }
+
+        /// <summary>
+        ///     Reader converts each line of the data source into BaseData objects. Each data type creates its own factory method,
+        ///     and returns a new instance of the object
+        ///     each time it is called. The returned object is assumed to be time stamped in the config.ExchangeTimeZone.
+        /// </summary>
+        /// <param name="config">Subscription data config setup object</param>
+        /// <param name="content">Content of the source document</param>
+        /// <param name="date">Date of the requested data</param>
+        /// <param name="isLiveMode">true if we're in live mode, false for backtesting mode</param>
+        /// <returns>
+        ///     Instance of the T:BaseData object generated by this line of the CSV
+        /// </returns>
+        public override BaseData Reader(SubscriptionDataConfig config, string content, DateTime date, bool isLiveMode)
+        {
+            var list = JsonConvert.DeserializeObject<List<TiingoDailyData>>(content);
+
+            foreach (var item in list)
+            {
+                item.Symbol = config.Symbol;
+                item.Time = item.Date;
+            }
+
+            return new BaseDataCollection(date, config.Symbol, list);
+        }
+    }
+}

--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -38,12 +38,12 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// Volume:
         /// </summary>
-        public decimal Volume { get; set; }
+        public virtual decimal Volume { get; set; }
 
         /// <summary>
         /// Opening price of the bar: Defined as the price at the start of the time period.
         /// </summary>
-        public decimal Open
+        public virtual decimal Open
         {
             get { return _open; }
             set
@@ -56,7 +56,7 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// High price of the TradeBar during the time period.
         /// </summary>
-        public decimal High
+        public virtual decimal High
         {
             get { return _high; }
             set
@@ -69,7 +69,7 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// Low price of the TradeBar during the time period.
         /// </summary>
-        public decimal Low
+        public virtual decimal Low
         {
             get { return _low; }
             set
@@ -82,7 +82,7 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// Closing price of the TradeBar. Defined as the price at Start Time + TimeSpan.
         /// </summary>
-        public decimal Close
+        public virtual decimal Close
         {
             get { return Value; }
             set
@@ -104,7 +104,7 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// The period of this trade bar, (second, minute, daily, ect...)
         /// </summary>
-        public TimeSpan Period { get; set; }
+        public virtual TimeSpan Period { get; set; }
 
         //In Base Class: Alias of Closing:
         //public decimal Price;

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -177,6 +177,8 @@
     <Compile Include="Data\Custom\Intrinio\IntrinioConfig.cs" />
     <Compile Include="Data\Custom\Intrinio\IntrinioEconomicData.cs" />
     <Compile Include="Data\Custom\Intrinio\EconomicDataSources.cs" />
+    <Compile Include="Data\Custom\Tiingo\Tiingo.cs" />
+    <Compile Include="Data\Custom\Tiingo\TiingoDailyData.cs" />
     <Compile Include="Data\Fundamental\Fundamentals.cs" />
     <Compile Include="Data\Fundamental\Generated\AssetClassification.cs" />
     <Compile Include="Data\Fundamental\Generated\CompanyProfile.cs" />

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Data.Custom;
+using QuantConnect.Data.Custom.Tiingo;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
@@ -450,6 +451,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     {
                         // we're not using the SubscriptionDataReader, so be sure to set the auth token here
                         Quandl.SetAuthCode(Config.Get("quandl-auth-token"));
+                    }
+
+                    if (!Tiingo.IsAuthCodeSet)
+                    {
+                        // we're not using the SubscriptionDataReader, so be sure to set the auth token here
+                        Tiingo.SetAuthCode(Config.Get("tiingo-auth-token"));
                     }
 
                     var factory = new LiveCustomDataSubscriptionEnumeratorFactory(_timeProvider);

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -22,6 +22,7 @@ using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Custom;
+using QuantConnect.Data.Custom.Tiingo;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
@@ -175,6 +176,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 if (!Quandl.IsAuthCodeSet)
                 {
                     Quandl.SetAuthCode(Config.Get("quandl-auth-token"));
+                }
+            }
+
+            // If Tiingo data, set the access token in data factory
+            var tiingo = _dataFactory as TiingoDailyData;
+            if (tiingo != null)
+            {
+                if (!Tiingo.IsAuthCodeSet)
+                {
+                    Tiingo.SetAuthCode(Config.Get("tiingo-auth-token"));
                 }
             }
 


### PR DESCRIPTION

#### Description
This PR adds `Tiingo` daily prices as custom data.

#### Related Issue
#2252 
(does not close the issue because News data is not included in this PR)

#### Requires Documentation Change
Possibly we could add the new `TiingoDailyData` type in the documentation, in addition to `Quandl`

#### How Has This Been Tested?
Backtesting and Live testing with basic algorithm using `AddData<TiingoDailyData>()`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`