### PR TITLE
Fix underlying security seeding at OnEndOfStep

### DIFF
--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -94,7 +94,20 @@ namespace QuantConnect.Algorithm
 
                         if (LiveMode && underlyingSecurity.GetLastData() == null)
                         {
-                            requiredHistoryRequests.Add(underlyingSecurity, (Resolution)Math.Max((int)security.Resolution, (int)Resolution.Minute));
+                            if (requiredHistoryRequests.ContainsKey(underlyingSecurity))
+                            {
+                                // lets request the higher resolution
+                                var currentResolutionRequest = requiredHistoryRequests[underlyingSecurity];
+                                if (currentResolutionRequest != Resolution.Minute  // Can not be less than Minute
+                                    && security.Resolution < currentResolutionRequest)
+                                {
+                                    requiredHistoryRequests[underlyingSecurity] = (Resolution)Math.Max((int)security.Resolution, (int)Resolution.Minute);
+                                }
+                            }
+                            else
+                            {
+                                requiredHistoryRequests.Add(underlyingSecurity, (Resolution)Math.Max((int)security.Resolution, (int)Resolution.Minute));
+                            }
                         }
                         // set the underlying security on the derivative -- we do this in two places since it's possible
                         // to do AddOptionContract w/out the underlying already added and normalized properly

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -143,6 +143,30 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
+        public void OnEndOfTimeStepDoesNotThrowWhenSeedsSameUnderlyingForTwoSecurities()
+        {
+            var qcAlgorithm = new QCAlgorithm();
+            qcAlgorithm.SetLiveMode(true);
+            var testHistoryProvider = new TestHistoryProvider();
+            qcAlgorithm.HistoryProvider = testHistoryProvider;
+            var option = qcAlgorithm.AddOption(testHistoryProvider.underlyingSymbol);
+
+            var symbol = Symbol.CreateOption(testHistoryProvider.underlyingSymbol, Market.USA, OptionStyle.American,
+                OptionRight.Call, 1, new DateTime(2015, 12, 24));
+            var symbol2 = Symbol.CreateOption(testHistoryProvider.underlyingSymbol, Market.USA, OptionStyle.American,
+                OptionRight.Put, 1, new DateTime(2015, 12, 24));
+
+            var optionContract = qcAlgorithm.AddOptionContract(symbol, Resolution.Daily);
+            var optionContract2 = qcAlgorithm.AddOptionContract(symbol2, Resolution.Minute);
+
+            qcAlgorithm.OnEndOfTimeStep();
+            var data = qcAlgorithm.Securities[testHistoryProvider.underlyingSymbol].GetLastData();
+            Assert.AreEqual(testHistoryProvider.LastResolutionRequest, Resolution.Minute);
+            Assert.IsNotNull(data);
+            Assert.AreEqual(data.Price, 2);
+        }
+
+        [Test]
         public void PythonCustomDataTypes_AreAddedToSubscriptions_Successfully()
         {
             var qcAlgorithm = new AlgorithmPythonWrapper("Test_CustomDataAlgorithm");
@@ -195,6 +219,7 @@ namespace QuantConnect.Tests.Algorithm
             public string underlyingSymbol = "GOOG";
             public string underlyingSymbol2 = "AAPL";
             public int DataPointCount { get; }
+            public Resolution LastResolutionRequest;
             public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider,
                 IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
             {
@@ -204,6 +229,7 @@ namespace QuantConnect.Tests.Algorithm
             public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
             {
                 var now = DateTime.UtcNow;
+                LastResolutionRequest = requests.First().Resolution;
                 var tradeBar1 = new TradeBar(now, underlyingSymbol, 1, 1, 1, 1, 1, TimeSpan.FromDays(1));
                 var tradeBar2 = new TradeBar(now, underlyingSymbol2, 3, 3, 3, 3, 3, TimeSpan.FromDays(1));
                 var slice1 = new Slice(now, new List<BaseData> { tradeBar1, tradeBar2 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `OnEndOfTimeStep()` will not throw when seeding underlying security shared by two other securities. It will seed underlying security with the lesser `Resolution` of the other two securities.
     - Adding unit test
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2405
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`OnEndOfTimeStep()` does not throw an exception when seeding underlying security
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->