### PR TITLE
Sets PYTHONPATH in CommonAlphaModelTests TestFixtureSetup

### DIFF
--- a/Algorithm.Framework/Alphas/RsiAlphaModel.py
+++ b/Algorithm.Framework/Alphas/RsiAlphaModel.py
@@ -86,16 +86,14 @@ class RsiAlphaModel(AlphaModel):
         if len(addedSymbols) == 0: return
 
         history = algorithm.History(addedSymbols, self.period, self.resolution)
-        if history.empty: return
 
-        tickers = history.index.levels[0]
-        for ticker in tickers:
-
-            symbol = SymbolCache.GetSymbol(ticker)
+        for symbol in addedSymbols:
             rsi = algorithm.RSI(symbol, self.period, MovingAverageType.Wilders, self.resolution)
 
-            for tuple in history.loc[ticker].itertuples():
-                rsi.Update(tuple.Index, tuple.close)
+            if not history.empty:
+                ticker = SymbolCache.GetTicker(symbol)
+                for tuple in history.loc[ticker].itertuples():
+                    rsi.Update(tuple.Index, tuple.close)
 
             self.symbolDataBySymbol[symbol] = SymbolData(symbol, rsi)
 

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Util;
+using System.IO;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 {
@@ -41,6 +42,9 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         [TestFixtureSetUp]
         public void Initialize()
         {
+            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Alphas");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+
             _algorithm = new QCAlgorithmFramework();
             _algorithm.PortfolioConstruction = new NullPortfolioConstructionModel();
             _algorithm.HistoryProvider = new SineHistoryProvider(_algorithm.Securities);

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -28,7 +28,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Util;
-using System.IO;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 {
@@ -42,9 +41,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         [TestFixtureSetUp]
         public void Initialize()
         {
-            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Alphas");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-
             _algorithm = new QCAlgorithmFramework();
             _algorithm.PortfolioConstruction = new NullPortfolioConstructionModel();
             _algorithm.HistoryProvider = new SineHistoryProvider(_algorithm.Securities);


### PR DESCRIPTION
#### Description
Sets PYTHONPATH in `CommonAlphaModelTests` `TestFixtureSetup`.
- When the PYTHONPATH is explicitly set to include the location of the modules, python easily find and load them.

Fixing this issue also exposed a bug in `RsiAlphaModel`.
- The model was assuming that we could only add elements to the dictionary field if there was data in the history request which is not required.

#### Related Issue
Closes #2374 

#### Motivation and Context
Improve unit tests.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`