### PR TITLE
Fixes MVOPC: it was not testing whether all magnitures are zero

### DIFF
--- a/Algorithm.CSharp/BlackLittermanPortfolioOptimizationFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BlackLittermanPortfolioOptimizationFrameworkAlgorithm.cs
@@ -21,7 +21,6 @@ using QuantConnect.Algorithm.Framework.Execution;
 using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Algorithm.Framework.Risk;
 using QuantConnect.Algorithm.Framework.Selection;
-using QuantConnect.Orders;
 using QuantConnect.Interfaces;
 using QuantConnect.Data.UniverseSelection;
 
@@ -47,14 +46,11 @@ namespace QuantConnect.Algorithm.CSharp
             // Forex, CFD, Equities Resolutions: Tick, Second, Minute, Hour, Daily.
             // Futures Resolution: Tick, Second, Minute
             // Options Resolution: Minute Only.
-            
+
             // set algorithm framework models
             SetUniverseSelection(new CoarseFundamentalUniverseSelectionModel(CoarseSelector));
-            //SetAlpha(new CompositeAlphaModel(
-            //    new HistoricalReturnsAlphaModel(resolution: Resolution.Daily),
-            //    new RsiAlphaModel()));
             SetAlpha(new HistoricalReturnsAlphaModel(resolution: Resolution.Daily));
-            SetPortfolioConstruction(new BlackLittermanPortfolioConstructionModel());
+            SetPortfolioConstruction(new BlackLittermanOptimizationPortfolioConstructionModel());
             SetExecution(new ImmediateExecutionModel());
             SetRiskManagement(new NullRiskManagementModel());
         }
@@ -63,14 +59,6 @@ namespace QuantConnect.Algorithm.CSharp
         {
             int last = Time.Day > 8 ? 3 : _symbols.Count();
             return _symbols.Take(last);
-        }
-
-        public override void OnOrderEvent(OrderEvent orderEvent)
-        {
-            if (orderEvent.Status.IsFill())
-            {                
-                Debug(orderEvent.ToString());
-            }
         }
 
         public bool CanRunLocally => true;        
@@ -110,7 +98,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Insights Analysis Completed", "0"},
             {"Long Insight Count", "6"},
             {"Short Insight Count", "4"},
-            {"Long/Short Ratio", "150%"},
+            {"Long/Short Ratio", "150.0%"},
             {"Total Accumulated Estimated Alpha Value", "$0"},
             {"Mean Population Estimated Insight Value", "$0"},
             {"Mean Population Direction", "0%"},

--- a/Algorithm.CSharp/MeanVarianceOptimizationFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/MeanVarianceOptimizationFrameworkAlgorithm.cs
@@ -20,7 +20,6 @@ using QuantConnect.Algorithm.Framework.Execution;
 using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Algorithm.Framework.Risk;
 using QuantConnect.Algorithm.Framework.Selection;
-using QuantConnect.Orders;
 using QuantConnect.Interfaces;
 using System.Linq;
 using QuantConnect.Data.UniverseSelection;
@@ -62,14 +61,6 @@ namespace QuantConnect.Algorithm.CSharp
             return _symbols.Take(last);
         }
 
-        public override void OnOrderEvent(OrderEvent orderEvent)
-        {
-            if (orderEvent.Status.IsFill())
-            {
-                Debug(orderEvent.ToString());
-            }
-        }
-
         public bool CanRunLocally => true;
 
         /// <summary>
@@ -82,31 +73,31 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "14"},
-            {"Average Win", "0.42%"},
-            {"Average Loss", "-0.08%"},
-            {"Compounding Annual Return", "83.733%"},
-            {"Drawdown", "1.700%"},
-            {"Expectancy", "1.671"},
-            {"Net Profit", "0.837%"},
-            {"Sharpe Ratio", "2.239"},
-            {"Loss Rate", "57%"},
-            {"Win Rate", "43%"},
-            {"Profit-Loss Ratio", "5.23"},
+            {"Total Trades", "11"},
+            {"Average Win", "0.50%"},
+            {"Average Loss", "-0.14%"},
+            {"Compounding Annual Return", "564.274%"},
+            {"Drawdown", "0.600%"},
+            {"Expectancy", "1.248"},
+            {"Net Profit", "2.628%"},
+            {"Sharpe Ratio", "8.542"},
+            {"Loss Rate", "50%"},
+            {"Win Rate", "50%"},
+            {"Profit-Loss Ratio", "3.50"},
             {"Alpha", "0"},
-            {"Beta", "31.394"},
-            {"Annual Standard Deviation", "0.161"},
-            {"Annual Variance", "0.026"},
-            {"Information Ratio", "2.168"},
-            {"Tracking Error", "0.161"},
+            {"Beta", "95.538"},
+            {"Annual Standard Deviation", "0.129"},
+            {"Annual Variance", "0.017"},
+            {"Information Ratio", "8.459"},
+            {"Tracking Error", "0.129"},
             {"Treynor Ratio", "0.011"},
-            {"Total Fees", "$55.58"},
+            {"Total Fees", "$23.99"},
             {"Total Insights Generated", "14"},
             {"Total Insights Closed", "4"},
             {"Total Insights Analysis Completed", "0"},
             {"Long Insight Count", "6"},
             {"Short Insight Count", "4"},
-            {"Long/Short Ratio", "150%"},
+            {"Long/Short Ratio", "150.0%"},
             {"Estimated Monthly Alpha Value", "$0"},
             {"Total Accumulated Estimated Alpha Value", "$0"},
             {"Mean Population Estimated Insight Value", "$0"},

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
     /// The default model uses the 0.0025 as weight-on-views scalar parameter tau. The optimization method
     /// maximizes the Sharpe ratio with the weight range from -1 to 1.
     /// </summary>
-    public class BlackLittermanPortfolioConstructionModel : PortfolioConstructionModel
+    public class BlackLittermanOptimizationPortfolioConstructionModel : PortfolioConstructionModel
     {
         private readonly int _lookback;
         private readonly int _period;
@@ -56,7 +56,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <param name="riskFreeRate">The risk free rate</param>
         /// <param name="tau">The model parameter indicating the uncertainty of the CAPM prior</param>
         /// <param name="optimizer">The portfolio optimization algorithm. If no algorithm is explicitly provided then the default will be max Sharpe ratio optimization.</param>
-        public BlackLittermanPortfolioConstructionModel(
+        public BlackLittermanOptimizationPortfolioConstructionModel(
             int lookback = 1,
             int period = 63,
             Resolution resolution = Resolution.Daily,
@@ -170,9 +170,9 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             {
                 if (!_symbolDataDict.ContainsKey(added.Symbol))
                 {
-                    var symbolData = new ReturnsSymbolData(algorithm, added.Symbol, _lookback, _period, _resolution);
+                    var symbolData = new ReturnsSymbolData(added.Symbol, _lookback, _period);
                     _symbolDataDict[added.Symbol] = symbolData;
-                    addedSymbols.Add(symbolData.Symbol);
+                    addedSymbols.Add(added.Symbol);
                 }
             }
             if (addedSymbols.Count == 0)

--- a/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.cs
@@ -84,9 +84,9 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             _pendingRemoval.Clear();
 
             var symbols = insights.Select(x => x.Symbol).Distinct();
-            if (symbols.Count() == 0)
+            if (symbols.Count() == 0 || insights.All(x => x.Magnitude == 0))
             {
-                return Enumerable.Empty<IPortfolioTarget>();
+                return targets;
             }
 
             foreach (var insight in insights)
@@ -160,9 +160,9 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             {
                 if (!_symbolDataDict.ContainsKey(added.Symbol))
                 {
-                    var symbolData = new ReturnsSymbolData(algorithm, added.Symbol, _lookback, _period, _resolution);
+                    var symbolData = new ReturnsSymbolData(added.Symbol, _lookback, _period);
                     _symbolDataDict[added.Symbol] = symbolData;
-                    addedSymbols.Add(symbolData.Symbol);
+                    addedSymbols.Add(added.Symbol);
                 }
             }
             if (addedSymbols.Count == 0)
@@ -177,7 +177,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                     {
                         symbolData.Update(bar.EndTime, bar.Value);
                     }
-                });        
+                });
         }
     }
 }

--- a/Algorithm.Framework/Portfolio/ReturnsSymbolData.cs
+++ b/Algorithm.Framework/Portfolio/ReturnsSymbolData.cs
@@ -16,8 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using QuantConnect.Data;
-using QuantConnect.Data.Consolidators;
 using QuantConnect.Indicators;
 using QuantConnect.Util;
 
@@ -28,14 +26,14 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
     /// </summary>
     public class ReturnsSymbolData
     {
-        internal readonly Symbol Symbol;
+        private readonly Symbol _symbol;
         private readonly RateOfChange _roc;
         private readonly RollingWindow<IndicatorDataPoint> _window;
 
-        public ReturnsSymbolData(QCAlgorithmFramework algorithm, Symbol symbol, int lookback, int period, Resolution resolution)
+        public ReturnsSymbolData(Symbol symbol, int lookback, int period)
         {
-            Symbol = symbol;
-            _roc = new RateOfChange($"{Symbol}.ROC(1)", lookback);
+            _symbol = symbol;
+            _roc = new RateOfChange($"{_symbol}.ROC({lookback})", lookback);
             _window = new RollingWindow<IndicatorDataPoint>(period);
             _roc.Updated += OnRateOfChangeUpdated;
         }
@@ -44,7 +42,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
         public void Add(DateTime time, decimal value)
         {
-            var item = new IndicatorDataPoint(Symbol, time, value);
+            var item = new IndicatorDataPoint(_symbol, time, value);
             _window.Add(item);
         }
 

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -91,7 +91,7 @@
     <Compile Include="Execution\VolumeWeightedAveragePriceExecutionModel.cs" />
     <Compile Include="INotifiedSecurityChanges.cs" />
     <Compile Include="NotifiedSecurityChanges.cs" />
-    <Compile Include="Portfolio\BlackLittermanPortfolioConstructionModel.cs" />
+    <Compile Include="Portfolio\BlackLittermanOptimizationPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\IPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\IPortfolioOptimizer.cs" />
     <Compile Include="Portfolio\MaximumSharpeRatioPortfolioOptimizer.cs" />


### PR DESCRIPTION
#### Description
- Changes `ExpectedStatistics` in MVOFA
  - All regression tests now
- Removes unnecessary constructor arguments in `ReturnsSymbolData`
- Tide up code and add method summaries.

#### How Has This Been Tested?
Regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`