### PR TITLE
Add unit tests for StandardDeviationExecutionModel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: csharp
 mono:
   - 5.8.0
 solution: QuantConnect.Lean.sln
+before_install:
+  - export PATH="$HOME/miniconda3/bin:$PATH"
+  - wget http://cdn.quantconnect.com.s3.amazonaws.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
+  - bash Miniconda3-4.3.31-Linux-x86_64.sh -b
+  - rm -rf Miniconda3-4.3.31-Linux-x86_64.sh
+  - sudo ln -s $HOME/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6m.so
+  - conda update -y python conda pip
+  - conda install -y cython pandas
 install:
   - nuget restore QuantConnect.Lean.sln
   - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ mono:
 solution: QuantConnect.Lean.sln
 before_install:
   - export PATH="$HOME/miniconda3/bin:$PATH"
-  - wget http://cdn.quantconnect.com.s3.amazonaws.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
+  - wget https://cdn.quantconnect.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
   - bash Miniconda3-4.3.31-Linux-x86_64.sh -b
   - rm -rf Miniconda3-4.3.31-Linux-x86_64.sh
   - sudo ln -s $HOME/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6m.so

--- a/Algorithm.Python/readme.md
+++ b/Algorithm.Python/readme.md
@@ -25,7 +25,7 @@ Before we enable python support, follow the [installation instructions](https://
 By default, **miniconda** is installed in the users home directory (`$HOME`):
 ```
 export PATH="$HOME/miniconda3/bin:$PATH"
-wget http://cdn.quantconnect.com.s3.amazonaws.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
+wget https://cdn.quantconnect.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
 bash Miniconda3-4.3.31-Linux-x86_64.sh -b
 rm -rf Miniconda3-4.3.31-Linux-x86_64.sh
 sudo ln -s $HOME/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6m.so

--- a/DockerfileJupyter
+++ b/DockerfileJupyter
@@ -26,7 +26,7 @@ RUN conda install -c conda-forge jupyterlab && \
     conda clean -y --all
 
 #Install ICSharp (Jupyter C# Kernel)
-RUN wget https://s3.amazonaws.com/data.quantconnect.com/builds/iCSharp/iCSharp.Kernel.zip && \
+RUN wget https://cdn.quantconnect.com/icsharp/iCSharp.Kernel.zip && \
     unzip iCSharp.Kernel.zip && rm -irf iCSharp.Kernel.zip && cd icsharp && \
     jupyter kernelspec install kernel-spec --name=csharp && cd ..
 
@@ -38,7 +38,7 @@ ENV PYTHONPATH=${WORK}:${PYTHONPATH}
 COPY ./Launcher/bin/Debug/ ${WORK}
 RUN rm -irf ${WORK}/*Python* && \
     find ${WORK} -type f -not -name '*.dll' -not -name '*.ipynb' -not -name '*.csx' -delete && \
-    echo "{ \"data-folder\": \"/home/Data/\", \"composer-dll-directory\": \"$WORK\" }" > ${WORK}/config.json 
+    echo "{ \"data-folder\": \"/home/Data/\", \"composer-dll-directory\": \"$WORK\" }" > ${WORK}/config.json
 
 EXPOSE 8888
 WORKDIR $WORK

--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y wget bzip2 python3-pip python-opengl &&
 
 # Install miniconda and supported third party python packages
 ENV PATH="/opt/miniconda3/bin:${PATH}"
-RUN wget http://cdn.quantconnect.com.s3.amazonaws.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh && \
+RUN wget https://cdn.quantconnect.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh && \
     bash Miniconda3-4.3.31-Linux-x86_64.sh -b -p /opt/miniconda3 && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh && \
     ln -s /opt/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6.so && \

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -40,8 +40,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         [TestFixtureSetUp]
         public void Initialize()
         {
-            PythonHelper.SetDefaultPythonPath();
-
             _algorithm = new QCAlgorithmFramework();
             _algorithm.PortfolioConstruction = new NullPortfolioConstructionModel();
             _algorithm.HistoryProvider = new SineHistoryProvider(_algorithm.Securities);

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -26,7 +26,6 @@ using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Alphas
@@ -41,8 +40,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         [TestFixtureSetUp]
         public void Initialize()
         {
-            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Alphas");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+            PythonHelper.SetDefaultPythonPath();
 
             _algorithm = new QCAlgorithmFramework();
             _algorithm.PortfolioConstruction = new NullPortfolioConstructionModel();
@@ -285,24 +283,17 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         {
             model = default(IAlphaModel);
 
-            try
+            switch (language)
             {
-                switch (language)
-                {
-                    case Language.CSharp:
-                        model = CreateCSharpAlphaModel();
-                        return true;
-                    case Language.Python:
-                        _algorithm.SetPandasConverter();
-                        model = CreatePythonAlphaModel();
-                        return true;
-                    default:
-                        return false;
-                }
-            }
-            catch
-            {
-                return false;
+                case Language.CSharp:
+                    model = CreateCSharpAlphaModel();
+                    return true;
+                case Language.Python:
+                    _algorithm.SetPandasConverter();
+                    model = CreatePythonAlphaModel();
+                    return true;
+                default:
+                    return false;
             }
         }
     }

--- a/Tests/Algorithm/Framework/Execution/StandardDeviationExecutionModelTests.cs
+++ b/Tests/Algorithm/Framework/Execution/StandardDeviationExecutionModelTests.cs
@@ -1,0 +1,163 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Moq;
+using NodaTime;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Execution
+{
+    [TestFixture]
+    public class StandardDeviationExecutionModelTests
+    {
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Execution");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+        }
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void OrdersAreNotSubmittedWhenNoTargetsToExecute(Language language)
+        {
+            var actualOrdersSubmitted = new List<SubmitOrderRequest>();
+
+            var orderProcessor = new Mock<IOrderProcessor>();
+            orderProcessor.Setup(m => m.Process(It.IsAny<SubmitOrderRequest>()))
+                .Returns((OrderTicket)null)
+                .Callback((SubmitOrderRequest request) => actualOrdersSubmitted.Add(request));
+
+            var algorithm = new QCAlgorithmFramework();
+            algorithm.Transactions.SetOrderProcessor(orderProcessor.Object);
+
+            var model = GetExecutionModel(language);
+            algorithm.SetExecution(model);
+
+            var changes = new SecurityChanges(Enumerable.Empty<Security>(), Enumerable.Empty<Security>());
+            model.OnSecuritiesChanged(algorithm, changes);
+
+            model.Execute(algorithm, new IPortfolioTarget[0]);
+
+            Assert.AreEqual(0, actualOrdersSubmitted.Count);
+        }
+
+        [TestCase(Language.CSharp, new[] { 270d, 260d, 250d }, 1, 10)]
+        [TestCase(Language.CSharp, new[] { 250d, 250d, 250d }, 0, 0)]
+        [TestCase(Language.Python, new[] { 270d, 260d, 250d }, 1, 10)]
+        [TestCase(Language.Python, new[] { 250d, 250d, 250d }, 0, 0)]
+        public void OrdersAreSubmittedWhenRequiredForTargetsToExecute(
+            Language language,
+            double[] historicalPrices,
+            int expectedOrdersSubmitted,
+            decimal expectedTotalQuantity)
+        {
+            var actualOrdersSubmitted = new List<SubmitOrderRequest>();
+
+            var i = 1;
+            var time = new DateTime(2018, 8, 2, 16, 0, 0);
+            var historyProvider = new Mock<IHistoryProvider>();
+            historyProvider.Setup(m => m.GetHistory(It.IsAny<IEnumerable<HistoryRequest>>(), It.IsAny<DateTimeZone>()))
+                .Returns(historicalPrices.Select(x =>
+                    new Slice(time.AddMinutes(i++),
+                        new List<BaseData>
+                        {
+                            new TradeBar
+                            {
+                                Time = time.AddMinutes(i),
+                                Symbol = Symbols.AAPL,
+                                Open = Convert.ToDecimal(x),
+                                High = Convert.ToDecimal(x),
+                                Low = Convert.ToDecimal(x),
+                                Close = Convert.ToDecimal(x),
+                                Volume = 100m
+                            }
+                        })));
+
+            var algorithm = new QCAlgorithmFramework();
+            algorithm.SetPandasConverter();
+            algorithm.SetHistoryProvider(historyProvider.Object);
+            algorithm.SetDateTime(time.AddMinutes(5));
+
+            var security = algorithm.AddEquity(Symbols.AAPL.Value);
+            security.SetMarketPrice(new TradeBar { Value = 250 });
+
+            algorithm.SetFinishedWarmingUp();
+
+            var orderProcessor = new Mock<IOrderProcessor>();
+            orderProcessor.Setup(m => m.Process(It.IsAny<SubmitOrderRequest>()))
+                .Returns((SubmitOrderRequest request) => new OrderTicket(algorithm.Transactions, request))
+                .Callback((SubmitOrderRequest request) => actualOrdersSubmitted.Add(request));
+            orderProcessor.Setup(m => m.GetOpenOrders(It.IsAny<Func<Order, bool>>()))
+                .Returns(new List<Order>());
+            algorithm.Transactions.SetOrderProcessor(orderProcessor.Object);
+
+            var model = GetExecutionModel(language);
+            algorithm.SetExecution(model);
+
+            var changes = new SecurityChanges(new[] { security }, Enumerable.Empty<Security>());
+            model.OnSecuritiesChanged(algorithm, changes);
+
+            var targets = new IPortfolioTarget[] { new PortfolioTarget(Symbols.AAPL, 10) };
+            model.Execute(algorithm, targets);
+
+            Assert.AreEqual(expectedOrdersSubmitted, actualOrdersSubmitted.Count);
+            Assert.AreEqual(expectedTotalQuantity, actualOrdersSubmitted.Sum(x => x.Quantity));
+        }
+
+        private static IExecutionModel GetExecutionModel(Language language)
+        {
+            const int period = 2;
+            const decimal deviations = 1.5m;
+
+            if (language == Language.Python)
+            {
+                try
+                {
+                    using (Py.GIL())
+                    {
+                        const string name = nameof(StandardDeviationExecutionModel);
+                        var instance = Py.Import(name).GetAttr(name).Invoke(period.ToPython(), deviations.ToPython());
+                        return new ExecutionModelPythonWrapper(instance);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Assert.Ignore(e.Message);
+                }
+            }
+            else
+            {
+                return new StandardDeviationExecutionModel(period, deviations);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Tests/Algorithm/Framework/Execution/StandardDeviationExecutionModelTests.cs
+++ b/Tests/Algorithm/Framework/Execution/StandardDeviationExecutionModelTests.cs
@@ -39,8 +39,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Execution
         [TestFixtureSetUp]
         public void SetUp()
         {
-            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Execution");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+            AddFolderToPythonPath("../../../Algorithm.Framework/Execution");
         }
 
         [TestCase(Language.CSharp)]
@@ -158,6 +157,18 @@ namespace QuantConnect.Tests.Algorithm.Framework.Execution
             }
 
             return null;
+        }
+
+        private static void AddFolderToPythonPath(string folderPath)
+        {
+            var pythonPath = new[]
+            {
+                new DirectoryInfo(folderPath).FullName,
+                new DirectoryInfo(Environment.CurrentDirectory).FullName,
+                Environment.GetEnvironmentVariable("PYTHONPATH")
+            };
+
+            Environment.SetEnvironmentVariable("PYTHONPATH", string.Join(OS.IsLinux ? ":" : ";", pythonPath));
         }
     }
 }

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -37,8 +37,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestFixtureSetUp]
         public void SetUp()
         {
-            PythonHelper.SetDefaultPythonPath();
-
             _algorithm = new QCAlgorithmFramework();
             _algorithm.SetDateTime(new DateTime(2018, 7, 31));
 

--- a/Tests/Algorithm/Framework/PythonHelper.cs
+++ b/Tests/Algorithm/Framework/PythonHelper.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Tests.Algorithm.Framework
+{
+    public static class PythonHelper
+    {
+        public static void SetDefaultPythonPath()
+        {
+            var pythonPath = string.Join(
+                OS.IsLinux ? ":" : ";",
+                "./Alphas", "./Execution", "./Portfolio", "./Risk", "./Selection");
+
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath);
+        }
+    }
+}

--- a/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
+++ b/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
@@ -28,12 +28,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Risk
     [TestFixture]
     public class MaximumDrawdownPercentPerSecurityTests
     {
-        [TestFixtureSetUp]
-        public void SetUp()
-        {
-            PythonHelper.SetDefaultPythonPath();
-        }
-
         [Test]
         [TestCase(Language.CSharp, 0.1, false, 0, 0, false)]
         [TestCase(Language.CSharp, 0.1, true, -50, 1000, false)]

--- a/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
+++ b/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
@@ -14,8 +14,6 @@
  *
 */
 
-using System;
-using System.IO;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
@@ -33,8 +31,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Risk
         [TestFixtureSetUp]
         public void SetUp()
         {
-            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Risk");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+            PythonHelper.SetDefaultPythonPath();
         }
 
         [Test]
@@ -68,23 +65,17 @@ namespace QuantConnect.Tests.Algorithm.Framework.Risk
             security.Object.Holdings = holding.Object;
 
             var algorithm = new QCAlgorithmFramework();
+            algorithm.SetPandasConverter();
             algorithm.Securities.Add(Symbols.AAPL, security.Object);
 
             if (language == Language.Python)
             {
-                try
+                using (Py.GIL())
                 {
-                    using (Py.GIL())
-                    {
-                        var name = nameof(MaximumDrawdownPercentPerSecurity);
-                        var instance = Py.Import(name).GetAttr(name).Invoke(maxDrawdownPercent.ToPython());
-                        var model = new RiskManagementModelPythonWrapper(instance);
-                        algorithm.SetRiskManagement(model);
-                    }
-                }
-                catch (Exception e)
-                {
-                    Assert.Ignore(e.Message);
+                    const string name = nameof(MaximumDrawdownPercentPerSecurity);
+                    var instance = Py.Import(name).GetAttr(name).Invoke(maxDrawdownPercent.ToPython());
+                    var model = new RiskManagementModelPythonWrapper(instance);
+                    algorithm.SetRiskManagement(model);
                 }
             }
             else

--- a/Tests/PythonSetup.cs
+++ b/Tests/PythonSetup.cs
@@ -14,18 +14,26 @@
 */
 
 using System;
+using NUnit.Framework;
 
-namespace QuantConnect.Tests.Algorithm.Framework
+namespace QuantConnect.Tests
 {
-    public static class PythonHelper
+    [SetUpFixture]
+    public class PythonSetup
     {
-        public static void SetDefaultPythonPath()
+        [SetUp]
+        public void SetUp()
         {
             var pythonPath = string.Join(
                 OS.IsLinux ? ":" : ";",
                 "./Alphas", "./Execution", "./Portfolio", "./Risk", "./Selection");
 
             Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
         }
     }
 }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
+    <Compile Include="Algorithm\Framework\PythonHelper.cs" />
     <Compile Include="Algorithm\Framework\QCAlgorithmFrameworkTests.cs" />
     <Compile Include="Algorithm\Framework\Risk\MaximumDrawdownPercentPerSecurityTests.cs" />
     <Compile Include="Algorithm\Framework\Selection\ManualUniverseSelectionModelTests.cs" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Algorithm\Framework\Alphas\BasePairsTradingAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\RsiAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\Serialization\InsightJsonConverterTests.cs" />
+    <Compile Include="Algorithm\Framework\Execution\StandardDeviationExecutionModelTests.cs" />
     <Compile Include="Algorithm\Framework\InsightTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -130,7 +130,7 @@
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
-    <Compile Include="Algorithm\Framework\PythonHelper.cs" />
+    <Compile Include="PythonSetup.cs" />
     <Compile Include="Algorithm\Framework\QCAlgorithmFrameworkTests.cs" />
     <Compile Include="Algorithm\Framework\Risk\MaximumDrawdownPercentPerSecurityTests.cs" />
     <Compile Include="Algorithm\Framework\Selection\ManualUniverseSelectionModelTests.cs" />


### PR DESCRIPTION
#### Description
- Unit tests for `StandardDeviationExecutionModel` have been added.
- Added support for Python unit tests in Travis
- Existing Python framework model unit tests were being silently ignored by Travis, now they are all running and passing

#### Related Issue
Closes #2339

#### Motivation and Context
The model did not have accompanying unit tests.

#### Requires Documentation Change
No.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`