### PR TITLE
DataManager receives UniverseSelection instance

### DIFF
--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -37,10 +37,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// Creates a new instance of the DataManager
         /// </summary>
-        public DataManager(IDataFeed dataFeed, IAlgorithm algorithm)
+        public DataManager(IDataFeed dataFeed, UniverseSelection universeSelection)
         {
             _dataFeed = dataFeed;
-            UniverseSelection = new UniverseSelection(dataFeed, algorithm);
+            UniverseSelection = universeSelection;
         }
 
         #region IDataFeedSubscriptionManager

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -124,7 +124,8 @@ namespace QuantConnect.Lean.Engine
                     IBrokerageFactory factory;
                     brokerage = _algorithmHandlers.Setup.CreateBrokerage(job, algorithm, out factory);
 
-                    dataManager = new DataManager(_algorithmHandlers.DataFeed, algorithm);
+                    dataManager = new DataManager(_algorithmHandlers.DataFeed,
+                                                  new UniverseSelection(_algorithmHandlers.DataFeed, algorithm));
 
                     algorithm.SubscriptionManager.SetDataManager(dataManager);
 

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -69,7 +69,8 @@ namespace QuantConnect.Jupyter
                 var algorithmHandlers = LeanEngineAlgorithmHandlers.FromConfiguration(composer);
                 _dataCacheProvider = new ZipDataCacheProvider(algorithmHandlers.DataProvider);
 
-                SubscriptionManager.SetDataManager(new DataManager(new NullDataFeed(), this));
+                var nullDataFeed = new NullDataFeed();
+                SubscriptionManager.SetDataManager(new DataManager(nullDataFeed, new UniverseSelection(nullDataFeed, this)));
 
                 var mapFileProvider = algorithmHandlers.MapFileProvider;
                 HistoryProvider = composer.GetExportedValueByTypeName<IHistoryProvider>(Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider"));

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -163,7 +163,7 @@ from QuantConnect.Indicators import *
 from QuantConnect.Lean.Engine.DataFeeds import *
 
 algo = QCAlgorithm()
-algo.SubscriptionManager.SetDataManager(DataManager(None, algo))
+algo.SubscriptionManager.SetDataManager(DataManager(None, None))
 forex = algo.AddForex('EURUSD', Resolution.Daily)
 indicator = IchimokuKinkoHyo('EURUSD', 9, 26, 26, 52, 26, 26)
 algo.RegisterIndicator(forex.Symbol, indicator, Resolution.Daily)";

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Tests.Engine
             var algorithm = PerformanceBenchmarkAlgorithms.SingleSecurity_Second;
             var job = new BacktestNodePacket(1, 2, "3", null, 9m, $"{nameof(AlgorithmManagerTests)}.{nameof(TestAlgorithmManagerSpeed)}");
             var feed = new MockDataFeed();
-            var dataManager = new DataManager(feed, algorithm);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm));
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             var transactions = new BacktestingTransactionHandler();
             var results = new BacktestingResultHandler();

--- a/Tests/Engine/DataFeeds/DataManagerStub.cs
+++ b/Tests/Engine/DataFeeds/DataManagerStub.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         }
 
         public DataManagerStub(IAlgorithm algorithm)
-            : base(new NullDataFeed(), algorithm)
+            : base(new NullDataFeed(), new UniverseSelection(new NullDataFeed(), algorithm))
         {
 
         }

--- a/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var algorithm = PerformanceBenchmarkAlgorithms.SingleSecurity_Second;
             var feed = new FileSystemDataFeed();
-            var dataManager = new DataManager(feed, algorithm);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm));
             algorithm.SubscriptionManager.SetDataManager(dataManager);
 
             feed.Initialize(algorithm, job, resultHandler, mapFileProvider, factorFileProvider, dataProvider, dataManager);

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -598,7 +598,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var resultHandler = new BacktestingResultHandler();
 
             var feed = new TestableLiveTradingDataFeed();
-            var dataManager = new DataManager(feed, algorithm);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm));
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             algorithm.AddSecurities(Resolution.Tick, Enumerable.Range(0, 20).Select(x => x.ToString()).ToList());
             var getNextTicksFunction = Enumerable.Range(0, 20).Select(x => new Tick { Symbol = SymbolCache.GetSymbol(x.ToString()) }).ToList();
@@ -671,7 +671,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var feed = new TestableLiveTradingDataFeed(dataQueueHandler, _manualTimeProvider);
             var mapFileProvider = new LocalDiskMapFileProvider();
             var fileProvider = new DefaultDataProvider();
-            var dataManager = new DataManager(feed, _algorithm);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, _algorithm));
             _algorithm.SubscriptionManager.SetDataManager(dataManager);
             _algorithm.AddSecurities(resolution, equities, forex);
 

--- a/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         private void TestSubscriptionSynchronizerSpeed(QCAlgorithm algorithm)
         {
             var feed = new AlgorithmManagerTests.MockDataFeed();
-            var dataManager = new DataManager(feed, algorithm);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm));
             algorithm.SubscriptionManager.SetDataManager(dataManager);
 
             algorithm.Initialize();

--- a/Tests/Engine/RealTimePriceUpdateTests.cs
+++ b/Tests/Engine/RealTimePriceUpdateTests.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Tests.Engine
             };
 
             var algo = new TestAlgorithm();
-            var dataManager = new DataManager(_liveTradingDataFeed, algo);
+            var dataManager = new DataManager(_liveTradingDataFeed, new UniverseSelection(_liveTradingDataFeed, algo));
             algo.SubscriptionManager.SetDataManager(dataManager);
 
             _liveTradingDataFeed.Initialize(algo, jobPacket, new LiveTradingResultHandler(), new LocalDiskMapFileProvider(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `DataManager` will now receive `UniverseSelection` instance as a constructor
parameter, with the objective of avoiding tight coupling.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2545
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoiding unnecessary tight coupling
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->