### PR TITLE
Fix insight pie chart sum

### DIFF
--- a/Common/Chart.cs
+++ b/Common/Chart.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using Newtonsoft.Json;
 using QuantConnect.Logging;
 
@@ -79,6 +80,32 @@ namespace QuantConnect
             {
                 throw new Exception("Chart.AddSeries(): Chart series name already exists");
             }
+        }
+
+        /// <summary>
+        /// Gets Series if already present in chart, else will add a new series and return it
+        /// </summary>
+        /// <param name="name">Name of the series</param>
+        /// <param name="type">Type of the series</param>
+        /// <param name="index">Index position on the chart of the series</param>
+        /// <param name="unit">Unit for the series axis</param>
+        /// <param name="color">Color of the series</param>
+        /// <param name="symbol">Symbol for the marker in a scatter plot series</param>
+        public Series TryAddAndGetSeries(string name, SeriesType type, int index, string unit,
+                                      Color color, ScatterMarkerSymbol symbol)
+        {
+            Series series;
+            if (!Series.TryGetValue(name, out series))
+            {
+                series = new Series(name, type, index, unit)
+                {
+                    Color = color,
+                    ScatterMarkerSymbol = symbol
+                };
+                Series[name] = series;
+            }
+
+            return series;
         }
 
         /// <summary>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -607,6 +607,7 @@
     <Compile Include="Util\RateGate.cs" />
     <Compile Include="Util\SecurityExtensions.cs" />
     <Compile Include="Util\SecurityIdentifierJsonConverter.cs" />
+    <Compile Include="Util\SeriesJsonConverter.cs" />
     <Compile Include="Util\StreamReaderEnumerable.cs" />
     <Compile Include="Util\TypeChangeJsonConverter.cs" />
     <Compile Include="Util\LinqExtensions.cs" />

--- a/Common/Util/SeriesJsonConverter.cs
+++ b/Common/Util/SeriesJsonConverter.cs
@@ -1,0 +1,79 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace QuantConnect.Util
+{
+    /// <summary>
+    /// Json Converter for Series which handles special Pie Series serialization case
+    /// </summary>
+    public class SeriesJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var series = value as Series;
+            if (series == null)
+            {
+                return;
+            }
+
+            writer.WriteStartObject();
+
+            List<ChartPoint> values;
+            if (series.SeriesType == SeriesType.Pie)
+            {
+                values = new List<ChartPoint>();
+                var dataPoint = series.ConsolidateChartPoints();
+                if (dataPoint != null)
+                {
+                    values.Add(dataPoint);
+                }
+            }
+            else
+            {
+                values = series.Values;
+            }
+
+            writer.WritePropertyName("Name");
+            writer.WriteValue(series.Name);
+            writer.WritePropertyName("Unit");
+            writer.WriteValue(series.Unit);
+            writer.WritePropertyName("Index");
+            writer.WriteValue(series.Index);
+            writer.WritePropertyName("Values");
+            serializer.Serialize(writer, values);
+            writer.WritePropertyName("SeriesType");
+            writer.WriteValue(series.SeriesType);
+            writer.WritePropertyName("Color");
+            serializer.Serialize(writer, series.Color);
+            writer.WritePropertyName("ScatterMarkerSymbol");
+            serializer.Serialize(writer, series.ScatterMarkerSymbol);
+            writer.WriteEndObject();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Series);
+        }
+    }
+}

--- a/Engine/Alphas/ChartingInsightManagerExtension.cs
+++ b/Engine/Alphas/ChartingInsightManagerExtension.cs
@@ -39,7 +39,6 @@ namespace QuantConnect.Lean.Engine.Alphas
         private readonly Chart _dailyInsightCountPerSymbolChart = new Chart("Alpha Asset Breakdown"); // stacked area
         private readonly Series _totalInsightCountSeries = new Series("Count", SeriesType.Bar, "#");
 
-        private readonly Dictionary<Symbol, int> _insightCountPerSymbol = new Dictionary<Symbol, int>();
         private readonly Dictionary<Symbol, int> _dailyInsightCountPerSymbol = new Dictionary<Symbol, int>();
         private readonly Dictionary<InsightScoreType, Series> _insightScoreSeriesByScoreType = new Dictionary<InsightScoreType, Series>();
 
@@ -91,15 +90,17 @@ namespace QuantConnect.Lean.Engine.Alphas
             {
                 _lastInsightCountSampleDateUtc = frontierTimeUtc.Date;
 
-                // populate charts with the daily insight counts per symbol, resetting our storage
+                // populate charts with the daily insight counts per symbol
                 var sumInsights = PopulateChartWithSeriesPerSymbol(_dailyInsightCountPerSymbol, _dailyInsightCountPerSymbolChart, SeriesType.StackedArea, frontierTimeUtc);
-                _dailyInsightCountPerSymbol.Clear();
 
                 // add sum of daily insight counts to the total insight count series
                 _totalInsightCountSeries.AddPoint(frontierTimeUtc.Date, sumInsights);
 
-                // populate charts with the total insight counts per symbol, no need to reset
-                PopulateChartWithSeriesPerSymbol(_insightCountPerSymbol, _totalInsightCountPerSymbolChart, SeriesType.Pie, frontierTimeUtc);
+                // populate charts with the daily insight counts per symbol diff
+                PopulateChartWithSeriesPerSymbol(_dailyInsightCountPerSymbol, _totalInsightCountPerSymbolChart, SeriesType.Pie, frontierTimeUtc);
+
+                // Resetting our storage
+                _dailyInsightCountPerSymbol.Clear();
             }
 
             // sample average population scores
@@ -164,14 +165,10 @@ namespace QuantConnect.Lean.Engine.Alphas
         {
             if (!_dailyInsightCountPerSymbol.ContainsKey(context.Symbol))
             {
-                _insightCountPerSymbol[context.Symbol] = 1;
                 _dailyInsightCountPerSymbol[context.Symbol] = 1;
             }
             else
             {
-                // track total assets for life of backtest
-                _insightCountPerSymbol[context.Symbol] += 1;
-
                 // track daily assets
                 _dailyInsightCountPerSymbol[context.Symbol] += 1;
             }

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -646,23 +646,18 @@ namespace QuantConnect.Lean.Engine.Results
                     {
                         //If we don't already have this record, its the first packet
                         var chart = Charts[update.Name];
-                        if (!chart.Series.ContainsKey(series.Name))
-                        {
-                            chart.Series.Add(series.Name, new Series(series.Name, series.SeriesType, series.Index, series.Unit)
-                            {
-                                Color = series.Color, ScatterMarkerSymbol = series.ScatterMarkerSymbol
-                            });
-                        }
 
-                        var thisSeries = chart.Series[series.Name];
+                        var thisSeries = chart.TryAddAndGetSeries(series.Name, series.SeriesType, series.Index,
+                                                               series.Unit, series.Color, series.ScatterMarkerSymbol);
                         if (series.Values.Count > 0)
                         {
-                            // only keep last point for pie charts
                             if (series.SeriesType == SeriesType.Pie)
                             {
-                                var lastValue = series.Values.Last();
-                                thisSeries.Purge();
-                                thisSeries.Values.Add(lastValue);
+                                var dataPoint = series.ConsolidateChartPoints();
+                                if (dataPoint != null)
+                                {
+                                    thisSeries.AddPoint(dataPoint);
+                                }
                             }
                             else
                             {

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -644,23 +644,18 @@ namespace QuantConnect.Lean.Engine.Results
                     {
                         //If we don't already have this record, its the first packet
                         var chart = Charts[update.Name];
-                        if (!chart.Series.ContainsKey(series.Name))
-                        {
-                            chart.Series.Add(series.Name, new Series(series.Name, series.SeriesType, series.Index, series.Unit)
-                            {
-                                Color = series.Color, ScatterMarkerSymbol = series.ScatterMarkerSymbol
-                            });
-                        }
 
-                        var thisSeries = chart.Series[series.Name];
+                        var thisSeries = chart.TryAddAndGetSeries(series.Name, series.SeriesType, series.Index,
+                                                               series.Unit, series.Color, series.ScatterMarkerSymbol);
                         if (series.Values.Count > 0)
                         {
-                            // only keep last point for pie charts
                             if (series.SeriesType == SeriesType.Pie)
                             {
-                                var lastValue = series.Values.Last();
-                                thisSeries.Purge();
-                                thisSeries.Values.Add(lastValue);
+                                var dataPoint = series.ConsolidateChartPoints();
+                                if (dataPoint != null)
+                                {
+                                    thisSeries.AddPoint(dataPoint);
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding new method `ConsolidateDataPoints()` to `Series` that will sum up all values into a single one and return it. This will be used for Pie Charts during execution updates and before saving the results.
- Adding a `BaseSeries` class and a `SeriesJsonConverter` that uses it as a way of handling the Pie Series special storage case.
- `ChartingInsightManagerExtension` had a bug around `_insightCountPerSymbol`. When `_dailyInsightCountPerSymbol` was cleaned it also cleaned `_insightCountPerSymbol` indirectly, since next call to `OnInsightGenerated()` would step on the value. Since we actually need diff updates decided to remove `_insightCountPerSymbol` and directly use `_dailyInsightCountPerSymbol`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2379
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Pie Chart works correctly during and after backtests when loading results
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally and at QC lab
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->