### PR TITLE
Replace Fixer API with QC API for GDAX FX conversion rates

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -275,7 +275,8 @@ namespace QuantConnect.Brokerages.GDAX
                     }
                     else if (new[] {"GBP", "EUR"}.Contains(item.Currency))
                     {
-                        var rate = GetConversionRate(item.Currency);
+                        var symbol = Symbol.Create(item.Currency + "USD", SecurityType.Forex, Market.FXCM);
+                        var rate = GetConversionRate(symbol);
                         list.Add(new Cash(item.Currency.ToUpper(), item.Balance, rate));
                     }
                     else

--- a/Brokerages/GDAX/GDAXBrokerageFactory.cs
+++ b/Brokerages/GDAX/GDAXBrokerageFactory.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Brokerages.GDAX
             {
                 var dataQueueHandler = new GDAXDataQueueHandler(job.BrokerageData["gdax-url"], webSocketClient,
                     restClient, job.BrokerageData["gdax-api-key"], job.BrokerageData["gdax-api-secret"],
-                    job.BrokerageData["gdax-passphrase"], algorithm);
+                    job.BrokerageData["gdax-passphrase"], algorithm, job.UserId, job.Channel);
 
                 Composer.Instance.AddPart<IDataQueueHandler>(dataQueueHandler);
 
@@ -91,7 +91,7 @@ namespace QuantConnect.Brokerages.GDAX
             {
                 brokerage = new GDAXBrokerage(job.BrokerageData["gdax-url"], webSocketClient,
                     restClient, job.BrokerageData["gdax-api-key"], job.BrokerageData["gdax-api-secret"],
-                    job.BrokerageData["gdax-passphrase"], algorithm);
+                    job.BrokerageData["gdax-passphrase"], algorithm, job.UserId, job.Channel);
             }
 
             return brokerage;

--- a/Brokerages/GDAX/GDAXDataQueueHandler.cs
+++ b/Brokerages/GDAX/GDAXDataQueueHandler.cs
@@ -30,8 +30,9 @@ namespace QuantConnect.Brokerages.GDAX
         /// <summary>
         /// Initializes a new instance of the <see cref="GDAXDataQueueHandler"/> class
         /// </summary>
-        public GDAXDataQueueHandler(string wssUrl, IWebSocket websocket, IRestClient restClient, string apiKey, string apiSecret, string passPhrase, IAlgorithm algorithm)
-            : base(wssUrl, websocket, restClient, apiKey, apiSecret, passPhrase, algorithm)
+        public GDAXDataQueueHandler(string wssUrl, IWebSocket websocket, IRestClient restClient, string apiKey, string apiSecret, string passPhrase, IAlgorithm algorithm,
+            int userId, string userToken)
+            : base(wssUrl, websocket, restClient, apiKey, apiSecret, passPhrase, algorithm, userId, userToken)
         {
         }
 

--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -552,6 +552,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Api\QuantConnect.Api.csproj">
+      <Project>{C5D44209-49A0-4505-A870-043C5EF5FDDF}</Project>
+      <Name>QuantConnect.Api</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Common\QuantConnect.csproj">
       <Project>{2545c0b4-fabb-49c9-8dd1-9ad7ee23f86b}</Project>
       <Name>QuantConnect</Name>

--- a/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
@@ -62,8 +62,10 @@ namespace QuantConnect.Tests.Brokerages.GDAX
             var apiSecret = Config.Get("gdax-api-secret");
             var passPhrase = Config.Get("gdax-passphrase");
             var algorithm = new QCAlgorithm();
+            var userId = Config.GetInt("job-user-id");
+            var userToken = Config.Get("api-access-token");
 
-            var brokerage = new GDAXBrokerage(wssUrl, webSocketClient, restClient, apiKey, apiSecret, passPhrase, algorithm);
+            var brokerage = new GDAXBrokerage(wssUrl, webSocketClient, restClient, apiKey, apiSecret, passPhrase, algorithm, userId, userToken);
             brokerage.Connect();
 
             return brokerage;

--- a/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
@@ -72,8 +72,9 @@ namespace QuantConnect.Tests.Brokerages.GDAX
             var algorithm = new Mock<IAlgorithm>();
             algorithm.Setup(a => a.BrokerageModel).Returns(new GDAXBrokerageModel(AccountType.Cash));
 
-            return new GDAXBrokerage(Config.Get("gdax-url", "wss://ws-feed.pro.coinbase.com"), webSocketClient, restClient, Config.Get("gdax-api-key"), Config.Get("gdax-api-secret"),
-                Config.Get("gdax-passphrase"), algorithm.Object);
+            return new GDAXBrokerage(Config.Get("gdax-url", "wss://ws-feed.pro.coinbase.com"), webSocketClient, restClient,
+                Config.Get("gdax-api-key"), Config.Get("gdax-api-secret"), Config.Get("gdax-passphrase"), algorithm.Object,
+                Config.GetInt("job-user-id"), Config.Get("api-access-token"));
         }
 
         /// <summary>


### PR DESCRIPTION

#### Description
The Fixer API has been replaced by the new QC Pricing API in the `GDAXBrokerage`.

#### Related Issue
Closes #2383 

#### Motivation and Context
Remove the dependency on an external service.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
A live GDAX algorithm using BTCEUR (which requires the EURUSD conversion rate) has been tested locally.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`