### PR TITLE
Fix for Quandl custom data race condition

### DIFF
--- a/Common/Data/Custom/Quandl.cs
+++ b/Common/Data/Custom/Quandl.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ using System.Globalization;
 namespace QuantConnect.Data.Custom
 {
     /// <summary>
-    /// Quandl Data Type - Import generic data from quandl, without needing to define Reader methods. 
+    /// Quandl Data Type - Import generic data from quandl, without needing to define Reader methods.
     /// This reads the headers of the data imported, and dynamically creates properties for the imported data.
     /// </summary>
     public class Quandl : DynamicData

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -105,9 +105,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 return enumerator;
             });
 
-            // prevent calls to the enumerator stack if current is in the future
-            var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Security.Exchange.TimeZone, request.StartTimeUtc, request.EndTimeUtc);
-            return new FrontierAwareEnumerator(refresher, _timeProvider, timeZoneOffsetProvider);
+            return refresher;
         }
 
         private IEnumerator<BaseData> EnumerateDataSourceReader(SubscriptionDataConfig config, IDataProvider dataProvider, Ref<DateTime> localFrontier, SubscriptionDataSource source, DateTime localDate)

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -228,21 +228,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 Assert.IsNotNull(_enumerator.Current);
                 Assert.AreEqual(_referenceLocal, _enumerator.Current.EndTime);
 
-                Assert.IsTrue(_enumerator.MoveNext());
-                Assert.IsNull(_enumerator.Current);
-
                 _timeProvider.AdvanceSeconds(1);
 
                 Assert.IsTrue(_enumerator.MoveNext());
                 Assert.IsNotNull(_enumerator.Current);
                 Assert.AreEqual(_referenceLocal.AddSeconds(1), _enumerator.Current.EndTime);
-
-                // these are rate limited by the refresh enumerator's func guard clause
-                Assert.IsTrue(_enumerator.MoveNext());
-                Assert.IsNull(_enumerator.Current);
-
-                Assert.IsTrue(_enumerator.MoveNext());
-                Assert.IsNull(_enumerator.Current);
 
                 _dataSourceReader.Verify(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
                         sds.Source == "remote.file.source" &&
@@ -305,16 +295,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 Assert.IsTrue(_enumerator.MoveNext());
                 Assert.IsNotNull(_enumerator.Current);
                 Assert.AreEqual(_referenceLocal, _enumerator.Current.EndTime);
-                VerifyGetSourceInvocation(0);
-
-                // these are limitted by frontier aware enumerator preventing future data
-                Assert.IsTrue(_enumerator.MoveNext());
-                Assert.IsNull(_enumerator.Current);
-                VerifyGetSourceInvocation(0);
-
-                // still prevented by frontier aware
-                Assert.IsTrue(_enumerator.MoveNext());
-                Assert.IsNull(_enumerator.Current);
                 VerifyGetSourceInvocation(0);
 
                 _timeProvider.Advance(Time.OneDay);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Removing `FrontierAwareEnumerator` from the custom live data subscription, because it caused already available data to be sent to the algorithm some `ms` late. `LiveTradingDataFeed` already has it own `FrontierAwareEnumerator`.
- Adding a unit test that reproduces the original issue
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2330
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Quandl custom data race condition emits data twice in live trading.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests. Live algorithm.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->