### PR TITLE
Issue-2564 - Fixes 8 character datetime parsing from csv

### DIFF
--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -270,7 +270,23 @@ namespace QuantConnect.Data.Market
             if (config.Resolution == Resolution.Daily || config.Resolution == Resolution.Hour)
             {
                 // hourly and daily have different time format, and can use slow, robust c# parser.
-                tradeBar.Time = DateTime.ParseExact(csv[0], DateFormat.TwelveCharacter, CultureInfo.InvariantCulture).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
+                string determinedDateFormat;
+                switch (csv[0].Length)
+                {
+                    case 12:
+                        determinedDateFormat = DateFormat.TwelveCharacter;
+                        break;
+                    case 8:
+                        determinedDateFormat = DateFormat.EightCharacter;
+                        break;
+                    default:
+                        determinedDateFormat = DateFormat.TwelveCharacter;
+                        break;
+                }
+
+                tradeBar.Time = DateTime
+                    .ParseExact(csv[0], determinedDateFormat, CultureInfo.InvariantCulture)
+                    .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
             }
             else
             {


### PR DESCRIPTION
#### Description
When parsing data from csv containing 8 character dates, we should check the date length and parse accordingly. The code currently defaults to 12 character dates and fails to parse DateTime for data sets such as free data set provided by QuantConnect.

#### Related Issue
https://github.com/QuantConnect/Lean/issues/2564

#### Motivation and Context
This change will allow folks to use the free data set provided from QuantConnect, which uses an 8 character date

#### Requires Documentation Change
No documentation needed

#### How Has This Been Tested?
Verified that this continues to parse 12 character dates and detects 8 character dates and parses them correctly as well.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`