### PR TITLE
Futures ticker will now support daily and weekly expirations

### DIFF
--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -79,8 +79,9 @@ namespace QuantConnect
 
 
         /// <summary>
-        /// Function returns underlying name, expiration year, expiration month for the future contract ticker. Function detects if
-        /// the format is used either XYZH6 or XYZH16. Returns null, if parsing failed.
+        /// Function returns underlying name, expiration year, expiration month, expiration day for the future contract ticker. Function detects if
+        /// the format used is either 1 or 2 digits year, and if day code is present (will default to 1rst day of month). Returns null, if parsing failed.
+        /// Format [Ticker][2 digit day code OPTIONAL][1 char month code][2/1 digit year code]
         /// </summary>
         /// <param name="ticker"></param>
         /// <returns>Results containing 1) underlying name, 2) short expiration year, 3) expiration month</returns>
@@ -130,7 +131,8 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Returns future symbol ticker from underlying and expiration date. Function can generate tickers of two formats: one and two digits year
+        /// Returns future symbol ticker from underlying and expiration date. Function can generate tickers of two formats: one and two digits year.
+        /// Format [Ticker][2 digit day code][1 char month code][2/1 digit year code], more information at http://help.tradestation.com/09_01/tradestationhelp/symbology/futures_symbology.htm
         /// </summary>
         /// <param name="underlying">String underlying</param>
         /// <param name="expiration">Expiration date</param>

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -53,15 +53,31 @@ namespace QuantConnect.Tests.Common
         [Test]
         public void ParseFuturesTickers()
         {
-            // ticker contains two digits year of expiration
-            var result = SymbolRepresentation.ParseFutureTicker("EDX20");
-            Assert.AreEqual(result.Underlying, "ED");
+            // ticker contains two digits year of expiration, no day expiration
+            var result = SymbolRepresentation.ParseFutureTicker("EX20");
+            Assert.AreEqual(result.Underlying, "E");
+            Assert.AreEqual(result.ExpirationDay, 1);
             Assert.AreEqual(result.ExpirationYearShort, 20);
             Assert.AreEqual(result.ExpirationMonth, 11); // November
 
-            // ticker contains one digit year of expiration
+            // ticker contains one digit year of expiration, no day expiration
             result = SymbolRepresentation.ParseFutureTicker("ABCZ1");
             Assert.AreEqual(result.Underlying, "ABC");
+            Assert.AreEqual(result.ExpirationDay, 1);
+            Assert.AreEqual(result.ExpirationYearShort, 1);
+            Assert.AreEqual(result.ExpirationMonth, 12); // December
+
+            // ticker contains two digits year of expiration, with day expiration
+            result = SymbolRepresentation.ParseFutureTicker("ED01X20");
+            Assert.AreEqual(result.Underlying, "ED");
+            Assert.AreEqual(result.ExpirationDay, 1);
+            Assert.AreEqual(result.ExpirationYearShort, 20);
+            Assert.AreEqual(result.ExpirationMonth, 11); // November
+
+            // ticker contains one digit year of expiration, with day expiration
+            result = SymbolRepresentation.ParseFutureTicker("ABC11Z1");
+            Assert.AreEqual(result.Underlying, "ABC");
+            Assert.AreEqual(result.ExpirationDay, 11);
             Assert.AreEqual(result.ExpirationYearShort, 1);
             Assert.AreEqual(result.ExpirationMonth, 12); // December
         }
@@ -73,21 +89,21 @@ namespace QuantConnect.Tests.Common
             var result = SymbolRepresentation.GenerateFutureTicker(ticker, new DateTime(2016, 12, 12));
 
             // ticker contains two digits year of expiration
-            Assert.AreEqual(result, "EDZ16");
+            Assert.AreEqual(result, "ED12Z16");
 
             // ticker contains one digit year of expiration
             result = SymbolRepresentation.GenerateFutureTicker(ticker, new DateTime(2016, 12, 12), false);
-            Assert.AreEqual(result, "EDZ6");
+            Assert.AreEqual(result, "ED12Z6");
         }
 
         [Test]
         public void GenerateFuturesTickersBackAndForth()
         {
-            const string expected = @"EDZ16";
+            const string expected = @"ED01Z16";
             var result = SymbolRepresentation.ParseFutureTicker(expected);
-            var ticker = SymbolRepresentation.GenerateFutureTicker(result.Underlying, new DateTime(2000 + result.ExpirationYearShort, result.ExpirationMonth, 1));
+            var ticker = SymbolRepresentation.GenerateFutureTicker(result.Underlying, new DateTime(2000 + result.ExpirationYearShort, result.ExpirationMonth, result.ExpirationDay));
 
-            Assert.AreEqual(ticker, expected);
+            Assert.AreEqual(expected, ticker);
         }
 
         [Test]
@@ -103,7 +119,7 @@ namespace QuantConnect.Tests.Common
             // CL Dec17 expires in Nov17
             var result = SymbolRepresentation.GenerateFutureTicker("CL", new DateTime(2017, 11, 20));
 
-            Assert.AreEqual("CLZ17", result);
+            Assert.AreEqual("CL20Z17", result);
         }
     }
 }

--- a/Tests/ToolBox/LeanDataReaderTests.cs
+++ b/Tests/ToolBox/LeanDataReaderTests.cs
@@ -44,9 +44,9 @@ namespace QuantConnect.Tests.ToolBox
             var canonicalFutures = new Dictionary<Symbol, string>()
             {
                 { Symbol.Create(Futures.Indices.SP500EMini, SecurityType.Future, Market.USA),
-                    "ESZ13|ESH14|ESM14|ESU14|ESZ14" },
+                    "ES20Z13|ES21H14|ES20M14|ES19U14|ES19Z14" },
                 {Symbol.Create(Futures.Metals.Gold, SecurityType.Future, Market.USA),
-                    "GCV13|GCX13|GCZ13|GCG14|GCJ14|GCM14|GCQ14|GCV14|GCZ14|GCG15|GCJ15|GCM15|GCQ15|GCZ15|GCM16|GCZ16|GCM17|GCZ17|GCM18|GCZ18|GCM19"},
+                    "GC29V13|GC26X13|GC27Z13|GC26G14|GC28J14|GC26M14|GC27Q14|GC29V14|GC29Z14|GC25G15|GC28J15|GC26M15|GC27Q15|GC29Z15|GC28M16|GC28Z16|GC28M17|GC27Z17|GC27M18|GC27Z18|GC26M19"},
             };
 
             var tickTypes = new[] { TickType.Trade, TickType.Quote, TickType.OpenInterest };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `GenerateFutureTicker()` will now follow format: `[Ticker][2 digit day code][Month code][2/1 digit year code]`
> http://help.tradestation.com/09_01/tradestationhelp/symbology/futures_symbology.htm#Daily_Expiring_Contracts
- `ParseFutureTicker()` will now support parsing the new format, optionally will also support old format version (no 2 digit day code). This is only used in the tool box code.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2493
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix Live algorithm errors
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression tests. **Live trading algorithm.**
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->