### PR TITLE
Improve IB error messages in GetAccountHoldings and GetOpenOrders

### DIFF
--- a/Brokerages/InteractiveBrokers/Client/OpenOrderEventArgs.cs
+++ b/Brokerages/InteractiveBrokers/Client/OpenOrderEventArgs.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// </summary>
         public override string ToString()
         {
-            return $"OrderId: {OrderId}, Symbol: {Contract.Symbol}, OrderStatus: {OrderState.Status}";
+            return $"OrderId: {OrderId}, Contract: {Contract}, OrderStatus: {OrderState.Status}";
         }
     }
 }

--- a/Brokerages/InteractiveBrokers/Client/SecurityType.cs
+++ b/Brokerages/InteractiveBrokers/Client/SecurityType.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,6 +74,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// Bill
         /// </summary>
         public const string Bill = "BILL";
+
+        /// <summary>
+        /// Contract For Difference
+        /// </summary>
+        public const string ContractForDifference = "CFD";
 
         /// <summary>
         /// Undefined Security Type

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1649,8 +1649,16 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             catch (Exception exception)
             {
                 Log.Error($"InteractiveBrokersBrokerage.HandlePortfolioUpdates(): {exception}");
-                _accountHoldingsLastException = exception;
-                _accountHoldingsResetEvent.Set();
+
+                if (e.Position != 0)
+                {
+                    // Force a runtime error only with a nonzero position for an unsupported security type,
+                    // because after the user has manually closed the position and restarted the algorithm,
+                    // he'll have a zero position but a nonzero realized PNL, so this event handler will be called again.
+
+                    _accountHoldingsLastException = exception;
+                    _accountHoldingsResetEvent.Set();
+                }
             }
         }
 

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -626,7 +626,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                             {
                                 // if an exception was thrown during account download, do not retry but exit immediately
                                 attempt = maxAttempts;
-                                throw new Exception("InteractiveBrokersBrokerage.Connect(): ", _accountHoldingsLastException);
+                                throw new Exception(_accountHoldingsLastException.Message, _accountHoldingsLastException);
                             }
 
                             if (attempt++ < maxAttempts)
@@ -650,7 +650,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                             {
                                 // if an exception was thrown during account download, do not retry but exit immediately
                                 attempt = maxAttempts;
-                                throw new Exception("InteractiveBrokersBrokerage.DownloadAccount(): ", _accountHoldingsLastException);
+                                throw new Exception(_accountHoldingsLastException.Message, _accountHoldingsLastException);
                             }
 
                             if (attempt++ < maxAttempts)
@@ -1650,6 +1650,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 Log.Error($"InteractiveBrokersBrokerage.HandlePortfolioUpdates(): {exception}");
                 _accountHoldingsLastException = exception;
+                _accountHoldingsResetEvent.Set();
             }
         }
 

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -184,8 +184,8 @@ namespace QuantConnect.Lean.Engine
                 catch (Exception err)
                 {
                     Log.Error(err);
-                    var runtimeMessage = "Algorithm.Initialize() Error: " + err.Message + " Stack Trace: " + err.StackTrace;
-                    _algorithmHandlers.Results.RuntimeError(runtimeMessage, err.StackTrace);
+                    var runtimeMessage = "Algorithm.Initialize() Error: " + err.Message + " Stack Trace: " + err;
+                    _algorithmHandlers.Results.RuntimeError(runtimeMessage, err.ToString());
                     _systemHandlers.Api.SetAlgorithmStatus(job.AlgorithmId, AlgorithmStatus.RuntimeError, runtimeMessage);
                 }
 


### PR DESCRIPTION
#### Description
- Added full contract description in `OpenOrderEventArgs.ToString`
- Improved error handling and messaging in brokerage initialization
- Updated `ConvertSecurityType` error message for unsupported security types
- Update catch block in Engine to include inner exceptions instead of current stack trace


#### Related Issue
Closes #2441 

#### Motivation and Context
Depending on the error type, occasional incomplete error messages and/or stack traces.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local and cloud exceptions during brokerage initialization (`GetAccountHoldings` and `GetOpenOrders`).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`