### PR TITLE
Refactoring IBrokerageModel. Removing some unnecessary parameters

### DIFF
--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
@@ -239,11 +240,10 @@ namespace QuantConnect.Brokerages
         /// Gets a new settlement model for the security
         /// </summary>
         /// <param name="security">The security to get a settlement model for</param>
-        /// <param name="accountType">The account type</param>
         /// <returns>The settlement model for this brokerage</returns>
-        public virtual ISettlementModel GetSettlementModel(Security security, AccountType accountType)
+        public virtual ISettlementModel GetSettlementModel(Security security)
         {
-            if (accountType == AccountType.Cash)
+            if (AccountType == AccountType.Cash)
             {
                 switch (security.Type)
                 {
@@ -259,14 +259,26 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
+        /// Gets a new settlement model for the security
+        /// </summary>
+        /// <param name="security">The security to get a settlement model for</param>
+        /// <param name="accountType">The account type</param>
+        /// <returns>The settlement model for this brokerage</returns>
+        [Obsolete("Flagged deprecated and will remove December 1st 2018")]
+        public ISettlementModel GetSettlementModel(Security security, AccountType accountType)
+        {
+            return GetSettlementModel(security);
+        }
+
+        /// <summary>
         /// Gets a new buying power model for the security, returning the default model with the security's configured leverage.
         /// For cash accounts, leverage = 1 is used.
         /// </summary>
         /// <param name="security">The security to get a buying power model for</param>
-        /// <param name="accountType">The account type</param>
         /// <returns>The buying power model for this brokerage/security</returns>
-        public virtual IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType)
+        public virtual IBuyingPowerModel GetBuyingPowerModel(Security security)
         {
+            var leverage = GetLeverage(security);
             switch (security.Type)
             {
                 case SecurityType.Crypto:
@@ -274,7 +286,7 @@ namespace QuantConnect.Brokerages
 
                 case SecurityType.Forex:
                 case SecurityType.Cfd:
-                    return new SecurityMarginModel(50m);
+                    return new SecurityMarginModel(leverage);
 
                 case SecurityType.Option:
                     return new OptionMarginModel();
@@ -283,8 +295,20 @@ namespace QuantConnect.Brokerages
                     return new FutureMarginModel();
 
                 default:
-                    return new SecurityMarginModel(2m);
+                    return new SecurityMarginModel(leverage);
             }
+        }
+
+        /// <summary>
+        /// Gets a new buying power model for the security
+        /// </summary>
+        /// <param name="security">The security to get a buying power model for</param>
+        /// <param name="accountType">The account type</param>
+        /// <returns>The buying power model for this brokerage/security</returns>
+        [Obsolete("Flagged deprecated and will remove December 1st 2018")]
+        public IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType)
+        {
+            return GetBuyingPowerModel(security);
         }
     }
 }

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -172,9 +172,8 @@ namespace QuantConnect.Brokerages
         /// For cash accounts, leverage = 1 is used.
         /// </summary>
         /// <param name="security">The security to get a buying power model for</param>
-        /// <param name="accountType">The account type</param>
         /// <returns>The buying power model for this brokerage/security</returns>
-        public override IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType)
+        public override IBuyingPowerModel GetBuyingPowerModel(Security security)
         {
             // margin trading is not currently supported by GDAX
             return new CashBuyingPowerModel();

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -117,9 +117,24 @@ namespace QuantConnect.Brokerages
         /// Gets a new settlement model for the security
         /// </summary>
         /// <param name="security">The security to get a settlement model for</param>
+        /// <returns>The settlement model for this brokerage</returns>
+        ISettlementModel GetSettlementModel(Security security);
+
+        /// <summary>
+        /// Gets a new settlement model for the security
+        /// </summary>
+        /// <param name="security">The security to get a settlement model for</param>
         /// <param name="accountType">The account type</param>
         /// <returns>The settlement model for this brokerage</returns>
+        [Obsolete("Flagged deprecated and will remove December 1st 2018")]
         ISettlementModel GetSettlementModel(Security security, AccountType accountType);
+
+        /// <summary>
+        /// Gets a new buying power model for the security
+        /// </summary>
+        /// <param name="security">The security to get a buying power model for</param>
+        /// <returns>The buying power model for this brokerage/security</returns>
+        IBuyingPowerModel GetBuyingPowerModel(Security security);
 
         /// <summary>
         /// Gets a new buying power model for the security
@@ -127,6 +142,7 @@ namespace QuantConnect.Brokerages
         /// <param name="security">The security to get a buying power model for</param>
         /// <param name="accountType">The account type</param>
         /// <returns>The buying power model for this brokerage/security</returns>
+        [Obsolete("Flagged deprecated and will remove December 1st 2018")]
         IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType);
     }
 

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using Python.Runtime;
 using QuantConnect.Brokerages;
@@ -178,8 +179,22 @@ namespace QuantConnect.Python
         /// Gets a new settlement model for the security
         /// </summary>
         /// <param name="security">The security to get a settlement model for</param>
+        /// <returns>The settlement model for this brokerage</returns>
+        public ISettlementModel GetSettlementModel(Security security)
+        {
+            using (Py.GIL())
+            {
+                return _model.GetSettlementModel(security);
+            }
+        }
+
+        /// <summary>
+        /// Gets a new settlement model for the security
+        /// </summary>
+        /// <param name="security">The security to get a settlement model for</param>
         /// <param name="accountType">The account type</param>
         /// <returns>The settlement model for this brokerage</returns>
+        [Obsolete("Flagged deprecated and will remove December 1st 2018")]
         public ISettlementModel GetSettlementModel(Security security, AccountType accountType)
         {
             using (Py.GIL())
@@ -206,8 +221,22 @@ namespace QuantConnect.Python
         /// For cash accounts, leverage = 1 is used.
         /// </summary>
         /// <param name="security">The security to get a buying power model for</param>
+        /// <returns>The buying power model for this brokerage/security</returns>
+        public IBuyingPowerModel GetBuyingPowerModel(Security security)
+        {
+            using (Py.GIL())
+            {
+                return _model.GetBuyingPowerModel(security);
+            }
+        }
+
+        /// <summary>
+        /// Gets a new buying power model for the security
+        /// </summary>
+        /// <param name="security">The security to get a buying power model for</param>
         /// <param name="accountType">The account type</param>
         /// <returns>The buying power model for this brokerage/security</returns>
+        [Obsolete("Flagged deprecated and will remove December 1st 2018")]
         public IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType)
         {
             using (Py.GIL())

--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -60,8 +60,8 @@ namespace QuantConnect.Securities
             security.FillModel = _brokerageModel.GetFillModel(security);
             security.FeeModel = _brokerageModel.GetFeeModel(security);
             security.SlippageModel = _brokerageModel.GetSlippageModel(security);
-            security.SettlementModel = _brokerageModel.GetSettlementModel(security, _brokerageModel.AccountType);
-            security.BuyingPowerModel = _brokerageModel.GetBuyingPowerModel(security, _brokerageModel.AccountType);
+            security.SettlementModel = _brokerageModel.GetSettlementModel(security);
+            security.BuyingPowerModel = _brokerageModel.GetBuyingPowerModel(security);
 
             _securitySeeder.SeedSecurity(security);
         }

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Tests.Common.Brokerages
         [Test]
         public void GetBuyingPowerModelTest()
         {
-            Assert.IsInstanceOf<CashBuyingPowerModel>(_unit.GetBuyingPowerModel(GDAXTestsHelpers.GetSecurity(), AccountType.Cash));
+            Assert.IsInstanceOf<CashBuyingPowerModel>(_unit.GetBuyingPowerModel(GDAXTestsHelpers.GetSecurity()));
         }
 
         [Test]

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -138,5 +138,18 @@ namespace QuantConnect.Tests.Common.Securities
             // Assert
             Assert.IsTrue(_tradeBarSecurity.Price == 0);
         }
+
+        [Test]
+        public void BrokerageModelSecurityInitializer_SetLeverageForBuyingPowerModel_Successfully()
+        {
+            var brokerageModel = new DefaultBrokerageModel(AccountType.Cash);
+            var localBrokerageInitializer = new BrokerageModelSecurityInitializer(brokerageModel,
+                new FuncSecuritySeeder(_algo.GetLastKnownPrice));
+            Assert.AreEqual(1.0, _tradeBarSecurity.Leverage);
+            localBrokerageInitializer.Initialize(_tradeBarSecurity);
+            Assert.AreEqual(1.0, _tradeBarSecurity.Leverage);
+            Assert.AreEqual(1.0, _tradeBarSecurity.BuyingPowerModel.GetLeverage(_tradeBarSecurity));
+        }
+
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `IBrokerageModel` methods will now use its own AccountType property, versus a parameter.
- Calling `IBrokerageModel.GetBuyingPowerModel` will now always return a BuyingPowerModel with the correct leverage set.
    - Adding unit test
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2337 and https://github.com/QuantConnect/Lean/issues/2336
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve `IBrokerageModel`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->