### PR TITLE
Fix PostInitialize called too early in BrokerageSetupHandler.Setup

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -215,9 +215,6 @@ namespace QuantConnect.Lean.Engine.Setup
                         //Initialise the algorithm, get the required data:
                         algorithm.Initialize();
 
-                        //Finalize Initialization
-                        algorithm.PostInitialize();
-
                         if (liveJob.Brokerage != "PaperBrokerage")
                         {
                             //Zero the CashBook - we'll populate directly from brokerage
@@ -346,6 +343,9 @@ namespace QuantConnect.Lean.Engine.Setup
                     AddInitializationError("Error getting account holdings from brokerage: " + err.Message, err);
                     return false;
                 }
+
+                //Finalize Initialization
+                algorithm.PostInitialize();
 
                 //Set the starting portfolio value for the strategy to calculate performance:
                 StartingPortfolioValue = algorithm.Portfolio.TotalPortfolioValue;


### PR DESCRIPTION

#### Description
The `PostInitialize` call in `BrokerageSetupHandler.Setup` has been moved below the `brokerage.GetAccountHoldings` and `brokerage.GetOpenOrders` calls.

#### Related Issue
Closes #2507

#### Motivation and Context
`PostInitialize` should be called when all securities have been added, including the ones required because of existing holdings and open orders.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test cases and live brokerage testing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`