### PR TITLE
Fix empty dataframe from QuantBook.Indicator

### DIFF
--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -488,14 +488,12 @@ namespace QuantConnect.Jupyter
 
             selector = selector ?? (x => x.Value);
 
-            foreach (var slice in history)
+            history.PushThrough(bar =>
             {
-                foreach(var bar in slice.Values)
-                {
-                    var value = selector(bar);
-                    indicator.Update(bar.EndTime, value);
-                }
-            }
+                var value = selector(bar);
+                indicator.Update(bar.EndTime, value);
+            });
+
             return PandasConverter.GetIndicatorDataFrame(properties);
         }
 
@@ -533,16 +531,11 @@ namespace QuantConnect.Jupyter
                     kvp.Value.Add((IndicatorDataPoint)dataPoint);
                 }
             };
-            
+
             selector = selector ?? (x => (T)x);
 
-            foreach (var slice in history)
-            {
-                foreach (var bar in slice.Values)
-                {
-                    indicator.Update(selector(bar));
-                }
-            }
+            history.PushThrough(bar => indicator.Update(selector(bar)));
+
             return PandasConverter.GetIndicatorDataFrame(properties);
         }
         

--- a/Tests/Jupyter/QuantBookIndicatorsTests.cs
+++ b/Tests/Jupyter/QuantBookIndicatorsTests.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using System;
+using System.IO;
+
+namespace QuantConnect.Tests.Jupyter
+{
+    [TestFixture, Category("TravisExclude")]
+    public class QuantBookIndicatorsTests
+    {
+        dynamic _module;
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            var pythonPath = new DirectoryInfo("Jupyter/RegressionScripts");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+            using (Py.GIL())
+            {
+                _module = Py.Import("Test_QuantBookIndicator");
+            }
+        }
+
+        [Test]
+        [TestCase(2013, 10, 11, SecurityType.Equity, "SPY")]
+        [TestCase(2014, 5, 9, SecurityType.Forex, "EURUSD")]
+        [TestCase(2016, 10, 9, SecurityType.Crypto, "BTCUSD")]
+        public void QuantBookIndicatorTests(int year, int month, int day, SecurityType securityType, string symbol)
+        {
+            var startDate = new DateTime(year, month, day);
+            var indicatorTest = _module.IndicatorTest(startDate, securityType, symbol);
+
+            var endDate = startDate;
+            startDate = endDate.AddYears(-1);
+
+            // Tests a data point indicator
+            var dfBB = indicatorTest.test_bollinger_bands(symbol, startDate, endDate, Resolution.Daily);
+            Assert.IsTrue(GetDataFrameLength(dfBB) > 0);
+
+            // Tests a bar indicator
+            var dfATR = indicatorTest.test_average_true_range(symbol, startDate, endDate, Resolution.Daily);
+            Assert.IsTrue(GetDataFrameLength(dfATR) > 0);
+
+            if (securityType == SecurityType.Forex)
+            {
+                return;
+            }
+
+            // Tests a trade bar indicator
+            var dfOBV = indicatorTest.test_on_balance_volume(symbol, startDate, endDate, Resolution.Daily);
+            Assert.IsTrue(GetDataFrameLength(dfOBV) > 0);
+        }
+
+        private int GetDataFrameLength(dynamic df) => (int)(df.shape[0] as PyObject).AsManagedObject(typeof(int));
+    }
+}

--- a/Tests/Jupyter/RegressionScripts/Test_QuantBookIndicator.py
+++ b/Tests/Jupyter/RegressionScripts/Test_QuantBookIndicator.py
@@ -1,0 +1,40 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("QuantConnect.Jupyter")
+AddReference("QuantConnect.Indicators")
+
+from QuantConnect.Jupyter import *
+from QuantConnect.Indicators import *
+
+class IndicatorTest():
+    def __init__(self, start_date, security_type, symbol):
+        self.qb = QuantBook()
+        self.qb.SetStartDate(start_date)
+        self.symbol = self.qb.AddSecurity(security_type, symbol).Symbol
+
+    def __str__(self):
+        return "{} on {}".format(self.symbol.ID, self.qb.StartDate)
+
+    def test_bollinger_bands(self, symbol, start, end, resolution):
+        ind = BollingerBands(10, 2)
+        return self.qb.Indicator(ind, symbol, start, end, resolution)
+
+    def test_average_true_range(self, symbol, start, end, resolution):
+        ind = AverageTrueRange(14)
+        return self.qb.Indicator(ind, symbol, start, end, resolution)
+
+    def test_on_balance_volume(self, symbol, start, end, resolution):
+        ind = OnBalanceVolume(symbol)
+        return self.qb.Indicator(ind, symbol, start, end, resolution)

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Indicators\RateOfChangePercentTests.cs" />
     <Compile Include="Indicators\RateOfChangeTests.cs" />
     <Compile Include="Indicators\StochasticTests.cs" />
+    <Compile Include="Jupyter\QuantBookIndicatorsTests.cs" />
     <Compile Include="Jupyter\QuantBookHistoryTests.cs" />
     <Compile Include="Messaging\StreamingMessageHandlerTests.cs" />
     <Compile Include="Python\AlgorithmPythonWrapperTests.cs" />
@@ -374,6 +375,9 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+    <Content Include="Jupyter\RegressionScripts\Test_QuantBookIndicator.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="RegressionAlgorithms\Test_Cash.cs" />
     <None Include="RegressionAlgorithms\Test_LiveAlgorithm.cs" />
     <None Include="RegressionAlgorithms\Test_MixedAssets.cs" />


### PR DESCRIPTION
#### Description
When a history request is made to update a indicator, it can return an empty enumerable if there is no data from the default data type (e.g.: `QuoteBar` for Crypto). In this case, the indicator should be updated with the available data.

We changed the History requests within `QuantBook.Indicator` the  to fetch `IEnumerable<Slice>` and assure that any data is present.

#### Related Issue
Closes #2256 

#### Motivation and Context
Bug fix.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually with code snipped provided in issue #2256.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`