### PR TITLE
Add IBrokerage.GetHistory to GDAXBrokerage

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -20,14 +20,19 @@ using RestSharp;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
 using QuantConnect.Logging;
 
 namespace QuantConnect.Brokerages.GDAX
 {
     public partial class GDAXBrokerage : BaseWebsocketsBrokerage
     {
+        private const int MaxDataPointsPerHistoricalRequest = 300;
+
         #region IBrokerage
         /// <summary>
         /// Checks if the websocket connection is connected or in the process of connecting
@@ -290,6 +295,125 @@ namespace QuantConnect.Brokerages.GDAX
 
             return list;
         }
+
+        /// <summary>
+        /// Gets the history for the requested security
+        /// </summary>
+        /// <param name="request">The historical data request</param>
+        /// <returns>An enumerable of bars covering the span specified in the request</returns>
+        public override IEnumerable<BaseData> GetHistory(HistoryRequest request)
+        {
+            // GDAX API only allows us to support history requests for TickType.Trade
+            if (request.TickType != TickType.Trade)
+            {
+                yield break;
+            }
+
+            if (request.EndTimeUtc < request.StartTimeUtc)
+            {
+                Log.Error("GDAXBrokerage.GetHistory(): The start date must precede the end date, no history returned");
+                yield break;
+            }
+
+            if (request.Resolution == Resolution.Tick || request.Resolution == Resolution.Second)
+            {
+                Log.Error($"GDAXBrokerage.GetHistory(): {request.Resolution} resolution not supported, no history returned");
+                yield break;
+            }
+
+            Log.Trace($"GDAXBrokerage.GetHistory(): Submitting request: {request.Symbol.Value}: {request.Resolution} {request.StartTimeUtc} UTC -> {request.EndTimeUtc} UTC");
+
+            foreach (var tradeBar in GetHistoryFromCandles(request))
+            {
+                yield return tradeBar;
+            }
+        }
+
+        /// <summary>
+        /// Returns TradeBars from GDAX candles (only for Minute/Hour/Daily resolutions)
+        /// </summary>
+        /// <param name="request">The history request instance</param>
+        private IEnumerable<TradeBar> GetHistoryFromCandles(HistoryRequest request)
+        {
+            var productId = ConvertSymbol(request.Symbol);
+            var granularity = Convert.ToInt32(request.Resolution.ToTimeSpan().TotalSeconds);
+
+            var startTime = request.StartTimeUtc;
+            var endTime = request.EndTimeUtc;
+            var maximumRange = TimeSpan.FromSeconds(MaxDataPointsPerHistoricalRequest * granularity);
+
+            do
+            {
+                var maximumEndTime = startTime.Add(maximumRange);
+                if (endTime > maximumEndTime)
+                {
+                    endTime = maximumEndTime;
+                }
+
+                var restRequest = new RestRequest($"/products/{productId}/candles?start={startTime:o}&end={endTime:o}&granularity={granularity}", Method.GET);
+                var response = ExecuteRestRequest(restRequest, GdaxEndpointType.Public);
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    Log.Error($"GDAXBrokerage.GetHistory: request failed: [{(int)response.StatusCode}] {response.StatusDescription}, Content: {response.Content}, ErrorMessage: {response.ErrorMessage}");
+                    yield break;
+                }
+
+                var bars = ParseCandleData(request.Symbol, granularity, response.Content, startTime);
+
+                TradeBar lastPointReceived = null;
+                foreach (var datapoint in bars.OrderBy(x => x.Time))
+                {
+                    lastPointReceived = datapoint;
+                    yield return datapoint;
+                }
+
+                startTime = lastPointReceived?.EndTime ?? request.EndTimeUtc;
+                endTime = request.EndTimeUtc;
+            } while (startTime < request.EndTimeUtc);
+        }
+
+        /// <summary>
+        /// Parse TradeBars from JSON response
+        /// https://docs.pro.coinbase.com/#get-historic-rates
+        /// </summary>
+        private static IEnumerable<TradeBar> ParseCandleData(Symbol symbol, int granularity, string data, DateTime startTimeUtc)
+        {
+            if (data.Length > 0)
+            {
+                var parsedData = JsonConvert.DeserializeObject<string[][]>(data);
+                var period = TimeSpan.FromSeconds(granularity);
+
+                foreach (var datapoint in parsedData)
+                {
+                    var time = Time.UnixTimeStampToDateTime(double.Parse(datapoint[0], CultureInfo.InvariantCulture));
+
+                    if (time < startTimeUtc)
+                    {
+                        // Note from GDAX docs:
+                        // If data points are readily available, your response may contain as many as 300 candles
+                        // and some of those candles may precede your declared start value.
+                        yield break;
+                    }
+
+                    var close = datapoint[4].ToDecimal();
+
+                    yield return new TradeBar
+                    {
+                        Symbol = symbol,
+                        Time = time,
+                        Period = period,
+                        Open = datapoint[3].ToDecimal(),
+                        High = datapoint[2].ToDecimal(),
+                        Low = datapoint[1].ToDecimal(),
+                        Close = close,
+                        Value = close,
+                        Volume = decimal.Parse(datapoint[5], NumberStyles.Float, CultureInfo.InvariantCulture)
+                    };
+                }
+            }
+        }
+
         #endregion
 
         /// <summary>

--- a/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
@@ -1,0 +1,121 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Brokerages.GDAX;
+using QuantConnect.Configuration;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.HistoricalData;
+using QuantConnect.Logging;
+using QuantConnect.Securities;
+using RestSharp;
+
+namespace QuantConnect.Tests.Brokerages.GDAX
+{
+    [TestFixture]
+    //[Ignore("This test requires a configured and testable GDAX account")]
+    public class GDAXBrokerageHistoryProviderTests
+    {
+        [Test, TestCaseSource(nameof(TestParameters))]
+        public void GetsHistory(Symbol symbol, Resolution resolution, TickType tickType, TimeSpan period, bool shouldBeEmpty)
+        {
+            var restClient = new RestClient("https://api.pro.coinbase.com");
+            var webSocketClient = new WebSocketWrapper();
+
+            var brokerage = new GDAXBrokerage(
+                Config.Get("gdax-url", "wss://ws-feed.pro.coinbase.com"), webSocketClient, restClient,
+                Config.Get("gdax-api-key"), Config.Get("gdax-api-secret"), Config.Get("gdax-passphrase"), null, null);
+
+            var historyProvider = new BrokerageHistoryProvider();
+            historyProvider.SetBrokerage(brokerage);
+            historyProvider.Initialize(null, null, null, null, null, null);
+
+            var now = DateTime.UtcNow;
+
+            var requests = new[]
+            {
+                new HistoryRequest(now.Add(-period),
+                    now,
+                    typeof(TradeBar),
+                    symbol,
+                    resolution,
+                    SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                    DateTimeZone.Utc,
+                    resolution,
+                    false,
+                    false,
+                    DataNormalizationMode.Adjusted,
+                    tickType)
+            };
+
+            var history = historyProvider.GetHistory(requests, TimeZones.Utc).ToList();
+
+            foreach (var slice in history)
+            {
+                var bar = slice.Bars[symbol];
+
+                Log.Trace($"{bar.Time}: {bar.Symbol} - O={bar.Open}, H={bar.High}, L={bar.Low}, C={bar.Close}, V={bar.Volume}");
+            }
+
+            if (shouldBeEmpty)
+            {
+                Assert.IsTrue(history.Count == 0);
+            }
+            else
+            {
+                Assert.IsTrue(history.Count > 0);
+            }
+
+            Log.Trace("Data points retrieved: " + historyProvider.DataPointCount);
+        }
+
+        public TestCaseData[] TestParameters
+        {
+            get
+            {
+                var btcusd = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX);
+
+                return new[]
+                {
+                    // valid parameters
+                    new TestCaseData(btcusd, Resolution.Minute, TickType.Trade, Time.OneHour, false),
+                    new TestCaseData(btcusd, Resolution.Hour, TickType.Trade, Time.OneDay, false),
+                    new TestCaseData(btcusd, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false),
+
+                    // quote tick type, no error, empty result
+                    new TestCaseData(btcusd, Resolution.Daily, TickType.Quote, TimeSpan.FromDays(15), true),
+
+                    // invalid resolution, no error, empty result
+                    new TestCaseData(btcusd, Resolution.Tick, TickType.Trade, TimeSpan.FromSeconds(15), true),
+                    new TestCaseData(btcusd, Resolution.Second, TickType.Trade, Time.OneMinute, true),
+
+                    // invalid period, no error, empty result
+                    new TestCaseData(btcusd, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(-15), true),
+
+                    // invalid symbol, no error, empty result
+                    new TestCaseData(Symbol.Create("ABCXYZ", SecurityType.Crypto, Market.GDAX), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true),
+
+                    // invalid security type, no error, empty result
+                    new TestCaseData(Symbols.EURGBP, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true)
+                };
+            }
+        }
+    }
+}

--- a/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
@@ -29,8 +29,7 @@ using RestSharp;
 
 namespace QuantConnect.Tests.Brokerages.GDAX
 {
-    [TestFixture]
-    //[Ignore("This test requires a configured and testable GDAX account")]
+    [TestFixture, Ignore("This test requires a configured and testable GDAX account")]
     public class GDAXBrokerageHistoryProviderTests
     {
         [Test, TestCaseSource(nameof(TestParameters))]

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileRowTests.cs" />
+    <Compile Include="Brokerages\GDAX\GDAXBrokerageHistoryProviderTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileTests.cs" />
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />


### PR DESCRIPTION

#### Description
`IBrokerage.GetHistory` has been implemented in `GDAXBrokerage`.

#### Related Issue
Closes #1000 

#### Motivation and Context
When using the `BrokerageHistoryProvider` with `GDAXBrokerage` locally, any history request returned an empty enumerable (as implemented in the base class in `Brokerage.GetHistory`).

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests and history calls in example algorithms.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`