### PR TITLE
Fix errors with unit and regression tests in the same run

### DIFF
--- a/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.py
+++ b/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.py
@@ -13,11 +13,14 @@
 
 from clr import AddReference
 AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Indicators")
 
 from QuantConnect import *
 from QuantConnect.Indicators import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import *
 from datetime import timedelta
 from enum import Enum
@@ -59,7 +62,7 @@ class BasePairsTradingAlphaModel(AlphaModel):
 
         for key, pair in self.pairs.items():
             insights.extend(pair.GetInsightGroup())
- 
+
         return insights
 
     def OnSecuritiesChanged(self, algorithm, changes):
@@ -146,7 +149,7 @@ class BasePairsTradingAlphaModel(AlphaModel):
 
             lower = ConstantIndicator[IndicatorDataPoint]("ct", 1 - threshold / 100)
             self.lowerThreshold = IndicatorExtensions.Times(self.mean, lower)
-            
+
             self.predictionInterval = predictionInterval
 
         def GetInsightGroup(self):

--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.py
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.py
@@ -12,10 +12,13 @@
 # limitations under the License.
 
 from clr import AddReference
-AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
 
 from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import AlphaModel, Insight, InsightType, InsightDirection
 
 
@@ -26,7 +29,7 @@ class ConstantAlphaModel(AlphaModel):
         '''Initializes a new instance of the ConstantAlphaModel class
         Args:
             type: The type of insight
-            direction: The direction of the insight 
+            direction: The direction of the insight
             period: The period over which the insight with come to fruition
             magnitude: The predicted change in magnitude as a +- percentage
             confidence: The confidence in the insight'''
@@ -40,7 +43,7 @@ class ConstantAlphaModel(AlphaModel):
 
         typeString = Extensions.GetEnumString(type, InsightType)
         directionString = Extensions.GetEnumString(direction, InsightDirection)
-        
+
         self.Name = '{}({},{},{}'.format(self.__class__.__name__, typeString, directionString, strfdelta(period))
         if magnitude is not None:
             self.Name += ',{}'.format(magnitude)

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
@@ -13,11 +13,14 @@
 
 from clr import AddReference
 AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Indicators")
 
 from QuantConnect import *
 from QuantConnect.Indicators import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import *
 
 

--- a/Algorithm.Framework/Alphas/MacdAlphaModel.py
+++ b/Algorithm.Framework/Alphas/MacdAlphaModel.py
@@ -13,11 +13,14 @@
 
 from clr import AddReference
 AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Indicators")
 
 from QuantConnect import *
 from QuantConnect.Indicators import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import *
 
 

--- a/Algorithm.Framework/Alphas/RsiAlphaModel.py
+++ b/Algorithm.Framework/Alphas/RsiAlphaModel.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from clr import AddReference
+AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Indicators")
 AddReference("QuantConnect.Logging")
@@ -20,6 +21,8 @@ AddReference("QuantConnect.Common")
 from QuantConnect import *
 from QuantConnect.Indicators import *
 from QuantConnect.Logging import Log
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import *
 from datetime import timedelta
 from enum import Enum
@@ -94,7 +97,7 @@ class RsiAlphaModel(AlphaModel):
 
             if not history.empty:
                 ticker = SymbolCache.GetTicker(symbol)
-                
+
                 if ticker not in history.index.levels[0]:
                     Log.Trace(f'RsiAlphaModel.OnSecuritiesChanged: {ticker} not found in history data frame.')
                     continue

--- a/Algorithm.Framework/Execution/ImmediateExecutionModel.py
+++ b/Algorithm.Framework/Execution/ImmediateExecutionModel.py
@@ -14,13 +14,16 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Algorithm.Framework")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Orders import *
-from QuantConnect.Algorithm.Framework.Execution import ExecutionModel
-from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTargetCollection
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
 
 class ImmediateExecutionModel(ExecutionModel):
     '''Provides an implementation of IExecutionModel that immediately submits market orders to achieve the desired portfolio targets'''

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
@@ -15,15 +15,19 @@ from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Indicators")
+AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Algorithm.Framework")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Indicators import *
-from QuantConnect.Data.Market import TradeBar
+from QuantConnect.Data import *
+from QuantConnect.Data.Market import *
 from QuantConnect.Orders import *
-from QuantConnect.Algorithm.Framework.Execution import ExecutionModel
-from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTargetCollection
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
 import numpy as np
 
 

--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.py
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.py
@@ -15,15 +15,19 @@ from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Indicators")
+AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Algorithm.Framework")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Indicators import *
-from QuantConnect.Data.Market import Tick, TradeBar
+from QuantConnect.Data import *
+from QuantConnect.Data.Market import *
 from QuantConnect.Orders import *
-from QuantConnect.Algorithm.Framework.Execution import ExecutionModel
-from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTargetCollection
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
 import numpy as np
 from datetime import datetime
 

--- a/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.py
+++ b/Algorithm.Framework/Risk/MaximumDrawdownPercentPerSecurity.py
@@ -14,8 +14,12 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Algorithm.Framework")
 
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget
 from QuantConnect.Algorithm.Framework.Risk import RiskManagementModel
 

--- a/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.py
+++ b/Algorithm.Framework/Risk/MaximumSectorExposureRiskManagementModel.py
@@ -14,8 +14,11 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
 AddReference("QuantConnect.Algorithm.Framework")
 
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget, PortfolioTargetCollection
 from QuantConnect.Algorithm.Framework.Risk import RiskManagementModel
 from itertools import groupby

--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -22,8 +22,8 @@ using System.Runtime.InteropServices;
 using System.Security.Policy;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
-using Python.Runtime;
 using QuantConnect.AlgorithmFactory.Python.Wrappers;
+using QuantConnect.Python;
 
 namespace QuantConnect.AlgorithmFactory
 {
@@ -41,9 +41,6 @@ namespace QuantConnect.AlgorithmFactory
 
         // Defines how we resolve a list of type names into a single type name to be instantiated
         private readonly Func<List<string>, string> _multipleTypeNameResolverFunction;
-
-        // Used to allow multiple Python regression tests
-        private static bool _isBeginAllowThreadsCalled;
 
         /// <summary>
         /// Memory space of the user algorithm
@@ -169,13 +166,9 @@ namespace QuantConnect.AlgorithmFactory
 
             try
             {
-                algorithmInstance = new AlgorithmPythonWrapper(moduleName);
+                PythonInitializer.Initialize();
 
-                if (!_isBeginAllowThreadsCalled)
-                {
-                    PythonEngine.BeginAllowThreads();
-                    _isBeginAllowThreadsCalled = true;
-                }
+                algorithmInstance = new AlgorithmPythonWrapper(moduleName);
             }
             catch (Exception e)
             {

--- a/Common/Exceptions/StackExceptionInterpreter.cs
+++ b/Common/Exceptions/StackExceptionInterpreter.cs
@@ -116,6 +116,8 @@ namespace QuantConnect.Exceptions
                 where type.IsPublic && !type.IsAbstract
                 // type implements IExceptionInterpreter
                 where typeof(IExceptionInterpreter).IsAssignableFrom(type)
+                // type is not mocked with MOQ library
+                where type.FullName != null && !type.FullName.StartsWith("Castle.Proxies.ObjectProxy")
                 // type has default parameterless ctor
                 where type.GetConstructor(new Type[0]) != null
                 // provide guarantee of deterministic ordering

--- a/Common/Python/PythonInitializer.cs
+++ b/Common/Python/PythonInitializer.cs
@@ -11,36 +11,35 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
 */
 
-using System;
-using NUnit.Framework;
+using Python.Runtime;
 
-namespace QuantConnect.Tests
+namespace QuantConnect.Python
 {
-    [SetUpFixture]
-    public class PythonSetup
+    /// <summary>
+    /// Helper class for Python initialization
+    /// </summary>
+    public static class PythonInitializer
     {
-        [SetUp]
-        public void SetUp()
-        {
-            var pythonPath = string.Join(
-                OS.IsLinux ? ":" : ";",
-                "./Alphas",
-                "./Execution",
-                "./Portfolio",
-                "./Risk",
-                "./Selection",
-                "./RegressionAlgorithms",
-                "./Jupyter/RegressionScripts",
-                "../../../Algorithm.Python");
+        // Used to allow multiple Python unit and regression tests to be run in the same test run
+        private static bool _isBeginAllowThreadsCalled;
 
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath);
-        }
-
-        [TearDown]
-        public void TearDown()
+        /// <summary>
+        /// Initialize the Python.NET library
+        /// </summary>
+        public static void Initialize()
         {
+            if (!_isBeginAllowThreadsCalled)
+            {
+                PythonEngine.Initialize();
+
+                // required for multi-threading usage
+                PythonEngine.BeginAllowThreads();
+
+                _isBeginAllowThreadsCalled = true;
+            }
         }
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
+    <Compile Include="Python\PythonInitializer.cs" />
     <Compile Include="Securities\ICurrencyConverter.cs" />
     <Compile Include="Python\BuyingPowerModelPythonWrapper.cs" />
     <Compile Include="Securities\CashAmount.cs" />

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -27,6 +27,7 @@ using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Python;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Alphas
@@ -41,6 +42,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         [TestFixtureSetUp]
         public void Initialize()
         {
+            PythonInitializer.Initialize();
+
             _algorithm = new QCAlgorithmFramework();
             _algorithm.PortfolioConstruction = new NullPortfolioConstructionModel();
             _algorithm.HistoryProvider = new SineHistoryProvider(_algorithm.Securities);

--- a/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
@@ -24,8 +24,6 @@ using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
@@ -40,9 +38,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestFixtureSetUp]
         public void SetUp()
         {
-            var pythonPath = new DirectoryInfo("../../../Algorithm.Framework/Portfolio");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-
             _algorithm = new QCAlgorithmFramework();
             SetUtcTime(new DateTime(2018, 8, 7));
 
@@ -235,7 +230,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
             public override void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
             {
-                
+
             }
         }
 

--- a/Tests/Jupyter/QuantBookHistoryTests.cs
+++ b/Tests/Jupyter/QuantBookHistoryTests.cs
@@ -43,89 +43,105 @@ namespace QuantConnect.Tests.Jupyter
         [TestCase(2016, 10, 9, SecurityType.Crypto, "BTCUSD")]
         public void SecurityQuantBookHistoryTests(int year, int month, int day, SecurityType securityType, string symbol)
         {
-            var startDate = new DateTime(year, month, day);
-            var securityTestHistory = _module.SecurityHistoryTest(startDate, securityType, symbol);
+            using (Py.GIL())
+            {
+                var startDate = new DateTime(year, month, day);
+                var securityTestHistory = _module.SecurityHistoryTest(startDate, securityType, symbol);
 
-            // Get the last 10 candles
-            var periodHistory = securityTestHistory.test_period_overload(10);
-            var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
-            Assert.AreEqual(10, count);
+                // Get the last 10 candles
+                var periodHistory = securityTestHistory.test_period_overload(10);
+                var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
+                Assert.AreEqual(10, count);
 
-            // Get the one day of data
-            var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(1));
-            var firstIndex = (DateTime)(timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
-            Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
+                // Get the one day of data
+                var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(1));
+                var firstIndex = (DateTime) (timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+                Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
 
-            // Get the one day of data, ending one day before start date
-            var startEndHistory = securityTestHistory.test_daterange_overload(startDate.AddDays(-1));
-            firstIndex = (DateTime)(startEndHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
-            Assert.GreaterOrEqual(startDate.AddDays(-2).Date, firstIndex.Date);
+                // Get the one day of data, ending one day before start date
+                var startEndHistory = securityTestHistory.test_daterange_overload(startDate.AddDays(-1));
+                firstIndex = (DateTime) (startEndHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+                Assert.GreaterOrEqual(startDate.AddDays(-2).Date, firstIndex.Date);
+            }
         }
 
         [Test]
         [TestCase(2014, 5, 9, "Nifty", "NIFTY")]
         public void CustomDataQuantBookHistoryTests(int year, int month, int day, string customDataType, string symbol)
         {
-            var startDate = new DateTime(year, month, day);
-            var securityTestHistory = _module.CustomDataHistoryTest(startDate, customDataType, symbol);
+            using (Py.GIL())
+            {
+                var startDate = new DateTime(year, month, day);
+                var securityTestHistory = _module.CustomDataHistoryTest(startDate, customDataType, symbol);
 
-            // Get the last 5 candles
-            var periodHistory = securityTestHistory.test_period_overload(5);
-            var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
-            Assert.AreEqual(5, count);
+                // Get the last 5 candles
+                var periodHistory = securityTestHistory.test_period_overload(5);
+                var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
+                Assert.AreEqual(5, count);
 
-            // Get the one day of data
-            var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(8));
-            var firstIndex = (DateTime)(timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
-            Assert.AreEqual(startDate.AddDays(-7), firstIndex);
+                // Get the one day of data
+                var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(8));
+                var firstIndex =
+                    (DateTime) (timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+                Assert.AreEqual(startDate.AddDays(-7), firstIndex);
 
-            // Get the one day of data, ending one day before start date
-            var startEndHistory = securityTestHistory.test_daterange_overload(startDate.AddDays(-2));
-            firstIndex = (DateTime)(startEndHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
-            Assert.AreEqual(startDate.AddDays(-2).Date, firstIndex.Date);
+                // Get the one day of data, ending one day before start date
+                var startEndHistory = securityTestHistory.test_daterange_overload(startDate.AddDays(-2));
+                firstIndex = (DateTime) (startEndHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+                Assert.AreEqual(startDate.AddDays(-2).Date, firstIndex.Date);
+            }
         }
 
         [Test]
         public void MultipleSecuritiesQuantBookHistoryTests()
         {
-            var startDate = new DateTime(2014, 5, 9);
-            var securityTestHistory = _module.MultipleSecuritiesHistoryTest(startDate, null, null);
+            using (Py.GIL())
+            {
+                var startDate = new DateTime(2014, 5, 9);
+                var securityTestHistory = _module.MultipleSecuritiesHistoryTest(startDate, null, null);
 
-            // Get the last 5 candles
-            var periodHistory = securityTestHistory.test_period_overload(5);
-            var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
-            Assert.AreEqual(6, count);
+                // Get the last 5 candles
+                var periodHistory = securityTestHistory.test_period_overload(5);
+                var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
+                Assert.AreEqual(6, count);
 
-            // Get the one day of data
-            var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(8));
-            var firstIndex = (DateTime)(timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
-            Assert.AreEqual(startDate.AddDays(-8), firstIndex);
+                // Get the one day of data
+                var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(8));
+                var firstIndex = (DateTime) (timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
+                Assert.AreEqual(startDate.AddDays(-8), firstIndex);
+            }
         }
 
         [Test]
         public void OptionQuantBookHistoryTests()
         {
-            var symbol = "TWX";
-            var startDate = new DateTime(2014, 6, 6);
-            var securityTestHistory = _module.OptionHistoryTest(startDate, SecurityType.Option, symbol);
+            using (Py.GIL())
+            {
+                var symbol = "TWX";
+                var startDate = new DateTime(2014, 6, 6);
+                var securityTestHistory = _module.OptionHistoryTest(startDate, SecurityType.Option, symbol);
 
-            // Get the one day of data, ending on start date
-            var startEndHistory = securityTestHistory.test_daterange_overload(startDate);
-            var firstIndex = (DateTime)(startEndHistory.index.values[0][4] as PyObject).AsManagedObject(typeof(DateTime));
-            Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
+                // Get the one day of data, ending on start date
+                var startEndHistory = securityTestHistory.test_daterange_overload(startDate);
+                var firstIndex = (DateTime) (startEndHistory.index.values[0][4] as PyObject).AsManagedObject(typeof(DateTime));
+                Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
+            }
         }
 
         [Test]
         public void FutureQuantBookHistoryTests()
         {
-            var symbol = Futures.Indices.SP500EMini;
-            var startDate = new DateTime(2013, 10, 11);
-            var securityTestHistory = _module.FutureHistoryTest(startDate, SecurityType.Future, symbol);
+            using (Py.GIL())
+            {
+                var symbol = Futures.Indices.SP500EMini;
+                var startDate = new DateTime(2013, 10, 11);
+                var securityTestHistory = _module.FutureHistoryTest(startDate, SecurityType.Future, symbol);
 
-            // Get the one day of data, ending on start date
-            var startEndHistory = securityTestHistory.test_daterange_overload(startDate);
-            var firstIndex = (DateTime)(startEndHistory.index.values[0][2] as PyObject).AsManagedObject(typeof(DateTime));
-            Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
+                // Get the one day of data, ending on start date
+                var startEndHistory = securityTestHistory.test_daterange_overload(startDate);
+                var firstIndex = (DateTime) (startEndHistory.index.values[0][2] as PyObject).AsManagedObject(typeof(DateTime));
+                Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
+            }
         }
     }
 }

--- a/Tests/Jupyter/QuantBookIndicatorsTests.cs
+++ b/Tests/Jupyter/QuantBookIndicatorsTests.cs
@@ -43,28 +43,31 @@ namespace QuantConnect.Tests.Jupyter
         [TestCase(2016, 10, 9, SecurityType.Crypto, "BTCUSD")]
         public void QuantBookIndicatorTests(int year, int month, int day, SecurityType securityType, string symbol)
         {
-            var startDate = new DateTime(year, month, day);
-            var indicatorTest = _module.IndicatorTest(startDate, securityType, symbol);
-
-            var endDate = startDate;
-            startDate = endDate.AddYears(-1);
-
-            // Tests a data point indicator
-            var dfBB = indicatorTest.test_bollinger_bands(symbol, startDate, endDate, Resolution.Daily);
-            Assert.IsTrue(GetDataFrameLength(dfBB) > 0);
-
-            // Tests a bar indicator
-            var dfATR = indicatorTest.test_average_true_range(symbol, startDate, endDate, Resolution.Daily);
-            Assert.IsTrue(GetDataFrameLength(dfATR) > 0);
-
-            if (securityType == SecurityType.Forex)
+            using (Py.GIL())
             {
-                return;
-            }
+                var startDate = new DateTime(year, month, day);
+                var indicatorTest = _module.IndicatorTest(startDate, securityType, symbol);
 
-            // Tests a trade bar indicator
-            var dfOBV = indicatorTest.test_on_balance_volume(symbol, startDate, endDate, Resolution.Daily);
-            Assert.IsTrue(GetDataFrameLength(dfOBV) > 0);
+                var endDate = startDate;
+                startDate = endDate.AddYears(-1);
+
+                // Tests a data point indicator
+                var dfBB = indicatorTest.test_bollinger_bands(symbol, startDate, endDate, Resolution.Daily);
+                Assert.IsTrue(GetDataFrameLength(dfBB) > 0);
+
+                // Tests a bar indicator
+                var dfATR = indicatorTest.test_average_true_range(symbol, startDate, endDate, Resolution.Daily);
+                Assert.IsTrue(GetDataFrameLength(dfATR) > 0);
+
+                if (securityType == SecurityType.Forex)
+                {
+                    return;
+                }
+
+                // Tests a trade bar indicator
+                var dfOBV = indicatorTest.test_on_balance_volume(symbol, startDate, endDate, Resolution.Daily);
+                Assert.IsTrue(GetDataFrameLength(dfOBV) > 0);
+            }
         }
 
         private int GetDataFrameLength(dynamic df) => (int)(df.shape[0] as PyObject).AsManagedObject(typeof(int));

--- a/Tests/Jupyter/RegressionScripts/Test_QuantBookHistory.py
+++ b/Tests/Jupyter/RegressionScripts/Test_QuantBookHistory.py
@@ -19,6 +19,7 @@ AddReference("QuantConnect.Common")
 
 from System import *
 from QuantConnect import *
+from QuantConnect.Data import *
 from QuantConnect.Jupyter import *
 from datetime import datetime, timedelta
 from custom_data import QuandlFuture, Nifty

--- a/Tests/Jupyter/RegressionScripts/Test_QuantBookIndicator.py
+++ b/Tests/Jupyter/RegressionScripts/Test_QuantBookIndicator.py
@@ -15,6 +15,9 @@ from clr import AddReference
 AddReference("QuantConnect.Jupyter")
 AddReference("QuantConnect.Indicators")
 
+from System import *
+from QuantConnect import *
+from QuantConnect.Data import *
 from QuantConnect.Jupyter import *
 from QuantConnect.Indicators import *
 

--- a/Tests/Python/AlgorithmPythonWrapperTests.cs
+++ b/Tests/Python/AlgorithmPythonWrapperTests.cs
@@ -30,9 +30,7 @@ namespace QuantConnect.Tests.Python
         [SetUp]
         public void Setup()
         {
-            var pythonPath = new DirectoryInfo("RegressionAlgorithms");
-            Environment.SetEnvironmentVariable("PYTHONPATH", pythonPath.FullName);
-            _baseCode = File.ReadAllText(Path.Combine(pythonPath.FullName, "Test_AlgorithmPythonWrapper.py"));
+            _baseCode = File.ReadAllText(Path.Combine("./RegressionAlgorithms", "Test_AlgorithmPythonWrapper.py"));
         }
 
         [Test]
@@ -90,7 +88,7 @@ namespace QuantConnect.Tests.Python
 
             using (Py.GIL())
             {
-                PythonEngine.ModuleFromString("Test_AlgorithmPythonWrapper", code);
+                 PythonEngine.ModuleFromString("Test_AlgorithmPythonWrapper", code);
                 return new AlgorithmPythonWrapper("Test_AlgorithmPythonWrapper");
             }
         }

--- a/Tests/Python/MethodOverloadTests.cs
+++ b/Tests/Python/MethodOverloadTests.cs
@@ -16,6 +16,7 @@
 
 using NUnit.Framework;
 using Python.Runtime;
+using QuantConnect.Python;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Python
@@ -31,6 +32,8 @@ namespace QuantConnect.Tests.Python
         [SetUp]
         public void Setup()
         {
+            PythonInitializer.Initialize();
+
             using (Py.GIL())
             {
                 var module = Py.Import("Test_MethodOverload");
@@ -43,23 +46,26 @@ namespace QuantConnect.Tests.Python
         [Test]
         public void CallPlotTests()
         {
-            // self.Plot('NUMBER', 0.1)
-            Assert.DoesNotThrow(() => _algorithm.call_plot_number_test());
+            using (Py.GIL())
+            {
+                // self.Plot('NUMBER', 0.1)
+                Assert.DoesNotThrow(() => _algorithm.call_plot_number_test());
 
-            // self.Plot('STD', self.std), where self.sma = self.SMA('SPY', 20)
-            Assert.DoesNotThrow(() => _algorithm.call_plot_sma_test());
+                // self.Plot('STD', self.std), where self.sma = self.SMA('SPY', 20)
+                Assert.DoesNotThrow(() => _algorithm.call_plot_sma_test());
 
-            // self.Plot('SMA', self.sma), where self.std = self.STD('SPY', 20)
-            Assert.DoesNotThrow(() => _algorithm.call_plot_std_test());
+                // self.Plot('SMA', self.sma), where self.std = self.STD('SPY', 20)
+                Assert.DoesNotThrow(() => _algorithm.call_plot_std_test());
 
-            // self.Plot("ERROR", self.Name), where self.Name is IAlgorithm.Name: string
-            Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_test());
+                // self.Plot("ERROR", self.Name), where self.Name is IAlgorithm.Name: string
+                Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_test());
 
-            // self.Plot("ERROR", self.Portfolio), where self.Portfolio is IAlgorithm.Portfolio: instance of SecurityPortfolioManager
-            Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_managed_test());
+                // self.Plot("ERROR", self.Portfolio), where self.Portfolio is IAlgorithm.Portfolio: instance of SecurityPortfolioManager
+                Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_managed_test());
 
-            // self.Plot("ERROR", self.a), where self.a is an instance of a python object
-            Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_pyobject_test());
+                // self.Plot("ERROR", self.a), where self.a is an instance of a python object
+                Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_pyobject_test());
+            }
         }
     }
 }

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -419,56 +419,60 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         [Test, TestCaseSource(nameof(SpotMarketCases))]
         public void HandlesLeanDataReaderOutputForSpotMarkets(string securityType, string market, string resolution, string ticker, string fileName, int rowsInfile, double sumValue)
         {
-            // Arrange
-            var dataFolder = "../../../Data";
-            var filepath = LeanDataReaderTests.GenerateFilepathForTesting(dataFolder, securityType, market, resolution, ticker, fileName);
-            var leanDataReader = new LeanDataReader(filepath);
-            var data = leanDataReader.Parse();
-            var converter = new PandasConverter();
-            // Act
-            dynamic df = converter.GetDataFrame(data);
-            // Assert
-            Assert.AreEqual(rowsInfile, df.shape[0].AsManagedObject(typeof(int)));
+            using (Py.GIL())
+            {
+                // Arrange
+                var dataFolder = "../../../Data";
+                var filepath = LeanDataReaderTests.GenerateFilepathForTesting(dataFolder, securityType, market, resolution, ticker, fileName);
+                var leanDataReader = new LeanDataReader(filepath);
+                var data = leanDataReader.Parse();
+                var converter = new PandasConverter();
+                // Act
+                dynamic df = converter.GetDataFrame(data);
+                // Assert
+                Assert.AreEqual(rowsInfile, df.shape[0].AsManagedObject(typeof(int)));
 
-            int columnsNumber = df.shape[1].AsManagedObject(typeof(int));
-            if (columnsNumber == 3 || columnsNumber == 6)
-            {
-                Assert.AreEqual(sumValue, df.get("lastprice").sum().AsManagedObject(typeof(double)), 1e-4);
-            }
-            else
-            {
-                Assert.AreEqual(sumValue, df.get("close").sum().AsManagedObject(typeof(double)), 1e-4);
+                int columnsNumber = df.shape[1].AsManagedObject(typeof(int));
+                if (columnsNumber == 3 || columnsNumber == 6)
+                {
+                    Assert.AreEqual(sumValue, df.get("lastprice").sum().AsManagedObject(typeof(double)), 1e-4);
+                }
+                else
+                {
+                    Assert.AreEqual(sumValue, df.get("close").sum().AsManagedObject(typeof(double)), 1e-4);
+                }
             }
         }
 
         [Test, TestCaseSource(nameof(OptionAndFuturesCases))]
         public void HandlesLeanDataReaderOutputForOptionAndFutures(string composedFilePath, Symbol symbol, int rowsInfile, double sumValue)
         {
-            // Arrange
-            var leanDataReader = new LeanDataReader(composedFilePath);
-            var data = leanDataReader.Parse();
-            var converter = new PandasConverter();
-            // Act
-            dynamic df = converter.GetDataFrame(data);
-            // Assert
-            Assert.AreEqual(rowsInfile, df.shape[0].AsManagedObject(typeof(int)));
+            using (Py.GIL())
+            {
+                // Arrange
+                var leanDataReader = new LeanDataReader(composedFilePath);
+                var data = leanDataReader.Parse();
+                var converter = new PandasConverter();
+                // Act
+                dynamic df = converter.GetDataFrame(data);
+                // Assert
+                Assert.AreEqual(rowsInfile, df.shape[0].AsManagedObject(typeof(int)));
 
-            int columnsNumber = df.shape[1].AsManagedObject(typeof(int));
-            if (columnsNumber == 3 || columnsNumber == 6)
-            {
-                Assert.AreEqual(sumValue, df.get("lastprice").sum().AsManagedObject(typeof(double)), 1e-4);
-            }
-            else if (columnsNumber == 1)
-            {
-                Assert.AreEqual(sumValue, df.get("openinterest").sum().AsManagedObject(typeof(double)), 1e-4);
-            }
-            else
-            {
-                Assert.AreEqual(sumValue, df.get("close").sum().AsManagedObject(typeof(double)), 1e-4);
+                int columnsNumber = df.shape[1].AsManagedObject(typeof(int));
+                if (columnsNumber == 3 || columnsNumber == 6)
+                {
+                    Assert.AreEqual(sumValue, df.get("lastprice").sum().AsManagedObject(typeof(double)), 1e-4);
+                }
+                else if (columnsNumber == 1)
+                {
+                    Assert.AreEqual(sumValue, df.get("openinterest").sum().AsManagedObject(typeof(double)), 1e-4);
+                }
+                else
+                {
+                    Assert.AreEqual(sumValue, df.get("close").sum().AsManagedObject(typeof(double)), 1e-4);
+                }
             }
         }
-
-
 
         public IEnumerable<Slice> GetHistory<T>(Symbol symbol, Resolution resolution, IEnumerable<T> data)
             where T : IBaseData

--- a/Tests/Python/PythonThreadingTests.cs
+++ b/Tests/Python/PythonThreadingTests.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Python;
+
+namespace QuantConnect.Tests.Python
+{
+    [TestFixture]
+    public class PythonThreadingTests
+    {
+        [Test]
+        public void ImportsCanBeExecutedFromDifferentThreads()
+        {
+            PythonInitializer.Initialize();
+
+            Task.Factory.StartNew(() =>
+            {
+                using (Py.GIL())
+                {
+                    var module = Py.Import("Test_MethodOverload");
+                    module.GetAttr("Test_MethodOverload").Invoke();
+                }
+            }).Wait();
+
+            PythonInitializer.Initialize();
+            Task.Factory.StartNew(() =>
+            {
+                using (Py.GIL())
+                {
+                    var module = Py.Import("Test_AlgorithmPythonWrapper");
+                    module.GetAttr("Test_AlgorithmPythonWrapper").Invoke();
+                }
+            }).Wait();
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -400,6 +400,7 @@
     <Compile Include="Python\AlgorithmPythonWrapperTests.cs" />
     <Compile Include="Python\MethodOverloadTests.cs" />
     <Compile Include="Python\PortfolioCustomModelTests.cs" />
+    <Compile Include="Python\PythonThreadingTests.cs" />
     <Compile Include="Python\SecurityCustomModelTests.cs" />
     <Compile Include="Python\PandasConverterTests.cs" />
     <Compile Include="RegressionTests.cs" />

--- a/Tests/RegressionAlgorithms/Test_AlgorithmPythonWrapper.py
+++ b/Tests/RegressionAlgorithms/Test_AlgorithmPythonWrapper.py
@@ -14,11 +14,18 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Common")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
 
 class Test_AlgorithmPythonWrapper(QCAlgorithm):
 

--- a/Tests/RegressionAlgorithms/Test_CustomDataAlgorithm.py
+++ b/Tests/RegressionAlgorithms/Test_CustomDataAlgorithm.py
@@ -14,12 +14,19 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Common")
 
 from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import *
-from QuantConnect.Data import SubscriptionDataSource
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from QuantConnect.Data import *
 from QuantConnect.Python import PythonData, PythonQuandl
 from datetime import datetime
 import decimal

--- a/Tests/RegressionAlgorithms/Test_MethodOverload.py
+++ b/Tests/RegressionAlgorithms/Test_MethodOverload.py
@@ -14,12 +14,19 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Indicators")
 AddReference("QuantConnect.Common")
 from System import *
 from QuantConnect import *
 from QuantConnect.Indicators import *
 from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
 
 class Test_MethodOverload(QCAlgorithm):
     def Initialize(self):

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -14,11 +14,18 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
 AddReference("QuantConnect.Common")
 from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import QCAlgorithm
-import decimal 
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
+import decimal
 
 class Test_PythonExceptionInterpreter(QCAlgorithm):
     def Initialize(self):


### PR DESCRIPTION

#### Description
- Excluded mocks from the exception interpreter loader
- Fixed Python initialization issues with multiple tests
- Fixed Python imports with multiple tests

#### Related Issue
Closes #2549 

#### Motivation and Context
Unit tests and regression tests could not be run together.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Full local test run
- Cloud Python backtest, just in case since the Python loader was slightly modified.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`