### PR TITLE
Fixes typo in PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py

### DIFF
--- a/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Algorithm.CSharp
                 QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA),
                 QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)));
 
-            SetAlpha(new PearsonCorrelationPairsTradingAlphaModel(365, Resolution.Daily));
+            SetAlpha(new PearsonCorrelationPairsTradingAlphaModel(252, Resolution.Daily));
             SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
             SetExecution(new ImmediateExecutionModel());
             SetRiskManagement(new NullRiskManagementModel());

--- a/Algorithm.Python/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py
@@ -47,7 +47,7 @@ class PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm(QCAlgorithmFram
             Symbol.Create('IBM', SecurityType.Equity, Market.USA),
             Symbol.Create('SPY', SecurityType.Equity, Market.USA)))
 
-        self.SetAlpha(PearsonCorrelationPairsTradingAlphaModel(360, Resolution.Daily))
+        self.SetAlpha(PearsonCorrelationPairsTradingAlphaModel(252, Resolution.Daily))
         self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
         self.SetExecution(ImmediateExecutionModel())
         self.SetRiskManagement(NullRiskManagementModel())


### PR DESCRIPTION
#### Description
The lookback period is not the same as of the C# version.

#### Related Issue
N/A

#### Motivation and Context
Consistency between multi-language algorithms.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Regression test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`