### PR TITLE
Fixes bugs in  BlackLittermanOptimizationPortfolioConstructionModel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - rm -rf Miniconda3-4.3.31-Linux-x86_64.sh
   - sudo ln -s $HOME/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6m.so
   - conda update -y python conda pip
-  - conda install -y cython pandas
+  - conda install -y cython pandas scipy
 install:
   - nuget restore QuantConnect.Lean.sln
   - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner

--- a/Algorithm.CSharp/BlackLittermanPortfolioOptimizationFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BlackLittermanPortfolioOptimizationFrameworkAlgorithm.cs
@@ -47,10 +47,12 @@ namespace QuantConnect.Algorithm.CSharp
             // Futures Resolution: Tick, Second, Minute
             // Options Resolution: Minute Only.
 
+            var optimizer = new UnconstrainedMeanVariancePortfolioOptimizer();
+
             // set algorithm framework models
             SetUniverseSelection(new CoarseFundamentalUniverseSelectionModel(CoarseSelector));
             SetAlpha(new HistoricalReturnsAlphaModel(resolution: Resolution.Daily));
-            SetPortfolioConstruction(new BlackLittermanOptimizationPortfolioConstructionModel());
+            SetPortfolioConstruction(new BlackLittermanOptimizationPortfolioConstructionModel(optimizer: optimizer));
             SetExecution(new ImmediateExecutionModel());
             SetRiskManagement(new NullRiskManagementModel());
         }
@@ -73,25 +75,25 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "11"},
-            {"Average Win", "0.12%"},
-            {"Average Loss", "0%"},
-            {"Compounding Annual Return", "1366.273%"},
-            {"Drawdown", "0.800%"},
-            {"Expectancy", "0"},
-            {"Net Profit", "3.747%"},
-            {"Sharpe Ratio", "9.273"},
-            {"Loss Rate", "0%"},
-            {"Win Rate", "100%"},
+            {"Total Trades", "21"},
+            {"Average Win", "0%"},
+            {"Average Loss", "-0.38%"},
+            {"Compounding Annual Return", "-82.902%"},
+            {"Drawdown", "4.300%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-2.390%"},
+            {"Sharpe Ratio", "-6.467"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
             {"Alpha", "0"},
-            {"Beta", "135.779"},
-            {"Annual Standard Deviation", "0.168"},
-            {"Annual Variance", "0.028"},
-            {"Information Ratio", "9.21"},
-            {"Tracking Error", "0.168"},
+            {"Beta", "-87.309"},
+            {"Annual Standard Deviation", "0.155"},
+            {"Annual Variance", "0.024"},
+            {"Information Ratio", "-6.538"},
+            {"Tracking Error", "0.155"},
             {"Treynor Ratio", "0.011"},
-            {"Total Fees", "$23.61"},
+            {"Total Fees", "$72.57"},
             {"Total Insights Generated", "14"},
             {"Total Insights Closed", "11"},
             {"Total Insights Analysis Completed", "11"},

--- a/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.cs
+++ b/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.cs
@@ -82,21 +82,27 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// </summary>
         /// <param name="historicalReturns">Matrix of annualized historical returns where each column represents a security and each row returns for the given date/time (size: K x N).</param>
         /// <param name="expectedReturns">Array of double with the portfolio annualized expected returns (size: K x 1).</param>
+        /// <param name="covariance">Multi-dimensional array of double with the portfolio covariance of annualized returns (size: K x K).</param>
         /// <returns>Array of double with the portfolio weights (size: K x 1)</returns>
-        public double[] Optimize(double[,] historicalReturns, double[] expectedReturns = null)
+        public double[] Optimize(double[,] historicalReturns, double[] expectedReturns = null, double[,] covariance = null)
         {
-            var cov = historicalReturns.Covariance();
-            var size = cov.GetLength(0);
+            covariance = covariance ?? historicalReturns.Covariance();
             var returns = (expectedReturns ?? historicalReturns.Mean(0)).Subtract(_riskFreeRate);
+
+            var size = covariance.GetLength(0);
+            var x0 = Vector.Create(size, 1.0 / size);
+            var k = returns.Dot(x0);
 
             var constraints = new List<LinearConstraint>
             {
-                // (µ − r_f)^T w = 1
+                // Sharpe Maximization under Quadratic Constraints
+                // https://quant.stackexchange.com/questions/18521/sharpe-maximization-under-quadratic-constraints
+                // (µ − r_f)^T w = k
                 new LinearConstraint(size)
                 {
                     CombinedAs = returns,
                     ShouldBe = ConstraintType.EqualTo,
-                    Value = 1.0
+                    Value = k
                 }
             };
 
@@ -107,12 +113,12 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             constraints.AddRange(GetBoundaryConditions(size));
 
             // Setup solver
-            var optfunc = new QuadraticObjectiveFunction(cov, Vector.Create(size, 0.0));
+            var optfunc = new QuadraticObjectiveFunction(covariance, Vector.Create(size, 0.0));
             var solver = new GoldfarbIdnani(optfunc, constraints);
 
             // Solve problem
-            var x0 = Vector.Create(size, 1.0 / size);
-            bool success = solver.Minimize(Vector.Copy(x0));
+            var success = solver.Minimize(Vector.Copy(x0));
+            var sharpeRatio = returns.Dot(solver.Solution) / solver.Value;
             return success ? solver.Solution : x0;
         }
     }

--- a/Algorithm.Framework/Portfolio/MinimumVariancePortfolioOptimizer.cs
+++ b/Algorithm.Framework/Portfolio/MinimumVariancePortfolioOptimizer.cs
@@ -81,11 +81,12 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// </summary>
         /// <param name="historicalReturns">Matrix of annualized historical returns where each column represents a security and each row returns for the given date/time (size: K x N).</param>
         /// <param name="expectedReturns">Array of double with the portfolio annualized expected returns (size: K x 1).</param>
+        /// <param name="covariance">Multi-dimensional array of double with the portfolio covariance of annualized returns (size: K x K).</param>
         /// <returns>Array of double with the portfolio weights (size: K x 1)</returns>
-        public double[] Optimize(double[,] historicalReturns, double[] expectedReturns = null)
+        public double[] Optimize(double[,] historicalReturns, double[] expectedReturns = null, double[,] covariance = null)
         {
-            var cov = historicalReturns.Covariance();
-            var size = cov.GetLength(0);
+            covariance = covariance ?? historicalReturns.Covariance();
+            var size = covariance.GetLength(0);
             var returns = expectedReturns ?? historicalReturns.Mean(0);
 
             var constraints = new List<LinearConstraint>
@@ -106,7 +107,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             constraints.AddRange(GetBoundaryConditions(size));
 
             // Setup solver
-            var optfunc = new QuadraticObjectiveFunction(cov, Vector.Create(size, 0.0));
+            var optfunc = new QuadraticObjectiveFunction(covariance, Vector.Create(size, 0.0));
             var solver = new GoldfarbIdnani(optfunc, constraints);
 
             // Solve problem

--- a/Algorithm.Framework/Portfolio/UnconstrainedMeanVariancePortfolioOptimizer.cs
+++ b/Algorithm.Framework/Portfolio/UnconstrainedMeanVariancePortfolioOptimizer.cs
@@ -13,12 +13,15 @@
  * limitations under the License.
 */
 
+using Accord.Math;
+using Accord.Statistics;
+
 namespace QuantConnect.Algorithm.Framework.Portfolio
 {
     /// <summary>
-    /// Interface for portfolio optimization algorithms
+    /// Provides an implementation of a portfolio optimizer with unconstrained mean variance.
     /// </summary>
-    public interface IPortfolioOptimizer
+    public class UnconstrainedMeanVariancePortfolioOptimizer : IPortfolioOptimizer
     {
         /// <summary>
         /// Perform portfolio optimization for a provided matrix of historical returns and an array of expected returns
@@ -27,6 +30,11 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <param name="expectedReturns">Array of double with the portfolio annualized expected returns (size: K x 1).</param>
         /// <param name="covariance">Multi-dimensional array of double with the portfolio covariance of annualized returns (size: K x K).</param>
         /// <returns>Array of double with the portfolio weights (size: K x 1)</returns>
-        double[] Optimize(double[,] historicalReturns, double[] expectedReturns = null, double[,] covariance = null);
+        public double[] Optimize(double[,] historicalReturns, double[] expectedReturns = null, double[,] covariance = null)
+        {
+            var Π = (expectedReturns ?? historicalReturns.Mean(0));
+            var Σ = covariance ?? historicalReturns.Covariance();
+            return Π.Dot(Σ.Inverse());
+        }
     }
 }

--- a/Algorithm.Framework/Portfolio/UnconstrainedMeanVariancePortfolioOptimizer.py
+++ b/Algorithm.Framework/Portfolio/UnconstrainedMeanVariancePortfolioOptimizer.py
@@ -1,0 +1,37 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from numpy import dot
+from numpy.linalg import inv
+
+### <summary>
+### Provides an implementation of a portfolio optimizer with unconstrained mean variance.'''
+### </summary>
+class UnconstrainedMeanVariancePortfolioOptimizer:
+    '''Provides an implementation of a portfolio optimizer with unconstrained mean variance.'''
+    def Optimize(self, historicalReturns, expectedReturns = None, covariance = None):
+        '''
+        Perform portfolio optimization for a provided matrix of historical returns and an array of expected returns
+        args:
+            historicalReturns: Matrix of annualized historical returns where each column represents a security and each row returns for the given date/time (size: K x N).
+            expectedReturns: Array of double with the portfolio annualized expected returns (size: K x 1).
+            covariance: Multi-dimensional array of double with the portfolio covariance of annualized returns (size: K x K).</param>
+        Returns:
+            Array of double with the portfolio weights (size: K x 1)
+        '''
+        if expectedReturns is None:
+            expectedReturns = historicalReturns.mean()
+        if covariance is None:
+            covariance = historicalReturns.cov()
+
+        return expectedReturns.dot(inv(covariance))

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Portfolio\BlackLittermanOptimizationPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\IPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\IPortfolioOptimizer.cs" />
+    <Compile Include="Portfolio\UnconstrainedMeanVariancePortfolioOptimizer.cs" />
     <Compile Include="Portfolio\MaximumSharpeRatioPortfolioOptimizer.cs" />
     <Compile Include="Portfolio\MeanVarianceOptimizationPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\MinimumVariancePortfolioOptimizer.cs" />
@@ -146,6 +147,9 @@
   <ItemGroup>
     <None Include="packages.config" />
     <Content Include="Portfolio\BlackLittermanOptimizationPortfolioConstructionModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Portfolio\UnconstrainedMeanVariancePortfolioOptimizer.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Portfolio\MaximumSharpeRatioPortfolioOptimizer.py">

--- a/Algorithm.Python/BlackLittermanPortfolioOptimizationFrameworkAlgorithm.py
+++ b/Algorithm.Python/BlackLittermanPortfolioOptimizationFrameworkAlgorithm.py
@@ -27,6 +27,8 @@ from Alphas.HistoricalReturnsAlphaModel import HistoricalReturnsAlphaModel
 from Execution.ImmediateExecutionModel import ImmediateExecutionModel
 from Risk.NullRiskManagementModel import NullRiskManagementModel
 from Portfolio.BlackLittermanOptimizationPortfolioConstructionModel import *
+from Portfolio.UnconstrainedMeanVariancePortfolioOptimizer import UnconstrainedMeanVariancePortfolioOptimizer
+
 
 ### <summary>
 ### Black-Litterman framework algorithm
@@ -50,10 +52,12 @@ class BlackLittermanPortfolioOptimizationFrameworkAlgorithm(QCAlgorithmFramework
 
         self.symbols = [ Symbol.Create(x, SecurityType.Equity, Market.USA) for x in [ 'AIG', 'BAC', 'IBM', 'SPY' ] ]
 
+        optimizer = UnconstrainedMeanVariancePortfolioOptimizer()
+
         # set algorithm framework models
         self.SetUniverseSelection(CoarseFundamentalUniverseSelectionModel(self.coarseSelector))
         self.SetAlpha(HistoricalReturnsAlphaModel(resolution = Resolution.Daily))
-        self.SetPortfolioConstruction(BlackLittermanOptimizationPortfolioConstructionModel())
+        self.SetPortfolioConstruction(BlackLittermanOptimizationPortfolioConstructionModel(optimizer = optimizer))
         self.SetExecution(ImmediateExecutionModel())
         self.SetRiskManagement(NullRiskManagementModel())
 

--- a/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
@@ -1,0 +1,289 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Accord.Math;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
+{
+    [TestFixture]
+    public class BlackLittermanOptimizationPortfolioConstructionModelTests
+    {
+        private QCAlgorithmFramework _algorithm;
+        private Insight[] _view1Insights;
+        private Insight[] _view2Insights;
+
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Portfolio");
+            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
+
+            _algorithm = new QCAlgorithmFramework();
+            SetUtcTime(new DateTime(2018, 8, 7));
+
+            // Germany will outperform the other European markets by 5%
+            _view1Insights = new[]
+            {
+                GetInsight("View 1", "AUS",  0),
+                GetInsight("View 1", "CAN",  0),
+                GetInsight("View 1", "FRA", -0.01475),
+                GetInsight("View 1", "GER",  0.05000),
+                GetInsight("View 1", "JAP",  0),
+                GetInsight("View 1", "UK" , -0.03525),
+                GetInsight("View 1", "USA",  0)
+            };
+
+            // Canadian Equities will outperform US equities by 3 %
+            _view2Insights = new[]
+            {
+                GetInsight("View 2", "AUS",  0),
+                GetInsight("View 2", "CAN",  0.03),
+                GetInsight("View 2", "FRA",  0),
+                GetInsight("View 2", "GER",  0),
+                GetInsight("View 2", "JAP",  0),
+                GetInsight("View 2", "UK" ,  0),
+                GetInsight("View 2", "USA", -0.03)
+            };
+
+            foreach (var symbol in _view1Insights.Select(x => x.Symbol))
+            {
+                var security = GetSecurity(symbol, Resolution.Daily);
+                security.SetMarketPrice(new Tick(_algorithm.Time, symbol, 1m, 1m));
+                _algorithm.Securities.Add(symbol, security);
+            }
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void EmptyInsightsReturnsEmptyTargets(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            var insights = new Insight[0];
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);
+
+            Assert.AreEqual(0, actualTargets.Count());
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void OneViewTest(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            // Results from http://www.blacklitterman.org/code/hl_py.html (View 1)
+            var expectedTargets = new[]
+            {
+                PortfolioTarget.Percent(_algorithm, GetSymbol("AUS"), 0.0152381),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("CAN"), 0.02095238),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("FRA"), -0.03948465),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("GER"), 0.35410454),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("JAP"), 0.11047619),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("UK"), -0.09461989),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("USA"), 0.58571429)
+            };
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, _view1Insights);
+
+            Assert.AreEqual(expectedTargets.Count(), actualTargets.Count());
+
+            foreach (var expected in expectedTargets)
+            {
+                var actual = actualTargets.FirstOrDefault(x => x.Symbol == expected.Symbol);
+                Assert.IsNotNull(actual);
+                Assert.AreEqual(expected.Quantity, actual.Quantity);
+            }
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void TwoViewsTest(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            // Results from http://www.blacklitterman.org/code/hl_py.html (View 1+2)
+            var expectedTargets = new[]
+            {
+                PortfolioTarget.Percent(_algorithm, GetSymbol("AUS"), 0.0152381),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("CAN"), 0.41863571),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("FRA"), -0.03409321),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("GER"), 0.33582847),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("JAP"), 0.11047619),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("UK"), -0.08173526),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("USA"), 0.18803095)
+            };
+
+            var insights = _view1Insights.Concat(_view2Insights);
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
+
+            Assert.AreEqual(expectedTargets.Count(), actualTargets.Count());
+
+            foreach (var expected in expectedTargets)
+            {
+                var actual = actualTargets.FirstOrDefault(x => x.Symbol == expected.Symbol);
+                Assert.IsNotNull(actual);
+                Assert.AreEqual(expected.Quantity, actual.Quantity);
+            }
+        }
+
+        private Security GetSecurity(Symbol symbol, Resolution resolution)
+        {
+            var timezone = _algorithm.TimeZone;
+            var exchangeHours = SecurityExchangeHours.AlwaysOpen(timezone);
+            var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, resolution, timezone, timezone, true, false, false);
+            return new Security(exchangeHours, config, new Cash("USD", 0, 1), SymbolProperties.GetDefault("USD"));
+        }
+
+        private Symbol GetSymbol(string ticker) => Symbol.Create(ticker, SecurityType.Equity, Market.USA);
+
+        private Insight GetInsight(string SourceModel, string ticker, double magnitude)
+        {
+            var period = Time.OneDay;
+            var direction = (InsightDirection)Math.Sign(magnitude);
+            var insight = Insight.Price(GetSymbol(ticker), period, direction, magnitude, sourceModel: SourceModel);
+            insight.GeneratedTimeUtc = _algorithm.UtcTime;
+            insight.CloseTimeUtc = _algorithm.UtcTime.Add(insight.Period);
+            return insight;
+        }
+
+        private void SetPortfolioConstruction(Language language)
+        {
+            _algorithm.SetPortfolioConstruction(new BLOPCM(new UnconstrainedMeanVariancePortfolioOptimizer()));
+            if (language == Language.Python)
+            {
+                try
+                {
+                    using (Py.GIL())
+                    {
+                        var name = nameof(BLOPCM);
+                        var instance = PythonEngine.ModuleFromString(name, GetPythonBLOPCM()).GetAttr(name).Invoke();
+                        var model = new PortfolioConstructionModelPythonWrapper(instance);
+                        _algorithm.SetPortfolioConstruction(model);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Assert.Ignore(e.Message);
+                }
+            }
+
+            var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToList().ToArray());
+            _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+        }
+
+        private void SetUtcTime(DateTime dateTime)
+        {
+            _algorithm.SetDateTime(dateTime.ConvertToUtc(_algorithm.TimeZone));
+        }
+
+        private class BLOPCM : BlackLittermanOptimizationPortfolioConstructionModel
+        {
+            public BLOPCM(IPortfolioOptimizer optimizer)
+                : base(optimizer: optimizer)
+            {
+            }
+
+            public override double[] GetEquilibriumReturns(double[,] returns, out double[,] Σ)
+            {
+                // Take the values from He & Litterman, 1999.
+                var C = new[,]
+                {
+                    { 1.000, 0.488, 0.478, 0.515, 0.439, 0.512, 0.491 },
+                    { 0.488, 1.000, 0.664, 0.655, 0.310, 0.608, 0.779 },
+                    { 0.478, 0.664, 1.000, 0.861, 0.355, 0.783, 0.668 },
+                    { 0.515, 0.655, 0.861, 1.000, 0.354, 0.777, 0.653 },
+                    { 0.439, 0.310, 0.355, 0.354, 1.000, 0.405, 0.306 },
+                    { 0.512, 0.608, 0.783, 0.777, 0.405, 1.000, 0.652 },
+                    { 0.491, 0.779, 0.668, 0.653, 0.306, 0.652, 1.000 }
+                };
+                var σ = new[] { 0.160, 0.203, 0.248, 0.271, 0.210, 0.200, 0.187 };
+                var w = new[] { 0.016, 0.022, 0.052, 0.055, 0.116, 0.124, 0.615 };
+                var delta = 2.5;
+
+                // Equilibrium covariance matrix
+                Σ = Elementwise.Multiply(C, σ.Outer(σ));
+                return w.Dot(Σ.Multiply(delta));
+            }
+
+            public override void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+            {
+                
+            }
+        }
+
+        private string GetPythonBLOPCM()
+        {
+            return @"import os, sys
+sys.path.append(os.getcwd())
+
+from clr import AddReference
+AddReference('QuantConnect.Common')
+from QuantConnect import *
+
+from Portfolio.BlackLittermanOptimizationPortfolioConstructionModel import BlackLittermanOptimizationPortfolioConstructionModel
+from Portfolio.UnconstrainedMeanVariancePortfolioOptimizer import UnconstrainedMeanVariancePortfolioOptimizer
+import numpy as np
+import pandas as pd
+
+def GetSymbol(ticker):
+    return str(Symbol.Create(ticker, SecurityType.Equity, Market.USA))
+
+class BLOPCM(BlackLittermanOptimizationPortfolioConstructionModel):
+
+    def __init__(self):
+        super().__init__(optimizer = UnconstrainedMeanVariancePortfolioOptimizer())
+
+    def get_equilibrium_return(self, returns):
+
+        # Take the values from He & Litterman, 1999.
+        weq = np.array([0.016, 0.022, 0.052, 0.055, 0.116, 0.124, 0.615])
+        C = np.array([[ 1.000, 0.488, 0.478, 0.515, 0.439, 0.512, 0.491],
+                       [0.488, 1.000, 0.664, 0.655, 0.310, 0.608, 0.779],
+                       [0.478, 0.664, 1.000, 0.861, 0.355, 0.783, 0.668],
+                       [0.515, 0.655, 0.861, 1.000, 0.354, 0.777, 0.653],
+                       [0.439, 0.310, 0.355, 0.354, 1.000, 0.405, 0.306],
+                       [0.512, 0.608, 0.783, 0.777, 0.405, 1.000, 0.652],
+                       [0.491, 0.779, 0.668, 0.653, 0.306, 0.652, 1.000]])
+        Sigma = np.array([0.160, 0.203, 0.248, 0.271, 0.210, 0.200, 0.187])
+        refPi = np.array([0.039, 0.069, 0.084, 0.090, 0.043, 0.068, 0.076])
+        assets= [GetSymbol(x) for x in ['AUS', 'CAN', 'FRA', 'GER', 'JAP', 'UK', 'USA']]
+        delta = 2.5
+
+        # Equilibrium covariance matrix
+        V = np.multiply(np.outer(Sigma,Sigma), C)
+
+        return weq.dot(V * delta), pd.DataFrame(V, columns=assets, index=assets)
+
+    def OnSecuritiesChanged(self, algorithm, changes):
+        pass";
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -37,6 +37,15 @@
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Accord, Version=3.6.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Accord.3.6.0\lib\net45\Accord.dll</HintPath>
+    </Reference>
+    <Reference Include="Accord.Math, Version=3.6.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Accord.Math.3.6.0\lib\net45\Accord.Math.dll</HintPath>
+    </Reference>
+    <Reference Include="Accord.Math.Core, Version=3.6.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Accord.Math.3.6.0\lib\net45\Accord.Math.Core.dll</HintPath>
+    </Reference>
     <Reference Include="AsyncIO, Version=0.1.25.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
       <HintPath>..\packages\AsyncIO.0.1.26.0\lib\net40\AsyncIO.dll</HintPath>
     </Reference>
@@ -84,6 +93,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
@@ -130,6 +140,7 @@
     <Compile Include="Algorithm\Framework\Execution\ImmediateExecutionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Execution\StandardDeviationExecutionModelTests.cs" />
     <Compile Include="Algorithm\Framework\InsightTests.cs" />
+    <Compile Include="Algorithm\Framework\Portfolio\BlackLittermanOptimizationPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
@@ -799,7 +810,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\QuantConnect.pythonnet.1.0.5.8\build\QuantConnect.pythonnet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.pythonnet.1.0.5.8\build\QuantConnect.pythonnet.targets'))" />
+    <Error Condition="!Exists('..\packages\Accord.3.6.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.6.0\build\Accord.targets'))" />
   </Target>
+  <Import Project="..\packages\Accord.3.6.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.6.0\build\Accord.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Accord" version="3.6.0" targetFramework="net452" />
+  <package id="Accord.Math" version="3.6.0" targetFramework="net452" />
   <package id="AsyncIO" version="0.1.26.0" targetFramework="net452" />
   <package id="Castle.Core" version="4.1.0" targetFramework="net452" />
   <package id="CloneExtensions" version="1.3.0" targetFramework="net452" />


### PR DESCRIPTION
#### Description
- Adds covariance parameter in `IPortfolioOptimizer.Optimize`
  Add a multi-dimensional array of double representing the covariance. Some models, e.g., Black-Litterman may want to optimize a covariance that is different from the historical one.

- Adds `UnconstrainedMeanVariancePortfolioOptimizer`: a simple optimizer that has a solution, therefore no numerical optimization method is required.

- Refactors BlackLittermanOptimizationPortfolioConstructionModel
  1. Apply the pattern used in `EqualWeightingPortfolioConstructionModel`
  2. Change the logic to compute the views from the insights.
  3. Change the logis to compute the posterior mean and covariance
- Use `UnconstrainedMeanVariancePortfolioOptimizer` in `BlackLittermanPortfolioOptimizationFrameworkAlgorithm` to bypass the difference in regression tests with `IPortfolioOptimizer` that rely on different algorithms in C# and python.
- Adds unit tests for BLOPCV to test the implementation against Black and Litterman 1999 paper.

#### Related Issue
Closes #2358 

#### Motivation and Context
Improve framework models modelling.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added unit test and regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`