### PR TITLE
Fixes Div by Zero exceptions in framework models

### DIFF
--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -52,13 +52,18 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
             if (insights.Length == 0)
             {
-                return Enumerable.Empty<IPortfolioTarget>();
+                return targets;
             }
 
             // Get symbols that have emit insights, are still in the universe, and insigths haven't expired
             var symbols = _insightCollection
                 .Where(x => x.CloseTimeUtc > algorithm.UtcTime)
                 .Select(x => x.Symbol).Distinct().ToList();
+
+            if (symbols.Count == 0)
+            {
+                return targets;
+            }
 
             // give equal weighting to each security
             var percent = 1m / symbols.Count;

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
@@ -48,6 +48,9 @@ class EqualWeightingPortfolioConstructionModel(PortfolioConstructionModel):
         # Get symbols that have emit insights and still in the universe
         symbols = list(set([x.Symbol for x in self.insightCollection if x.CloseTimeUtc > algorithm.UtcTime]))
 
+        if len(symbol) == 0:
+            return targets
+
         # give equal weighting to each security
         percent = 1.0 / len(symbols)
         for symbol in symbols:

--- a/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
@@ -74,7 +74,7 @@ class MeanVarianceOptimizationPortfolioConstructionModel(PortfolioConstructionMo
 
         symbols = [insight.Symbol for insight in insights]
         if len(symbols) == 0:
-            return []
+            return targets
 
         for insight in insights:
             symbolData = self.symbolDataBySymbol.get(insight.Symbol)

--- a/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.cs
+++ b/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.cs
@@ -38,7 +38,12 @@ namespace QuantConnect.Algorithm.Framework.Risk
             decimal maximumSectorExposure = 0.20m
             )
         {
-            _maximumSectorExposure = Math.Abs(maximumSectorExposure);
+            if (maximumSectorExposure <= 0)
+            {
+                throw new ArgumentOutOfRangeException("MaximumSectorExposureRiskManagementModel: the maximum sector exposure cannot be a non-positive value.");
+            }
+
+            _maximumSectorExposure = maximumSectorExposure;
             _targetsCollection = new PortfolioTargetCollection();
         }
 

--- a/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.py
+++ b/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.py
@@ -27,7 +27,10 @@ class MaximumSectorExposureRiskManagementModel(RiskManagementModel):
         '''Initializes a new instance of the MaximumSectorExposureRiskManagementModel class
         Args:
             maximumDrawdownPercent: The maximum exposure for any sector, defaults to 20% sector exposure.'''
-        self.maximumSectorExposure = abs(maximumSectorExposure)
+        if maximumSectorExposure <= 0:
+            raise ValueError('MaximumSectorExposureRiskManagementModel: the maximum sector exposure cannot be a non-positive value.')
+
+        self.maximumSectorExposure = maximumSectorExposure
         self.targetsCollection = PortfolioTargetCollection()
 
     def ManageRisk(self, algorithm, targets):


### PR DESCRIPTION
#### Description
Adds missing zero checks to `EqualWeightingPortfolioConstructionModel` and `MaximumSectorExposureRiskManagementModel`. 

#### Related Issue
Closes #2211

#### Motivation and Context
Framework classes should not throw.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manually running algorithm provided in issue #2211.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`