### PR TITLE
Fix duplicate application of dividends in live paper

### DIFF
--- a/QuantConnect.Lean.sln.DotSettings
+++ b/QuantConnect.Lean.sln.DotSettings
@@ -1,6 +1,8 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
     <s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_INVOCATION_PARS/@EntryValue">INSIDE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_INVOCATION_RPAR/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 </wpf:ResourceDictionary>

--- a/Tests/Brokerages/Paper/PaperBrokerageTests.cs
+++ b/Tests/Brokerages/Paper/PaperBrokerageTests.cs
@@ -14,12 +14,30 @@
  *
 */
 
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using QuantConnect.Brokerages.Paper;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine;
+using QuantConnect.Lean.Engine.Alphas;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.RealTime;
+using QuantConnect.Lean.Engine.Results;
+using QuantConnect.Lean.Engine.Server;
+using QuantConnect.Lean.Engine.Setup;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Messaging;
+using QuantConnect.Packets;
+using QuantConnect.Tests.Engine;
 using QuantConnect.Tests.Engine.DataFeeds;
+using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Brokerages.Paper
 {
@@ -29,34 +47,153 @@ namespace QuantConnect.Tests.Brokerages.Paper
         [Test]
         public void AppliesDividendDistributionDirectlyToPortfolioCashBook()
         {
-            // init algo
-            var algo = new AlgorithmStub();
-            algo.AddSecurities(equities: new List<string> {"SPY"});
-            algo.PostInitialize();
+            // init algorithm
+            var algorithm = new AlgorithmStub();
+            algorithm.AddSecurities(equities: new List<string> {"SPY"});
+            algorithm.PostInitialize();
 
             // init holdings
-            var SPY = algo.Securities[Symbols.SPY];
+            var SPY = algorithm.Securities[Symbols.SPY];
             SPY.SetMarketPrice(new Tick {Value = 100m});
             SPY.Holdings.SetHoldings(100m, 1000);
 
             // resolve expected outcome
-            var USD = algo.Portfolio.CashBook["USD"];
+            var USD = algorithm.Portfolio.CashBook["USD"];
             var preDistributionCash = USD.Amount;
             var distributionPerShare = 10m;
             var expectedTotalDistribution = distributionPerShare * SPY.Holdings.Quantity;
 
             // create slice w/ dividend
-            var slice = new Slice(algo.Time, new List<BaseData>());
-            slice.Dividends.Add(new Dividend(Symbols.SPY, algo.Time, distributionPerShare, 100m));
-            algo.SetCurrentSlice(slice);
+            var slice = new Slice(algorithm.Time, new List<BaseData>());
+            slice.Dividends.Add(new Dividend(Symbols.SPY, algorithm.Time, distributionPerShare, 100m));
+            algorithm.SetCurrentSlice(slice);
 
             // invoke brokerage
-            var brokerage = new PaperBrokerage(algo, null);
+            var brokerage = new PaperBrokerage(algorithm, null);
             brokerage.Scan();
 
             // verify results
             var postDistributionCash = USD.Amount;
             Assert.AreEqual(preDistributionCash + expectedTotalDistribution, postDistributionCash);
+        }
+
+        [Test]
+        public void AppliesDividendsOnce()
+        {
+            // init algorithm
+            var algorithm = new AlgorithmStub();
+            algorithm.SetLiveMode(true);
+            var dividend = new Dividend(Symbols.SPY, DateTime.UtcNow, 10m, 100m);
+            var feed = new TestDividendDataFeed(algorithm, dividend);
+            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings, algorithm.TimeKeeper);
+            algorithm.SubscriptionManager.SetDataManager(dataManager);
+            algorithm.AddSecurities(equities: new List<string> {"SPY"});
+            algorithm.Securities[Symbols.SPY].Holdings.SetHoldings(100m, 1);
+            algorithm.PostInitialize();
+
+            var initializedCash = algorithm.Portfolio.CashBook["USD"].Amount;
+
+            // init algorithm manager
+            var manager = new AlgorithmManager(true);
+            var job = new LiveNodePacket
+            {
+                UserId = 1,
+                ProjectId = 2,
+                DeployId = $"{nameof(PaperBrokerageTests)}.{nameof(AppliesDividendsOnce)}"
+            };
+            var results = new LiveTradingResultHandler();
+            var transactions = new BacktestingTransactionHandler();
+            var brokerage = new PaperBrokerage(algorithm, job);
+
+            // initialize results and transactions
+            results.Initialize(job, new EventMessagingHandler(), new Api.Api(), feed, new BrokerageSetupHandler(), transactions);
+            results.SetAlgorithm(algorithm);
+            transactions.Initialize(algorithm, brokerage, results);
+
+            // run algorithm manager
+            manager.Run(job,
+                algorithm,
+                dataManager,
+                transactions,
+                results,
+                new BacktestingRealTimeHandler(),
+                new AlgorithmManagerTests.NullLeanManager(),
+                new AlgorithmManagerTests.NullAlphaHandler(),
+                new CancellationToken()
+            );
+
+            var postDividendCash = algorithm.Portfolio.CashBook["USD"].Amount;
+
+            Assert.AreEqual(initializedCash + dividend.Distribution, postDividendCash);
+        }
+
+        class TestDividendDataFeed : IDataFeed
+        {
+            private readonly IAlgorithm _algorithm;
+            private readonly Dividend _dividend;
+            private readonly Symbol _symbol;
+
+            public TestDividendDataFeed(IAlgorithm algorithm, Dividend dividend)
+            {
+                _algorithm = algorithm;
+                _dividend = dividend;
+                _symbol = dividend.Symbol;
+            }
+            public IEnumerator<TimeSlice> GetEnumerator()
+            {
+                var dataFeedPacket = new DataFeedPacket(_algorithm.Securities[_symbol],
+                    _algorithm.SubscriptionManager.Subscriptions.First(s => s.Symbol == _symbol),
+                    new List<BaseData> {_dividend}, Ref.CreateReadOnly(() => false));
+
+                yield return TimeSlice.Create(DateTime.UtcNow,
+                    TimeZones.NewYork,
+                    _algorithm.Portfolio.CashBook,
+                    new List<DataFeedPacket> {dataFeedPacket},
+                    SecurityChanges.None,
+                    new Dictionary<Universe, BaseDataCollection>()
+                );
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public IEnumerable<Subscription> Subscriptions => new List<Subscription>();
+            public bool IsActive => true;
+
+            public void Initialize(
+                IAlgorithm algorithm,
+                AlgorithmNodePacket job,
+                IResultHandler resultHandler,
+                IMapFileProvider mapFileProvider,
+                IFactorFileProvider factorFileProvider,
+                IDataProvider dataProvider,
+                IDataFeedSubscriptionManager subscriptionManager
+                )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool AddSubscription(SubscriptionRequest request)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool RemoveSubscription(SubscriptionDataConfig configuration)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Run()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Exit()
+            {
+                throw new System.NotImplementedException();
+            }
         }
     }
 }

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -181,7 +181,7 @@ namespace QuantConnect.Tests.Engine
             }
         }
 
-        class NullAlphaHandler : IAlphaHandler
+        public class NullAlphaHandler : IAlphaHandler
         {
             public bool IsActive { get; }
             public AlphaRuntimeStatistics RuntimeStatistics { get; }
@@ -206,7 +206,7 @@ namespace QuantConnect.Tests.Engine
             }
         }
 
-        class NullLeanManager : ILeanManager
+        public class NullLeanManager : ILeanManager
         {
             public void Dispose()
             {


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This bug was only recently introduced via PR #2592. The issue is that the PaperBrokerage's Scan method is invoked twice per time loop. This change adds tracking to ensure we only invoke the dividend detection/application on the first Scan invocation of a time loop. Tests added to confirm behavior.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #2569 and #2592 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix duplication application of dividend distribution in live mode.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test added.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->