### PR TITLE
 Fixes InsightDirection.Flat allocation in EqualWeightingPortfolioConstructionModel

### DIFF
--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -57,9 +57,13 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
             // Get last insight that haven't expired of each symbol that is still in the universe
             var activeInsights = (from insight in _insightCollection
+                                  // Remove expired insights
+                                  where insight.CloseTimeUtc > algorithm.UtcTime
+                                  // Force one group per symbol
                                   group insight by insight.Symbol into g
-                                  where g.LastOrDefault().CloseTimeUtc > algorithm.UtcTime
-                                  select g.LastOrDefault()).ToList();
+                                  // For direction, we'll trust the most recent insight
+                                  select g.OrderBy(x => x.GeneratedTimeUtc).LastOrDefault())
+                                  .ToList();
 
             if (activeInsights.Count == 0)
             {

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -55,26 +55,24 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 return targets;
             }
 
-            // Get symbols that have emit insights, are still in the universe, and insigths haven't expired
-            var symbols = _insightCollection
-                .Where(x => x.CloseTimeUtc > algorithm.UtcTime)
-                .Select(x => x.Symbol).Distinct().ToList();
+            // Get last insight that haven't expired of each symbol that is still in the universe
+            var activeInsights = (from insight in _insightCollection
+                                  group insight by insight.Symbol into g
+                                  where g.LastOrDefault().CloseTimeUtc > algorithm.UtcTime
+                                  select g.LastOrDefault()).ToList();
 
-            if (symbols.Count == 0)
+            if (activeInsights.Count == 0)
             {
                 return targets;
             }
 
             // give equal weighting to each security
-            var percent = 1m / symbols.Count;
-            foreach (var symbol in symbols)
+            var count = activeInsights.Count(x => x.Direction != InsightDirection.Flat);
+            var percent = count == 0 ? 0 : 1m / count;
+
+            foreach (var insight in activeInsights)
             {
-                List<Insight> activeInsights;
-                if (_insightCollection.TryGetValue(symbol, out activeInsights))
-                {
-                    var direction = activeInsights.Last().Direction;
-                    targets.Add(PortfolioTarget.Percent(algorithm, symbol, (int)direction * percent));
-                }
+                targets.Add(PortfolioTarget.Percent(algorithm, insight.Symbol, (int)insight.Direction * percent));
             }
 
             return targets;

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
@@ -48,10 +48,12 @@ class EqualWeightingPortfolioConstructionModel(PortfolioConstructionModel):
 
         # Get last insight that haven't expired of each symbol that is still in the universe
         activeInsights = list()
-        for symbol, g in groupby(self.insightCollection, lambda x: x.Symbol):
-            last = list(g)[-1]
-            if last.CloseTimeUtc > algorithm.UtcTime:
-                activeInsights.append(last)
+        # Remove expired insights
+        validInsights = [ i for i in self.insightCollection if i.CloseTimeUtc > algorithm.UtcTime ]
+        # Force one group per symbol
+        for symbol, g in groupby(validInsights, lambda x: x.Symbol):
+            # For direction, we'll trust the most recent insight
+            activeInsights.append(sorted(g, key = lambda x: x.GeneratedTimeUtc)[-1])
 
         if len(activeInsights) == 0:
             return targets

--- a/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
@@ -23,11 +23,11 @@ from QuantConnect.Orders import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import *
-from QuantConnect.Algorithm.Framework.Portfolio import *
 from QuantConnect.Algorithm.Framework.Selection import *
 from Alphas.ConstantAlphaModel import ConstantAlphaModel
 from Execution.ImmediateExecutionModel import ImmediateExecutionModel
 from Risk.MaximumDrawdownPercentPerSecurity import MaximumDrawdownPercentPerSecurity
+from Portfolio.EqualWeightingPortfolioConstructionModel import EqualWeightingPortfolioConstructionModel
 from datetime import timedelta
 import numpy as np
 

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -1,0 +1,183 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NodaTime;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Equity;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
+{
+    [TestFixture]
+    public class EqualWeightingPortfolioConstructionModelTests
+    {
+        private QCAlgorithmFramework _algorithm;
+
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Portfolio");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+
+            _algorithm = new QCAlgorithmFramework();
+            _algorithm.SetDateTime(new DateTime(2018, 7, 31));
+            
+            var prices = new Dictionary<Symbol, decimal>
+            {
+                { Symbol.Create("AIG", SecurityType.Equity, Market.USA), 55.22m },
+                { Symbol.Create("IBM", SecurityType.Equity, Market.USA), 145.17m },
+                { Symbol.Create("SPY", SecurityType.Equity, Market.USA), 281.79m },
+            };
+
+            foreach (var kvp in prices)
+            {
+                var symbol = kvp.Key;
+                var security = GetSecurity(symbol);
+                security.SetMarketPrice(new Tick(_algorithm.Time, symbol, kvp.Value, kvp.Value));
+                _algorithm.Securities.Add(symbol, security);
+            }
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void EmptyInsightsReturnsEmptyTargets(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            var insights = Enumerable.Empty<Insight>();
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
+
+            Assert.AreEqual(0, actualTargets.Count());
+        }
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language);
+
+            // Equity will be divided by all securities
+            var amount = _algorithm.Portfolio.TotalPortfolioValue / _algorithm.Securities.Count;
+            var expectedTargets = _algorithm.Securities
+                .Select(x => new PortfolioTarget(x.Key, (int)direction * Math.Floor(amount / x.Value.Price)));
+
+            var insights = _algorithm.Securities.Keys.Select(x => GetInsight(x, direction, _algorithm.UtcTime));
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
+            
+            Assert.AreEqual(expectedTargets.Count(), actualTargets.Count());
+
+            foreach (var expected in expectedTargets)
+            {
+                var actual = actualTargets.FirstOrDefault(x => x.Symbol == expected.Symbol);
+                Assert.IsNotNull(actual);
+                Assert.AreEqual(expected.Quantity, actual.Quantity);
+            }
+        }
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public void FlatDirectionNotAccountedToAllocation(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language);
+
+            // Equity will be divided by all securities minus 1, since its insight will have flat direction
+            var amount = _algorithm.Portfolio.TotalPortfolioValue / (_algorithm.Securities.Count - 1);
+            var expectedTargets = _algorithm.Securities.Select(x =>
+            {
+                // Expected target quantity for SPY is zero, since its insight will have flat direction
+                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction * Math.Floor(amount / x.Value.Price);
+                return new PortfolioTarget(x.Key, quantity);
+            });
+
+            var insights = _algorithm.Securities.Keys.Select(x =>
+            {
+                // SPY insight direction is flat
+                var actualDirection = x.Value == "SPY" ? InsightDirection.Flat : direction;
+                return GetInsight(x, actualDirection, _algorithm.UtcTime);
+            });
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
+
+            Assert.AreEqual(expectedTargets.Count(), actualTargets.Count());
+
+            foreach (var expected in expectedTargets)
+            {
+                var actual = actualTargets.FirstOrDefault(x => x.Symbol == expected.Symbol);
+                Assert.IsNotNull(actual);
+                Assert.AreEqual(expected.Quantity, actual.Quantity);
+            }
+        }
+
+        private Security GetSecurity(Symbol symbol)
+        {
+            var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);
+            return new Equity(symbol, config, new Cash("USD", 0, 1), SymbolProperties.GetDefault("USD"));
+        }
+
+        private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc)
+        {
+            var period = TimeSpan.FromDays(1);
+            var insight = Insight.Price(symbol, period, direction);
+            insight.GeneratedTimeUtc = generatedTimeUtc;
+            insight.CloseTimeUtc = generatedTimeUtc.Add(period);
+            return insight;
+        }
+
+        private void SetPortfolioConstruction(Language language)
+        {
+            _algorithm.SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            if (language == Language.Python)
+            {
+                try
+                {
+                    using (Py.GIL())
+                    {
+                        var name = nameof(EqualWeightingPortfolioConstructionModel);
+                        var instance = Py.Import(name).GetAttr(name).Invoke();
+                        var model = new PortfolioConstructionModelPythonWrapper(instance);
+                        _algorithm.SetPortfolioConstruction(model);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Assert.Ignore(e.Message);
+                }
+            }
+
+            var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
+            _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Algorithm\Framework\Alphas\Serialization\InsightJsonConverterTests.cs" />
     <Compile Include="Algorithm\Framework\InsightTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />
+    <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
     <Compile Include="Algorithm\Framework\QCAlgorithmFrameworkTests.cs" />
     <Compile Include="Algorithm\Framework\Selection\ManualUniverseSelectionModelTests.cs" />


### PR DESCRIPTION
#### Description
The allocation should be calculated for symbols which last insights are not `InsightDirection.Flat`. For example, if the last insight of SPY and of IBM are Up, and of AIG is flat, then 50% of equity should be allocated in SPY, 50% in IBM and 0% in AIG. Before this fix, we would have 33% SPY, 33%, IBM and 0% AIG.

#### Related Issue
Closes #2327 

#### Motivation and Context
Fix and improve framework models.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Ran a backtest with the `VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm` and modified `RsiAlphaModel` to emit `InsightDirection.Flat` when `State.Middle`.
Note: Lean doesn't have an alpha model that emits an insight with direction of `InsightDirection.Flat`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`