### PR TITLE
Fixes EqualWeightingPortfolioConstructionModel

### DIFF
--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -79,6 +79,12 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 targets.Add(PortfolioTarget.Percent(algorithm, insight.Symbol, (int)insight.Direction * percent));
             }
 
+            // add targets to remove invested securities
+            targets.AddRange(from kvp in algorithm.Portfolio
+                             where kvp.Value.Invested
+                             where targets.All(x => kvp.Key != x.Symbol)
+                             select new PortfolioTarget(kvp.Key, 0));
+
             return targets;
         }
 

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
@@ -65,6 +65,11 @@ class EqualWeightingPortfolioConstructionModel(PortfolioConstructionModel):
         for insight in activeInsights:
             targets.append(PortfolioTarget.Percent(algorithm, insight.Symbol, insight.Direction * percent))
 
+        # add targets to remove invested securities
+        for kvp in algorithm.Portfolio:
+            if kvp.Value.Invested and all([kvp.Key != x.Symbol for x in targets]):
+                targets.append(PortfolioTarget(kvp.Key, 0))
+
         return targets
 
     def OnSecuritiesChanged(self, algorithm, changes):

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -34,6 +34,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
     public class EqualWeightingPortfolioConstructionModelTests
     {
         private QCAlgorithmFramework _algorithm;
+        private const decimal _startingCash = 100000;
 
         [TestFixtureSetUp]
         public void SetUp()
@@ -42,6 +43,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
 
             _algorithm = new QCAlgorithmFramework();
+            _algorithm.SetCash(_startingCash);
             _algorithm.SetDateTime(new DateTime(2018, 7, 31));
             
             var prices = new Dictionary<Symbol, decimal>
@@ -102,7 +104,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             }
         }
 
-        [Test]
         [TestCase(Language.CSharp, InsightDirection.Up)]
         [TestCase(Language.CSharp, InsightDirection.Down)]
         [TestCase(Language.CSharp, InsightDirection.Flat)]
@@ -139,6 +140,49 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 Assert.AreEqual(expected.Quantity, actual.Quantity);
             }
         }
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public void AutomaticallyRemoveInvested(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language);
+
+            var spyHolding = _algorithm.Portfolio[Symbols.SPY];
+            spyHolding.SetHoldings(spyHolding.Price, 100);
+            _algorithm.Portfolio.SetCash(_startingCash - spyHolding.HoldingsValue);
+
+            // Equity will be divided by all securities minus 1, since SPY is already invested and we want to remove it
+            var amount = _algorithm.Portfolio.TotalPortfolioValue / (_algorithm.Securities.Count - 1);
+            var expectedTargets = _algorithm.Securities.Select(x =>
+            {
+                // Expected target quantity for SPY is zero, since it will be removed
+                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction * Math.Floor(amount / x.Value.Price);
+                return new PortfolioTarget(x.Key, quantity);
+            });
+
+            // Do no include SPY in the insights
+            var insights = _algorithm.Securities.Keys
+                .Where(x=> x.Value != "SPY")
+                .Select(x => GetInsight(x, direction, _algorithm.UtcTime));
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
+
+            Assert.AreEqual(expectedTargets.Count(), actualTargets.Count());
+
+            foreach (var expected in expectedTargets)
+            {
+                var actual = actualTargets.FirstOrDefault(x => x.Symbol == expected.Symbol);
+                Assert.IsNotNull(actual);
+                Assert.AreEqual(expected.Quantity, actual.Quantity);
+            }
+        }
+
+
 
         private Security GetSecurity(Symbol symbol)
         {


### PR DESCRIPTION
#### Description
Adds targets with direction zero to remove invested securities that do not have active insights.

#### Related Issue
Closes #2353 

#### Motivation and Context
Improve featured framework models.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added unit test and regression models.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`