### PR TITLE
Update BrokerageSetupHandler to call AddSecurity for open orders

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Lean.Engine.Setup
         /// <summary>
         /// Get the maximum runtime for this algorithm job.
         /// </summary>
-        public TimeSpan MaximumRuntime { get; private set; }
+        public TimeSpan MaximumRuntime { get; }
 
         /// <summary>
         /// Algorithm starting capital for statistics calculations
@@ -64,7 +64,7 @@ namespace QuantConnect.Lean.Engine.Setup
         /// <summary>
         /// Maximum number of orders for the algorithm run -- applicable for backtests only.
         /// </summary>
-        public int MaxOrders { get; private set; }
+        public int MaxOrders { get; }
 
         // saves ref to algo so we can call quit if runtime error encountered
         private IBrokerageFactory _factory;
@@ -161,7 +161,7 @@ namespace QuantConnect.Lean.Engine.Setup
             {
                 if (args.Type == BrokerageMessageType.Error)
                 {
-                    AddInitializationError(string.Format("Brokerage Error Code: {0} - {1}", args.Code, args.Message));
+                    AddInitializationError($"Brokerage Error Code: {args.Code} - {args.Message}");
                 }
             };
 
@@ -253,8 +253,9 @@ namespace QuantConnect.Lean.Engine.Setup
                 catch (Exception err)
                 {
                     Log.Error(err);
-                    AddInitializationError(string.Format("Error connecting to brokerage: {0}. " +
-                        "This may be caused by incorrect login credentials or an unsupported account type.", err.Message), err);
+                    AddInitializationError(
+                        $"Error connecting to brokerage: {err.Message}. " +
+                        "This may be caused by incorrect login credentials or an unsupported account type.", err);
                     return false;
                 }
 
@@ -283,10 +284,16 @@ namespace QuantConnect.Lean.Engine.Setup
                     return false;
                 }
 
+                var supportedSecurityTypes = new HashSet<SecurityType>
+                {
+                    SecurityType.Equity, SecurityType.Forex, SecurityType.Cfd, SecurityType.Option, SecurityType.Future, SecurityType.Crypto
+                };
+                var minResolution = new Lazy<Resolution>(() => algorithm.Securities.Select(x => x.Value.Resolution).DefaultIfEmpty(Resolution.Second).Min());
+
                 Log.Trace("BrokerageSetupHandler.Setup(): Fetching open orders from brokerage...");
                 try
                 {
-                    GetOpenOrders(algorithm, resultHandler, transactionHandler, brokerage);
+                    GetOpenOrders(algorithm, resultHandler, transactionHandler, brokerage, supportedSecurityTypes, minResolution.Value);
                 }
                 catch (Exception err)
                 {
@@ -300,11 +307,6 @@ namespace QuantConnect.Lean.Engine.Setup
                 {
                     // populate the algorithm with the account's current holdings
                     var holdings = brokerage.GetAccountHoldings();
-                    var supportedSecurityTypes = new HashSet<SecurityType>
-                    {
-                        SecurityType.Equity, SecurityType.Forex, SecurityType.Cfd, SecurityType.Option, SecurityType.Future, SecurityType.Crypto
-                    };
-                    var minResolution = new Lazy<Resolution>(() => algorithm.Securities.Select(x => x.Value.Resolution).DefaultIfEmpty(Resolution.Second).Min());
                     foreach (var holding in holdings)
                     {
                         Log.Trace("BrokerageSetupHandler.Setup(): Has existing holding: " + holding);
@@ -320,26 +322,7 @@ namespace QuantConnect.Lean.Engine.Setup
                             continue;
                         }
 
-                        if (!algorithm.Portfolio.ContainsKey(holding.Symbol))
-                        {
-                            Log.Trace("BrokerageSetupHandler.Setup(): Adding unrequested security: " + holding.Symbol.Value);
-
-                            if (holding.Type == SecurityType.Option)
-                            {
-                                // add current option contract to the system
-                                algorithm.AddOptionContract(holding.Symbol, minResolution.Value, true, 1.0m);
-                            }
-                            else if (holding.Type == SecurityType.Future)
-                            {
-                                // add current future contract to the system
-                                algorithm.AddFutureContract(holding.Symbol, minResolution.Value, true, 1.0m);
-                            }
-                            else
-                            {
-                                // for items not directly requested set leverage to 1 and at the min resolution
-                                algorithm.AddSecurity(holding.Type, holding.Symbol.Value, minResolution.Value, null, true, 1.0m, false);
-                            }
-                        }
+                        AddUnrequestedSecurity(algorithm, holding.Symbol, minResolution.Value);
 
                         algorithm.Portfolio[holding.Symbol].SetHoldings(holding.AveragePrice, holding.Quantity);
                         algorithm.Securities[holding.Symbol].SetMarketPrice(new TradeBar
@@ -381,6 +364,30 @@ namespace QuantConnect.Lean.Engine.Setup
             return Errors.Count == 0;
         }
 
+        private static void AddUnrequestedSecurity(IAlgorithm algorithm, Symbol symbol, Resolution minResolution)
+        {
+            if (!algorithm.Portfolio.ContainsKey(symbol))
+            {
+                Log.Trace("BrokerageSetupHandler.Setup(): Adding unrequested security: " + symbol.Value);
+
+                if (symbol.SecurityType == SecurityType.Option)
+                {
+                    // add current option contract to the system
+                    algorithm.AddOptionContract(symbol, minResolution, true, 1.0m);
+                }
+                else if (symbol.SecurityType == SecurityType.Future)
+                {
+                    // add current future contract to the system
+                    algorithm.AddFutureContract(symbol, minResolution, true, 1.0m);
+                }
+                else
+                {
+                    // for items not directly requested set leverage to 1 and at the min resolution
+                    algorithm.AddSecurity(symbol.SecurityType, symbol.Value, minResolution, null, true, 1.0m, false);
+                }
+            }
+        }
+
         /// <summary>
         /// Get the open orders from a brokerage. Adds <see cref="Orders.Order"/> and <see cref="Orders.OrderTicket"/> to the transaction handler
         /// </summary>
@@ -388,9 +395,12 @@ namespace QuantConnect.Lean.Engine.Setup
         /// <param name="resultHandler">The configured result handler</param>
         /// <param name="transactionHandler">The configurated transaction handler</param>
         /// <param name="brokerage">Brokerage output instance</param>
-        protected void GetOpenOrders(IAlgorithm algorithm, IResultHandler resultHandler, ITransactionHandler transactionHandler, IBrokerage brokerage)
+        /// <param name="supportedSecurityTypes">The list of supported security types</param>
+        /// <param name="minResolution">The resolution for the security to add, if required</param>
+        protected void GetOpenOrders(IAlgorithm algorithm, IResultHandler resultHandler, ITransactionHandler transactionHandler, IBrokerage brokerage,
+            HashSet<SecurityType> supportedSecurityTypes, Resolution minResolution)
         {
-            // populate the algorithm with the account's outstanding orders  resultHandler
+            // populate the algorithm with the account's outstanding orders
             var openOrders = brokerage.GetOpenOrders();
             foreach (var order in openOrders)
             {
@@ -399,6 +409,19 @@ namespace QuantConnect.Lean.Engine.Setup
                 resultHandler.DebugMessage($"BrokerageSetupHandler.Setup(): Open order detected.  Creating order tickets for open order {order.Symbol.Value} with quantity {order.Quantity}. Beware that this order ticket may not accurately reflect the quantity of the order if the open order is partially filled.");
                 order.Id = algorithm.Transactions.GetIncrementOrderId();
                 transactionHandler.AddOpenOrder(order, order.ToOrderTicket(algorithm.Transactions));
+
+                // verify existing holding security type
+                if (!supportedSecurityTypes.Contains(order.SecurityType))
+                {
+                    Log.Error("BrokerageSetupHandler.Setup(): Unsupported security type: " + order.SecurityType + "-" + order.Symbol.Value);
+                    AddInitializationError("Found unsupported security type in existing brokerage open orders: " + order.SecurityType + ". " +
+                                           "QuantConnect currently supports the following security types: " + string.Join(",", supportedSecurityTypes));
+
+                    // keep aggregating these errors
+                    continue;
+                }
+
+                AddUnrequestedSecurity(algorithm, order.Symbol, minResolution);
             }
         }
 


### PR DESCRIPTION

#### Description
The `BrokerageSetupHandler` has been updated to add securities for open orders to the algorithm, if not already added during `Initialize`.

#### Related Issue
Closes #2445 

#### Motivation and Context
Securities should be added to the algorithm for all open orders.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Updated unit test + live algorithm with IB.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`