### PR TITLE
Adding new ISubscriptionDataConfigService

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -119,7 +119,7 @@ namespace QuantConnect.Algorithm
             DefaultOrderProperties = new OrderProperties();
 
             //Initialise Data Manager
-            SubscriptionManager = new SubscriptionManager(_timeKeeper);
+            SubscriptionManager = new SubscriptionManager();
 
             Securities = new SecurityManager(_timeKeeper);
             Transactions = new SecurityTransactionManager(this, Securities);
@@ -191,6 +191,11 @@ namespace QuantConnect.Algorithm
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets the time keeper instance
+        /// </summary>
+        public ITimeKeeper TimeKeeper => _timeKeeper;
 
         /// <summary>
         /// Generic Data Manager - Required for compiling all data feeds in order, and passing them into algorithm event methods.

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -336,6 +336,11 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         }
 
         /// <summary>
+        /// Gets the time keeper instance
+        /// </summary>
+        public ITimeKeeper TimeKeeper => _baseAlgorithm.TimeKeeper;
+
+        /// <summary>
         /// Data subscription manager controls the information and subscriptions the algorithms recieves.
         /// Subscription configurations can be added through the Subscription Manager.
         /// </summary>

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -25,7 +25,7 @@ using QuantConnect.Util;
 namespace QuantConnect.Data
 {
     /// <summary>
-    /// Enumerable Subscription Management Class
+    ///     Enumerable Subscription Management Class
     /// </summary>
     public class SubscriptionManager
     {
@@ -33,27 +33,27 @@ namespace QuantConnect.Data
         private IAlgorithmSubscriptionManager _subscriptionManager;
 
         /// <summary>
-        /// Instance that implements <see cref="ISubscriptionDataConfigBuilder"/>
+        ///     Instance that implements <see cref="ISubscriptionDataConfigBuilder" />
         /// </summary>
         public ISubscriptionDataConfigBuilder SubscriptionDataConfigBuilder => _subscriptionManager;
 
         /// <summary>
-        /// Returns an IEnumerable of Subscriptions
+        ///     Returns an IEnumerable of Subscriptions
         /// </summary>
         public IEnumerable<SubscriptionDataConfig> Subscriptions => _subscriptionManager.SubscriptionManagerSubscriptions;
 
         /// <summary>
-        /// Flags the existence of custom data in the subscriptions
+        ///     Flags the existence of custom data in the subscriptions
         /// </summary>
         public bool HasCustomData { get; set; }
 
         /// <summary>
-        /// The different <see cref="TickType"/> each <see cref="SecurityType"/> supports
+        ///     The different <see cref="TickType" /> each <see cref="SecurityType" /> supports
         /// </summary>
         public Dictionary<SecurityType, List<TickType>> AvailableDataTypes { get; }
 
         /// <summary>
-        /// Initialise the Generic Data Manager Class
+        ///     Initialise the Generic Data Manager Class
         /// </summary>
         /// <param name="timeKeeper">The algorithm's time keeper</param>
         public SubscriptionManager(TimeKeeper timeKeeper)
@@ -65,23 +65,36 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// Get the count of assets:
+        ///     Get the count of assets:
         /// </summary>
         public int Count => _subscriptionManager.SubscriptionManagerCount();
 
         /// <summary>
-        /// Add Market Data Required (Overloaded method for backwards compatibility).
+        ///     Add Market Data Required (Overloaded method for backwards compatibility).
         /// </summary>
         /// <param name="symbol">Symbol of the asset we're like</param>
         /// <param name="resolution">Resolution of Asset Required</param>
         /// <param name="timeZone">The time zone the subscription's data is time stamped in</param>
-        /// <param name="exchangeTimeZone">Specifies the time zone of the exchange for the security this subscription is for. This
-        /// is this output time zone, that is, the time zone that will be used on BaseData instances</param>
+        /// <param name="exchangeTimeZone">
+        ///     Specifies the time zone of the exchange for the security this subscription is for. This
+        ///     is this output time zone, that is, the time zone that will be used on BaseData instances
+        /// </param>
         /// <param name="isCustomData">True if this is custom user supplied data, false for normal QC data</param>
         /// <param name="fillDataForward">when there is no data pass the last tradebar forward</param>
         /// <param name="extendedMarketHours">Request premarket data as well when true </param>
-        /// <returns>The newly created <see cref="SubscriptionDataConfig"/> or existing instance if it already existed <see cref="GetOrAdd"/></returns>
-        public SubscriptionDataConfig Add(Symbol symbol, Resolution resolution, DateTimeZone timeZone, DateTimeZone exchangeTimeZone, bool isCustomData = false, bool fillDataForward = true, bool extendedMarketHours = false)
+        /// <returns>
+        ///     The newly created <see cref="SubscriptionDataConfig" /> or existing instance if it already existed
+        ///     <see cref="GetOrAdd" />
+        /// </returns>
+        public SubscriptionDataConfig Add(
+            Symbol symbol,
+            Resolution resolution,
+            DateTimeZone timeZone,
+            DateTimeZone exchangeTimeZone,
+            bool isCustomData = false,
+            bool fillDataForward = true,
+            bool extendedMarketHours = false
+            )
         {
             //Set the type: market data only comes in two forms -- ticks(trade by trade) or tradebar(time summaries)
             var dataType = typeof(TradeBar);
@@ -89,36 +102,61 @@ namespace QuantConnect.Data
             {
                 dataType = typeof(Tick);
             }
+
             var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType);
-            return Add(dataType, tickType, symbol, resolution, timeZone, exchangeTimeZone, isCustomData, fillDataForward, extendedMarketHours);
+            return Add(dataType, tickType, symbol, resolution, timeZone, exchangeTimeZone, isCustomData, fillDataForward,
+                extendedMarketHours);
         }
 
         /// <summary>
-        /// Add Market Data Required - generic data typing support as long as Type implements BaseData.
+        ///     Add Market Data Required - generic data typing support as long as Type implements BaseData.
         /// </summary>
         /// <param name="dataType">Set the type of the data we're subscribing to.</param>
         /// <param name="tickType">Tick type for the subscription.</param>
         /// <param name="symbol">Symbol of the asset we're like</param>
         /// <param name="resolution">Resolution of Asset Required</param>
         /// <param name="dataTimeZone">The time zone the subscription's data is time stamped in</param>
-        /// <param name="exchangeTimeZone">Specifies the time zone of the exchange for the security this subscription is for. This
-        /// is this output time zone, that is, the time zone that will be used on BaseData instances</param>
+        /// <param name="exchangeTimeZone">
+        ///     Specifies the time zone of the exchange for the security this subscription is for. This
+        ///     is this output time zone, that is, the time zone that will be used on BaseData instances
+        /// </param>
         /// <param name="isCustomData">True if this is custom user supplied data, false for normal QC data</param>
         /// <param name="fillDataForward">when there is no data pass the last tradebar forward</param>
         /// <param name="extendedMarketHours">Request premarket data as well when true </param>
-        /// <param name="isInternalFeed">Set to true to prevent data from this subscription from being sent into the algorithm's OnData events</param>
-        /// <param name="isFilteredSubscription">True if this subscription should have filters applied to it (market hours/user filters from security), false otherwise</param>
-        /// <returns>The newly created <see cref="SubscriptionDataConfig"/> or existing instance if it already existed <see cref="GetOrAdd"/></returns>
-        public SubscriptionDataConfig Add(Type dataType, TickType tickType, Symbol symbol, Resolution resolution, DateTimeZone dataTimeZone, DateTimeZone exchangeTimeZone, bool isCustomData, bool fillDataForward = true, bool extendedMarketHours = false, bool isInternalFeed = false, bool isFilteredSubscription = true)
+        /// <param name="isInternalFeed">
+        ///     Set to true to prevent data from this subscription from being sent into the algorithm's
+        ///     OnData events
+        /// </param>
+        /// <param name="isFilteredSubscription">
+        ///     True if this subscription should have filters applied to it (market hours/user
+        ///     filters from security), false otherwise
+        /// </param>
+        /// <returns>
+        ///     The newly created <see cref="SubscriptionDataConfig" /> or existing instance if it already existed
+        ///     <see cref="GetOrAdd" />
+        /// </returns>
+        public SubscriptionDataConfig Add(
+            Type dataType,
+            TickType tickType,
+            Symbol symbol,
+            Resolution resolution,
+            DateTimeZone dataTimeZone,
+            DateTimeZone exchangeTimeZone,
+            bool isCustomData,
+            bool fillDataForward = true,
+            bool extendedMarketHours = false,
+            bool isInternalFeed = false,
+            bool isFilteredSubscription = true
+            )
         {
             var newConfig = SubscriptionDataConfigBuilder.Create(symbol, resolution, fillDataForward,
-                                                                 extendedMarketHours, isFilteredSubscription, isInternalFeed, isCustomData,
-                                                                 new List<Tuple<Type, TickType>> {new Tuple<Type, TickType>(dataType, tickType)}).First();
+                extendedMarketHours, isFilteredSubscription, isInternalFeed, isCustomData,
+                new List<Tuple<Type, TickType>> {new Tuple<Type, TickType>(dataType, tickType)}).First();
             return GetOrAdd(newConfig);
         }
 
         /// <summary>
-        /// Gets existing or adds new <see cref="SubscriptionDataConfig"/>
+        ///     Gets existing or adds new <see cref="SubscriptionDataConfig" />
         /// </summary>
         /// <returns>Returns the SubscriptionDataConfig instance used</returns>
         public SubscriptionDataConfig GetOrAdd(SubscriptionDataConfig newConfig)
@@ -135,7 +173,7 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// For each <see cref="SubscriptionDataConfig"/> in a provided list, gets existing or adds it
+        ///     For each <see cref="SubscriptionDataConfig" /> in a provided list, gets existing or adds it
         /// </summary>
         /// <returns>Returns the SubscriptionDataConfig instance used</returns>
         public List<SubscriptionDataConfig> GetOrAdd(List<SubscriptionDataConfig> newConfigs)
@@ -144,11 +182,12 @@ namespace QuantConnect.Data
             {
                 newConfigs[i] = GetOrAdd(newConfigs[i]);
             }
+
             return newConfigs;
         }
 
         /// <summary>
-        /// Add a consolidator for the symbol
+        ///     Add a consolidator for the symbol
         /// </summary>
         /// <param name="symbol">Symbol of the asset to consolidate</param>
         /// <param name="consolidator">The consolidator</param>
@@ -160,7 +199,8 @@ namespace QuantConnect.Data
             if (subscriptions.Count == 0)
             {
                 // If we made it here it is because we never found the symbol in the subscription list
-                throw new ArgumentException("Please subscribe to this symbol before adding a consolidator for it. Symbol: " + symbol.Value);
+                throw new ArgumentException("Please subscribe to this symbol before adding a consolidator for it. Symbol: " +
+                    symbol.Value);
             }
 
             foreach (var subscription in subscriptions)
@@ -174,12 +214,12 @@ namespace QuantConnect.Data
             }
 
             throw new ArgumentException("Type mismatch found between consolidator and symbol. " +
-                                        $"Symbol: {symbol.Value} does not support input type: {consolidator.InputType.Name}. " +
-                                        $"Supported types: {string.Join(",", subscriptions.Select(x => x.Type.Name))}.");
+                $"Symbol: {symbol.Value} does not support input type: {consolidator.InputType.Name}. " +
+                $"Supported types: {string.Join(",", subscriptions.Select(x => x.Type.Name))}.");
         }
 
         /// <summary>
-        /// Removes the specified consolidator for the symbol
+        ///     Removes the specified consolidator for the symbol
         /// </summary>
         /// <param name="symbol">The symbol the consolidator is receiving data from</param>
         /// <param name="consolidator">The consolidator instance to be removed</param>
@@ -196,25 +236,25 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// Hard code the set of default available data feeds
+        ///     Hard code the set of default available data feeds
         /// </summary>
         public Dictionary<SecurityType, List<TickType>> DefaultDataTypes()
         {
-            return new Dictionary<SecurityType, List<TickType>>()
+            return new Dictionary<SecurityType, List<TickType>>
             {
-                {SecurityType.Base, new List<TickType>() { TickType.Trade } },
-                {SecurityType.Forex, new List<TickType>() { TickType.Quote } },
-                {SecurityType.Equity, new List<TickType>() { TickType.Trade } },
-                {SecurityType.Option, new List<TickType>() { TickType.Quote, TickType.Trade, TickType.OpenInterest } },
-                {SecurityType.Cfd, new List<TickType>() { TickType.Quote } },
-                {SecurityType.Future, new List<TickType>() { TickType.Quote, TickType.Trade, TickType.OpenInterest } },
-                {SecurityType.Commodity, new List<TickType>() { TickType.Trade } },
-                {SecurityType.Crypto, new List<TickType>() { TickType.Trade, TickType.Quote } },
+                {SecurityType.Base, new List<TickType> {TickType.Trade}},
+                {SecurityType.Forex, new List<TickType> {TickType.Quote}},
+                {SecurityType.Equity, new List<TickType> {TickType.Trade}},
+                {SecurityType.Option, new List<TickType> {TickType.Quote, TickType.Trade, TickType.OpenInterest}},
+                {SecurityType.Cfd, new List<TickType> {TickType.Quote}},
+                {SecurityType.Future, new List<TickType> {TickType.Quote, TickType.Trade, TickType.OpenInterest}},
+                {SecurityType.Commodity, new List<TickType> {TickType.Trade}},
+                {SecurityType.Crypto, new List<TickType> {TickType.Trade, TickType.Quote}}
             };
         }
 
         /// <summary>
-        /// Get the available data types for a security
+        ///     Get the available data types for a security
         /// </summary>
         public IReadOnlyList<TickType> GetDataTypesForSecurity(SecurityType securityType)
         {
@@ -222,19 +262,23 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// Get the data feed types for a given <see cref="SecurityType"/> <see cref="Resolution"/>
+        ///     Get the data feed types for a given <see cref="SecurityType" /> <see cref="Resolution" />
         /// </summary>
-        /// <param name="symbolSecurityType">The <see cref="SecurityType"/> used to determine the types</param>
+        /// <param name="symbolSecurityType">The <see cref="SecurityType" /> used to determine the types</param>
         /// <param name="resolution">The resolution of the data requested</param>
         /// <param name="isCanonical">Indicates whether the security is Canonical (future and options)</param>
-        /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig"/></returns>
-        public List<Tuple<Type, TickType>> LookupSubscriptionConfigDataTypes(SecurityType symbolSecurityType, Resolution resolution, bool isCanonical)
+        /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig" /></returns>
+        public List<Tuple<Type, TickType>> LookupSubscriptionConfigDataTypes(
+            SecurityType symbolSecurityType,
+            Resolution resolution,
+            bool isCanonical
+            )
         {
             return _subscriptionManager.LookupSubscriptionConfigDataTypes(symbolSecurityType, resolution, isCanonical);
         }
 
         /// <summary>
-        /// Sets the Subscription Manager
+        ///     Sets the Subscription Manager
         /// </summary>
         public void SetDataManager(IAlgorithmSubscriptionManager subscriptionManager)
         {

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -51,6 +51,14 @@ namespace QuantConnect.Interfaces
         event AlgorithmEvent<GeneratedInsightsCollection> InsightsGenerated;
 
         /// <summary>
+        /// Gets the time keeper instance
+        /// </summary>
+        ITimeKeeper TimeKeeper
+        {
+            get;
+        }
+
+        /// <summary>
         /// Data subscription manager controls the information and subscriptions the algorithms recieves.
         /// Subscription configurations can be added through the Subscription Manager.
         /// </summary>

--- a/Common/Interfaces/IAlgorithmSubscriptionManager.cs
+++ b/Common/Interfaces/IAlgorithmSubscriptionManager.cs
@@ -14,6 +14,7 @@
  *
 */
 
+using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
 
@@ -22,7 +23,7 @@ namespace QuantConnect.Interfaces
     /// <summary>
     /// AlgorithmSubscriptionManager interface will manage the subscriptions for the SubscriptionManager
     /// </summary>
-    public interface IAlgorithmSubscriptionManager
+    public interface IAlgorithmSubscriptionManager : ISubscriptionDataConfigBuilder
     {
         /// <summary>
         /// Gets all the current data config subscriptions that are being processed for the SubscriptionManager
@@ -39,5 +40,19 @@ namespace QuantConnect.Interfaces
         /// Returns the amount of data config subscriptions processed for the SubscriptionManager
         /// </summary>
         int SubscriptionManagerCount();
+
+        /// <summary>
+        /// Get the data feed types for a given <see cref="SecurityType"/> <see cref="Resolution"/>
+        /// </summary>
+        /// <param name="symbolSecurityType">The <see cref="SecurityType"/> used to determine the types</param>
+        /// <param name="resolution">The resolution of the data requested</param>
+        /// <param name="isCanonical">Indicates whether the security is Canonical (future and options)</param>
+        /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig"/></returns>
+        List<Tuple<Type, TickType>> LookupSubscriptionConfigDataTypes(SecurityType symbolSecurityType,
+                                                                      Resolution resolution, bool isCanonical);
+        /// <summary>
+        /// Sets up the available data types
+        /// </summary>
+        void SetAvailableDataTypes(Dictionary<SecurityType, List<TickType>> availableDataTypes);
     }
 }

--- a/Common/Interfaces/IAlgorithmSubscriptionManager.cs
+++ b/Common/Interfaces/IAlgorithmSubscriptionManager.cs
@@ -14,7 +14,6 @@
  *
 */
 
-using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
 

--- a/Common/Interfaces/IAlgorithmSubscriptionManager.cs
+++ b/Common/Interfaces/IAlgorithmSubscriptionManager.cs
@@ -21,37 +21,41 @@ using QuantConnect.Data;
 namespace QuantConnect.Interfaces
 {
     /// <summary>
-    /// AlgorithmSubscriptionManager interface will manage the subscriptions for the SubscriptionManager
+    ///     AlgorithmSubscriptionManager interface will manage the subscriptions for the SubscriptionManager
     /// </summary>
     public interface IAlgorithmSubscriptionManager : ISubscriptionDataConfigBuilder
     {
         /// <summary>
-        /// Gets all the current data config subscriptions that are being processed for the SubscriptionManager
+        ///     Gets all the current data config subscriptions that are being processed for the SubscriptionManager
         /// </summary>
         IEnumerable<SubscriptionDataConfig> SubscriptionManagerSubscriptions { get; }
 
         /// <summary>
-        /// Gets existing or adds new <see cref="SubscriptionDataConfig"/>
+        ///     Gets existing or adds new <see cref="SubscriptionDataConfig" />
         /// </summary>
         /// <returns>Returns the SubscriptionDataConfig instance used</returns>
         SubscriptionDataConfig SubscriptionManagerGetOrAdd(SubscriptionDataConfig config);
 
         /// <summary>
-        /// Returns the amount of data config subscriptions processed for the SubscriptionManager
+        ///     Returns the amount of data config subscriptions processed for the SubscriptionManager
         /// </summary>
         int SubscriptionManagerCount();
 
         /// <summary>
-        /// Get the data feed types for a given <see cref="SecurityType"/> <see cref="Resolution"/>
+        ///     Get the data feed types for a given <see cref="SecurityType" /> <see cref="Resolution" />
         /// </summary>
-        /// <param name="symbolSecurityType">The <see cref="SecurityType"/> used to determine the types</param>
+        /// <param name="symbolSecurityType">The <see cref="SecurityType" /> used to determine the types</param>
         /// <param name="resolution">The resolution of the data requested</param>
         /// <param name="isCanonical">Indicates whether the security is Canonical (future and options)</param>
-        /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig"/></returns>
-        List<Tuple<Type, TickType>> LookupSubscriptionConfigDataTypes(SecurityType symbolSecurityType,
-                                                                      Resolution resolution, bool isCanonical);
+        /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig" /></returns>
+        List<Tuple<Type, TickType>> LookupSubscriptionConfigDataTypes(
+            SecurityType symbolSecurityType,
+            Resolution resolution,
+            bool isCanonical
+            );
+
         /// <summary>
-        /// Sets up the available data types
+        ///     Sets up the available data types
         /// </summary>
         void SetAvailableDataTypes(Dictionary<SecurityType, List<TickType>> availableDataTypes);
     }

--- a/Common/Interfaces/ISubscriptionDataConfigBuilder.cs
+++ b/Common/Interfaces/ISubscriptionDataConfigBuilder.cs
@@ -17,21 +17,28 @@
 using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
+
 namespace QuantConnect.Interfaces
 {
     /// <summary>
-    /// This interface exposes methods for creating a list of <see cref="SubscriptionDataConfig"/> for a given configuration
+    ///     This interface exposes methods for creating a list of <see cref="SubscriptionDataConfig" /> for a given
+    ///     configuration
     /// </summary>
     public interface ISubscriptionDataConfigBuilder
     {
         /// <summary>
-        /// Creates a list of <see cref="SubscriptionDataConfig"/> for a given symbol and configuration.
-        /// Can optionally pass in desired subscription data types to use.
+        ///     Creates a list of <see cref="SubscriptionDataConfig" /> for a given symbol and configuration.
+        ///     Can optionally pass in desired subscription data types to use.
         /// </summary>
-        List<SubscriptionDataConfig> Create(Symbol symbol, Resolution resolution,
-                                            bool fillForward = true, bool extendedMarketHours = false,
-                                            bool isFilteredSubscription = true,
-                                            bool isInternalFeed = false, bool isCustomData = false,
-                                            List<Tuple<Type, TickType>> subscriptionDataTypes = null);
+        List<SubscriptionDataConfig> Create(
+            Symbol symbol,
+            Resolution resolution,
+            bool fillForward = true,
+            bool extendedMarketHours = false,
+            bool isFilteredSubscription = true,
+            bool isInternalFeed = false,
+            bool isCustomData = false,
+            List<Tuple<Type, TickType>> subscriptionDataTypes = null
+            );
     }
 }

--- a/Common/Interfaces/ISubscriptionDataConfigBuilder.cs
+++ b/Common/Interfaces/ISubscriptionDataConfigBuilder.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+namespace QuantConnect.Interfaces
+{
+    /// <summary>
+    /// This interface exposes methods for creating a list of <see cref="SubscriptionDataConfig"/> for a given configuration
+    /// </summary>
+    public interface ISubscriptionDataConfigBuilder
+    {
+        /// <summary>
+        /// Creates a list of <see cref="SubscriptionDataConfig"/> for a given symbol and configuration.
+        /// Can optionally pass in desired subscription data types to use.
+        /// </summary>
+        List<SubscriptionDataConfig> Create(Symbol symbol, Resolution resolution,
+                                            bool fillForward = true, bool extendedMarketHours = false,
+                                            bool isFilteredSubscription = true,
+                                            bool isInternalFeed = false, bool isCustomData = false,
+                                            List<Tuple<Type, TickType>> subscriptionDataTypes = null);
+    }
+}

--- a/Common/Interfaces/ISubscriptionDataConfigService.cs
+++ b/Common/Interfaces/ISubscriptionDataConfigService.cs
@@ -24,13 +24,14 @@ namespace QuantConnect.Interfaces
     ///     This interface exposes methods for creating a list of <see cref="SubscriptionDataConfig" /> for a given
     ///     configuration
     /// </summary>
-    public interface ISubscriptionDataConfigBuilder
+    public interface ISubscriptionDataConfigService
     {
         /// <summary>
-        ///     Creates a list of <see cref="SubscriptionDataConfig" /> for a given symbol and configuration.
+        ///     Creates and adds a list of <see cref="SubscriptionDataConfig" /> for a given symbol and configuration.
         ///     Can optionally pass in desired subscription data types to use.
+        ///     If the config already existed will return existing instance instead
         /// </summary>
-        List<SubscriptionDataConfig> Create(
+        List<SubscriptionDataConfig> Add(
             Symbol symbol,
             Resolution resolution,
             bool fillForward = true,
@@ -40,5 +41,23 @@ namespace QuantConnect.Interfaces
             bool isCustomData = false,
             List<Tuple<Type, TickType>> subscriptionDataTypes = null
             );
+
+        /// <summary>
+        ///     Get the data feed types for a given <see cref="SecurityType" /> <see cref="Resolution" />
+        /// </summary>
+        /// <param name="symbolSecurityType">The <see cref="SecurityType" /> used to determine the types</param>
+        /// <param name="resolution">The resolution of the data requested</param>
+        /// <param name="isCanonical">Indicates whether the security is Canonical (future and options)</param>
+        /// <returns>Types that should be added to the <see cref="SubscriptionDataConfig" /></returns>
+        List<Tuple<Type, TickType>> LookupSubscriptionConfigDataTypes(
+            SecurityType symbolSecurityType,
+            Resolution resolution,
+            bool isCanonical
+            );
+
+        /// <summary>
+        ///     Gets the available data types
+        /// </summary>
+        Dictionary<SecurityType, List<TickType>> AvailableDataTypes { get; }
     }
 }

--- a/Common/Interfaces/ITimeKeeper.cs
+++ b/Common/Interfaces/ITimeKeeper.cs
@@ -11,33 +11,21 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
 */
 
-using System;
-using System.Collections.Generic;
-using QuantConnect.Data;
+using NodaTime;
 
 namespace QuantConnect.Interfaces
 {
     /// <summary>
-    ///     AlgorithmSubscriptionManager interface will manage the subscriptions for the SubscriptionManager
+    /// Interface implemented by <see cref="TimeKeeper"/>
     /// </summary>
-    public interface IAlgorithmSubscriptionManager : ISubscriptionDataConfigService
+    public interface ITimeKeeper
     {
         /// <summary>
-        ///     Gets all the current data config subscriptions that are being processed for the SubscriptionManager
+        /// Adds the specified time zone to this time keeper
         /// </summary>
-        IEnumerable<SubscriptionDataConfig> SubscriptionManagerSubscriptions { get; }
-
-        /// <summary>
-        ///     Returns the amount of data config subscriptions processed for the SubscriptionManager
-        /// </summary>
-        int SubscriptionManagerCount();
-
-        /// <summary>
-        ///     Flags the existence of custom data in the subscriptions
-        /// </summary>
-        bool HasCustomData { get; set; }
+        /// <param name="timeZone"></param>
+        void AddTimeZone(DateTimeZone timeZone);
     }
 }

--- a/Common/Interfaces/ITimeKeeper.cs
+++ b/Common/Interfaces/ITimeKeeper.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using NodaTime;
 
 namespace QuantConnect.Interfaces
@@ -23,9 +24,21 @@ namespace QuantConnect.Interfaces
     public interface ITimeKeeper
     {
         /// <summary>
+        /// Gets the current time in UTC
+        /// </summary>
+        DateTime UtcTime { get; }
+
+        /// <summary>
         /// Adds the specified time zone to this time keeper
         /// </summary>
         /// <param name="timeZone"></param>
         void AddTimeZone(DateTimeZone timeZone);
+
+        /// <summary>
+        /// Gets the <see cref="LocalTimeKeeper"/> instance for the specified time zone
+        /// </summary>
+        /// <param name="timeZone">The time zone whose <see cref="LocalTimeKeeper"/> we seek</param>
+        /// <returns>The <see cref="LocalTimeKeeper"/> instance for the specified time zone</returns>
+        LocalTimeKeeper GetLocalTimeKeeper(DateTimeZone timeZone);
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -182,7 +182,8 @@
     <Compile Include="Chart.cs" />
     <Compile Include="ChartPoint.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />
-    <Compile Include="Interfaces\ISubscriptionDataConfigBuilder.cs" />
+    <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
+    <Compile Include="Interfaces\ITimeKeeper.cs" />
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Securities\ICurrencyConverter.cs" />
     <Compile Include="Python\BuyingPowerModelPythonWrapper.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Chart.cs" />
     <Compile Include="ChartPoint.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />
+    <Compile Include="Interfaces\ISubscriptionDataConfigBuilder.cs" />
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Securities\ICurrencyConverter.cs" />
     <Compile Include="Python\BuyingPowerModelPythonWrapper.cs" />

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -21,6 +21,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using NodaTime;
 using QuantConnect.Data;
+using QuantConnect.Interfaces;
 using QuantConnect.Util;
 
 namespace QuantConnect.Securities
@@ -36,7 +37,7 @@ namespace QuantConnect.Securities
         /// </summary>
         public event NotifyCollectionChangedEventHandler CollectionChanged;
 
-        private readonly TimeKeeper _timeKeeper;
+        private readonly ITimeKeeper _timeKeeper;
 
         //Internal dictionary implementation:
         private readonly ConcurrentDictionary<Symbol, Security> _securityManager;
@@ -53,7 +54,7 @@ namespace QuantConnect.Securities
         /// Initialise the algorithm security manager with two empty dictionaries
         /// </summary>
         /// <param name="timeKeeper"></param>
-        public SecurityManager(TimeKeeper timeKeeper)
+        public SecurityManager(ITimeKeeper timeKeeper)
         {
             _timeKeeper = timeKeeper;
             _securityManager = new ConcurrentDictionary<Symbol, Security>();

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -319,10 +319,9 @@ namespace QuantConnect.Securities
             if (addToSymbolCache) SymbolCache.Set(symbol.Value, symbol);
 
             // Add the symbol to Data Manager -- generate unified data streams for algorithm events
-            var configs = subscriptionManager.SubscriptionDataConfigBuilder.Create(symbol, resolution, fillDataForward,
-                                                                                   extendedMarketHours, isFilteredSubscription, isInternalFeed,
-                                                                                   isCustomData, subscriptionDataTypes);
-            configs = subscriptionManager.GetOrAdd(configs);
+            var configs = subscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward,
+                                                                                extendedMarketHours, isFilteredSubscription, isInternalFeed,
+                                                                                isCustomData, subscriptionDataTypes);
             var configList = new SubscriptionDataConfigList(symbol);
             configList.AddRange(configs);
 

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -315,25 +315,16 @@ namespace QuantConnect.Securities
             bool addToSymbolCache = true,
             bool isFilteredSubscription = true)
         {
-            if (!subscriptionDataTypes.Any())
-            {
-                throw new ArgumentNullException(nameof(subscriptionDataTypes), "At least one type needed to create security");
-            }
-
             // add the symbol to our cache
             if (addToSymbolCache) SymbolCache.Set(symbol.Value, symbol);
 
             // Add the symbol to Data Manager -- generate unified data streams for algorithm events
+            var configs = subscriptionManager.SubscriptionDataConfigBuilder.Create(symbol, resolution, fillDataForward,
+                                                                                   extendedMarketHours, isFilteredSubscription, isInternalFeed,
+                                                                                   isCustomData, subscriptionDataTypes);
+            configs = subscriptionManager.GetOrAdd(configs);
             var configList = new SubscriptionDataConfigList(symbol);
-            configList.AddRange(from subscriptionDataType
-                                in subscriptionDataTypes
-                                let dataType = subscriptionDataType.Item1
-                                let tickType = subscriptionDataType.Item2
-                                select subscriptionManager.Add(dataType, tickType,
-                                                               symbol, resolution, dataTimeZone,
-                                                               exchangeHours.TimeZone, isCustomData,
-                                                               fillDataForward, extendedMarketHours,
-                                                               isInternalFeed, isFilteredSubscription));
+            configList.AddRange(configs);
 
             // verify the cash book is in a ready state
             var quoteCurrency = symbolProperties.QuoteCurrency;
@@ -363,7 +354,7 @@ namespace QuantConnect.Securities
             var quoteCash = securityPortfolioManager.CashBook[symbolProperties.QuoteCurrency];
 
             Security security;
-            switch (configList.Symbol.ID.SecurityType)
+            switch (symbol.ID.SecurityType)
             {
                 case SecurityType.Equity:
                     security = new Equity.Equity(symbol, exchangeHours, quoteCash, symbolProperties);
@@ -371,12 +362,10 @@ namespace QuantConnect.Securities
 
                 case SecurityType.Option:
                     if (addToSymbolCache) SymbolCache.Set(symbol.Underlying.Value, symbol.Underlying);
-                    configList.SetDataNormalizationMode(DataNormalizationMode.Raw);
                     security = new Option.Option(symbol, exchangeHours, securityPortfolioManager.CashBook[CashBook.AccountCurrency], new Option.OptionSymbolProperties(symbolProperties));
                     break;
 
                 case SecurityType.Future:
-                    configList.SetDataNormalizationMode(DataNormalizationMode.Raw);
                     security = new Future.Future(symbol, exchangeHours, securityPortfolioManager.CashBook[CashBook.AccountCurrency], symbolProperties);
                     break;
 
@@ -400,7 +389,7 @@ namespace QuantConnect.Securities
 
             // if we're just creating this security and it only has an internal
             // feed, mark it as non-tradable since the user didn't request this data
-            if (!configList.IsInternalFeed)
+            if (!isInternalFeed)
             {
                 security.IsTradable = true;
             }

--- a/Common/TimeKeeper.cs
+++ b/Common/TimeKeeper.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +17,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NodaTime;
+using QuantConnect.Interfaces;
 
 namespace QuantConnect
 {
     /// <summary>
     /// Provides a means of centralizing time for various time zones.
     /// </summary>
-    public class TimeKeeper
+    public class TimeKeeper : ITimeKeeper
     {
         private DateTime _utcDateTime;
 

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -126,7 +126,7 @@ namespace QuantConnect.Lean.Engine
 
                     dataManager = new DataManager(_algorithmHandlers.DataFeed,
                                                   new UniverseSelection(_algorithmHandlers.DataFeed, algorithm),
-                                                  algorithm.Settings);
+                                                  algorithm.Settings, algorithm.TimeKeeper);
 
                     algorithm.SubscriptionManager.SetDataManager(dataManager);
 

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Jupyter
                 _dataCacheProvider = new ZipDataCacheProvider(algorithmHandlers.DataProvider);
 
                 var nullDataFeed = new NullDataFeed();
-                SubscriptionManager.SetDataManager(new DataManager(nullDataFeed, new UniverseSelection(nullDataFeed, this), Settings));
+                SubscriptionManager.SetDataManager(new DataManager(nullDataFeed, new UniverseSelection(nullDataFeed, this), Settings, TimeKeeper));
 
                 var mapFileProvider = algorithmHandlers.MapFileProvider;
                 HistoryProvider = composer.GetExportedValueByTypeName<IHistoryProvider>(Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider"));

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -163,7 +163,7 @@ from QuantConnect.Indicators import *
 from QuantConnect.Lean.Engine.DataFeeds import *
 
 algo = QCAlgorithm()
-algo.SubscriptionManager.SetDataManager(DataManager(None, UniverseSelection(None, algo), algo.Settings))
+algo.SubscriptionManager.SetDataManager(DataManager(None, UniverseSelection(None, algo), algo.Settings, algo.TimeKeeper))
 forex = algo.AddForex('EURUSD', Resolution.Daily)
 indicator = IchimokuKinkoHyo('EURUSD', 9, 26, 26, 52, 26, 26)
 algo.RegisterIndicator(forex.Symbol, indicator, Resolution.Daily)";

--- a/Tests/Common/Data/SubscriptionManagerTests.cs
+++ b/Tests/Common/Data/SubscriptionManagerTests.cs
@@ -155,10 +155,31 @@ namespace QuantConnect.Tests.Common.Data
             Task.WaitAll(addTask, readTask);
         }
 
+        [Test]
+        public void GetsCustomSubscriptionDataTypes()
+        {
+            var timeKeeper = new TimeKeeper(DateTime.UtcNow);
+            var subscriptionManager = new SubscriptionManager(timeKeeper);
+            subscriptionManager.SetDataManager(new DataManagerStub());
+            subscriptionManager.AvailableDataTypes[SecurityType.Commodity] = new List<TickType> { TickType.OpenInterest, TickType.Quote, TickType.Trade };
+            var types = subscriptionManager.LookupSubscriptionConfigDataTypes(SecurityType.Commodity, Resolution.Daily, false);
+
+            Assert.AreEqual(3, types.Count);
+
+            Assert.AreEqual(typeof(OpenInterest), types[0].Item1);
+            Assert.AreEqual(typeof(QuoteBar), types[1].Item1);
+            Assert.AreEqual(typeof(TradeBar), types[2].Item1);
+
+            Assert.AreEqual(TickType.OpenInterest, types[0].Item2);
+            Assert.AreEqual(TickType.Quote, types[1].Item2);
+            Assert.AreEqual(TickType.Trade, types[2].Item2);
+        }
+
         private static List<Tuple<Type, TickType>> GetSubscriptionDataTypes(SecurityType securityType, Resolution resolution, bool isCanonical = false)
         {
             var timeKeeper = new TimeKeeper(DateTime.UtcNow);
             var subscriptionManager = new SubscriptionManager(timeKeeper);
+            subscriptionManager.SetDataManager(new DataManagerStub());
             return subscriptionManager.LookupSubscriptionConfigDataTypes(securityType, resolution, isCanonical);
         }
     }

--- a/Tests/Common/Data/SubscriptionManagerTests.cs
+++ b/Tests/Common/Data/SubscriptionManagerTests.cs
@@ -121,8 +121,7 @@ namespace QuantConnect.Tests.Common.Data
         [Test]
         public void SubscriptionsMemberIsThreadSafe()
         {
-            var timeKeeper = new TimeKeeper(DateTime.UtcNow);
-            var subscriptionManager = new SubscriptionManager(timeKeeper);
+            var subscriptionManager = new SubscriptionManager();
             subscriptionManager.SetDataManager(new DataManagerStub());
             var start = DateTime.UtcNow;
             var end = start.AddSeconds(5);
@@ -158,8 +157,7 @@ namespace QuantConnect.Tests.Common.Data
         [Test]
         public void GetsCustomSubscriptionDataTypes()
         {
-            var timeKeeper = new TimeKeeper(DateTime.UtcNow);
-            var subscriptionManager = new SubscriptionManager(timeKeeper);
+            var subscriptionManager = new SubscriptionManager();
             subscriptionManager.SetDataManager(new DataManagerStub());
             subscriptionManager.AvailableDataTypes[SecurityType.Commodity] = new List<TickType> { TickType.OpenInterest, TickType.Quote, TickType.Trade };
             var types = subscriptionManager.LookupSubscriptionConfigDataTypes(SecurityType.Commodity, Resolution.Daily, false);
@@ -177,8 +175,7 @@ namespace QuantConnect.Tests.Common.Data
 
         private static List<Tuple<Type, TickType>> GetSubscriptionDataTypes(SecurityType securityType, Resolution resolution, bool isCanonical = false)
         {
-            var timeKeeper = new TimeKeeper(DateTime.UtcNow);
-            var subscriptionManager = new SubscriptionManager(timeKeeper);
+            var subscriptionManager = new SubscriptionManager();
             subscriptionManager.SetDataManager(new DataManagerStub());
             return subscriptionManager.LookupSubscriptionConfigDataTypes(securityType, resolution, isCanonical);
         }

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -25,6 +25,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -72,7 +73,7 @@ namespace QuantConnect.Tests.Common.Securities
                                        null);
 
             _algo.HistoryProvider = historyProvider;
-
+            _algo.SubscriptionManager.SetDataManager(new DataManagerStub(_algo));
             _tradeBarSecurity = new Security(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                                         _tradeBarConfig,
                                         new Cash(CashBook.AccountCurrency, 0, 1m),

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -87,7 +87,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cash = new Cash("JPY", quantity, conversionRate);
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, abcConfig, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
@@ -104,7 +105,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cash = new Cash("JPY", quantity, conversionRate);
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, abcConfig, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
@@ -127,7 +129,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             securities.Add(Symbols.EURUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.EURUSD, minimumResolution, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
@@ -145,7 +148,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.EURUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.EURUSD, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -163,7 +167,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.USDJPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -185,7 +190,8 @@ namespace QuantConnect.Tests.Common.Securities
 
             var symbol = Symbol.Create("GBPJPY", SecurityType.Forex, Market.FXCM);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(symbol, new Security(SecurityExchangeHours, subscriptions.Add(symbol, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -213,7 +219,8 @@ namespace QuantConnect.Tests.Common.Securities
                 {"XAU", new Cash("XAU", 100, 17) }
             };
 
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
 
             book.EnsureCurrencyDataFeeds(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, SecurityChanges.None);
@@ -244,7 +251,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.USDJPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -267,7 +275,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("GBP", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.GBPUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.GBPUSD, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -299,7 +308,8 @@ namespace QuantConnect.Tests.Common.Securities
                 {"USD", new Cash("USD", 100, 1) },
                 {"EUR", new Cash("EUR", 100, 1.2m) }
             };
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
 
             book.EnsureCurrencyDataFeeds(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, SecurityChanges.None);

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -87,8 +87,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cash = new Cash("JPY", quantity, conversionRate);
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, abcConfig, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
@@ -105,8 +105,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cash = new Cash("JPY", quantity, conversionRate);
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, abcConfig, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
@@ -129,8 +129,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
             securities.Add(Symbols.EURUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.EURUSD, minimumResolution, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
@@ -148,8 +148,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.EURUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.EURUSD, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -167,8 +167,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.USDJPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -190,8 +190,8 @@ namespace QuantConnect.Tests.Common.Securities
 
             var symbol = Symbol.Create("GBPJPY", SecurityType.Forex, Market.FXCM);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(symbol, new Security(SecurityExchangeHours, subscriptions.Add(symbol, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -219,8 +219,8 @@ namespace QuantConnect.Tests.Common.Securities
                 {"XAU", new Cash("XAU", 100, 17) }
             };
 
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
 
             book.EnsureCurrencyDataFeeds(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, SecurityChanges.None);
@@ -251,8 +251,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.USDJPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -275,8 +275,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("GBP", cash);
 
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(Symbols.GBPUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.GBPUSD, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
 
@@ -308,8 +308,8 @@ namespace QuantConnect.Tests.Common.Securities
                 {"USD", new Cash("USD", 100, 1) },
                 {"EUR", new Cash("EUR", 100, 1.2m) }
             };
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
 
             book.EnsureCurrencyDataFeeds(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, SecurityChanges.None);

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -47,7 +47,8 @@ namespace QuantConnect.Tests.Common.Securities
             _securityManager = new SecurityManager(timeKeeper);
             _securityTransactionManager = new SecurityTransactionManager(null, _securityManager);
             _securityPortfolioManager = new SecurityPortfolioManager(_securityManager, _securityTransactionManager);
-            _subscriptionManager = new SubscriptionManager(timeKeeper, new DataManagerStub());
+            _subscriptionManager = new SubscriptionManager(timeKeeper);
+            _subscriptionManager.SetDataManager(new DataManagerStub());
             _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
             _securityInitializer = SecurityInitializer.Null;
@@ -217,7 +218,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SecurityManagerCanCreate_Cfd_WithCorrectSubscriptions()
         {
             var symbol = Symbol.Create("abc", SecurityType.Cfd, Market.USA);
-            var marketHoursDbEntry = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, SecurityType.Equity);
+            var marketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "abc", SecurityType.Cfd, TimeZones.NewYork);
             var defaultQuoteCurrency = CashBook.AccountCurrency;
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
 
@@ -315,7 +316,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var identifier = SecurityIdentifier.GenerateFuture(new DateTime(2020, 12, 15), "ED", Market.USA);
             var symbol = new Symbol(identifier, "ED", Symbol.Empty);
-            var marketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "ED", SecurityType.Equity, TimeZones.NewYork);
+            var marketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "ED", SecurityType.Future, TimeZones.NewYork);
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, "ED", symbol.ID.SecurityType, CashBook.AccountCurrency);
 
             var subscriptionTypes = new List<Tuple<Type, TickType>>

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -47,8 +47,8 @@ namespace QuantConnect.Tests.Common.Securities
             _securityManager = new SecurityManager(timeKeeper);
             _securityTransactionManager = new SecurityTransactionManager(null, _securityManager);
             _securityPortfolioManager = new SecurityPortfolioManager(_securityManager, _securityTransactionManager);
-            _subscriptionManager = new SubscriptionManager(timeKeeper);
-            _subscriptionManager.SetDataManager(new DataManagerStub());
+            _subscriptionManager = new SubscriptionManager();
+            _subscriptionManager.SetDataManager(new DataManagerStub(timeKeeper));
             _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
             _securityInitializer = SecurityInitializer.Null;

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -85,8 +85,10 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(fills.Count + 1, equity.Count);
 
             // we're going to process fills and very our equity after each fill
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
+            MarketHoursDatabase.FromDataFolder().SetEntryAlwaysOpen(CASH.ID.Market, CASH.Value, CASH.SecurityType, TimeZones.NewYork);
             var security = new Security(SecurityExchangeHours, subscriptions.Add(CASH, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
             security.SetLeverage(10m);
             securities.Add(CASH, security);
@@ -148,7 +150,8 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(fills.Count + 1, equity.Count);
 
             // we're going to process fills and very our equity after each fill
-            var subscriptions = new SubscriptionManager(TimeKeeper, new DataManagerStub());
+            var subscriptions = new SubscriptionManager(TimeKeeper);
+            subscriptions.SetDataManager(new DataManagerStub());
             var securities = new SecurityManager(TimeKeeper);
             var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -85,8 +85,8 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(fills.Count + 1, equity.Count);
 
             // we're going to process fills and very our equity after each fill
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
             MarketHoursDatabase.FromDataFolder().SetEntryAlwaysOpen(CASH.ID.Market, CASH.Value, CASH.SecurityType, TimeZones.NewYork);
             var security = new Security(SecurityExchangeHours, subscriptions.Add(CASH, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
@@ -150,8 +150,8 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(fills.Count + 1, equity.Count);
 
             // we're going to process fills and very our equity after each fill
-            var subscriptions = new SubscriptionManager(TimeKeeper);
-            subscriptions.SetDataManager(new DataManagerStub());
+            var subscriptions = new SubscriptionManager();
+            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
             var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Tests.Engine
             var algorithm = PerformanceBenchmarkAlgorithms.SingleSecurity_Second;
             var job = new BacktestNodePacket(1, 2, "3", null, 9m, $"{nameof(AlgorithmManagerTests)}.{nameof(TestAlgorithmManagerSpeed)}");
             var feed = new MockDataFeed();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings, algorithm.TimeKeeper);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             var transactions = new BacktestingTransactionHandler();
             var results = new BacktestingResultHandler();

--- a/Tests/Engine/DataFeeds/DataManagerStub.cs
+++ b/Tests/Engine/DataFeeds/DataManagerStub.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using QuantConnect.Algorithm;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
@@ -27,14 +28,26 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
         }
 
-        public DataManagerStub(IAlgorithm algorithm)
-            : this(new NullDataFeed(), algorithm)
+        public DataManagerStub(TimeKeeper timeKeeper)
+            : this(new QCAlgorithm(), timeKeeper)
         {
 
         }
 
-        public DataManagerStub(IDataFeed dataFeed, IAlgorithm algorithm)
-            : base(dataFeed, new UniverseSelection(dataFeed, algorithm), algorithm.Settings)
+        public DataManagerStub(IAlgorithm algorithm)
+            : this(new NullDataFeed(), algorithm, new TimeKeeper(DateTime.UtcNow, TimeZones.NewYork))
+        {
+
+        }
+
+        public DataManagerStub(IAlgorithm algorithm, TimeKeeper timeKeeper)
+            : this(new NullDataFeed(), algorithm, timeKeeper)
+        {
+
+        }
+
+        public DataManagerStub(IDataFeed dataFeed, IAlgorithm algorithm, TimeKeeper timeKeeper)
+            : base(dataFeed, new UniverseSelection(dataFeed, algorithm), algorithm.Settings, timeKeeper)
         {
 
         }

--- a/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var algorithm = PerformanceBenchmarkAlgorithms.SingleSecurity_Second;
             var feed = new FileSystemDataFeed();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings, algorithm.TimeKeeper);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
 
             feed.Initialize(algorithm, job, resultHandler, mapFileProvider, factorFileProvider, dataProvider, dataManager);

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -598,7 +598,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var resultHandler = new BacktestingResultHandler();
 
             var feed = new TestableLiveTradingDataFeed();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm),
+                algorithm.Settings, algorithm.TimeKeeper);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             algorithm.AddSecurities(Resolution.Tick, Enumerable.Range(0, 20).Select(x => x.ToString()).ToList());
             var getNextTicksFunction = Enumerable.Range(0, 20).Select(x => new Tick { Symbol = SymbolCache.GetSymbol(x.ToString()) }).ToList();
@@ -671,7 +672,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var feed = new TestableLiveTradingDataFeed(dataQueueHandler, _manualTimeProvider);
             var mapFileProvider = new LocalDiskMapFileProvider();
             var fileProvider = new DefaultDataProvider();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, _algorithm), _algorithm.Settings);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, _algorithm),
+                _algorithm.Settings, _algorithm.TimeKeeper);
             _algorithm.SubscriptionManager.SetDataManager(dataManager);
             _algorithm.AddSecurities(resolution, equities, forex);
 

--- a/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         private void TestSubscriptionSynchronizerSpeed(QCAlgorithm algorithm)
         {
             var feed = new AlgorithmManagerTests.MockDataFeed();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings, algorithm.TimeKeeper);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
 
             algorithm.Initialize();

--- a/Tests/Engine/RealTimePriceUpdateTests.cs
+++ b/Tests/Engine/RealTimePriceUpdateTests.cs
@@ -59,7 +59,8 @@ namespace QuantConnect.Tests.Engine
             };
 
             var algo = new TestAlgorithm();
-            var dataManager = new DataManager(_liveTradingDataFeed, new UniverseSelection(_liveTradingDataFeed, algo), algo.Settings);
+            var dataManager = new DataManager(_liveTradingDataFeed, new UniverseSelection(_liveTradingDataFeed, algo),
+                algo.Settings, algo.TimeKeeper);
             algo.SubscriptionManager.SetDataManager(dataManager);
 
             _liveTradingDataFeed.Initialize(algo, jobPacket, new LiveTradingResultHandler(), new LocalDiskMapFileProvider(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding new `ISubscriptionDataConfigService` implemented by `DataManager`, exposed by
`SubscriptionManager`
- `SecurityManager` and `SubscriptionManager` will use new interface.
In a next `PR`, its intended for it to also be consumed by `Universe.GetSubscriptionRequests()`, since it does not have enough data/context to successfully create a new `SubscriptionDataConfig`
- Moving from `SubscriptionManager` into `DataManager`:
     - `LookupSubscriptionConfigDataTypes` implementation
     - `HasCustomData` , `TimeKeeper` and `AvailableDataTypes`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2551
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/5
`Universe.GetSubscriptionRequests()` does not have enough data/context to successfully create a new `SubscriptionDataConfig`, this new interface will be provided as a parameter
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->