### PR TITLE
Add unit tests for MaximumDrawdownPercentPerSecurity risk management model

### DIFF
--- a/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.py
+++ b/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.py
@@ -32,6 +32,7 @@ class MaximumDrawdownPercentPerSecurity(RiskManagementModel):
         '''Manages the algorithm's risk at each time step
         Args:
             algorithm: The algorithm instance'''
+        targets = []
         for kvp in algorithm.Securities:
             security = kvp.Value
 
@@ -40,8 +41,7 @@ class MaximumDrawdownPercentPerSecurity(RiskManagementModel):
 
             pnl = security.Holdings.UnrealizedProfitPercent
             if pnl < self.maximumDrawdownPercent:
-                # remove PortfolioTarget with symbol to be liquidated and add new PortfolioTarget
-                targets = list(filter(lambda x: x.Symbol != security.Symbol, targets))
+                # liquidate
                 targets.append(PortfolioTarget(security.Symbol, 0))
 
         return targets

--- a/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
+++ b/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
@@ -1,0 +1,110 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.IO;
+using System.Linq;
+using Moq;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Equity;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Risk
+{
+    [TestFixture]
+    public class MaximumDrawdownPercentPerSecurityTests
+    {
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Risk");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp, 0.1, false, 0, 0, false)]
+        [TestCase(Language.CSharp, 0.1, true, -50, 1000, false)]
+        [TestCase(Language.CSharp, 0.1, true, -100, 1000, false)]
+        [TestCase(Language.CSharp, 0.1, true, -150, 1000, true)]
+        [TestCase(Language.Python, 0.1, false, 0, 0, false)]
+        [TestCase(Language.Python, 0.1, true, -50, 1000, false)]
+        [TestCase(Language.Python, 0.1, true, -100, 1000, false)]
+        [TestCase(Language.Python, 0.1, true, -150, 1000, true)]
+        public void ReturnsExpectedPortfolioTarget(
+            Language language,
+            decimal maxDrawdownPercent,
+            bool invested,
+            decimal unrealizedProfit,
+            decimal absoluteHoldingsCost,
+            bool shouldLiquidate)
+        {
+            var security = new Mock<Equity>(
+                Symbols.AAPL,
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new Cash(CashBook.AccountCurrency, 0, 1),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            security.Setup(m => m.Invested).Returns(invested);
+
+            var holding = new Mock<EquityHolding>(security.Object);
+            holding.Setup(m => m.UnrealizedProfit).Returns(unrealizedProfit);
+            holding.Setup(m => m.AbsoluteHoldingsCost).Returns(absoluteHoldingsCost);
+
+            security.Object.Holdings = holding.Object;
+
+            var algorithm = new QCAlgorithmFramework();
+            algorithm.Securities.Add(Symbols.AAPL, security.Object);
+
+            if (language == Language.Python)
+            {
+                try
+                {
+                    using (Py.GIL())
+                    {
+                        var name = nameof(MaximumDrawdownPercentPerSecurity);
+                        var instance = Py.Import(name).GetAttr(name).Invoke(maxDrawdownPercent.ToPython());
+                        var model = new RiskManagementModelPythonWrapper(instance);
+                        algorithm.SetRiskManagement(model);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Assert.Ignore(e.Message);
+                }
+            }
+            else
+            {
+                var model = new MaximumDrawdownPercentPerSecurity(maxDrawdownPercent);
+                algorithm.SetRiskManagement(model);
+            }
+
+            var targets = algorithm.RiskManagement.ManageRisk(algorithm, null).ToList();
+
+            if (shouldLiquidate)
+            {
+                Assert.AreEqual(1, targets.Count);
+                Assert.AreEqual(Symbols.AAPL, targets[0].Symbol);
+                Assert.AreEqual(0, targets[0].Quantity);
+            }
+            else
+            {
+                Assert.AreEqual(0, targets.Count);
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
     <Compile Include="Algorithm\Framework\QCAlgorithmFrameworkTests.cs" />
+    <Compile Include="Algorithm\Framework\Risk\MaximumDrawdownPercentPerSecurityTests.cs" />
     <Compile Include="Algorithm\Framework\Selection\ManualUniverseSelectionModelTests.cs" />
     <Compile Include="API\ApiTests.cs" />
     <Compile Include="Brokerages\BrokerageTests.cs" />


### PR DESCRIPTION

#### Description
- Unit tests for the `MaximumDrawdownPercentPerSecurity` model have been added
- A minor fix was made in the Python version of the model to make the C# and Python implementations identical.

#### Motivation and Context
Missing unit tests for the model.

#### How Has This Been Tested?
Unit test + regression test using this model.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`