### PR TITLE
Fix infinite loop at ExchangeRoundDownInTimeZone

### DIFF
--- a/Tests/Common/TimeZoneOffsetProviderTests.cs
+++ b/Tests/Common/TimeZoneOffsetProviderTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,6 +49,32 @@ namespace QuantConnect.Tests.Common
             var offsetProvider = new TimeZoneOffsetProvider(TimeZones.NewYork, utcDate, utcDate.AddDays(1));
             var currentOffset = offsetProvider.GetOffsetTicks(utcDate);
             Assert.AreEqual(-TimeSpan.FromHours(4).TotalHours, TimeSpan.FromTicks(currentOffset).TotalHours);
+        }
+
+        [Test]
+        public void ConvertFromUtcAfterDST()
+        {
+            // the exact instant DST goes into affect
+            var tzDate = new DateTime(2015, 03, 08, 2, 0, 0);
+            var utcDate = tzDate.AddHours(5);
+            var offsetProvider = new TimeZoneOffsetProvider(TimeZones.NewYork, utcDate, utcDate.AddDays(1));
+            var result = offsetProvider.ConvertFromUtc(utcDate);
+
+            // We add an hour due to the effect of DST
+            Assert.AreEqual(tzDate + TimeSpan.FromHours(1), result);
+        }
+
+        [Test]
+        public void ConvertToUtcAfterDST()
+        {
+            // the exact instant DST goes into affect
+            var tzDate = new DateTime(2015, 03, 08, 2, 0, 0);
+            var utcDate = tzDate.AddHours(5);
+            var offsetProvider = new TimeZoneOffsetProvider(TimeZones.NewYork, utcDate, utcDate.AddDays(1));
+            var result = offsetProvider.ConvertToUtc(tzDate);
+
+            // We substract an hour due to the effect of DST
+            Assert.AreEqual(utcDate - TimeSpan.FromHours(1), result);
         }
     }
 }

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -89,6 +89,31 @@ namespace QuantConnect.Tests.Common.Util
         }
 
         [Test]
+        public void ConvertToSkipsDiscontinuitiesBecauseOfDaylightSavingsStart_AddingOneHour()
+        {
+            var expected = new DateTime(2014, 3, 9, 3, 0, 0);
+            var time = new DateTime(2014, 3, 9, 2, 0, 0).ConvertTo(TimeZones.NewYork, TimeZones.NewYork);
+            var time2 = new DateTime(2014, 3, 9, 2, 0, 1).ConvertTo(TimeZones.NewYork, TimeZones.NewYork);
+            Assert.AreEqual(expected, time);
+            Assert.AreEqual(expected, time2);
+        }
+
+        [Test]
+        public void ConvertToIgnoreDaylightSavingsEnd_SubtractingOneHour()
+        {
+            var time1Expected = new DateTime(2014, 11, 2, 1, 59, 59);
+            var time2Expected = new DateTime(2014, 11, 2, 2, 0, 0);
+            var time3Expected = new DateTime(2014, 11, 2, 2, 0, 1);
+            var time1 = time1Expected.ConvertTo(TimeZones.NewYork, TimeZones.NewYork);
+            var time2 = time2Expected.ConvertTo(TimeZones.NewYork, TimeZones.NewYork);
+            var time3 = time3Expected.ConvertTo(TimeZones.NewYork, TimeZones.NewYork);
+
+            Assert.AreEqual(time1Expected, time1);
+            Assert.AreEqual(time2Expected, time2);
+            Assert.AreEqual(time3Expected, time3);
+        }
+
+        [Test]
         public void ExchangeRoundDownInTimeZoneSkipsWeekends()
         {
             // moment before EST market open in UTC (time + one day)
@@ -97,6 +122,174 @@ namespace QuantConnect.Tests.Common.Util
             var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, null, SecurityType.Equity);
             var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneDay, hours, TimeZones.Utc, false);
             Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        // This unit test reproduces a fixed infinite loop situation, due to a daylight saving time change, in ExchangeRoundDownInTimeZone, GH issue 2368.
+        public void ExchangeRoundDownInTimeZoneCorrectValuesAroundDaylightTimeChanges_AddingOneHour_UTC()
+        {
+            var time = new DateTime(2014, 3, 9, 16, 0, 1);
+            var expected = new DateTime(2014, 3, 7, 16, 0, 0);
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.Oanda, null, SecurityType.Forex);
+            var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneHour, hours, TimeZones.Utc, false);
+            Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        // This unit test reproduces a fixed infinite loop situation, due to a daylight saving time change, in ExchangeRoundDownInTimeZone, GH issue 2368.
+        public void ExchangeRoundDownInTimeZoneCorrectValuesAroundDaylightTimeChanges_SubtractingOneHour_UTC()
+        {
+            var time = new DateTime(2014, 11, 2, 2, 0, 1);
+            var expected = new DateTime(2014, 10, 31, 16, 0, 0);
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.Oanda, null, SecurityType.Forex);
+            var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneHour, hours, TimeZones.Utc, false);
+            Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        public void ExchangeRoundDownInTimeZoneCorrectValuesAroundDaylightTimeChanges_AddingOneHour_ExtendedHours_UTC()
+        {
+            var time = new DateTime(2014, 3, 9, 2, 0, 1);
+            var expected = new DateTime(2014, 3, 9, 2, 0, 0);
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.GDAX, null, SecurityType.Crypto);
+            var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneHour, hours, TimeZones.Utc, true);
+            Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        public void ExchangeRoundDownInTimeZoneCorrectValuesAroundDaylightTimeChanges_SubtractingOneHour_ExtendedHours_UTC()
+        {
+            var time = new DateTime(2014, 11, 2, 2, 0, 1);
+            var expected = new DateTime(2014, 11, 2, 2, 0, 0);
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.GDAX, null, SecurityType.Crypto);
+            var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneHour, hours, TimeZones.Utc, true);
+            Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        public void RoundDownInTimeZoneReturnsCorrectValuesAroundDaylightTimeChanges_AddingOneHour_UTC()
+        {
+            var timeAt = new DateTime(2014, 3, 9, 2, 0, 0);
+            var timeAfter = new DateTime(2014, 3, 9, 2, 0, 1);
+            var timeBefore = new DateTime(2014, 3, 9, 1, 59, 59);
+            var timeAfterDaylightTimeChanges = new DateTime(2014, 3, 9, 3, 0, 0);
+
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.Oanda, null, SecurityType.Forex);
+
+            var exchangeRoundedAt = timeAt.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.Utc);
+            var exchangeRoundedAfter = timeAfter.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.Utc);
+            var exchangeRoundedBefore = timeBefore.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.Utc);
+            var exchangeRoundedAfterDaylightTimeChanges = timeAfterDaylightTimeChanges.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.Utc);
+
+            var expected = new DateTime(2014, 3, 9, 3, 0, 0);
+            Assert.AreEqual(expected, exchangeRoundedAt);
+            Assert.AreEqual(expected, exchangeRoundedAfter);
+            Assert.AreEqual(timeBefore, exchangeRoundedBefore);
+            Assert.AreEqual(expected, exchangeRoundedAfterDaylightTimeChanges);
+        }
+
+        [Test]
+        public void RoundDownInTimeZoneReturnsCorrectValuesAroundDaylightTimeChanges_SubtractingOneHour_UTC()
+        {
+            var timeAt = new DateTime(2014, 11, 2, 2, 0, 0);
+            var timeAfter = new DateTime(2014, 11, 2, 2, 0, 1);
+            var timeBefore = new DateTime(2014, 11, 2, 1, 59, 59);
+            var timeAfterDaylightTimeChanges = new DateTime(2014, 11, 2, 3, 0, 0);
+
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.Oanda, null, SecurityType.Forex);
+
+            var exchangeRoundedAt = timeAt.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.Utc);
+            var exchangeRoundedAfter = timeAfter.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.Utc);
+            var exchangeRoundedBefore = timeBefore.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.Utc);
+            var exchangeRoundedAfterDaylightTimeChanges = timeAfterDaylightTimeChanges.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.Utc);
+
+            Assert.AreEqual(timeAt, exchangeRoundedAt);
+            Assert.AreEqual(timeAfter, exchangeRoundedAfter);
+            Assert.AreEqual(timeBefore, exchangeRoundedBefore);
+            Assert.AreEqual(timeAfterDaylightTimeChanges, exchangeRoundedAfterDaylightTimeChanges);
+        }
+
+        [Test]
+        public void ExchangeRoundDownInTimeZoneCorrectValuesAroundDaylightTimeChanges_AddingOneHour_NewYork()
+        {
+            var time = new DateTime(2014, 3, 9, 16, 0, 1);
+            var expected = new DateTime(2014, 3, 7, 16, 0, 0);
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.Oanda, null, SecurityType.Forex);
+            var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneHour, hours, TimeZones.NewYork, false);
+            Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        public void ExchangeRoundDownInTimeZoneCorrectValuesAroundDaylightTimeChanges_SubtractingOneHour_NewYork()
+        {
+            var time = new DateTime(2014, 11, 2, 2, 0, 1);
+            var expected = new DateTime(2014, 10, 31, 16, 0, 0);
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.Oanda, null, SecurityType.Forex);
+            var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneHour, hours, TimeZones.NewYork, false);
+            Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        public void ExchangeRoundDownInTimeZoneCorrectValuesAroundDaylightTimeChanges_AddingOneHour_ExtendedHours_NewYork()
+        {
+            var time = new DateTime(2014, 3, 9, 2, 0, 1);
+            var expected = new DateTime(2014, 3, 9, 2, 0, 0);
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.GDAX, null, SecurityType.Crypto);
+            var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneHour, hours, TimeZones.NewYork, true);
+            Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        public void ExchangeRoundDownInTimeZoneCorrectValuesAroundDaylightTimeChanges_SubtractingOneHour_ExtendedHours_NewYork()
+        {
+            var time = new DateTime(2014, 11, 2, 2, 0, 1);
+            var expected = new DateTime(2014, 11, 2, 2, 0, 0);
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.GDAX, null, SecurityType.Crypto);
+            var exchangeRounded = time.ExchangeRoundDownInTimeZone(Time.OneHour, hours, TimeZones.NewYork, true);
+            Assert.AreEqual(expected, exchangeRounded);
+        }
+
+        [Test]
+        public void RoundDownInTimeZoneReturnsCorrectValuesAroundDaylightTimeChanges_AddingOneHour_NewYork()
+        {
+            var timeAt = new DateTime(2014, 3, 9, 2, 0, 0);
+            var timeAfter = new DateTime(2014, 3, 9, 2, 0, 1);
+            var timeBefore = new DateTime(2014, 3, 9, 1, 59, 59);
+            var timeAfterDaylightTimeChanges = new DateTime(2014, 3, 9, 3, 0, 0);
+
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.Oanda, null, SecurityType.Forex);
+
+            var exchangeRoundedAt = timeAt.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.NewYork);
+            var exchangeRoundedAfter = timeAfter.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.NewYork);
+            var exchangeRoundedBefore = timeBefore.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.NewYork);
+            var exchangeRoundedAfterDaylightTimeChanges = timeAfterDaylightTimeChanges.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.NewYork);
+
+            var expected = new DateTime(2014, 3, 9, 3, 0, 0);
+            Assert.AreEqual(expected, exchangeRoundedAt);
+            Assert.AreEqual(expected, exchangeRoundedAfter);
+            Assert.AreEqual(timeBefore, exchangeRoundedBefore);
+            Assert.AreEqual(expected, exchangeRoundedAfterDaylightTimeChanges);
+        }
+
+        [Test]
+        public void RoundDownInTimeZoneReturnsCorrectValuesAroundDaylightTimeChanges_SubtractingOneHour_NewYork()
+        {
+            var timeAt = new DateTime(2014, 11, 2, 2, 0, 0);
+            var timeAfter = new DateTime(2014, 11, 2, 2, 0, 1);
+            var timeBefore = new DateTime(2014, 11, 2, 1, 59, 59);
+            var timeAfterDaylightTimeChanges = new DateTime(2014, 11, 2, 3, 0, 0);
+
+            var hours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.Oanda, null, SecurityType.Forex);
+
+            var exchangeRoundedAt = timeAt.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.NewYork);
+            var exchangeRoundedAfter = timeAfter.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.NewYork);
+            var exchangeRoundedBefore = timeBefore.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.NewYork);
+            var exchangeRoundedAfterDaylightTimeChanges = timeAfterDaylightTimeChanges.RoundDownInTimeZone(Time.OneSecond, hours.TimeZone, TimeZones.NewYork);
+
+            Assert.AreEqual(timeAt, exchangeRoundedAt);
+            Assert.AreEqual(timeAfter, exchangeRoundedAfter);
+            Assert.AreEqual(timeBefore, exchangeRoundedBefore);
+            Assert.AreEqual(timeAfterDaylightTimeChanges, exchangeRoundedAfterDaylightTimeChanges);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix an infite loop situation at `ExchangeRoundDownInTimeZone` due to Time savings changes
    - Adding unit tests that reproduced the issue
- `ConvertTo()` will now always perform conversion even if both time zones are equals. This helps solves any discontinuity in that TZ.
    - Adding unit tests
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2368
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Nobody likes an infinite loop situation 
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->