### PR TITLE
Fixes NoMethodMatchPythonExceptionInterpreterTests

### DIFF
--- a/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Tests.Common.Exceptions
 
                 try
                 {
-                    // self.AddCash('SPY')
+                    // self.SetCash('SPY')
                     algorithm.no_method_match();
                 }
                 catch (PythonException pythonException)
@@ -56,7 +56,7 @@ namespace QuantConnect.Tests.Common.Exceptions
         [TestCase(typeof(KeyNotFoundException), ExpectedResult = false)]
         [TestCase(typeof(DivideByZeroException), ExpectedResult = false)]
         [TestCase(typeof(InvalidOperationException), ExpectedResult = false)]
-        [TestCase(typeof(PythonException), ExpectedResult = false)]
+        [TestCase(typeof(PythonException), ExpectedResult = true)]
         public bool CanInterpretReturnsTrueForOnlyNoMethodMatchPythonExceptionType(Type exceptionType)
         {
             var exception = CreateExceptionFromType(exceptionType);
@@ -84,7 +84,7 @@ namespace QuantConnect.Tests.Common.Exceptions
             var assembly = typeof(PythonExceptionInterpreter).Assembly;
             var interpreter = StackExceptionInterpreter.CreateFromAssemblies(new[] { assembly });
             exception = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
-            Assert.True(exception.Message.Contains("self.AddCash(\\'SPY\\')"));
+            Assert.True(exception.Message.Contains("self.SetCash(\\'SPY\\')"));
         }
 
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);

--- a/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
@@ -23,7 +23,7 @@ using System.IO;
 
 namespace QuantConnect.Tests.Common.Exceptions
 {
-    [TestFixture, Ignore]
+    [TestFixture, Category("TravisExclude")]
     public class NoMethodMatchPythonExceptionInterpreterTests
     {
         private PythonException _pythonException;
@@ -41,7 +41,7 @@ namespace QuantConnect.Tests.Common.Exceptions
 
                 try
                 {
-                    // self.Log(1)
+                    // self.AddCash('SPY')
                     algorithm.no_method_match();
                 }
                 catch (PythonException pythonException)
@@ -56,7 +56,7 @@ namespace QuantConnect.Tests.Common.Exceptions
         [TestCase(typeof(KeyNotFoundException), ExpectedResult = false)]
         [TestCase(typeof(DivideByZeroException), ExpectedResult = false)]
         [TestCase(typeof(InvalidOperationException), ExpectedResult = false)]
-        [TestCase(typeof(PythonException), ExpectedResult = true)]
+        [TestCase(typeof(PythonException), ExpectedResult = false)]
         public bool CanInterpretReturnsTrueForOnlyNoMethodMatchPythonExceptionType(Type exceptionType)
         {
             var exception = CreateExceptionFromType(exceptionType);
@@ -84,7 +84,7 @@ namespace QuantConnect.Tests.Common.Exceptions
             var assembly = typeof(PythonExceptionInterpreter).Assembly;
             var interpreter = StackExceptionInterpreter.CreateFromAssemblies(new[] { assembly });
             exception = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
-            Assert.True(exception.Message.Contains("self.Log(1)"));
+            Assert.True(exception.Message.Contains("self.AddCash(\\'SPY\\')"));
         }
 
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -28,7 +28,7 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
         x = dict()['SPY']
 
     def no_method_match(self):
-        self.AddCash('SPY')
+        self.SetCash('SPY')
 
     def unsupported_operand(self):
         x = decimal.Decimal(1) * 1.1

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -28,7 +28,7 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
         x = dict()['SPY']
 
     def no_method_match(self):
-        self.Log(1)
+        self.AddCash('SPY')
 
     def unsupported_operand(self):
         x = decimal.Decimal(1) * 1.1


### PR DESCRIPTION
#### Description
Changes the method call that should fail to `AddCash(String)`.

#### Related Issue
Closes #2366 

#### Motivation and Context
Change unit test when API change.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Running this unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`