### PR TITLE
Adds BasicTemplateFuturesAlgorithm as regression test.

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -15,8 +15,10 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
+using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 
@@ -30,7 +32,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="using data" />
     /// <meta name="tag" content="benchmarks" />
     /// <meta name="tag" content="futures" />
-    public class BasicTemplateFuturesAlgorithm : QCAlgorithm
+    public class BasicTemplateFuturesAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         // S&P 500 EMini futures
         private const string RootSP500 = Futures.Indices.SP500EMini;
@@ -45,8 +47,8 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public override void Initialize()
         {
-            SetStartDate(2013, 10, 07);
-            SetEndDate(2013, 10, 11);
+            SetStartDate(2013, 10, 08);
+            SetEndDate(2013, 10, 10);
             SetCash(1000000);
 
             var futureSP500 = AddFuture(RootSP500);
@@ -75,7 +77,7 @@ namespace QuantConnect.Algorithm.CSharp
                         from futuresContract in chain.Value.OrderBy(x => x.Expiry)
                         where futuresContract.Expiry > Time.Date.AddDays(90)
                         select futuresContract
-                        ).FirstOrDefault();
+                    ).FirstOrDefault();
 
                     // if found, trade it
                     if (contract != null)
@@ -99,5 +101,30 @@ namespace QuantConnect.Algorithm.CSharp
         {
             Log(orderEvent.ToString());
         }
+
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "8218"},
+            {"Average Win", "0.00%"},
+            {"Average Loss", "-0.01%"},
+            {"Compounding Annual Return", "-100.0%"},
+            {"Drawdown", "26.400%"},
+            {"Expectancy", "-0.862"},
+            {"Net Profit", "-26.370%"},
+            {"Sharpe Ratio", "-32.599"},
+            {"Loss Rate", "90%"},
+            {"Win Rate", "10%"},
+            {"Profit-Loss Ratio", "0.39"},
+            {"Alpha", "-15.5"},
+            {"Beta", "-2.098"},
+            {"Annual Standard Deviation", "0.566"},
+            {"Annual Variance", "0.32"},
+            {"Information Ratio", "-28.931"},
+            {"Tracking Error", "0.686"},
+            {"Treynor Ratio", "8.788"},
+            {"Total Fees", "$15203.30"}
+        };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -102,8 +102,14 @@ namespace QuantConnect.Algorithm.CSharp
             Log(orderEvent.ToString());
         }
 
-        public Language[] Languages { get; } = { Language.CSharp };
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "8218"},

--- a/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
@@ -33,8 +33,8 @@ from datetime import timedelta
 class BasicTemplateFuturesAlgorithm(QCAlgorithm):
 
     def Initialize(self):
-        self.SetStartDate(2013, 10, 7)
-        self.SetEndDate(2013, 10, 11)
+        self.SetStartDate(2013, 10, 8)
+        self.SetEndDate(2013, 10, 10)
         self.SetCash(1000000)
 
         # Subscribe and set our expiry filter for the futures chain


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Implements `IRegressionAlgorithmDefinition` to `BasicTemplateFuturesAlgorithm` to make it part of the regression test suite.

In order to get similar results in cloud, locally and in test environment, the algorithm's start and end dates were modified.
- *Start date:* changed from 2013-10-**07** to 2013-10-**08** because as `ES` has Chicago time zone, the first hours of the of the 2013-10-07 ask data from the 2013-10-06 files. Those files are available in the cloud but no in the open source data, generating differences in the final statistics.
- *End date:* changed from 2013-10-**11** to 2013-10-**10** because the algorithm fires more than 10000 orders and in testing environment it throws `ERROR:: You have exceeded maximum number of orders (10000), for unlimited orders upgrade your account.`. this error also generates differences in the final statistics. Finishing the algorithm a day earlier fixes this issue.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2208 and closes #2241 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There was no regression test for Futures in Lean.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests run and pass locally.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->