### PR TITLE
Add IRegressionAlgorithmDefinition.CanRunLocally

### DIFF
--- a/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
@@ -186,6 +186,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp };

--- a/Algorithm.CSharp/AddRemoveSecurityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveSecurityRegressionAlgorithm.cs
@@ -97,6 +97,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/BasicTemplateAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateAlgorithm.cs
@@ -63,6 +63,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
@@ -180,6 +180,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/BasicTemplateDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateDailyAlgorithm.cs
@@ -54,6 +54,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/BasicTemplateFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFrameworkAlgorithm.cs
@@ -68,6 +68,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -103,6 +103,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/BasicTemplateIntrinioEconomicData.cs
+++ b/Algorithm.CSharp/BasicTemplateIntrinioEconomicData.cs
@@ -106,6 +106,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
@@ -94,6 +94,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -137,6 +137,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/CancelOpenOrdersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CancelOpenOrdersRegressionAlgorithm.cs
@@ -113,6 +113,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp };

--- a/Algorithm.CSharp/CoarseFineFundamentalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseFineFundamentalRegressionAlgorithm.cs
@@ -147,6 +147,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/CoarseFundamentalTop5Algorithm.cs
+++ b/Algorithm.CSharp/CoarseFundamentalTop5Algorithm.cs
@@ -101,6 +101,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
@@ -58,6 +58,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = {Language.CSharp, Language.Python};

--- a/Algorithm.CSharp/ConvertToFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/ConvertToFrameworkAlgorithm.cs
@@ -103,6 +103,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
@@ -66,6 +66,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/DelistingEventsAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingEventsAlgorithm.cs
@@ -106,6 +106,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/DisplacedMovingAverageRibbon.cs
+++ b/Algorithm.CSharp/DisplacedMovingAverageRibbon.cs
@@ -152,6 +152,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/DropboxBaseDataUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/DropboxBaseDataUniverseSelectionAlgorithm.cs
@@ -170,6 +170,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/DropboxUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/DropboxUniverseSelectionAlgorithm.cs
@@ -143,6 +143,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/DuplicateSecurityWithBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DuplicateSecurityWithBenchmarkRegressionAlgorithm.cs
@@ -76,6 +76,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp };

--- a/Algorithm.CSharp/ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm.cs
@@ -91,6 +91,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp };

--- a/Algorithm.CSharp/ForexInternalFeedOnDataSameResolutionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ForexInternalFeedOnDataSameResolutionRegressionAlgorithm.cs
@@ -91,6 +91,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp };

--- a/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
@@ -84,6 +84,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/HistoryAlgorithm.cs
+++ b/Algorithm.CSharp/HistoryAlgorithm.cs
@@ -283,6 +283,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/HourReverseSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HourReverseSplitRegressionAlgorithm.cs
@@ -50,6 +50,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/HourSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HourSplitRegressionAlgorithm.cs
@@ -50,6 +50,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
@@ -227,6 +227,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/LimitFillRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitFillRegressionAlgorithm.cs
@@ -60,6 +60,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/MACDTrendAlgorithm.cs
+++ b/Algorithm.CSharp/MACDTrendAlgorithm.cs
@@ -84,6 +84,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/OptionChainConsistencyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainConsistencyRegressionAlgorithm.cs
@@ -105,6 +105,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/OptionDelistedDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionDelistedDataRegressionAlgorithm.cs
@@ -88,6 +88,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp };

--- a/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
@@ -108,6 +108,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
@@ -90,6 +90,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
@@ -122,6 +122,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
@@ -112,6 +112,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/ParameterizedAlgorithm.cs
+++ b/Algorithm.CSharp/ParameterizedAlgorithm.cs
@@ -68,6 +68,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
@@ -49,6 +49,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/RegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionAlgorithm.cs
@@ -72,6 +72,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/RenkoConsolidatorAlgorithm.cs
+++ b/Algorithm.CSharp/RenkoConsolidatorAlgorithm.cs
@@ -102,6 +102,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -178,6 +178,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
@@ -69,6 +69,11 @@ namespace QuantConnect.Algorithm.CSharp
         private IEnumerable<Symbol> SelectFine(IEnumerable<FineFundamental> fine) => fine.Select(f => f.Symbol);
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
@@ -59,6 +59,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/TimeInForceAlgorithm.cs
+++ b/Algorithm.CSharp/TimeInForceAlgorithm.cs
@@ -136,6 +136,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/UniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UniverseSelectionRegressionAlgorithm.cs
@@ -158,6 +158,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -179,6 +179,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
@@ -61,6 +61,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Algorithm.CSharp/WeeklyUniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WeeklyUniverseSelectionRegressionAlgorithm.cs
@@ -84,6 +84,11 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         public Language[] Languages { get; } = { Language.CSharp, Language.Python };

--- a/Common/Interfaces/IRegressionAlgorithmDefinition.cs
+++ b/Common/Interfaces/IRegressionAlgorithmDefinition.cs
@@ -25,6 +25,11 @@ namespace QuantConnect.Interfaces
     public interface IRegressionAlgorithmDefinition
     {
         /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        bool CanRunLocally { get; }
+
+        /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
         Language[] Languages { get; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This flag indicates whether or not the local regression test system, via `RegressionTests.AlgorithmStatisticsRegression` should run a given `IRegressionAlgorithmDefinition`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2271 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Ability to define regression tests that require more data than available in open source.
* Allow us to reduce the binary size of the repository by removing excess data for rare cases (still can run them in the cloud)

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran local regression tests w/ mock regression algorithm definition and observed it not running when `CanRunLocally` is set to `false`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->