### PR TITLE
SubscriptionSynchronizer will depend on new SubscriptionFrontierTimeProvider 

### DIFF
--- a/Engine/DataFeeds/ManualTimeProvider.cs
+++ b/Engine/DataFeeds/ManualTimeProvider.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/Engine/DataFeeds/SubscriptionFrontierTimeProvider.cs
+++ b/Engine/DataFeeds/SubscriptionFrontierTimeProvider.cs
@@ -1,0 +1,80 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// A time provider which updates 'now' time based on the current data emit time of all subscriptions
+    /// </summary>
+    public class SubscriptionFrontierTimeProvider : ITimeProvider
+    {
+        private static readonly long MaxDateTimeTicks = DateTime.MaxValue.Ticks;
+        private DateTime _utcNow;
+        private readonly IDataFeedSubscriptionManager _subscriptionManager;
+
+        /// <summary>
+        /// Creates a new instance of the SubscriptionFrontierTimeProvider
+        /// </summary>
+        /// <param name="utcNow">Initial UTC now time</param>
+        /// <param name="subscriptionManager">Subscription manager. Will be used to obtain current subscriptions</param>
+        public SubscriptionFrontierTimeProvider(DateTime utcNow, IDataFeedSubscriptionManager subscriptionManager)
+        {
+            _utcNow = utcNow;
+            _subscriptionManager = subscriptionManager;
+        }
+
+        /// <summary>
+        /// Gets the current time in UTC
+        /// </summary>
+        /// <returns>The current time in UTC</returns>
+        public DateTime GetUtcNow()
+        {
+            UpdateCurrentTime();
+            return _utcNow;
+        }
+
+        /// <summary>
+        /// Sets the current time calculated as the minimum current data emit time of all the subscriptions.
+        /// If there are no subscriptions current time will remain unchanged
+        /// </summary>
+        private void UpdateCurrentTime()
+        {
+            long earlyBirdTicks = MaxDateTimeTicks;
+            foreach (var subscription in _subscriptionManager.DataFeedSubscriptions)
+            {
+                if (subscription.Current != null)
+                {
+                    if (earlyBirdTicks == MaxDateTimeTicks)
+                    {
+                        earlyBirdTicks = subscription.Current.EmitTimeUtc.Ticks;
+                    }
+                    else
+                    {
+                        // take the earliest between the next piece of data or the current earliest bird
+                        earlyBirdTicks = Math.Min(earlyBirdTicks, subscription.Current.EmitTimeUtc.Ticks);
+                    }
+                }
+            }
+
+            if (earlyBirdTicks != MaxDateTimeTicks)
+            {
+                _utcNow = new DateTime(Math.Max(earlyBirdTicks, _utcNow.Ticks), DateTimeKind.Utc);
+            }
+        }
+    }
+}

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -157,6 +157,7 @@
     <Compile Include="DataFeeds\ISubscriptionSynchronizer.cs" />
     <Compile Include="DataFeeds\LiveFutureChainProvider.cs" />
     <Compile Include="DataFeeds\LiveOptionChainProvider.cs" />
+    <Compile Include="DataFeeds\SubscriptionFrontierTimeProvider.cs" />
     <Compile Include="DataFeeds\SingleEntryDataCacheProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\BaseDataCollectionAggregatorEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\EnqueueableEnumerator.cs" />

--- a/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
@@ -62,17 +62,24 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var endTimeUtc = algorithm.EndDate.ConvertToUtc(TimeZones.NewYork);
             var startTimeUtc = algorithm.StartDate.ConvertToUtc(TimeZones.NewYork);
+            var dataFeedSubscriptionManager = new DataFeedSubscriptionManager
+            {
+                DataFeedSubscriptions = new SubscriptionCollection()
+            };
+            var subscriptionBasedTimeProvider = new SubscriptionFrontierTimeProvider(startTimeUtc, dataFeedSubscriptionManager);
 
             var feed = new AlgorithmManagerTests.MockDataFeed();
             var universeSelection = new UniverseSelection(feed, algorithm);
-            var synchronizer = new SubscriptionSynchronizer(universeSelection, algorithm.TimeZone, algorithm.Portfolio.CashBook, startTimeUtc);
+            var synchronizer = new SubscriptionSynchronizer(universeSelection, algorithm.TimeZone,
+                                                            algorithm.Portfolio.CashBook,
+                                                            subscriptionBasedTimeProvider);
 
             var totalDataPoints = 0;
-            var subscriptions = new List<Subscription>();
+            var subscriptions = dataFeedSubscriptionManager.DataFeedSubscriptions;
             foreach (var kvp in algorithm.Securities)
             {
                 int dataPointCount;
-                subscriptions.Add(CreateSubscription(algorithm, kvp.Value, startTimeUtc, endTimeUtc, out dataPointCount));
+                subscriptions.TryAdd(CreateSubscription(algorithm, kvp.Value, startTimeUtc, endTimeUtc, out dataPointCount));
                 totalDataPoints += dataPointCount;
             }
 
@@ -80,24 +87,26 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             synchronizer.Sync(subscriptions);
 
             // log what we're doing
-            Console.WriteLine($"Running {subscriptions.Count} subscriptions with a total of {totalDataPoints} data points. Start: {algorithm.StartDate:yyyy-MM-dd} End: {algorithm.EndDate:yyyy-MM-dd}");
+            Console.WriteLine($"Running {subscriptions.Count()} subscriptions with a total of {totalDataPoints} data points. Start: {algorithm.StartDate:yyyy-MM-dd} End: {algorithm.EndDate:yyyy-MM-dd}");
 
             var count = 0;
-            DateTime currentTime;
-            var dateTimeMaxValue = DateTime.MaxValue;
+            DateTime currentTime = DateTime.MaxValue;
+            DateTime previousValue;
             var stopwatch = Stopwatch.StartNew();
             do
             {
+                previousValue = currentTime;
                 var timeSlice = synchronizer.Sync(subscriptions);
                 currentTime = timeSlice.Time;
                 count += timeSlice.DataPointCount;
             }
-            while (currentTime != dateTimeMaxValue);
+            while (currentTime != previousValue);
 
             stopwatch.Stop();
 
             var kps = count / 1000d / stopwatch.Elapsed.TotalSeconds;
             Console.WriteLine($"Current Time: {currentTime:u}  Elapsed time: {(int)stopwatch.Elapsed.TotalSeconds,4}s  KPS: {kps,7:.00}  COUNT: {count,10}");
+            Assert.GreaterOrEqual(count, 100); // this assert is for sanity purpose
         }
 
         private Subscription CreateSubscription(QCAlgorithm algorithm, Security security, DateTime startTimeUtc, DateTime endTimeUtc, out int dataPointCount)
@@ -122,6 +131,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         private class DataPoint : BaseData
         {
             // bare bones base data to minimize memory footprint
+        }
+
+        private class DataFeedSubscriptionManager : IDataFeedSubscriptionManager
+        {
+            public SubscriptionCollection DataFeedSubscriptions { get; set; }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- SubscriptionSynchronizer:
     - Will depend on a provided `ITimeProvider` for determining next frontier.
     - For it to be compatible with the `LiveTradingDataFeed` enumerator stack, I removed the exception throwing if `subscription.Current == null` and adding a check for `subscription.Current != null`
- Adding new SubscriptionFrontierTimeProvider which updates current time based on the current data emit time of all subscriptions.
- Following results show there is no significant impact in performance:
       ![imagen](https://user-images.githubusercontent.com/18473240/45240275-728a5980-b2be-11e8-92cb-e17addd42638.png)


<details><summary>ALGORITHM 1 used for performance tests, 465 tickers, daily resolution, adding 1 equity every two days, from 2010 to 2018</summary>
<p>

```
/*
 * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
 * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
*/

using System.Collections.Generic;
using QuantConnect.Data;

namespace QuantConnect.Algorithm.CSharp
{
    /// <summary>
    /// Basic template algorithm simply initializes the date range and cash. This is a skeleton
    /// framework you can use for designing an algorithm.
    /// </summary>
    /// <meta name="tag" content="using data" />
    /// <meta name="tag" content="using quantconnect" />
    /// <meta name="tag" content="trading and orders" />
    public class BasicTemplateAlgorithm : QCAlgorithm
    {
        private long _count;
        private int _currentIndex;

        public readonly IReadOnlyList<string> EquitySymbols = new List<string>
        {
            "ABT", "ABBV", "ACN", "ACE", "ADBE", "ADT", "AAP", "AES", "AET", "AFL", "AMG", "A", "GAS", "APD", "ARG", "AKAM", "AA", "AGN",
                "ALXN", "ALLE", "ADS", "ALL", "ALTR", "MO", "AMZN", "AEE", "AAL", "AEP", "AXP", "AIG", "AMT", "AMP", "ABC", "AME", "AMGN",
            "APH", "APC", "ADI", "AON", "APA", "AIV", "AMAT", "ADM", "AIZ", "T", "ADSK", "ADP", "AN", "AZO", "AVGO", "AVB", "AVY", "BHI",
            "BLL", "BAC", "BK", "BCR", "BXLT", "BAX", "BBT", "BDX", "BBBY", "BBY", "BLX", "HRB", "BA", "BWA", "BXP", "BMY", "BRCM", "CHRW",
            "CA", "CVC", "COG", "CAM", "CPB", "COF", "CAH", "HSIC", "KMX", "CCL", "CAT", "CBG", "CBS", "CELG", "CNP", "CTL", "CERN",
            "CF", "SCHW", "CHK", "CVX", "CMG", "CB", "CI", "XEC", "CINF", "CTAS", "CSCO", "C", "CTXS", "CLX", "CME", "CMS", "COH",
            "KO", "CCE", "CTSH", "CL", "CMCSA", "CMA", "CSC", "CAG", "COP", "CNX", "ED", "STZ", "GLW", "COST", "CCI", "CSX", "CMI",
            "CVS", "DHI", "DHR", "DRI", "DVA", "DE", "DLPH", "DAL", "XRAY", "DVN", "DO", "DTV", "DFS", "DISCA", "DISCK", "DG", "DLTR",
            "D", "DOV", "DOW", "DPS", "DTE", "DD", "DUK", "DNB", "ETFC", "EMN", "ETN", "EBAY", "ECL", "EIX", "EW", "EA", "EMC", "EMR",
            "ENDP", "ESV", "ETR", "EOG", "EQT", "EFX", "EQIX", "EQR", "ESS", "EL", "ES", "EXC", "EXPE", "EXPD", "ESRX", "XOM", "FFIV",
            "FB", "FAST", "FDX", "FIS", "FITB", "FSLR", "FE", "FLIR", "FLS", "FLR", "FMC", "FTI", "F", "FOSL", "BEN", "FCX", "FTR",
            "GME", "GPS", "GRMN", "GD", "GE", "GGP", "GIS", "GM", "GPC", "GNW", "GILD", "GS", "GT", "GOOGL", "GOOG", "GWW", "HAL", "HBI",
            "HOG", "HAR", "HRS", "HIG", "HAS", "HCA", "HCP", "HCN", "HP", "HES", "HPQ", "HD", "HON", "HRL", "HSP", "HST", "HCBK", "HUM",
            "HBAN", "ITW", "IR", "INTC", "ICE", "IBM", "IP", "IPG", "IFF", "INTU", "ISRG", "IVZ", "IRM", "JEC", "JBHT", "JNJ", "JCI", "JOY",
            "JPM", "JNPR", "KSU", "K", "KEY", "GMCR", "KMB", "KIM", "KMI", "KLAC", "KSS", "KRFT", "KR", "LB", "LLL", "LH", "LRCX", "LM",
            "LEG", "LEN", "LVLT", "LUK", "LLY", "LNC", "LLTC", "LMT", "L", "LOW", "LYB", "MTB", "MAC", "M", "MNK", "MRO", "MPC", "MAR",
            "MMC", "MLM", "MAS", "MA", "MAT", "MKC", "MCD", "MHFI", "MCK", "MJN", "MMV", "MDT", "MRK", "MET", "KORS", "MCHP", "MU",
            "MSFT", "MHK", "TAP", "MDLZ", "MON", "MNST", "MCO", "MS", "MOS", "MSI", "MUR", "MYL", "NDAQ", "NOV", "NAVI", "NTAP", "NFLX",
            "NWL", "NFX", "NEM", "NWSA", "NEE", "NLSN", "NKE", "NI", "NE", "NBL", "JWN", "NSC", "NTRS", "NOC", "NRG", "NUE", "NVDA",
            "ORLY", "OXY", "OMC", "OKE", "ORCL", "OI", "PCAR", "PLL", "PH", "PDCO", "PAYX", "PNR", "PBCT", "POM", "PEP", "PKI", "PRGO",
            "PFE", "PCG", "PM", "PSX", "PNW", "PXD", "PBI", "PCL", "PNC", "RL", "PPG", "PPL", "PX", "PCP", "PCLN", "PFG", "PG", "PGR",
            "PLD", "PRU", "PEG", "PSA", "PHM", "PVH", "QRVO", "PWR", "QCOM", "DGX", "RRC", "RTN", "O", "RHT", "REGN", "RF", "RSG",
            "RAI", "RHI", "ROK", "COL", "ROP", "ROST", "RLC", "R", "CRM", "SNDK", "SCG", "SLB", "SNI", "STX", "SEE", "SRE", "SHW",
            "SIAL", "SPG", "SWKS", "SLG", "SJM", "SNA", "SO", "LUV", "SWN", "SE", "STJ", "SWK", "SPLS", "SBUX", "HOT", "STT", "SRCL",
            "SYK", "STI", "SYMC", "SYY", "TROW", "TGT", "TEL", "TE", "TGNA", "THC", "TDC", "TSO", "TXN", "TXT", "HSY", "TRV", "TMO",
            "TIF", "TWX", "TWC", "TJK", "TMK", "TSS", "TSCO", "RIG", "TRIP", "FOXA", "TSN", "TYC", "UA", "UNP", "UNH", "UPS", "URI",
            "UTX", "UHS", "UNM", "URBN", "VFC", "VLO", "VAR", "VTR", "VRSN", "VZ", "VRTX", "VIAB", "V", "VNO", "VMC", "WMT", "WBA",
            "DIS", "WM", "WAT", "ANTM", "WFC", "WDC", "WU", "WY", "WHR", "WFM", "WMB", "WEC", "WYN", "WYNN", "XEL", "XRX", "XLNX",
            "XL", "XYL", "YHOO", "YUM", "ZBH", "ZION", "ZTS"
        };

        /// <summary>
        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
        /// </summary>
        public override void Initialize()
        {
            SetStartDate(2010, 01, 01);  //Set Start Date
            SetEndDate(2018, 01, 01);    //Set End Date
            SetCash(100000);             //Set Strategy Cash

            AddEquity("SPY", Resolution.Daily);
        }

        /// <summary>
        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
        /// </summary>
        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
        public override void OnData(Slice data)
        {
            _count++;
            if (_count % 2 == 0 && _currentIndex < EquitySymbols.Count)
            {
                AddEquity(EquitySymbols[_currentIndex++], Resolution.Daily);
            }
        }
    }
}
```

</p>
</details>

<details><summary>ALGORITHM 2 used for performance tests, 184 tickers, hour resolution, adding 1 equity every two days, from 2010 to 2018</summary>
<p>

```
/*
 * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
 * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
*/

using System.Collections.Generic;
using QuantConnect.Data;

namespace QuantConnect.Algorithm.CSharp
{
    /// <summary>
    /// Basic template algorithm simply initializes the date range and cash. This is a skeleton
    /// framework you can use for designing an algorithm.
    /// </summary>
    /// <meta name="tag" content="using data" />
    /// <meta name="tag" content="using quantconnect" />
    /// <meta name="tag" content="trading and orders" />
    public class BasicTemplateAlgorithm : QCAlgorithm
    {
        private long _count;
        private int _currentIndex;

        public readonly IReadOnlyList<string> EquitySymbols = new List<string>
        {
            "audcad","audchf","audcny","audczk","auddkk","audhkd","audhuf","audinr","audjpy","audmxn","audnok","audnzd","audpln",
            "audsar","audsek","audsgd","audthb","audtry","audtwd","audusd","audzar","cadaud","cadchf","cadcny","cadczk","caddkk",
            "cadhkd","cadhuf","cadinr","cadjpy","cadmxn","cadnok","cadnzd","cadpln","cadsar","cadsek","cadsgd","cadthb","cadtry",
            "cadtwd","cadzar","chfaud","chfcad","chfcny","chfczk","chfdkk","chfhkd","chfhuf","chfinr","chfjpy","chfmxn","chfnok",
            "chfnzd","chfpln","chfsar","chfsek","chfsgd","chfthb","chftry","chftwd","chfusd","chfzar","cnhusd","cnyjpy","czkjpy",
            "dkkjpy","euraud","eurcad","eurchf","eurcny","eurczk","eurdkk","eurgbp","eurhkd","eurhuf","eurinr","eurjpy","eurmxn",
            "eurnok","eurnzd","eurpln","eursar","eursek","eursgd","eurthb","eurtry","eurtwd","eurusd","eurzar","gbpaud","gbpcad",
            "gbpchf","gbpcny","gbpczk","gbpdkk","gbphkd","gbphuf","gbpinr","gbpjpy","gbpmxn","gbpnok","gbpnzd","gbppln","gbpsar",
            "gbpsek","gbpsgd","gbpthb","gbptry","gbptwd","gbpusd","gbpzar","hkdcny","hkdczk","hkddkk","hkdhuf","hkdinr","hkdjpy",
            "hkdmxn","hkdnok","hkdpln","hkdsar","hkdsek","hkdsgd","hkdthb","hkdtry","hkdtwd","hkdzar","inrjpy","jpyhuf","jpyusd",
            "mxnjpy","nokjpy","nzdcad","nzdchf","nzdhkd","nzdjpy","nzdsgd","nzdusd","plnjpy","sarjpy","sekjpy","sgdchf","sgdcny",
            "sgdczk","sgddkk","sgdhkd","sgdhuf","sgdinr","sgdjpy","sgdmxn","sgdnok","sgdpln","sgdsar","sgdsek","sgdthb","sgdtry",
            "sgdtwd","sgdzar","thbjpy","tryjpy","twdjpy","usdaud","usdcad","usdchf","usdcnh","usdcny","usdczk","usddkk","usdeur",
            "usdgbp","usdhkd","usdhuf","usdinr","usdjpy","usdmxn","usdnok","usdpln","usdsar","usdsek","usdsgd","usdthb","usdtry",
            "usdtwd","usdzar","zarjpy"
        };

        /// <summary>
        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
        /// </summary>
        public override void Initialize()
        {
            SetStartDate(2010, 01, 01);  //Set Start Date
            SetEndDate(2018, 01, 01);    //Set End Date
            SetCash(100000);             //Set Strategy Cash

            AddEquity("SPY", Resolution.Daily);
        }

        /// <summary>
        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
        /// </summary>
        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
        public override void OnData(Slice data)
        {
            _count++;
            if (_count % 2 == 0 && _currentIndex < EquitySymbols.Count)
            {
                AddForex(EquitySymbols[_currentIndex++], Resolution.Hour, Market.Oanda);
            }
        }
    }
}

```

</p>
</details>

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2460
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Project https://github.com/QuantConnect/Lean/projects/5. `SubscriptionSynchronizer` is shared by both live and backtest data feeds
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests, a few times. Tested the new `SubscriptionSynchronizer` in the cloud running live algorithms too.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->