### PR TITLE
Update start date for OptionSplitRegressionAlgorithm

### DIFF
--- a/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Algorithm.CSharp
         public override void Initialize()
         {
             // this test opens position in the first day of trading, lives through stock split (7 for 1), and closes adjusted position on the second day
-            SetStartDate(2014, 06, 05);
+            SetStartDate(2014, 06, 06);
             SetEndDate(2014, 06, 09);
             SetCash(1000000);
 
@@ -129,21 +129,21 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "2"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.02%"},
-            {"Compounding Annual Return", "-1.242%"},
+            {"Compounding Annual Return", "-1.564%"},
             {"Drawdown", "0.000%"},
             {"Expectancy", "-1"},
             {"Net Profit", "-0.017%"},
-            {"Sharpe Ratio", "-7.099"},
+            {"Sharpe Ratio", "-7.937"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "-0.01"},
+            {"Alpha", "-0.014"},
             {"Beta", "0"},
             {"Annual Standard Deviation", "0.001"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "7.126"},
-            {"Tracking Error", "6.064"},
-            {"Treynor Ratio", "174.306"},
+            {"Information Ratio", "7.935"},
+            {"Tracking Error", "6.786"},
+            {"Treynor Ratio", "161.568"},
             {"Total Fees", "$0.50"}
         };
     }

--- a/Algorithm.Python/OptionSplitRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionSplitRegressionAlgorithm.py
@@ -35,7 +35,7 @@ class OptionSplitRegressionAlgorithm(QCAlgorithm):
         # and closes adjusted position on the second day
 
         self.SetCash(1000000)
-        self.SetStartDate(2014,6,5)
+        self.SetStartDate(2014,6,6)
         self.SetEndDate(2014,6,9)
 
         option = self.AddOption("AAPL")


### PR DESCRIPTION

#### Description
The start date for `OptionSplitRegressionAlgorithm` has been changed from `6/5/2014` to `6/6/2014` and the regression statistics have been updated to reflect this.

#### Related Issue
Closes #2306 

#### Motivation and Context
The regression test was getting different statistics when run locally vs cloud.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
`OptionSplitRegressionAlgorithm` regression test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`