### PR TITLE
Fixes custom data type mismatch in python algorithms

### DIFF
--- a/Algorithm.CSharp/BasicTemplateIntrinioEconomicData.cs
+++ b/Algorithm.CSharp/BasicTemplateIntrinioEconomicData.cs
@@ -46,6 +46,8 @@ namespace QuantConnect.Algorithm.CSharp
 
         private CompositeIndicator<IndicatorDataPoint> _spread;
 
+        private ExponentialMovingAverage _emaWti;
+
         /// <summary>
         ///     Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All
         ///     algorithms must initialized.
@@ -69,6 +71,8 @@ namespace QuantConnect.Algorithm.CSharp
             AddData<IntrinioEconomicData>(IntrinioEconomicDataSources.Commodities.CrudeOilWTI, Resolution.Daily);
             AddData<IntrinioEconomicData>(IntrinioEconomicDataSources.Commodities.CrudeOilBrent, Resolution.Daily);
             _spread = _brent.Minus(_wti);
+
+            _emaWti = EMA(Securities[IntrinioEconomicDataSources.Commodities.CrudeOilWTI].Symbol, 10);
         }
 
         /// <summary>
@@ -99,7 +103,7 @@ namespace QuantConnect.Algorithm.CSharp
                     new[] {"higher", "long", "short"} :
                     new[] {"lower", "short", "long"};
 
-                Log($"Brent Price is {logText[0]} than West Texas. Go {logText[1]} BNO and {logText[2]} USO.");
+                Log($"Brent Price is {logText[0]} than West Texas. Go {logText[1]} BNO and {logText[2]} USO. West Texas EMA: {_emaWti}");
                 SetHoldings(_bno, 0.25 * Math.Sign(_spread));
                 SetHoldings(_uso, -0.25 * Math.Sign(_spread));
             }

--- a/Algorithm.Python/BasicTemplateIntrinioEconomicData.py
+++ b/Algorithm.Python/BasicTemplateIntrinioEconomicData.py
@@ -48,6 +48,8 @@ class BasicTemplateIntrinioEconomicData(QCAlgorithm):
 
         self.AddData(IntrinioEconomicData, "$DCOILWTICO", Resolution.Daily)
         self.AddData(IntrinioEconomicData, "$DCOILBRENTEU", Resolution.Daily)
+        
+        self.emaWti = self.EMA("$DCOILWTICO", 10)
 
 
     def OnData(self, slice):


### PR DESCRIPTION
#### Description
If the custom data type is a C# type, it should be used instead of wrapping it around a `PythonActivator` object.

#### Related Issue
Closes #2293 

#### Motivation and Context
Fixes custom data support for python algorithms.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Algorithm provided at #2293 and Tiingo algorithm (yet to be merged).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`