### PR TITLE
AddOptionContract - throw if existing underlying equity not in Raw mode

### DIFF
--- a/Algorithm.CSharp/OptionChainProviderAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainProviderAlgorithm.cs
@@ -4,12 +4,6 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
-/*
- * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
- * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -22,7 +16,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
-using QuantConnect.Securities.Option;
+using QuantConnect.Interfaces;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -35,7 +29,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="using data" />
     /// <meta name="tag" content="selecting options" />
     /// <meta name="tag" content="manual selection" />
-    public class OptionChainProviderAlgorithm : QCAlgorithm
+    public class OptionChainProviderAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol _equitySymbol;
         private Symbol _optionContract = string.Empty;
@@ -47,6 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2015, 12, 24);
             SetCash(100000);
             var equity = AddEquity("GOOG", Resolution.Minute);
+            equity.SetDataNormalizationMode(DataNormalizationMode.Raw);
             _equitySymbol = equity.Symbol;
         }
 
@@ -86,6 +81,11 @@ namespace QuantConnect.Algorithm.CSharp
                 MarketOrder(_optionContract, -1);
             }
         }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
 
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.

--- a/Algorithm.Python/OptionChainProviderAlgorithm.py
+++ b/Algorithm.Python/OptionChainProviderAlgorithm.py
@@ -41,6 +41,7 @@ class OptionChainProviderAlgorithm(QCAlgorithm):
         self.SetCash(100000)
         # add the underlying asset
         self.equity = self.AddEquity("GOOG", Resolution.Minute)
+        self.equity.SetDataNormalizationMode(DataNormalizationMode.Raw)
         # initialize the option contract with empty string
         self.contract = str()
         self.contractsAdded = set()

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1588,7 +1588,8 @@ namespace QuantConnect.Algorithm
             }
             else if (equity.DataNormalizationMode != DataNormalizationMode.Raw)
             {
-                Debug($"Warning: The {underlying.ToString()} equity security was set the raw price normalization mode to work with options.");
+                throw new ArgumentException($"The underlying equity asset ({underlying.Value}) is set to {equity.DataNormalizationMode}, " +
+                                            "please change this to DataNormalizationMode.Raw with the SetDataNormalization() method");
             }
             equity.SetDataNormalizationMode(DataNormalizationMode.Raw);
 


### PR DESCRIPTION

#### Description
- `AddOptionContract` will now throw an exception if the underlying equity security has been added previously and the `DataNormalizationMode` has not been set to `DataNormalizationMode.Raw`
- Added `OptionChainProviderAlgorithm` to regression test suite

#### Related Issue
Closes #2064 

#### Motivation and Context
When working with options, the `DataNormalizationMode` for the underlying equity security must be set to Raw.

#### Requires Documentation Change
No

#### How Has This Been Tested?
OptionChainProviderAlgorithm locally, algorithm in #2064 in cloud

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`