### PR TITLE
Add new and enable ignored LiveTradingDataFeed tests

### DIFF
--- a/Tests/Engine/DataFeeds/AlgorithmStub.cs
+++ b/Tests/Engine/DataFeeds/AlgorithmStub.cs
@@ -31,6 +31,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         {
             dataManager = new DataManager();
             SubscriptionManager.SetDataManager(dataManager);
+            AddSecurities(resolution, equities, forex);
+        }
+
+        public void AddSecurities(Resolution resolution = Resolution.Second, List<string> equities = null, List<string> forex = null)
+        {
             foreach (var ticker in equities ?? new List<string>())
             {
                 AddSecurity(SecurityType.Equity, ticker, resolution);

--- a/Tests/Engine/DataFeeds/CustomLiveDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/CustomLiveDataFeedTests.cs
@@ -162,6 +162,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 Log.Trace($"Error: {exception}");
             }
 
+            timer.Value.Dispose();
             Assert.AreEqual(14 * tickers.Length, dataPointsEmitted);
         }
 
@@ -250,6 +251,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 Log.Trace($"Error: {exception}");
             }
 
+            timer.Value.Dispose();
             Assert.AreEqual(14, slicesEmitted);
             Assert.AreEqual(14 * symbols.Count, dataPointsEmitted);
         }

--- a/Tests/Engine/DataFeeds/CustomMockedFileBaseData.cs
+++ b/Tests/Engine/DataFeeds/CustomMockedFileBaseData.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,34 +22,27 @@ namespace QuantConnect.Tests.Engine.DataFeeds
     /// <summary>
     /// Custom data type that uses a remote file download
     /// </summary>
-    public class RemoteFileBaseData : BaseData
+    public class CustomMockedFileBaseData : BaseData
     {
+        private int _minutesToAdd;
+        public static DateTime StartDate;
+
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
-            var csv = line.Split(',');
-            if (csv[1].ToLower() != config.Symbol.ToString().ToLower())
-            {
-                // this row isn't for me
-                return null;
-            }
-
-            var time = QuantConnect.Time.UnixTimeStampToDateTime(double.Parse(csv[0])).ConvertFromUtc(config.DataTimeZone).Subtract(config.Increment);
-            return new RemoteFileBaseData
+            var start = StartDate.Add(TimeSpan.FromMinutes(_minutesToAdd++)).ConvertFromUtc(config.DataTimeZone);
+            return new CustomMockedFileBaseData
             {
                 Symbol = config.Symbol,
-                Time = time,
-                EndTime = time.Add(config.Increment),
-                Value = decimal.Parse(csv[3])
-
+                Time = start,
+                EndTime = start.Add(config.Increment),
+                Value = 10
             };
         }
 
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
-            // this file is only a few seconds worth of data, so it's quick to download
-            var remoteFileSource = @"http://www.quantconnect.com/live-test?type=file&symbols=" + config.Symbol.Value;
-            remoteFileSource = @"http://beta.quantconnect.com/live-test?type=file&symbols=" + config.Symbol.Value;
-            return new SubscriptionDataSource(remoteFileSource, SubscriptionTransportMedium.RemoteFile, FileFormat.Csv);
+            // using an already existing file, the file it self and its contents don't really matter. The reader will mock the values
+            return new SubscriptionDataSource("./TestData/spy_with_ichimoku.csv", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
         }
     }
 }

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -99,10 +99,11 @@ namespace QuantConnect.Tests.Engine.Setup
         {
             var algorithm = new TestAlgorithm();
             var job = new LiveNodePacket { UserId = 1, ProjectId = 1, DeployId = "1", Brokerage = "PaperBrokerage", DataQueueHandler = "none"};
+            // Increasing RAM limit, else the tests fail. This is happening in master, when running all the tests together, locally (not travis).
+            job.Controls.RamAllocation = 1024 * 1024 * 1024;
             var resultHandler = new Mock<IResultHandler>();
             var transactionHandler = new Mock<ITransactionHandler>();
             var realTimeHandler = new Mock<IRealTimeHandler>();
-
             var brokerage = new Mock<IBrokerage>();
             brokerage.Setup(x => x.IsConnected).Returns(true);
             brokerage.Setup(x => x.GetCashBalance()).Returns(new List<Cash>());

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -325,7 +325,7 @@
     <Compile Include="Engine\DataFeeds\FillForwardEnumeratorTest.cs" />
     <Compile Include="Engine\DataFeeds\IEXDataQueueHandlerTests.cs" />
     <Compile Include="Engine\DataFeeds\IQFeedRealtimeDataFeedTests.cs" />
-    <Compile Include="Engine\DataFeeds\RemoteFileBaseData.cs" />
+    <Compile Include="Engine\DataFeeds\CustomMockedFileBaseData.cs" />
     <Compile Include="Engine\DataFeeds\RestApiBaseData.cs" />
     <Compile Include="Engine\DataFeeds\FuncDataQueueHandler.cs" />
     <Compile Include="Engine\DataFeeds\LiveTradingDataFeedTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Enable and refactor old ignored tests
    - Previous testing `RemoteFileBaseData.cs` will now be `CustomMockedFileBaseData.cs` which will return data starting from a set date and increasing by one minute. For `GetSource()` it will use an already existing file, the file itself and its contents don't really matter, the `reader` will mock the values.
    - Adding new asserts and consolidating shared code
- Add 3 new tests
- Adding a couple of missing `timer.Dispose();`. If not called, the timer could live on from one test to another.
- Increasing the ram limit for test `BrokerageSetupHandlerTests.LoadsExistingHoldingsAndOrders` else the tests fail due to exceeding ram limit. _This is happening in master, locally (not travis)._
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2468
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reduce risk when incorporating the `SubscriptionSynchronizer` to the `LiveTradingDataFeed`.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executing the tests multiple times
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->