### PR TITLE
Fix for null reference in TimeSlice.Create when calling HandleOptionData

### DIFF
--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -16,11 +16,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Logging;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
 
@@ -333,6 +333,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var option = security as Option;
             if (option != null)
             {
+                if (option.Underlying == null)
+                {
+                    Log.Error($"TimeSlice.HandleOptionData(): {algorithmTime}: Option underlying is null");
+                    return false;
+                }
                 var underlyingData = option.Underlying.GetLastData();
 
                 BaseData underlyingUpdate;
@@ -341,6 +346,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     underlyingData = underlyingUpdate;
                 }
 
+                if (underlyingData == null)
+                {
+                    Log.Error($"TimeSlice.HandleOptionData(): {algorithmTime}: Option underlying GetLastData returned null");
+                    return false;
+                }
                 chain.Underlying = underlyingData;
             }
 

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -2,10 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using NodaTime;
 using NUnit.Framework;
-using Python.Runtime;
 using QuantConnect.Algorithm;
-using QuantConnect.Algorithm.CSharp;
 using QuantConnect.AlgorithmFactory.Python.Wrappers;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
@@ -13,9 +12,12 @@ using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Packets;
 using QuantConnect.Securities;
 using QuantConnect.Util;
 using Bitcoin = QuantConnect.Algorithm.CSharp.LiveTradingFeaturesAlgorithm.Bitcoin;
+using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Algorithm
 {
@@ -105,6 +107,27 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(quandlSubscription.Type, typeof(Quandl));
         }
 
+        [Test]
+        public void OnEndOfTimeStepSeedsUnderlyingSecuritiesThatHaveNoData()
+        {
+            var qcAlgorithm = new QCAlgorithm();
+            qcAlgorithm.SetLiveMode(true);
+            var testHistoryProvider = new TestHistoryProvider();
+            qcAlgorithm.HistoryProvider = testHistoryProvider;
+
+            var option = qcAlgorithm.AddSecurity(SecurityType.Option, testHistoryProvider.underlyingSymbol);
+            var option2 = qcAlgorithm.AddSecurity(SecurityType.Option, testHistoryProvider.underlyingSymbol2);
+            Assert.IsFalse(qcAlgorithm.Securities.ContainsKey(option.Symbol.Underlying));
+            Assert.IsFalse(qcAlgorithm.Securities.ContainsKey(option2.Symbol.Underlying));
+            qcAlgorithm.OnEndOfTimeStep();
+            var data = qcAlgorithm.Securities[testHistoryProvider.underlyingSymbol].GetLastData();
+            var data2 = qcAlgorithm.Securities[testHistoryProvider.underlyingSymbol2].GetLastData();
+            Assert.IsNotNull(data);
+            Assert.IsNotNull(data2);
+            Assert.AreEqual(data.Price, 2);
+            Assert.AreEqual(data2.Price, 3);
+        }
+
         [Test, Ignore]
         public void PythonCustomDataTypes_AreAddedToSubscriptions_Successfully()
         {
@@ -157,6 +180,39 @@ namespace QuantConnect.Tests.Algorithm
             return (from sub in security.Subscriptions.OrderByDescending(s => s.Resolution)
                     where type.IsAssignableFrom(sub.Type)
                     select sub).FirstOrDefault();
+        }
+
+        private class TestHistoryProvider : IHistoryProvider
+        {
+            public string underlyingSymbol = "GOOG";
+            public string underlyingSymbol2 = "AAPL";
+            public int DataPointCount { get; }
+            public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider,
+                IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+            {
+                var now = DateTime.UtcNow;
+                var tradeBar1 = new TradeBar(now, underlyingSymbol, 1, 1, 1, 1, 1, TimeSpan.FromDays(1));
+                var tradeBar2 = new TradeBar(now, underlyingSymbol2, 3, 3, 3, 3, 3, TimeSpan.FromDays(1));
+                var slice1 = new Slice(now, new List<BaseData> { tradeBar1, tradeBar2 },
+                                    new TradeBars(now), new QuoteBars(),
+                                    new Ticks(), new OptionChains(),
+                                    new FuturesChains(), new Splits(),
+                                    new Dividends(now), new Delistings(),
+                                    new SymbolChangedEvents());
+                var tradeBar1_2 = new TradeBar(now, underlyingSymbol, 2, 2, 2, 2, 2, TimeSpan.FromDays(1));
+                var slice2 = new Slice(now, new List<BaseData> { tradeBar1_2 },
+                    new TradeBars(now), new QuoteBars(),
+                    new Ticks(), new OptionChains(),
+                    new FuturesChains(), new Splits(),
+                    new Dividends(now), new Delistings(),
+                    new SymbolChangedEvents());
+                return new[] { slice1, slice2 };
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding null checks and logs for `Engine/DataFeeds/TimeSlice.cs` `HandleOptionData()` :
     - When underlying is null. Adding unit test
     - When underlying data is null. Adding unit test
- For `LiveMode` will seed underlying
    - Adding unit test
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2284
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
No null reference is thrown when calling TimeSlice.HandleOptionData
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests, paper trading IB account.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->