### PR TITLE
Quantity in trade ticks should always be positive

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -363,7 +363,7 @@ namespace QuantConnect.Brokerages.Bitfinex
                     if (amount > 0)
                         orderBook.UpdateBidRow(price, amount);
                     else
-                        orderBook.UpdateAskRow(price, amount);
+                        orderBook.UpdateAskRow(price, Math.Abs(amount));
                 }
 
                 orderBook.BestBidAskUpdated += OnBestBidAskUpdated;
@@ -447,7 +447,7 @@ namespace QuantConnect.Brokerages.Bitfinex
                     }
                     else if (amount < 0)
                     {
-                        orderBook.UpdateAskRow(price, amount);
+                        orderBook.UpdateAskRow(price, Math.Abs(amount));
                     }
                 }
             }
@@ -611,8 +611,8 @@ namespace QuantConnect.Brokerages.Bitfinex
                     Time = DateTime.UtcNow,
                     Symbol = symbol,
                     TickType = TickType.Quote,
-                    AskSize = askSize,
-                    BidSize = bidSize
+                    AskSize = Math.Abs(askSize),
+                    BidSize = Math.Abs(bidSize)
                 });
             }
         }


### PR DESCRIPTION
- use abs value for internal orderbook copy
- use abs value on quote tick emit


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Bitfinex brokerage returns negative quantity values for ask orders, so we need to use absolute value for internal order book copy and trade ticks.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Lean does not support negative quantity values in trade ticks

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->