### PR TITLE
Sets the scale factor to one for VIX futures

### DIFF
--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesReader.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesReader.cs
@@ -231,7 +231,10 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
                 var expirationYearMonth = new DateTime(expirationYear, expirationMonth, DateTime.DaysInMonth(expirationYear, expirationMonth));
                 var symbol = Symbol.CreateFuture(underlying, Market.USA, expirationYearMonth);
 
-                var price = csv[_columnPrice].ToDecimal() / 10000000000m;
+                // All futures but VIX are delivered with a scale factor of 10000000000.
+                var scaleFactor = symbol.ID.Symbol == "VX" ? decimal.One : 10000000000m;
+
+                var price = csv[_columnPrice].ToDecimal() / scaleFactor;
                 var quantity = csv[_columnQuantity].ToInt32();
 
                 price *= _symbolMultipliers.ContainsKey(underlying) ? _symbolMultipliers[underlying] : 1.0m;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Supports factor  

#### Description
<!--- Describe your changes in detail -->
All futures but VIX are delivered with prices adjusted factor of 10000000000.
VIX futures prices are delivered without transformation.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Making use of the same `AlgoSeekFuturesReader` object for all futures.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run a full day for all futures locally.