### PR TITLE
Add Insight.IsActive and Insight.IsExpired methods

### DIFF
--- a/Common/Algorithm/Framework/Alphas/Insight.cs
+++ b/Common/Algorithm/Framework/Alphas/Insight.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using QuantConnect.Algorithm.Framework.Alphas.Serialization;
+using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Algorithm.Framework.Alphas
@@ -109,6 +110,26 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// Gets the estimated value of this insight in the account currency
         /// </summary>
         public decimal EstimatedValue { get; internal set; }
+
+        /// <summary>
+        /// Determines whether or not this insight is considered expired at the specified <paramref name="utcTime"/>
+        /// </summary>
+        /// <param name="utcTime">The algorithm's current time in UTC. See <see cref="IAlgorithm.UtcTime"/></param>
+        /// <returns>True if this insight is expired, false otherwise</returns>
+        public bool IsExpired(DateTime utcTime)
+        {
+            return CloseTimeUtc < utcTime;
+        }
+
+        /// <summary>
+        /// Determines whether or not this insight is considered active at the specified <paramref name="utcTime"/>
+        /// </summary>
+        /// <param name="utcTime">The algorithm's current time in UTC. See <see cref="IAlgorithm.UtcTime"/></param>
+        /// <returns>True if this insight is active, false otherwise</returns>
+        public bool IsActive(DateTime utcTime)
+        {
+            return !IsExpired(utcTime);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Insight"/> class

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -335,5 +335,29 @@ namespace QuantConnect.Tests.Algorithm.Framework
             Assert.That(() => insight.SetPeriodAndCloseTime(exchangeHours),
                 Throws.Nothing);
         }
+
+        [Test]
+        public void IsExpiredUsesOpenIntervalSemantics()
+        {
+            var generatedTime = new DateTime(2000, 01, 01);
+            var insight = Insight.Price(Symbols.SPY, Time.OneMinute, InsightDirection.Up);
+            insight.GeneratedTimeUtc = generatedTime;
+            insight.CloseTimeUtc = insight.GeneratedTimeUtc + insight.Period;
+
+            Assert.IsFalse(insight.IsExpired(insight.CloseTimeUtc));
+            Assert.IsTrue(insight.IsExpired(insight.CloseTimeUtc.AddTicks(1)));
+        }
+
+        [Test]
+        public void IsActiveUsesClosedIntervalSemantics()
+        {
+            var generatedTime = new DateTime(2000, 01, 01);
+            var insight = Insight.Price(Symbols.SPY, Time.OneMinute, InsightDirection.Up);
+            insight.GeneratedTimeUtc = generatedTime;
+            insight.CloseTimeUtc = insight.GeneratedTimeUtc + insight.Period;
+
+            Assert.IsTrue(insight.IsActive(insight.CloseTimeUtc));
+            Assert.IsFalse(insight.IsActive(insight.CloseTimeUtc.AddTicks(1)));
+        }
     }
 }


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Adds `Insight.IsExpired(DateTime)` and `Insight.IsActive(DateTime)` to easily check insight expiry/active status.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2386 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These definitions should be standardized.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Perhaps, I'll let you decide :)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests included.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->