### PR TITLE
Fix error getting account option holdings from brokerage

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1586,8 +1586,10 @@ namespace QuantConnect.Algorithm
             {
                 equity = AddEquity(underlying.Value, option.Resolution, underlying.ID.Market, false);
             }
-            else if (equity.DataNormalizationMode != DataNormalizationMode.Raw)
+            else if (equity.DataNormalizationMode != DataNormalizationMode.Raw && _locked)
             {
+                // We check the "locked" flag here because during initialization we need to load existing open orders and holdings from brokerages.
+                // There is no data streaming yet, so it is safe to change the data normalization mode to Raw.
                 throw new ArgumentException($"The underlying equity asset ({underlying.Value}) is set to {equity.DataNormalizationMode}, " +
                                             "please change this to DataNormalizationMode.Raw with the SetDataNormalization() method");
             }

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -177,6 +177,17 @@ namespace QuantConnect.Tests.Engine.Setup
                 new TestCaseData(
                         new List<Holding>
                         {
+                            new Holding { Type = SecurityType.Option, Symbol = Symbols.SPY_C_192_Feb19_2016, Quantity = 1 }
+                        },
+                        new List<Order>
+                        {
+                            new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow),
+                        })
+                    .SetName("Equity open order + Option holding"),
+
+                new TestCaseData(
+                        new List<Holding>
+                        {
                             new Holding { Type = SecurityType.Forex, Symbol = Symbols.EURUSD, Quantity = 1 }
                         },
                         new List<Order>


### PR DESCRIPTION

#### Description
When loading existing option holdings in `BrokerageSetupHandler`, we no longer throw an exception if the underlying equity has been added with `DataNormalizationMode` **not** set to `Raw`.
This PR handles an edge case which was not covered by PR #2462 .

#### Related Issue
Closes #2500 

#### Motivation and Context
Exception was thrown when loading existing option holdings from a live brokerage account.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`