### PR TITLE
Fix ConsoleSetupHandler overwriting Job.BacktestId

### DIFF
--- a/Engine/Setup/ConsoleSetupHandler.cs
+++ b/Engine/Setup/ConsoleSetupHandler.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Lean.Engine.Setup
         /// <summary>
         /// Maximum runtime of the strategy. (Set to 10 years for local backtesting).
         /// </summary>
-        public TimeSpan MaximumRuntime { get; private set; }
+        public TimeSpan MaximumRuntime { get; }
 
         /// <summary>
         /// Starting capital for the algorithm (Loaded from the algorithm code).
@@ -59,7 +59,7 @@ namespace QuantConnect.Lean.Engine.Setup
         /// <summary>
         /// Maximum number of orders for this backtest.
         /// </summary>
-        public int MaxOrders { get; private set; }
+        public int MaxOrders { get; }
 
         /// <summary>
         /// Setup the algorithm data, cash, job start end date etc:
@@ -130,6 +130,11 @@ namespace QuantConnect.Lean.Engine.Setup
                 if (baseJob.Type == PacketType.BacktestNode)
                 {
                     var backtestJob = baseJob as BacktestNodePacket;
+                    if (backtestJob == null)
+                    {
+                        throw new ArgumentException("Expected BacktestNodePacket but received " + baseJob.GetType().Name);
+                    }
+
                     algorithm.SetMaximumOrders(int.MaxValue);
 
                     // set our parameters
@@ -158,10 +163,6 @@ namespace QuantConnect.Lean.Engine.Setup
                     //Construct the backtest job packet:
                     backtestJob.PeriodStart = algorithm.StartDate;
                     backtestJob.PeriodFinish = algorithm.EndDate;
-                    backtestJob.BacktestId = algorithm.GetType().Name;
-                    backtestJob.Type = PacketType.BacktestNode;
-                    backtestJob.UserId = baseJob.UserId;
-                    backtestJob.Channel = baseJob.Channel;
 
                     //Backtest Specific Parameters:
                     StartingDate = backtestJob.PeriodStart;


### PR DESCRIPTION

#### Description
A few minor changes have been made to `ConsoleSetupHandler`:
- the `job.BacktestId` property is no longer overwritten by the algorithm class name
- a few unnecessary assignments have been removed
- a missing null check has been added

#### Related Issue
Closes #2472 

#### Motivation and Context
Inconsistency between `ConsoleSetupHandler` and `BacktestingSetupHandler`.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local debugging.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`