### PR TITLE
Delay first packet upload in BacktestingResultHandler

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -192,6 +192,9 @@ namespace QuantConnect.Lean.Engine.Results
             //Set the start time for the algorithm
             _startTime = DateTime.Now;
 
+            // Delay uploading first packet
+            _nextS3Update = _startTime.AddSeconds(30);
+
             //Default charts:
             Charts.AddOrUpdate("Strategy Equity", new Chart("Strategy Equity"));
             Charts["Strategy Equity"].Series.Add("Equity", new Series("Equity", SeriesType.Candle, 0, "$"));


### PR DESCRIPTION

#### Description
This PR introduces a 30-second delay for backtest packet uploads in the `BacktestingResultHandler`.

#### Related Issue
n/a

#### Motivation and Context
This prevents an empty backtest result packet from being uploaded at the start of the backtest, which was also causing some intermittent failures in cloud regression test runs. 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
The complete cloud regression test suite was run successfully.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
