### PR TITLE
Fix NullReferenceException in DukascopyDownloader

### DIFF
--- a/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
+++ b/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -112,21 +112,31 @@ namespace QuantConnect.ToolBox.DukascopyDownloader
         /// <param name="ticks"></param>
         /// <param name="resolution"></param>
         /// <returns></returns>
-        internal static IEnumerable<TradeBar> AggregateTicks(Symbol symbol, IEnumerable<Tick> ticks, TimeSpan resolution)
+        internal static IEnumerable<QuoteBar> AggregateTicks(Symbol symbol, IEnumerable<Tick> ticks, TimeSpan resolution)
         {
-            return 
-                (from t in ticks
-                 group t by t.Time.RoundDown(resolution)
-                     into g
-                     select new TradeBar
-                     {
-                         Symbol = symbol,
-                         Time = g.Key,
-                         Open = g.First().LastPrice,
-                         High = g.Max(t => t.LastPrice),
-                         Low = g.Min(t => t.LastPrice),
-                         Close = g.Last().LastPrice
-                     });
+            return
+                from t in ticks
+                group t by t.Time.RoundDown(resolution)
+                into g
+                select new QuoteBar
+                {
+                    Symbol = symbol,
+                    Time = g.Key,
+                    Bid = new Bar
+                    {
+                        Open = g.First().BidPrice,
+                        High = g.Max(b => b.BidPrice),
+                        Low = g.Min(b => b.BidPrice),
+                        Close = g.Last().BidPrice
+                    },
+                    Ask = new Bar
+                    {
+                        Open = g.First().AskPrice,
+                        High = g.Max(b => b.AskPrice),
+                        Low = g.Min(b => b.AskPrice),
+                        Close = g.Last().AskPrice
+                    }
+                };
         }
 
         /// <summary>
@@ -213,9 +223,9 @@ namespace QuantConnect.ToolBox.DukascopyDownloader
                             if (bid > 0 && ask > 0)
                             {
                                 ticks.Add(new Tick(
-                                    date.AddMilliseconds(timeOffset + time), 
-                                    symbol, 
-                                    Convert.ToDecimal(bid / pointValue), 
+                                    date.AddMilliseconds(timeOffset + time),
+                                    symbol,
+                                    Convert.ToDecimal(bid / pointValue),
                                     Convert.ToDecimal(ask / pointValue)));
                             }
                         }


### PR DESCRIPTION

#### Description
The `DukascopyDownloader` has been updated to save `QuoteBar`s instead of `TradeBar`s.

#### Related Issue
Closes #2486 

#### Motivation and Context
This downloader was only working with `Tick` resolution, throwing an exception in all other cases.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Manual testing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`