### PR TITLE
Fix symbol name in ManualUniverseSelectionModel

### DIFF
--- a/Algorithm.Framework/Selection/ManualUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ManualUniverseSelectionModel.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
@@ -99,7 +98,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
 
                 var market = grp.Key.Market;
                 var securityType = grp.Key.SecurityType;
-                var universeSymbol = Symbol.Create($"manual-portfolio-selection-model-{securityType}-{market}", securityType, market);
+                var universeSymbol = Symbol.Create($"manual-universe-selection-model-{securityType}-{market}", securityType, market);
                 if (securityType == SecurityType.Base)
                 {
                     // add an entry for this custom universe symbol -- we don't really know the time zone for sure,


### PR DESCRIPTION

#### Description
The universe symbols created in `ManualUniverseSelectionModel.CreateUniverses` have been updated to match the class name (which was previously renamed from PortfolioSelection to UniverseSelection).

#### Related Issue
Closes #2426

#### Motivation and Context
Currently brokerage implementations of `CanSubscribe` are relying on the presence of the string "universe" in the symbol name to detect universe symbols.
For now this simple fix solves the live trading issue reported, but for the future we should find a better way to handle universe symbol detection (e.g. adding `IsUniverseSymbol` property to `SecurityIdentifier` and `Symbol`).

#### Requires Documentation Change
No.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`