### PR TITLE
Enable Python unit tests ignored with TravisExclude

### DIFF
--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -21,7 +36,6 @@ using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Algorithm
 {
-
     [TestFixture]
     public class AlgorithmAddDataTests
     {
@@ -128,12 +142,9 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(data2.Price, 3);
         }
 
-        [Test, Ignore]
+        [Test]
         public void PythonCustomDataTypes_AreAddedToSubscriptions_Successfully()
         {
-            var pythonPath = new System.IO.DirectoryInfo("RegressionAlgorithms");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-
             var qcAlgorithm = new AlgorithmPythonWrapper("Test_CustomDataAlgorithm");
 
             // Initialize contains the statements:
@@ -154,12 +165,9 @@ namespace QuantConnect.Tests.Algorithm
             Assert.DoesNotThrow(() => quandlFactory.GetSource(quandlSubscription, DateTime.UtcNow, false));
         }
 
-        [Test, Ignore]
+        [Test]
         public void PythonCustomDataTypes_AreAddedToConsolidator_Successfully()
         {
-            var pythonPath = new System.IO.DirectoryInfo("RegressionAlgorithms");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-
             var qcAlgorithm = new AlgorithmPythonWrapper("Test_CustomDataAlgorithm");
 
             // Initialize contains the statements:

--- a/Tests/Algorithm/AlgorithmDownloadTests.cs
+++ b/Tests/Algorithm/AlgorithmDownloadTests.cs
@@ -1,4 +1,19 @@
-﻿using NUnit.Framework;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Algorithm;
 using System;
@@ -35,7 +50,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.IsNotEmpty(content);
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void Download_With_Python_Parameter_Successfully()
         {
             var algo = new QCAlgorithm();

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,6 @@
 using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Algorithm;
-using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 using QuantConnect.Tests.Indicators;
@@ -84,7 +83,7 @@ namespace QuantConnect.Tests.Algorithm
             }
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void RegistersIndicatorProperlyPython()
         {
             var expected = 0;
@@ -117,7 +116,7 @@ namespace QuantConnect.Tests.Algorithm
             }
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void RegisterPythonCustomIndicatorProperly()
         {
             using (Py.GIL())
@@ -145,7 +144,7 @@ namespace QuantConnect.Tests.Algorithm
             }
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void RegistersIndicatorProperlyPythonScript()
         {
             var code = @"from clr import AddReference

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -27,7 +27,6 @@ using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 {
@@ -96,7 +95,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
                 Console.WriteLine(insight);
             }
 
-            Assert.AreEqual(actualInsights.Count, expectedInsights.Count);
+            Assert.AreEqual(expectedInsights.Count, actualInsights.Count);
 
             for (var i = 0; i < actualInsights.Count; i++)
             {

--- a/Tests/Common/Exceptions/DllNotFoundPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/DllNotFoundPythonExceptionInterpreterTests.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 
 namespace QuantConnect.Tests.Common.Exceptions
 {
-    [TestFixture, Ignore]
+    [TestFixture]
     public class DllNotFoundPythonExceptionInterpreterTests
     {
         [Test]

--- a/Tests/Common/Exceptions/InvalidTokenPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/InvalidTokenPythonExceptionInterpreterTests.cs
@@ -22,7 +22,7 @@ using System.Collections.Generic;
 
 namespace QuantConnect.Tests.Common.Exceptions
 {
-    [TestFixture, Ignore]
+    [TestFixture]
     public class InvalidTokenPythonExceptionInterpreterTests
     {
         private PythonException _pythonException;

--- a/Tests/Common/Exceptions/KeyErrorPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/KeyErrorPythonExceptionInterpreterTests.cs
@@ -19,11 +19,10 @@ using Python.Runtime;
 using QuantConnect.Exceptions;
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace QuantConnect.Tests.Common.Exceptions
 {
-    [TestFixture, Ignore]
+    [TestFixture]
     public class KeyErrorPythonExceptionInterpreterTests
     {
         private PythonException _pythonException;
@@ -31,9 +30,6 @@ namespace QuantConnect.Tests.Common.Exceptions
         [TestFixtureSetUp]
         public void Setup()
         {
-            var pythonPath = new DirectoryInfo("RegressionAlgorithms");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-
             using (Py.GIL())
             {
                 var module = Py.Import("Test_PythonExceptionInterpreter");

--- a/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
@@ -19,11 +19,10 @@ using Python.Runtime;
 using QuantConnect.Exceptions;
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace QuantConnect.Tests.Common.Exceptions
 {
-    [TestFixture, Category("TravisExclude")]
+    [TestFixture]
     public class NoMethodMatchPythonExceptionInterpreterTests
     {
         private PythonException _pythonException;
@@ -31,9 +30,6 @@ namespace QuantConnect.Tests.Common.Exceptions
         [TestFixtureSetUp]
         public void Setup()
         {
-            var pythonPath = new DirectoryInfo("RegressionAlgorithms");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-
             using (Py.GIL())
             {
                 var module = Py.Import("Test_PythonExceptionInterpreter");

--- a/Tests/Common/Exceptions/PythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/PythonExceptionInterpreterTests.cs
@@ -19,11 +19,10 @@ using Python.Runtime;
 using QuantConnect.Exceptions;
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace QuantConnect.Tests.Common.Exceptions
 {
-    [TestFixture, Ignore]
+    [TestFixture]
     public class PythonExceptionInterpreterTests
     {
         private PythonException _pythonException;
@@ -31,9 +30,6 @@ namespace QuantConnect.Tests.Common.Exceptions
         [TestFixtureSetUp]
         public void Setup()
         {
-            var pythonPath = new DirectoryInfo("RegressionAlgorithms");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-
             using (Py.GIL())
             {
                 var module = Py.Import("Test_PythonExceptionInterpreter");

--- a/Tests/Common/Exceptions/ScheduledEventExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/ScheduledEventExceptionInterpreterTests.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;

--- a/Tests/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreterTests.cs
@@ -19,11 +19,10 @@ using Python.Runtime;
 using QuantConnect.Exceptions;
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace QuantConnect.Tests.Common.Exceptions
 {
-    [TestFixture, Ignore]
+    [TestFixture]
     public class UnsupportedOperandPythonExceptionInterpreterTests
     {
         private PythonException _pythonException;
@@ -31,9 +30,6 @@ namespace QuantConnect.Tests.Common.Exceptions
         [TestFixtureSetUp]
         public void Setup()
         {
-            var pythonPath = new DirectoryInfo("RegressionAlgorithms");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-
             using (Py.GIL())
             {
                 var module = Py.Import("Test_PythonExceptionInterpreter");

--- a/Tests/Common/Orders/Fills/PartialMarketFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/PartialMarketFillModelTests.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
     [TestFixture, Ignore]
     public class PartialMarketFillModelTests
     {
-        [Test, Category("TravisExclude")]
+        [Test]
         public void CreatesSpecificNumberOfFills()
         {
             Security security;

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -336,7 +336,7 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreNotEqual(expected, actual);
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertQuoteBar()
         {
             // Wrap a QuoteBar around a PyObject and convert it back
@@ -349,7 +349,7 @@ namespace QuantConnect.Tests.Common.Util
             Assert.IsAssignableFrom<QuoteBar>(quoteBar);
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertSMA()
         {
             // Wrap a SimpleMovingAverage around a PyObject and convert it back
@@ -362,7 +362,7 @@ namespace QuantConnect.Tests.Common.Util
             Assert.IsAssignableFrom<SimpleMovingAverage>(indicatorBaseDataPoint);
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertATR()
         {
             // Wrap a AverageTrueRange around a PyObject and convert it back
@@ -375,7 +375,7 @@ namespace QuantConnect.Tests.Common.Util
             Assert.IsAssignableFrom<AverageTrueRange>(indicatorBaseDataBar);
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertAD()
         {
             // Wrap a AccumulationDistribution around a PyObject and convert it back
@@ -388,7 +388,7 @@ namespace QuantConnect.Tests.Common.Util
             Assert.IsAssignableFrom<AccumulationDistribution>(indicatorBaseTradeBar);
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertSymbolArray()
         {
             PyObject value;
@@ -405,7 +405,7 @@ namespace QuantConnect.Tests.Common.Util
             Assert.IsAssignableFrom<Symbol[]>(symbols);
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertFailCSharp()
         {
             // Try to convert a AccumulationDistribution as a QuoteBar
@@ -417,7 +417,7 @@ namespace QuantConnect.Tests.Common.Util
             Assert.IsNull(quoteBar);
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertFailPython()
         {
             using (Py.GIL())
@@ -434,7 +434,7 @@ namespace QuantConnect.Tests.Common.Util
             }
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         [TestCase("coarseSelector = lambda coarse: [ x.Symbol for x in coarse if x.Price % 2 == 0 ]")]
         [TestCase("def coarseSelector(coarse): return [ x.Symbol for x in coarse if x.Price % 2 == 0 ]")]
         public void PyObjectTryConvertToFunc(string code)
@@ -463,7 +463,7 @@ namespace QuantConnect.Tests.Common.Util
             }
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertToAction1()
         {
             Action<int> action;
@@ -487,7 +487,7 @@ namespace QuantConnect.Tests.Common.Util
             }
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertToAction2()
         {
             Action<int, decimal> action;
@@ -511,7 +511,7 @@ namespace QuantConnect.Tests.Common.Util
             }
         }
 
-        [Test, Category("TravisExclude")]
+        [Test]
         public void PyObjectTryConvertToNonDelegateFail()
         {
             int action;

--- a/Tests/Python/AlgorithmPythonWrapperTests.cs
+++ b/Tests/Python/AlgorithmPythonWrapperTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ using System.IO;
 
 namespace QuantConnect.Tests.Python
 {
-    [TestFixture, Ignore]
+    [TestFixture]
     public class AlgorithmPythonWrapperTests
     {
         private string _baseCode;

--- a/Tests/Python/MethodOverloadTests.cs
+++ b/Tests/Python/MethodOverloadTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +16,10 @@
 
 using NUnit.Framework;
 using Python.Runtime;
-using System;
-using System.IO;
 
 namespace QuantConnect.Tests.Python
 {
-    [TestFixture, Ignore]
+    [TestFixture]
     public class MethodOverloadTests
     {
         private dynamic _algorithm;
@@ -32,9 +30,6 @@ namespace QuantConnect.Tests.Python
         [SetUp]
         public void Setup()
         {
-            var pythonPath = new DirectoryInfo("RegressionAlgorithms");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-
             using (Py.GIL())
             {
                 var module = Py.Import("Test_MethodOverload");

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,7 @@ using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
 {
-    [TestFixture, Ignore]
+    [TestFixture]
     public class PandasConverterTests
     {
         [Test]
@@ -41,7 +41,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var converter = new PandasConverter();
             var rawBars = Enumerable.Empty<TradeBar>().ToArray();
 
-            // GetDataFrame with argument of type IEnumerable<TradeBar> 
+            // GetDataFrame with argument of type IEnumerable<TradeBar>
             dynamic dataFrame = converter.GetDataFrame(rawBars);
 
             using (Py.GIL())
@@ -49,7 +49,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 Assert.IsTrue(dataFrame.empty.AsManagedObject(typeof(bool)));
             }
 
-            // GetDataFrame with argument of type IEnumerable<TradeBar> 
+            // GetDataFrame with argument of type IEnumerable<TradeBar>
             var history = GetHistory(Symbols.SPY, Resolution.Minute, rawBars);
             dataFrame = converter.GetDataFrame(history);
 
@@ -70,7 +70,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 .Select(i => new TradeBar(DateTime.UtcNow.AddMinutes(i), symbol, i + 101m, i + 102m, i + 100m, i + 101m, 0m))
                 .ToArray();
 
-            // GetDataFrame with argument of type IEnumerable<TradeBar> 
+            // GetDataFrame with argument of type IEnumerable<TradeBar>
             dynamic dataFrame = converter.GetDataFrame(rawBars);
 
             using (Py.GIL())
@@ -91,7 +91,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 }
             }
 
-            // GetDataFrame with argument of type IEnumerable<TradeBar> 
+            // GetDataFrame with argument of type IEnumerable<TradeBar>
             var history = GetHistory(symbol, Resolution.Minute, rawBars);
             dataFrame = converter.GetDataFrame(history);
 
@@ -125,7 +125,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 .Select(i => new QuoteBar(DateTime.UtcNow.AddMinutes(i), symbol, new Bar(i + 1.01m, i + 1.02m, i + 1.00m, i + 1.01m), 0m, new Bar(i + 1.01m, i + 1.02m, i + 1.00m, i + 1.01m), 0m))
                 .ToArray();
 
-            // GetDataFrame with argument of type IEnumerable<QuoteBar> 
+            // GetDataFrame with argument of type IEnumerable<QuoteBar>
             dynamic dataFrame = converter.GetDataFrame(rawBars);
 
             using (Py.GIL())
@@ -146,7 +146,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 }
             }
 
-            // GetDataFrame with argument of type IEnumerable<QuoteBar> 
+            // GetDataFrame with argument of type IEnumerable<QuoteBar>
             var history = GetHistory(symbol, Resolution.Minute, rawBars);
             dataFrame = converter.GetDataFrame(history);
 
@@ -180,7 +180,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 .Select(i => new Tick(symbol, $"1440{i:D2}00,167{i:D2}00,1{i:D2},T,T,0", new DateTime(2013, 10, 7)))
                 .ToArray();
 
-            // GetDataFrame with argument of type IEnumerable<QuoteBar> 
+            // GetDataFrame with argument of type IEnumerable<QuoteBar>
             dynamic dataFrame = converter.GetDataFrame(rawBars);
 
             using (Py.GIL())
@@ -204,7 +204,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 }
             }
 
-            // GetDataFrame with argument of type IEnumerable<QuoteBar> 
+            // GetDataFrame with argument of type IEnumerable<QuoteBar>
             var history = GetHistory(symbol, Resolution.Tick, rawBars);
             dataFrame = converter.GetDataFrame(history);
 
@@ -241,7 +241,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 .Select(i => new Tick(DateTime.UtcNow.AddMilliseconds(100 * i), symbol, 0.99m, 1.01m))
                 .ToArray();
 
-            // GetDataFrame with argument of type IEnumerable<QuoteBar> 
+            // GetDataFrame with argument of type IEnumerable<QuoteBar>
             dynamic dataFrame = converter.GetDataFrame(rawBars);
 
             using (Py.GIL())
@@ -265,7 +265,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 }
             }
 
-            // GetDataFrame with argument of type IEnumerable<QuoteBar> 
+            // GetDataFrame with argument of type IEnumerable<QuoteBar>
             var history = GetHistory(symbol, Resolution.Tick, rawBars);
             dataFrame = converter.GetDataFrame(history);
 
@@ -361,7 +361,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 })
                 .ToArray();
 
-            // GetDataFrame with argument of type IEnumerable<BaseData> 
+            // GetDataFrame with argument of type IEnumerable<BaseData>
             dynamic dataFrame = converter.GetDataFrame(rawBars);
 
             using (Py.GIL())
@@ -386,7 +386,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 }
             }
 
-            // GetDataFrame with argument of type IEnumerable<BaseData> 
+            // GetDataFrame with argument of type IEnumerable<BaseData>
             var history = GetHistory(symbol, Resolution.Daily, rawBars);
             dataFrame = converter.GetDataFrame(history);
 
@@ -398,7 +398,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 Assert.IsFalse(subDataFrame.empty.AsManagedObject(typeof(bool)));
 
                 var count = subDataFrame.__len__().AsManagedObject(typeof(int));
-                Assert.AreEqual(count, 10);
+                Assert.AreEqual(10, count);
 
                 for (var i = 0; i < count; i++)
                 {
@@ -428,16 +428,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             // Act
             dynamic df = converter.GetDataFrame(data);
             // Assert
-            Assert.AreEqual(df.shape[0].AsManagedObject(typeof(int)), rowsInfile);
+            Assert.AreEqual(rowsInfile, df.shape[0].AsManagedObject(typeof(int)));
 
             int columnsNumber = df.shape[1].AsManagedObject(typeof(int));
             if (columnsNumber == 3 || columnsNumber == 6)
             {
-                Assert.AreEqual(df.get("lastprice").sum().AsManagedObject(typeof(double)), sumValue, 1e-4);
+                Assert.AreEqual(sumValue, df.get("lastprice").sum().AsManagedObject(typeof(double)), 1e-4);
             }
             else
             {
-                Assert.AreEqual(df.get("close").sum().AsManagedObject(typeof(double)), sumValue, 1e-4);
+                Assert.AreEqual(sumValue, df.get("close").sum().AsManagedObject(typeof(double)), 1e-4);
             }
         }
 
@@ -451,20 +451,20 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             // Act
             dynamic df = converter.GetDataFrame(data);
             // Assert
-            Assert.AreEqual(df.shape[0].AsManagedObject(typeof(int)), rowsInfile);
+            Assert.AreEqual(rowsInfile, df.shape[0].AsManagedObject(typeof(int)));
 
             int columnsNumber = df.shape[1].AsManagedObject(typeof(int));
             if (columnsNumber == 3 || columnsNumber == 6)
             {
-                Assert.AreEqual(df.get("lastprice").sum().AsManagedObject(typeof(double)), sumValue, 1e-4);
+                Assert.AreEqual(sumValue, df.get("lastprice").sum().AsManagedObject(typeof(double)), 1e-4);
             }
             else if (columnsNumber == 1)
             {
-                Assert.AreEqual(df.get("openinterest").sum().AsManagedObject(typeof(double)), sumValue, 1e-4);
+                Assert.AreEqual(sumValue, df.get("openinterest").sum().AsManagedObject(typeof(double)), 1e-4);
             }
             else
             {
-                Assert.AreEqual(df.get("close").sum().AsManagedObject(typeof(double)), sumValue, 1e-4);
+                Assert.AreEqual(sumValue, df.get("close").sum().AsManagedObject(typeof(double)), 1e-4);
             }
         }
 

--- a/Tests/PythonSetup.cs
+++ b/Tests/PythonSetup.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Tests
         {
             var pythonPath = string.Join(
                 OS.IsLinux ? ":" : ";",
-                "./Alphas", "./Execution", "./Portfolio", "./Risk", "./Selection");
+                "./Alphas", "./Execution", "./Portfolio", "./Risk", "./Selection", "./RegressionAlgorithms");
 
             Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath);
         }

--- a/Tests/ToolBox/LeanDataReaderTests.cs
+++ b/Tests/ToolBox/LeanDataReaderTests.cs
@@ -19,7 +19,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using NUnit.Framework;
-using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Securities;
@@ -27,7 +26,6 @@ using QuantConnect.ToolBox;
 using QuantConnect.Util;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Data.Consolidators;
-using QuantConnect.Data.Market;
 
 namespace QuantConnect.Tests.ToolBox
 {
@@ -224,7 +222,7 @@ namespace QuantConnect.Tests.ToolBox
         #endregion
 
 
-        [Test, TestCaseSource(nameof(OptionAndFuturesCases)), Category("TravisExclude")]
+        [Test, TestCaseSource(nameof(OptionAndFuturesCases))]
         public void ReadLeanFutureAndOptionDataFromFilePath(string composedFilePath, Symbol symbol,  int rowsInfile, double sumValue)
         {
             // Act
@@ -302,7 +300,7 @@ namespace QuantConnect.Tests.ToolBox
                                                 Resolution.Minute,
                                                 "20140606_aapl_minute_quote_american_put_7500000_20141018.csv"),
                 391,
-                44212.225
+                44210.7
             },
 
             new object[]
@@ -311,8 +309,8 @@ namespace QuantConnect.Tests.ToolBox
                 LeanData.ReadSymbolFromZipEntry(Symbol.Create("AAPL", SecurityType.Option, Market.USA),
                                                 Resolution.Minute,
                                                 "20140606_aapl_minute_trade_american_call_6475000_20140606.csv"),
-                377,
-                750.1
+                374,
+                745.35
             },
 
             new object[]
@@ -327,7 +325,7 @@ namespace QuantConnect.Tests.ToolBox
         };
 
 
-        [Test, TestCaseSource(nameof(SpotMarketCases)), Category("TravisExclude")]
+        [Test, TestCaseSource(nameof(SpotMarketCases))]
         public void ReadLeanSpotMarketsSecuritiesDataFromFilePath(string securityType, string market, string resolution, string ticker, string fileName, int rowsInfile, double sumValue)
         {
             // Arrange
@@ -342,26 +340,23 @@ namespace QuantConnect.Tests.ToolBox
             var data = ldr.Parse().ToArray();
             // Assert
             Assert.True(symbol.Equals(data.First().Symbol));
-            Assert.AreEqual(data.Length, rowsInfile);
-            Assert.AreEqual(data.Sum(c => c.Value), sumValue);
+            Assert.AreEqual(rowsInfile, data.Length);
+            Assert.AreEqual(sumValue, data.Sum(c => c.Value));
         }
 
         public static object[] SpotMarketCases =
         {
-            new object[] {"equity", "usa", "daily", "aig", "aig.zip", 4433, 267747.235},
+            new object[] {"equity", "usa", "daily", "aig", "aig.zip", 5157, 310723.935},
             new object[] {"equity", "usa", "minute", "aapl", "20140605_trade.zip", 658, 425068.8450},
             new object[] {"equity", "usa", "second", "ibm", "20131010_trade.zip", 4409, 809851.9580},
             new object[] {"equity", "usa", "tick", "bac", "20131011_trade.zip", 112230, 1592319.5871},
             new object[] {"forex", "fxcm", "minute", "eurusd", "20140502_quote.zip", 958, 1327.638085},
             new object[] {"forex", "fxcm", "second", "nzdusd", "20140514_quote.zip", 25895, 22432.757185},
-            new object[] {"forex", "fxcm", "tick", "eurusd", "20140507_quote.zip", 89826, 125073.092245},
-            new object[] {"cfd", "oanda", "hour", "xauusd", "xauusd.zip", 69081, 80935843.1265},
+            new object[] {"forex", "fxcm", "tick", "eurusd", "20140507_quote.zip", 89504, 124613.655665},
+            new object[] {"cfd", "oanda", "hour", "xauusd", "xauusd.zip", 74920, 88476989.559 },
             new object[] {"crypto", "gdax", "second", "btcusd", "20161008_trade.zip", 3453, 2137057.57},
-            new object[] {"crypto", "gdax", "second", "btcusd", "20161009_quote.zip", 1438, 889045.065},
             new object[] {"crypto", "gdax", "minute", "ethusd", "20170903_trade.zip", 1440, 510470.66},
-            new object[] {"crypto", "gdax", "minute", "btcusd", "20161007_quote.zip", 1438, 884448.535},
-            new object[] {"crypto", "gdax", "daily", "btcusd", "btcusd_trade.zip", 1025, 1020535.83},
-            new object[] {"crypto", "gdax", "daily", "btcusd", "btcusd_quote.zip", 788, 954122.585}
+            new object[] {"crypto", "gdax", "daily", "btcusd", "btcusd_trade.zip", 1276, 3429172.98},
         };
 
         public static string GenerateFilepathForTesting(string dataDirectory, string securityType, string market, string resolution, string ticker,


### PR DESCRIPTION
#### Description
Python unit tests previously excluded from Travis build are now enabled.

> Note: Requires merging PR #2343 first

#### Related Issue
Closes #2361 

#### Motivation and Context
A few Python unit tests are currently ignored with the `[TravisExclude]` attribute.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`