### PR TITLE
Fix Python version of RsiAlphaModel to be same as C# version

### DIFF
--- a/Algorithm.Framework/Alphas/RsiAlphaModel.py
+++ b/Algorithm.Framework/Alphas/RsiAlphaModel.py
@@ -23,10 +23,10 @@ from datetime import timedelta
 from enum import Enum
 
 class RsiAlphaModel(AlphaModel):
-    '''Uses Wilder's RSI to create insights. 
+    '''Uses Wilder's RSI to create insights.
     Using default settings, a cross over below 30 or above 70 will trigger a new insight.'''
 
-    def __init__(self, 
+    def __init__(self,
                  period = 14,
                  resolution = Resolution.Daily):
         '''Initializes a new instance of the RsiAlphaModel class
@@ -85,18 +85,22 @@ class RsiAlphaModel(AlphaModel):
         symbols = [ x.Symbol for x in changes.AddedSecurities ]
         if len(symbols) == 0: return
 
-        history = algorithm.History(symbols, self.period, self.resolution)
-        if history.empty: return
-
-        tickers = history.index.levels[0]
-        
-        for ticker in tickers:
-            symbol = SymbolCache.GetSymbol(ticker)
-
+        addedSymbols = []
+        for symbol in symbols:
             if symbol not in self.symbolDataBySymbol:
                 rsi = algorithm.RSI(symbol, self.period, MovingAverageType.Wilders, self.resolution)
                 symbolData = SymbolData(symbol, rsi)
                 self.symbolDataBySymbol[symbol] = symbolData
+                addedSymbols.append(symbol)
+
+        if len(addedSymbols) > 0:
+            history = algorithm.History(symbols, self.period, self.resolution)
+            if history.empty: return
+
+            tickers = history.index.levels[0]
+
+            for ticker in tickers:
+                symbol = SymbolCache.GetSymbol(ticker)
 
                 for tuple in history.loc[ticker].itertuples():
                     symbolData.RSI.Update(tuple.Index, tuple.close)


### PR DESCRIPTION

#### Description
The Python version of the `RsiAlphaModel` has been updated to match the C# version

#### Related Issue
Closes #2346 

#### Motivation and Context
The `InsightsGenerationTest` unit test was passing for C# but failing for Python.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`