### PR TITLE
TimeSpan for indicators

### DIFF
--- a/Algorithm/CandlestickPatterns.cs
+++ b/Algorithm/CandlestickPatterns.cs
@@ -18,6 +18,7 @@ using System;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators.CandlestickPatterns;
+using QuantConnect.Util;
 
 namespace QuantConnect.Algorithm
 {
@@ -45,7 +46,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public TwoCrows TwoCrows(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public TwoCrows TwoCrows(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "TWOCROWS", resolution);
             var pattern = new TwoCrows(name);
@@ -61,7 +62,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeBlackCrows ThreeBlackCrows(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ThreeBlackCrows ThreeBlackCrows(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREEBLACKCROWS", resolution);
             var pattern = new ThreeBlackCrows(name);
@@ -77,7 +78,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeInside ThreeInside(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ThreeInside ThreeInside(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREEINSIDE", resolution);
             var pattern = new ThreeInside(name);
@@ -93,7 +94,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeLineStrike ThreeLineStrike(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ThreeLineStrike ThreeLineStrike(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREELINESTRIKE", resolution);
             var pattern = new ThreeLineStrike(name);
@@ -109,7 +110,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeOutside ThreeOutside(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ThreeOutside ThreeOutside(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREEOUTSIDE", resolution);
             var pattern = new ThreeOutside(name);
@@ -125,7 +126,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeStarsInSouth ThreeStarsInSouth(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ThreeStarsInSouth ThreeStarsInSouth(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREESTARSINSOUTH", resolution);
             var pattern = new ThreeStarsInSouth(name);
@@ -141,7 +142,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ThreeWhiteSoldiers ThreeWhiteSoldiers(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ThreeWhiteSoldiers ThreeWhiteSoldiers(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THREEWHITESOLDIERS", resolution);
             var pattern = new ThreeWhiteSoldiers(name);
@@ -158,7 +159,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public AbandonedBaby AbandonedBaby(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AbandonedBaby AbandonedBaby(Symbol symbol, decimal penetration = 0.3m, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "ABANDONEDBABY", resolution);
             var pattern = new AbandonedBaby(name, penetration);
@@ -174,7 +175,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public AdvanceBlock AdvanceBlock(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AdvanceBlock AdvanceBlock(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "ADVANCEBLOCK", resolution);
             var pattern = new AdvanceBlock(name);
@@ -190,7 +191,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public BeltHold BeltHold(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public BeltHold BeltHold(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "BELTHOLD", resolution);
             var pattern = new BeltHold(name);
@@ -206,7 +207,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Breakaway Breakaway(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Breakaway Breakaway(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "BREAKAWAY", resolution);
             var pattern = new Breakaway(name);
@@ -222,7 +223,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ClosingMarubozu ClosingMarubozu(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ClosingMarubozu ClosingMarubozu(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "CLOSINGMARUBOZU", resolution);
             var pattern = new ClosingMarubozu(name);
@@ -238,7 +239,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ConcealedBabySwallow ConcealedBabySwallow(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ConcealedBabySwallow ConcealedBabySwallow(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "CONCEALEDBABYSWALLOW", resolution);
             var pattern = new ConcealedBabySwallow(name);
@@ -254,7 +255,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Counterattack Counterattack(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Counterattack Counterattack(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "COUNTERATTACK", resolution);
             var pattern = new Counterattack(name);
@@ -271,7 +272,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public DarkCloudCover DarkCloudCover(Symbol symbol, decimal penetration = 0.5m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public DarkCloudCover DarkCloudCover(Symbol symbol, decimal penetration = 0.5m, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "DARKCLOUDCOVER", resolution);
             var pattern = new DarkCloudCover(name, penetration);
@@ -287,7 +288,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Doji Doji(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Doji Doji(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "DOJI", resolution);
             var pattern = new Doji(name);
@@ -303,7 +304,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public DojiStar DojiStar(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public DojiStar DojiStar(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "DOJISTAR", resolution);
             var pattern = new DojiStar(name);
@@ -319,7 +320,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public DragonflyDoji DragonflyDoji(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public DragonflyDoji DragonflyDoji(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "DRAGONFLYDOJI", resolution);
             var pattern = new DragonflyDoji(name);
@@ -335,7 +336,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Engulfing Engulfing(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Engulfing Engulfing(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "ENGULFING", resolution);
             var pattern = new Engulfing(name);
@@ -352,7 +353,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public EveningDojiStar EveningDojiStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public EveningDojiStar EveningDojiStar(Symbol symbol, decimal penetration = 0.3m, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "EVENINGDOJISTAR", resolution);
             var pattern = new EveningDojiStar(name, penetration);
@@ -369,7 +370,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public EveningStar EveningStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public EveningStar EveningStar(Symbol symbol, decimal penetration = 0.3m, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "EVENINGSTAR", resolution);
             var pattern = new EveningStar(name, penetration);
@@ -385,7 +386,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public GapSideBySideWhite GapSideBySideWhite(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public GapSideBySideWhite GapSideBySideWhite(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "GAPSIDEBYSIDEWHITE", resolution);
             var pattern = new GapSideBySideWhite(name);
@@ -401,7 +402,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public GravestoneDoji GravestoneDoji(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public GravestoneDoji GravestoneDoji(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "GRAVESTONEDOJI", resolution);
             var pattern = new GravestoneDoji(name);
@@ -417,7 +418,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Hammer Hammer(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Hammer Hammer(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HAMMER", resolution);
             var pattern = new Hammer(name);
@@ -433,7 +434,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HangingMan HangingMan(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public HangingMan HangingMan(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HANGINGMAN", resolution);
             var pattern = new HangingMan(name);
@@ -449,7 +450,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Harami Harami(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Harami Harami(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HARAMI", resolution);
             var pattern = new Harami(name);
@@ -465,7 +466,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HaramiCross HaramiCross(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public HaramiCross HaramiCross(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HARAMICROSS", resolution);
             var pattern = new HaramiCross(name);
@@ -481,7 +482,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HighWaveCandle HighWaveCandle(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public HighWaveCandle HighWaveCandle(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HIGHWAVECANDLE", resolution);
             var pattern = new HighWaveCandle(name);
@@ -497,7 +498,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Hikkake Hikkake(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Hikkake Hikkake(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HIKKAKE", resolution);
             var pattern = new Hikkake(name);
@@ -513,7 +514,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HikkakeModified HikkakeModified(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public HikkakeModified HikkakeModified(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HIKKAKEMODIFIED", resolution);
             var pattern = new HikkakeModified(name);
@@ -529,7 +530,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public HomingPigeon HomingPigeon(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public HomingPigeon HomingPigeon(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "HOMINGPIGEON", resolution);
             var pattern = new HomingPigeon(name);
@@ -545,7 +546,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public IdenticalThreeCrows IdenticalThreeCrows(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public IdenticalThreeCrows IdenticalThreeCrows(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "IDENTICALTHREECROWS", resolution);
             var pattern = new IdenticalThreeCrows(name);
@@ -561,7 +562,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public InNeck InNeck(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public InNeck InNeck(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "INNECK", resolution);
             var pattern = new InNeck(name);
@@ -577,7 +578,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public InvertedHammer InvertedHammer(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public InvertedHammer InvertedHammer(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "INVERTEDHAMMER", resolution);
             var pattern = new InvertedHammer(name);
@@ -593,7 +594,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Kicking Kicking(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Kicking Kicking(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "KICKING", resolution);
             var pattern = new Kicking(name);
@@ -609,7 +610,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public KickingByLength KickingByLength(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public KickingByLength KickingByLength(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "KICKINGBYLENGTH", resolution);
             var pattern = new KickingByLength(name);
@@ -625,7 +626,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public LadderBottom LadderBottom(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public LadderBottom LadderBottom(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "LADDERBOTTOM", resolution);
             var pattern = new LadderBottom(name);
@@ -641,7 +642,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public LongLeggedDoji LongLeggedDoji(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public LongLeggedDoji LongLeggedDoji(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "LONGLEGGEDDOJI", resolution);
             var pattern = new LongLeggedDoji(name);
@@ -657,7 +658,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public LongLineCandle LongLineCandle(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public LongLineCandle LongLineCandle(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "LONGLINECANDLE", resolution);
             var pattern = new LongLineCandle(name);
@@ -673,7 +674,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Marubozu Marubozu(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Marubozu Marubozu(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MARUBOZU", resolution);
             var pattern = new Marubozu(name);
@@ -689,7 +690,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public MatchingLow MatchingLow(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public MatchingLow MatchingLow(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MATCHINGLOW", resolution);
             var pattern = new MatchingLow(name);
@@ -706,7 +707,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public MatHold MatHold(Symbol symbol, decimal penetration = 0.5m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public MatHold MatHold(Symbol symbol, decimal penetration = 0.5m, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MATHOLD", resolution);
             var pattern = new MatHold(name, penetration);
@@ -723,7 +724,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public MorningDojiStar MorningDojiStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public MorningDojiStar MorningDojiStar(Symbol symbol, decimal penetration = 0.3m, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MORNINGDOJISTAR", resolution);
             var pattern = new MorningDojiStar(name, penetration);
@@ -740,7 +741,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public MorningStar MorningStar(Symbol symbol, decimal penetration = 0.3m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public MorningStar MorningStar(Symbol symbol, decimal penetration = 0.3m, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "MORNINGSTAR", resolution);
             var pattern = new MorningStar(name, penetration);
@@ -756,7 +757,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public OnNeck OnNeck(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public OnNeck OnNeck(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "ONNECK", resolution);
             var pattern = new OnNeck(name);
@@ -772,7 +773,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Piercing Piercing(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Piercing Piercing(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "PIERCING", resolution);
             var pattern = new Piercing(name);
@@ -788,7 +789,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public RickshawMan RickshawMan(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public RickshawMan RickshawMan(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "RICKSHAWMAN", resolution);
             var pattern = new RickshawMan(name);
@@ -804,7 +805,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public RiseFallThreeMethods RiseFallThreeMethods(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public RiseFallThreeMethods RiseFallThreeMethods(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "RISEFALLTHREEMETHODS", resolution);
             var pattern = new RiseFallThreeMethods(name);
@@ -820,7 +821,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public SeparatingLines SeparatingLines(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public SeparatingLines SeparatingLines(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "SEPARATINGLINES", resolution);
             var pattern = new SeparatingLines(name);
@@ -836,7 +837,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ShootingStar ShootingStar(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ShootingStar ShootingStar(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "SHOOTINGSTAR", resolution);
             var pattern = new ShootingStar(name);
@@ -852,7 +853,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public ShortLineCandle ShortLineCandle(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ShortLineCandle ShortLineCandle(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "SHORTLINECANDLE", resolution);
             var pattern = new ShortLineCandle(name);
@@ -868,7 +869,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public SpinningTop SpinningTop(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public SpinningTop SpinningTop(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "SPINNINGTOP", resolution);
             var pattern = new SpinningTop(name);
@@ -884,7 +885,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public StalledPattern StalledPattern(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public StalledPattern StalledPattern(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "STALLEDPATTERN", resolution);
             var pattern = new StalledPattern(name);
@@ -900,7 +901,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public StickSandwich StickSandwich(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public StickSandwich StickSandwich(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "STICKSANDWICH", resolution);
             var pattern = new StickSandwich(name);
@@ -916,7 +917,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Takuri Takuri(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Takuri Takuri(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "TAKURI", resolution);
             var pattern = new Takuri(name);
@@ -932,7 +933,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public TasukiGap TasukiGap(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public TasukiGap TasukiGap(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "TASUKIGAP", resolution);
             var pattern = new TasukiGap(name);
@@ -948,7 +949,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Thrusting Thrusting(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Thrusting Thrusting(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "THRUSTING", resolution);
             var pattern = new Thrusting(name);
@@ -964,7 +965,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public Tristar Tristar(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public Tristar Tristar(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "TRISTAR", resolution);
             var pattern = new Tristar(name);
@@ -980,7 +981,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public UniqueThreeRiver UniqueThreeRiver(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public UniqueThreeRiver UniqueThreeRiver(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "UNIQUETHREERIVER", resolution);
             var pattern = new UniqueThreeRiver(name);
@@ -996,7 +997,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public UpsideGapTwoCrows UpsideGapTwoCrows(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public UpsideGapTwoCrows UpsideGapTwoCrows(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "UPSIDEGAPTWOCROWS", resolution);
             var pattern = new UpsideGapTwoCrows(name);
@@ -1012,7 +1013,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The pattern indicator for the requested symbol.</returns>
-        public UpDownGapThreeMethods UpDownGapThreeMethods(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public UpDownGapThreeMethods UpDownGapThreeMethods(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = _algorithm.CreateIndicatorName(symbol, "UPDOWNGAPTHREEMETHODS", resolution);
             var pattern = new UpDownGapThreeMethods(name);

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -17,6 +17,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
+using QuantConnect.Util;
 using System;
 using System.Linq;
 
@@ -35,7 +36,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar.</param>
         /// <returns></returns>
         public AccelerationBands ABANDS(Symbol symbol, int period, decimal width = 4, MovingAverageType movingAverageType = MovingAverageType.Simple,
-            Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
+            ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ABANDS_{0}_{1}", period, width), resolution);
             var abands = new AccelerationBands(name, period, width, movingAverageType);
@@ -50,7 +51,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AccumulationDistribution indicator for the requested symbol over the speified period</returns>
-        public AccumulationDistribution AD(Symbol symbol, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public AccumulationDistribution AD(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "AD", resolution);
             var ad = new AccumulationDistribution(name);
@@ -67,7 +68,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AccumulationDistributionOscillator indicator for the requested symbol over the speified period</returns>
-        public AccumulationDistributionOscillator ADOSC(Symbol symbol, int fastPeriod, int slowPeriod, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public AccumulationDistributionOscillator ADOSC(Symbol symbol, int fastPeriod, int slowPeriod, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ADOSC({0},{1})", fastPeriod, slowPeriod), resolution);
             var adOsc = new AccumulationDistributionOscillator(name, fastPeriod, slowPeriod);
@@ -84,7 +85,7 @@ namespace QuantConnect.Algorithm
         /// <param name="period">The period over which to compute the Average Directional Index</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Average Directional Index indicator for the requested symbol.</returns>
-        public AverageDirectionalIndex ADX(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AverageDirectionalIndex ADX(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "ADX", resolution);
             var averageDirectionalIndex = new AverageDirectionalIndex(name, period);
@@ -100,7 +101,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AverageDirectionalMovementIndexRating indicator for the requested symbol over the specified period</returns>
-        public AverageDirectionalMovementIndexRating ADXR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AverageDirectionalMovementIndexRating ADXR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "ADXR" + period, resolution);
             var adxr = new AverageDirectionalMovementIndexRating(name, period);
@@ -122,7 +123,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The ArnaudLegouxMovingAverage indicator for the requested symbol over the specified period</returns>
-        public ArnaudLegouxMovingAverage ALMA(Symbol symbol, int period, int sigma = 6, decimal offset = 0.85m, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public ArnaudLegouxMovingAverage ALMA(Symbol symbol, int period, int sigma = 6, decimal offset = 0.85m, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ALMA_{0}_{1}_{2}", period, sigma, offset), resolution);
             var alma = new ArnaudLegouxMovingAverage(name, period, sigma, offset);
@@ -140,7 +141,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AbsolutePriceOscillator indicator for the requested symbol over the specified period</returns>
-        public AbsolutePriceOscillator APO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public AbsolutePriceOscillator APO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("APO({0},{1})", fastPeriod, slowPeriod), resolution);
             var apo = new AbsolutePriceOscillator(name, fastPeriod, slowPeriod, movingAverageType);
@@ -156,7 +157,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>An AroonOscillator configured with the specied periods</returns>
-        public AroonOscillator AROON(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AroonOscillator AROON(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             return AROON(symbol, period, period, resolution, selector);
         }
@@ -170,7 +171,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>An AroonOscillator configured with the specified periods</returns>
-        public AroonOscillator AROON(Symbol symbol, int upPeriod, int downPeriod, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AroonOscillator AROON(Symbol symbol, int upPeriod, int downPeriod, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("AROON({0},{1})", upPeriod, downPeriod), resolution);
             var aroon = new AroonOscillator(name, upPeriod, downPeriod);
@@ -188,7 +189,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>A new AverageTrueRange indicator with the specified smoothing type and period</returns>
-        public AverageTrueRange ATR(Symbol symbol, int period, MovingAverageType type = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AverageTrueRange ATR(Symbol symbol, int period, MovingAverageType type = MovingAverageType.Simple, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             string name = CreateIndicatorName(symbol, "ATR" + period, resolution);
             var atr = new AverageTrueRange(name, period, type);
@@ -206,7 +207,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>A BollingerBands configured with the specied period</returns>
-        public BollingerBands BB(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public BollingerBands BB(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("BB({0},{1})", period, k), resolution);
             var bb = new BollingerBands(name, period, k, movingAverageType);
@@ -222,7 +223,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Balance Of Power indicator for the requested symbol.</returns>
-        public BalanceOfPower BOP(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public BalanceOfPower BOP(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "BOP", resolution);
             var bop = new BalanceOfPower(name);
@@ -240,7 +241,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Coppock Curve indicator for the requested symbol over the specified period</returns>
-        public CoppockCurve CC(Symbol symbol, int shortRocPeriod = 11, int longRocPeriod = 14, int lwmaPeriod = 10, Resolution? resolution = null,
+        public CoppockCurve CC(Symbol symbol, int shortRocPeriod = 11, int longRocPeriod = 14, int lwmaPeriod = 10, ResolutionTimeSpan resolution = null,
                                Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "CC", resolution);
@@ -259,7 +260,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The CommodityChannelIndex indicator for the requested symbol over the specified period</returns>
-        public CommodityChannelIndex CCI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public CommodityChannelIndex CCI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Simple, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "CCI" + period, resolution);
             var cci = new CommodityChannelIndex(name, period, movingAverageType);
@@ -275,7 +276,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The ChandeMomentumOscillator indicator for the requested symbol over the specified period</returns>
-        public ChandeMomentumOscillator CMO(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public ChandeMomentumOscillator CMO(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "CMO" + period, resolution);
             var cmo = new ChandeMomentumOscillator(name, period);
@@ -293,7 +294,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Donchian Channel indicator for the requested symbol.</returns>
-        public DonchianChannel DCH(Symbol symbol, int upperPeriod, int lowerPeriod, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public DonchianChannel DCH(Symbol symbol, int upperPeriod, int lowerPeriod, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "DCH", resolution);
             var donchianChannel = new DonchianChannel(name, upperPeriod, lowerPeriod);
@@ -310,7 +311,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Donchian Channel indicator for the requested symbol.</returns>
-        public DonchianChannel DCH(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public DonchianChannel DCH(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             return DCH(symbol, period, period, resolution, selector);
         }
@@ -323,7 +324,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The DoubleExponentialMovingAverage indicator for the requested symbol over the specified period</returns>
-        public DoubleExponentialMovingAverage DEMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public DoubleExponentialMovingAverage DEMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "DEMA" + period, resolution);
             var dema = new DoubleExponentialMovingAverage(name, period);
@@ -339,7 +340,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>A new registered DetrendedPriceOscillator indicator for the requested symbol over the specified period</returns>
-        public DetrendedPriceOscillator DPO(Symbol symbol, int period, Resolution? resolution = null,
+        public DetrendedPriceOscillator DPO(Symbol symbol, int period, ResolutionTimeSpan resolution = null,
                                             Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "DPO" + period, resolution);
@@ -358,7 +359,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The ExponentialMovingAverage for the given parameters</returns>
-        public ExponentialMovingAverage EMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public ExponentialMovingAverage EMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "EMA" + period, resolution);
             var ema = new ExponentialMovingAverage(name, period);
@@ -427,7 +428,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The FRAMA for the given parameters</returns>
-        public FractalAdaptiveMovingAverage FRAMA(Symbol symbol, int period, int longPeriod = 198, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public FractalAdaptiveMovingAverage FRAMA(Symbol symbol, int period, int longPeriod = 198, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "FRAMA" + period, resolution);
             var frama = new FractalAdaptiveMovingAverage(name, period, longPeriod);
@@ -442,7 +443,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Heikin-Ashi indicator for the requested symbol over the specified period</returns>
-        public HeikinAshi HeikinAshi(Symbol symbol, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public HeikinAshi HeikinAshi(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "HA", resolution);
             var ha = new HeikinAshi(name);
@@ -458,7 +459,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns></returns>
-        public HullMovingAverage HMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public HullMovingAverage HMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "HMA" + period, resolution);
             var hma = new HullMovingAverage(name, period);
@@ -479,7 +480,7 @@ namespace QuantConnect.Algorithm
         /// <param name="senkouBDelayPeriod">The period to calculate the Tenkan-sen period</param>
         /// <param name="resolution">The resolution</param>
         /// <returns>A new IchimokuKinkoHyo indicator with the specified periods and delays</returns>
-        public IchimokuKinkoHyo ICHIMOKU(Symbol symbol, int tenkanPeriod, int kijunPeriod, int senkouAPeriod, int senkouBPeriod, int senkouADelayPeriod, int senkouBDelayPeriod, Resolution? resolution = null)
+        public IchimokuKinkoHyo ICHIMOKU(Symbol symbol, int tenkanPeriod, int kijunPeriod, int senkouAPeriod, int senkouBPeriod, int senkouADelayPeriod, int senkouBDelayPeriod, ResolutionTimeSpan resolution = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ICHIMOKU({0},{1})", tenkanPeriod, kijunPeriod), resolution);
             var ichimoku = new IchimokuKinkoHyo(name, tenkanPeriod, kijunPeriod, senkouAPeriod, senkouBPeriod, senkouADelayPeriod, senkouBDelayPeriod);
@@ -543,7 +544,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The KaufmanAdaptiveMovingAverage indicator for the requested symbol over the specified period</returns>
-        public KaufmanAdaptiveMovingAverage KAMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public KaufmanAdaptiveMovingAverage KAMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "KAMA" + period, resolution);
             var kama = new KaufmanAdaptiveMovingAverage(name, period);
@@ -562,7 +563,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Keltner Channel indicator for the requested symbol.</returns>
-        public KeltnerChannels KCH(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public KeltnerChannels KCH(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "KCH", resolution);
             var keltnerChannels = new KeltnerChannels(name, period, k, movingAverageType);
@@ -578,7 +579,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar.</param>
         /// <returns>log return indicator for the requested symbol.</returns>
-        public LogReturn LOGR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public LogReturn LOGR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "LOGR", resolution);
             var logr = new LogReturn(name, period);
@@ -594,7 +595,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar.</param>
         /// <returns>A LeastSquaredMovingAverage configured with the specified period</returns>
-        public LeastSquaresMovingAverage LSMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public LeastSquaresMovingAverage LSMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "LSMA" + period, resolution);
             var lsma = new LeastSquaresMovingAverage(name, period);
@@ -611,7 +612,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns></returns>
-        public LinearWeightedMovingAverage LWMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public LinearWeightedMovingAverage LWMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "LWMA" + period, resolution);
             var lwma = new LinearWeightedMovingAverage(name, period);
@@ -630,7 +631,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The moving average convergence divergence between the fast and slow averages</returns>
-        public MovingAverageConvergenceDivergence MACD(Symbol symbol, int fastPeriod, int slowPeriod, int signalPeriod, MovingAverageType type = MovingAverageType.Exponential, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public MovingAverageConvergenceDivergence MACD(Symbol symbol, int fastPeriod, int slowPeriod, int signalPeriod, MovingAverageType type = MovingAverageType.Exponential, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("MACD({0},{1})", fastPeriod, slowPeriod), resolution);
             var macd = new MovingAverageConvergenceDivergence(name, fastPeriod, slowPeriod, signalPeriod, type);
@@ -646,7 +647,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MeanAbsoluteDeviation indicator for the requested symbol over the specified period</returns>
-        public MeanAbsoluteDeviation MAD(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public MeanAbsoluteDeviation MAD(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MAD" + period, resolution);
             var mad = new MeanAbsoluteDeviation(name, period);
@@ -663,7 +664,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null and the symbol is of type TradeBar defaults to the High property,
         /// otherwise it defaults to Value property of BaseData (x => x.Value)</param>
         /// <returns>A Maximum indicator that compute the max value and the periods since the max value</returns>
-        public Maximum MAX(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public Maximum MAX(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MAX" + period, resolution);
             var max = new Maximum(name, period);
@@ -692,7 +693,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MoneyFlowIndex indicator for the requested symbol over the specified period</returns>
-        public MoneyFlowIndex MFI(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public MoneyFlowIndex MFI(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MFI" + period, resolution);
             var mfi = new MoneyFlowIndex(name, period);
@@ -711,7 +712,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Mass Index indicator for the requested symbol over the specified period</returns>
-        public MassIndex MASS(Symbol symbol, int emaPeriod = 9, int sumPeriod = 25, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public MassIndex MASS(Symbol symbol, int emaPeriod = 9, int sumPeriod = 25, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MII" + emaPeriod + sumPeriod, resolution);
             var mi = new MassIndex(name, emaPeriod, sumPeriod);
@@ -727,7 +728,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MidPoint indicator for the requested symbol over the specified period</returns>
-        public MidPoint MIDPOINT(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public MidPoint MIDPOINT(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MIDPOINT" + period, resolution);
             var midpoint = new MidPoint(name, period);
@@ -743,7 +744,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MidPrice indicator for the requested symbol over the specified period</returns>
-        public MidPrice MIDPRICE(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public MidPrice MIDPRICE(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MIDPRICE" + period, resolution);
             var midprice = new MidPrice(name, period);
@@ -760,7 +761,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null and the symbol is of type TradeBar defaults to the Low property,
         /// otherwise it defaults to Value property of BaseData (x => x.Value)</param>
         /// <returns>A Minimum indicator that compute the in value and the periods since the min value</returns>
-        public Minimum MIN(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public Minimum MIN(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MIN" + period, resolution);
             var min = new Minimum(name, period);
@@ -789,7 +790,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The momentum indicator for the requested symbol over the specified period</returns>
-        public Momentum MOM(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public Momentum MOM(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "MOM" + period, resolution);
             var momentum = new Momentum(name, period);
@@ -806,7 +807,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Momersion indicator for the requested symbol over the specified period</returns>
-        public MomersionIndicator MOMERSION(Symbol symbol, int minPeriod, int fullPeriod, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public MomersionIndicator MOMERSION(Symbol symbol, int minPeriod, int fullPeriod, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("MOMERSION({0},{1})", minPeriod, fullPeriod), resolution);
             var momersion = new MomersionIndicator(name, minPeriod, fullPeriod);
@@ -823,7 +824,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The momentum indicator for the requested symbol over the specified period</returns>
-        public MomentumPercent MOMP(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public MomentumPercent MOMP(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "MOMP" + period, resolution);
             var momentum = new MomentumPercent(name, period);
@@ -839,7 +840,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The NormalizedAverageTrueRange indicator for the requested symbol over the specified period</returns>
-        public NormalizedAverageTrueRange NATR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public NormalizedAverageTrueRange NATR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "NATR" + period, resolution);
             var natr = new NormalizedAverageTrueRange(name, period);
@@ -856,7 +857,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The On Balance Volume indicator for the requested symbol.</returns>
-        public OnBalanceVolume OBV(Symbol symbol, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public OnBalanceVolume OBV(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "OBV", resolution);
             var onBalanceVolume = new OnBalanceVolume(name);
@@ -874,7 +875,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The PercentagePriceOscillator indicator for the requested symbol over the specified period</returns>
-        public PercentagePriceOscillator PPO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public PercentagePriceOscillator PPO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("PPO({0},{1})", fastPeriod, slowPeriod), resolution);
             var ppo = new PercentagePriceOscillator(name, fastPeriod, slowPeriod, movingAverageType);
@@ -892,7 +893,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>A ParabolicStopAndReverse configured with the specified periods</returns>
-        public ParabolicStopAndReverse PSAR(Symbol symbol, decimal afStart = 0.02m, decimal afIncrement = 0.02m, decimal afMax = 0.2m, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ParabolicStopAndReverse PSAR(Symbol symbol, decimal afStart = 0.02m, decimal afIncrement = 0.02m, decimal afMax = 0.2m, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("PSAR({0},{1},{2})", afStart, afIncrement, afMax), resolution);
             var psar = new ParabolicStopAndReverse(name, afStart, afIncrement, afMax);
@@ -909,7 +910,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>A Regression Channel configured with the specied period and number of standard deviation</returns>
-        public RegressionChannel RC(Symbol symbol, int period, decimal k, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public RegressionChannel RC(Symbol symbol, int period, decimal k, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("RC({0},{1})", period, k), resolution);
             var rc = new RegressionChannel(name, period, k);
@@ -926,7 +927,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RateOfChange indicator for the requested symbol over the specified period</returns>
-        public RateOfChange ROC(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public RateOfChange ROC(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "ROC" + period, resolution);
             var rateofchange = new RateOfChange(name, period);
@@ -943,7 +944,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RateOfChangePercent indicator for the requested symbol over the specified period</returns>
-        public RateOfChangePercent ROCP(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public RateOfChangePercent ROCP(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "ROCP" + period, resolution);
             var rateofchangepercent = new RateOfChangePercent(name, period);
@@ -959,7 +960,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RateOfChangeRatio indicator for the requested symbol over the specified period</returns>
-        public RateOfChangeRatio ROCR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public RateOfChangeRatio ROCR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "ROCR" + period, resolution);
             var rocr = new RateOfChangeRatio(name, period);
@@ -977,7 +978,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RelativeStrengthIndex indicator for the requested symbol over the specified period</returns>
-        public RelativeStrengthIndex RSI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Wilders, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public RelativeStrengthIndex RSI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Wilders, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "RSI" + period, resolution);
             var rsi = new RelativeStrengthIndex(name, period, movingAverageType);
@@ -994,7 +995,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The SimpleMovingAverage for the given parameters</returns>
-        public SimpleMovingAverage SMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public SimpleMovingAverage SMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "SMA" + period, resolution);
             var sma = new SimpleMovingAverage(name, period);
@@ -1009,7 +1010,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The StandardDeviation indicator for the requested symbol over the speified period</returns>
-        public StandardDeviation STD(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public StandardDeviation STD(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "STD" + period, resolution);
             var std = new StandardDeviation(name, period);
@@ -1025,7 +1026,7 @@ namespace QuantConnect.Algorithm
         /// <param name="kPeriod">The sum period of the stochastic. Normally 14</param>
         /// <param name="dPeriod">The sum period of the stochastic. Normally 3</param>
         /// <returns>Stochastic indicator for the requested symbol.</returns>
-        public Stochastic STO(Symbol symbol, int period, int kPeriod, int dPeriod, Resolution? resolution = null)
+        public Stochastic STO(Symbol symbol, int period, int kPeriod, int dPeriod, ResolutionTimeSpan resolution = null)
         {
             string name = CreateIndicatorName(symbol, "STO", resolution);
             var stoch = new Stochastic(name, period, kPeriod, dPeriod);
@@ -1040,7 +1041,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="period">The period of the stochastic. Normally 14</param>
         /// <returns>Stochastic indicator for the requested symbol.</returns>
-        public Stochastic STO(Symbol symbol, int period, Resolution? resolution = null)
+        public Stochastic STO(Symbol symbol, int period, ResolutionTimeSpan resolution = null)
         {
             return STO(symbol, period, period, 3, resolution);
         }
@@ -1053,7 +1054,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Sum indicator for the requested symbol over the specified period</returns>
-        public Sum SUM(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public Sum SUM(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "SUM" + period, resolution);
             var sum = new Sum(name, period);
@@ -1072,7 +1073,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">elects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The calculation using the given tool</returns>
-        public SwissArmyKnife SWISS(Symbol symbol, int period, double delta, SwissArmyKnifeTool tool, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public SwissArmyKnife SWISS(Symbol symbol, int period, double delta, SwissArmyKnifeTool tool, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "SWISS" + period, resolution);
             var swiss = new SwissArmyKnife(name, period, delta, tool);
@@ -1089,7 +1090,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The T3MovingAverage indicator for the requested symbol over the specified period</returns>
-        public T3MovingAverage T3(Symbol symbol, int period, decimal volumeFactor = 0.7m, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public T3MovingAverage T3(Symbol symbol, int period, decimal volumeFactor = 0.7m, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("T3({0},{1})", period, volumeFactor), resolution);
             var t3 = new T3MovingAverage(name, period, volumeFactor);
@@ -1105,7 +1106,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The TripleExponentialMovingAverage indicator for the requested symbol over the specified period</returns>
-        public TripleExponentialMovingAverage TEMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public TripleExponentialMovingAverage TEMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TEMA" + period, resolution);
             var tema = new TripleExponentialMovingAverage(name, period);
@@ -1120,7 +1121,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The TrueRange indicator for the requested symbol.</returns>
-        public TrueRange TR(Symbol symbol, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public TrueRange TR(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TR", resolution);
             var tr = new TrueRange(name);
@@ -1136,7 +1137,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The TriangularMovingAverage indicator for the requested symbol over the specified period</returns>
-        public TriangularMovingAverage TRIMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public TriangularMovingAverage TRIMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TRIMA" + period, resolution);
             var trima = new TriangularMovingAverage(name, period);
@@ -1152,7 +1153,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Trix indicator for the requested symbol over the specified period</returns>
-        public Trix TRIX(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public Trix TRIX(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TRIX" + period, resolution);
             var trix = new Trix(name, period);
@@ -1170,7 +1171,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The UltimateOscillator indicator for the requested symbol over the specified period</returns>
-        public UltimateOscillator ULTOSC(Symbol symbol, int period1, int period2, int period3, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public UltimateOscillator ULTOSC(Symbol symbol, int period1, int period2, int period3, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ULTOSC({0},{1},{2})", period1, period2, period3), resolution);
             var ultosc = new UltimateOscillator(name, period1, period2, period3);
@@ -1186,7 +1187,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Variance indicator for the requested symbol over the speified period</returns>
-        public Variance VAR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public Variance VAR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "VAR" + period, resolution);
             var variance = new Variance(name, period);
@@ -1203,7 +1204,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The VolumeWeightedAveragePrice for the given parameters</returns>
-        public VolumeWeightedAveragePriceIndicator VWAP(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public VolumeWeightedAveragePriceIndicator VWAP(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "VWAP" + period, resolution);
             var vwap = new VolumeWeightedAveragePriceIndicator(name, period);
@@ -1235,7 +1236,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The rateofchangepercent indicator for the requested symbol over the specified period</returns>
-        public WilliamsPercentR WILR(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public WilliamsPercentR WILR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             string name = CreateIndicatorName(symbol, "WILR" + period, resolution);
             var williamspercentr = new WilliamsPercentR(name, period);
@@ -1253,7 +1254,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The WilderMovingAverage for the given parameters</returns>
         /// <remarks>WWMA for Welles Wilder Moving Average</remarks>
-        public WilderMovingAverage WWMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public WilderMovingAverage WWMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "WWMA" + period, resolution);
             var wwma = new WilderMovingAverage(name, period);
@@ -1268,44 +1269,9 @@ namespace QuantConnect.Algorithm
         /// <param name="type">The indicator type, for example, 'SMA5'</param>
         /// <param name="resolution">The resolution requested</param>
         /// <returns>A unique for the given parameters</returns>
-        public string CreateIndicatorName(Symbol symbol, string type, Resolution? resolution)
+        public string CreateIndicatorName(Symbol symbol, string type, ResolutionTimeSpan resolution)
         {
-            if (!resolution.HasValue)
-            {
-                resolution = GetSubscription(symbol).Resolution;
-            }
-            string res;
-            switch (resolution)
-            {
-                case Resolution.Tick:
-                    res = "_tick";
-                    break;
-
-                case Resolution.Second:
-                    res = "_sec";
-                    break;
-
-                case Resolution.Minute:
-                    res = "_min";
-                    break;
-
-                case Resolution.Hour:
-                    res = "_hr";
-                    break;
-
-                case Resolution.Daily:
-                    res = "_day";
-                    break;
-
-                case null:
-                    res = string.Empty;
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException("resolution");
-            }
-
-            return string.Format("{0}({1}{2})", type, symbol.ToString(), res);
+            return string.Format("{0}({1}{2})", type, symbol.ToString(), resolution.ToString());
         }
 
         /// <summary>
@@ -1358,7 +1324,7 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="resolution">The resolution at which to send data to the indicator, null to use the same resolution as the subscription</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
-        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
         {
             RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution), selector ?? (x => x.Value));
         }
@@ -1407,7 +1373,7 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to register against</param>
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="resolution">The resolution at which to send data to the indicator, null to use the same resolution as the subscription</param>
-        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, Resolution? resolution = null)
+        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, ResolutionTimeSpan resolution = null)
             where T : IBaseData
         {
             RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution));

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar.</param>
         /// <returns></returns>
         public AccelerationBands ABANDS(Symbol symbol, int period, decimal width = 4, MovingAverageType movingAverageType = MovingAverageType.Simple,
-            ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
+            ResolutionTimeSpan? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ABANDS_{0}_{1}", period, width), resolution);
             var abands = new AccelerationBands(name, period, width, movingAverageType);
@@ -51,7 +51,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AccumulationDistribution indicator for the requested symbol over the speified period</returns>
-        public AccumulationDistribution AD(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public AccumulationDistribution AD(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "AD", resolution);
             var ad = new AccumulationDistribution(name);
@@ -68,7 +68,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AccumulationDistributionOscillator indicator for the requested symbol over the speified period</returns>
-        public AccumulationDistributionOscillator ADOSC(Symbol symbol, int fastPeriod, int slowPeriod, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public AccumulationDistributionOscillator ADOSC(Symbol symbol, int fastPeriod, int slowPeriod, ResolutionTimeSpan? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ADOSC({0},{1})", fastPeriod, slowPeriod), resolution);
             var adOsc = new AccumulationDistributionOscillator(name, fastPeriod, slowPeriod);
@@ -85,7 +85,7 @@ namespace QuantConnect.Algorithm
         /// <param name="period">The period over which to compute the Average Directional Index</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Average Directional Index indicator for the requested symbol.</returns>
-        public AverageDirectionalIndex ADX(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AverageDirectionalIndex ADX(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "ADX", resolution);
             var averageDirectionalIndex = new AverageDirectionalIndex(name, period);
@@ -101,7 +101,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AverageDirectionalMovementIndexRating indicator for the requested symbol over the specified period</returns>
-        public AverageDirectionalMovementIndexRating ADXR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AverageDirectionalMovementIndexRating ADXR(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "ADXR" + period, resolution);
             var adxr = new AverageDirectionalMovementIndexRating(name, period);
@@ -123,7 +123,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The ArnaudLegouxMovingAverage indicator for the requested symbol over the specified period</returns>
-        public ArnaudLegouxMovingAverage ALMA(Symbol symbol, int period, int sigma = 6, decimal offset = 0.85m, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public ArnaudLegouxMovingAverage ALMA(Symbol symbol, int period, int sigma = 6, decimal offset = 0.85m, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ALMA_{0}_{1}_{2}", period, sigma, offset), resolution);
             var alma = new ArnaudLegouxMovingAverage(name, period, sigma, offset);
@@ -141,7 +141,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The AbsolutePriceOscillator indicator for the requested symbol over the specified period</returns>
-        public AbsolutePriceOscillator APO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public AbsolutePriceOscillator APO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("APO({0},{1})", fastPeriod, slowPeriod), resolution);
             var apo = new AbsolutePriceOscillator(name, fastPeriod, slowPeriod, movingAverageType);
@@ -157,7 +157,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>An AroonOscillator configured with the specied periods</returns>
-        public AroonOscillator AROON(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AroonOscillator AROON(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             return AROON(symbol, period, period, resolution, selector);
         }
@@ -171,7 +171,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>An AroonOscillator configured with the specified periods</returns>
-        public AroonOscillator AROON(Symbol symbol, int upPeriod, int downPeriod, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AroonOscillator AROON(Symbol symbol, int upPeriod, int downPeriod, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("AROON({0},{1})", upPeriod, downPeriod), resolution);
             var aroon = new AroonOscillator(name, upPeriod, downPeriod);
@@ -189,7 +189,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>A new AverageTrueRange indicator with the specified smoothing type and period</returns>
-        public AverageTrueRange ATR(Symbol symbol, int period, MovingAverageType type = MovingAverageType.Simple, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AverageTrueRange ATR(Symbol symbol, int period, MovingAverageType type = MovingAverageType.Simple, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             string name = CreateIndicatorName(symbol, "ATR" + period, resolution);
             var atr = new AverageTrueRange(name, period, type);
@@ -207,7 +207,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>A BollingerBands configured with the specied period</returns>
-        public BollingerBands BB(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public BollingerBands BB(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("BB({0},{1})", period, k), resolution);
             var bb = new BollingerBands(name, period, k, movingAverageType);
@@ -223,7 +223,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Balance Of Power indicator for the requested symbol.</returns>
-        public BalanceOfPower BOP(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public BalanceOfPower BOP(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "BOP", resolution);
             var bop = new BalanceOfPower(name);
@@ -241,7 +241,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Coppock Curve indicator for the requested symbol over the specified period</returns>
-        public CoppockCurve CC(Symbol symbol, int shortRocPeriod = 11, int longRocPeriod = 14, int lwmaPeriod = 10, ResolutionTimeSpan resolution = null,
+        public CoppockCurve CC(Symbol symbol, int shortRocPeriod = 11, int longRocPeriod = 14, int lwmaPeriod = 10, ResolutionTimeSpan? resolution = null,
                                Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "CC", resolution);
@@ -260,7 +260,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The CommodityChannelIndex indicator for the requested symbol over the specified period</returns>
-        public CommodityChannelIndex CCI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Simple, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public CommodityChannelIndex CCI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Simple, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "CCI" + period, resolution);
             var cci = new CommodityChannelIndex(name, period, movingAverageType);
@@ -276,7 +276,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The ChandeMomentumOscillator indicator for the requested symbol over the specified period</returns>
-        public ChandeMomentumOscillator CMO(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public ChandeMomentumOscillator CMO(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "CMO" + period, resolution);
             var cmo = new ChandeMomentumOscillator(name, period);
@@ -294,7 +294,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Donchian Channel indicator for the requested symbol.</returns>
-        public DonchianChannel DCH(Symbol symbol, int upperPeriod, int lowerPeriod, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public DonchianChannel DCH(Symbol symbol, int upperPeriod, int lowerPeriod, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "DCH", resolution);
             var donchianChannel = new DonchianChannel(name, upperPeriod, lowerPeriod);
@@ -311,7 +311,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Donchian Channel indicator for the requested symbol.</returns>
-        public DonchianChannel DCH(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public DonchianChannel DCH(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             return DCH(symbol, period, period, resolution, selector);
         }
@@ -324,7 +324,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The DoubleExponentialMovingAverage indicator for the requested symbol over the specified period</returns>
-        public DoubleExponentialMovingAverage DEMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public DoubleExponentialMovingAverage DEMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "DEMA" + period, resolution);
             var dema = new DoubleExponentialMovingAverage(name, period);
@@ -340,7 +340,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>A new registered DetrendedPriceOscillator indicator for the requested symbol over the specified period</returns>
-        public DetrendedPriceOscillator DPO(Symbol symbol, int period, ResolutionTimeSpan resolution = null,
+        public DetrendedPriceOscillator DPO(Symbol symbol, int period, ResolutionTimeSpan? resolution = null,
                                             Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "DPO" + period, resolution);
@@ -359,7 +359,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The ExponentialMovingAverage for the given parameters</returns>
-        public ExponentialMovingAverage EMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public ExponentialMovingAverage EMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "EMA" + period, resolution);
             var ema = new ExponentialMovingAverage(name, period);
@@ -428,7 +428,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The FRAMA for the given parameters</returns>
-        public FractalAdaptiveMovingAverage FRAMA(Symbol symbol, int period, int longPeriod = 198, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public FractalAdaptiveMovingAverage FRAMA(Symbol symbol, int period, int longPeriod = 198, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "FRAMA" + period, resolution);
             var frama = new FractalAdaptiveMovingAverage(name, period, longPeriod);
@@ -443,7 +443,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Heikin-Ashi indicator for the requested symbol over the specified period</returns>
-        public HeikinAshi HeikinAshi(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public HeikinAshi HeikinAshi(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "HA", resolution);
             var ha = new HeikinAshi(name);
@@ -459,7 +459,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns></returns>
-        public HullMovingAverage HMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public HullMovingAverage HMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "HMA" + period, resolution);
             var hma = new HullMovingAverage(name, period);
@@ -480,7 +480,7 @@ namespace QuantConnect.Algorithm
         /// <param name="senkouBDelayPeriod">The period to calculate the Tenkan-sen period</param>
         /// <param name="resolution">The resolution</param>
         /// <returns>A new IchimokuKinkoHyo indicator with the specified periods and delays</returns>
-        public IchimokuKinkoHyo ICHIMOKU(Symbol symbol, int tenkanPeriod, int kijunPeriod, int senkouAPeriod, int senkouBPeriod, int senkouADelayPeriod, int senkouBDelayPeriod, ResolutionTimeSpan resolution = null)
+        public IchimokuKinkoHyo ICHIMOKU(Symbol symbol, int tenkanPeriod, int kijunPeriod, int senkouAPeriod, int senkouBPeriod, int senkouADelayPeriod, int senkouBDelayPeriod, ResolutionTimeSpan? resolution = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ICHIMOKU({0},{1})", tenkanPeriod, kijunPeriod), resolution);
             var ichimoku = new IchimokuKinkoHyo(name, tenkanPeriod, kijunPeriod, senkouAPeriod, senkouBPeriod, senkouADelayPeriod, senkouBDelayPeriod);
@@ -544,7 +544,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The KaufmanAdaptiveMovingAverage indicator for the requested symbol over the specified period</returns>
-        public KaufmanAdaptiveMovingAverage KAMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public KaufmanAdaptiveMovingAverage KAMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "KAMA" + period, resolution);
             var kama = new KaufmanAdaptiveMovingAverage(name, period);
@@ -563,7 +563,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Keltner Channel indicator for the requested symbol.</returns>
-        public KeltnerChannels KCH(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public KeltnerChannels KCH(Symbol symbol, int period, decimal k, MovingAverageType movingAverageType = MovingAverageType.Simple, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "KCH", resolution);
             var keltnerChannels = new KeltnerChannels(name, period, k, movingAverageType);
@@ -579,7 +579,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar.</param>
         /// <returns>log return indicator for the requested symbol.</returns>
-        public LogReturn LOGR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public LogReturn LOGR(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "LOGR", resolution);
             var logr = new LogReturn(name, period);
@@ -595,7 +595,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar.</param>
         /// <returns>A LeastSquaredMovingAverage configured with the specified period</returns>
-        public LeastSquaresMovingAverage LSMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public LeastSquaresMovingAverage LSMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "LSMA" + period, resolution);
             var lsma = new LeastSquaresMovingAverage(name, period);
@@ -612,7 +612,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns></returns>
-        public LinearWeightedMovingAverage LWMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public LinearWeightedMovingAverage LWMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "LWMA" + period, resolution);
             var lwma = new LinearWeightedMovingAverage(name, period);
@@ -631,7 +631,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The moving average convergence divergence between the fast and slow averages</returns>
-        public MovingAverageConvergenceDivergence MACD(Symbol symbol, int fastPeriod, int slowPeriod, int signalPeriod, MovingAverageType type = MovingAverageType.Exponential, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public MovingAverageConvergenceDivergence MACD(Symbol symbol, int fastPeriod, int slowPeriod, int signalPeriod, MovingAverageType type = MovingAverageType.Exponential, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("MACD({0},{1})", fastPeriod, slowPeriod), resolution);
             var macd = new MovingAverageConvergenceDivergence(name, fastPeriod, slowPeriod, signalPeriod, type);
@@ -647,7 +647,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MeanAbsoluteDeviation indicator for the requested symbol over the specified period</returns>
-        public MeanAbsoluteDeviation MAD(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public MeanAbsoluteDeviation MAD(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MAD" + period, resolution);
             var mad = new MeanAbsoluteDeviation(name, period);
@@ -664,7 +664,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null and the symbol is of type TradeBar defaults to the High property,
         /// otherwise it defaults to Value property of BaseData (x => x.Value)</param>
         /// <returns>A Maximum indicator that compute the max value and the periods since the max value</returns>
-        public Maximum MAX(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public Maximum MAX(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MAX" + period, resolution);
             var max = new Maximum(name, period);
@@ -693,7 +693,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MoneyFlowIndex indicator for the requested symbol over the specified period</returns>
-        public MoneyFlowIndex MFI(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public MoneyFlowIndex MFI(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MFI" + period, resolution);
             var mfi = new MoneyFlowIndex(name, period);
@@ -712,7 +712,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Mass Index indicator for the requested symbol over the specified period</returns>
-        public MassIndex MASS(Symbol symbol, int emaPeriod = 9, int sumPeriod = 25, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public MassIndex MASS(Symbol symbol, int emaPeriod = 9, int sumPeriod = 25, ResolutionTimeSpan? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MII" + emaPeriod + sumPeriod, resolution);
             var mi = new MassIndex(name, emaPeriod, sumPeriod);
@@ -728,7 +728,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MidPoint indicator for the requested symbol over the specified period</returns>
-        public MidPoint MIDPOINT(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public MidPoint MIDPOINT(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MIDPOINT" + period, resolution);
             var midpoint = new MidPoint(name, period);
@@ -744,7 +744,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The MidPrice indicator for the requested symbol over the specified period</returns>
-        public MidPrice MIDPRICE(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public MidPrice MIDPRICE(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MIDPRICE" + period, resolution);
             var midprice = new MidPrice(name, period);
@@ -761,7 +761,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null and the symbol is of type TradeBar defaults to the Low property,
         /// otherwise it defaults to Value property of BaseData (x => x.Value)</param>
         /// <returns>A Minimum indicator that compute the in value and the periods since the min value</returns>
-        public Minimum MIN(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public Minimum MIN(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "MIN" + period, resolution);
             var min = new Minimum(name, period);
@@ -790,7 +790,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The momentum indicator for the requested symbol over the specified period</returns>
-        public Momentum MOM(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public Momentum MOM(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "MOM" + period, resolution);
             var momentum = new Momentum(name, period);
@@ -807,7 +807,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Momersion indicator for the requested symbol over the specified period</returns>
-        public MomersionIndicator MOMERSION(Symbol symbol, int minPeriod, int fullPeriod, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public MomersionIndicator MOMERSION(Symbol symbol, int minPeriod, int fullPeriod, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("MOMERSION({0},{1})", minPeriod, fullPeriod), resolution);
             var momersion = new MomersionIndicator(name, minPeriod, fullPeriod);
@@ -824,7 +824,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The momentum indicator for the requested symbol over the specified period</returns>
-        public MomentumPercent MOMP(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public MomentumPercent MOMP(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "MOMP" + period, resolution);
             var momentum = new MomentumPercent(name, period);
@@ -840,7 +840,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The NormalizedAverageTrueRange indicator for the requested symbol over the specified period</returns>
-        public NormalizedAverageTrueRange NATR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public NormalizedAverageTrueRange NATR(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "NATR" + period, resolution);
             var natr = new NormalizedAverageTrueRange(name, period);
@@ -857,7 +857,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The On Balance Volume indicator for the requested symbol.</returns>
-        public OnBalanceVolume OBV(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public OnBalanceVolume OBV(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "OBV", resolution);
             var onBalanceVolume = new OnBalanceVolume(name);
@@ -875,7 +875,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The PercentagePriceOscillator indicator for the requested symbol over the specified period</returns>
-        public PercentagePriceOscillator PPO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public PercentagePriceOscillator PPO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType movingAverageType, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("PPO({0},{1})", fastPeriod, slowPeriod), resolution);
             var ppo = new PercentagePriceOscillator(name, fastPeriod, slowPeriod, movingAverageType);
@@ -893,7 +893,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>A ParabolicStopAndReverse configured with the specified periods</returns>
-        public ParabolicStopAndReverse PSAR(Symbol symbol, decimal afStart = 0.02m, decimal afIncrement = 0.02m, decimal afMax = 0.2m, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public ParabolicStopAndReverse PSAR(Symbol symbol, decimal afStart = 0.02m, decimal afIncrement = 0.02m, decimal afMax = 0.2m, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("PSAR({0},{1},{2})", afStart, afIncrement, afMax), resolution);
             var psar = new ParabolicStopAndReverse(name, afStart, afIncrement, afMax);
@@ -910,7 +910,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>A Regression Channel configured with the specied period and number of standard deviation</returns>
-        public RegressionChannel RC(Symbol symbol, int period, decimal k, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public RegressionChannel RC(Symbol symbol, int period, decimal k, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("RC({0},{1})", period, k), resolution);
             var rc = new RegressionChannel(name, period, k);
@@ -927,7 +927,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RateOfChange indicator for the requested symbol over the specified period</returns>
-        public RateOfChange ROC(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public RateOfChange ROC(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "ROC" + period, resolution);
             var rateofchange = new RateOfChange(name, period);
@@ -944,7 +944,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RateOfChangePercent indicator for the requested symbol over the specified period</returns>
-        public RateOfChangePercent ROCP(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public RateOfChangePercent ROCP(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "ROCP" + period, resolution);
             var rateofchangepercent = new RateOfChangePercent(name, period);
@@ -960,7 +960,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RateOfChangeRatio indicator for the requested symbol over the specified period</returns>
-        public RateOfChangeRatio ROCR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public RateOfChangeRatio ROCR(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "ROCR" + period, resolution);
             var rocr = new RateOfChangeRatio(name, period);
@@ -978,7 +978,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The RelativeStrengthIndex indicator for the requested symbol over the specified period</returns>
-        public RelativeStrengthIndex RSI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Wilders, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public RelativeStrengthIndex RSI(Symbol symbol, int period, MovingAverageType movingAverageType = MovingAverageType.Wilders, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "RSI" + period, resolution);
             var rsi = new RelativeStrengthIndex(name, period, movingAverageType);
@@ -995,7 +995,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The SimpleMovingAverage for the given parameters</returns>
-        public SimpleMovingAverage SMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public SimpleMovingAverage SMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "SMA" + period, resolution);
             var sma = new SimpleMovingAverage(name, period);
@@ -1010,7 +1010,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The StandardDeviation indicator for the requested symbol over the speified period</returns>
-        public StandardDeviation STD(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public StandardDeviation STD(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "STD" + period, resolution);
             var std = new StandardDeviation(name, period);
@@ -1026,7 +1026,7 @@ namespace QuantConnect.Algorithm
         /// <param name="kPeriod">The sum period of the stochastic. Normally 14</param>
         /// <param name="dPeriod">The sum period of the stochastic. Normally 3</param>
         /// <returns>Stochastic indicator for the requested symbol.</returns>
-        public Stochastic STO(Symbol symbol, int period, int kPeriod, int dPeriod, ResolutionTimeSpan resolution = null)
+        public Stochastic STO(Symbol symbol, int period, int kPeriod, int dPeriod, ResolutionTimeSpan? resolution = null)
         {
             string name = CreateIndicatorName(symbol, "STO", resolution);
             var stoch = new Stochastic(name, period, kPeriod, dPeriod);
@@ -1041,7 +1041,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution.</param>
         /// <param name="period">The period of the stochastic. Normally 14</param>
         /// <returns>Stochastic indicator for the requested symbol.</returns>
-        public Stochastic STO(Symbol symbol, int period, ResolutionTimeSpan resolution = null)
+        public Stochastic STO(Symbol symbol, int period, ResolutionTimeSpan? resolution = null)
         {
             return STO(symbol, period, period, 3, resolution);
         }
@@ -1054,7 +1054,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Sum indicator for the requested symbol over the specified period</returns>
-        public Sum SUM(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public Sum SUM(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "SUM" + period, resolution);
             var sum = new Sum(name, period);
@@ -1073,7 +1073,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">elects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The calculation using the given tool</returns>
-        public SwissArmyKnife SWISS(Symbol symbol, int period, double delta, SwissArmyKnifeTool tool, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public SwissArmyKnife SWISS(Symbol symbol, int period, double delta, SwissArmyKnifeTool tool, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "SWISS" + period, resolution);
             var swiss = new SwissArmyKnife(name, period, delta, tool);
@@ -1090,7 +1090,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The T3MovingAverage indicator for the requested symbol over the specified period</returns>
-        public T3MovingAverage T3(Symbol symbol, int period, decimal volumeFactor = 0.7m, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public T3MovingAverage T3(Symbol symbol, int period, decimal volumeFactor = 0.7m, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("T3({0},{1})", period, volumeFactor), resolution);
             var t3 = new T3MovingAverage(name, period, volumeFactor);
@@ -1106,7 +1106,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The TripleExponentialMovingAverage indicator for the requested symbol over the specified period</returns>
-        public TripleExponentialMovingAverage TEMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public TripleExponentialMovingAverage TEMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TEMA" + period, resolution);
             var tema = new TripleExponentialMovingAverage(name, period);
@@ -1121,7 +1121,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The TrueRange indicator for the requested symbol.</returns>
-        public TrueRange TR(Symbol symbol, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public TrueRange TR(Symbol symbol, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TR", resolution);
             var tr = new TrueRange(name);
@@ -1137,7 +1137,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The TriangularMovingAverage indicator for the requested symbol over the specified period</returns>
-        public TriangularMovingAverage TRIMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public TriangularMovingAverage TRIMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TRIMA" + period, resolution);
             var trima = new TriangularMovingAverage(name, period);
@@ -1153,7 +1153,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Trix indicator for the requested symbol over the specified period</returns>
-        public Trix TRIX(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public Trix TRIX(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "TRIX" + period, resolution);
             var trix = new Trix(name, period);
@@ -1171,7 +1171,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The UltimateOscillator indicator for the requested symbol over the specified period</returns>
-        public UltimateOscillator ULTOSC(Symbol symbol, int period1, int period2, int period3, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public UltimateOscillator ULTOSC(Symbol symbol, int period1, int period2, int period3, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, string.Format("ULTOSC({0},{1},{2})", period1, period2, period3), resolution);
             var ultosc = new UltimateOscillator(name, period1, period2, period3);
@@ -1187,7 +1187,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Variance indicator for the requested symbol over the speified period</returns>
-        public Variance VAR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public Variance VAR(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             var name = CreateIndicatorName(symbol, "VAR" + period, resolution);
             var variance = new Variance(name, period);
@@ -1204,7 +1204,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The VolumeWeightedAveragePrice for the given parameters</returns>
-        public VolumeWeightedAveragePriceIndicator VWAP(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public VolumeWeightedAveragePriceIndicator VWAP(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, "VWAP" + period, resolution);
             var vwap = new VolumeWeightedAveragePriceIndicator(name, period);
@@ -1236,7 +1236,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The rateofchangepercent indicator for the requested symbol over the specified period</returns>
-        public WilliamsPercentR WILR(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public WilliamsPercentR WILR(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             string name = CreateIndicatorName(symbol, "WILR" + period, resolution);
             var williamspercentr = new WilliamsPercentR(name, period);
@@ -1254,7 +1254,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The WilderMovingAverage for the given parameters</returns>
         /// <remarks>WWMA for Welles Wilder Moving Average</remarks>
-        public WilderMovingAverage WWMA(Symbol symbol, int period, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public WilderMovingAverage WWMA(Symbol symbol, int period, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             string name = CreateIndicatorName(symbol, "WWMA" + period, resolution);
             var wwma = new WilderMovingAverage(name, period);
@@ -1269,8 +1269,12 @@ namespace QuantConnect.Algorithm
         /// <param name="type">The indicator type, for example, 'SMA5'</param>
         /// <param name="resolution">The resolution requested</param>
         /// <returns>A unique for the given parameters</returns>
-        public string CreateIndicatorName(Symbol symbol, string type, ResolutionTimeSpan resolution)
+        public string CreateIndicatorName(Symbol symbol, string type, ResolutionTimeSpan? resolution)
         {
+            if (!resolution.HasValue)
+            {
+                resolution = GetSubscription(symbol).Resolution;
+            }
             return string.Format("{0}({1}{2})", type, symbol.ToString(), resolution.ToString());
         }
 
@@ -1324,7 +1328,7 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="resolution">The resolution at which to send data to the indicator, null to use the same resolution as the subscription</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
-        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, ResolutionTimeSpan resolution = null, Func<IBaseData, decimal> selector = null)
+        public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, ResolutionTimeSpan? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution), selector ?? (x => x.Value));
         }
@@ -1373,7 +1377,7 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to register against</param>
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
         /// <param name="resolution">The resolution at which to send data to the indicator, null to use the same resolution as the subscription</param>
-        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, ResolutionTimeSpan resolution = null)
+        public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, ResolutionTimeSpan? resolution = null)
             where T : IBaseData
         {
             RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution));
@@ -1676,7 +1680,7 @@ namespace QuantConnect.Algorithm
                 if (typeof(T) == typeof(TradeBar) && consolidator.OutputType == typeof(QuoteBar))
                 {
                     // collapse quote bar into trade bar (ignore the funky casting, required due to generics)
-                    consolidator.DataConsolidated += (sender, consolidated) => handler((T)(object)((QuoteBar) consolidated).Collapse());
+                    consolidator.DataConsolidated += (sender, consolidated) => handler((T)(object)((QuoteBar)consolidated).Collapse());
                 }
 
                 throw new ArgumentException(
@@ -1685,7 +1689,7 @@ namespace QuantConnect.Algorithm
             }
 
             // register user-defined handler to receive consolidated data events
-            consolidator.DataConsolidated += (sender, consolidated) => handler((T) consolidated);
+            consolidator.DataConsolidated += (sender, consolidated) => handler((T)consolidated);
 
             return consolidator;
         }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -598,6 +598,7 @@
     <Compile Include="Util\ColorJsonConverter.cs" />
     <Compile Include="Util\PythonUtil.cs" />
     <Compile Include="Util\RateGate.cs" />
+    <Compile Include="Util\ResolutionTimeSpan.cs" />
     <Compile Include="Util\SecurityExtensions.cs" />
     <Compile Include="Util\SecurityIdentifierJsonConverter.cs" />
     <Compile Include="Util\TypeChangeJsonConverter.cs" />

--- a/Common/Util/ResolutionTimeSpan.cs
+++ b/Common/Util/ResolutionTimeSpan.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Util
             return new ResolutionTimeSpan(timeSpan);
         }
 
-        //  User-defined conversion from TimeSpan to ResolutionTimeSpan
+        //  User-defined conversion from Resolution to ResolutionTimeSpan
         public static implicit operator ResolutionTimeSpan(Resolution resolution)
         {
             return new ResolutionTimeSpan(resolution.ToTimeSpan());

--- a/Common/Util/ResolutionTimeSpan.cs
+++ b/Common/Util/ResolutionTimeSpan.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace QuantConnect.Util
+{
+    /// <summary>
+    /// This class allows implicit conversions between Resolution and TimeSpan
+    /// </summary>
+    public class ResolutionTimeSpan
+    {
+        public ResolutionTimeSpan(TimeSpan timeSpan) { val = timeSpan; }
+        public TimeSpan val;
+
+        // User-defined conversion from ResolutionTimeSpan to TimeSpan
+        public static implicit operator TimeSpan(ResolutionTimeSpan resolutionTimeSpan)
+        {
+            return resolutionTimeSpan.val;
+        }
+
+        //  User-defined conversion from TimeSpan to ResolutionTimeSpan
+        public static implicit operator ResolutionTimeSpan(TimeSpan timeSpan)
+        {
+            return new ResolutionTimeSpan(timeSpan);
+        }
+
+        //  User-defined conversion from TimeSpan to ResolutionTimeSpan
+        public static implicit operator ResolutionTimeSpan(Resolution resolution)
+        {
+            return new ResolutionTimeSpan(resolution.ToTimeSpan());
+        }
+    }
+}

--- a/Common/Util/ResolutionTimeSpan.cs
+++ b/Common/Util/ResolutionTimeSpan.cs
@@ -1,31 +1,101 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
 
 namespace QuantConnect.Util
 {
     /// <summary>
     /// This class allows implicit conversions between Resolution and TimeSpan
     /// </summary>
-    public class ResolutionTimeSpan
+    public struct ResolutionTimeSpan
     {
-        public ResolutionTimeSpan(TimeSpan timeSpan) { val = timeSpan; }
-        public TimeSpan val;
+        private readonly TimeSpan _value;
 
-        // User-defined conversion from ResolutionTimeSpan to TimeSpan
-        public static implicit operator TimeSpan(ResolutionTimeSpan resolutionTimeSpan)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResolutionTimeSpan"/> class
+        /// </summary>
+        /// <param name="timeSpan">The timespan to use</param>
+        public ResolutionTimeSpan(TimeSpan timeSpan)
         {
-            return resolutionTimeSpan.val;
+            _value = timeSpan;
         }
 
-        //  User-defined conversion from TimeSpan to ResolutionTimeSpan
+        /// <summary>
+        ///  User-defined conversion from ResolutionTimeSpan to TimeSpan
+        /// </summary>
+        /// <param name="resolutionTimeSpan">The <see cref="ResolutionTimeSpan"/> to convert from</param>
+        public static implicit operator TimeSpan(ResolutionTimeSpan resolutionTimeSpan)
+        {
+            return resolutionTimeSpan._value;
+        }
+
+        /// <summary>
+        /// User-defined conversion from TimeSpan to ResolutionTimeSpan
+        /// </summary>
+        /// <param name="timeSpan">The <see cref="TimeSpan"/> to convert from</param>
         public static implicit operator ResolutionTimeSpan(TimeSpan timeSpan)
         {
             return new ResolutionTimeSpan(timeSpan);
         }
 
-        //  User-defined conversion from Resolution to ResolutionTimeSpan
+        /// <summary>
+        /// User-defined conversion from Resolution to ResolutionTimeSpan
+        /// </summary>
+        /// <param name="resolution">the <see cref="Resolution"/> to convert from</param>
         public static implicit operator ResolutionTimeSpan(Resolution resolution)
         {
             return new ResolutionTimeSpan(resolution.ToTimeSpan());
+        }
+
+        /// <summary>
+        /// Returns a nice name for the resolution where possible.
+        /// </summary>
+        /// <returns></returns>
+        public new string ToString()
+        {
+            var higherResolutionEquivalent = ((TimeSpan)this).ToHigherResolutionEquivalent(false);
+
+            string res;
+            switch (higherResolutionEquivalent)
+            {
+                case Resolution.Tick:
+                    res = "_tick";
+                    break;
+
+                case Resolution.Second:
+                    res = "_sec";
+                    break;
+
+                case Resolution.Minute:
+                    res = "_min";
+                    break;
+
+                case Resolution.Hour:
+                    res = "_hr";
+                    break;
+
+                case Resolution.Daily:
+                    res = "_day";
+                    break;
+
+                default:
+                    res = ((TimeSpan)this).ToString();
+                    break;
+            }
+            return res;
         }
     }
 }

--- a/Tests/Common/Util/ResolutionTimeSpanTests.cs
+++ b/Tests/Common/Util/ResolutionTimeSpanTests.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using NUnit.Framework;
+using QuantConnect.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuantConnect.Tests.Common.Util
+{
+    [TestFixture]
+    public class ResolutionTimeSpanTests
+    {
+        [Test]
+        public void ShouldGiveNiceName()
+        {
+            Assert.AreEqual(new ResolutionTimeSpan(TimeSpan.FromSeconds(0)).ToString(), ((ResolutionTimeSpan)Resolution.Tick).ToString());
+            Assert.AreEqual(new ResolutionTimeSpan(TimeSpan.FromSeconds(1)).ToString(), ((ResolutionTimeSpan)Resolution.Second).ToString());
+            Assert.AreEqual(new ResolutionTimeSpan(TimeSpan.FromMinutes(1)).ToString(), ((ResolutionTimeSpan)Resolution.Minute).ToString());
+            Assert.AreEqual(new ResolutionTimeSpan(TimeSpan.FromHours(1)).ToString(), ((ResolutionTimeSpan)Resolution.Hour).ToString());
+            Assert.AreEqual(new ResolutionTimeSpan(TimeSpan.FromDays(1)).ToString(), ((ResolutionTimeSpan)Resolution.Daily).ToString());
+
+            //TODO more tests
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -266,6 +266,7 @@
     <Compile Include="Common\Util\ObjectActivatorTests.cs" />
     <Compile Include="Common\Util\ObjectToListJsonConverterTests.cs" />
     <Compile Include="Common\Util\ReaderWriterLockSlimExtensionsTests.cs" />
+    <Compile Include="Common\Util\ResolutionTimeSpanTests.cs" />
     <Compile Include="Common\Util\VersionHelperTests.cs" />
     <Compile Include="Common\Util\WhoCalledMeTests.cs" />
     <Compile Include="Common\Util\YahooDataDownloaderTests.cs" />


### PR DESCRIPTION
Allow indicators to accept TimeSpans so users can fine tune their indicators. (5m etc)

#### Description
Added a `ResolutionTimeSpan` class which implicitly converts between `Resolution` and `TimeSpan`, then F&R'd everything in QCAlgo.Indicators to use this new class instead for complete backwards compatibility. (Except perhaps indicator names changing)

#### Related Issue
https://github.com/QuantConnect/Lean/issues/1529

#### Motivation and Context
It allows fine tuning of indicator resolution

#### Requires Documentation Change
It would require the documentation to be appended to say that "TimeSpan.FromX can also be used"

#### How Has This Been Tested?
It's not yet.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->