### PR TITLE
Dispose queues after consumers - Improve regression tests speed

### DIFF
--- a/Common/Util/ParallelRunner.cs
+++ b/Common/Util/ParallelRunner.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -172,13 +171,14 @@ namespace QuantConnect.Util
                     worker.DisposeSafely();
                 }
 
-                if (_holdQueue != null) _holdQueue.Dispose();
-                if (_processQueue != null) _processQueue.Dispose();
+                _holdQueue?.DisposeSafely();
+                _processQueue?.DisposeSafely();
 
-                if (_waitHandle != null)
+                // if IsClosed means its already disposed
+                if (_waitHandle != null && !_waitHandle.SafeWaitHandle.IsClosed)
                 {
                     _waitHandle.Set();
-                    _waitHandle.Dispose();
+                    _waitHandle.DisposeSafely();
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Removing `sleep` and disposing queues after consumers. I believe this should also solve the original issue while saving time.
> For 100 regression tests, this reduces execution time by 16 minutes (100 * 10 sec / 60)
- Will first `Join` with 1-second timeout and `Abort` if it failed (tests showed `Abort` was never called). Adding try-catch just for robustness.
- Using `DisposeSafely` versus `Dispose`. 
- Adding check for `_waitHandle` to verify the handle is not already closed.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/QuantConnect/Lean/issues/831
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Faster is better
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executed unit and regressions tests (multiple times) and verified logs
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->