### PR TITLE
Enables custom margin call model setting in python

### DIFF
--- a/Common/Python/MarginCallModelPythonWrapper.cs
+++ b/Common/Python/MarginCallModelPythonWrapper.cs
@@ -1,0 +1,134 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Python.Runtime;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Python
+{
+    /// <summary>
+    /// Provides a margin call model that wraps a <see cref="PyObject"/> object that represents the model responsible for picking which orders should be executed during a margin call
+    /// </summary>
+    public class MarginCallModelPythonWrapper : IMarginCallModel
+    {
+        private readonly dynamic _model;
+
+        /// <summary>
+        /// Constructor for initialising the <see cref="MarginCallModelPythonWrapper"/> class with wrapped <see cref="PyObject"/> object
+        /// </summary>
+        /// <param name="model">Represents the model responsible for picking which orders should be executed during a margin call</param>
+        public MarginCallModelPythonWrapper(PyObject model)
+        {
+            using (Py.GIL())
+            {
+                foreach (var attributeName in new[] { "ExecuteMarginCall", "GenerateMarginCallOrder", "GetMarginCallOrders" })
+                {
+                    if (!model.HasAttr(attributeName))
+                    {
+                        throw new NotImplementedException($"IMarginCallModel.{attributeName} must be implemented. Please implement this missing method on {model.GetPythonType()}");
+                    }
+                }
+            }
+            _model = model;
+        }
+
+        /// <summary>
+        /// Executes synchronous orders to bring the account within margin requirements.
+        /// </summary>
+        /// <param name="generatedMarginCallOrders">These are the margin call orders that were generated
+        /// by individual security margin models.</param>
+        /// <returns>The list of orders that were actually executed</returns>
+        public List<OrderTicket> ExecuteMarginCall(IEnumerable<SubmitOrderRequest> generatedMarginCallOrders)
+        {
+            using (Py.GIL())
+            {
+                var marginCalls = _model.ExecuteMarginCall(generatedMarginCallOrders) as PyObject;
+
+                // Since ExecuteMarginCall may return a python list
+                // Need to convert to C# list
+                var tickets = new List<OrderTicket>();
+                foreach (PyObject pyObject in marginCalls)
+                {
+                    OrderTicket ticket;
+                    if (pyObject.TryConvert(out ticket))
+                    {
+                        tickets.Add(ticket);
+                    }
+                }
+                return tickets;
+            }
+        }
+
+        /// <summary>
+        /// Generates a new order for the specified security taking into account the total margin
+        /// used by the account. Returns null when no margin call is to be issued.
+        /// </summary>
+        /// <param name="security">The security to generate a margin call order for</param>
+        /// <param name="netLiquidationValue">The net liquidation value for the entire account</param>
+        /// <param name="totalMargin">The totl margin used by the account in units of base currency</param>
+        /// <param name="maintenanceMarginRequirement">The percentage of the holding's absolute cost that must be held in free cash in order to avoid a margin call</param>
+        /// <returns>An order object representing a liquidation order to be executed to bring the account within margin requirements</returns>
+        public SubmitOrderRequest GenerateMarginCallOrder(Security security, decimal netLiquidationValue, decimal totalMargin, decimal maintenanceMarginRequirement)
+        {
+            using (Py.GIL())
+            {
+                return _model.GenerateMarginCallOrder(security, netLiquidationValue, totalMargin, maintenanceMarginRequirement);
+            }
+        }
+
+        /// <summary>
+        /// Scan the portfolio and the updated data for a potential margin call situation which may get the holdings below zero!
+        /// If there is a margin call, liquidate the portfolio immediately before the portfolio gets sub zero.
+        /// </summary>
+        /// <param name="issueMarginCallWarning">Set to true if a warning should be issued to the algorithm</param>
+        /// <returns>True for a margin call on the holdings.</returns>
+        public List<SubmitOrderRequest> GetMarginCallOrders(out bool issueMarginCallWarning)
+        {
+            using (Py.GIL())
+            {
+                var value = _model.GetMarginCallOrders(out issueMarginCallWarning);
+
+                // Since pythonnet does not support out parameters, the methods return 
+                // a tuple where the out parameter comes after the other returned values
+                if (!PyTuple.IsTupleType(value))
+                {
+                    throw new ArgumentException($"{_model.__class__.__name__}.GetMarginCallOrders: Must return a tuple, where the first item is a list and the second a boolean");
+                }
+
+                // In this case, the first item holds the list of margin calls
+                // and the second the out parameter 'issueMarginCallWarning' 
+                var marginCallOrders = value[0] as PyObject;
+                issueMarginCallWarning = value[1];
+
+                // Since GetMarginCallOrders may return a python list
+                // Need to convert to C# list
+                var requests = new List<SubmitOrderRequest>();
+                foreach (PyObject pyObject in marginCallOrders)
+                {
+                    SubmitOrderRequest request;
+                    if (pyObject.TryConvert(out request))
+                    {
+                        requests.Add(request);
+                    }
+                }
+                issueMarginCallWarning |= requests.Count > 0;
+                return requests;
+            }
+        }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Chart.cs" />
     <Compile Include="ChartPoint.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />
+    <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Securities\ICurrencyConverter.cs" />
     <Compile Include="Python\BuyingPowerModelPythonWrapper.cs" />
     <Compile Include="Securities\CashAmount.cs" />

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -18,10 +18,12 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Python.Runtime;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
+using QuantConnect.Python;
 
 namespace QuantConnect.Securities
 {
@@ -716,6 +718,24 @@ namespace QuantConnect.Securities
                           $"MarginUsed: {marginUsed.ToString("F2", CultureInfo.InvariantCulture)}, " +
                           $"MarginRemaining: {marginRemaining.ToString("F2", CultureInfo.InvariantCulture)}");
             }
+        }
+
+        /// <summary>
+        /// Sets the margin call model
+        /// </summary>
+        /// <param name="marginCallModel">Model that represents a portfolio's model to executed margin call orders.</param>
+        public void SetMarginCallModel(IMarginCallModel marginCallModel)
+        {
+            MarginCallModel = marginCallModel;
+        }
+
+        /// <summary>
+        /// Sets the margin call model
+        /// </summary>
+        /// <param name="pyObject">Model that represents a portfolio's model to executed margin call orders.</param>
+        public void SetMarginCallModel(PyObject pyObject)
+        {
+            SetMarginCallModel(new MarginCallModelPythonWrapper(pyObject));
         }
     }
 }

--- a/Tests/Python/PortfolioCustomModelTests.cs
+++ b/Tests/Python/PortfolioCustomModelTests.cs
@@ -1,0 +1,152 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Python;
+using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
+using QuantConnect.Tests.Engine.DataFeeds;
+using System;
+
+namespace QuantConnect.Tests.Python
+{
+    [TestFixture]
+    public class PortfolioCustomModelTests
+    {
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetMarginCallModelSuccess(bool isChild)
+        {
+            var algorithm = new QCAlgorithm();
+            var portfolio = algorithm.Portfolio;
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+            algorithm.SetDateTime(new DateTime(2018, 8, 20, 15, 0, 0));
+            algorithm.Transactions.SetOrderProcessor(new FakeOrderProcessor());
+            
+            var spy = algorithm.AddEquity("SPY", Resolution.Daily);
+            spy.SetMarketPrice(new Tick(algorithm.Time, Symbols.SPY, 100m, 100m));
+
+            // Test two custom buying power models.
+            // The first inherits from C# SecurityMarginModel and the other is 100% python
+            var code = isChild
+                ? CreateCustomMarginCallModelFromSecurityMarginModelCode()
+                : CreateCustomMarginCallModelCode();
+
+            portfolio.SetMarginCallModel(CreateCustomMarginCallModel(code, portfolio));
+            Assert.IsAssignableFrom<MarginCallModelPythonWrapper>(portfolio.MarginCallModel);
+
+            var marginCallOrder = portfolio.MarginCallModel.GenerateMarginCallOrder(spy, 0m, 0m, 0m);
+            Assert.IsNotNull(marginCallOrder);
+            Assert.AreEqual(0, marginCallOrder.Quantity);
+
+            bool issueMarginCallWarning;
+            var marginCallOrders = portfolio.MarginCallModel.GetMarginCallOrders(out issueMarginCallWarning);
+
+            if (isChild)
+            {
+                Assert.IsFalse(issueMarginCallWarning);
+                Assert.AreEqual(0, marginCallOrders.Count);
+            }
+            else
+            {
+                Assert.IsTrue(issueMarginCallWarning);
+                Assert.AreEqual(3, marginCallOrders.Count);
+            }
+        }
+
+        [Test]
+        public void SetMarginCallModelFails()
+        {
+            var algorithm = new QCAlgorithm();
+            var portfolio = algorithm.Portfolio;
+
+            // Renaming GetMarginCall will cause a NotImplementedException exception
+            var code = CreateCustomMarginCallModelCode();
+            code = code.Replace("GetMarginCall", "SetMarginCall");
+            var pyObject = CreateCustomMarginCallModel(code, portfolio);
+            Assert.Throws<NotImplementedException>(() => portfolio.SetMarginCallModel(CreateCustomMarginCallModel(code, portfolio)));
+        }
+
+        private PyObject CreateCustomMarginCallModel(string code, SecurityPortfolioManager portfolio)
+        {
+            using (Py.GIL())
+            {
+                var module = PythonEngine.ModuleFromString("CustomMarginCallModel", code);
+                dynamic CustomMarginCallModel = module.GetAttr("CustomMarginCallModel");
+                return CustomMarginCallModel(portfolio, null);
+            }
+        }
+
+        private string CreateCustomMarginCallModelCode() => @"
+import os, sys
+sys.path.append(os.getcwd())
+
+from clr import AddReference
+AddReference('QuantConnect.Common')
+from QuantConnect import *
+from QuantConnect.Securities import *
+from QuantConnect.Orders import *
+
+class CustomMarginCallModel:
+    def __init__(self, portfolio, defaultOrderProperties):
+        self.portfolio = portfolio
+        self.defaultOrderProperties = defaultOrderProperties
+
+    def ExecuteMarginCall(self, generatedMarginCallOrders):
+        return []
+    
+    def GenerateMarginCallOrder(self, security, netLiquidationValue, totalMargin, maintenanceMarginRequirement):
+        time = Extensions.ConvertToUtc(security.LocalTime, security.Exchange.TimeZone)
+        quantity = netLiquidationValue / security.Price
+        return SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, quantity, 0, 0, time, 'Margin Call', None)
+
+    def GetMarginCallOrders(self, issueMarginCallWarning):
+        issueMarginCallWarning = True
+        spy = self.portfolio.Securities['SPY']
+        totalPortfolioValue = self.portfolio.TotalPortfolioValue
+        totalMarginUsed = self.portfolio.TotalMarginUsed
+
+        order = self.GenerateMarginCallOrder(spy, totalPortfolioValue, totalMarginUsed, 0)
+        
+        return [order, order, order], issueMarginCallWarning";
+
+        private string CreateCustomMarginCallModelFromSecurityMarginModelCode() => @"
+import os, sys
+sys.path.append(os.getcwd())
+
+from clr import AddReference
+AddReference('QuantConnect.Common')
+from QuantConnect import *
+from QuantConnect.Securities import *
+from QuantConnect.Orders import *
+
+class CustomMarginCallModel(DefaultMarginCallModel):
+    def __init__(self, portfolio, defaultOrderProperties):
+        self.porfolio = portfolio
+        self.defaultOrderProperties = defaultOrderProperties
+        super().__init__(portfolio, defaultOrderProperties)
+
+    def GenerateMarginCallOrder(self, security, netLiquidationValue, totalMargin, maintenanceMarginRequirement):
+        time = Extensions.ConvertToUtc(security.LocalTime, security.Exchange.TimeZone)
+        quantity = netLiquidationValue / security.Price
+        return SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, quantity, 0, 0, time, 'Margin Call', None)";
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -398,6 +398,7 @@
     <Compile Include="Messaging\StreamingMessageHandlerTests.cs" />
     <Compile Include="Python\AlgorithmPythonWrapperTests.cs" />
     <Compile Include="Python\MethodOverloadTests.cs" />
+    <Compile Include="Python\PortfolioCustomModelTests.cs" />
     <Compile Include="Python\SecurityCustomModelTests.cs" />
     <Compile Include="Python\PandasConverterTests.cs" />
     <Compile Include="RegressionTests.cs" />


### PR DESCRIPTION
#### Description
- Adds `MarginCallModelPythonWrapper` to wrap a python class that represents a margin call model.
- Adds `SetMarginCallModel` to enable the setting of custom margin call model.

#### Related Issue
Close #2528

#### Motivation and Context
Enables custom margin call model setting in python

#### Requires Documentation Change
Yes, we should add a subsection on [Reality Modelling](https://www.quantconnect.com/docs/algorithm-reference/reality-modelling).

#### How Has This Been Tested?
Unit test.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`