### PR TITLE
Add check to avoid FillForward for Resolution.Tick

### DIFF
--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -16,9 +16,7 @@
 
 using System;
 using NodaTime;
-using QuantConnect.Data.Market;
 using QuantConnect.Securities;
-using QuantConnect.Util;
 
 namespace QuantConnect.Data
 {
@@ -27,6 +25,8 @@ namespace QuantConnect.Data
     /// </summary>
     public class HistoryRequest
     {
+        private Resolution? _fillForwardResolution;
+
         /// <summary>
         /// Gets the start time of the request.
         /// </summary>
@@ -53,9 +53,20 @@ namespace QuantConnect.Data
         public Resolution Resolution { get; set; }
 
         /// <summary>
-        /// Gets the requested fill forward resolution, set to null for no fill forward behavior
+        /// Gets the requested fill forward resolution, set to null for no fill forward behavior.
+        /// Will always return null when Resolution is set to Tick.
         /// </summary>
-        public Resolution? FillForwardResolution { get; set; }
+        public Resolution? FillForwardResolution
+        {
+            get
+            {
+                return Resolution == Resolution.Tick ? null : _fillForwardResolution;
+            }
+            set
+            {
+                _fillForwardResolution = value;
+            }
+        }
 
         /// <summary>
         /// Gets whether or not to include extended market hours data, set to false for only normal market hours

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -1,0 +1,137 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Packets;
+using QuantConnect.Tests.Engine.DataFeeds;
+using HistoryRequest = QuantConnect.Data.HistoryRequest;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    public class AlgorithmHistoryTests
+    {
+        private QCAlgorithm _algorithm;
+        private TestHistoryProvider _testHistoryProvider;
+
+        [SetUp]
+        public void Setup()
+        {
+            _algorithm = new QCAlgorithm();
+            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
+            _algorithm.HistoryProvider = _testHistoryProvider = new TestHistoryProvider();
+        }
+
+        [Test]
+        [TestCase(Resolution.Tick)]
+        [TestCase(Resolution.Second)]
+        [TestCase(Resolution.Minute)]
+        [TestCase(Resolution.Hour)]
+        [TestCase(Resolution.Daily)]
+        public void TimeSpanHistoryRequestIsCorrectlyBuilt(Resolution resolution)
+        {
+            _algorithm.SetStartDate(2013, 10, 07);
+            _algorithm.History(Symbols.SPY, TimeSpan.FromSeconds(2), resolution);
+            Resolution? fillForwardResolution = null;
+            if (resolution != Resolution.Tick)
+            {
+                fillForwardResolution = resolution;
+            }
+            Assert.AreEqual(1, _testHistoryProvider.HistryRequests.Count);
+            Assert.AreEqual(Symbols.SPY, _testHistoryProvider.HistryRequests.First().Symbol);
+            Assert.AreEqual(resolution, _testHistoryProvider.HistryRequests.First().Resolution);
+            Assert.IsFalse(_testHistoryProvider.HistryRequests.First().IncludeExtendedMarketHours);
+            Assert.IsFalse(_testHistoryProvider.HistryRequests.First().IsCustomData);
+            Assert.AreEqual(fillForwardResolution, _testHistoryProvider.HistryRequests.First().FillForwardResolution);
+            Assert.AreEqual(DataNormalizationMode.Adjusted, _testHistoryProvider.HistryRequests.First().DataNormalizationMode);
+            Assert.AreEqual(TickType.Trade, _testHistoryProvider.HistryRequests.First().TickType);
+        }
+
+        [Test]
+        [TestCase(Resolution.Tick)]
+        [TestCase(Resolution.Second)]
+        [TestCase(Resolution.Minute)]
+        [TestCase(Resolution.Hour)]
+        [TestCase(Resolution.Daily)]
+        public void BarCountHistoryRequestIsCorrectlyBuilt(Resolution resolution)
+        {
+            _algorithm.SetStartDate(2013, 10, 07);
+            _algorithm.History(Symbols.SPY, 10, resolution);
+            Resolution? fillForwardResolution = null;
+            if (resolution != Resolution.Tick)
+            {
+                fillForwardResolution = resolution;
+            }
+            Assert.AreEqual(1, _testHistoryProvider.HistryRequests.Count);
+            Assert.AreEqual(Symbols.SPY, _testHistoryProvider.HistryRequests.First().Symbol);
+            Assert.AreEqual(resolution, _testHistoryProvider.HistryRequests.First().Resolution);
+            Assert.IsFalse(_testHistoryProvider.HistryRequests.First().IncludeExtendedMarketHours);
+            Assert.IsFalse(_testHistoryProvider.HistryRequests.First().IsCustomData);
+            Assert.AreEqual(fillForwardResolution, _testHistoryProvider.HistryRequests.First().FillForwardResolution);
+            Assert.AreEqual(DataNormalizationMode.Adjusted, _testHistoryProvider.HistryRequests.First().DataNormalizationMode);
+            Assert.AreEqual(TickType.Trade, _testHistoryProvider.HistryRequests.First().TickType);
+        }
+
+        [Test]
+        public void TickHistoryRequestIgnoresFillForward()
+        {
+            _algorithm.SetStartDate(2013, 10, 07);
+            _algorithm.History(new [] {Symbols.SPY}, new DateTime(1,1,1,1,1,1), new DateTime(1, 1, 1, 1, 1, 2), Resolution.Tick, fillForward: true);
+
+            Assert.AreEqual(1, _testHistoryProvider.HistryRequests.Count);
+            Assert.AreEqual(Symbols.SPY, _testHistoryProvider.HistryRequests.First().Symbol);
+            Assert.AreEqual(Resolution.Tick, _testHistoryProvider.HistryRequests.First().Resolution);
+            Assert.IsFalse(_testHistoryProvider.HistryRequests.First().IncludeExtendedMarketHours);
+            Assert.IsFalse(_testHistoryProvider.HistryRequests.First().IsCustomData);
+            Assert.AreEqual(null, _testHistoryProvider.HistryRequests.First().FillForwardResolution);
+            Assert.AreEqual(DataNormalizationMode.Adjusted, _testHistoryProvider.HistryRequests.First().DataNormalizationMode);
+            Assert.AreEqual(TickType.Trade, _testHistoryProvider.HistryRequests.First().TickType);
+        }
+
+        private class TestHistoryProvider : IHistoryProvider
+        {
+            public int DataPointCount { get; }
+            public List<HistoryRequest> HistryRequests { get; } = new List<HistoryRequest>();
+
+            public void Initialize(
+                AlgorithmNodePacket job,
+                IDataProvider dataProvider,
+                IDataCacheProvider dataCacheProvider,
+                IMapFileProvider mapFileProvider,
+                IFactorFileProvider factorFileProvider,
+                Action<int> statusUpdate
+                )
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+            {
+                foreach (var request in requests)
+                {
+                    HistryRequests.Add(request);
+                }
+
+                return new List<Slice>();
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="AlgorithmRunner.cs" />
     <Compile Include="Algorithm\AlgorithmDownloadTests.cs" />
     <Compile Include="Algorithm\AlgorithmAddDataTests.cs" />
+    <Compile Include="Algorithm\AlgorithmHistoryTests.cs" />
     <Compile Include="Algorithm\AlgorithmInitializeTests.cs" />
     <Compile Include="Algorithm\AlgorithmLiveTradingTests.cs" />
     <Compile Include="Algorithm\AlgorithmPlottingTests.cs" />


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding two checks to avoid setting FillForward resolution for
Resolution.Tick History requests
- Adding unit tests which reproduce the original issue

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2575
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
HistoryRequest using Resolution.Tick is fill forwared causing infitine loop situation
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->