### PR TITLE
Fix time zone bug in BacktestingResultHandler

### DIFF
--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Orders
         public string PriceCurrency { get; internal set; }
 
         /// <summary>
-        /// Time the order was created.
+        /// Gets the utc time the order was created.
         /// </summary>
         public DateTime Time { get; internal set; }
 

--- a/Common/Orders/OrderRequest.cs
+++ b/Common/Orders/OrderRequest.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,7 +39,7 @@ namespace QuantConnect.Orders
         }
 
         /// <summary>
-        /// Gets the time the request was created
+        /// Gets the UTC time the request was created
         /// </summary>
         public DateTime Time
         {

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.Lean.Engine.Results
         private bool _processingFinalPacket;
 
         //Processing Time:
-        private readonly DateTime _startTime = DateTime.Now;
+        private readonly DateTime _startTime = DateTime.UtcNow;
         private DateTime _nextSample;
         private IMessagingHandler _messagingHandler;
         private ITransactionHandler _transactionHandler;
@@ -210,7 +210,7 @@ namespace QuantConnect.Lean.Engine.Results
                     return;
                 }
 
-                if (DateTime.Now <= _nextUpdate || !(_daysProcessed > (_lastDaysProcessed + 1))) return;
+                if (DateTime.UtcNow <= _nextUpdate || !(_daysProcessed > (_lastDaysProcessed + 1))) return;
 
                 //Extract the orders since last update
                 var deltaOrders = new Dictionary<int, Order>();
@@ -232,9 +232,9 @@ namespace QuantConnect.Lean.Engine.Results
                 //Reset loop variables:
                 try
                 {
-                    _lastUpdate = Algorithm.Time.Date;
+                    _lastUpdate = Algorithm.UtcTime.Date;
                     _lastDaysProcessed = _daysProcessed;
-                    _nextUpdate = DateTime.Now.AddSeconds(0.5);
+                    _nextUpdate = DateTime.UtcNow.AddSeconds(0.5);
                 }
                 catch (Exception err)
                 {
@@ -276,9 +276,9 @@ namespace QuantConnect.Lean.Engine.Results
                 var completeResult = new BacktestResult(Algorithm.IsFrameworkAlgorithm, Charts, _transactionHandler.Orders, Algorithm.Transactions.TransactionRecord, new Dictionary<string, string>(), runtimeStatistics, new Dictionary<string, AlgorithmPerformance>());
                 var complete = new BacktestResultPacket(_job, completeResult, progress);
 
-                if (DateTime.Now > _nextS3Update)
+                if (DateTime.UtcNow > _nextS3Update)
                 {
-                    _nextS3Update = DateTime.Now.AddSeconds(30);
+                    _nextS3Update = DateTime.UtcNow.AddSeconds(30);
                     StoreResult(complete);
                 }
 
@@ -401,7 +401,7 @@ namespace QuantConnect.Lean.Engine.Results
                 var result = new BacktestResultPacket((BacktestNodePacket) job,
                     new BacktestResult(Algorithm.IsFrameworkAlgorithm, charts, orders, profitLoss, statisticsResults.Summary, banner, statisticsResults.RollingPerformances, statisticsResults.TotalPerformance))
                 {
-                    ProcessingTime = (DateTime.Now - _startTime).TotalSeconds,
+                    ProcessingTime = (DateTime.UtcNow - _startTime).TotalSeconds,
                     DateFinished = DateTime.Now,
                     Progress = 1
                 };


### PR DESCRIPTION

#### Description
- Fixed a bug where a comparison was done between times in different time zones 
- Replaced usages of `DateTime.Now` with `DateTime.UtcNow` in all result handlers

#### Related Issue
Closes #2417 

#### Motivation and Context
Remove usages of `DateTime.Now`

#### Requires Documentation Change
No

#### How Has This Been Tested?
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`