### PR TITLE
Improving GetMaximumOrderQuantityForTargetValue

### DIFF
--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -207,13 +207,11 @@ namespace QuantConnect.Securities
             }
 
             // continue iterating while we do not have enough cash for the order
-            decimal cashRequired;
-            decimal orderValue;
-            decimal orderFees;
-            var feeToPriceRatio = 0m;
+            decimal cashRequired = 0;
+            decimal orderFees = 0;
 
             // compute the initial order quantity
-            var orderQuantity = targetOrderValue / unitPrice;
+            var orderQuantity = (cashRemaining < targetOrderValue ? cashRemaining : targetOrderValue) / unitPrice;
 
             // rounding off Order Quantity to the nearest multiple of Lot Size
             orderQuantity -= orderQuantity % security.SymbolProperties.LotSize;
@@ -224,9 +222,23 @@ namespace QuantConnect.Securities
 
             do
             {
-                // reduce order quantity by feeToPriceRatio, since it is faster than by lot size
-                // if it becomes nonpositive, return zero
-                orderQuantity -= feeToPriceRatio;
+                // Each loop will reduce the order quantity based on the difference between
+                // (cashRequired + orderFees) and targetOrderValue
+                // or cashRequired and cashRemaining, this last case should not be required but just in case
+                if (cashRequired + orderFees > targetOrderValue)
+                {
+                    var targetOrderValuePerOrder = (cashRequired + orderFees) / orderQuantity;
+                    var amountOfOrdersToRemove = (cashRequired + orderFees - targetOrderValue) / targetOrderValuePerOrder;
+                    orderQuantity -= amountOfOrdersToRemove;
+                }
+                else if (cashRequired > cashRemaining) // this shouldn't be true, but just in case
+                {
+                    var amountOfOrdersToRemove = (cashRequired - cashRemaining) / unitPrice;
+                    orderQuantity -= amountOfOrdersToRemove;
+                }
+
+                // rounding off Order Quantity to the nearest multiple of Lot Size
+                orderQuantity -= orderQuantity % security.SymbolProperties.LotSize;
                 if (orderQuantity <= 0)
                 {
                     return new GetMaximumOrderQuantityForTargetValueResult(0, $"The portfolio does not hold enough {currency} including the order fees.");
@@ -234,21 +246,9 @@ namespace QuantConnect.Securities
 
                 // generate the order
                 var order = new MarketOrder(security.Symbol, orderQuantity, DateTime.UtcNow);
-                orderValue = orderQuantity * unitPrice;
+                cashRequired = orderQuantity * unitPrice;
                 orderFees = security.FeeModel.GetOrderFee(security, order);
-
-                // find an incremental delta value for the next iteration step
-                feeToPriceRatio = orderFees / unitPrice;
-                feeToPriceRatio -= feeToPriceRatio % security.SymbolProperties.LotSize;
-                if (feeToPriceRatio < security.SymbolProperties.LotSize)
-                {
-                    feeToPriceRatio = security.SymbolProperties.LotSize;
-                }
-
-                // calculate the cash required for the order
-                cashRequired = orderValue;
-
-            } while (cashRequired > cashRemaining || orderValue + orderFees > targetOrderValue);
+            } while (cashRequired > cashRemaining || cashRequired + orderFees > targetOrderValue);
 
             // add directionality back in
             return new GetMaximumOrderQuantityForTargetValueResult((direction == OrderDirection.Sell ? -1 : 1) * orderQuantity);

--- a/Tests/Algorithm/CashModelAlgorithmTradingTests.cs
+++ b/Tests/Algorithm/CashModelAlgorithmTradingTests.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Tests.Algorithm
             Update(algo.Portfolio.CashBook, security, 25);
             var actual = algo.CalculateOrderQuantity(_symbol, 0.5m);
             // $1 in fees, so slightly less than 2k from SetHoldings_ZeroToLong
-            Assert.AreEqual(1999.96, actual);
+            Assert.AreEqual(1999.96m, actual);
         }
 
         [Test]
@@ -390,7 +390,7 @@ namespace QuantConnect.Tests.Algorithm
             var actual = algo.CalculateOrderQuantity(_symbol, 0.5m);
 
             //Need to sell $25k so 50% of $150k: $25k / $50-share = -500 shares, -$1 in fees
-            Assert.AreEqual(-499.98, actual);
+            Assert.AreEqual(-499.98m, actual);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Modified the algorithm that determines the maximum order quantity inside `GetMaximumOrderQuantityForTargetValue`
    - Default order quantity will take into account `cashRemaining` when `cashRemaining` < `targetOrderValue`
    - Each loop will reduce the order quantity based on the difference between:
          - `cashRequired + orderFees` and `targetOrderValue`
          - `cashRequired` and `cashRemaining`. This case should _not_ be required but just in case, since it will depend on the initial value of `targetOrderValue`.
 - Adding some new unit tests.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2318
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Calling `GetMaximumOrderQuantityForTargetValue` with an order fee of 0 will produce an infinite loop situation.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->