### PR TITLE
Update fill models to not fill Limit/StopMarket/StopLimit orders on stale data

### DIFF
--- a/Common/Orders/Fills/LatestPriceFillModel.cs
+++ b/Common/Orders/Fills/LatestPriceFillModel.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Linq;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
@@ -40,10 +41,11 @@ namespace QuantConnect.Orders.Fills
             var open = asset.Open;
             var close = asset.Close;
             var current = asset.Price;
+            var endTime = asset.Cache.GetData()?.EndTime ?? DateTime.MinValue;
 
             if (direction == OrderDirection.Hold)
             {
-                return new Prices(current, open, high, low, close);
+                return new Prices(endTime, current, open, high, low, close);
             }
 
             // Only fill with data types we are subscribed to
@@ -56,14 +58,14 @@ namespace QuantConnect.Orders.Fills
                 var price = direction == OrderDirection.Sell ? tick.BidPrice : tick.AskPrice;
                 if (price != 0m)
                 {
-                    return new Prices(price, 0, 0, 0, 0);
+                    return new Prices(endTime, price, 0, 0, 0, 0);
                 }
 
                 // If the ask/bid spreads are not available for ticks, try the price
                 price = tick.Price;
                 if (price != 0m)
                 {
-                    return new Prices(price, 0, 0, 0, 0);
+                    return new Prices(endTime, price, 0, 0, 0, 0);
                 }
             }
 
@@ -86,12 +88,12 @@ namespace QuantConnect.Orders.Fills
                     var bar = direction == OrderDirection.Sell ? quoteBar.Bid : quoteBar.Ask;
                     if (bar != null)
                     {
-                        return new Prices(bar);
+                        return new Prices(quoteBar.EndTime, bar);
                     }
                 }
             }
 
-            return new Prices(current, open, high, low, close);
+            return new Prices(endTime, current, open, high, low, close);
         }
     }
 }

--- a/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
@@ -16,7 +16,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         private QuoteBar _quote;
         private TradeBar _trade;
         private TestableLatestFillModel _fillModel;
-        
+
         [TestFixtureSetUp]
         public void Setup()
         {
@@ -52,7 +52,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             var cryptoSecurity = CreateCrypto();
             cryptoSecurity.Cache.AddData(_quote);
-            
+
             var price = _fillModel.GetPrices(cryptoSecurity, OrderDirection.Sell);
 
             // Bid prices are $1


### PR DESCRIPTION

#### Description
The existing fill models (`ImmediateFillModel` and `LatestPriceFillModel`) have been updated to emit `Limit`, `StopMarket` and `StopLimit` order fills only if the latest data point was received after the order submission time.

#### Related Issue
Closes #2547 

#### Motivation and Context
Order fills emitted based on stale data are unacceptable :)

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests included + backtests with thinly traded symbols.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`