### PR TITLE
Improve split/dividend application logging in live mode

### DIFF
--- a/Common/Data/Market/Dividend.cs
+++ b/Common/Data/Market/Dividend.cs
@@ -146,7 +146,7 @@ namespace QuantConnect.Data.Market
         /// <returns>string - a string formatted as SPY: 167.753</returns>
         public override string ToString()
         {
-            return $"{Symbol}: {Distribution}";
+            return $"Dividend: {Symbol}: {Distribution} | {ReferencePrice}";
         }
     }
 }

--- a/Common/Data/Market/Split.cs
+++ b/Common/Data/Market/Split.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Data.Market
         public override string ToString()
         {
             var type = Type == SplitType.Warning ? "Split Warning" : "Split";
-            return $"{type}: {Symbol}: {SplitFactor}";
+            return $"{type}: {Symbol}: {SplitFactor} | {ReferencePrice}";
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Log split/dividend contextual information in live mode to provide enough information to support triage efforts.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2530 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A user reported misapplication of a split event. The logs show that the split was received but the logs regarding application of the split are set to `Log.Debug` and didn't make the final cut. In addition, it's help to log more information, such as the reference price and relevant security holdings/prices before and after split/dividend application

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran locally w/out the live flag clauses and observed the logs being written as expected.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->