### PR TITLE
LiveTradingDataFeed will use SubscriptionSynchronizer

### DIFF
--- a/Tests/Engine/DataFeeds/AlgorithmStub.cs
+++ b/Tests/Engine/DataFeeds/AlgorithmStub.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using QuantConnect.Algorithm;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 
@@ -26,6 +27,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
     /// </summary>
     public class AlgorithmStub : QCAlgorithm
     {
+        public List<SecurityChanges> SecurityChangesRecord = new List<SecurityChanges>();
+
         public AlgorithmStub(out DataManager dataManager, Resolution resolution = Resolution.Second,
                              List<string> equities = null, List<string> forex = null)
         {
@@ -48,6 +51,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 var symbol = SymbolCache.GetSymbol(ticker);
                 Securities[symbol].Exchange = new SecurityExchange(SecurityExchangeHours.AlwaysOpen(TimeZones.EasternStandard));
             }
+        }
+
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            SecurityChangesRecord.Add(changes);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
 - `LiveTradingDataFeed` will now use `SubscriptionSynchronizer`
- `LiveTradingDataFeed` will now remove `UniverseSelectionSubscription` once it has ended
- Adding new unit test and modifying existing to assert `SecurityChanges` and to take into account that it will remove `UniverseSelectionSubscription` when its ended
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2491
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Project https://github.com/QuantConnect/Lean/projects/5
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression and live tests: Tested `tick, second, minute, hour, daily` data resolutions, custom subscriptions, many subscriptions (500) and few subscriptions, verified the data points logged were the same `master` vs `branch`, adding and removing securities, tested adding universe (with customer symbol `selector`). Verified there were no significant RAM increases.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->