### PR TITLE
Fix BasicTemplateFuturesAlgorithm C#/Python difference

### DIFF
--- a/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
@@ -44,6 +44,9 @@ class BasicTemplateFuturesAlgorithm(QCAlgorithm):
         futureGC = self.AddFuture(Futures.Metals.Gold)
         futureGC.SetFilter(timedelta(0), timedelta(182))
 
+        benchmark = self.AddEquity("SPY");
+        self.SetBenchmark(benchmark.Symbol);
+
 
     def OnData(self,slice):
         if not self.Portfolio.Invested:


### PR DESCRIPTION

#### Description
Updated the Python version of `BasicTemplateFuturesAlgorithm` to be identical to the C# version.

#### Related Issue
Closes #2275 

#### Motivation and Context
Regression test was failing.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Regression test run.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`