### PR TITLE
Remove AlgorithmDownload tests from Travis CI build

### DIFF
--- a/Tests/Algorithm/AlgorithmDownloadTests.cs
+++ b/Tests/Algorithm/AlgorithmDownloadTests.cs
@@ -22,7 +22,8 @@ using System.Text;
 
 namespace QuantConnect.Tests.Algorithm
 {
-    [TestFixture]
+    // For now these tests are excluded from the Travis build because of occasional web server errors.
+    [TestFixture, Category("TravisExclude")]
     public class AlgorithmDownloadTests
     {
         [Test]


### PR DESCRIPTION

#### Description
The `AlgorithmDownloadTests` unit tests have been excluded from the Travis CI build.

#### Related Issue
Closes #2517 

#### Motivation and Context
Random Travis build failure.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`