### PR TITLE
Logs python and pythonnet version after algorithm is loaded.

### DIFF
--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -33,6 +33,17 @@ namespace QuantConnect.Lean.Launcher
     {
         private const string _collapseMessage = "Unhandled exception breaking past controls and causing collapse of algorithm node. This is likely a memory leak of an external dependency or the underlying OS terminating the LEAN engine.";
 
+        static Program()
+        {
+            AppDomain.CurrentDomain.AssemblyLoad += (sender, e) =>
+            {
+                if (e.LoadedAssembly.FullName.ToLower().Contains("python"))
+                {
+                    Log.Trace($"Python for .NET Assembly: {e.LoadedAssembly.GetName()}");
+                }
+            };
+        }
+
         static void Main(string[] args)
         {
             //Initialize:


### PR DESCRIPTION
#### Description
Logs python and pythonnet version after algorithm is loaded.

#### Related Issue
Closes #2450.

#### Motivation and Context
Logging the version of pythonnet we are using is important to track improvements.

#### How Has This Been Tested?
Run a python algorithm manually and see the pythonnet version being displayed in the console.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`