### PR TITLE
Add ICurrencyConverter dependencies to Security objects

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Securities\ICurrencyConverter.cs" />
     <Compile Include="Python\BuyingPowerModelPythonWrapper.cs" />
     <Compile Include="Securities\CashAmount.cs" />
+    <Compile Include="Securities\IdentityCurrencyConverter.cs" />
     <Compile Include="Series.cs" />
     <Compile Include="Data\Custom\Intrinio\IntrinioConfig.cs" />
     <Compile Include="Data\Custom\Intrinio\IntrinioEconomicData.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -187,6 +187,7 @@
     <Compile Include="IsolatorLimitResult.cs" />
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Python\PythonInitializer.cs" />
+    <Compile Include="Securities\ErrorCurrencyConverter.cs" />
     <Compile Include="Securities\ICurrencyConverter.cs" />
     <Compile Include="Python\BuyingPowerModelPythonWrapper.cs" />
     <Compile Include="Securities\CashAmount.cs" />

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -235,15 +235,15 @@ namespace QuantConnect.Securities
                     Security security;
                     if (securityType == SecurityType.Cfd)
                     {
-                        security = new Cfd.Cfd(exchangeHours, quoteCash, config, symbolProperties);
+                        security = new Cfd.Cfd(exchangeHours, quoteCash, config, symbolProperties, cashBook);
                     }
                     else if (securityType == SecurityType.Crypto)
                     {
-                        security = new Crypto.Crypto(exchangeHours, quoteCash, config, symbolProperties);
+                        security = new Crypto.Crypto(exchangeHours, quoteCash, config, symbolProperties, cashBook);
                     }
                     else
                     {
-                        security = new Forex.Forex(exchangeHours, quoteCash, config, symbolProperties);
+                        security = new Forex.Forex(exchangeHours, quoteCash, config, symbolProperties, cashBook);
                     }
 
                     ConversionRateSecurity = security;

--- a/Common/Securities/Cfd/Cfd.cs
+++ b/Common/Securities/Cfd/Cfd.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,9 @@ namespace QuantConnect.Securities.Cfd
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="config">The subscription configuration for this security</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Cfd(SecurityExchangeHours exchangeHours, Cash quoteCurrency, SubscriptionDataConfig config, SymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Cfd(SecurityExchangeHours exchangeHours, Cash quoteCurrency, SubscriptionDataConfig config, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -48,7 +50,8 @@ namespace QuantConnect.Securities.Cfd
                 Securities.VolatilityModel.Null,
                 new SecurityMarginModel(50m),
                 new CfdDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
             Holdings = new CfdHolding(this);
@@ -61,7 +64,9 @@ namespace QuantConnect.Securities.Cfd
         /// <param name="exchangeHours">Defines the hours this exchange is open</param>
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Cfd(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Cfd(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -75,7 +80,8 @@ namespace QuantConnect.Securities.Cfd
                 Securities.VolatilityModel.Null,
                 new SecurityMarginModel(50m),
                 new CfdDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
             Holdings = new CfdHolding(this);

--- a/Common/Securities/Crypto/Crypto.cs
+++ b/Common/Securities/Crypto/Crypto.cs
@@ -35,7 +35,9 @@ namespace QuantConnect.Securities.Crypto
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="config">The subscription configuration for this security</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Crypto(SecurityExchangeHours exchangeHours, Cash quoteCurrency, SubscriptionDataConfig config, SymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Crypto(SecurityExchangeHours exchangeHours, Cash quoteCurrency, SubscriptionDataConfig config, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -49,7 +51,8 @@ namespace QuantConnect.Securities.Crypto
                 Securities.VolatilityModel.Null,
                 new CashBuyingPowerModel(),
                 new ForexDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
             Holdings = new CryptoHolding(this);
@@ -67,7 +70,9 @@ namespace QuantConnect.Securities.Crypto
         /// <param name="exchangeHours">Defines the hours this exchange is open</param>
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Crypto(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Crypto(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -81,7 +86,8 @@ namespace QuantConnect.Securities.Crypto
                 Securities.VolatilityModel.Null,
                 new CashBuyingPowerModel(),
                 new ForexDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
             Holdings = new CryptoHolding(this);

--- a/Common/Securities/Equity/Equity.cs
+++ b/Common/Securities/Equity/Equity.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@ using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Slippage;
 
-namespace QuantConnect.Securities.Equity 
+namespace QuantConnect.Securities.Equity
 {
     /// <summary>
     /// Equity Security Type : Extension of the underlying Security class for equity specific behaviours.
@@ -40,7 +40,7 @@ namespace QuantConnect.Securities.Equity
         /// <summary>
         /// Construct the Equity Object
         /// </summary>
-        public Equity(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties)
+        public Equity(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -54,7 +54,8 @@ namespace QuantConnect.Securities.Equity
                 Securities.VolatilityModel.Null,
                 new SecurityMarginModel(2m),
                 new EquityDataFilter(),
-                new AdjustedPriceVariationModel()
+                new AdjustedPriceVariationModel(),
+                currencyConverter
                 )
         {
             Holdings = new EquityHolding(this);
@@ -63,7 +64,7 @@ namespace QuantConnect.Securities.Equity
         /// <summary>
         /// Construct the Equity Object
         /// </summary>
-        public Equity(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties)
+        public Equity(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(
                 config,
                 quoteCurrency,
@@ -78,7 +79,8 @@ namespace QuantConnect.Securities.Equity
                 Securities.VolatilityModel.Null,
                 new SecurityMarginModel(2m),
                 new EquityDataFilter(),
-                new AdjustedPriceVariationModel()
+                new AdjustedPriceVariationModel(),
+                currencyConverter
                 )
         {
             Holdings = new EquityHolding(this);

--- a/Common/Securities/ErrorCurrencyConverter.cs
+++ b/Common/Securities/ErrorCurrencyConverter.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="ICurrencyConverter"/> for use in
+    /// tests that don't depend on this behavior.
+    /// </summary>
+    public class ErrorCurrencyConverter : ICurrencyConverter
+    {
+        /// <summary>
+        /// Provides access to the single instance of <see cref="ErrorCurrencyConverter"/>.
+        /// This is done this way to ensure usage is explicit.
+        /// </summary>
+        public static ICurrencyConverter Instance = new ErrorCurrencyConverter();
+
+        private ErrorCurrencyConverter()
+        {
+        }
+
+        /// <summary>
+        /// Converts a cash amount to the account currency
+        /// </summary>
+        /// <param name="cashAmount">The <see cref="CashAmount"/> instance to convert</param>
+        /// <returns>A new <see cref="CashAmount"/> instance denominated in the account currency</returns>
+        public CashAmount ConvertToAccountCurrency(CashAmount cashAmount)
+        {
+            throw new InvalidOperationException($"This method purposefully throws as a proof that a " +
+                $"test does not depend on {nameof(ICurrencyConverter)}.If this exception is encountered, " +
+                $"it means the test DOES depend on {nameof(ICurrencyConverter)} and should be properly " +
+                $"updated to use a real implementation of {nameof(ICurrencyConverter)}.");
+        }
+    }
+}

--- a/Common/Securities/Forex/Forex.cs
+++ b/Common/Securities/Forex/Forex.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@ using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Slippage;
 
-namespace QuantConnect.Securities.Forex 
+namespace QuantConnect.Securities.Forex
 {
     /// <summary>
     /// FOREX Security Object Implementation for FOREX Assets
@@ -34,7 +34,9 @@ namespace QuantConnect.Securities.Forex
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="config">The subscription configuration for this security</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Forex(SecurityExchangeHours exchangeHours, Cash quoteCurrency, SubscriptionDataConfig config, SymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Forex(SecurityExchangeHours exchangeHours, Cash quoteCurrency, SubscriptionDataConfig config, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -48,7 +50,8 @@ namespace QuantConnect.Securities.Forex
                 Securities.VolatilityModel.Null,
                 new SecurityMarginModel(50m),
                 new ForexDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
             Holdings = new ForexHolding(this);
@@ -66,7 +69,9 @@ namespace QuantConnect.Securities.Forex
         /// <param name="exchangeHours">Defines the hours this exchange is open</param>
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Forex(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Forex(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -80,7 +85,8 @@ namespace QuantConnect.Securities.Forex
                 Securities.VolatilityModel.Null,
                 new SecurityMarginModel(50m),
                 new ForexDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
             Holdings = new ForexHolding(this);

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -46,7 +46,9 @@ namespace QuantConnect.Securities.Future
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="config">The subscription configuration for this security</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Future(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Future(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -60,7 +62,8 @@ namespace QuantConnect.Securities.Future
                 Securities.VolatilityModel.Null,
                 new FutureMarginModel(),
                 new SecurityDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
             // for now all futures are cash settled as we don't allow underlying (Live Cattle?) to be posted on the account
@@ -77,7 +80,9 @@ namespace QuantConnect.Securities.Future
         /// <param name="exchangeHours">Defines the hours this exchange is open</param>
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Future(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Future(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -91,7 +96,8 @@ namespace QuantConnect.Securities.Future
                 Securities.VolatilityModel.Null,
                 new FutureMarginModel(),
                 new SecurityDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
             // for now all futures are cash settled as we don't allow underlying (Live Cattle?) to be posted on the account

--- a/Common/Securities/IdentityCurrencyConverter.cs
+++ b/Common/Securities/IdentityCurrencyConverter.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="ICurrencyConverter"/> that does NOT perform conversions.
+    /// This implementation will throw if the specified cashAmount is not in units of account currency.
+    /// </summary>
+    public class IdentityCurrencyConverter : ICurrencyConverter
+    {
+        private readonly string _accountCurrency;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ICurrencyConverter"/> class
+        /// </summary>
+        /// <param name="accountCurrency">The algorithm's account currency</param>
+        public IdentityCurrencyConverter(string accountCurrency)
+        {
+            this._accountCurrency = accountCurrency;
+        }
+
+        /// <summary>
+        /// Converts a cash amount to the account currency.
+        /// This implementation can only handle cash amounts in units of the account currency.
+        /// </summary>
+        /// <param name="cashAmount">The <see cref="CashAmount"/> instance to convert</param>
+        /// <returns>A new <see cref="CashAmount"/> instance denominated in the account currency</returns>
+        public CashAmount ConvertToAccountCurrency(CashAmount cashAmount)
+        {
+            if (!string.Equals(cashAmount.Currency, _accountCurrency, StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new ArgumentException($"The {nameof(IdentityCurrencyConverter)} can only handle CashAmounts in units of the account currency");
+            }
+
+            return cashAmount;
+        }
+    }
+}

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -47,7 +47,9 @@ namespace QuantConnect.Securities.Option
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="config">The subscription configuration for this security</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Option(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, OptionSymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Option(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, OptionSymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -61,7 +63,8 @@ namespace QuantConnect.Securities.Option
                 Securities.VolatilityModel.Null,
                 new OptionMarginModel(),
                 new OptionDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
             ExerciseSettlement = SettlementType.PhysicalDelivery;
@@ -80,7 +83,9 @@ namespace QuantConnect.Securities.Option
         /// <param name="exchangeHours">Defines the hours this exchange is open</param>
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
-        public Option(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, OptionSymbolProperties symbolProperties)
+        /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
+        /// instances into units of the account currency</param>
+        public Option(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, OptionSymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
            : base(symbol,
                quoteCurrency,
                symbolProperties,
@@ -94,7 +99,8 @@ namespace QuantConnect.Securities.Option
                Securities.VolatilityModel.Null,
                new OptionMarginModel(),
                new OptionDataFilter(),
-               new SecurityPriceVariationModel()
+               new SecurityPriceVariationModel(),
+               currencyConverter
                )
         {
             ExerciseSettlement = SettlementType.PhysicalDelivery;

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -41,6 +41,8 @@ namespace QuantConnect.Securities
     /// </remarks>
     public class Security
     {
+        private readonly ICurrencyConverter _currencyConverter;
+
         private LocalTimeKeeper _localTimeKeeper;
         // using concurrent bag to avoid list enumeration threading issues
         protected readonly ConcurrentBag<SubscriptionDataConfig> SubscriptionsBag;
@@ -300,7 +302,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Construct a new security vehicle based on the user options.
         /// </summary>
-        public Security(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties)
+        public Security(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : this(config,
                 quoteCurrency,
                 symbolProperties,
@@ -314,14 +316,16 @@ namespace QuantConnect.Securities
                 Securities.VolatilityModel.Null,
                 new SecurityMarginModel(),
                 new SecurityDataFilter(),
-                new SecurityPriceVariationModel())
+                new SecurityPriceVariationModel(),
+                currencyConverter
+                )
         {
         }
 
         /// <summary>
         /// Construct a new security vehicle based on the user options.
         /// </summary>
-        public Security(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties)
+        public Security(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
             : this(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -335,7 +339,8 @@ namespace QuantConnect.Securities
                 Securities.VolatilityModel.Null,
                 new SecurityMarginModel(),
                 new SecurityDataFilter(),
-                new SecurityPriceVariationModel()
+                new SecurityPriceVariationModel(),
+                currencyConverter
                 )
         {
         }
@@ -356,7 +361,8 @@ namespace QuantConnect.Securities
             IVolatilityModel volatilityModel,
             IBuyingPowerModel buyingPowerModel,
             ISecurityDataFilter dataFilter,
-            IPriceVariationModel priceVariationModel
+            IPriceVariationModel priceVariationModel,
+            ICurrencyConverter currencyConverter
             )
         {
             if (symbolProperties == null)
@@ -368,6 +374,8 @@ namespace QuantConnect.Securities
             {
                 throw new ArgumentException("symbolProperties.QuoteCurrency must match the quoteCurrency.Symbol");
             }
+
+            this._currencyConverter = currencyConverter;
 
             Symbol = symbol;
             SubscriptionsBag = new ConcurrentBag<SubscriptionDataConfig>();
@@ -407,7 +415,8 @@ namespace QuantConnect.Securities
             IVolatilityModel volatilityModel,
             IBuyingPowerModel buyingPowerModel,
             ISecurityDataFilter dataFilter,
-            IPriceVariationModel priceVariationModel
+            IPriceVariationModel priceVariationModel,
+            ICurrencyConverter currencyConverter
             )
             : this(config.Symbol,
                 quoteCurrency,
@@ -422,7 +431,8 @@ namespace QuantConnect.Securities
                 volatilityModel,
                 buyingPowerModel,
                 dataFilter,
-                priceVariationModel
+                priceVariationModel,
+                currencyConverter
                 )
         {
             SubscriptionsBag.Add(config);

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -357,33 +357,33 @@ namespace QuantConnect.Securities
             switch (symbol.ID.SecurityType)
             {
                 case SecurityType.Equity:
-                    security = new Equity.Equity(symbol, exchangeHours, quoteCash, symbolProperties);
+                    security = new Equity.Equity(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
                     break;
 
                 case SecurityType.Option:
                     if (addToSymbolCache) SymbolCache.Set(symbol.Underlying.Value, symbol.Underlying);
-                    security = new Option.Option(symbol, exchangeHours, securityPortfolioManager.CashBook[CashBook.AccountCurrency], new Option.OptionSymbolProperties(symbolProperties));
+                    security = new Option.Option(symbol, exchangeHours, securityPortfolioManager.CashBook[CashBook.AccountCurrency], new Option.OptionSymbolProperties(symbolProperties), securityPortfolioManager.CashBook);
                     break;
 
                 case SecurityType.Future:
-                    security = new Future.Future(symbol, exchangeHours, securityPortfolioManager.CashBook[CashBook.AccountCurrency], symbolProperties);
+                    security = new Future.Future(symbol, exchangeHours, securityPortfolioManager.CashBook[CashBook.AccountCurrency], symbolProperties, securityPortfolioManager.CashBook);
                     break;
 
                 case SecurityType.Forex:
-                    security = new Forex.Forex(symbol, exchangeHours, quoteCash, symbolProperties);
+                    security = new Forex.Forex(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
                     break;
 
                 case SecurityType.Cfd:
-                    security = new Cfd.Cfd(symbol, exchangeHours, quoteCash, symbolProperties);
+                    security = new Cfd.Cfd(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
                     break;
 
                 case SecurityType.Crypto:
-                    security = new Crypto.Crypto(symbol, exchangeHours, quoteCash, symbolProperties);
+                    security = new Crypto.Crypto(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
                     break;
 
                 default:
                 case SecurityType.Base:
-                    security = new Security(symbol, exchangeHours, quoteCash, symbolProperties);
+                    security = new Security(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
                     break;
             }
 

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -106,7 +106,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             if (!_algorithm.Securities.TryGetValue(config.Symbol, out security))
                             {
                                 // create a canonical security object if it doesn't exist
-                                security = new Security(exchangeHours, config, _algorithm.Portfolio.CashBook[CashBook.AccountCurrency], SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                                security = new Security(
+                                    exchangeHours,
+                                    config,
+                                    _algorithm.Portfolio.CashBook[CashBook.AccountCurrency],
+                                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                                    _algorithm.Portfolio.CashBook
+                                );
                             }
 
                             var end = _algorithm.EndDate.ConvertToUtc(_algorithm.TimeZone);

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -135,7 +135,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             if (!_algorithm.Securities.TryGetValue(config.Symbol, out security))
                             {
                                 // create a canonical security object
-                                security = new Security(exchangeHours, config, _algorithm.Portfolio.CashBook[CashBook.AccountCurrency], SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                                security = new Security(
+                                    exchangeHours,
+                                    config,
+                                    _algorithm.Portfolio.CashBook[CashBook.AccountCurrency],
+                                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                                    _algorithm.Portfolio.CashBook
+                                );
                             }
 
                             AddSubscription(new SubscriptionRequest(true, universe, security, config, start, Time.EndOfTime));

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, CashBook.AccountCurrency);
                         var quoteCash = _algorithm.Portfolio.CashBook[symbolProperties.QuoteCurrency];
 
-                        var security = new Equity(symbol, exchangeHours, quoteCash, symbolProperties);
+                        var security = new Equity(symbol, exchangeHours, quoteCash, symbolProperties, _algorithm.Portfolio.CashBook);
 
                         var localStartTime = dateTimeUtc.ConvertFromUtc(exchangeHours.TimeZone).AddDays(-1);
                         var factory = new FineFundamentalSubscriptionEnumeratorFactory(_algorithm.LiveMode, x => new[] { localStartTime });

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -104,7 +104,13 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 request.DataNormalizationMode
                 );
 
-            var security = new Security(request.ExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                request.ExchangeHours,
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             var reader = history.GetEnumerator();
 

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -108,7 +108,13 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 request.DataNormalizationMode
                 );
 
-            var security = new Security(request.ExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                request.ExchangeHours,
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             IEnumerator<BaseData> reader = new SubscriptionDataReader(config,
                 start,

--- a/QuantConnect.Lean.sln.DotSettings
+++ b/QuantConnect.Lean.sln.DotSettings
@@ -1,3 +1,6 @@
-<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
     <s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_INVOCATION_RPAR/@EntryValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
@@ -25,6 +25,7 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
 using System;
 using System.Linq;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 {
@@ -154,7 +155,13 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             var timezone = _algorithm.TimeZone;
             var exchangeHours = SecurityExchangeHours.AlwaysOpen(timezone);
             var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, resolution, timezone, timezone, true, false, false);
-            return new Security(exchangeHours, config, new Cash("USD", 0, 1), SymbolProperties.GetDefault("USD"));
+            return new Security(
+                exchangeHours,
+                config,
+                new Cash("USD", 0, 1),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
         }
 
         private Symbol GetSymbol(string ticker) => Symbol.Create(ticker, SecurityType.Equity, Market.USA);

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Orders.Fees;
+using QuantConnect.Tests.Common.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
@@ -330,7 +331,13 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         private Security GetSecurity(Symbol symbol)
         {
             var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);
-            return new Equity(symbol, config, new Cash("USD", 0, 1), SymbolProperties.GetDefault("USD"));
+            return new Equity(
+                symbol,
+                config,
+                new Cash("USD", 0, 1),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
         }
 
         private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null)

--- a/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
+++ b/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
@@ -49,7 +49,9 @@ namespace QuantConnect.Tests.Algorithm.Framework.Risk
                 Symbols.AAPL,
                 SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
                 new Cash(CashBook.AccountCurrency, 0, 1),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.Setup(m => m.Invested).Returns(invested);
 
             var holding = new Mock<EquityHolding>(security.Object);

--- a/Tests/Brokerages/Bitfinex/BitfinexFeeModelTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexFeeModelTests.cs
@@ -11,6 +11,7 @@ using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Brokerages;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Brokerages.Bitfinex
 {
@@ -22,9 +23,22 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
         {
             get
             {
-                var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                    new SubscriptionDataConfig(typeof(TradeBar), Symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
-                    new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                var security = new Security(
+                    SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                    new SubscriptionDataConfig(
+                        typeof(TradeBar),
+                        Symbol,
+                        Resolution.Minute,
+                        TimeZones.NewYork,
+                        TimeZones.NewYork,
+                        false,
+                        false,
+                        false
+                    ),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                );
                 security.SetMarketPrice(new Tick(DateTime.UtcNow, Symbol, LowPrice, HighPrice));
 
                 return security;

--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -24,6 +24,7 @@ using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Brokerages
 {
@@ -181,9 +182,22 @@ namespace QuantConnect.Tests.Brokerages
 
         internal static Security CreateSecurity(Symbol symbol)
         {
-            return new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
-                new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            return new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    symbol,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    false,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
         }
 
         public OrderProvider OrderProvider

--- a/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
+++ b/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
@@ -19,6 +19,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Securities;
 using System.Collections.Generic;
 using QuantConnect.Brokerages;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Brokerages.GDAX
 {
@@ -28,8 +29,13 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
         public static Security GetSecurity(decimal price = 1m, SecurityType securityType = SecurityType.Crypto, Resolution resolution = Resolution.Minute)
         {
-            return new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), CreateConfig(securityType, resolution), new Cash(CashBook.AccountCurrency, 1000, price),
-                new SymbolProperties("BTCUSD", CashBook.AccountCurrency, 1, 1, 0.01m));
+            return new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                CreateConfig(securityType, resolution),
+                new Cash(CashBook.AccountCurrency, 1000, price),
+                new SymbolProperties("BTCUSD", CashBook.AccountCurrency, 1, 1, 0.01m),
+                ErrorCurrencyConverter.Instance
+            );
         }
 
         private static SubscriptionDataConfig CreateConfig(SecurityType securityType = SecurityType.Crypto, Resolution resolution = Resolution.Minute)

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -28,6 +28,7 @@ using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 using Order = QuantConnect.Orders.Order;
 
 namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
@@ -148,9 +149,22 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 
             // grabs account info from configuration
             var securityProvider = new SecurityProvider();
-            securityProvider[Symbols.USDJPY] = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.USDJPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
-                new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            securityProvider[Symbols.USDJPY] = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.USDJPY,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    false,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             var brokerage = new InteractiveBrokersBrokerage(new QCAlgorithm(), new OrderProvider(_orders), securityProvider);
             brokerage.Connect();

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
@@ -27,6 +27,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 {
@@ -52,9 +53,22 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 
             // grabs account info from configuration
             var securityProvider = new SecurityProvider();
-            securityProvider[Symbols.USDJPY] = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.USDJPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
-                new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            securityProvider[Symbols.USDJPY] = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.USDJPY,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    false,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             _interactiveBrokersBrokerage = new InteractiveBrokersBrokerage(new QCAlgorithm(), new OrderProvider(_orders), securityProvider);
             _interactiveBrokersBrokerage.Connect();

--- a/Tests/Common/Brokerages/BitfinexBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BitfinexBrokerageModelTests.cs
@@ -18,6 +18,7 @@ using QuantConnect.Brokerages;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
@@ -29,9 +30,22 @@ namespace QuantConnect.Tests.Common.Brokerages
         {
             get
             {
-                return new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                    new SubscriptionDataConfig(typeof(TradeBar), Symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
-                    new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                return new Security(
+                    SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                    new SubscriptionDataConfig(
+                        typeof(TradeBar),
+                        Symbol,
+                        Resolution.Minute,
+                        TimeZones.NewYork,
+                        TimeZones.NewYork,
+                        false,
+                        false,
+                        false
+                    ),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                );
             }
         }
 

--- a/Tests/Common/Brokerages/FxcmBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/FxcmBrokerageModelTests.cs
@@ -20,6 +20,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
@@ -55,9 +56,20 @@ namespace QuantConnect.Tests.Common.Brokerages
 
             return new Security(
                 SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                new SubscriptionDataConfig(typeof(QuoteBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false),
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    symbol,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    false,
+                    false,
+                    false
+                ),
                 new Cash(quoteCurrency, 0, 1m),
-                _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.SecurityType, quoteCurrency));
+                _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.SecurityType, quoteCurrency),
+                ErrorCurrencyConverter.Instance
+            );
         }
 
         public TestCaseData[] GetOrderTestData()

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var quoteCash = new Cash("USD", 1000, 1);
             var symbolProperties = SymbolProperties.GetDefault("USD");
             var config = new SubscriptionDataConfig(typeof(Tick), symbol, Resolution.Tick, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
-            var security = new Forex(exchangeHours, quoteCash, config, symbolProperties);
+            var security = new Forex(exchangeHours, quoteCash, config, symbolProperties, ErrorCurrencyConverter.Instance);
 
             var reference = DateTime.Now;
             var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
@@ -70,7 +70,13 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var timeKeeper = new TimeKeeper(noon.ConvertToUtc(TimeZones.NewYork), new[] { TimeZones.NewYork });
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
             var config = new SubscriptionDataConfig(typeof(Tick), Symbols.SPY, Resolution.Tick, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, noon, 101.123m));
 
@@ -96,7 +102,13 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
             // Minute subscription
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, noon, 101.123m));
 
@@ -123,7 +135,13 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
 
             var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
             var tradeBar = new TradeBar(time, symbol, 290m, 292m, 289m, 291m, 12345);
@@ -167,7 +185,13 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
 
             var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
             var tradeBar = new TradeBar(time, symbol, 290m, 292m, 289m, 291m, 12345);
@@ -211,7 +235,13 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
 
             var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
             var tradeBar = new TradeBar(time, symbol, 290m, 292m, 289m, 291m, 12345);

--- a/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
@@ -6,6 +6,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Orders.Fills
 {
@@ -96,10 +97,22 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
         private Security CreateCrypto()
         {
-            return new Security(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
-                new SubscriptionDataConfig(typeof(QuoteBar), _symbol, Resolution.Second, TimeZones.Utc, TimeZones.Utc, true, true, false),
+            return new Security(
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    _symbol,
+                    Resolution.Second,
+                    TimeZones.Utc,
+                    TimeZones.Utc,
+                    true,
+                    true,
+                    false
+                ),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
         }
 
         internal class TestableLatestFillModel : LatestPriceFillModel

--- a/Tests/Common/Orders/Fills/PartialMarketFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/PartialMarketFillModelTests.cs
@@ -25,6 +25,7 @@ using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 using QuantConnect.Tests.Engine;
 
 namespace QuantConnect.Tests.Common.Orders.Fills
@@ -99,7 +100,13 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             algorithm.Transactions.SetOrderProcessor(transactionHandler);
 
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
-            security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             model = new PartialMarketFillModel(algorithm.Transactions, 2);
 

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,7 @@ using QuantConnect.Securities.Cfd;
 using QuantConnect.Securities.Equity;
 using QuantConnect.Securities.Forex;
 using QuantConnect.Securities.Option;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Orders
 {
@@ -49,21 +50,54 @@ namespace QuantConnect.Tests.Common.Orders
 
             var time = new DateTime(2016, 2, 4, 16, 0, 0).ConvertToUtc(tz);
 
-            var equity = new Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick {Value = price});
 
             var gbpCash = new Cash("GBP", 0, 1.46m);
             var properties = SymbolProperties.GetDefault(gbpCash.Symbol);
-            var forex = new Forex(SecurityExchangeHours.AlwaysOpen(tz), gbpCash, new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURGBP, Resolution.Minute, tz, tz, true, false, false), properties);
+            var forex = new Forex(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                gbpCash,
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURGBP, Resolution.Minute, tz, tz, true, false, false),
+                properties,
+                ErrorCurrencyConverter.Instance
+            );
             forex.SetMarketPrice(new Tick {Value= price});
 
             var eurCash = new Cash("EUR", 0, 1.12m);
             properties = new SymbolProperties("Euro-Bund", eurCash.Symbol, 10, 0.1m, 1);
-            var cfd = new Cfd(SecurityExchangeHours.AlwaysOpen(tz), eurCash, new SubscriptionDataConfig(typeof(TradeBar), Symbols.DE10YBEUR, Resolution.Minute, tz, tz, true, false, false), properties);
+            var cfd = new Cfd(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                eurCash,
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.DE10YBEUR, Resolution.Minute, tz, tz, true, false, false),
+                properties,
+                ErrorCurrencyConverter.Instance
+            );
             cfd.SetMarketPrice(new Tick { Value = price });
             var multiplierTimesConversionRate = properties.ContractMultiplier*eurCash.ConversionRate;
 
-            var option = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var option = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_P_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
             option.SetMarketPrice(new Tick { Value = price });
 
             return new List<ValueTestParameters>
@@ -91,7 +125,7 @@ namespace QuantConnect.Tests.Common.Orders
                 new ValueTestParameters("ForexLongStopMarketOrder", forex, new StopMarketOrder(Symbols.EURGBP, quantity, pricePlusDelta, time), quantity*price*forex.QuoteCurrency.ConversionRate),
                 new ValueTestParameters("ForexShortStopMarketOrder", forex, new StopMarketOrder(Symbols.EURGBP, -quantity, pricePlusDelta, time), -quantity*pricePlusDelta*forex.QuoteCurrency.ConversionRate),
                 new ValueTestParameters("ForexShortStopMarketOrder", forex, new StopMarketOrder(Symbols.EURGBP, -quantity, priceMinusDelta, time), -quantity*price*forex.QuoteCurrency.ConversionRate),
-                
+
                 // cfd orders
                 new ValueTestParameters("CfdLongMarketOrder", cfd, new MarketOrder(Symbols.DE10YBEUR, quantity, time), quantity*price*multiplierTimesConversionRate),
                 new ValueTestParameters("CfdShortMarketOrder", cfd, new MarketOrder(Symbols.DE10YBEUR, -quantity, time), -quantity*price*multiplierTimesConversionRate),

--- a/Tests/Common/Orders/Slippage/SlippageModelsTests.cs
+++ b/Tests/Common/Orders/Slippage/SlippageModelsTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ using QuantConnect.Securities;
 using QuantConnect.Securities.Equity;
 using QuantConnect.Securities.Forex;
 using System;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Orders.Slippage
 {
@@ -39,7 +40,9 @@ namespace QuantConnect.Tests.Common.Orders.Slippage
                 Symbols.SPY,
                 SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             _equity.SetMarketPrice(new TradeBar(DateTime.Now, Symbols.SPY, 100m, 100m, 100m, 100m, 1));
 
@@ -50,7 +53,9 @@ namespace QuantConnect.Tests.Common.Orders.Slippage
                 Symbols.EURUSD,
                 SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             _forex.SetMarketPrice(new TradeBar(DateTime.Now, Symbols.EURUSD, 100m, 100m, 100m, 100m, 0));
 
@@ -63,7 +68,7 @@ namespace QuantConnect.Tests.Common.Orders.Slippage
             var slippagePercent = 1m;
             var model = new ConstantSlippageModel(slippagePercent);
 
-            var expected = _equity.Price * slippagePercent; 
+            var expected = _equity.Price * slippagePercent;
             var actual = model.GetSlippageApproximation(_equity, _equityBuyOrder);
             Assert.AreEqual(expected, actual);
         }
@@ -114,7 +119,7 @@ namespace QuantConnect.Tests.Common.Orders.Slippage
             var volumeShare = _equityBuyOrder.Quantity / (decimal)volume;
             Assert.Greater(volume, volumeLimit * _equityBuyOrder.Quantity);
             _equity.SetMarketPrice(new TradeBar(DateTime.Now, Symbols.SPY, 100m, 100m, 100m, 100m, volume));
-            
+
             var expected = _equity.Price * priceImpact * volumeShare * volumeShare;
             var actual = model.GetSlippageApproximation(_equity, _equityBuyOrder);
             Assert.AreEqual(expected, actual);

--- a/Tests/Common/Orders/TimeInForces/TimeInForceTests.cs
+++ b/Tests/Common/Orders/TimeInForces/TimeInForceTests.cs
@@ -35,9 +35,20 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
         {
             var security = new Equity(
                 SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             var timeInForce = new GoodTilCanceledTimeInForce();
             var order = new LimitOrder(Symbols.SPY, 10, 100, DateTime.UtcNow);
@@ -58,9 +69,20 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
 
             var security = new Equity(
                 SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -95,8 +117,19 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var security = new Forex(
                 SecurityExchangeHoursTests.CreateForexSecurityExchangeHours(),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                new SubscriptionDataConfig(typeof(QuoteBar), Symbols.EURUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    Symbols.EURUSD,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -133,8 +166,19 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var security = new Forex(
                 SecurityExchangeHoursTests.CreateForexSecurityExchangeHours(),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                new SubscriptionDataConfig(typeof(QuoteBar), Symbols.EURUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    Symbols.EURUSD,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -174,8 +218,19 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var security = new Crypto(
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                new SubscriptionDataConfig(typeof(QuoteBar), Symbols.BTCUSD, Resolution.Minute, TimeZones.Utc, TimeZones.Utc, true, true, true),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    Symbols.BTCUSD,
+                    Resolution.Minute,
+                    TimeZones.Utc,
+                    TimeZones.Utc,
+                    true,
+                    true,
+                    true
+                ),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.Utc);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -208,9 +263,20 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
 
             var security = new Equity(
                 SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -259,8 +325,19 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var security = new Forex(
                 SecurityExchangeHoursTests.CreateForexSecurityExchangeHours(),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                new SubscriptionDataConfig(typeof(QuoteBar), Symbols.EURUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    Symbols.EURUSD,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -308,8 +385,19 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var security = new Crypto(
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                new SubscriptionDataConfig(typeof(QuoteBar), Symbols.BTCUSD, Resolution.Minute, TimeZones.Utc, TimeZones.Utc, true, true, true),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    Symbols.BTCUSD,
+                    Resolution.Minute,
+                    TimeZones.Utc,
+                    TimeZones.Utc,
+                    true,
+                    true,
+                    true
+                ),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.Utc);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -356,9 +444,20 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
 
             var security = new Equity(
                 SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -393,8 +492,19 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var security = new Forex(
                 SecurityExchangeHoursTests.CreateForexSecurityExchangeHours(),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                new SubscriptionDataConfig(typeof(QuoteBar), Symbols.EURUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    Symbols.EURUSD,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -431,8 +541,19 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var security = new Forex(
                 SecurityExchangeHoursTests.CreateForexSecurityExchangeHours(),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                new SubscriptionDataConfig(typeof(QuoteBar), Symbols.EURUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    Symbols.EURUSD,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
 
@@ -472,8 +593,19 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
             var security = new Crypto(
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                new SubscriptionDataConfig(typeof(QuoteBar), Symbols.BTCUSD, Resolution.Minute, TimeZones.Utc, TimeZones.Utc, true, true, true),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                new SubscriptionDataConfig(
+                    typeof(QuoteBar),
+                    Symbols.BTCUSD,
+                    Resolution.Minute,
+                    TimeZones.Utc,
+                    TimeZones.Utc,
+                    true,
+                    true,
+                    true
+                ),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.Utc);
             security.SetLocalTimeKeeper(localTimeKeeper);
 

--- a/Tests/Common/Scheduling/DateRulesTests.cs
+++ b/Tests/Common/Scheduling/DateRulesTests.cs
@@ -22,6 +22,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Scheduling;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Scheduling
 {
@@ -255,7 +256,16 @@ namespace QuantConnect.Tests.Common.Scheduling
             var manager = new SecurityManager(timeKeeper);
             var securityExchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, null, SecurityType.Equity);
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, true, false, false);
-            manager.Add(Symbols.SPY, new Security(securityExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            manager.Add(
+                Symbols.SPY,
+                new Security(
+                    securityExchangeHours,
+                    config,
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             var rules = new DateRules(manager);
             return rules;
         }

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Scheduling;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Scheduling
 {
@@ -178,7 +179,7 @@ namespace QuantConnect.Tests.Common.Scheduling
             var rules = GetTimeRules(TimeZones.Utc);
             var rule = rules.BeforeMarketClose(Symbols.SPY, 30, true);
             var times = rule.CreateUtcEventTimes(new[] { new DateTime(2000, 01, 03) });
-            
+
             int count = 0;
             foreach (var time in times)
             {
@@ -195,7 +196,16 @@ namespace QuantConnect.Tests.Common.Scheduling
             var marketHourDbEntry = MarketHoursDatabase.FromDataFolder().GetEntry(Market.USA, (string)null, SecurityType.Equity);
             var securityExchangeHours = marketHourDbEntry.ExchangeHours;
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Daily, marketHourDbEntry.DataTimeZone, securityExchangeHours.TimeZone, true, false, false);
-            manager.Add(Symbols.SPY, new Security(securityExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            manager.Add(
+                Symbols.SPY,
+                new Security(
+                    securityExchangeHours,
+                    config,
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             var rules = new TimeRules(manager, dateTimeZone);
             return rules;
         }

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -74,15 +74,21 @@ namespace QuantConnect.Tests.Common.Securities
 
             _algo.HistoryProvider = historyProvider;
             _algo.SubscriptionManager.SetDataManager(new DataManagerStub(_algo));
-            _tradeBarSecurity = new Security(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
-                                        _tradeBarConfig,
-                                        new Cash(CashBook.AccountCurrency, 0, 1m),
-                                        SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            _tradeBarSecurity = new Security(
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                _tradeBarConfig,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
-            _quoteBarSecurity = new Security(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
-                                    _quoteBarConfig,
-                                    new Cash(CashBook.AccountCurrency, 0, 1m),
-                                    SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            _quoteBarSecurity = new Security(
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                _quoteBarConfig,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             _brokerageInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(),
                                                                           new FuncSecuritySeeder(_algo.GetLastKnownPrice));

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -68,25 +68,33 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(tz),
                 _portfolio.CashBook[CashBook.AccountCurrency],
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCUSD, Resolution.Minute, tz, tz, true, false, false),
-                new SymbolProperties("BTCUSD", "USD", 1, 0.01m, 0.00000001m));
+                new SymbolProperties("BTCUSD", "USD", 1, 0.01m, 0.00000001m),
+                ErrorCurrencyConverter.Instance
+            );
 
             _ethusd = new Crypto(
                 SecurityExchangeHours.AlwaysOpen(tz),
                 _portfolio.CashBook[CashBook.AccountCurrency],
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.ETHUSD, Resolution.Minute, tz, tz, true, false, false),
-                new SymbolProperties("ETHUSD", "USD", 1, 0.01m, 0.00000001m));
+                new SymbolProperties("ETHUSD", "USD", 1, 0.01m, 0.00000001m),
+                ErrorCurrencyConverter.Instance
+            );
 
             _btceur = new Crypto(
                 SecurityExchangeHours.AlwaysOpen(tz),
                 _portfolio.CashBook["EUR"],
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCEUR, Resolution.Minute, tz, tz, true, false, false),
-                new SymbolProperties("BTCEUR", "EUR", 1, 0.01m, 0.00000001m));
+                new SymbolProperties("BTCEUR", "EUR", 1, 0.01m, 0.00000001m),
+                ErrorCurrencyConverter.Instance
+            );
 
             _ethbtc = new Crypto(
                 SecurityExchangeHours.AlwaysOpen(tz),
                 _portfolio.CashBook["BTC"],
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.ETHBTC, Resolution.Minute, tz, tz, true, false, false),
-                new SymbolProperties("ETHBTC", "BTC", 1, 0.00001m, 0.00000001m));
+                new SymbolProperties("ETHBTC", "BTC", 1, 0.00001m, 0.00000001m),
+                ErrorCurrencyConverter.Instance
+            );
 
             _buyingPowerModel = new CashBuyingPowerModel();
         }

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -91,7 +91,16 @@ namespace QuantConnect.Tests.Common.Securities
             subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, abcConfig, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    abcConfig,
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
             Assert.AreEqual(1, subscriptions.Subscriptions.Count(x => x.Symbol == Symbols.USDJPY));
             Assert.AreEqual(1, securities.Values.Count(x => x.Symbol == Symbols.USDJPY));
@@ -109,8 +118,17 @@ namespace QuantConnect.Tests.Common.Securities
             subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, abcConfig, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            var usdjpy = new Security(Symbols.USDJPY, SecurityExchangeHours, new Cash("JPY", 0, 0), SymbolProperties.GetDefault("JPY"));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    abcConfig,
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            var usdjpy = new Security(Symbols.USDJPY, SecurityExchangeHours, new Cash("JPY", 0, 0), SymbolProperties.GetDefault("JPY"), ErrorCurrencyConverter.Instance);
             var changes = new SecurityChanges(new[] {usdjpy}, Enumerable.Empty<Security>());
             var addedSecurity = cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, changes);
 
@@ -132,8 +150,26 @@ namespace QuantConnect.Tests.Common.Securities
             var subscriptions = new SubscriptionManager();
             subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.EURUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.EURUSD, minimumResolution, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.EURUSD,
+                new Security(
+                    SecurityExchangeHours,
+                    subscriptions.Add(Symbols.EURUSD, minimumResolution, TimeZone, TimeZone),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
             Assert.AreEqual(minimumResolution, subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY).Resolution);
@@ -151,7 +187,16 @@ namespace QuantConnect.Tests.Common.Securities
             var subscriptions = new SubscriptionManager();
             subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(Symbols.EURUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.EURUSD, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.EURUSD,
+                new Security(
+                    SecurityExchangeHours,
+                    subscriptions.Add(Symbols.EURUSD, Resolution.Minute, TimeZone, TimeZone),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
             var config = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY);
@@ -170,7 +215,16 @@ namespace QuantConnect.Tests.Common.Securities
             var subscriptions = new SubscriptionManager();
             subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(Symbols.USDJPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.USDJPY,
+                new Security(
+                    SecurityExchangeHours,
+                    subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
             var config = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY);
@@ -193,7 +247,16 @@ namespace QuantConnect.Tests.Common.Securities
             var subscriptions = new SubscriptionManager();
             subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(symbol, new Security(SecurityExchangeHours, subscriptions.Add(symbol, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                symbol,
+                new Security(
+                    SecurityExchangeHours,
+                    subscriptions.Add(symbol, Resolution.Minute, TimeZone, TimeZone),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             cashJPY.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
             var config1 = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY);
@@ -254,7 +317,16 @@ namespace QuantConnect.Tests.Common.Securities
             var subscriptions = new SubscriptionManager();
             subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(Symbols.USDJPY, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.USDJPY,
+                new Security(
+                    SecurityExchangeHours,
+                    subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             // we need to get subscription index
             cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
@@ -278,7 +350,16 @@ namespace QuantConnect.Tests.Common.Securities
             var subscriptions = new SubscriptionManager();
             subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(Symbols.GBPUSD, new Security(SecurityExchangeHours, subscriptions.Add(Symbols.GBPUSD, Resolution.Minute, TimeZone, TimeZone), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.GBPUSD,
+                new Security(
+                    SecurityExchangeHours,
+                    subscriptions.Add(Symbols.GBPUSD, Resolution.Minute, TimeZone, TimeZone),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             // we need to get subscription index
             cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);

--- a/Tests/Common/Securities/Cfd/CfdTests.cs
+++ b/Tests/Common/Securities/Cfd/CfdTests.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Tests.Common.Securities.Cfd
             var symbol = Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda);
             var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.Utc, TimeZones.NewYork, true, true, true);
             var symbolProperties = new SymbolProperties("Dax German index", "EUR", 1, 1, 1);
-            var cfd = new QuantConnect.Securities.Cfd.Cfd(SecurityExchangeHours.AlwaysOpen(config.DataTimeZone), new Cash("EUR", 0, 0), config, symbolProperties);
+            var cfd = new QuantConnect.Securities.Cfd.Cfd(SecurityExchangeHours.AlwaysOpen(config.DataTimeZone), new Cash("EUR", 0, 0), config, symbolProperties, ErrorCurrencyConverter.Instance);
             Assert.AreEqual("EUR", cfd.QuoteCurrency.Symbol);
         }
 

--- a/Tests/Common/Securities/DelayedSettlementModelTests.cs
+++ b/Tests/Common/Securities/DelayedSettlementModelTests.cs
@@ -36,7 +36,13 @@ namespace QuantConnect.Tests.Common.Securities
             // settlement at T+3, 8:00 AM
             var model = new DelayedSettlementModel(3, TimeSpan.FromHours(8));
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             portfolio.SetCash(3000);
             Assert.AreEqual(3000, portfolio.Cash);
@@ -83,7 +89,13 @@ namespace QuantConnect.Tests.Common.Securities
             // settlement at T+3, 8:00 AM
             var model = new DelayedSettlementModel(3, TimeSpan.FromHours(8));
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             portfolio.SetCash(3000);
             Assert.AreEqual(3000, portfolio.Cash);

--- a/Tests/Common/Securities/Equity/EquityTransactionModelTests.cs
+++ b/Tests/Common/Securities/Equity/EquityTransactionModelTests.cs
@@ -36,7 +36,13 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var model = new EquityTransactionModel();
             var order = new MarketOrder(Symbols.SPY, 100, Noon);
             var config = CreateTradeBarConfig();
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.123m));
 
@@ -51,7 +57,13 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var model = new EquityTransactionModel();
             var order = new MarketOrder(Symbols.SPY, -100, Noon);
             var config = CreateTradeBarConfig();
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.123m));
 
@@ -67,7 +79,13 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var model = new EquityTransactionModel();
             var order = new LimitOrder(Symbols.SPY, 100, 101.5m, Noon);
             var config = CreateTradeBarConfig();
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 
@@ -93,7 +111,13 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var model = new EquityTransactionModel();
             var order = new LimitOrder(Symbols.SPY, -100, 101.5m, Noon);
             var config = CreateTradeBarConfig();
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
 
@@ -119,7 +143,13 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var model = new EquityTransactionModel();
             var order = new StopLimitOrder(Symbols.SPY, 100, 101.5m, 101.75m, Noon);
             var config = CreateTradeBarConfig();
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 100m));
 
@@ -153,7 +183,13 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var model = new EquityTransactionModel();
             var order = new StopLimitOrder(Symbols.SPY, -100, 101.75m, 101.50m, Noon);
             var config = CreateTradeBarConfig();
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 
@@ -187,7 +223,13 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var model = new EquityTransactionModel();
             var order = new StopMarketOrder(Symbols.SPY, 100, 101.5m, Noon);
             var config = CreateTradeBarConfig();
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
 
@@ -213,7 +255,13 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var model = new EquityTransactionModel();
             var order = new StopMarketOrder(Symbols.SPY, -100, 101.5m, Noon);
             var config = CreateTradeBarConfig();
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 

--- a/Tests/Common/Securities/ErrorCurrencyConverterTests.cs
+++ b/Tests/Common/Securities/ErrorCurrencyConverterTests.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class ErrorCurrencyConverterTests
+    {
+        [Test]
+        public void AlwaysThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(() => ErrorCurrencyConverter.Instance.ConvertToAccountCurrency(default(CashAmount)));
+        }
+    }
+}

--- a/Tests/Common/Securities/Forex/ForexHoldingTest.cs
+++ b/Tests/Common/Securities/Forex/ForexHoldingTest.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Tests.Common.Securities.Forex
             var pair = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
                                                                cash, subscription,
                                                                new SymbolProperties("", pairQuoteCurrency, 1,
-                                                                                    minimumPriceVariation, lotSize));
+                                                                                    minimumPriceVariation, lotSize), ErrorCurrencyConverter.Instance);
             pair.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             pair.SetFeeModel(new ConstantFeeModel(decimal.Zero));
             var forexHolding = new ForexHolding(pair);

--- a/Tests/Common/Securities/Forex/ForexTests.cs
+++ b/Tests/Common/Securities/Forex/ForexTests.cs
@@ -57,7 +57,7 @@ namespace QuantConnect.Tests.Common.Securities.Forex
         public void ConstructorDecomposesBaseAndQuoteCurrencies()
         {
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true);
-            var forex = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours.AlwaysOpen(config.DataTimeZone), new Cash("usd", 0, 0), config, SymbolProperties.GetDefault("usd"));
+            var forex = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours.AlwaysOpen(config.DataTimeZone), new Cash("usd", 0, 0), config, SymbolProperties.GetDefault("usd"), ErrorCurrencyConverter.Instance);
             Assert.AreEqual("EUR", forex.BaseCurrencySymbol);
             Assert.AreEqual("USD", forex.QuoteCurrency.Symbol);
         }

--- a/Tests/Common/Securities/Forex/ForexTransactionModelTests.cs
+++ b/Tests/Common/Securities/Forex/ForexTransactionModelTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -245,7 +245,13 @@ namespace QuantConnect.Tests.Common.Securities.Forex
         private Security CreateSecurity()
         {
             var config = CreateTradeBarDataConfig(SecurityType.Forex);
-            var security = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), new Cash("abc", 0, 0), config, SymbolProperties.GetDefault("abc"));
+            var security = new QuantConnect.Securities.Forex.Forex(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new Cash("abc", 0, 0),
+                config,
+                SymbolProperties.GetDefault("abc"),
+                ErrorCurrencyConverter.Instance
+            );
             return security;
         }
     }

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -47,7 +47,13 @@ namespace QuantConnect.Tests.Common.Securities
             var ticker = QuantConnect.Securities.Futures.Softs.Coffee;
             var symbol = Symbol.CreateFuture(ticker, Market.USA, expDate);
 
-            var futureSecurity = new Future(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var futureSecurity = new Future(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
@@ -67,7 +73,7 @@ namespace QuantConnect.Tests.Common.Securities
             var ticker = "NOT-A-SYMBOL";
             var symbol = Symbol.CreateFuture(ticker, Market.USA, expDate);
 
-            var futureSecurity = new Future(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var futureSecurity = new Future(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)), ErrorCurrencyConverter.Instance);
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
@@ -87,7 +93,13 @@ namespace QuantConnect.Tests.Common.Securities
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var symbol = Symbol.CreateFuture(ticker, Market.USA, expDate);
 
-            var futureSecurity = new Future(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var futureSecurity = new Future(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 

--- a/Tests/Common/Securities/IdentityCurrencyConverterTests.cs
+++ b/Tests/Common/Securities/IdentityCurrencyConverterTests.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class IdentityCurrencyConverterTests
+    {
+        [Test]
+        public void ThrowsArgumentExceptionOnCashAmountNotInAccountCurrency()
+        {
+            var converter = new IdentityCurrencyConverter("USD");
+            var cashAmount = new CashAmount(1m, "EUR", converter);
+            Assert.Throws<ArgumentException>(() => converter.ConvertToAccountCurrency(cashAmount));
+        }
+
+        [Test]
+        public void ConvertsAccountCurrencyAsIdentity()
+        {
+            var converter = new IdentityCurrencyConverter("ABC");
+            var cashAmount = new CashAmount(1m, "ABC", converter);
+            Assert.AreEqual(cashAmount, converter.ConvertToAccountCurrency(cashAmount));
+        }
+    }
+}

--- a/Tests/Common/Securities/ImmediateSettlementModelTests.cs
+++ b/Tests/Common/Securities/ImmediateSettlementModelTests.cs
@@ -35,7 +35,13 @@ namespace QuantConnect.Tests.Common.Securities
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             var model = new ImmediateSettlementModel();
             var config = CreateTradeBarConfig();
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             portfolio.SetCash(1000);
             Assert.AreEqual(1000, portfolio.Cash);

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -234,9 +234,20 @@ namespace QuantConnect.Tests.Common.Securities
         {
             return new Security(
                 SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    symbol,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    true,
+                    true,
+                    true
+                ),
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
         }
     }
 }

--- a/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
@@ -41,7 +41,22 @@ namespace QuantConnect.Tests.Common.Securities
         public void OptionMarginBuyingPowerModelInitializationTests()
         {
             var tz = TimeZones.NewYork;
-            var option = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+            var option = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_P_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance
+            );
             var buyingPowerModel = new OptionMarginModel();
 
             // we test that options dont have leverage (100%) and it cannot be changed
@@ -57,15 +72,51 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal underlyingPrice = 200m;
             var tz = TimeZones.NewYork;
 
-            var equity = new QuantConnect.Securities.Equity.Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
-            var optionPut = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+            var optionPut = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_P_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance
+            );
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(1m, 2);
 
-            var optionCall = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_C_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+            var optionCall = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_C_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance
+            );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(1.5m, 2);
@@ -84,10 +135,31 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal underlyingPrice = 196m;
             var tz = TimeZones.NewYork;
 
-            var equity = new QuantConnect.Securities.Equity.Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
-            var optionCall = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_C_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+            var optionCall = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_C_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance
+            );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(price, -2);
@@ -106,10 +178,31 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal underlyingPrice = 180m;
             var tz = TimeZones.NewYork;
 
-            var equity = new QuantConnect.Securities.Equity.Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
-            var optionCall = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_C_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+            var optionCall = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_C_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance
+            );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(price, -2);
@@ -128,10 +221,31 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal underlyingPrice = 182m;
             var tz = TimeZones.NewYork;
 
-            var equity = new QuantConnect.Securities.Equity.Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
-            var optionPut = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+            var optionPut = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_P_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance
+            );
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(price, -2);
@@ -150,10 +264,31 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal underlyingPrice = 196m;
             var tz = TimeZones.NewYork;
 
-            var equity = new QuantConnect.Securities.Equity.Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
-            var optionCall = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+            var optionCall = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_P_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance
+            );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(price, -2);
@@ -172,11 +307,23 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal underlyingPrice = 200m;
 
             var tz = TimeZones.NewYork;
-            var equity = new QuantConnect.Securities.Equity.Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
             var optionPutSymbol = Symbol.CreateOption(Symbols.SPY, Market.USA, OptionStyle.American, OptionRight.Put, 207m, new DateTime(2015, 02, 27));
-            var optionPut = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), optionPutSymbol, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+            var optionPut = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), optionPutSymbol, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance
+            );
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(price, -2);
@@ -197,11 +344,23 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal underlyingPriceEnd = 200m;
 
             var tz = TimeZones.NewYork;
-            var equity = new QuantConnect.Securities.Equity.Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPriceStart });
 
             var optionPutSymbol = Symbol.CreateOption(Symbols.SPY, Market.USA, OptionStyle.American, OptionRight.Put, 207m, new DateTime(2015, 02, 27));
-            var optionPut = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), optionPutSymbol, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1));
+            var optionPut = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), optionPutSymbol, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties("", CashBook.AccountCurrency.ToUpper(), 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance
+            );
             optionPut.SetMarketPrice(new Tick { Value = optionPriceStart });
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(optionPriceStart, -2);

--- a/Tests/Common/Securities/OptionPriceModelTests.cs
+++ b/Tests/Common/Securities/OptionPriceModelTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ using QuantConnect.Securities;
 using QuantConnect.Securities.Equity;
 using QuantConnect.Securities.Option;
 using System.Collections.Generic;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common
 {
@@ -41,18 +42,36 @@ namespace QuantConnect.Tests.Common
             var SPY_P_192_Feb19_2016E = Symbol.CreateOption("SPY", Market.USA, OptionStyle.European, OptionRight.Put, 192m, new DateTime(2016, 02, 19));
 
             // setting up underlying
-            var equity = new Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
 
             // setting up European style call option
             var contractCall = new OptionContract(SPY_C_192_Feb19_2016E, Symbols.SPY) { Time = evaluationDate };
-            var optionCall = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var optionCall = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
             optionCall.Underlying = equity;
 
             // setting up European style put option
             var contractPut = new OptionContract(SPY_P_192_Feb19_2016E, Symbols.SPY) { Time = evaluationDate };
-            var optionPut = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), SPY_P_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var optionPut = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), SPY_P_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
             optionPut.Underlying = equity;
 
             // running evaluation
@@ -81,13 +100,25 @@ namespace QuantConnect.Tests.Common
             var SPY_C_192_Feb19_2016E = Symbol.CreateOption("SPY", Market.USA, OptionStyle.European, OptionRight.Call, 192m, new DateTime(2016, 02, 19));
 
             // setting up underlying
-            var equity = new Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
 
             // setting up European style option
             var contract = new OptionContract(SPY_C_192_Feb19_2016E, Symbols.SPY) { Time = evaluationDate };
-            var optionCall = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var optionCall = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
 
@@ -114,12 +145,33 @@ namespace QuantConnect.Tests.Common
             var tz = TimeZones.NewYork;
             var evaluationDate = new DateTime(2015, 2, 19);
 
-            var equity = new Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
 
             var contract = new OptionContract(Symbols.SPY_C_192_Feb19_2016, Symbols.SPY) { Time = evaluationDate };
-            var optionCall = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_C_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var optionCall = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_C_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
 
@@ -151,12 +203,33 @@ namespace QuantConnect.Tests.Common
             var evaluationDate1 = new DateTime(2015, 2, 19);
             var evaluationDate2 = new DateTime(2015, 2, 20);
 
-            var equity = new Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
 
             var contract = new OptionContract(Symbols.SPY_C_192_Feb19_2016, Symbols.SPY) { Time = evaluationDate1 };
-            var optionCall = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_C_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var optionCall = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_C_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
 
@@ -182,12 +255,33 @@ namespace QuantConnect.Tests.Common
             var tz = TimeZones.NewYork;
             var evaluationDate = new DateTime(2016, 1, 19);
 
-            var equity = new Equity(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
 
             var contract = new OptionContract(Symbols.SPY_P_192_Feb19_2016, Symbols.SPY) { Time = evaluationDate };
-            var optionPut = new Option(SecurityExchangeHours.AlwaysOpen(tz), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, tz, tz, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var optionPut = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_P_192_Feb19_2016,
+                    Resolution.Minute,
+                    tz,
+                    tz,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;
 

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -280,7 +280,13 @@ namespace QuantConnect.Tests.Common.Securities
 
         private static Security CreateSecurity(DateTime newLocalTime)
         {
-            var security = new Security(CreateUsEquitySecurityExchangeHours(), CreateTradeBarConfig(), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                CreateUsEquitySecurityExchangeHours(),
+                CreateTradeBarConfig(),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             TimeKeeper.SetUtcDateTime(newLocalTime.ConvertToUtc(security.Exchange.TimeZone));
             security.Exchange.SetLocalDateTimeFrontier(newLocalTime);
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));

--- a/Tests/Common/Securities/PriceVariationModelsTests.cs
+++ b/Tests/Common/Securities/PriceVariationModelsTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,17 +62,39 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             {
                 security = new QuantConnect.Securities.Equity.Equity(
                     SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                    new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false),
+                    new SubscriptionDataConfig(
+                        typeof(TradeBar),
+                        symbol,
+                        Resolution.Minute,
+                        TimeZones.NewYork,
+                        TimeZones.NewYork,
+                        true,
+                        true,
+                        false
+                    ),
                     new Cash(CashBook.AccountCurrency, 0, 1m),
-                    symbolProperties);
+                    symbolProperties,
+                    ErrorCurrencyConverter.Instance
+                );
             }
             else
             {
                 security = new QuantConnect.Securities.Forex.Forex(
-                   SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                   new Cash(CashBook.AccountCurrency, 0, 1m),
-                   new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false),
-                   symbolProperties);
+                    SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new SubscriptionDataConfig(
+                        typeof(TradeBar),
+                        symbol,
+                        Resolution.Minute,
+                        TimeZones.NewYork,
+                        TimeZones.NewYork,
+                        true,
+                        true,
+                        false
+                    ),
+                    symbolProperties,
+                    ErrorCurrencyConverter.Instance
+                );
             }
 
             var TimeKeeper = new TimeKeeper(DateTime.Now.ConvertToUtc(TimeZones.NewYork), new[] { TimeZones.NewYork });

--- a/Tests/Common/Securities/RelativeStandardDeviationVolatilityModelTests.cs
+++ b/Tests/Common/Securities/RelativeStandardDeviationVolatilityModelTests.cs
@@ -34,7 +34,13 @@ namespace QuantConnect.Tests.Common.Securities
             var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
             var timeKeeper = new TimeKeeper(referenceUtc);
             var config = new SubscriptionDataConfig(typeof (TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, false, false);
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), config, new Cash("USD", 0, 0), SymbolProperties.GetDefault("USD"));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash("USD", 0, 0),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
             var model = new RelativeStandardDeviationVolatilityModel(periodSpan, periods);
@@ -69,7 +75,13 @@ namespace QuantConnect.Tests.Common.Securities
             var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
             var timeKeeper = new TimeKeeper(referenceUtc);
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, false, false);
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), config, new Cash("USD", 0, 0), SymbolProperties.GetDefault("USD"));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash("USD", 0, 0),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
             var model = new RelativeStandardDeviationVolatilityModel(periodSpan, periods);

--- a/Tests/Common/Securities/SecurityHoldingTests.cs
+++ b/Tests/Common/Securities/SecurityHoldingTests.cs
@@ -62,11 +62,13 @@ namespace QuantConnect.Tests.Common.Securities
                 true,
                 false);
 
-            var security =new Security(
+            var security = new Security(
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 subscriptionDataConfig,
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             var reference = DateTime.Now;
             var referenceUtc = reference.ConvertToUtc(subscriptionDataConfig.DataTimeZone);

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -60,7 +60,13 @@ namespace QuantConnect.Tests.Common.Securities
             var timeKeeper = new TimeKeeper(new DateTime(2015, 12, 07));
             var manager = new SecurityManager(timeKeeper);
 
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), CreateTradeBarConfig(), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                CreateTradeBarConfig(),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             manager.CollectionChanged += (sender, args) =>
             {
                 if (args.NewItems.OfType<object>().Single() != security)
@@ -83,7 +89,13 @@ namespace QuantConnect.Tests.Common.Securities
             var timeKeeper = new TimeKeeper(new DateTime(2015, 12, 07));
             var manager = new SecurityManager(timeKeeper);
 
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), CreateTradeBarConfig(), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                CreateTradeBarConfig(),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             manager.CollectionChanged += (sender, args) =>
             {
                 if (args.NewItems.OfType<object>().Single() != security)
@@ -106,7 +118,13 @@ namespace QuantConnect.Tests.Common.Securities
             var timeKeeper = new TimeKeeper(new DateTime(2015, 12, 07));
             var manager = new SecurityManager(timeKeeper);
 
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), CreateTradeBarConfig(), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                CreateTradeBarConfig(),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             manager.Add(security.Symbol, security);
             manager.CollectionChanged += (sender, args) =>
             {

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -89,7 +89,13 @@ namespace QuantConnect.Tests.Common.Securities
             subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
             var securities = new SecurityManager(TimeKeeper);
             MarketHoursDatabase.FromDataFolder().SetEntryAlwaysOpen(CASH.ID.Market, CASH.Value, CASH.SecurityType, TimeZones.NewYork);
-            var security = new Security(SecurityExchangeHours, subscriptions.Add(CASH, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours,
+                subscriptions.Add(CASH, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLeverage(10m);
             securities.Add(CASH, security);
             var transactions = new SecurityTransactionManager(null, securities);
@@ -163,11 +169,29 @@ namespace QuantConnect.Tests.Common.Securities
             var mchCash = portfolio.CashBook["MCH"];
             var usdCash = portfolio.CashBook["USD"];
 
-            var mchJwbSecurity = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours, jwbCash, subscriptions.Add(MCHJWB, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork), SymbolProperties.GetDefault(jwbCash.Symbol));
+            var mchJwbSecurity = new QuantConnect.Securities.Forex.Forex(
+                SecurityExchangeHours,
+                jwbCash,
+                subscriptions.Add(MCHJWB, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork),
+                SymbolProperties.GetDefault(jwbCash.Symbol),
+                ErrorCurrencyConverter.Instance
+            );
             mchJwbSecurity.SetLeverage(10m);
-            var mchUsdSecurity = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours, usdCash, subscriptions.Add(MCHUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork), SymbolProperties.GetDefault(usdCash.Symbol));
+            var mchUsdSecurity = new QuantConnect.Securities.Forex.Forex(
+                SecurityExchangeHours,
+                usdCash,
+                subscriptions.Add(MCHUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork),
+                SymbolProperties.GetDefault(usdCash.Symbol),
+                ErrorCurrencyConverter.Instance
+            );
             mchUsdSecurity.SetLeverage(10m);
-            var usdJwbSecurity = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours, mchCash, subscriptions.Add(USDJWB, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork), SymbolProperties.GetDefault(mchCash.Symbol));
+            var usdJwbSecurity = new QuantConnect.Securities.Forex.Forex(
+                SecurityExchangeHours,
+                mchCash,
+                subscriptions.Add(USDJWB, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork),
+                SymbolProperties.GetDefault(mchCash.Symbol),
+                ErrorCurrencyConverter.Instance
+            );
             usdJwbSecurity.SetLeverage(10m);
 
             // no fee model
@@ -246,7 +270,15 @@ namespace QuantConnect.Tests.Common.Securities
             portfolio.CashBook["USD"].SetAmount(quantity);
 
             var config = CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL);
-            securities.Add(new Security(SecurityExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                new Security(
+                    SecurityExchangeHours,
+                    config,
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             var security = securities[Symbols.AAPL];
             security.SetLeverage(leverage);
 
@@ -352,19 +384,43 @@ namespace QuantConnect.Tests.Common.Securities
 
             var time = DateTime.Now;
             var config1 = CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL);
-            securities.Add(new Security(SecurityExchangeHours, config1, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                new Security(
+                    SecurityExchangeHours,
+                    config1,
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.AAPL].SetLeverage(2m);
             securities[Symbols.AAPL].Holdings.SetHoldings(100, 100);
             securities[Symbols.AAPL].SetMarketPrice(new TradeBar{Time = time, Value = 100});
 
             var config2 = CreateTradeBarDataConfig(SecurityType.Forex, Symbols.EURUSD);
-            securities.Add(new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours, usdCash, config2, SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                new QuantConnect.Securities.Forex.Forex(
+                    SecurityExchangeHours,
+                    usdCash,
+                    config2,
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.EURUSD].SetLeverage(100m);
             securities[Symbols.EURUSD].Holdings.SetHoldings(1.1m, 1000);
             securities[Symbols.EURUSD].SetMarketPrice(new TradeBar { Time = time, Value = 1.1m });
 
             var config3 = CreateTradeBarDataConfig(SecurityType.Forex, Symbols.EURGBP);
-            securities.Add(new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours, gbpCash, config3, SymbolProperties.GetDefault(gbpCash.Symbol)));
+            securities.Add(
+                new QuantConnect.Securities.Forex.Forex(
+                    SecurityExchangeHours,
+                    gbpCash,
+                    config3,
+                    SymbolProperties.GetDefault(gbpCash.Symbol),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.EURGBP].SetLeverage(100m);
             securities[Symbols.EURGBP].Holdings.SetHoldings(1m, 1000);
             securities[Symbols.EURGBP].SetMarketPrice(new TradeBar { Time = time, Value = 1m });
@@ -391,7 +447,16 @@ namespace QuantConnect.Tests.Common.Securities
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.Fut_SPY_Feb19_2016, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Future, Symbols.Fut_SPY_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.Fut_SPY_Feb19_2016,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Future, Symbols.Fut_SPY_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             var fillBuy = new OrderEvent(1, Symbols.Fut_SPY_Feb19_2016, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Buy, 100, 100, 0);
             portfolio.ProcessFill(fillBuy);
@@ -414,7 +479,16 @@ namespace QuantConnect.Tests.Common.Securities
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.Fut_SPY_Feb19_2016, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Future, Symbols.Fut_SPY_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), new SymbolProperties("", CashBook.AccountCurrency.ToUpper(), 50, 0.01m, 1)));
+            securities.Add(
+                Symbols.Fut_SPY_Feb19_2016,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Future, Symbols.Fut_SPY_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new SymbolProperties("", CashBook.AccountCurrency.ToUpper(), 50, 0.01m, 1),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             var fillBuy = new OrderEvent(1, Symbols.Fut_SPY_Feb19_2016, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Buy, 100, 100, 0);
             portfolio.ProcessFill(fillBuy);
@@ -437,7 +511,16 @@ namespace QuantConnect.Tests.Common.Securities
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.Fut_SPY_Feb19_2016, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Future, Symbols.Fut_SPY_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), new SymbolProperties("", CashBook.AccountCurrency.ToUpper(), 50, 0.01m, 1)));
+            securities.Add(
+                Symbols.Fut_SPY_Feb19_2016,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Future, Symbols.Fut_SPY_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new SymbolProperties("", CashBook.AccountCurrency.ToUpper(), 50, 0.01m, 1),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             var fillBuy = new OrderEvent(1, Symbols.Fut_SPY_Feb19_2016, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Buy, 100, 100, 0);
             portfolio.ProcessFill(fillBuy);
@@ -458,7 +541,16 @@ namespace QuantConnect.Tests.Common.Securities
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.AAPL, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.AAPL,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             var fill = new OrderEvent(1, Symbols.AAPL, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Sell,  100, -100, 0);
             portfolio.ProcessFill(fill);
@@ -475,7 +567,16 @@ namespace QuantConnect.Tests.Common.Securities
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.AAPL, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.AAPL,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.AAPL].Holdings.SetHoldings(100, 100);
 
             var fill = new OrderEvent(1, Symbols.AAPL, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Sell,  100, -100, 0);
@@ -493,7 +594,16 @@ namespace QuantConnect.Tests.Common.Securities
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.AAPL, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.AAPL,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.AAPL].Holdings.SetHoldings(100, -100);
 
             var fill = new OrderEvent(1, Symbols.AAPL, DateTime.MinValue,  OrderStatus.Filled, OrderDirection.Sell,  100, -100, 0);
@@ -513,7 +623,16 @@ namespace QuantConnect.Tests.Common.Securities
             portfolio.SetCash(1000);
             portfolio.CashBook.Add("EUR", 0, 1.1000m);
 
-            securities.Add(Symbols.EURUSD, new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours, portfolio.CashBook["USD"], CreateTradeBarDataConfig(SecurityType.Forex, Symbols.EURUSD), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.EURUSD,
+                new QuantConnect.Securities.Forex.Forex(
+                    SecurityExchangeHours,
+                    portfolio.CashBook["USD"],
+                    CreateTradeBarDataConfig(SecurityType.Forex, Symbols.EURUSD),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             var security = securities[Symbols.EURUSD];
             Assert.AreEqual(0, security.Holdings.Quantity);
             Assert.AreEqual(1000, portfolio.Cash);
@@ -536,8 +655,19 @@ namespace QuantConnect.Tests.Common.Securities
             portfolio.SetCash(10000);
             portfolio.CashBook.Add("BTC", 0, 4000.01m);
 
-            securities.Add(Symbols.BTCUSD, new QuantConnect.Securities.Crypto.Crypto(SecurityExchangeHours, portfolio.CashBook["USD"], CreateTradeBarDataConfig(SecurityType.Crypto,
-                Symbols.BTCUSD), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.BTCUSD,
+                new QuantConnect.Securities.Crypto.Crypto(
+                    SecurityExchangeHours,
+                    portfolio.CashBook["USD"],
+                    CreateTradeBarDataConfig(
+                        SecurityType.Crypto,
+                        Symbols.BTCUSD
+                    ),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             var security = securities[Symbols.BTCUSD];
             Assert.AreEqual(0, security.Holdings.Quantity);
             Assert.AreEqual(10000, portfolio.Cash);
@@ -559,7 +689,16 @@ namespace QuantConnect.Tests.Common.Securities
             var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             portfolio.SetCash(1000);
-            securities.Add(Symbols.AAPL, new QuantConnect.Securities.Equity.Equity(securityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.AAPL,
+                new QuantConnect.Securities.Equity.Equity(
+                    securityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             var security = securities[Symbols.AAPL];
             security.SettlementModel = new DelayedSettlementModel(3, TimeSpan.FromHours(8));
             Assert.AreEqual(0, security.Holdings.Quantity);
@@ -613,7 +752,15 @@ namespace QuantConnect.Tests.Common.Securities
             portfolio.CashBook["USD"].SetAmount(amount);
 
             var config = CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL);
-            securities.Add(new Security(SecurityExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                new Security(
+                    SecurityExchangeHours,
+                    config,
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             var security = securities[Symbols.AAPL];
             security.SetLeverage(leverage);
 
@@ -670,7 +817,15 @@ namespace QuantConnect.Tests.Common.Securities
             portfolio.CashBook["USD"].SetAmount(amount);
 
             var config = CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL);
-            securities.Add(new Security(SecurityExchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                new Security(
+                    SecurityExchangeHours,
+                    config,
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             var security = securities[Symbols.AAPL];
             security.SetLeverage(leverage);
 
@@ -729,8 +884,26 @@ namespace QuantConnect.Tests.Common.Securities
             // Adding cash: strike price times number of shares
             portfolio.SetCash(192 * 100);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 1);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 200 });
 
@@ -771,8 +944,26 @@ namespace QuantConnect.Tests.Common.Securities
 
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 100);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 20 });
 
@@ -812,8 +1003,26 @@ namespace QuantConnect.Tests.Common.Securities
 
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_P_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_P_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, 100);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 2000 });
 
@@ -854,8 +1063,26 @@ namespace QuantConnect.Tests.Common.Securities
             transactions.SetOrderProcessor(transactionHandler);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_P_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_P_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, 1);
 
             transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, 1, 0, 0, securities.UtcTime, ""));
@@ -897,8 +1124,26 @@ namespace QuantConnect.Tests.Common.Securities
             // Adding cash: strike price times number of shares
             portfolio.SetCash(192 * 100);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 2);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 200 });
 
@@ -938,8 +1183,26 @@ namespace QuantConnect.Tests.Common.Securities
             transactions.SetOrderProcessor(transactionHandler);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, -1);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 200 });
 
@@ -987,8 +1250,26 @@ namespace QuantConnect.Tests.Common.Securities
             // Adding cash: strike price times number of shares
             portfolio.SetCash(192 * 100);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_P_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_P_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -1);
 
             transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -1, 0, 0, securities.UtcTime, ""));
@@ -1032,8 +1313,26 @@ namespace QuantConnect.Tests.Common.Securities
             // Adding cash: strike price times number of shares
             portfolio.SetCash(192 * 100);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_P_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_P_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -2);
 
             transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -1, 0, 0, securities.UtcTime, ""));
@@ -1077,8 +1376,26 @@ namespace QuantConnect.Tests.Common.Securities
 
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 1);
 
@@ -1118,8 +1435,26 @@ namespace QuantConnect.Tests.Common.Securities
 
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 190 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 100);
 
@@ -1158,8 +1493,26 @@ namespace QuantConnect.Tests.Common.Securities
             transactions.SetOrderProcessor(transactionHandler);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_P_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_P_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 189 });
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, 1);
 
@@ -1199,8 +1552,26 @@ namespace QuantConnect.Tests.Common.Securities
 
             portfolio.SetCash(1000);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 10);
 
@@ -1241,8 +1612,26 @@ namespace QuantConnect.Tests.Common.Securities
 
             portfolio.SetCash(1000);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, -10);
 
@@ -1282,8 +1671,26 @@ namespace QuantConnect.Tests.Common.Securities
             transactions.SetOrderProcessor(transactionHandler);
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 2);
 
@@ -1324,8 +1731,26 @@ namespace QuantConnect.Tests.Common.Securities
             // (underlying price - strike price) times number of shares
             portfolio.SetCash((195 - 192) * 100);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, -1);
 
@@ -1368,8 +1793,26 @@ namespace QuantConnect.Tests.Common.Securities
 
             portfolio.SetCash(0);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_C_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_C_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 10 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, -100);
 
@@ -1414,8 +1857,26 @@ namespace QuantConnect.Tests.Common.Securities
             // (strike price - underlying price) times number of shares
             portfolio.SetCash((192 - 189) * 100);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_P_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_P_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 189 });
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -1);
 
@@ -1460,8 +1921,26 @@ namespace QuantConnect.Tests.Common.Securities
             // (strike price - underlying price) times number of shares
             portfolio.SetCash((192 - 189) * 100);
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
-            securities.Add(Symbols.SPY_P_192_Feb19_2016, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016), new Cash(CashBook.AccountCurrency, 0, 1m), GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+            securities.Add(
+                Symbols.SPY_P_192_Feb19_2016,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 189 });
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -2);
 

--- a/Tests/Common/Securities/SecurityPortfolioModelTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioModelTests.cs
@@ -191,7 +191,13 @@ namespace QuantConnect.Tests.Common.Securities
 
         private Security InitializeTest(DateTime reference, out SecurityPortfolioManager portfolio)
         {
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), CreateTradeBarConfig(), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                CreateTradeBarConfig(),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetMarketPrice(new Tick { Value = 100 });
             var timeKeeper = new TimeKeeper(reference);
             var securityManager = new SecurityManager(timeKeeper);

--- a/Tests/Common/Securities/SecurityTests.cs
+++ b/Tests/Common/Securities/SecurityTests.cs
@@ -35,7 +35,13 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var exchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork);
             var config = CreateTradeBarConfig();
-            var security = new Security(exchangeHours, config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                exchangeHours,
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             Assert.AreEqual(config, security.Subscriptions.Single());
             Assert.AreEqual(config.Symbol, security.Symbol);
@@ -152,7 +158,22 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void DefaultDataNormalizationModeForOptionsIsRaw()
         {
-            var option = new Option(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, DateTimeZone.Utc, DateTimeZone.Utc, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var option = new Option(
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_P_192_Feb19_2016,
+                    Resolution.Minute,
+                    DateTimeZone.Utc,
+                    DateTimeZone.Utc,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
 
             Assert.AreEqual(option.DataNormalizationMode, DataNormalizationMode.Raw);
         }
@@ -160,7 +181,22 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void SetDataNormalizationForOptions()
         {
-            var option = new Option(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY_P_192_Feb19_2016, Resolution.Minute, DateTimeZone.Utc, DateTimeZone.Utc, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            var option = new Option(
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY_P_192_Feb19_2016,
+                    Resolution.Minute,
+                    DateTimeZone.Utc,
+                    DateTimeZone.Utc,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                ErrorCurrencyConverter.Instance
+            );
 
             Assert.DoesNotThrow(() => { option.SetDataNormalizationMode(DataNormalizationMode.Raw); });
 
@@ -173,7 +209,22 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void SetDataNormalizationForEquities()
         {
-            var equity = new QuantConnect.Securities.Equity.Equity(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, DateTimeZone.Utc, DateTimeZone.Utc, true, false, false), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var equity = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY,
+                    Resolution.Minute,
+                    DateTimeZone.Utc,
+                    DateTimeZone.Utc,
+                    true,
+                    false,
+                    false
+                ),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             Assert.DoesNotThrow(() => { equity.SetDataNormalizationMode(DataNormalizationMode.Raw); });
             Assert.DoesNotThrow(() => { equity.SetDataNormalizationMode(DataNormalizationMode.Adjusted); });
@@ -206,7 +257,13 @@ namespace QuantConnect.Tests.Common.Securities
 
         private Security GetSecurity()
         {
-            return new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), CreateTradeBarConfig(), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            return new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                CreateTradeBarConfig(),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
         }
 
         private static SubscriptionDataConfig CreateTradeBarConfig()

--- a/Tests/Common/Securities/SecurityTransactionModelTests.cs
+++ b/Tests/Common/Securities/SecurityTransactionModelTests.cs
@@ -35,7 +35,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new MarketOrder(Symbols.SPY, 100, Noon);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.123m));
 
@@ -50,7 +56,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new MarketOrder(Symbols.SPY, -100, Noon);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.123m));
 
@@ -66,7 +78,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new LimitOrder(Symbols.SPY, 100, 101.5m, Noon);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 
@@ -92,7 +110,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new LimitOrder(Symbols.SPY, -100, 101.5m, Noon);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
 
@@ -118,7 +142,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new StopLimitOrder(Symbols.SPY, 100, 101.5m, 101.75m, Noon);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 100m));
 
@@ -152,7 +182,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new StopLimitOrder(Symbols.SPY, -100, 101.75m, 101.50m, Noon);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 
@@ -186,7 +222,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new StopMarketOrder(Symbols.SPY, 100, 101.5m, Noon);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
 
@@ -212,7 +254,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new StopMarketOrder(Symbols.SPY, -100, 101.5m, Noon);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 
@@ -239,7 +287,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new MarketOnOpenOrder(Symbols.SPY, 100, reference);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             var time = reference;
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
@@ -273,7 +327,13 @@ namespace QuantConnect.Tests.Common.Securities
             var model = new SecurityTransactionModel();
             var order = new MarketOnCloseOrder(Symbols.SPY, 100, reference);
             var config = CreateTradeBarConfig(Symbols.SPY);
-            var security = new Security(SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(), config, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             var time = reference;
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));

--- a/Tests/Common/Securities/StandardDeviationOfReturnsVolatilityModelTests.cs
+++ b/Tests/Common/Securities/StandardDeviationOfReturnsVolatilityModelTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,7 +35,13 @@ namespace QuantConnect.Tests.Common.Securities
             var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
             var timeKeeper = new TimeKeeper(referenceUtc);
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, false, false);
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), config, new Cash("USD", 0, 0), SymbolProperties.GetDefault("USD"));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash("USD", 0, 0),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
             var model = new StandardDeviationOfReturnsVolatilityModel(periods);
@@ -69,7 +75,13 @@ namespace QuantConnect.Tests.Common.Securities
             var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
             var timeKeeper = new TimeKeeper(referenceUtc);
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, false, false);
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), config, new Cash("USD", 0, 0), SymbolProperties.GetDefault("USD"));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash("USD", 0, 0),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
             var model = new StandardDeviationOfReturnsVolatilityModel(periods);

--- a/Tests/Common/Securities/TradingCalendarTests.cs
+++ b/Tests/Common/Securities/TradingCalendarTests.cs
@@ -24,21 +24,66 @@ namespace QuantConnect.Tests.Common.Securities
             var securities = new SecurityManager(TimeKeeper);
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
 
             var option1 = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 192m, new DateTime(2016, 02, 16));
-            securities.Add(option1, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Option, option1), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency))));
+            securities.Add(
+                option1,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Option, option1),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             var option2 = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 193m, new DateTime(2016, 03, 19));
-            securities.Add(option2, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Option, option2), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency))));
+            securities.Add(
+                option2,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Option, option2),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             var future1= Symbol.CreateFuture("ES", Market.USA, new DateTime(2016, 02, 16));
-            securities.Add(future1, new Future(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Future, future1), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency))));
+            securities.Add(
+                future1,
+                new Future(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Future, future1),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             var future2 = Symbol.CreateFuture("ES", Market.USA, new DateTime(2016, 02, 19));
-            securities.Add(future2, new Future(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Future, future2), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency))));
-            
+            securities.Add(
+                future2,
+                new Future(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Future, future2),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
+
             var cal = new TradingCalendar(securities, marketHoursDatabase);
 
             var optionDays = cal.GetDaysByType(TradingDayType.OptionExpiration, new DateTime(2016, 02, 16), new DateTime(2016, 03, 19)).Count();

--- a/Tests/Engine/BasicOptionAssignmentSimulationTests.cs
+++ b/Tests/Engine/BasicOptionAssignmentSimulationTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +27,7 @@ using QuantConnect.Securities;
 using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Data.Market;
 using QuantConnect.Data;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Engine
 {
@@ -48,17 +49,53 @@ namespace QuantConnect.Tests.Engine
 
             algorithm.Securities = securities;
 
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
 
             var option1 = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 192m, new DateTime(2016, 02, 16));
-            securities.Add(option1, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, option1), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency))));
+            securities.Add(
+                option1,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, option1),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             var option2 = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 193m, new DateTime(2016, 02, 19));
-            securities.Add(option2, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, option2), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency))));
+            securities.Add(
+                option2,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, option2),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             var option3 = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 190m, new DateTime(2016, 03, 18));
-            securities.Add(option3, new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, option3), new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency))));
+            securities.Add(
+                option3,
+                new Option(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, option3),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
 
             securities[option1].Holdings.SetHoldings(1, -100);
             securities[option2].Holdings.SetHoldings(1, -100);
@@ -69,7 +106,7 @@ namespace QuantConnect.Tests.Engine
             algorithm.SetDateTime(startSim);
 
             // we run request for simulation every minute up to the expiration date of option2
-            // Option3 is too far in the future - we update dates list every month 
+            // Option3 is too far in the future - we update dates list every month
             int countSims = 0;
             foreach (var count in Enumerable.Range(0, (int)(endSim - startSim).TotalMinutes))
             {
@@ -121,8 +158,13 @@ namespace QuantConnect.Tests.Engine
                 (right, strikePrice, bidPrice, askPrice) =>
                 {
                     var symbol = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, right, strikePrice, expiration);
-                    var option = new Option(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Option, symbol),
-                        new Cash(CashBook.AccountCurrency, 0, 1m), new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+                    var option = new Option(
+                        SecurityExchangeHours,
+                        CreateTradeBarDataConfig(SecurityType.Option, symbol),
+                        new Cash(CashBook.AccountCurrency, 0, 1m),
+                        new OptionSymbolProperties(SymbolProperties.GetDefault(CashBook.AccountCurrency)),
+                        ErrorCurrencyConverter.Instance
+                    );
                     securities.Add(symbol, option);
 
                     securities[symbol].Holdings.SetHoldings(1, -1000);
@@ -131,7 +173,16 @@ namespace QuantConnect.Tests.Engine
                 };
 
             // setting up the underlying instrument
-            securities.Add(Symbols.SPY, new Security(SecurityExchangeHours, CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY), new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency)));
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                )
+            );
             securities[Symbols.SPY].SetMarketPrice(new Tick { Symbol = Symbols.SPY, AskPrice = 217.94m, BidPrice = 217.86m, Value = 217.90m, Time = securities.UtcTime });
 
             foreach (var def in optionChain)

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactoryTests.cs
@@ -24,6 +24,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories;
 using QuantConnect.Logging;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
 {
@@ -36,7 +37,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
         {
             var symbol = CoarseFundamental.CreateUniverseSymbol(Market.USA);
             var config = new SubscriptionDataConfig(typeof(CoarseFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), config, new Cash(CashBook.AccountCurrency, 0, 1), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             var universeSettings = new UniverseSettings(Resolution.Daily, 2m, true, false, TimeSpan.FromDays(1));
             var securityInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(), SecuritySeeder.Null);

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactoryTests.cs
@@ -24,6 +24,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories;
 using QuantConnect.Logging;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
 {
@@ -36,7 +37,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
         {
             var symbol = Symbols.AAPL;
             var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), config, new Cash(CashBook.AccountCurrency, 0, 1), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             var mapFileProvider = new LocalDiskMapFileProvider();
             var factorFileProvider = new LocalDiskFactorFileProvider(mapFileProvider);

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
@@ -27,6 +27,7 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 using Log = QuantConnect.Logging.Log;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
@@ -41,7 +42,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             var rows = new List<FineFundamental>();
 
             var config = new SubscriptionDataConfig(typeof(FineFundamental), parameters.Symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), config, new Cash(CashBook.AccountCurrency, 0, 1), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var request = new SubscriptionRequest(false, null, security, config, parameters.StartDate, parameters.EndDate);
             var fileProvider = new DefaultDataProvider();
 
@@ -95,7 +102,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             var endDate = new DateTime(2014, 4, 30);
 
             var config = new SubscriptionDataConfig(typeof(FineFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork), config, new Cash(CashBook.AccountCurrency, 0, 1), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(CashBook.AccountCurrency, 0, 1),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var request = new SubscriptionRequest(false, null, security, config, startDate, endDate);
             var fileProvider = new DefaultDataProvider();
             var factory = new FineFundamentalSubscriptionEnumeratorFactory(false);

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -26,6 +26,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Equity;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
 {
@@ -62,7 +63,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 var quoteCurrency = new Cash(CashBook.AccountCurrency, 0, 1);
                 var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, Symbols.SPY, SecurityType.Equity);
                 var config = new SubscriptionDataConfig(typeof(RestData), Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
-                var security = new Equity(Symbols.SPY, exchangeHours, quoteCurrency, SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                var security = new Equity(
+                    Symbols.SPY,
+                    exchangeHours,
+                    quoteCurrency,
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                );
                 var request = new SubscriptionRequest(false, null, security, config, _referenceUtc.AddSeconds(-1), _referenceUtc.AddDays(1));
 
                 var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(_timeProvider, _dataSourceReader.Object);
@@ -130,7 +137,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 var quoteCurrency = new Cash(CashBook.AccountCurrency, 0, 1);
                 var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, Symbols.SPY, SecurityType.Equity);
                 var config = new SubscriptionDataConfig(typeof(RestCollectionData), Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
-                var security = new Equity(Symbols.SPY, exchangeHours, quoteCurrency, SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                var security = new Equity(
+                    Symbols.SPY,
+                    exchangeHours,
+                    quoteCurrency,
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                );
                 var request = new SubscriptionRequest(false, null, security, config, _referenceUtc.AddSeconds(-4), _referenceUtc.AddDays(1));
 
                 var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(_timeProvider, _dataSourceReader.Object);
@@ -205,7 +218,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 var quoteCurrency = new Cash(CashBook.AccountCurrency, 0, 1);
                 var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, Symbols.SPY, SecurityType.Equity);
                 var config = new SubscriptionDataConfig(typeof(RemoteFileData), Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
-                var security = new Equity(Symbols.SPY, exchangeHours, quoteCurrency, SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                var security = new Equity(
+                    Symbols.SPY,
+                    exchangeHours,
+                    quoteCurrency,
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                );
                 var request = new SubscriptionRequest(false, null, security, config, _referenceUtc.AddSeconds(-6), _referenceUtc.AddDays(1));
 
                 var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(_timeProvider, _dataSourceReader.Object);
@@ -275,7 +294,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 var quoteCurrency = new Cash(CashBook.AccountCurrency, 0, 1);
                 var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, Symbols.SPY, SecurityType.Equity);
                 var config = new SubscriptionDataConfig(typeof(RemoteFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
-                var security = new Equity(Symbols.SPY, exchangeHours, quoteCurrency, SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                var security = new Equity(
+                    Symbols.SPY,
+                    exchangeHours,
+                    quoteCurrency,
+                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                    ErrorCurrencyConverter.Instance
+                );
                 var request = new SubscriptionRequest(false, null, security, config, _referenceUtc.AddDays(-2), _referenceUtc.AddDays(1));
 
                 var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(_timeProvider, _dataSourceReader.Object);

--- a/Tests/Engine/DataFeeds/SubscriptionCollectionTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionCollectionTests.cs
@@ -28,6 +28,7 @@ using QuantConnect.Securities;
 using QuantConnect.Securities.Equity;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Option;
+using QuantConnect.Tests.Common.Securities;
 using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
@@ -43,7 +44,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var start = DateTime.UtcNow;
             var end = start.AddSeconds(10);
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, DateTimeZone.Utc, DateTimeZone.Utc, true, false, false);
-            var security = new Equity(Symbols.SPY, SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), new Cash("USD", 0, 1), SymbolProperties.GetDefault("USD"));
+            var security = new Equity(
+                Symbols.SPY,
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                new Cash("USD", 0, 1),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(DateTimeZone.Utc, start, end);
             var enumerator = new EnqueueableEnumerator<BaseData>();
             var subscriptionDataEnumerator = SubscriptionData.Enumerator(config, security, timeZoneOffsetProvider, enumerator);
@@ -316,19 +323,37 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             if (type == SecurityType.Equity)
             {
                 _symbol = new Symbol(SecurityIdentifier.GenerateEquity(DateTime.Now, symbol, Market.USA), symbol);
-                security = new Equity(_symbol, SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), new Cash("USD", 0, 1), SymbolProperties.GetDefault("USD"));
+                security = new Equity(
+                    _symbol,
+                    SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                    new Cash("USD", 0, 1),
+                    SymbolProperties.GetDefault("USD"),
+                    ErrorCurrencyConverter.Instance
+                );
             }
             else if (type == SecurityType.Option)
             {
                 _symbol = new Symbol(SecurityIdentifier.GenerateOption(DateTime.Now,
                     SecurityIdentifier.GenerateEquity(DateTime.Now, symbol, Market.USA),
                     Market.USA, 0.0m, OptionRight.Call, OptionStyle.American), symbol);
-                security = new Option(_symbol, SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), new Cash("USD", 0, 1), new OptionSymbolProperties(SymbolProperties.GetDefault("USD")));
+                security = new Option(
+                    _symbol,
+                    SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                    new Cash("USD", 0, 1),
+                    new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
+                    ErrorCurrencyConverter.Instance
+                );
             }
             else if (type == SecurityType.Future)
             {
                 _symbol = new Symbol(SecurityIdentifier.GenerateFuture(DateTime.Now, symbol, Market.USA), symbol);
-                security = new Future(_symbol, SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), new Cash("USD", 0, 1), SymbolProperties.GetDefault("USD"));
+                security = new Future(
+                    _symbol,
+                    SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                    new Cash("USD", 0, 1),
+                    SymbolProperties.GetDefault("USD"),
+                    ErrorCurrencyConverter.Instance
+                );
             }
             else
             {

--- a/Tests/Engine/DataFeeds/TimeSliceTests.cs
+++ b/Tests/Engine/DataFeeds/TimeSliceTests.cs
@@ -28,6 +28,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Equity;
 using QuantConnect.Securities.Option;
+using QuantConnect.Tests.Common.Securities;
 using QuandlFuture = QuantConnect.Algorithm.CSharp.QCUQuandlFutures.QuandlFuture;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
@@ -52,7 +53,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 subscriptionDataConfig,
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             DateTime refTime = DateTime.UtcNow;
 
@@ -101,13 +104,17 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 subscriptionDataConfig1,
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             var security2 = new Security(
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 subscriptionDataConfig1,
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             var timeSlice = TimeSlice.Create(DateTime.UtcNow, TimeZones.Utc, new CashBook(),
                 new List<DataFeedPacket>
@@ -143,7 +150,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 subscriptionDataConfig,
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
 
             var refTime = DateTime.UtcNow;
 
@@ -206,14 +215,23 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void TimeSliceCreateDoesNotThrowNullReferanceWhenUnderlyingIsNull()
         {
             var optionSymbol = Symbol.Create("SVXY", SecurityType.Option, Market.USA);
-            var underlyingSecurity = new Equity(optionSymbol.Underlying, SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), new Cash("USD", 0, 1), SymbolProperties.GetDefault("USD"));
+            var underlyingSecurity = new Equity(
+                optionSymbol.Underlying,
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                new Cash("USD", 0, 1),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
             var subscriptionDataConfig = new SubscriptionDataConfig(
                 typeof(DailyFx), optionSymbol, Resolution.Daily, TimeZones.Utc, TimeZones.Utc, true, true, false, isCustom: true);
 
-            var optionSecurity = new Option(optionSymbol,
-                    SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
-                    new Cash(CashBook.AccountCurrency, 0, 1m),
-                    new OptionSymbolProperties(SymbolProperties.GetDefault("USD")));
+            var optionSecurity = new Option(
+                optionSymbol,
+                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
+                ErrorCurrencyConverter.Instance
+            );
 
             var refTime = DateTime.UtcNow;
             var timeSlice = TimeSlice.Create(refTime, TimeZones.Utc, new CashBook(),
@@ -233,15 +251,24 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void TimeSliceCreateDoesNotThrowNullReferanceWhenUnderlyingSecurityLastDataIsNull()
         {
             var optionSymbol = Symbol.Create("SVXY", SecurityType.Option, Market.USA);
-            var underlyingSecurity = new Equity(optionSymbol.Underlying, SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc), new Cash("USD", 0, 1), SymbolProperties.GetDefault("USD"));
+            var underlyingSecurity = new Equity(
+                optionSymbol.Underlying,
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                new Cash("USD", 0, 1),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
             var subscriptionDataConfig = new SubscriptionDataConfig(
                 typeof(DailyFx), optionSymbol, Resolution.Daily, TimeZones.Utc, TimeZones.Utc, true, true, false, isCustom: true);
 
-            var optionSecurity = new Option(optionSymbol,
-                                            SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
-                                            new Cash(CashBook.AccountCurrency, 0, 1m),
-                                            new OptionSymbolProperties(SymbolProperties.GetDefault("USD")))
-            { Underlying = underlyingSecurity };
+            var optionSecurity = new Option(
+                    optionSymbol,
+                    SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                    new Cash(CashBook.AccountCurrency, 0, 1m),
+                    new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
+                    ErrorCurrencyConverter.Instance
+                )
+                {Underlying = underlyingSecurity};
 
             var refTime = DateTime.UtcNow;
             var timeSlice = TimeSlice.Create(refTime, TimeZones.Utc, new CashBook(),
@@ -260,7 +287,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         private IEnumerable<Slice> GetSlices(Symbol symbol, int initialVolume)
         {
             var subscriptionDataConfig = new SubscriptionDataConfig(typeof(ZipEntryName), symbol, Resolution.Second, TimeZones.Utc, TimeZones.Utc, true, true, false);
-            var security = new Security(SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), subscriptionDataConfig, new Cash(CashBook.AccountCurrency, 0, 1m), SymbolProperties.GetDefault(CashBook.AccountCurrency));
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                subscriptionDataConfig,
+                new Cash(CashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
             var refTime = DateTime.UtcNow;
 
             return Enumerable

--- a/Tests/Engine/RealTimePriceUpdateTests.cs
+++ b/Tests/Engine/RealTimePriceUpdateTests.cs
@@ -25,6 +25,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Packets;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Engine
 {
@@ -94,7 +95,13 @@ namespace QuantConnect.Tests.Engine
         [Test]
         public void ClosedExchanges_DoNotIndicateRealTimePriceUpdates()
         {
-            var security = new Security(Symbol.Empty, _exchangeHours, new Cash("USA", 100m, 1m), SymbolProperties.GetDefault("USA"));
+            var security = new Security(
+                Symbol.Empty,
+                _exchangeHours,
+                new Cash("USA", 100m, 1m),
+                SymbolProperties.GetDefault("USA"),
+                ErrorCurrencyConverter.Instance
+            );
             var subscription = new Subscription(null, security, null, null, new TimeZoneOffsetProviderNeverOpen(), DateTime.MinValue, DateTime.MaxValue, false);
             Assert.IsFalse(_liveTradingDataFeed.UpdateRealTimePrice(subscription, new TimeZoneOffsetProviderNeverOpen()));
         }
@@ -102,7 +109,13 @@ namespace QuantConnect.Tests.Engine
         [Test]
         public void OpenExchanges_DoIndicateRealTimePriceUpdates()
         {
-            var security = new Security(Symbol.Empty, _exchangeHours, new Cash("USA", 100m, 1m), SymbolProperties.GetDefault("USA"));
+            var security = new Security(
+                Symbol.Empty,
+                _exchangeHours,
+                new Cash("USA", 100m, 1m),
+                SymbolProperties.GetDefault("USA"),
+                ErrorCurrencyConverter.Instance
+            );
             var subscription = new Subscription(null, security, null, null, new TimeZoneOffsetProviderAlwaysOpen(), DateTime.MinValue, DateTime.MaxValue, false);
             Assert.IsTrue(_liveTradingDataFeed.UpdateRealTimePrice(subscription, new TimeZoneOffsetProviderAlwaysOpen()));
         }

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -26,6 +26,7 @@ using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Tests.Common.Securities;
 using QuantConnect.Tests.ToolBox;
 using QuantConnect.ToolBox;
 using QuantConnect.Util;
@@ -508,7 +509,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 subscriptionDataConfig,
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
         }
     }
 }

--- a/Tests/Python/SecurityCustomModelTests.cs
+++ b/Tests/Python/SecurityCustomModelTests.cs
@@ -142,7 +142,9 @@ class CustomBuyingPowerModel(SecurityMarginModel):
                 SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 subscriptionDataConfig,
                 new Cash(CashBook.AccountCurrency, 0, 1m),
-                SymbolProperties.GetDefault(CashBook.AccountCurrency));
+                SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance
+            );
         }
     }
 }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
     <Compile Include="Common\Securities\CashAmountTests.cs" />
     <Compile Include="Common\Data\Custom\QuandlTests.cs" />
+    <Compile Include="Common\Securities\ErrorCurrencyConverterTests.cs" />
     <Compile Include="Common\Securities\IdentityCurrencyConverterTests.cs" />
     <Compile Include="Common\Securities\SecurityHoldingTests.cs" />
     <Compile Include="Common\Util\SeriesJsonConverterTests.cs" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
     <Compile Include="Common\Securities\CashAmountTests.cs" />
     <Compile Include="Common\Data\Custom\QuandlTests.cs" />
+    <Compile Include="Common\Securities\IdentityCurrencyConverterTests.cs" />
     <Compile Include="Common\Securities\SecurityHoldingTests.cs" />
     <Compile Include="Common\Util\SeriesJsonConverterTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The scope of this change is small but the breadth is large, which is why I've decided to submit this as a standalone PR so it doesn't create noise for future changes that involve more involved logic/refactoring.

This change adds two new `ICurrencyConverter` implementations, an `IdentityCurrencyConverter` (currently unused), and an `ErrorCurrencyConverter`. The identity implementation returns the input `CashAmount` untouched unless the specified amount is not in units of the account currency, in which case it throws. This is a sensible default value that can be used in situations where we're guaranteed to be working in units of the account currency. This type is purposefully not used in LEAN infrastructure but is provided in the inevitable case that it's required to maintain backwards compatibility. The `ErrorCurrencyConverter` is intended to be used everywhere we assume that it won't be invoked, as it's implementation throws an exception immediately on every call. This implementation has widespread use among the exist unit tests and also in certain contexts where we create temporary security objects, for example, history requests, that won't require it's services. If in the future they do require these conversion services, we'll need to properly pipe the required algorithm dependencies into those providers.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #1418 - this is but a small step towards satisfying the goals set out in this issue.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A (conceptually) small change to embed the `ICurrencyConverter` dependency privately inside security objects as it was identified as a place that requires it (for example, `TotalCloseProfit()`). This is being PR'd separately to avoid noise in future changes that have impact on behavior and logic.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Wrote unit tests for new classes, as well as existing coverage via regression and existing unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) [on the way to a feature]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

### A note to reviewers:
> All unit test edits appear worse than they are due to long lines being formatted in a more sensible way. Some of these lines of codes were almost 300 characters long! So I let R# handle reformatting of the affected lines to ensure consistency of formatting (and speed of implementation).