### PR TITLE
Fix ManualUniverse duplicate effort

### DIFF
--- a/Algorithm.CSharp/Alphas/RebalancingLeveragedETFAlpha.cs
+++ b/Algorithm.CSharp/Alphas/RebalancingLeveragedETFAlpha.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Algorithm.CSharp.Alphas
 			}
 
 			// Manually curated universe
-			SetUniverseSelection(new ManualUniverseSelectionModel(Securities.Keys));
+			SetUniverseSelection(new ManualUniverseSelectionModel());
 
 			// Select the demonstration alpha model
 			SetAlpha(new RebalancingLeveragedETFAlphaModel(Groups));

--- a/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Algorithm.CSharp
             AddEquity("AIG");
 
             // define a manual universe of all the securities we manually registered
-            SetUniverseSelection(new ManualUniverseSelectionModel(Securities.Keys));
+            SetUniverseSelection(new ManualUniverseSelectionModel());
 
             // define alpha model as a composite of the rsi and ema cross models
             SetAlpha(new CompositeAlphaModel(

--- a/Algorithm.Framework/QCAlgorithmFrameworkBridge.cs
+++ b/Algorithm.Framework/QCAlgorithmFrameworkBridge.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Algorithm.Framework
             // set universe model if still null, needed to wait for AddSecurity calls
             if (UniverseSelection == null)
             {
-                SetUniverseSelection(new ManualUniverseSelectionModel(Securities.Keys));
+                SetUniverseSelection(new ManualUniverseSelectionModel());
             }
 
             base.PostInitialize();

--- a/Algorithm.Framework/Selection/ManualUniverse.cs
+++ b/Algorithm.Framework/Selection/ManualUniverse.cs
@@ -27,6 +27,8 @@ namespace QuantConnect.Algorithm.Framework.Selection
     /// Defines a universe as a set of manually set symbols. This differs from <see cref="UserDefinedUniverse"/>
     /// in that these securities were not added via AddSecurity.
     /// </summary>
+    /// <remarks>Incompatible with multiple <see cref="Universe"/> selecting the same <see cref="Symbol"/>.
+    /// with different <see cref="SubscriptionDataConfig"/>. More information <see cref="GetSubscriptionRequests"/></remarks>
     public class ManualUniverse : UserDefinedUniverse
     {
         /// <summary>
@@ -60,18 +62,26 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="subscriptionService">Instance which implements <see cref="ISubscriptionDataConfigService"/> interface</param>
         /// <returns>All subscriptions required by this security</returns>
         public override IEnumerable<SubscriptionRequest> GetSubscriptionRequests(Security security, DateTime currentTimeUtc, DateTime maximumEndTimeUtc,
-                                                                                ISubscriptionDataConfigService subscriptionService)
+            ISubscriptionDataConfigService subscriptionService)
         {
-            return security.Subscriptions.Select(config =>
-                new SubscriptionRequest(
-                    isUniverseSubscription: false,
-                    universe: this,
-                    security: security,
-                    configuration: new SubscriptionDataConfig(config, isInternalFeed: false),
-                    startTimeUtc: currentTimeUtc,
-                    endTimeUtc: maximumEndTimeUtc
-                )
-            );
+            // ManualUniverse will return any existing SDC for the symbol, else will create new, using universe settings.
+            // This is for maintaining existing behavior and preventing breaking changes: Specifically motivated
+            // by usages of Algorithm.Securities.Keys as constructor parameter of the ManualUniverseSelectionModel.
+            // Symbols at Algorithm.Securities.Keys added by Addxxx() calls will already be added by the UserDefinedUniverse.
+
+            var existingSubscriptionDataConfigs = subscriptionService.GetSubscriptionDataConfigs(security.Symbol);
+
+            if (existingSubscriptionDataConfigs.Any())
+            {
+                return existingSubscriptionDataConfigs.Select(
+                    config => new SubscriptionRequest(isUniverseSubscription: false,
+                        universe: this,
+                        security: security,
+                        configuration: config,
+                        startTimeUtc: currentTimeUtc,
+                        endTimeUtc: maximumEndTimeUtc));
+            }
+            return base.GetSubscriptionRequests(security, currentTimeUtc, maximumEndTimeUtc, subscriptionService);
         }
     }
 }

--- a/Algorithm.Framework/Selection/ManualUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ManualUniverseSelectionModel.cs
@@ -39,7 +39,17 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// Initializes a new instance of the <see cref="ManualUniverseSelectionModel"/> class using the algorithm's
         /// security initializer and universe settings
         /// </summary>
-        /// <param name="symbols">The symbols to subscribe to</param>
+        public ManualUniverseSelectionModel()
+            : this(Enumerable.Empty<Symbol>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManualUniverseSelectionModel"/> class using the algorithm's
+        /// security initializer and universe settings
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe to.
+        /// Should not send in symbols at <see cref="QCAlgorithm.Securities"/> since those will be managed by the <see cref="UserDefinedUniverse"/></param>
         public ManualUniverseSelectionModel(IEnumerable<Symbol> symbols)
             : this(symbols.ToArray())
         {
@@ -49,7 +59,8 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// Initializes a new instance of the <see cref="ManualUniverseSelectionModel"/> class using the algorithm's
         /// security initializer and universe settings
         /// </summary>
-        /// <param name="symbols">The symbols to subscribe to</param>
+        /// <param name="symbols">The symbols to subscribe to
+        /// Should not send in symbols at <see cref="QCAlgorithm.Securities"/> since those will be managed by the <see cref="UserDefinedUniverse"/></param>
         public ManualUniverseSelectionModel(params Symbol[] symbols)
             : this (symbols?.AsEnumerable(), null, null)
         {
@@ -58,7 +69,8 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <summary>
         /// Initializes a new instance of the <see cref="ManualUniverseSelectionModel"/> class
         /// </summary>
-        /// <param name="symbols">The symbols to subscribe to</param>
+        /// <param name="symbols">The symbols to subscribe to
+        /// Should not send in symbols at <see cref="QCAlgorithm.Securities"/> since those will be managed by the <see cref="UserDefinedUniverse"/></param>
         /// <param name="universeSettings">The settings used when adding symbols to the algorithm, specify null to use algorthm.UniverseSettings</param>
         /// <param name="securityInitializer">Optional security initializer invoked when creating new securities, specify null to use algorithm.SecurityInitializer</param>
         public ManualUniverseSelectionModel(IEnumerable<Symbol> symbols, UniverseSettings universeSettings, ISecurityInitializer securityInitializer)

--- a/Algorithm.Python/Alphas/RebalancingLeveragedETFAlpha.py
+++ b/Algorithm.Python/Alphas/RebalancingLeveragedETFAlpha.py
@@ -52,7 +52,7 @@ class RebalancingLeveragedETFAlpha(QCAlgorithmFramework):
             groups.append(group)
 
         # Manually curated universe
-        self.SetUniverseSelection(ManualUniverseSelectionModel(self.Securities.Keys))
+        self.SetUniverseSelection(ManualUniverseSelectionModel())
         # Select the demonstration alpha model
         self.SetAlpha(RebalancingLeveragedETFAlphaModel(groups))
         # Select our default model types

--- a/Algorithm.Python/CompositeAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/CompositeAlphaModelFrameworkAlgorithm.py
@@ -52,7 +52,7 @@ class CompositeAlphaModelFrameworkAlgorithm(QCAlgorithmFramework):
         self.AddEquity("AIG")
 
         # define a manual universe of all the securities we manually registered
-        self.SetUniverseSelection(ManualUniverseSelectionModel(self.Securities.Keys))
+        self.SetUniverseSelection(ManualUniverseSelectionModel())
 
         # define alpha model as a composite of the rsi and ema cross models
         self.SetAlpha(CompositeAlphaModel(RsiAlphaModel(), EmaCrossAlphaModel()))

--- a/Common/Interfaces/ISubscriptionDataConfigService.cs
+++ b/Common/Interfaces/ISubscriptionDataConfigService.cs
@@ -21,15 +21,15 @@ using QuantConnect.Data;
 namespace QuantConnect.Interfaces
 {
     /// <summary>
-    ///     This interface exposes methods for creating a list of <see cref="SubscriptionDataConfig" /> for a given
-    ///     configuration
+    /// This interface exposes methods for creating a list of <see cref="SubscriptionDataConfig" /> for a given
+    /// configuration
     /// </summary>
     public interface ISubscriptionDataConfigService
     {
         /// <summary>
-        ///     Creates and adds a list of <see cref="SubscriptionDataConfig" /> for a given symbol and configuration.
-        ///     Can optionally pass in desired subscription data types to use.
-        ///     If the config already existed will return existing instance instead
+        /// Creates and adds a list of <see cref="SubscriptionDataConfig" /> for a given symbol and configuration.
+        /// Can optionally pass in desired subscription data types to use.
+        /// If the config already existed will return existing instance instead
         /// </summary>
         List<SubscriptionDataConfig> Add(
             Symbol symbol,
@@ -43,7 +43,7 @@ namespace QuantConnect.Interfaces
             );
 
         /// <summary>
-        ///     Get the data feed types for a given <see cref="SecurityType" /> <see cref="Resolution" />
+        /// Get the data feed types for a given <see cref="SecurityType" /> <see cref="Resolution" />
         /// </summary>
         /// <param name="symbolSecurityType">The <see cref="SecurityType" /> used to determine the types</param>
         /// <param name="resolution">The resolution of the data requested</param>
@@ -56,8 +56,13 @@ namespace QuantConnect.Interfaces
             );
 
         /// <summary>
-        ///     Gets the available data types
+        /// Gets the available data types
         /// </summary>
         Dictionary<SecurityType, List<TickType>> AvailableDataTypes { get; }
+
+        /// <summary>
+        /// Gets a list of all registered <see cref="SubscriptionDataConfig"/> for a given <see cref="Symbol"/>
+        /// </summary>
+        List<SubscriptionDataConfig> GetSubscriptionDataConfigs(Symbol symbol);
     }
 }

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -28,7 +28,7 @@ using QuantConnect.Util;
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
     /// <summary>
-    ///     DataManager will manage the subscriptions for both the DataFeeds and the SubscriptionManager
+    /// DataManager will manage the subscriptions for both the DataFeeds and the SubscriptionManager
     /// </summary>
     public class DataManager : IAlgorithmSubscriptionManager, IDataFeedSubscriptionManager, IDataManager
     {
@@ -43,7 +43,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             = new ConcurrentDictionary<SubscriptionDataConfig, SubscriptionDataConfig>();
 
         /// <summary>
-        ///     Creates a new instance of the DataManager
+        /// Creates a new instance of the DataManager
         /// </summary>
         public DataManager(IDataFeed dataFeed, UniverseSelection universeSelection, IAlgorithmSettings algorithmSettings, ITimeKeeper timeKeeper)
         {
@@ -57,7 +57,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         #region IDataFeedSubscriptionManager
 
         /// <summary>
-        ///     Gets the data feed subscription collection
+        /// Gets the data feed subscription collection
         /// </summary>
         public SubscriptionCollection DataFeedSubscriptions { get; } = new SubscriptionCollection();
 
@@ -66,18 +66,26 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         #region IAlgorithmSubscriptionManager
 
         /// <summary>
-        ///     Flags the existence of custom data in the subscriptions
+        /// Flags the existence of custom data in the subscriptions
         /// </summary>
         public bool HasCustomData { get; set; }
 
         /// <summary>
-        ///     Gets all the current data config subscriptions that are being processed for the SubscriptionManager
+        /// Gets all the current data config subscriptions that are being processed for the SubscriptionManager
         /// </summary>
         public IEnumerable<SubscriptionDataConfig> SubscriptionManagerSubscriptions =>
             _subscriptionManagerSubscriptions.Select(x => x.Key);
 
         /// <summary>
-        ///     Gets existing or adds new <see cref="SubscriptionDataConfig" />
+        /// Gets a list of all registered <see cref="SubscriptionDataConfig"/> for a given <see cref="Symbol"/>
+        /// </summary>
+        public List<SubscriptionDataConfig> GetSubscriptionDataConfigs(Symbol symbol)
+        {
+            return SubscriptionManagerSubscriptions.Where(x => x.Symbol == symbol).ToList();
+        }
+
+        /// <summary>
+        /// Gets existing or adds new <see cref="SubscriptionDataConfig" />
         /// </summary>
         /// <returns>Returns the SubscriptionDataConfig instance used</returns>
         public SubscriptionDataConfig SubscriptionManagerGetOrAdd(SubscriptionDataConfig newConfig)
@@ -116,7 +124,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        ///     Returns the amount of data config subscriptions processed for the SubscriptionManager
+        /// Returns the amount of data config subscriptions processed for the SubscriptionManager
         /// </summary>
         public int SubscriptionManagerCount()
         {
@@ -126,14 +134,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         #region ISubscriptionDataConfigService
 
         /// <summary>
-        ///     The different <see cref="TickType" /> each <see cref="SecurityType" /> supports
+        /// The different <see cref="TickType" /> each <see cref="SecurityType" /> supports
         /// </summary>
         public Dictionary<SecurityType, List<TickType>> AvailableDataTypes { get; }
 
         /// <summary>
-        ///     Creates and adds a list of <see cref="SubscriptionDataConfig" /> for a given symbol and configuration.
-        ///     Can optionally pass in desired subscription data types to use.
-        ///     If the config already existed will return existing instance instead
+        /// Creates and adds a list of <see cref="SubscriptionDataConfig" /> for a given symbol and configuration.
+        /// Can optionally pass in desired subscription data types to use.
+        /// If the config already existed will return existing instance instead
         /// </summary>
         public List<SubscriptionDataConfig> Add(
             Symbol symbol,
@@ -175,10 +183,18 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var result = (from subscriptionDataType in dataTypes
                 let dataType = subscriptionDataType.Item1
                 let tickType = subscriptionDataType.Item2
-                select new SubscriptionDataConfig(dataType, symbol, resolution, marketHoursDbEntry.DataTimeZone,
-                    exchangeHours.TimeZone, fillForward, extendedMarketHours,
-                    isInternalFeed, isCustomData,
-                    isFilteredSubscription: isFilteredSubscription, tickType: tickType,
+                select new SubscriptionDataConfig(
+                    dataType,
+                    symbol,
+                    resolution,
+                    marketHoursDbEntry.DataTimeZone,
+                    exchangeHours.TimeZone,
+                    fillForward,
+                    extendedMarketHours,
+                    isInternalFeed,
+                    isCustomData,
+                    isFilteredSubscription: isFilteredSubscription,
+                    tickType: tickType,
                     dataNormalizationMode: dataNormalizationMode)).ToList();
 
             for (int i = 0; i < result.Count; i++)
@@ -189,7 +205,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        ///     Get the data feed types for a given <see cref="SecurityType" /> <see cref="Resolution" />
+        /// Get the data feed types for a given <see cref="SecurityType" /> <see cref="Resolution" />
         /// </summary>
         /// <param name="symbolSecurityType">The <see cref="SecurityType" /> used to determine the types</param>
         /// <param name="resolution">The resolution of the data requested</param>
@@ -217,12 +233,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         #region IDataManager
 
         /// <summary>
-        ///     Get the universe selection instance
+        /// Get the universe selection instance
         /// </summary>
         public UniverseSelection UniverseSelection { get; }
 
         /// <summary>
-        ///     Returns an enumerable which provides the data to stream to the algorithm
+        /// Returns an enumerable which provides the data to stream to the algorithm
         /// </summary>
         public IEnumerable<TimeSlice> StreamData()
         {

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             // Set the alpha model
             _algorithm.SetAlpha(model);
-            _algorithm.SetUniverseSelection(new ManualUniverseSelectionModel(_algorithm.Securities.Keys));
+            _algorithm.SetUniverseSelection(new ManualUniverseSelectionModel());
 
             var changes = new SecurityChanges(AddedSecurities, RemovedSecurities);
             _algorithm.OnFrameworkSecuritiesChanged(changes);

--- a/Tests/Algorithm/Framework/QCAlgorithmFrameworkTests.cs
+++ b/Tests/Algorithm/Framework/QCAlgorithmFrameworkTests.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
                 Assert.IsTrue(insights.All(insight => insight.CloseTimeUtc != default(DateTime)));
             };
             var security = algo.AddEquity("SPY");
-            algo.SetUniverseSelection(new ManualUniverseSelectionModel(algo.Securities.Keys));
+            algo.SetUniverseSelection(new ManualUniverseSelectionModel());
 
             var alpha = new FakeAlpha();
             algo.SetAlpha(alpha);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Removed usages of `algorithm.Securities.key` as a parameter for the
`ManualUniverseSelectionModel()` since those securities, added through
`AddXXXX` calls will be managed by the `UserDefinedUniverse`. This was
causing both Universes to try to add the same subscription requests
- Adding new empty constructor for `ManualUniverseSelectionModel`,
required for Python
- ManualUniverse will return any existing SDC for the symbol (when security.subscriptions is removed it will be able to return empty). This is for maintaining existing behavior and preventing breaking changes: Specifically motivated by usages of `Algorithm.Securities.Keys` as constructor parameter of the `ManualUniverseSelectionModel`, since those `Symbols` added by `Addxxx()` calls will already be managed by the UserDefinedUniverse
- Making some format modifications to aling with used Lean formatting

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2596
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/5
This change helps in the effort of stop using `Security.Subscriptions`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Adding a note to the constructors of `ManualUniverseSelectionModel()`
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->