### PR TITLE
Add CurrentTimeStepElapsed to Isolator logging

### DIFF
--- a/Common/Isolator.cs
+++ b/Common/Isolator.cs
@@ -119,7 +119,7 @@ namespace QuantConnect
 
                 // check to see if we're within other custom limits defined by the caller
                 isolatorLimitResult = withinCustomLimits();
-                if (!string.IsNullOrEmpty(isolatorLimitResult.ErrorMessage))
+                if (!isolatorLimitResult.IsWithinCustomLimits)
                 {
                     message = isolatorLimitResult.ErrorMessage;
                     break;

--- a/Common/Isolator.cs
+++ b/Common/Isolator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +18,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using QuantConnect.Logging;
 
-namespace QuantConnect 
+namespace QuantConnect
 {
     /// <summary>
-    /// Isolator class - create a new instance of the algorithm and ensure it doesn't 
+    /// Isolator class - create a new instance of the algorithm and ensure it doesn't
     /// exceed memory or time execution limits.
     /// </summary>
     public class Isolator
@@ -67,16 +67,17 @@ namespace QuantConnect
         /// <param name="codeBlock">Action codeblock to execute</param>
         /// <param name="memoryCap">Maximum memory allocation, default 1024Mb</param>
         /// <returns>True if algorithm exited successfully, false if cancelled because it exceeded limits.</returns>
-        public bool ExecuteWithTimeLimit(TimeSpan timeSpan, Func<string> withinCustomLimits, Action codeBlock, long memoryCap = 1024)
+        public bool ExecuteWithTimeLimit(TimeSpan timeSpan, Func<IsolatorLimitResult> withinCustomLimits, Action codeBlock, long memoryCap = 1024)
         {
             // default to always within custom limits
-            withinCustomLimits = withinCustomLimits ?? (() => null);
+            withinCustomLimits = withinCustomLimits ?? (() => new IsolatorLimitResult(TimeSpan.Zero, string.Empty));
 
             var message = "";
             var emaPeriod = 60d;
             var memoryUsed = 0L;
             var end = DateTime.Now + timeSpan;
             var memoryLogger = DateTime.Now + TimeSpan.FromMinutes(1);
+            var isolatorLimitResult = new IsolatorLimitResult(TimeSpan.Zero, string.Empty);
 
             //Convert to bytes
             memoryCap *= 1024 * 1024;
@@ -106,15 +107,21 @@ namespace QuantConnect
                     {
                         Log.Error("Execution Security Error: Memory usage over 80% capacity. Sampled at {0}", sample);
                     }
-                    Log.Trace("{0} Isolator.ExecuteWithTimeLimit(): Used: {1} Sample: {2}", DateTime.Now.ToString("u"), PrettyFormatRam(memoryUsed), PrettyFormatRam((long)sample));
+
+                    Log.Trace("{0} Isolator.ExecuteWithTimeLimit(): Used: {1} Sample: {2} CurrentTimeStepElapsed: {3}",
+                        DateTime.Now.ToString("u"),
+                        PrettyFormatRam(memoryUsed),
+                        PrettyFormatRam((long)sample),
+                        isolatorLimitResult.CurrentTimeStepElapsed.ToString("mm\\:ss\\.fff"));
+
                     memoryLogger = DateTime.Now.AddMinutes(1);
                 }
 
                 // check to see if we're within other custom limits defined by the caller
-                var possibleMessage = withinCustomLimits();
-                if (!string.IsNullOrEmpty(possibleMessage))
+                isolatorLimitResult = withinCustomLimits();
+                if (!string.IsNullOrEmpty(isolatorLimitResult.ErrorMessage))
                 {
-                    message = possibleMessage;
+                    message = isolatorLimitResult.ErrorMessage;
                     break;
                 }
 

--- a/Common/IsolatorLimitResult.cs
+++ b/Common/IsolatorLimitResult.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect
+{
+    /// <summary>
+    /// Represents the result of the <see cref="Isolator"/> limiter callback
+    /// </summary>
+    public class IsolatorLimitResult
+    {
+        /// <summary>
+        /// Gets the amount of time spent on the current time step
+        /// </summary>
+        public TimeSpan CurrentTimeStepElapsed { get; }
+
+        /// <summary>
+        /// Gets the error message or an empty string if no error on the current time step
+        /// </summary>
+        public string ErrorMessage { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IsolatorLimitResult"/> class
+        /// </summary>
+        /// <param name="currentTimeStepElapsed">The amount of time spent on the current time step</param>
+        /// <param name="errorMessage">The error message or an empty string if no error on the current time step</param>
+        public IsolatorLimitResult(TimeSpan currentTimeStepElapsed, string errorMessage)
+        {
+            CurrentTimeStepElapsed = currentTimeStepElapsed;
+            ErrorMessage = errorMessage;
+        }
+    }
+}

--- a/Common/IsolatorLimitResult.cs
+++ b/Common/IsolatorLimitResult.cs
@@ -33,6 +33,11 @@ namespace QuantConnect
         public string ErrorMessage { get; }
 
         /// <summary>
+        /// Returns true if there are no errors in the current time step
+        /// </summary>
+        public bool IsWithinCustomLimits => string.IsNullOrEmpty(ErrorMessage);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="IsolatorLimitResult"/> class
         /// </summary>
         /// <param name="currentTimeStepElapsed">The amount of time spent on the current time step</param>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -184,6 +184,7 @@
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />
+    <Compile Include="IsolatorLimitResult.cs" />
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Python\PythonInitializer.cs" />
     <Compile Include="Securities\ICurrencyConverter.cs" />

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Lean.Engine
         /// Gets a function used with the Isolator for verifying we're not spending too much time in each
         /// algo manager timer loop
         /// </summary>
-        public readonly Func<string> TimeLoopWithinLimits;
+        public readonly Func<IsolatorLimitResult> TimeLoopWithinLimits;
 
         private readonly bool _liveMode;
 
@@ -110,14 +110,13 @@ namespace QuantConnect.Lean.Engine
         {
             TimeLoopWithinLimits = () =>
             {
+                var message = string.Empty;
                 if (CurrentTimeStepElapsed > _timeLoopMaximum)
                 {
-                    return ("Algorithm took longer than " +
-                            _timeLoopMaximum.TotalMinutes.ToString() +
-                            " minutes on a single time loop.");
+                    message = $"Algorithm took longer than {_timeLoopMaximum.TotalMinutes} minutes on a single time loop.";
                 }
 
-                return null;
+                return new IsolatorLimitResult(CurrentTimeStepElapsed, message);
             };
             _liveMode = liveMode;
         }


### PR DESCRIPTION

#### Description
The elapsed time for the current `AlgorithmManager` loop has been added to the existing log trace in the `Isolator.ExecuteWithTimeLimit` method.

#### Motivation and Context
Adding extra debugging information for troubleshooting occasional 10-minute timeout errors.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Tested locally with a live algorithm.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`