### PR TITLE
Exclude warmup period from sampling data

### DIFF
--- a/Algorithm.CSharp/WarmupConversionRatesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupConversionRatesRegressionAlgorithm.cs
@@ -49,7 +49,10 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 throw new Exception("Conversion rate for BTC should not be zero.");
             }
-
+            if (!Portfolio.Invested && !IsWarmingUp)
+            {
+                SetHoldings("BTCUSD", 1);
+            }
             Log($"BTC current price: {Securities["BTCUSD"].Price}");
             Log($"BTC conversion rate: {conversionRate}");
         }
@@ -69,24 +72,24 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "0"},
+            {"Total Trades", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "0%"},
-            {"Drawdown", "0%"},
+            {"Compounding Annual Return", "3067.390%"},
+            {"Drawdown", "11.600%"},
             {"Expectancy", "0"},
-            {"Net Profit", "0%"},
-            {"Sharpe Ratio", "0"},
+            {"Net Profit", "16.171%"},
+            {"Sharpe Ratio", "3.223"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "0"},
-            {"Beta", "0"},
-            {"Annual Standard Deviation", "0"},
-            {"Annual Variance", "0"},
-            {"Information Ratio", "0"},
-            {"Tracking Error", "0"},
-            {"Treynor Ratio", "0"},
+            {"Alpha", "0.006"},
+            {"Beta", "192.615"},
+            {"Annual Standard Deviation", "0.778"},
+            {"Annual Variance", "0.605"},
+            {"Information Ratio", "3.206"},
+            {"Tracking Error", "0.778"},
+            {"Treynor Ratio", "0.013"},
             {"Total Fees", "$0.00"}
         };
     }

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -642,6 +642,12 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="value">Value for the chart sample.</param>
         public void Sample(string chartName, string seriesName, int seriesIndex, SeriesType seriesType, DateTime time, decimal value, string unit = "$")
         {
+            // Sampling during warming up period skews statistics
+            if (_algorithm.IsWarmingUp)
+            {
+                return;
+            }
+
             lock (_chartLock)
             {
                 //Add a copy locally:

--- a/Engine/Results/DesktopResultHandler.cs
+++ b/Engine/Results/DesktopResultHandler.cs
@@ -234,6 +234,12 @@ namespace QuantConnect.Lean.Engine.Results
         /// <remarks>Sample can be used to create new charts or sample equity - daily performance.</remarks>
         public void Sample(string chartName, string seriesName, int seriesIndex, SeriesType seriesType, DateTime time, decimal value, string unit = "$")
         {
+            // Sampling during warming up period skews statistics
+            if (_algorithm.IsWarmingUp)
+            {
+                return;
+            }
+
             lock (_chartLock)
             {
                 //Add a copy locally:

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -601,6 +601,12 @@ namespace QuantConnect.Lean.Engine.Results
         /// <remarks>Sample can be used to create new charts or sample equity - daily performance.</remarks>
         public void Sample(string chartName, string seriesName, int seriesIndex, SeriesType seriesType, DateTime time, decimal value, string unit = "$")
         {
+            // Sampling during warming up period skews statistics
+            if (_algorithm.IsWarmingUp)
+            {
+                return;
+            }
+
             Log.Debug("LiveTradingResultHandler.Sample(): Sampling " + chartName + "." + seriesName);
             lock (_chartLock)
             {


### PR DESCRIPTION
#### Description
Do not add samples to equity and benchmark charts during warm up.

#### Related Issue
Closes #2279

#### Motivation and Context
Get correct and consistent statistics. When we add samples to the equity and benchmark charts during the warm up, the statistics calculations include the warm up time.
Also, do not show warm up flat line when plotting the equity curve.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Algorithm provided in issue #2279. 
Results with and without `SetCash(100000);` match.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`