### PR TITLE
Split dividend improvements

### DIFF
--- a/Common/Data/Auxiliary/FactorFile.cs
+++ b/Common/Data/Auxiliary/FactorFile.cs
@@ -50,6 +50,12 @@ namespace QuantConnect.Data.Auxiliary
         public DateTime? FactorFileMinimumDate { get; set; }
 
         /// <summary>
+        /// Gets the most recent factor change in the factor file
+        /// </summary>
+        public DateTime MostRecentFactorChange => SortedFactorFileData.Reverse()
+            .FirstOrDefault(kvp => kvp.Key != Time.EndOfTime).Key;
+
+        /// <summary>
         /// Gets the symbol this factor file represents
         /// </summary>
         public string Permtick { get; }
@@ -257,6 +263,12 @@ namespace QuantConnect.Data.Auxiliary
         public List<BaseData> GetSplitsAndDividends(Symbol symbol, SecurityExchangeHours exchangeHours)
         {
             var dividendsAndSplits = new List<BaseData>();
+            if (SortedFactorFileData.Count == 0)
+            {
+                Log.Trace($"{symbol} has no factors!");
+                return dividendsAndSplits;
+            }
+
             var futureFactorFileRow = SortedFactorFileData.Last().Value;
             for (var i = SortedFactorFileData.Count - 2; i >= 0 ; i--)
             {

--- a/Common/Data/Auxiliary/FactorFileRow.cs
+++ b/Common/Data/Auxiliary/FactorFileRow.cs
@@ -270,7 +270,7 @@ namespace QuantConnect.Data.Auxiliary
         public string ToCsv(string source = null)
         {
             source = source == null ? "" : $",{source}";
-            return $"{Date.ToString(DateFormat.EightCharacter)},{PriceFactor.Normalize()},{SplitFactor.Normalize()},{ReferencePrice.Normalize()}{source}";
+            return $"{Date.ToString(DateFormat.EightCharacter)},{Math.Round(PriceFactor, 6).Normalize()},{Math.Round(SplitFactor, 7).Normalize()},{ReferencePrice.Normalize()}{source}";
         }
 
         /// <summary>

--- a/Common/Data/Auxiliary/FactorFileRow.cs
+++ b/Common/Data/Auxiliary/FactorFileRow.cs
@@ -180,14 +180,14 @@ namespace QuantConnect.Data.Auxiliary
                 throw new ArgumentException("Unable to apply split with reference price of zero.");
             }
 
+            var previousTradingDay = exchangeHours.GetPreviousTradingDay(split.Time);
+
             // this instance must be chronologically at or in front of the split
             // this is because the factors are defined working from current to past
-            if (Date < split.Time.Date)
+            if (Date < previousTradingDay)
             {
                 throw new ArgumentException($"Factor file row date '{Date:yyy-MM-dd}' is before split date '{split.Time.Date:yyyy-MM-dd}'.");
             }
-
-            var previousTradingDay = exchangeHours.GetPreviousTradingDay(split.Time);
 
             return new FactorFileRow(
                 previousTradingDay,
@@ -267,9 +267,10 @@ namespace QuantConnect.Data.Auxiliary
         /// <summary>
         /// Writes this row to csv format
         /// </summary>
-        public string ToCsv()
+        public string ToCsv(string source = null)
         {
-            return $"{Date.ToString(DateFormat.EightCharacter)},{PriceFactor.Normalize()},{SplitFactor.Normalize()},{ReferencePrice.Normalize()}";
+            source = source == null ? "" : $",{source}";
+            return $"{Date.ToString(DateFormat.EightCharacter)},{PriceFactor.Normalize()},{SplitFactor.Normalize()},{ReferencePrice.Normalize()}{source}";
         }
 
         /// <summary>

--- a/Common/Data/Auxiliary/MapFile.cs
+++ b/Common/Data/Auxiliary/MapFile.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Data.Auxiliary
         /// <summary>
         /// Gets the entity's unique symbol, i.e OIH.1
         /// </summary>
-        public string Permtick { get; private set; }
+        public string Permtick { get; }
 
         /// <summary>
         /// Gets the last date in the map file which is indicative of a delisting event
@@ -55,12 +55,34 @@ namespace QuantConnect.Data.Auxiliary
         }
 
         /// <summary>
+        /// Gets the first ticker for the security represented by this map file
+        /// </summary>
+        public string FirstTicker { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MapFile"/> class.
         /// </summary>
         public MapFile(string permtick, IEnumerable<MapFileRow> data)
         {
             Permtick = permtick.ToUpper();
             _data = new SortedDictionary<DateTime, MapFileRow>(data.Distinct().ToDictionary(x => x.Date));
+
+            var firstTicker = GetMappedSymbol(FirstDate, Permtick);
+            if (char.IsDigit(firstTicker.Last()))
+            {
+                var dotIndex = firstTicker.LastIndexOf(".", StringComparison.Ordinal);
+                if (dotIndex > 0)
+                {
+                    int value;
+                    var number = firstTicker.Substring(dotIndex + 1);
+                    if (int.TryParse(number, out value))
+                    {
+                        firstTicker = firstTicker.Substring(0, dotIndex);
+                    }
+                }
+            }
+
+            FirstTicker = firstTicker;
         }
 
         /// <summary>

--- a/Common/Data/Market/Dividend.cs
+++ b/Common/Data/Market/Dividend.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Data.Market
         public decimal ReferencePrice
         {
             get;
-            private set;
+            set;
         }
 
         /// <summary>

--- a/Tests/Common/Data/Auxiliary/FactorFileRowTests.cs
+++ b/Tests/Common/Data/Auxiliary/FactorFileRowTests.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Tests.Common.Data.Auxiliary
             var row = new FactorFileRow(new DateTime(2018, 08, 23), 1m, 2m, 123m);
             var dividend = new Dividend(Symbols.SPY, row.Date.AddDays(1), 1m, 123m);
             var updated = row.Apply(dividend, SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork));
-            Assert.AreEqual("20180823,0.9918699186991869918699186992,2,123", updated.ToCsv());
+            Assert.AreEqual("20180823,0.99187,2,123", updated.ToCsv());
         }
 
         [Test]

--- a/Tests/Common/Data/Auxiliary/FactorFileRowTests.cs
+++ b/Tests/Common/Data/Auxiliary/FactorFileRowTests.cs
@@ -1,0 +1,55 @@
+﻿/*
+* QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+* Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Data.Auxiliary
+{
+    [TestFixture]
+    public class FactorFileRowTests
+    {
+        [Test]
+        public void ToCsv()
+        {
+            var row = new FactorFileRow(new DateTime(2000, 01, 01), 1m, 2m, 123m);
+            var actual = row.ToCsv("source");
+            var expected = "20000101,1,2,123,source";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void AppliesDividendWithPreviousTradingDateEqualToRowDate()
+        {
+            var row = new FactorFileRow(new DateTime(2018, 08, 23), 1m, 2m, 123m);
+            var dividend = new Dividend(Symbols.SPY, row.Date.AddDays(1), 1m, 123m);
+            var updated = row.Apply(dividend, SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork));
+            Assert.AreEqual("20180823,0.9918699186991869918699186992,2,123", updated.ToCsv());
+        }
+
+        [Test]
+        public void AppliesSplitWithPreviousTradingDateEqualToRowDate()
+        {
+            var row = new FactorFileRow(new DateTime(2018, 08, 23), 1m, 2m, 123m);
+            var dividend = new Split(Symbols.SPY, row.Date.AddDays(1), 123m, 2m, SplitType.SplitOccurred);
+            var updated = row.Apply(dividend, SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork));
+            Assert.AreEqual("20180823,1,4,123", updated.ToCsv());
+        }
+    }
+}

--- a/Tests/Common/Data/Auxiliary/FactorFileTests.cs
+++ b/Tests/Common/Data/Auxiliary/FactorFileTests.cs
@@ -268,7 +268,31 @@ namespace QuantConnect.Tests.Common.Data.Auxiliary
             Assert.AreEqual(1m, thirdRow.PriceFactor);
             Assert.AreEqual(1m, thirdRow.SplitFactor);
             Assert.AreEqual(0m, firstRow.ReferencePrice);
+        }
 
+        [Test]
+        public void ResolvesCorrectMostRecentFactorChangeDate()
+        {
+            var lines = new[]
+            {
+                "19980102,1.0000000,0.5",
+                "20130828,1.0000000,0.5",
+                "20501231,1.0000000,1"
+            };
+
+            var factorFile = FactorFile.Parse("bno", lines);
+            Assert.AreEqual(new DateTime(2013, 08, 28), factorFile.MostRecentFactorChange);
+        }
+
+        [Test]
+        [TestCase("")]
+        [TestCase("20501231,1.0000000,1")]
+        public void EmptyFactorFileReturnsEmptyListForSplitsAndDividends(string contents)
+        {
+            var lines = contents.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l));
+
+            var factorFile = FactorFile.Parse("bno", lines);
+            Assert.IsEmpty(factorFile.GetSplitsAndDividends(Symbols.SPY, SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork)));
         }
 
         private static FactorFile GetTestFactorFile(string symbol, DateTime reference)

--- a/Tests/Common/Data/Auxiliary/MapFileTests.cs
+++ b/Tests/Common/Data/Auxiliary/MapFileTests.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Tests.Common.Data.Auxiliary
                 new MapFileRow(new DateTime(2050, 12, 31), "goog")
             });
 
-            Assert.AreEqual("goocv", mapFile.FirstTicker);
+            Assert.AreEqual("GOOCV", mapFile.FirstTicker);
         }
 
         [Test]

--- a/Tests/Common/Data/Auxiliary/MapFileTests.cs
+++ b/Tests/Common/Data/Auxiliary/MapFileTests.cs
@@ -1,0 +1,69 @@
+﻿/*
+* QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+* Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using QuantConnect.Data.Auxiliary;
+
+namespace QuantConnect.Tests.Common.Data.Auxiliary
+{
+    [TestFixture]
+    public class MapFileTests
+    {
+        [Test]
+        public void ResolvesFirstTicker()
+        {
+            var mapFile = new MapFile("goog", new List<MapFileRow>
+            {
+                new MapFileRow(new DateTime(2014, 03, 27), "goocv"),
+                new MapFileRow(new DateTime(2014, 04, 02), "goocv"),
+                new MapFileRow(new DateTime(2050, 12, 31), "goog")
+            });
+
+            Assert.AreEqual("goocv", mapFile.FirstTicker);
+        }
+
+        [Test]
+        [TestCase("abc", "ABC")]
+        [TestCase("abc.1", "ABC")]
+        [TestCase("brk.a", "BRK.A")]
+        [TestCase("brk.a.1", "BRK.A")]
+        public void ResolvesFirstTickerFromPermtickIfEmptyMapFile(string permtick, string expectedFirstTicker)
+        {
+            var mapFile = new MapFile(permtick, new List<MapFileRow>());
+            Assert.AreEqual(expectedFirstTicker, mapFile.FirstTicker);
+        }
+
+        [Test]
+        public void ResolvesFirstDate()
+        {
+            var mapFile = new MapFile("goog", new List<MapFileRow>
+            {
+                new MapFileRow(new DateTime(2014, 03, 27), "goocv"),
+                new MapFileRow(new DateTime(2014, 04, 02), "goocv"),
+                new MapFileRow(new DateTime(2050, 12, 31), "goog")
+            });
+
+            Assert.AreEqual(new DateTime(2014, 03, 27), mapFile.FirstDate);
+        }
+
+
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileTests.cs" />
+    <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />
     <Compile Include="PythonSetup.cs" />
     <Compile Include="Algorithm\Framework\QCAlgorithmFrameworkTests.cs" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
+    <Compile Include="Common\Data\Auxiliary\FactorFileRowTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileTests.cs" />
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
* Add FactorFileRow.ToCsv(source) and fix Apply(Dividend) bug

    The time check in FactorFileRow.Apply(Dividend) was not using the previous
    trading date for comparison.

	Added a 'source' parameter to FactorFileRow.ToCsv() for tracking each row's
    data source.

* Make Dividend.ReferencePrice public set

    This is to be consistent with the other properties in Dividend

* Adds MapFile.FirstTicker

    The first ticker and first date are most commonly used to properly create
    security identifiers. Currently resolution of the first ticker is strewn
    about in various places and often times it doesn't take into account the
    case of an empty map file, where the first (and last) ticker are assumed
    to be the permtick after removing the '.<number>' specifier at the end.
    It's important to also not remove '.<letter>' -- as some securities are
    named as such.

* Add FactorFile.MostRecentFactorChange, bugfix for empty files

    Empty factor files (whether a single 2050 line or no lines), by definition don't
    have any splits or dividends.

    FactorFile.MostRecentFactorChange yields the maximum date that isn't the 2050 date

* Add FactorFile.MostRecentFactorChange, bugfix for empty files

    Empty factor files (whether a single 2050 line or no lines), by definition don't
    have any splits or dividends.

    FactorFile.MostRecentFactorChange yields the maximum date that isn't the 2050 date

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #2378 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provides improvements to splits/dividends required by the new factor file generation process.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added for new features and bug fixes.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`