### PR TITLE
Adds key check after History requests in framework models

### DIFF
--- a/Algorithm.Framework/Alphas/RsiAlphaModel.py
+++ b/Algorithm.Framework/Alphas/RsiAlphaModel.py
@@ -86,12 +86,17 @@ class RsiAlphaModel(AlphaModel):
         if len(addedSymbols) == 0: return
 
         history = algorithm.History(addedSymbols, self.period, self.resolution)
-
+        
         for symbol in addedSymbols:
             rsi = algorithm.RSI(symbol, self.period, MovingAverageType.Wilders, self.resolution)
 
             if not history.empty:
                 ticker = SymbolCache.GetTicker(symbol)
+                
+                if ticker not in history.index.levels[0]:
+                    algorithm.Log(f'RsiAlphaModel.OnSecuritiesChanged: {ticker} not found in history data frame.')
+                    continue
+
                 for tuple in history.loc[ticker].itertuples():
                     rsi.Update(tuple.Index, tuple.close)
 

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
@@ -187,6 +187,11 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
 
             if not history.empty:
                 ticker = SymbolCache.GetTicker(symbol)
+
+                if ticker not in history.index.levels[0]:
+                    algorithm.Log(f'BlackLittermanOptimizationPortfolioConstructionModel.OnSecuritiesChanged: {ticker} not found in history data frame.')
+                    continue
+
                 symbolData.WarmUpIndicators(history.loc[ticker])
 
             self.symbolDataBySymbol[symbol] = symbolData


### PR DESCRIPTION
#### Description
`RsiAlphaModel` and `BlackLittermanOptimizationPortfolioConstructionModel` didn't have a key check after a history request. If a history request retuns no data for a given symbol, trying to access the pandas dataframe results in a `KeyError`.

#### Related Issue
Closes #2522

#### Motivation and Context
Framework models should not throw exceptions.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Execution of Algorithm provided in issue #2522 in the cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`