### PR TITLE
Fix exception being thrown when using SetWarmup when adding option or future contract

### DIFF
--- a/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
@@ -15,9 +15,11 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Securities.Option;
 
@@ -32,7 +34,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="options" />
     /// <meta name="tag" content="option strategies" />
     /// <meta name="tag" content="filter selection" />
-    public class BasicTemplateOptionStrategyAlgorithm : QCAlgorithm
+    public class BasicTemplateOptionStrategyAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol _optionSymbol;
 
@@ -47,6 +49,9 @@ namespace QuantConnect.Algorithm.CSharp
 
             // set our strike/expiry filter for this option chain
             option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
+
+            // Adding this to reproduce GH issue #2314
+            SetWarmup(TimeSpan.FromMinutes(1));
 
             // use the underlying equity as the benchmark
             SetBenchmark("GOOG");
@@ -90,5 +95,41 @@ namespace QuantConnect.Algorithm.CSharp
         {
             Log(orderEvent.ToString());
         }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "778"},
+            {"Average Win", "0%"},
+            {"Average Loss", "-0.02%"},
+            {"Compounding Annual Return", "-100%"},
+            {"Drawdown", "6.800%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-6.821%"},
+            {"Sharpe Ratio", "0"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$389.00"}
+        };
     }
 }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -807,7 +807,20 @@ namespace QuantConnect.Lean.Engine
                 var us = new UniverseSelection(feed, algorithm);
                 foreach (var universe in algorithm.UniverseManager.Values)
                 {
-                    us.ApplyUniverseSelection(universe, new DateTime(start), new BaseDataCollection());
+                    BaseDataCollection dataCollection;
+                    switch (universe.SecurityType)
+                    {
+                        case SecurityType.Option:
+                            dataCollection = new OptionChainUniverseDataCollection();
+                            break;
+                        case SecurityType.Future:
+                            dataCollection = new FuturesChainUniverseDataCollection();
+                            break;
+                        default:
+                            dataCollection = new BaseDataCollection();
+                            break;
+                    }
+                    us.ApplyUniverseSelection(universe, new DateTime(start), dataCollection);
                 }
 
                 // make the history request and build time slices


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- When calling `ApplyUniverseSelection` at `AlgorithmManager.cs:810`, will now use a data collection based on security type. Issue was that, when `A-FuturesChainUniverse.SelectSymbols()` and `B-OptionChainUniverse.SelectSymbols()` were called they would fail to **cast** the base data collection to `FuturesChainUniverseDataCollection` and `OptionChainUniverseDataCollection`. Adding C# regression test which reproduces the issue.
   - A-https://github.com/QuantConnect/Lean/blob/master/Common/Data/UniverseSelection/FuturesChainUniverse.cs#L79
   - B-https://github.com/QuantConnect/Lean/blob/master/Common/Data/UniverseSelection/OptionChainUniverse.cs#L83
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2314
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`SetWarmUp()` in option and future algorithm throws an exception
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->