### PR TITLE
PortfolioTarget.Percent returns null if error

### DIFF
--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
@@ -155,7 +155,13 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 foreach (var symbol in symbols)
                 {
                     var weight = (decimal)W[sidx];
-                    targets.Add(PortfolioTarget.Percent(algorithm, symbol, weight));
+
+                    var target = PortfolioTarget.Percent(algorithm, symbol, weight);
+                    if (target != null)
+                    {
+                        targets.Add(target);
+                    }
+
                     sidx++;
                 }
             }

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -87,7 +87,11 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
             foreach (var insight in lastActiveInsights)
             {
-                targets.Add(PortfolioTarget.Percent(algorithm, insight.Symbol, (int)insight.Direction * percent));
+                var target = PortfolioTarget.Percent(algorithm, insight.Symbol, (int) insight.Direction * percent);
+                if (target != null)
+                {
+                    targets.Add(target);
+                }
             }
 
             // Get expired insights and create flatten targets for each symbol

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
             if (algorithm.UtcTime <= _nextExpiryTime &&
                 algorithm.UtcTime <= _rebalancingTime &&
-                insights.Length == 0 && 
+                insights.Length == 0 &&
                 _removedSymbols == null)
             {
                 return targets;
@@ -86,7 +86,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
             var errorSymbols = new HashSet<Symbol>();
 
-            foreach (var insight in activeInsights)
+            foreach (var insight in lastActiveInsights)
             {
                 var target = PortfolioTarget.Percent(algorithm, insight.Symbol, (int) insight.Direction * percent);
                 if (target != null)

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
@@ -75,7 +75,7 @@ class EqualWeightingPortfolioConstructionModel(PortfolioConstructionModel):
         percent = 0 if count == 0 else 1.0 / count
 
         errorSymbols = {}
-        for insight in activeInsights:
+        for insight in lastActiveInsights:
             target = PortfolioTarget.Percent(algorithm, insight.Symbol, insight.Direction * percent)
             if not target is None:
                 targets.append(target)
@@ -94,7 +94,7 @@ class EqualWeightingPortfolioConstructionModel(PortfolioConstructionModel):
         targets.extend(expiredTargets)
 
         self.nextExpiryTime = self.insightCollection.GetNextExpiryTime()
-        if self.nextExpiryTime is None: 
+        if self.nextExpiryTime is None:
             self.nextExpiryTime = UTCMIN
 
         self.rebalancingTime = algorithm.UtcTime + self.rebalancingPeriod

--- a/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.cs
@@ -127,7 +127,13 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 foreach (var symbol in symbols)
                 {
                     var weight = (decimal)W[sidx];
-                    targets.Add(PortfolioTarget.Percent(algorithm, symbol, weight));
+
+                    var target = PortfolioTarget.Percent(algorithm, symbol, weight);
+                    if (target != null)
+                    {
+                        targets.Add(target);
+                    }
+
                     sidx++;
                 }
             }

--- a/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
@@ -30,10 +30,10 @@ import pandas as pd
 
 ### <summary>
 ### Provides an implementation of Mean-Variance portfolio optimization based on modern portfolio theory.
-### The default model uses the MinimumVariancePortfolioOptimizer that accepts a 63-row matrix of 1-day returns. 
+### The default model uses the MinimumVariancePortfolioOptimizer that accepts a 63-row matrix of 1-day returns.
 ### </summary>
 class MeanVarianceOptimizationPortfolioConstructionModel(PortfolioConstructionModel):
-    def __init__(self, 
+    def __init__(self,
                  lookback = 1,
                  period = 63,
                  resolution = Resolution.Daily,
@@ -53,12 +53,12 @@ class MeanVarianceOptimizationPortfolioConstructionModel(PortfolioConstructionMo
         self.pendingRemoval = []
 
     def CreateTargets(self, algorithm, insights):
-        """ 
+        """
         Create portfolio targets from the specified insights
         Args:
             algorithm: The algorithm instance
             insights: The insights to create portoflio targets from
-        Returns: 
+        Returns:
             An enumerable of portoflio targets to be sent to the execution model
         """
         targets = []
@@ -81,14 +81,16 @@ class MeanVarianceOptimizationPortfolioConstructionModel(PortfolioConstructionMo
         returns = { str(symbol) : data.Return for symbol, data in self.symbolDataBySymbol.items() if symbol in symbols }
         returns = pd.DataFrame(returns)
 
-        # The portfolio optimizer finds the optional weights for the given data 
+        # The portfolio optimizer finds the optional weights for the given data
         weights = self.optimizer.Optimize(returns)
         weights = pd.Series(weights, index = returns.columns)
 
         # Create portfolio targets from the specified insights
         for insight in insights:
             weight = weights[str(insight.Symbol)]
-            targets.append(PortfolioTarget.Percent(algorithm, insight.Symbol, weight))
+            target = PortfolioTarget.Percent(algorithm, insight.Symbol, weight)
+            if target is not None:
+                targets.append(target)
 
         return targets
 

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
@@ -68,14 +68,14 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             var security = algorithm.Securities[symbol];
             if (security.Price == 0)
             {
-                return new PortfolioTarget(symbol, 0);
+                return null;
             }
 
             var result = security.BuyingPowerModel.GetMaximumOrderQuantityForTargetValue(algorithm.Portfolio, security, percent);
             if (result.IsError)
             {
-                algorithm.Log($"Unable to compute order quantity of {symbol}. Quantity set to zero. Reason: {result.Reason}");
-                return new PortfolioTarget(symbol, 0);
+                algorithm.Log($"Unable to compute order quantity of {symbol}. Quantity set to existing holdings. Reason: {result.Reason}");
+                return null;
             }
 
             // be sure to back out existing holdings quantity since the buying power model yields

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             var result = security.BuyingPowerModel.GetMaximumOrderQuantityForTargetValue(algorithm.Portfolio, security, percent);
             if (result.IsError)
             {
-                algorithm.Log($"Unable to compute order quantity of {symbol}. Quantity set to existing holdings. Reason: {result.Reason}");
+                algorithm.Log($"Unable to compute order quantity of {symbol}. Reason: {result.Reason}. Returning null.");
                 return null;
             }
 

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -137,7 +137,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python, InsightDirection.Flat)]
         public void AutomaticallyRemoveInvestedWithNewInsights(Language language, InsightDirection direction)
         {
-            SetPortfolioConstruction(language);
+            SetPortfolioConstruction(language, _algorithm);
 
             // Let's create a position for SPY
             var insights = new[] { GetInsight(Symbols.SPY, direction, _algorithm.UtcTime) };
@@ -174,7 +174,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python)]
         public void AutomaticallyRemoveInvestedWithoutNewInsights(Language language)
         {
-            SetPortfolioConstruction(language);
+            SetPortfolioConstruction(language, _algorithm);
 
             // Let's create a position for SPY
             var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, _algorithm.UtcTime) };
@@ -201,9 +201,9 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python)]
         public void LongTermInsightPreservesPosition(Language language)
         {
-            SetPortfolioConstruction(language);
+            SetPortfolioConstruction(language, _algorithm);
 
-            // First emit long term insight 
+            // First emit long term insight
             var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
             var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
             Assert.AreEqual(1, targets.Count);
@@ -230,7 +230,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python)]
         public void DelistedSecurityEmitsFlatTargetWithoutNewInsights(Language language)
         {
-            SetPortfolioConstruction(language);
+            SetPortfolioConstruction(language, _algorithm);
 
             var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
             var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
@@ -305,6 +305,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         {
             var algorithm = new QCAlgorithmFramework();
             algorithm.AddEquity(Symbols.SPY.Value);
+            algorithm.SetDateTime(DateTime.MinValue.ConvertToUtc(_algorithm.TimeZone));
 
             SetPortfolioConstruction(language, algorithm);
 

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -62,7 +62,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python)]
         public void EmptyInsightsReturnsEmptyTargets(Language language)
         {
-            SetPortfolioConstruction(language);
+            SetPortfolioConstruction(language, _algorithm);
 
             var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
 
@@ -78,7 +78,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python, InsightDirection.Flat)]
         public void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction)
         {
-            SetPortfolioConstruction(language);
+            SetPortfolioConstruction(language, _algorithm);
 
             // Equity will be divided by all securities
             var amount = _algorithm.Portfolio.TotalPortfolioValue / _algorithm.Securities.Count;
@@ -99,7 +99,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python, InsightDirection.Flat)]
         public void FlatDirectionNotAccountedToAllocation(Language language, InsightDirection direction)
         {
-            SetPortfolioConstruction(language);
+            SetPortfolioConstruction(language, _algorithm);
 
             // Modifying fee model for a constant one so numbers are simplified
             foreach (var security in _algorithm.Securities)
@@ -256,7 +256,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python, InsightDirection.Flat)]
         public void DelistedSecurityEmitsFlatTargetWithNewInsights(Language language, InsightDirection direction)
         {
-            SetPortfolioConstruction(language);
+            SetPortfolioConstruction(language, _algorithm);
 
             var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
             var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
@@ -298,6 +298,23 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             }
         }
 
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void DoesNotReturnTargetsIfSecurityPriceIsZero(Language language)
+        {
+            var algorithm = new QCAlgorithmFramework();
+            algorithm.AddEquity(Symbols.SPY.Value);
+
+            SetPortfolioConstruction(language, algorithm);
+
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, algorithm.UtcTime) };
+            var actualTargets = algorithm.PortfolioConstruction.CreateTargets(algorithm, insights);
+
+            Assert.AreEqual(0, actualTargets.Count());
+        }
+
+
         private Security GetSecurity(Symbol symbol)
         {
             var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);
@@ -313,9 +330,9 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             return insight;
         }
 
-        private void SetPortfolioConstruction(Language language)
+        private void SetPortfolioConstruction(Language language, QCAlgorithmFramework algorithm)
         {
-            _algorithm.SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            algorithm.SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
             if (language == Language.Python)
             {
                 using (Py.GIL())
@@ -323,7 +340,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                     var name = nameof(EqualWeightingPortfolioConstructionModel);
                     var instance = Py.Import(name).GetAttr(name).Invoke();
                     var model = new PortfolioConstructionModelPythonWrapper(instance);
-                    _algorithm.SetPortfolioConstruction(model);
+                    algorithm.SetPortfolioConstruction(model);
                 }
             }
 
@@ -335,7 +352,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             SetUtcTime(new DateTime(2018, 7, 31));
 
             var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
-            _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+            algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
         }
 
         private void SetUtcTime(DateTime dateTime)

--- a/Tests/Algorithm/Framework/QCAlgorithmFrameworkTests.cs
+++ b/Tests/Algorithm/Framework/QCAlgorithmFrameworkTests.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
                 Assert.IsTrue(insights.All(insight => insight.GeneratedTimeUtc != default(DateTime)));
                 Assert.IsTrue(insights.All(insight => insight.CloseTimeUtc != default(DateTime)));
             };
-            algo.AddEquity("SPY");
+            var security = algo.AddEquity("SPY");
             algo.SetUniverseSelection(new ManualUniverseSelectionModel(algo.Securities.Keys));
 
             var alpha = new FakeAlpha();
@@ -53,12 +53,15 @@ namespace QuantConnect.Tests.Algorithm.Framework
             var construction = new FakePortfolioConstruction();
             algo.SetPortfolioConstruction(construction);
 
-            algo.OnFrameworkData(new Slice(new DateTime(2000, 01, 01), algo.Securities.Select(s => new Tick
+            var tick = new Tick
             {
-                Symbol = s.Key,
+                Symbol = security.Symbol,
                 Value = 1,
                 Quantity = 2
-            })));
+            };
+            security.SetMarketPrice(tick);
+
+            algo.OnFrameworkData(new Slice(new DateTime(2000, 01, 01), algo.Securities.Select(s => tick)));
 
             Assert.IsTrue(eventFired);
             Assert.AreEqual(1, construction.Insights.Count);


### PR DESCRIPTION
#### Description
`PortfolioTarget.Percent` has been updated to return `null` instead of a target with zero quantity, if an error occurs.

#### Related Issue
Closes #2384

#### Motivation and Context
An error would cause existing positions to be closed.

#### Requires Documentation Change
Yes, new behavior.

#### How Has This Been Tested?
Unit tests included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`