### PR TITLE
Fixes SecurityCache tick update

### DIFF
--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -132,14 +132,18 @@ namespace QuantConnect.Securities
             {
                 if (tick.Value != 0) Price = tick.Value;
 
-                if (tick.BidPrice != 0) BidPrice = tick.BidPrice;
-                if (tick.BidSize != 0) BidSize = tick.BidSize;
+                if (tick.TickType == TickType.Trade && tick.Quantity != 0)
+                {
+                    Volume = tick.Quantity;
+                }
+                if (tick.TickType == TickType.Quote)
+                {
+                    if (tick.BidPrice != 0) BidPrice = tick.BidPrice;
+                    if (tick.BidSize != 0) BidSize = tick.BidSize;
 
-                if (tick.AskPrice != 0) AskPrice = tick.AskPrice;
-                if (tick.AskSize != 0) AskSize = tick.AskSize;
-
-                if (tick.Quantity != 0) Volume = tick.Quantity;
-
+                    if (tick.AskPrice != 0) AskPrice = tick.AskPrice;
+                    if (tick.AskSize != 0) AskSize = tick.AskSize;
+                }
                 return;
             }
 

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -998,12 +998,15 @@ namespace QuantConnect.Lean.Engine.Results
                 {
                     foreach (var subscription in _dataFeed.Subscriptions)
                     {
+                        var symbol = subscription.Configuration.Symbol;
+                        var tickType = subscription.Configuration.TickType;
+
                         // OI subscription doesn't contain asset market prices
-                        if (subscription.Configuration.TickType == TickType.OpenInterest)
+                        if (tickType == TickType.OpenInterest)
                             continue;
 
                         Security security;
-                        if (_algorithm.Securities.TryGetValue(subscription.Configuration.Symbol, out security))
+                        if (_algorithm.Securities.TryGetValue(symbol, out security))
                         {
                             //Sample Portfolio Value:
                             var price = subscription.RealtimePrice;
@@ -1029,12 +1032,12 @@ namespace QuantConnect.Lean.Engine.Results
                                 // we haven't gotten data yet so just spoof a tick to push through the system to start with
                                 if (price > 0)
                                 {
-                                    security.SetMarketPrice(new Tick(time, subscription.Configuration.Symbol, price, price));
+                                    security.SetMarketPrice(new Tick(time, symbol, price, price) { TickType = tickType });
                                 }
                             }
 
                             //Sample Asset Pricing:
-                            SampleAssetPrices(subscription.Configuration.Symbol, time, price);
+                            SampleAssetPrices(symbol, time, price);
                         }
                     }
                 }

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -140,7 +140,7 @@ namespace QuantConnect.Tests.Common.Brokerages
 
             Assert.AreEqual(0, orderFee);
 
-            security.SetMarketPrice(new Tick { Symbol = security.Symbol, BidPrice = 5000m, AskPrice = 5000.01m });
+            security.SetMarketPrice(new Tick { Symbol = security.Symbol, BidPrice = 5000m, AskPrice = 5000.01m, TickType = TickType.Quote });
             orderFee = security.FeeModel.GetOrderFee(security, new LimitOrder(security.Symbol, 1, 5000m, DateTime.MinValue)
             {
                 OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
@@ -170,7 +170,7 @@ namespace QuantConnect.Tests.Common.Brokerages
             // marketable buy limit fill at 5000
             Assert.AreEqual(15m, orderFee);
 
-            security.SetMarketPrice(new Tick { Symbol = security.Symbol, BidPrice = 5000m, AskPrice = 5000.01m });
+            security.SetMarketPrice(new Tick { Symbol = security.Symbol, BidPrice = 5000m, AskPrice = 5000.01m, TickType = TickType.Quote });
             orderFee = security.FeeModel.GetOrderFee(security, new LimitOrder(security.Symbol, 1, 5000.01m, DateTime.MinValue)
             {
                 OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -560,7 +560,7 @@ namespace QuantConnect.Tests.Common.Securities
             _portfolio.SetCash(10000);
 
             _btcusd = _algorithm.AddCrypto("BTCUSD");
-            _btcusd.SetMarketPrice(new Tick { Value = 10000m, BidPrice = 9950, AskPrice = 10050 });
+            _btcusd.SetMarketPrice(new Tick { Value = 10000m, BidPrice = 9950, AskPrice = 10050, TickType = TickType.Quote });
             _algorithm.SetFinishedWarmingUp();
 
             Assert.AreEqual(10000m, _portfolio.TotalPortfolioValue);

--- a/Tests/Common/Securities/SecurityCacheTests.cs
+++ b/Tests/Common/Securities/SecurityCacheTests.cs
@@ -195,6 +195,34 @@ namespace QuantConnect.Tests.Common.Securities
             }, map);
         }
 
+        [Test]
+        public void TickTypeDependencyTests()
+        {
+            // Arrange
+            var time = DateTime.Now;
+            var price = 100m;
+            var bidPrice = 99m;
+            var askPrice = 101m;
+            var volume = 1m;
+
+            var tick = new Tick(time, Symbols.AAPL, price, bidPrice, askPrice) { Quantity = volume }; ;
+
+            var securityCache = new SecurityCache();
+            securityCache.AddData(tick);
+            Assert.AreEqual(securityCache.Price, price);
+            Assert.AreEqual(securityCache.BidPrice, bidPrice);
+            Assert.AreEqual(securityCache.AskPrice, askPrice);
+            Assert.AreEqual(securityCache.Volume, 0m);
+
+            tick.TickType = TickType.Trade;
+            securityCache = new SecurityCache();
+            securityCache.AddData(tick);
+            Assert.AreEqual(securityCache.Price, price);
+            Assert.AreEqual(securityCache.BidPrice, 0m);
+            Assert.AreEqual(securityCache.AskPrice, 0m);
+            Assert.AreEqual(securityCache.Volume, volume);
+        }
+
         private void AddDataAndAssertChanges(SecurityCache cache, SecuritySeedData seedType, SecuritySeedData dataType, BaseData data, Dictionary<string, string> cacheToBaseDataPropertyMap = null)
         {
             var before = JObject.FromObject(cache);


### PR DESCRIPTION
#### Description
Trade ticks are not allowed to update quote variables and vice-versa.
Explicitly define the `TickType` of the tick with the subscription type.

#### Related Issue
Closes #2584 

#### Motivation and Context
Bug fix.
This bug would set the bid and ask prices at the algorithm start up for `Equity` type and it would use these values where it should use trade price since there are no subscriptions to update those prices. Consequently, equities unrealized profits and total unrealized profits would be wrong, since it would use  stale bid and ask prices.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test and running a live algorithm locally.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`