### PR TITLE
Adding cash buffer for IB Cash Accounts

### DIFF
--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -31,9 +31,18 @@ namespace QuantConnect.Brokerages
     public interface IBrokerageModel
     {
         /// <summary>
-        /// Gets or sets the account type used by this model
+        /// Gets the account type used by this model
         /// </summary>
         AccountType AccountType
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets the brokerages model percentage factor used to determine the required unused buying power for the account.
+        /// From 1 to 0. Example: 0 means no unused buying power is required. 0.5 means 50% of the buying power should be left unused.
+        /// </summary>
+        decimal RequiredFreeBuyingPowerPercent
         {
             get;
         }

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -37,6 +37,12 @@ namespace QuantConnect.Brokerages
         };
 
         /// <summary>
+        /// Gets the brokerages model percentage factor used to determine the required unused buying power for the account.
+        /// IB required 5% of the buying power to be unused
+        /// </summary>
+        public override decimal RequiredFreeBuyingPowerPercent => 0.05m;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="InteractiveBrokersBrokerageModel"/> class
         /// </summary>
         /// <param name="accountType">The type of account to be modelled, defaults to

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -56,6 +56,21 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
+        /// Gets the brokerages model percentage factor used to determine the required unused buying power for the account.
+        /// From 1 to 0. Example: 0 means no unused buying power is required. 0.5 means 50% of the buying power should be left unused.
+        /// </summary>
+        public decimal RequiredFreeBuyingPowerPercent
+        {
+            get
+            {
+                using (Py.GIL())
+                {
+                    return _model.RequiredFreeBuyingPowerPercent;
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets a map of the default markets to be used for each security type
         /// </summary>
         public IReadOnlyDictionary<SecurityType, string> DefaultMarkets

--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -33,6 +33,15 @@ namespace QuantConnect.Securities.Option
         private const decimal NakedPositionMarginRequirementOtm = 0.2m;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="OptionMarginModel"/>
+        /// </summary>
+        /// <param name="requiredFreeBuyingPowerPercent">The percentage used to determine the required unused buying power for the account.</param>
+        public OptionMarginModel(decimal requiredFreeBuyingPowerPercent = 0)
+        {
+            RequiredFreeBuyingPowerPercent = requiredFreeBuyingPowerPercent;
+        }
+
+        /// <summary>
         /// Gets the current leverage of the security
         /// </summary>
         /// <param name="security">The security to get leverage for</param>
@@ -90,50 +99,50 @@ namespace QuantConnect.Securities.Option
         /// <returns>The margin available for the trade</returns>
         protected override decimal GetMarginRemaining(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)
         {
-            var holdings = security.Holdings;
+            var result = portfolio.MarginRemaining;
 
-            if (direction == OrderDirection.Hold)
+            if (direction != OrderDirection.Hold)
             {
-                return portfolio.MarginRemaining;
-            }
-
-            //If the order is in the same direction as holdings, our remaining cash is our cash
-            //In the opposite direction, our remaining cash is 2 x current value of assets + our cash
-            if (holdings.IsLong)
-            {
-                switch (direction)
+                var holdings = security.Holdings;
+                //If the order is in the same direction as holdings, our remaining cash is our cash
+                //In the opposite direction, our remaining cash is 2 x current value of assets + our cash
+                if (holdings.IsLong)
                 {
-                    case OrderDirection.Buy:
-                        return portfolio.MarginRemaining;
-
-                    case OrderDirection.Sell:
-                        return
-                            // portion of margin to close the existing position
-                            GetMaintenanceMargin(security) +
-                            // portion of margin to open the new position
-                            security.Holdings.AbsoluteHoldingsValue * GetInitialMarginRequirement(security, security.Holdings.HoldingsValue) +
-                            portfolio.MarginRemaining;
+                    switch (direction)
+                    {
+                        case OrderDirection.Buy:
+                            result = portfolio.MarginRemaining;
+                            break;
+                        case OrderDirection.Sell:
+                            result =
+                                // portion of margin to close the existing position
+                                GetMaintenanceMargin(security) +
+                                // portion of margin to open the new position
+                                security.Holdings.AbsoluteHoldingsValue * GetInitialMarginRequirement(security, security.Holdings.HoldingsValue) +
+                                portfolio.MarginRemaining;
+                            break;
+                    }
+                }
+                else if (holdings.IsShort)
+                {
+                    switch (direction)
+                    {
+                        case OrderDirection.Buy:
+                            result =
+                                // portion of margin to close the existing position
+                                GetMaintenanceMargin(security) +
+                                // portion of margin to open the new position
+                                security.Holdings.AbsoluteHoldingsValue * GetInitialMarginRequirement(security, security.Holdings.HoldingsValue) +
+                                portfolio.MarginRemaining;
+                            break;
+                        case OrderDirection.Sell:
+                            result = portfolio.MarginRemaining;
+                            break;
+                    }
                 }
             }
-            else if (holdings.IsShort)
-            {
-                switch (direction)
-                {
-                    case OrderDirection.Buy:
-                        return
-                            // portion of margin to close the existing position
-                            GetMaintenanceMargin(security) +
-                            // portion of margin to open the new position
-                            security.Holdings.AbsoluteHoldingsValue * GetInitialMarginRequirement(security, security.Holdings.HoldingsValue) +
-                            portfolio.MarginRemaining;
 
-                    case OrderDirection.Sell:
-                        return portfolio.MarginRemaining;
-                }
-            }
-
-            //No holdings, return cash
-            return portfolio.MarginRemaining;
+            return result * (1 - RequiredFreeBuyingPowerPercent);
         }
 
         /// <summary>

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -312,7 +312,7 @@ namespace QuantConnect.Securities
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginModel(1m),
+                new SecurityMarginModel(),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel())
         {
@@ -333,7 +333,7 @@ namespace QuantConnect.Securities
                 new ConstantSlippageModel(0),
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
-                new SecurityMarginModel(1m),
+                new SecurityMarginModel(),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel()
                 )

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1202,7 +1202,7 @@ namespace QuantConnect.Tests.Algorithm
             algo.SetCash(100000);
             algo.Securities[Symbols.MSFT].TransactionModel = new ConstantFeeTransactionModel(fee);
             msft = algo.Securities[Symbols.MSFT];
-            msft.BuyingPowerModel = new SecurityMarginModel(initialMarginRequirement, maintenanceMarginRequirement);
+            msft.BuyingPowerModel = new SecurityMarginModel(initialMarginRequirement, maintenanceMarginRequirement, 0);
             return algo;
         }
 

--- a/Tests/Common/Securities/SecurityMarginModelTests.cs
+++ b/Tests/Common/Securities/SecurityMarginModelTests.cs
@@ -13,8 +13,13 @@
  * limitations under the License.
 */
 
+using System;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Securities
@@ -22,6 +27,9 @@ namespace QuantConnect.Tests.Common.Securities
     [TestFixture]
     public class SecurityMarginModelTests
     {
+        private static Symbol _symbol;
+        private static readonly string _cashSymbol = "USD";
+        private static FakeOrderProcessor _fakeOrderProcessor;
         [Test]
         public void ZeroTargetWithZeroHoldingsIsNotAnError()
         {
@@ -49,6 +57,220 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(-10, result.Quantity);
             Assert.AreEqual(string.Empty, result.Reason);
             Assert.AreEqual(false, result.IsError);
+        }
+
+        [Test]
+        public void ManuallySettingFreeBuyingPowerPercentWorksCorrectly()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5);
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * security.BuyingPowerModel.GetLeverage(security));
+            // (100000 * 2) / 25 - 1 order due to fees
+            Assert.AreEqual(7999m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual + security.SymbolProperties.LotSize, security, algo));
+            Assert.AreEqual(security.BuyingPowerModel.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), algo.Portfolio.Cash);
+
+            security.BuyingPowerModel = new SecurityMarginModel(2, 0.5m);
+            actual = algo.CalculateOrderQuantity(_symbol, 1m * security.BuyingPowerModel.GetLeverage(security));
+            // (100000 * 2 * 0.5) / 25 - 1 order due to fees
+            Assert.AreEqual(3999m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual + security.SymbolProperties.LotSize, security, algo));
+            Assert.AreEqual(security.BuyingPowerModel.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), algo.Portfolio.Cash / 2);
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentDefault_Equity()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5, SecurityType.Equity);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 2) / 25 - 1 order due to fees
+            Assert.AreEqual(7999m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.AreEqual(model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), algo.Portfolio.Cash);
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentDoesNotApplyForIBMarginAccount_Equity()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5);
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Margin);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 2) / 25 - 4 order due to fees
+            Assert.AreEqual(7996m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual + security.SymbolProperties.LotSize, security, algo));
+            Assert.AreEqual(model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), algo.Portfolio.Cash);
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentAppliesForIBCashAccount_Equity()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5);
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Cash);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 2 * 0.95) / 25 - 4 order due to fees
+            Assert.AreEqual(7596m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual + security.SymbolProperties.LotSize, security, algo));
+            var expectedBuyingPower = algo.Portfolio.Cash * (1 - algo.BrokerageModel.RequiredFreeBuyingPowerPercent);
+            Assert.AreEqual(model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), expectedBuyingPower);
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentDefault_Option()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5, SecurityType.Option);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 1) / (25 * 100 contract multiplier) - 1 order due to fees
+            Assert.AreEqual(39m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.AreEqual(model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), algo.Portfolio.Cash);
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentDoesNotApplyForIBMarginAccount_Option()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5, SecurityType.Option);
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Margin);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 1) / (25 * 100 contract multiplier) - 1 order due to fees
+            Assert.AreEqual(39m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.AreEqual(model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), algo.Portfolio.Cash);
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentAppliesForIBCashAccount_Option()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5, SecurityType.Option);
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Cash);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 1 * 0.95) / (25 * 100 contract multiplier) - 1 order due to fees
+            Assert.AreEqual(37m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            var expectedBuyingPower = algo.Portfolio.Cash * (1 - algo.BrokerageModel.RequiredFreeBuyingPowerPercent);
+            Assert.AreEqual(model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), expectedBuyingPower);
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentDefault_Future()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5, SecurityType.Future);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 1) / 25 - 1 order due to fees
+            Assert.AreEqual(3999m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.AreEqual(model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), algo.Portfolio.Cash);
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentDoesNotApplyForIBMarginAccount_Future()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5, SecurityType.Future);
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Margin);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 1 - 7K for fee) / 25
+            Assert.AreEqual(3704m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.AreEqual(model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), algo.Portfolio.Cash);
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentAppliesForIBCashAccount_Future()
+        {
+            Security security;
+            var algo = GetAlgorithm(out security, 5, SecurityType.Future);
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Cash);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 1 * 0.95 - 6.5K for fees / (25)
+            Assert.AreEqual(3519m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            var expectedBuyingPower = algo.Portfolio.Cash * (1 - algo.BrokerageModel.RequiredFreeBuyingPowerPercent);
+            Assert.AreEqual(model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy), expectedBuyingPower);
+        }
+
+        private static QCAlgorithm GetAlgorithm(out Security security, decimal fee, SecurityType securityType = SecurityType.Equity, string symbol = "SPY")
+        {
+            SymbolCache.Clear();
+            // Initialize algorithm
+            var algo = new QCAlgorithm();
+            algo.SetCash(100000);
+            algo.SetFinishedWarmingUp();
+            _fakeOrderProcessor = new FakeOrderProcessor();
+            algo.Transactions.SetOrderProcessor(_fakeOrderProcessor);
+
+            if (securityType == SecurityType.Equity)
+            {
+                security = algo.AddEquity(symbol);
+                _symbol = security.Symbol;
+            }
+            else if (securityType == SecurityType.Option)
+            {
+                security = algo.AddOption(symbol);
+                _symbol = security.Symbol;
+            }
+            else if (securityType == SecurityType.Future)
+            {
+                security = algo.AddFuture(symbol);
+                _symbol = security.Symbol;
+            }
+            else
+            {
+                throw new Exception("SecurityType not implemented");
+            }
+
+            security.TransactionModel = new ConstantFeeTransactionModel(fee);
+            Update(algo.Portfolio.CashBook, security, 25);
+            return algo;
+        }
+        private static void Update(CashBook cashBook, Security security, decimal close)
+        {
+            security.SetMarketPrice(new TradeBar
+            {
+                Time = DateTime.Now,
+                Symbol = security.Symbol,
+                Open = close,
+                High = close,
+                Low = close,
+                Close = close
+            });
+        }
+        private bool HasSufficientBuyingPowerForOrder(decimal orderQuantity, Security security, IAlgorithm algo)
+        {
+            var order = new MarketOrder(security.Symbol, orderQuantity, DateTime.UtcNow);
+            _fakeOrderProcessor.AddTicket(order.ToOrderTicket(algo.Transactions));
+            var hashSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(algo.Portfolio,
+                security, new MarketOrder(security.Symbol, orderQuantity, DateTime.UtcNow));
+            return hashSufficientBuyingPower.IsSufficient;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding new `RequiredFreeBuyingPowerPercent` for `IBrokerageModel.cs`. Default value is 0 except for IB which will use 0.05. This percentage factor will be used to determine the required unused buying power for the account.
     - Will be sent to the `IBuyingPowerModel`, through the constructor and only for cash accounts. Will affect `GetMarginRemaining()`, `GetBuyingPower()`, `HasSufficientBuyingPowerForOrder()` and `GetMaximumOrderQuantityForTargetValue()`
     - Adding unit tests
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2108
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For IB Cash Accounts backtesting allows 100% of capital purchasing vs in reality cash models capped at 94%.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->