### PR TITLE
Add logging of margin information in Live mode

### DIFF
--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -697,11 +697,25 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Logs margin information for debugging
         /// </summary>
-        public void LogMarginInformation()
+        public void LogMarginInformation(OrderRequest orderRequest = null)
         {
-            Log.Trace("Margin information: " +
+            Log.Trace("Total margin information: " +
                       $"TotalMarginUsed: {TotalMarginUsed.ToString("F2", CultureInfo.InvariantCulture)}, " +
                       $"MarginRemaining: {MarginRemaining.ToString("F2", CultureInfo.InvariantCulture)}");
+
+            var orderSubmitRequest = orderRequest as SubmitOrderRequest;
+            if (orderSubmitRequest != null)
+            {
+                var direction = orderSubmitRequest.Quantity > 0 ? OrderDirection.Buy : OrderDirection.Sell;
+                var security = Securities[orderSubmitRequest.Symbol];
+
+                var marginUsed = security.BuyingPowerModel.GetReservedBuyingPowerForPosition(security);
+                var marginRemaining = security.BuyingPowerModel.GetBuyingPower(this, security, direction);
+
+                Log.Trace("Order request margin information: " +
+                          $"MarginUsed: {marginUsed.ToString("F2", CultureInfo.InvariantCulture)}, " +
+                          $"MarginRemaining: {marginRemaining.ToString("F2", CultureInfo.InvariantCulture)}");
+            }
         }
     }
 }

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -16,9 +16,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
+using QuantConnect.Logging;
 using QuantConnect.Orders;
 
 namespace QuantConnect.Securities
@@ -692,5 +694,14 @@ namespace QuantConnect.Securities
             }
         }
 
+        /// <summary>
+        /// Logs margin information for debugging
+        /// </summary>
+        public void LogMarginInformation()
+        {
+            Log.Trace("Margin information: " +
+                      $"TotalMarginUsed: {TotalMarginUsed.ToString("F2", CultureInfo.InvariantCulture)}, " +
+                      $"MarginRemaining: {MarginRemaining.ToString("F2", CultureInfo.InvariantCulture)}");
+        }
     }
 }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -186,6 +186,8 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             if (_algorithm.LiveMode)
             {
                 Log.Trace("BrokerageTransactionHandler.Process(): " + request);
+
+                _algorithm.Portfolio.LogMarginInformation();
             }
 
             switch (request.OrderRequestType)
@@ -654,6 +656,8 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 {
                     _lastSyncTimeTicks = DateTime.UtcNow.Ticks;
                     Log.Trace("BrokerageTransactionHandler.PerformCashSync(): Verified cash sync.");
+
+                    _algorithm.Portfolio.LogMarginInformation();
                 }
             });
         }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -187,7 +187,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             {
                 Log.Trace("BrokerageTransactionHandler.Process(): " + request);
 
-                _algorithm.Portfolio.LogMarginInformation();
+                _algorithm.Portfolio.LogMarginInformation(request);
             }
 
             switch (request.OrderRequestType)


### PR DESCRIPTION

#### Description
Logging of margin information has been added (in Live mode only):
- before processing order requests (submit/update/cancel)
- after daily brokerage cash sync

#### Related Issue
Closes #2496 

#### Motivation and Context
Helpful for debugging Live algorithm margin issues.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Live algorithm deployed locally.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`