### PR TITLE
Updates FractionalQuantityRegressionAlgorithm to use SetBuyingPowerModel

### DIFF
--- a/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FractionalQuantityRegressionAlgorithm.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             // The default buying power model for the Crypto security type is now CashBuyingPowerModel.
             // Since this test algorithm uses leverage we need to set a buying power model with margin.
-            security.BuyingPowerModel = new SecurityMarginModel(3.3m);
+            security.SetBuyingPowerModel(new SecurityMarginModel(3.3m));
 
             var con = new TradeBarConsolidator(1);
             SubscriptionManager.AddConsolidator("BTCUSD", con);

--- a/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
+++ b/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
@@ -52,7 +52,7 @@ class FractionalQuantityRegressionAlgorithm(QCAlgorithm):
 
         ### The default buying power model for the Crypto security type is now CashBuyingPowerModel.
         ### Since this test algorithm uses leverage we need to set a buying power model with margin.
-        security.BuyingPowerModel = SecurityMarginModel(3.3)
+        security.SetBuyingPowerModel(SecurityMarginModel(3.3))
 
         con = TradeBarConsolidator(timedelta(1))
         self.SubscriptionManager.AddConsolidator("BTCUSD", con)


### PR DESCRIPTION
#### Description
Updates `FractionalQuantityRegressionAlgorithm` to use `SetBuyingPowerModel`.

#### Related Issue
Increments #2425 that closed #2422.

#### Motivation and Context
Adds example of new method in example algorithms.

#### Requires Documentation Change
Addressed in #2425.

#### How Has This Been Tested?
Regression test.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`