### PR TITLE
Exclude OptionChainProviderTests from Travis build

### DIFF
--- a/Tests/Common/Securities/Options/OptionChainProviderTests.cs
+++ b/Tests/Common/Securities/Options/OptionChainProviderTests.cs
@@ -24,7 +24,8 @@ using QuantConnect.Lean.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Common.Securities.Options
 {
-    [TestFixture]
+    // For now these tests are excluded from the Travis build because of occasional web server errors.
+    [TestFixture, Category("TravisExclude")]
     public class OptionChainProviderTests
     {
         [Test]


### PR DESCRIPTION

#### Description
The `OptionChainProvider` unit tests have been excluded from the Travis build.

#### Related Issue
Closes #2587 

#### Motivation and Context
Randomly failing unit tests.

#### Requires Documentation Change
No.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`