### PR TITLE
Add Quandl API key to URL in CustomDataRegressionAlgorithm

### DIFF
--- a/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
@@ -153,7 +153,7 @@ namespace QuantConnect.Algorithm.CSharp
 
                 //return "http://my-ftp-server.com/futures-data-" + date.ToString("Ymd") + ".zip";
                 // OR simply return a fixed small data file. Large files will slow down your backtest
-                return new SubscriptionDataSource("https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc", SubscriptionTransportMedium.RemoteFile);
+                return new SubscriptionDataSource("https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc&api_key=WyAazVXnq7ATy_fefTqm", SubscriptionTransportMedium.RemoteFile);
             }
 
             /// <summary>

--- a/Algorithm.Python/CustomDataRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataRegressionAlgorithm.py
@@ -60,7 +60,7 @@ class Bitcoin(PythonData):
 
         #return "http://my-ftp-server.com/futures-data-" + date.ToString("Ymd") + ".zip"
         # OR simply return a fixed small data file. Large files will slow down your backtest
-        return SubscriptionDataSource("https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc", SubscriptionTransportMedium.RemoteFile)
+        return SubscriptionDataSource("https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc&api_key=WyAazVXnq7ATy_fefTqm", SubscriptionTransportMedium.RemoteFile)
 
 
     def Reader(self, config, line, date, isLiveMode):


### PR DESCRIPTION
#### Description
The Quandl API Key used in regression tests has been added in `CustomDataRegressionAlgorithm`.

#### Related Issue
Closes #2311 

#### Motivation and Context
This regression test was failing in the cloud, caused by the algorithm calling the Quandl API as an anonymous user, which has a limit of 50 calls/day.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Run `CustomDataRegressionAlgorithm` in the cloud successfully after the fix.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`