### PR TITLE
Enable TLS 1.2 for Quandl API usage

### DIFF
--- a/Common/Data/Custom/Quandl.cs
+++ b/Common/Data/Custom/Quandl.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Net;
 
 namespace QuantConnect.Data.Custom
 {
@@ -29,6 +30,16 @@ namespace QuantConnect.Data.Custom
         private readonly List<string> _propertyNames = new List<string>();
         private readonly string _valueColumn;
         private static string _authCode = "";
+
+        /// <summary>
+        /// Static constructor for the <see cref="Quandl"/> class
+        /// </summary>
+        static Quandl()
+        {
+            // The Quandl API now requires TLS 1.2 for API requests (since 9/18/2018).
+            // NET 4.5.2 and below does not enable this more secure protocol by default, so we add it in here
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+        }
 
         /// <summary>
         /// Flag indicating whether or not the Quanl auth code has been set yet

--- a/Tests/Common/Data/Custom/QuandlTests.cs
+++ b/Tests/Common/Data/Custom/QuandlTests.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Algorithm.CSharp;
+using QuantConnect.Data;
+using QuantConnect.Data.Custom;
+using QuantConnect.Lean.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Common.Data.Custom
+{
+    [TestFixture]
+    public class QuandlTests
+    {
+        [Test]
+        public void QuandlDownloadDoesNotThrow()
+        {
+            Quandl.SetAuthCode("WyAazVXnq7ATy_fefTqm");
+
+            var data = new HistoryAlgorithm.QuandlFuture();
+
+            const string ticker = "CHRIS/CME_SP1";
+            var date = new DateTime(2018, 8, 31);
+
+            var config = new SubscriptionDataConfig(typeof(HistoryAlgorithm.QuandlFuture), Symbol.Create(ticker, SecurityType.Base, QuantConnect.Market.USA), Resolution.Daily, DateTimeZone.Utc, DateTimeZone.Utc, false, false, false, true);
+            var source = data.GetSource(config, date, false);
+            var dataCacheProvider = new SingleEntryDataCacheProvider(new DefaultDataProvider());
+            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false);
+
+            var rows = factory.Read(source).ToList();
+
+            Assert.IsTrue(rows.Count > 0);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Brokerages\GDAX\GDAXBrokerageHistoryProviderTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileTests.cs" />
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
+    <Compile Include="Common\Data\Custom\QuandlTests.cs" />
     <Compile Include="Common\Util\SeriesJsonConverterTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />
     <Compile Include="PythonSetup.cs" />


### PR DESCRIPTION

#### Description
The `Quandl` class has been updated to enable the `TLS 1.2` security protocol.

#### Related Issue
Closes #2524 

#### Motivation and Context
The newer security protocol has been enabled by Quandl on 9/18/2018.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test and local algorithm test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`