### PR TITLE
Fix initialization error handling in CollectionSubscriptionDataSourceReader.Read

### DIFF
--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -75,18 +75,26 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             IStreamReader reader = null;
             try
             {
-                switch (source.TransportMedium)
+                try
                 {
-                    default:
-                    case SubscriptionTransportMedium.Rest:
-                        reader = new RestSubscriptionStreamReader(source.Source, source.Headers, _isLiveMode);
-                        break;
-                    case SubscriptionTransportMedium.LocalFile:
-                        reader = new LocalFileSubscriptionStreamReader(_dataCacheProvider, source.Source);
-                        break;
-                    case SubscriptionTransportMedium.RemoteFile:
-                        reader = new RemoteFileSubscriptionStreamReader(_dataCacheProvider, source.Source, Globals.Cache, source.Headers);
-                        break;
+                    switch (source.TransportMedium)
+                    {
+                        default:
+                        case SubscriptionTransportMedium.Rest:
+                            reader = new RestSubscriptionStreamReader(source.Source, source.Headers, _isLiveMode);
+                            break;
+                        case SubscriptionTransportMedium.LocalFile:
+                            reader = new LocalFileSubscriptionStreamReader(_dataCacheProvider, source.Source);
+                            break;
+                        case SubscriptionTransportMedium.RemoteFile:
+                            reader = new RemoteFileSubscriptionStreamReader(_dataCacheProvider, source.Source, Globals.Cache, source.Headers);
+                            break;
+                    }
+                }
+                catch (Exception e)
+                {
+                    OnInvalidSource(source, e);
+                    yield break;
                 }
 
                 var raw = "";

--- a/Tests/Engine/DataFeeds/CollectionSubscriptionDataSourceReaderTests.cs
+++ b/Tests/Engine/DataFeeds/CollectionSubscriptionDataSourceReaderTests.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Custom.Tiingo;
+using QuantConnect.Lean.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture]
+    public class CollectionSubscriptionDataSourceReaderTests
+    {
+        [Test]
+        public void HandlesInitializationErrors()
+        {
+            var date = new DateTime(2018, 7, 7);
+            var config = new SubscriptionDataConfig(typeof(TiingoDailyData), Symbols.AAPL, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false, true);
+            var reader = new CollectionSubscriptionDataSourceReader(null, config, date, false);
+            var source = new TiingoDailyData().GetSource(config, date, false);
+
+            // should not throw with an empty or invalid Tiingo API token
+            Assert.DoesNotThrow(() =>
+            {
+                var list = reader.Read(source).ToList();
+                Assert.AreEqual(0, list.Count);
+            });
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Engine\DataFeeds\AlgorithmStub.cs" />
     <Compile Include="Engine\DataFeeds\Auxiliary\MapFileResolverTests.cs" />
     <Compile Include="Engine\DataFeeds\BaseDataExchangeTests.cs" />
+    <Compile Include="Engine\DataFeeds\CollectionSubscriptionDataSourceReaderTests.cs" />
     <Compile Include="Engine\DataFeeds\CustomLiveDataFeedTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\BaseDataCollectionAggregatorEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\EnqueableEnumeratorTests.cs" />


### PR DESCRIPTION

#### Description
Added missing `try...catch` block in `CollectionSubscriptionDataSourceReader.Read`

#### Related Issue
Closes #2309 

#### Motivation and Context
If an exception is thrown when instantiating the subscription stream readers, the exception is not handled locally and ends up only being logged in `ParallelRunnerWorker` instead of being reported to the user and terminating the algorithm.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local test of `TiingoDailyDataAlgorithm` and new unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`