### PR TITLE
Seed insight score EMAs with 50

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFrameworkAlgorithm.cs
@@ -112,8 +112,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Estimated Insight Value", "$257.8077"},
             {"Mean Population Direction", "48.8372%"},
             {"Mean Population Magnitude", "48.8372%"},
-            {"Rolling Averaged Population Direction", "68.2411%"},
-            {"Rolling Averaged Population Magnitude", "68.2411%"}
+            {"Rolling Averaged Population Direction", "63.7759%"},
+            {"Rolling Averaged Population Magnitude", "63.7759%"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -181,7 +181,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Estimated Insight Value", "$0.07898125"},
             {"Mean Population Direction", "33.3333%"},
             {"Mean Population Magnitude", "0%"},
-            {"Rolling Averaged Population Direction", "92.3114%"},
+            {"Rolling Averaged Population Direction", "48.0394%"},
             {"Rolling Averaged Population Magnitude", "0%"}
         };
     }

--- a/Algorithm.CSharp/BlackLittermanPortfolioOptimizationFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BlackLittermanPortfolioOptimizationFrameworkAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -92,13 +92,13 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.168"},
             {"Treynor Ratio", "0.011"},
             {"Total Fees", "$23.61"},
-            {"Estimated Monthly Alpha Value", "$0"},
             {"Total Insights Generated", "14"},
             {"Total Insights Closed", "4"},
             {"Total Insights Analysis Completed", "0"},
             {"Long Insight Count", "6"},
             {"Short Insight Count", "4"},
             {"Long/Short Ratio", "150.0%"},
+            {"Estimated Monthly Alpha Value", "$0"},
             {"Total Accumulated Estimated Alpha Value", "$0"},
             {"Mean Population Estimated Insight Value", "$0"},
             {"Mean Population Direction", "0%"},

--- a/Algorithm.CSharp/ConvertToFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/ConvertToFrameworkAlgorithm.cs
@@ -147,7 +147,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Estimated Insight Value", "$-899295.2"},
             {"Mean Population Direction", "53.5714%"},
             {"Mean Population Magnitude", "0%"},
-            {"Rolling Averaged Population Direction", "43.5549%"},
+            {"Rolling Averaged Population Direction", "48.2023%"},
             {"Rolling Averaged Population Magnitude", "0%"}
         };
     }

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -222,7 +222,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Estimated Insight Value", "$10028.0287"},
             {"Mean Population Direction", "73.913%"},
             {"Mean Population Magnitude", "0%"},
-            {"Rolling Averaged Population Direction", "84.6867%"},
+            {"Rolling Averaged Population Direction", "74.7322%"},
             {"Rolling Averaged Population Magnitude", "0%"}
         };
     }

--- a/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
@@ -113,7 +113,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Estimated Insight Value", "$-140335"},
             {"Mean Population Direction", "51.8519%"},
             {"Mean Population Magnitude", "0%"},
-            {"Rolling Averaged Population Direction", "78.9332%"},
+            {"Rolling Averaged Population Direction", "64.4014%"},
             {"Rolling Averaged Population Magnitude", "0%"}
         };
     }

--- a/Engine/Alphas/StatisticsInsightManagerExtension.cs
+++ b/Engine/Alphas/StatisticsInsightManagerExtension.cs
@@ -125,8 +125,8 @@ namespace QuantConnect.Lean.Engine.Alphas
                 var newMean = mean + (score - mean) / Statistics.TotalInsightsAnalysisCompleted;
                 Statistics.MeanPopulationScore.SetScore(scoreType, newMean, currentTime);
 
-                var newEma = score;
-                if (Statistics.TotalInsightsAnalysisCompleted > 1)
+                var newEma = newMean;
+                if (Statistics.TotalInsightsAnalysisCompleted > 4)
                 {
                     // compute the traditional ema
                     var ema = Statistics.RollingAveragedPopulationScore.GetScore(scoreType);


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This is to push the initial points closer to the middle line to prevent an early outlier from having an out-sized impact on the chart.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2319 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevent initial scores from having outsized effects on the EMA values.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local regression updated to match.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->