### PR TITLE
Fix custom data history requests failing silently for download errors

### DIFF
--- a/Brokerages/Tradier/TradierBrokerage.HistoryProvider.cs
+++ b/Brokerages/Tradier/TradierBrokerage.HistoryProvider.cs
@@ -31,6 +31,23 @@ namespace QuantConnect.Brokerages.Tradier
     {
         #region IHistoryProvider implementation
 
+#pragma warning disable CS0067 // The event is never used
+        /// <summary>
+        /// Event fired when an error message should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+
+        /// <summary>
+        /// Event fired when a debug message should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<DebugMessageEventArgs> DebugMessage;
+
+        /// <summary>
+        /// Event fired when a runtime error should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+#pragma warning restore CS0067
+
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
         /// </summary>

--- a/Brokerages/Tradier/TradierBrokerage.HistoryProvider.cs
+++ b/Brokerages/Tradier/TradierBrokerage.HistoryProvider.cs
@@ -31,22 +31,25 @@ namespace QuantConnect.Brokerages.Tradier
     {
         #region IHistoryProvider implementation
 
-#pragma warning disable CS0067 // The event is never used
         /// <summary>
-        /// Event fired when an error message should be sent to the algorithm
+        /// Event fired when an invalid configuration has been detected
         /// </summary>
-        public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+        public event EventHandler<InvalidConfigurationDetectedEventArgs> InvalidConfigurationDetected;
 
         /// <summary>
-        /// Event fired when a debug message should be sent to the algorithm
+        /// Event fired when the numerical precision in the factor file has been limited
         /// </summary>
-        public event EventHandler<DebugMessageEventArgs> DebugMessage;
+        public event EventHandler<NumericalPrecisionLimitedEventArgs> NumericalPrecisionLimited;
 
         /// <summary>
-        /// Event fired when a runtime error should be sent to the algorithm
+        /// Event fired when there was an error downloading a remote file
         /// </summary>
-        public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
-#pragma warning restore CS0067
+        public event EventHandler<DownloadFailedEventArgs> DownloadFailed;
+
+        /// <summary>
+        /// Event fired when there was an error reading the data
+        /// </summary>
+        public event EventHandler<ReaderErrorDetectedEventArgs> ReaderErrorDetected;
 
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
@@ -114,6 +117,42 @@ namespace QuantConnect.Brokerages.Tradier
                     yield return slice;
                 }
             }
+        }
+
+        /// <summary>
+        /// Event invocator for the <see cref="InvalidConfigurationDetected"/> event
+        /// </summary>
+        /// <param name="e">Event arguments for the <see cref="InvalidConfigurationDetected"/> event</param>
+        protected virtual void OnInvalidConfigurationDetected(InvalidConfigurationDetectedEventArgs e)
+        {
+            InvalidConfigurationDetected?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Event invocator for the <see cref="NumericalPrecisionLimited"/> event
+        /// </summary>
+        /// <param name="e">Event arguments for the <see cref="NumericalPrecisionLimited"/> event</param>
+        protected virtual void OnNumericalPrecisionLimited(NumericalPrecisionLimitedEventArgs e)
+        {
+            NumericalPrecisionLimited?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Event invocator for the <see cref="DownloadFailed"/> event
+        /// </summary>
+        /// <param name="e">Event arguments for the <see cref="DownloadFailed"/> event</param>
+        protected virtual void OnDownloadFailed(DownloadFailedEventArgs e)
+        {
+            DownloadFailed?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Event invocator for the <see cref="ReaderErrorDetected"/> event
+        /// </summary>
+        /// <param name="e">Event arguments for the <see cref="ReaderErrorDetected"/> event</param>
+        protected virtual void OnReaderErrorDetected(ReaderErrorDetectedEventArgs e)
+        {
+            ReaderErrorDetected?.Invoke(this, e);
         }
 
         private IEnumerable<Slice> GetHistoryTick(Symbol symbol, DateTime start, DateTime end)

--- a/Brokerages/Tradier/TradierBrokerage.HistoryProvider.cs
+++ b/Brokerages/Tradier/TradierBrokerage.HistoryProvider.cs
@@ -1,16 +1,16 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  *
 */
 
@@ -20,8 +20,6 @@ using System.Linq;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Interfaces;
-using QuantConnect.Packets;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Brokerages.Tradier
@@ -41,13 +39,8 @@ namespace QuantConnect.Brokerages.Tradier
         /// <summary>
         /// Initializes this history provider to work for the specified job
         /// </summary>
-        /// <param name="job">The job</param>
-        /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
-        /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
-        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
-        /// <param name="statusUpdate">Function used to send status updates</param>
-        /// <param name="dataCacheProvider">Provider used to cache history data files</param>
-        public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+        /// <param name="parameters">The initialization parameters</param>
+        public void Initialize(HistoryProviderInitializeParameters parameters)
         {
         }
 
@@ -146,12 +139,12 @@ namespace QuantConnect.Brokerages.Tradier
                 })
                 .GroupBy(x => x.Time.RoundDown(Time.OneSecond))
                 .Select(g => new TradeBar(
-                    g.Key, 
-                    symbol, 
-                    g.First().LastPrice, 
-                    g.Max(t => t.LastPrice), 
-                    g.Min(t => t.LastPrice), 
-                    g.Last().LastPrice, 
+                    g.Key,
+                    symbol,
+                    g.First().LastPrice,
+                    g.Max(t => t.LastPrice),
+                    g.Min(t => t.LastPrice),
+                    g.Last().LastPrice,
                     g.Sum(t => t.Quantity),
                     Time.OneSecond))
                 .Select(tradeBar => new Slice(tradeBar.EndTime, new[] { tradeBar }))

--- a/Common/Data/HistoryProviderBase.cs
+++ b/Common/Data/HistoryProviderBase.cs
@@ -16,10 +16,9 @@
 using System;
 using System.Collections.Generic;
 using NodaTime;
-using QuantConnect.Data;
 using QuantConnect.Interfaces;
 
-namespace QuantConnect.Lean.Engine.HistoricalData
+namespace QuantConnect.Data
 {
     /// <summary>
     /// Provides a base type for all history providers

--- a/Common/Data/HistoryProviderInitializeParameters.cs
+++ b/Common/Data/HistoryProviderInitializeParameters.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Interfaces;
+using QuantConnect.Packets;
+
+namespace QuantConnect.Data
+{
+    /// <summary>
+    /// Represents the set of parameters for the <see cref="IHistoryProvider.Initialize"/> method
+    /// </summary>
+    public class HistoryProviderInitializeParameters
+    {
+        /// <summary>
+        /// The job
+        /// </summary>
+        public AlgorithmNodePacket Job { get; }
+
+        /// <summary>
+        /// The provider used to get data when it is not present on disk
+        /// </summary>
+        public IDataProvider DataProvider { get; }
+
+        /// <summary>
+        /// The provider used to cache history data files
+        /// </summary>
+        public IDataCacheProvider DataCacheProvider { get; }
+
+        /// <summary>
+        /// The provider used to get a map file resolver to handle equity mapping
+        /// </summary>
+        public IMapFileProvider MapFileProvider { get; }
+
+        /// <summary>
+        /// The provider used to get factor files to handle equity price scaling
+        /// </summary>
+        public IFactorFileProvider FactorFileProvider { get; }
+
+        /// <summary>
+        /// A function used to send status updates
+        /// </summary>
+        public Action<int> StatusUpdateAction { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HistoryProviderInitializeParameters"/> class from the specified parameters
+        /// </summary>
+        /// <param name="job">The job</param>
+        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
+        /// <param name="dataCacheProvider">Provider used to cache history data files</param>
+        /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
+        /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
+        /// <param name="statusUpdateAction">Function used to send status updates</param>
+        public HistoryProviderInitializeParameters(
+            AlgorithmNodePacket job,
+            IDataProvider dataProvider,
+            IDataCacheProvider dataCacheProvider,
+            IMapFileProvider mapFileProvider,
+            IFactorFileProvider factorFileProvider,
+            Action<int> statusUpdateAction)
+        {
+            Job = job;
+            DataProvider = dataProvider;
+            DataCacheProvider = dataCacheProvider;
+            MapFileProvider = mapFileProvider;
+            FactorFileProvider = factorFileProvider;
+            StatusUpdateAction = statusUpdateAction;
+        }
+    }
+}

--- a/Common/HistoryProviderEvents.cs
+++ b/Common/HistoryProviderEvents.cs
@@ -1,0 +1,94 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect
+{
+    /// <summary>
+    /// Event arguments for the <see cref="IHistoryProvider.ErrorMessage"/> event
+    /// </summary>
+    public sealed class ErrorMessageEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the error message
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets the error stack trace
+        /// </summary>
+        public string StackTrace { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ErrorMessageEventArgs"/> class
+        /// </summary>
+        /// <param name="message">The error message</param>
+        /// <param name="stackTrace">The error stack trace</param>
+        public ErrorMessageEventArgs(string message, string stackTrace = "")
+        {
+            Message = message;
+            StackTrace = stackTrace;
+        }
+    }
+
+    /// <summary>
+    /// Event arguments for the <see cref="IHistoryProvider.DebugMessage"/> event
+    /// </summary>
+    public sealed class DebugMessageEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the error message
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DebugMessageEventArgs"/> class
+        /// </summary>
+        /// <param name="message">The debug message</param>
+        public DebugMessageEventArgs(string message)
+        {
+            Message = message;
+        }
+    }
+
+    /// <summary>
+    /// Event arguments for the <see cref="IHistoryProvider.RuntimeError"/> event
+    /// </summary>
+    public sealed class RuntimeErrorEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the error message
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets the error stack trace
+        /// </summary>
+        public string StackTrace { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RuntimeErrorEventArgs"/> class
+        /// </summary>
+        /// <param name="message">The error message</param>
+        /// <param name="stackTrace">The error stack trace</param>
+        public RuntimeErrorEventArgs(string message, string stackTrace = "")
+        {
+            Message = message;
+            StackTrace = stackTrace;
+        }
+    }
+}

--- a/Common/Interfaces/IHistoryProvider.cs
+++ b/Common/Interfaces/IHistoryProvider.cs
@@ -29,19 +29,24 @@ namespace QuantConnect.Interfaces
     public interface IHistoryProvider
     {
         /// <summary>
-        /// Event fired when an error message should be sent to the algorithm
+        /// Event fired when an invalid configuration has been detected
         /// </summary>
-        event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+        event EventHandler<InvalidConfigurationDetectedEventArgs> InvalidConfigurationDetected;
 
         /// <summary>
-        /// Event fired when a debug message should be sent to the algorithm
+        /// Event fired when the numerical precision in the factor file has been limited
         /// </summary>
-        event EventHandler<DebugMessageEventArgs> DebugMessage;
+        event EventHandler<NumericalPrecisionLimitedEventArgs> NumericalPrecisionLimited;
 
         /// <summary>
-        /// Event fired when a runtime error should be sent to the algorithm
+        /// Event fired when there was an error downloading a remote file
         /// </summary>
-        event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+        event EventHandler<DownloadFailedEventArgs> DownloadFailed;
+
+        /// <summary>
+        /// Event fired when there was an error reading the data
+        /// </summary>
+        event EventHandler<ReaderErrorDetectedEventArgs> ReaderErrorDetected;
 
         /// <summary>
         /// Gets the total number of data points emitted by this history provider

--- a/Common/Interfaces/IHistoryProvider.cs
+++ b/Common/Interfaces/IHistoryProvider.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,12 +13,10 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using NodaTime;
 using QuantConnect.Data;
-using QuantConnect.Packets;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Interfaces
@@ -37,13 +35,8 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Initializes this history provider to work for the specified job
         /// </summary>
-        /// <param name="job">The job</param>
-        /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
-        /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
-        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
-        /// <param name="statusUpdate">Function used to send status updates</param>
-        /// <param name="dataCacheProvider">Provider used to cache history data files</param>
-        void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate);
+        /// <param name="parameters">The initialization parameters</param>
+        void Initialize(HistoryProviderInitializeParameters parameters);
 
         /// <summary>
         /// Gets the history for the requested securities

--- a/Common/Interfaces/IHistoryProvider.cs
+++ b/Common/Interfaces/IHistoryProvider.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using NodaTime;
@@ -27,6 +28,21 @@ namespace QuantConnect.Interfaces
     [InheritedExport(typeof(IHistoryProvider))]
     public interface IHistoryProvider
     {
+        /// <summary>
+        /// Event fired when an error message should be sent to the algorithm
+        /// </summary>
+        event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+
+        /// <summary>
+        /// Event fired when a debug message should be sent to the algorithm
+        /// </summary>
+        event EventHandler<DebugMessageEventArgs> DebugMessage;
+
+        /// <summary>
+        /// Event fired when a runtime error should be sent to the algorithm
+        /// </summary>
+        event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
         /// </summary>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Chart.cs" />
     <Compile Include="ChartPoint.cs" />
     <Compile Include="Data\HistoryProviderInitializeParameters.cs" />
+    <Compile Include="HistoryProviderEvents.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Brokerages\GDAXBrokerageModel.cs" />
     <Compile Include="Chart.cs" />
     <Compile Include="ChartPoint.cs" />
+    <Compile Include="Data\HistoryProviderInitializeParameters.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Brokerages\GDAXBrokerageModel.cs" />
     <Compile Include="Chart.cs" />
     <Compile Include="ChartPoint.cs" />
+    <Compile Include="Data\HistoryProviderBase.cs" />
     <Compile Include="Data\HistoryProviderInitializeParameters.cs" />
     <Compile Include="HistoryProviderEvents.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -93,9 +93,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 _includeAuxiliaryData
                 );
 
-            dataReader.DebugMessage += (sender, args) => { _resultHandler.DebugMessage(args.Message); };
-            dataReader.ErrorMessage += (sender, args) => { _resultHandler.ErrorMessage(args.Message, args.StackTrace); };
-            dataReader.RuntimeError += (sender, args) => { _resultHandler.RuntimeError(args.Message, args.StackTrace); };
+            dataReader.InvalidConfigurationDetected += (sender, args) => { _resultHandler.ErrorMessage(args.Message); };
+            dataReader.NumericalPrecisionLimited += (sender, args) => { _resultHandler.DebugMessage(args.Message); };
+            dataReader.DownloadFailed += (sender, args) => { _resultHandler.ErrorMessage(args.Message, args.StackTrace); };
+            dataReader.ReaderErrorDetected += (sender, args) => { _resultHandler.RuntimeError(args.Message, args.StackTrace); };
 
             dataReader.Initialize();
 

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -77,23 +77,29 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <returns>An enumerator reading the subscription request</returns>
         public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
         {
-            var mapFileResolver = request.Configuration.SecurityType == SecurityType.Equity || 
+            var mapFileResolver = request.Configuration.SecurityType == SecurityType.Equity ||
                                   request.Configuration.SecurityType == SecurityType.Option
                                     ? _mapFileProvider.Get(request.Security.Symbol.ID.Market)
                                     : MapFileResolver.Empty;
 
-            return new SubscriptionDataReader(request.Configuration,
+            var dataReader = new SubscriptionDataReader(request.Configuration,
                 request.StartTimeLocal,
                 request.EndTimeLocal,
-                _resultHandler,
                 mapFileResolver,
                 _factorFileProvider,
-                _dataProvider,
                 _tradableDaysProvider(request),
                 _isLiveMode,
                  _zipDataCacheProvider,
                 _includeAuxiliaryData
                 );
+
+            dataReader.DebugMessage += (sender, args) => { _resultHandler.DebugMessage(args.Message); };
+            dataReader.ErrorMessage += (sender, args) => { _resultHandler.ErrorMessage(args.Message, args.StackTrace); };
+            dataReader.RuntimeError += (sender, args) => { _resultHandler.RuntimeError(args.Message, args.StackTrace); };
+
+            dataReader.Initialize();
+
+            return dataReader;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -37,6 +37,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     /// <remarks>The class accepts any subscription configuration and automatically makes it availble to enumerate</remarks>
     public class SubscriptionDataReader : IEnumerator<BaseData>
     {
+        private bool _initialized;
+
         // Source string to create memory stream:
         private SubscriptionDataSource _source;
 
@@ -175,6 +177,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public void Initialize()
         {
+            if (_initialized)
+            {
+                return;
+            }
+
             //Save the type of data we'll be getting from the source.
 
             //Create the dynamic type-activators:
@@ -287,6 +294,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             _subscriptionFactoryEnumerator = ResolveDataEnumerator(true);
+
+            _initialized = true;
         }
 
         /// <summary>
@@ -298,6 +307,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <exception cref="T:System.InvalidOperationException">The collection was modified after the enumerator was created. </exception><filterpriority>2</filterpriority>
         public bool MoveNext()
         {
+            if (!_initialized)
+            {
+                Initialize();
+            }
+
             if (_endOfStream)
             {
                 return false;
@@ -778,10 +792,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public void Dispose()
         {
-            if (_subscriptionFactoryEnumerator != null)
-            {
-                _subscriptionFactoryEnumerator.Dispose();
-            }
+            _subscriptionFactoryEnumerator?.Dispose();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/SubscriptionDataReaderEvents.cs
+++ b/Engine/DataFeeds/SubscriptionDataReaderEvents.cs
@@ -14,12 +14,11 @@
 */
 
 using System;
-using QuantConnect.Interfaces;
 
-namespace QuantConnect
+namespace QuantConnect.Lean.Engine.DataFeeds
 {
     /// <summary>
-    /// Event arguments for the <see cref="IHistoryProvider.InvalidConfigurationDetected"/> event
+    /// Event arguments for the <see cref="SubscriptionDataReader.InvalidConfigurationDetected"/> event
     /// </summary>
     public sealed class InvalidConfigurationDetectedEventArgs : EventArgs
     {
@@ -39,7 +38,7 @@ namespace QuantConnect
     }
 
     /// <summary>
-    /// Event arguments for the <see cref="IHistoryProvider.NumericalPrecisionLimited"/> event
+    /// Event arguments for the <see cref="SubscriptionDataReader.NumericalPrecisionLimited"/> event
     /// </summary>
     public sealed class NumericalPrecisionLimitedEventArgs : EventArgs
     {
@@ -59,7 +58,7 @@ namespace QuantConnect
     }
 
     /// <summary>
-    /// Event arguments for the <see cref="IHistoryProvider.DownloadFailed"/> event
+    /// Event arguments for the <see cref="SubscriptionDataReader.DownloadFailed"/> event
     /// </summary>
     public sealed class DownloadFailedEventArgs : EventArgs
     {
@@ -86,7 +85,7 @@ namespace QuantConnect
     }
 
     /// <summary>
-    /// Event arguments for the <see cref="IHistoryProvider.ReaderErrorDetected"/> event
+    /// Event arguments for the <see cref="SubscriptionDataReader.ReaderErrorDetected"/> event
     /// </summary>
     public sealed class ReaderErrorDetectedEventArgs : EventArgs
     {

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -164,9 +164,10 @@ namespace QuantConnect.Lean.Engine
                         )
                     );
 
-                    historyProvider.DebugMessage += (sender, args) => { _algorithmHandlers.Results.DebugMessage(args.Message); };
-                    historyProvider.ErrorMessage += (sender, args) => { _algorithmHandlers.Results.ErrorMessage(args.Message, args.StackTrace); };
-                    historyProvider.RuntimeError += (sender, args) => { _algorithmHandlers.Results.RuntimeError(args.Message, args.StackTrace); };
+                    historyProvider.InvalidConfigurationDetected += (sender, args) => { _algorithmHandlers.Results.ErrorMessage(args.Message); };
+                    historyProvider.NumericalPrecisionLimited += (sender, args) => { _algorithmHandlers.Results.DebugMessage(args.Message); };
+                    historyProvider.DownloadFailed += (sender, args) => { _algorithmHandlers.Results.ErrorMessage(args.Message, args.StackTrace); };
+                    historyProvider.ReaderErrorDetected += (sender, args) => { _algorithmHandlers.Results.RuntimeError(args.Message, args.StackTrace); };
 
                     algorithm.HistoryProvider = historyProvider;
 

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -164,6 +164,10 @@ namespace QuantConnect.Lean.Engine
                         )
                     );
 
+                    historyProvider.DebugMessage += (sender, args) => { _algorithmHandlers.Results.DebugMessage(args.Message); };
+                    historyProvider.ErrorMessage += (sender, args) => { _algorithmHandlers.Results.ErrorMessage(args.Message, args.StackTrace); };
+                    historyProvider.RuntimeError += (sender, args) => { _algorithmHandlers.Results.RuntimeError(args.Message, args.StackTrace); };
+
                     algorithm.HistoryProvider = historyProvider;
 
                     // initialize the default brokerage message handler

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Threading;
 using QuantConnect.Brokerages;
 using QuantConnect.Configuration;
+using QuantConnect.Data;
 using QuantConnect.Exceptions;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
@@ -144,15 +145,24 @@ namespace QuantConnect.Lean.Engine
                     }
 
                     var historyDataCacheProvider = new ZipDataCacheProvider(_algorithmHandlers.DataProvider);
-                    historyProvider.Initialize(job, _algorithmHandlers.DataProvider, historyDataCacheProvider, _algorithmHandlers.MapFileProvider, _algorithmHandlers.FactorFileProvider, progress =>
-                    {
-                        // send progress updates to the result handler only during initialization
-                        if (!algorithm.GetLocked() || algorithm.IsWarmingUp)
-                        {
-                            _algorithmHandlers.Results.SendStatusUpdate(AlgorithmStatus.History,
-                                string.Format("Processing history {0}%...", progress));
-                        }
-                    });
+                    historyProvider.Initialize(
+                        new HistoryProviderInitializeParameters(
+                            job,
+                            _algorithmHandlers.DataProvider,
+                            historyDataCacheProvider,
+                            _algorithmHandlers.MapFileProvider,
+                            _algorithmHandlers.FactorFileProvider,
+                            progress =>
+                            {
+                                // send progress updates to the result handler only during initialization
+                                if (!algorithm.GetLocked() || algorithm.IsWarmingUp)
+                                {
+                                    _algorithmHandlers.Results.SendStatusUpdate(AlgorithmStatus.History,
+                                        string.Format("Processing history {0}%...", progress));
+                                }
+                            }
+                        )
+                    );
 
                     algorithm.HistoryProvider = historyProvider;
 
@@ -506,7 +516,5 @@ namespace QuantConnect.Lean.Engine
                 }
             }
         }
-
-
     } // End Algorithm Node Core Thread
 } // End Namespace

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using NodaTime;
 using QuantConnect.Data;
@@ -21,7 +20,6 @@ using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
-using QuantConnect.Packets;
 using QuantConnect.Securities;
 using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
@@ -48,14 +46,8 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         /// <summary>
         /// Initializes this history provider to work for the specified job
         /// </summary>
-        /// <param name="job">The job</param>
-        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
-        /// <param name="dataCacheProvider">Provider used to cache history data files</param>
-        /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
-        /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
-        /// <param name="statusUpdate">Function used to send status updates</param>
-        public override void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider,
-            IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+        /// <param name="parameters">The initialization parameters</param>
+        public override void Initialize(HistoryProviderInitializeParameters parameters)
         {
             _brokerage.Connect();
         }

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using NodaTime;
 using QuantConnect.Data;
@@ -33,6 +34,23 @@ namespace QuantConnect.Lean.Engine.HistoricalData
     public class BrokerageHistoryProvider : SynchronizingHistoryProvider
     {
         private IBrokerage _brokerage;
+
+#pragma warning disable CS0067 // The event is never used
+        /// <summary>
+        /// Event fired when an error message should be sent to the algorithm
+        /// </summary>
+        public override event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+
+        /// <summary>
+        /// Event fired when a debug message should be sent to the algorithm
+        /// </summary>
+        public override event EventHandler<DebugMessageEventArgs> DebugMessage;
+
+        /// <summary>
+        /// Event fired when a runtime error should be sent to the algorithm
+        /// </summary>
+        public override event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+#pragma warning restore CS0067
 
         /// <summary>
         /// Sets the brokerage to be used for historical requests

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using NodaTime;
 using QuantConnect.Data;
@@ -34,23 +33,6 @@ namespace QuantConnect.Lean.Engine.HistoricalData
     public class BrokerageHistoryProvider : SynchronizingHistoryProvider
     {
         private IBrokerage _brokerage;
-
-#pragma warning disable CS0067 // The event is never used
-        /// <summary>
-        /// Event fired when an error message should be sent to the algorithm
-        /// </summary>
-        public override event EventHandler<ErrorMessageEventArgs> ErrorMessage;
-
-        /// <summary>
-        /// Event fired when a debug message should be sent to the algorithm
-        /// </summary>
-        public override event EventHandler<DebugMessageEventArgs> DebugMessage;
-
-        /// <summary>
-        /// Event fired when a runtime error should be sent to the algorithm
-        /// </summary>
-        public override event EventHandler<RuntimeErrorEventArgs> RuntimeError;
-#pragma warning restore CS0067
 
         /// <summary>
         /// Sets the brokerage to be used for historical requests

--- a/Engine/HistoricalData/HistoryProviderBase.cs
+++ b/Engine/HistoricalData/HistoryProviderBase.cs
@@ -1,0 +1,104 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NodaTime;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Lean.Engine.HistoricalData
+{
+    /// <summary>
+    /// Provides a base type for all history providers
+    /// </summary>
+    public abstract class HistoryProviderBase : IHistoryProvider
+    {
+        /// <summary>
+        /// Event fired when an invalid configuration has been detected
+        /// </summary>
+        public event EventHandler<InvalidConfigurationDetectedEventArgs> InvalidConfigurationDetected;
+
+        /// <summary>
+        /// Event fired when the numerical precision in the factor file has been limited
+        /// </summary>
+        public event EventHandler<NumericalPrecisionLimitedEventArgs> NumericalPrecisionLimited;
+
+        /// <summary>
+        /// Event fired when there was an error downloading a remote file
+        /// </summary>
+        public event EventHandler<DownloadFailedEventArgs> DownloadFailed;
+
+        /// <summary>
+        /// Event fired when there was an error reading the data
+        /// </summary>
+        public event EventHandler<ReaderErrorDetectedEventArgs> ReaderErrorDetected;
+
+        /// <summary>
+        /// Gets the total number of data points emitted by this history provider
+        /// </summary>
+        public abstract int DataPointCount { get; }
+
+        /// <summary>
+        /// Initializes this history provider to work for the specified job
+        /// </summary>
+        /// <param name="parameters">The initialization parameters</param>
+        public abstract void Initialize(HistoryProviderInitializeParameters parameters);
+
+        /// <summary>
+        /// Gets the history for the requested securities
+        /// </summary>
+        /// <param name="requests">The historical data requests</param>
+        /// <param name="sliceTimeZone">The time zone used when time stamping the slice instances</param>
+        /// <returns>An enumerable of the slices of data covering the span specified in each request</returns>
+        public abstract IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone);
+
+        /// <summary>
+        /// Event invocator for the <see cref="InvalidConfigurationDetected"/> event
+        /// </summary>
+        /// <param name="e">Event arguments for the <see cref="InvalidConfigurationDetected"/> event</param>
+        protected virtual void OnInvalidConfigurationDetected(InvalidConfigurationDetectedEventArgs e)
+        {
+            InvalidConfigurationDetected?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Event invocator for the <see cref="NumericalPrecisionLimited"/> event
+        /// </summary>
+        /// <param name="e">Event arguments for the <see cref="NumericalPrecisionLimited"/> event</param>
+        protected virtual void OnNumericalPrecisionLimited(NumericalPrecisionLimitedEventArgs e)
+        {
+            NumericalPrecisionLimited?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Event invocator for the <see cref="DownloadFailed"/> event
+        /// </summary>
+        /// <param name="e">Event arguments for the <see cref="DownloadFailed"/> event</param>
+        protected virtual void OnDownloadFailed(DownloadFailedEventArgs e)
+        {
+            DownloadFailed?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Event invocator for the <see cref="ReaderErrorDetected"/> event
+        /// </summary>
+        /// <param name="e">Event arguments for the <see cref="ReaderErrorDetected"/> event</param>
+        protected virtual void OnReaderErrorDetected(ReaderErrorDetectedEventArgs e)
+        {
+            ReaderErrorDetected?.Invoke(this, e);
+        }
+    }
+}

--- a/Engine/HistoricalData/SineHistoryProvider.cs
+++ b/Engine/HistoricalData/SineHistoryProvider.cs
@@ -19,7 +19,6 @@ using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
-using QuantConnect.Packets;
 using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
@@ -54,13 +53,8 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         /// <summary>
         /// Initializes this history provider to work for the specified job
         /// </summary>
-        /// <param name="job">The job</param>
-        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
-        /// <param name="dataCacheProvider">Provider used to cache history data files</param>
-        /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
-        /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
-        /// <param name="statusUpdate">Function used to send status updates</param>
-        public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+        /// <param name="parameters">The initialization parameters</param>
+        public void Initialize(HistoryProviderInitializeParameters parameters)
         {
         }
 

--- a/Engine/HistoricalData/SineHistoryProvider.cs
+++ b/Engine/HistoricalData/SineHistoryProvider.cs
@@ -36,6 +36,23 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         private readonly SecurityChanges _securityChanges = SecurityChanges.None;
         private readonly SecurityManager _securities;
 
+#pragma warning disable CS0067 // The event is never used
+        /// <summary>
+        /// Event fired when an error message should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+
+        /// <summary>
+        /// Event fired when a debug message should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<DebugMessageEventArgs> DebugMessage;
+
+        /// <summary>
+        /// Event fired when a runtime error should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+#pragma warning restore CS0067
+
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
         /// </summary>

--- a/Engine/HistoricalData/SineHistoryProvider.cs
+++ b/Engine/HistoricalData/SineHistoryProvider.cs
@@ -17,7 +17,6 @@ using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
-using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 using System;
@@ -30,33 +29,16 @@ namespace QuantConnect.Lean.Engine.HistoricalData
     /// <summary>
     /// Implements a History provider that always return a IEnumerable of Slice with prices following a sine function
     /// </summary>
-    public class SineHistoryProvider : IHistoryProvider
+    public class SineHistoryProvider : HistoryProviderBase
     {
         private readonly CashBook _cashBook = new CashBook();
         private readonly SecurityChanges _securityChanges = SecurityChanges.None;
         private readonly SecurityManager _securities;
 
-#pragma warning disable CS0067 // The event is never used
-        /// <summary>
-        /// Event fired when an error message should be sent to the algorithm
-        /// </summary>
-        public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
-
-        /// <summary>
-        /// Event fired when a debug message should be sent to the algorithm
-        /// </summary>
-        public event EventHandler<DebugMessageEventArgs> DebugMessage;
-
-        /// <summary>
-        /// Event fired when a runtime error should be sent to the algorithm
-        /// </summary>
-        public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
-#pragma warning restore CS0067
-
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
         /// </summary>
-        public int DataPointCount => 0;
+        public override int DataPointCount => 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SineHistoryProvider"/> class
@@ -71,7 +53,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         /// Initializes this history provider to work for the specified job
         /// </summary>
         /// <param name="parameters">The initialization parameters</param>
-        public void Initialize(HistoryProviderInitializeParameters parameters)
+        public override void Initialize(HistoryProviderInitializeParameters parameters)
         {
         }
 
@@ -81,7 +63,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         /// <param name="requests">The historical data requests</param>
         /// <param name="sliceTimeZone">The time zone used when time stamping the slice instances</param>
         /// <returns>An enumerable of the slices of data covering the span specified in each request</returns>
-        public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+        public override IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
         {
             var configsByDateTime = GetSubscriptionDataConfigByDateTime(requests);
             var count = configsByDateTime.Count;

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -45,8 +45,22 @@ namespace QuantConnect.Lean.Engine.HistoricalData
     {
         private IMapFileProvider _mapFileProvider;
         private IFactorFileProvider _factorFileProvider;
-        private IDataProvider _dataProvider;
         private IDataCacheProvider _dataCacheProvider;
+
+        /// <summary>
+        /// Event fired when an error message should be sent to the algorithm
+        /// </summary>
+        public override event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+
+        /// <summary>
+        /// Event fired when a debug message should be sent to the algorithm
+        /// </summary>
+        public override event EventHandler<DebugMessageEventArgs> DebugMessage;
+
+        /// <summary>
+        /// Event fired when a runtime error should be sent to the algorithm
+        /// </summary>
+        public override event EventHandler<RuntimeErrorEventArgs> RuntimeError;
 
         /// <summary>
         /// Initializes this history provider to work for the specified job
@@ -56,7 +70,6 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         {
             _mapFileProvider = parameters.MapFileProvider;
             _factorFileProvider = parameters.FactorFileProvider;
-            _dataProvider = parameters.DataProvider;
             _dataCacheProvider = parameters.DataCacheProvider;
         }
 
@@ -111,18 +124,24 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 ErrorCurrencyConverter.Instance
             );
 
-            IEnumerator<BaseData> reader = new SubscriptionDataReader(config,
+            var dataReader = new SubscriptionDataReader(config,
                 start,
                 end,
-                ResultHandlerStub.Instance,
                 config.SecurityType == SecurityType.Equity ? _mapFileProvider.Get(config.Market) : MapFileResolver.Empty,
                 _factorFileProvider,
-                _dataProvider,
                 Time.EachTradeableDay(request.ExchangeHours, start, end),
                 false,
                 _dataCacheProvider,
                 false
                 );
+
+            dataReader.DebugMessage += (sender, args) => { DebugMessage?.Invoke(this, args); };
+            dataReader.ErrorMessage += (sender, args) => { ErrorMessage?.Invoke(this, args); };
+            dataReader.RuntimeError += (sender, args) => { RuntimeError?.Invoke(this, args); };
+
+            dataReader.Initialize();
+
+            IEnumerator<BaseData> reader = dataReader;
 
             // optionally apply fill forward behavior
             if (request.FillForwardResolution.HasValue)
@@ -156,55 +175,6 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(security.Exchange.TimeZone, start, end);
             var subscriptionDataEnumerator = SubscriptionData.Enumerator(config, security, timeZoneOffsetProvider, reader);
             return new Subscription(null, security, config, subscriptionDataEnumerator, timeZoneOffsetProvider, start, end, false);
-        }
-
-        // this implementation is provided solely for the data reader's dependency,
-        // in the future we can refactor the data reader to not use the result handler
-        private class ResultHandlerStub : BaseResultsHandler, IResultHandler
-        {
-            public static readonly IResultHandler Instance = new ResultHandlerStub();
-
-            private ResultHandlerStub() { }
-
-            #region Implementation of IResultHandler
-
-            public ConcurrentQueue<Packet> Messages { get; set; }
-            public ConcurrentDictionary<string, Chart> Charts { get; set; }
-            public TimeSpan ResamplePeriod { get; private set; }
-            public TimeSpan NotificationPeriod { get; private set; }
-            public bool IsActive { get; private set; }
-
-            public void Initialize(AlgorithmNodePacket job,
-                IMessagingHandler messagingHandler,
-                IApi api,
-                IDataFeed dataFeed,
-                ISetupHandler setupHandler,
-                ITransactionHandler transactionHandler) { }
-            public void Run() { }
-            public void DebugMessage(string message) { }
-            public void SystemDebugMessage(string message) { }
-            public void SecurityType(List<SecurityType> types) { }
-            public void LogMessage(string message) { }
-            public void ErrorMessage(string error, string stacktrace = "") { }
-            public void RuntimeError(string message, string stacktrace = "") { }
-            public void Sample(string chartName, string seriesName, int seriesIndex, SeriesType seriesType, DateTime time, decimal value, string unit = "$") { }
-            public void SampleEquity(DateTime time, decimal value) { }
-            public void SamplePerformance(DateTime time, decimal value) { }
-            public void SampleBenchmark(DateTime time, decimal value) { }
-            public void SampleAssetPrices(Symbol symbol, DateTime time, decimal value) { }
-            public void SampleRange(List<Chart> samples) { }
-            public void SetAlgorithm(IAlgorithm algorithm) { }
-            public void StoreResult(Packet packet, bool async = false) { }
-            public void SendFinalResult(AlgorithmNodePacket job, Dictionary<int, Order> orders, Dictionary<DateTime, decimal> profitLoss, Dictionary<string, Holding> holdings, CashBook cashbook, StatisticsResults statisticsResults, Dictionary<string, string> banner) { }
-            public void SendStatusUpdate(AlgorithmStatus status, string message = "") { }
-            public void SetChartSubscription(string symbol) { }
-            public void RuntimeStatistic(string key, string value) { }
-            public void OrderEvent(OrderEvent newEvent) { }
-            public void Exit() { }
-            public void PurgeQueue() { }
-            public void ProcessSynchronousEvents(bool forceProcess = false) { }
-
-            #endregion
         }
 
         private class FilterEnumerator<T> : IEnumerator<T>

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -51,18 +51,13 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         /// <summary>
         /// Initializes this history provider to work for the specified job
         /// </summary>
-        /// <param name="job">The job</param>
-        /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
-        /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
-        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
-        /// <param name="statusUpdate">Function used to send status updates</param>
-        /// <param name="dataCacheProvider">Provider used to cache history data files</param>
-        public override void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+        /// <param name="parameters">The initialization parameters</param>
+        public override void Initialize(HistoryProviderInitializeParameters parameters)
         {
-            _mapFileProvider = mapFileProvider;
-            _factorFileProvider = factorFileProvider;
-            _dataProvider = dataProvider;
-            _dataCacheProvider = dataCacheProvider;
+            _mapFileProvider = parameters.MapFileProvider;
+            _factorFileProvider = parameters.FactorFileProvider;
+            _dataProvider = parameters.DataProvider;
+            _dataCacheProvider = parameters.DataCacheProvider;
         }
 
         /// <summary>

--- a/Engine/HistoricalData/SynchronizingHistoryProvider.cs
+++ b/Engine/HistoricalData/SynchronizingHistoryProvider.cs
@@ -22,7 +22,6 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
-using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Lean.Engine.HistoricalData
 {
@@ -30,46 +29,14 @@ namespace QuantConnect.Lean.Engine.HistoricalData
     /// Provides an abstract implementation of <see cref="IHistoryProvider"/>
     /// which provides synchronization of multiple history results
     /// </summary>
-    public abstract class SynchronizingHistoryProvider : IHistoryProvider
+    public abstract class SynchronizingHistoryProvider : HistoryProviderBase
     {
         private int _dataPointCount;
 
         /// <summary>
-        /// Event fired when an error message should be sent to the algorithm
-        /// </summary>
-        public abstract event EventHandler<ErrorMessageEventArgs> ErrorMessage;
-
-        /// <summary>
-        /// Event fired when a debug message should be sent to the algorithm
-        /// </summary>
-        public abstract event EventHandler<DebugMessageEventArgs> DebugMessage;
-
-        /// <summary>
-        /// Event fired when a runtime error should be sent to the algorithm
-        /// </summary>
-        public abstract event EventHandler<RuntimeErrorEventArgs> RuntimeError;
-
-        /// <summary>
         /// Gets the total number of data points emitted by this history provider
         /// </summary>
-        public int DataPointCount
-        {
-            get { return _dataPointCount; }
-        }
-
-        /// <summary>
-        /// Initializes this history provider to work for the specified job
-        /// </summary>
-        /// <param name="parameters">The initialization parameters</param>
-        public abstract void Initialize(HistoryProviderInitializeParameters parameters);
-
-        /// <summary>
-        /// Gets the history for the requested securities
-        /// </summary>
-        /// <param name="requests">The historical data requests</param>
-        /// <param name="sliceTimeZone">The time zone used when time stamping the slice instances</param>
-        /// <returns>An enumerable of the slices of data covering the span specified in each request</returns>
-        public abstract IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone);
+        public override int DataPointCount => _dataPointCount;
 
         /// <summary>
         /// Enumerates the subscriptions into slices

--- a/Engine/HistoricalData/SynchronizingHistoryProvider.cs
+++ b/Engine/HistoricalData/SynchronizingHistoryProvider.cs
@@ -35,6 +35,21 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         private int _dataPointCount;
 
         /// <summary>
+        /// Event fired when an error message should be sent to the algorithm
+        /// </summary>
+        public abstract event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+
+        /// <summary>
+        /// Event fired when a debug message should be sent to the algorithm
+        /// </summary>
+        public abstract event EventHandler<DebugMessageEventArgs> DebugMessage;
+
+        /// <summary>
+        /// Event fired when a runtime error should be sent to the algorithm
+        /// </summary>
+        public abstract event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+
+        /// <summary>
         /// Gets the total number of data points emitted by this history provider
         /// </summary>
         public int DataPointCount

--- a/Engine/HistoricalData/SynchronizingHistoryProvider.cs
+++ b/Engine/HistoricalData/SynchronizingHistoryProvider.cs
@@ -21,7 +21,6 @@ using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
-using QuantConnect.Packets;
 using QuantConnect.Securities;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
@@ -46,14 +45,8 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         /// <summary>
         /// Initializes this history provider to work for the specified job
         /// </summary>
-        /// <param name="job">The job</param>
-        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
-        /// <param name="dataCacheProvider">Provider used to cache history data files</param>
-        /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
-        /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
-        /// <param name="statusUpdate">Function used to send status updates</param>
-        public abstract void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider,
-            IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate);
+        /// <param name="parameters">The initialization parameters</param>
+        public abstract void Initialize(HistoryProviderInitializeParameters parameters);
 
         /// <summary>
         /// Gets the history for the requested securities

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -159,6 +159,7 @@
     <Compile Include="DataFeeds\LiveFutureChainProvider.cs" />
     <Compile Include="DataFeeds\LiveOptionChainProvider.cs" />
     <Compile Include="DataFeeds\NullDataFeed.cs" />
+    <Compile Include="DataFeeds\SubscriptionDataReaderEvents.cs" />
     <Compile Include="DataFeeds\SubscriptionFrontierTimeProvider.cs" />
     <Compile Include="DataFeeds\SingleEntryDataCacheProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\BaseDataCollectionAggregatorEnumerator.cs" />
@@ -215,6 +216,7 @@
     <Compile Include="DataFeeds\UpdateData.cs" />
     <Compile Include="DataFeeds\ZipDataCacheProvider.cs" />
     <Compile Include="DataFeeds\ZipEntryNameSubscriptionDataSourceReader.cs" />
+    <Compile Include="HistoricalData\HistoryProviderBase.cs" />
     <Compile Include="HistoricalData\SineHistoryProvider.cs" />
     <Compile Include="Results\BaseResultsHandler.cs" />
     <Compile Include="Results\RegressionResultHandler.cs" />

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -216,7 +216,6 @@
     <Compile Include="DataFeeds\UpdateData.cs" />
     <Compile Include="DataFeeds\ZipDataCacheProvider.cs" />
     <Compile Include="DataFeeds\ZipEntryNameSubscriptionDataSourceReader.cs" />
-    <Compile Include="HistoricalData\HistoryProviderBase.cs" />
     <Compile Include="HistoricalData\SineHistoryProvider.cs" />
     <Compile Include="Results\BaseResultsHandler.cs" />
     <Compile Include="Results\RegressionResultHandler.cs" />

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -23,7 +23,6 @@ using QuantConnect.Indicators;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine;
 using QuantConnect.Lean.Engine.DataFeeds;
-using QuantConnect.Python;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Option;
@@ -74,7 +73,16 @@ namespace QuantConnect.Jupyter
 
                 var mapFileProvider = algorithmHandlers.MapFileProvider;
                 HistoryProvider = composer.GetExportedValueByTypeName<IHistoryProvider>(Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider"));
-                HistoryProvider.Initialize(null, algorithmHandlers.DataProvider, _dataCacheProvider, mapFileProvider, algorithmHandlers.FactorFileProvider, null);
+                HistoryProvider.Initialize(
+                    new HistoryProviderInitializeParameters(
+                        null,
+                        algorithmHandlers.DataProvider,
+                        _dataCacheProvider,
+                        mapFileProvider,
+                        algorithmHandlers.FactorFileProvider,
+                        null
+                    )
+                );
 
                 SetOptionChainProvider(new CachingOptionChainProvider(new BacktestingOptionChainProvider()));
                 SetFutureChainProvider(new CachingFutureChainProvider(new BacktestingFutureChainProvider()));

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -28,7 +28,6 @@ using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
-using QuantConnect.Packets;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;
@@ -228,8 +227,7 @@ namespace QuantConnect.Tests.Algorithm
             public string underlyingSymbol2 = "AAPL";
             public int DataPointCount { get; }
             public Resolution LastResolutionRequest;
-            public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider,
-                IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+            public void Initialize(HistoryProviderInitializeParameters parameters)
             {
                 throw new NotImplementedException();
             }

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -27,7 +27,6 @@ using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Market;
-using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -27,7 +27,7 @@ using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Market;
-using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;
@@ -221,25 +221,19 @@ namespace QuantConnect.Tests.Algorithm
                     select sub).FirstOrDefault();
         }
 
-        private class TestHistoryProvider : IHistoryProvider
+        private class TestHistoryProvider : HistoryProviderBase
         {
             public string underlyingSymbol = "GOOG";
             public string underlyingSymbol2 = "AAPL";
-            public int DataPointCount { get; }
+            public override int DataPointCount { get; }
             public Resolution LastResolutionRequest;
 
-#pragma warning disable CS0067 // The event is never used
-            public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
-            public event EventHandler<DebugMessageEventArgs> DebugMessage;
-            public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
-#pragma warning restore CS0067
-
-            public void Initialize(HistoryProviderInitializeParameters parameters)
+            public override void Initialize(HistoryProviderInitializeParameters parameters)
             {
                 throw new NotImplementedException();
             }
 
-            public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+            public override IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
             {
                 var now = DateTime.UtcNow;
                 LastResolutionRequest = requests.First().Resolution;

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -227,6 +227,13 @@ namespace QuantConnect.Tests.Algorithm
             public string underlyingSymbol2 = "AAPL";
             public int DataPointCount { get; }
             public Resolution LastResolutionRequest;
+
+#pragma warning disable CS0067 // The event is never used
+            public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+            public event EventHandler<DebugMessageEventArgs> DebugMessage;
+            public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+#pragma warning restore CS0067
+
             public void Initialize(HistoryProviderInitializeParameters parameters)
             {
                 throw new NotImplementedException();

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -20,7 +20,7 @@ using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Data;
-using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Tests.Engine.DataFeeds;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
@@ -105,23 +105,17 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(TickType.Trade, _testHistoryProvider.HistryRequests.First().TickType);
         }
 
-        private class TestHistoryProvider : IHistoryProvider
+        private class TestHistoryProvider : HistoryProviderBase
         {
-#pragma warning disable CS0067 // The event is never used
-            public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
-            public event EventHandler<DebugMessageEventArgs> DebugMessage;
-            public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
-#pragma warning restore CS0067
-
-            public int DataPointCount { get; }
+            public override int DataPointCount { get; }
             public List<HistoryRequest> HistryRequests { get; } = new List<HistoryRequest>();
 
-            public void Initialize(HistoryProviderInitializeParameters parameters)
+            public override void Initialize(HistoryProviderInitializeParameters parameters)
             {
                 throw new NotImplementedException();
             }
 
-            public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+            public override IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
             {
                 foreach (var request in requests)
                 {

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -107,6 +107,12 @@ namespace QuantConnect.Tests.Algorithm
 
         private class TestHistoryProvider : IHistoryProvider
         {
+#pragma warning disable CS0067 // The event is never used
+            public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+            public event EventHandler<DebugMessageEventArgs> DebugMessage;
+            public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+#pragma warning restore CS0067
+
             public int DataPointCount { get; }
             public List<HistoryRequest> HistryRequests { get; } = new List<HistoryRequest>();
 

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -20,7 +20,6 @@ using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Data;
-using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Tests.Engine.DataFeeds;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -21,7 +21,6 @@ using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
-using QuantConnect.Packets;
 using QuantConnect.Tests.Engine.DataFeeds;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
@@ -111,14 +110,7 @@ namespace QuantConnect.Tests.Algorithm
             public int DataPointCount { get; }
             public List<HistoryRequest> HistryRequests { get; } = new List<HistoryRequest>();
 
-            public void Initialize(
-                AlgorithmNodePacket job,
-                IDataProvider dataProvider,
-                IDataCacheProvider dataCacheProvider,
-                IMapFileProvider mapFileProvider,
-                IFactorFileProvider factorFileProvider,
-                Action<int> statusUpdate
-                )
+            public void Initialize(HistoryProviderInitializeParameters parameters)
             {
                 throw new NotImplementedException();
             }

--- a/Tests/Brokerages/Bitfinex/BitfinexBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexBrokerageHistoryProviderTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,12 +14,8 @@
 */
 
 using System;
-using System.Diagnostics;
-using System.Linq;
 using NodaTime;
 using NUnit.Framework;
-using QuantConnect.Brokerages;
-using QuantConnect.Brokerages.Fxcm;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.HistoricalData;
@@ -38,7 +34,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
             {
                 return new[]
                 {
-                    // valid 
+                    // valid
                     new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Minute, Time.OneHour, false),
                     new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Hour, Time.OneDay, false),
                     new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Daily, TimeSpan.FromDays(15), false),
@@ -78,7 +74,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(null, null, null, null, null, null);
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
 
                 var now = DateTime.UtcNow;
 

--- a/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,6 @@ using System.Diagnostics;
 using System.Linq;
 using NodaTime;
 using NUnit.Framework;
-using QuantConnect.Brokerages;
 using QuantConnect.Brokerages.Fxcm;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -65,22 +64,22 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(null, null, null, null, null, null);
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
 
                 var now = DateTime.UtcNow;
 
                 var requests = new[]
                 {
-                    new HistoryRequest(now.Add(-period), 
-                                       now, 
-                                       typeof(QuoteBar), 
-                                       symbol, 
-                                       resolution, 
-                                       SecurityExchangeHours.AlwaysOpen(TimeZones.Utc), 
-                                       DateTimeZone.Utc, 
-                                       Resolution.Minute, 
-                                       false, 
-                                       false, 
+                    new HistoryRequest(now.Add(-period),
+                                       now,
+                                       typeof(QuoteBar),
+                                       symbol,
+                                       resolution,
+                                       SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                                       DateTimeZone.Utc,
+                                       Resolution.Minute,
+                                       false,
+                                       false,
                                        DataNormalizationMode.Adjusted,
                                        TickType.Quote)
                 };
@@ -130,7 +129,7 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
 
             var historyProvider = new BrokerageHistoryProvider();
             historyProvider.SetBrokerage(brokerage);
-            historyProvider.Initialize(null, null, null, null, null, null);
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
 
             var stopwatch = Stopwatch.StartNew();
 

--- a/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
             var historyProvider = new BrokerageHistoryProvider();
             historyProvider.SetBrokerage(brokerage);
-            historyProvider.Initialize(null, null, null, null, null, null);
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
 
             var now = DateTime.UtcNow;
 

--- a/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Tests.Brokerages.Oanda
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(null, null, null, null, null, null);
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
 
                 var now = DateTime.UtcNow;
 

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -65,12 +65,16 @@ namespace QuantConnect.Tests.Common.Securities
         {
             _algo =  new QCAlgorithm();
             var historyProvider = new SubscriptionDataReaderHistoryProvider();
-            historyProvider.Initialize(null,
-                                       new DefaultDataProvider(),
-                                       new SingleEntryDataCacheProvider(new DefaultDataProvider()),
-                                       new LocalDiskMapFileProvider(),
-                                       new LocalDiskFactorFileProvider(),
-                                       null);
+            historyProvider.Initialize(
+                new HistoryProviderInitializeParameters(
+                    null,
+                    new DefaultDataProvider(),
+                    new SingleEntryDataCacheProvider(new DefaultDataProvider()),
+                    new LocalDiskMapFileProvider(),
+                    new LocalDiskFactorFileProvider(),
+                    null
+                )
+            );
 
             _algo.HistoryProvider = historyProvider;
             _algo.SubscriptionManager.SetDataManager(new DataManagerStub(_algo));

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -844,6 +844,12 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
         internal class EmptyHistoryProvider : IHistoryProvider
         {
+#pragma warning disable CS0067 // The event is never used
+            public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+            public event EventHandler<DebugMessageEventArgs> DebugMessage;
+            public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+#pragma warning restore CS0067
+
             public int DataPointCount
             {
                 get { return 0; }

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -30,7 +30,6 @@ using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
-using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -30,7 +30,6 @@ using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
-using QuantConnect.Packets;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
@@ -850,7 +849,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
                 get { return 0; }
             }
 
-            public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+            public void Initialize(HistoryProviderInitializeParameters parameters)
             {
             }
 

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -30,6 +30,7 @@ using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
@@ -842,24 +843,15 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             broker.Verify(m => m.GetCashBalance(), Times.Exactly(0));
         }
 
-        internal class EmptyHistoryProvider : IHistoryProvider
+        internal class EmptyHistoryProvider : HistoryProviderBase
         {
-#pragma warning disable CS0067 // The event is never used
-            public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
-            public event EventHandler<DebugMessageEventArgs> DebugMessage;
-            public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
-#pragma warning restore CS0067
+            public override int DataPointCount => 0;
 
-            public int DataPointCount
-            {
-                get { return 0; }
-            }
-
-            public void Initialize(HistoryProviderInitializeParameters parameters)
+            public override void Initialize(HistoryProviderInitializeParameters parameters)
             {
             }
 
-            public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+            public override IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
             {
                 return Enumerable.Empty<Slice>();
             }

--- a/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
+++ b/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
@@ -233,7 +233,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     new TestCaseData(Symbols.SPY, Resolution.Tick, TimeSpan.FromSeconds(15), false),
                     new TestCaseData(Symbols.SPY, Resolution.Second, Time.OneMinute, false),
                     new TestCaseData(Symbols.SPY, Resolution.Hour, Time.OneDay, false),
-                    
+
                     // invalid period == empty result
                     new TestCaseData(Symbols.SPY, Resolution.Minute, TimeSpan.FromDays(45), false), // beyond 30 days
                     new TestCaseData(Symbols.SPY, Resolution.Daily, TimeSpan.FromDays(-15), false), // date in future
@@ -254,7 +254,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void IEXCouldGetHistory(Symbol symbol, Resolution resolution, TimeSpan period, bool received)
         {
             var historyProvider = new IEXDataQueueHandler();
-            historyProvider.Initialize(null, null, null, null, null, null);
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
 
             var now = DateTime.UtcNow;
 

--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -30,7 +30,6 @@ using System.Text;
 using QuantConnect.Interfaces;
 using NodaTime;
 using System.Globalization;
-using QuantConnect.Lean.Engine.HistoricalData;
 
 namespace QuantConnect.ToolBox.IEX
 {

--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -304,6 +304,23 @@ namespace QuantConnect.ToolBox.IEX
 
         #region IHistoryProvider implementation
 
+#pragma warning disable CS0067 // The event is never used
+        /// <summary>
+        /// Event fired when an error message should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+
+        /// <summary>
+        /// Event fired when a debug message should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<DebugMessageEventArgs> DebugMessage;
+
+        /// <summary>
+        /// Event fired when a runtime error should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+#pragma warning restore CS0067
+
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
         /// </summary>

--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
-using QuantConnect.Lean.Engine.DataFeeds.Queues;
 using QuantConnect.Packets;
 using Quobject.SocketIoClientDotNet.Client;
 using QuantConnect.Logging;
@@ -31,6 +30,7 @@ using System.Text;
 using QuantConnect.Interfaces;
 using NodaTime;
 using System.Globalization;
+using QuantConnect.Lean.Engine.HistoricalData;
 
 namespace QuantConnect.ToolBox.IEX
 {
@@ -38,7 +38,7 @@ namespace QuantConnect.ToolBox.IEX
     /// IEX live data handler.
     /// Data provided for free by IEX. See more at https://iextrading.com/api-exhibit-a
     /// </summary>
-    public class IEXDataQueueHandler : LiveDataQueue, IHistoryProvider, IDisposable
+    public class IEXDataQueueHandler : HistoryProviderBase, IDataQueueHandler, IDisposable
     {
         // using SocketIoClientDotNet is a temp solution until IEX implements standard WebSockets protocol
         private Socket _socket;
@@ -157,7 +157,7 @@ namespace QuantConnect.ToolBox.IEX
         /// Desktop/Local doesn't support live data from this handler
         /// </summary>
         /// <returns>Tick</returns>
-        public sealed override IEnumerable<BaseData> GetNextTicks()
+        public IEnumerable<BaseData> GetNextTicks()
         {
             return _outputCollection.GetConsumingEnumerable();
         }
@@ -165,7 +165,7 @@ namespace QuantConnect.ToolBox.IEX
         /// <summary>
         /// Subscribe to symbols
         /// </summary>
-        public sealed override void Subscribe(LiveNodePacket job, IEnumerable<Symbol> symbols)
+        public void Subscribe(LiveNodePacket job, IEnumerable<Symbol> symbols)
         {
             try
             {
@@ -201,7 +201,7 @@ namespace QuantConnect.ToolBox.IEX
         /// <summary>
         /// Unsubscribe from symbols
         /// </summary>
-        public sealed override void Unsubscribe(LiveNodePacket job, IEnumerable<Symbol> symbols)
+        public void Unsubscribe(LiveNodePacket job, IEnumerable<Symbol> symbols)
         {
             try
             {
@@ -304,36 +304,26 @@ namespace QuantConnect.ToolBox.IEX
 
         #region IHistoryProvider implementation
 
-#pragma warning disable CS0067 // The event is never used
-        /// <summary>
-        /// Event fired when an error message should be sent to the algorithm
-        /// </summary>
-        public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
-
-        /// <summary>
-        /// Event fired when a debug message should be sent to the algorithm
-        /// </summary>
-        public event EventHandler<DebugMessageEventArgs> DebugMessage;
-
-        /// <summary>
-        /// Event fired when a runtime error should be sent to the algorithm
-        /// </summary>
-        public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
-#pragma warning restore CS0067
-
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
         /// </summary>
-        public int DataPointCount
+        public override int DataPointCount => _dataPointCount;
+
+        /// <summary>
+        /// Initializes this history provider to work for the specified job
+        /// </summary>
+        /// <param name="parameters">The initialization parameters</param>
+        public override void Initialize(HistoryProviderInitializeParameters parameters)
         {
-            get { return _dataPointCount; }
         }
 
-        public void Initialize(HistoryProviderInitializeParameters parameters)
-        {
-        }
-
-        public IEnumerable<Slice> GetHistory(IEnumerable<Data.HistoryRequest> requests, DateTimeZone sliceTimeZone)
+        /// <summary>
+        /// Gets the history for the requested securities
+        /// </summary>
+        /// <param name="requests">The historical data requests</param>
+        /// <param name="sliceTimeZone">The time zone used when time stamping the slice instances</param>
+        /// <returns>An enumerable of the slices of data covering the span specified in each request</returns>
+        public override IEnumerable<Slice> GetHistory(IEnumerable<Data.HistoryRequest> requests, DateTimeZone sliceTimeZone)
         {
             foreach (var request in requests)
             {

--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -312,7 +312,7 @@ namespace QuantConnect.ToolBox.IEX
             get { return _dataPointCount; }
         }
 
-        public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+        public void Initialize(HistoryProviderInitializeParameters parameters)
         {
         }
 
@@ -338,7 +338,7 @@ namespace QuantConnect.ToolBox.IEX
 
             if (request.Resolution == Resolution.Minute && start <= DateTime.Today.AddDays(-30))
             {
-                Log.Error("IEXDataQueueHandler.GetHistory(): History calls with minute resolution for IEX available only for trailing 30 calendar days."); 
+                Log.Error("IEXDataQueueHandler.GetHistory(): History calls with minute resolution for IEX available only for trailing 30 calendar days.");
                 yield break;
             } else if (request.Resolution != Resolution.Daily && request.Resolution != Resolution.Minute)
             {
@@ -359,7 +359,7 @@ namespace QuantConnect.ToolBox.IEX
             {
                 var begin = start;
                 while (begin < end)
-                { 
+                {
                     suffixes.Add("date/" + begin.ToString("yyyyMMdd"));
                     begin = begin.AddDays(1);
                 }
@@ -384,7 +384,7 @@ namespace QuantConnect.ToolBox.IEX
             {
                 suffixes.Add("2y");
             }
-            else 
+            else
             {
                 suffixes.Add("5y");
             }
@@ -420,7 +420,7 @@ namespace QuantConnect.ToolBox.IEX
                     if (item["open"] == null)
                     {
                         continue;
-                    }                    
+                    }
                     var open = item["open"].Value<decimal>();
                     var high = item["high"].Value<decimal>();
                     var low = item["low"].Value<decimal>();

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -25,12 +25,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Net;
-using System.Linq;
-using System.Threading;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 using Timer = System.Timers.Timer;
-using QuantConnect.Lean.Engine.DataFeeds.Transport;
 
 
 namespace QuantConnect.ToolBox.IQFeed
@@ -192,15 +188,9 @@ namespace QuantConnect.ToolBox.IQFeed
         /// <summary>
         /// Initializes this history provider to work for the specified job
         /// </summary>
-        /// <param name="job">The job</param>
-        /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
-        /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
-        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
-        /// <param name="statusUpdate">Function used to send status updates</param>
-        /// <param name="dataCacheProvider">Provider used to cache history data files</param>
-        public void Initialize(AlgorithmNodePacket job, IDataProvider dataProvider, IDataCacheProvider dataCacheProvider, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Action<int> statusUpdate)
+        /// <param name="parameters">The initialization parameters</param>
+        public void Initialize(HistoryProviderInitializeParameters parameters)
         {
-            return;
         }
 
         /// <summary>

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using QuantConnect.Lean.Engine.HistoricalData;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 using Timer = System.Timers.Timer;
 
@@ -34,7 +35,7 @@ namespace QuantConnect.ToolBox.IQFeed
     /// <summary>
     /// IQFeedDataQueueHandler is an implementation of IDataQueueHandler and IHistoryProvider
     /// </summary>
-    public class IQFeedDataQueueHandler : IDataQueueHandler, IHistoryProvider, IDataQueueUniverseProvider
+    public class IQFeedDataQueueHandler : HistoryProviderBase, IDataQueueHandler, IDataQueueUniverseProvider
     {
         private bool _isConnected;
         private int _dataPointCount;
@@ -52,10 +53,7 @@ namespace QuantConnect.ToolBox.IQFeed
         /// <summary>
         /// Gets the total number of data points emitted by this history provider
         /// </summary>
-        public int DataPointCount
-        {
-            get { return _dataPointCount; }
-        }
+        public override int DataPointCount => _dataPointCount;
 
         /// <summary>
         /// IQFeedDataQueueHandler is an implementation of IDataQueueHandler:
@@ -87,8 +85,6 @@ namespace QuantConnect.ToolBox.IQFeed
                 }
             }
         }
-
-
 
         /// <summary>
         /// Adds the specified symbols to the subscription: new IQLevel1WatchItem("IBM", true)
@@ -185,28 +181,11 @@ namespace QuantConnect.ToolBox.IQFeed
             }
         }
 
-#pragma warning disable CS0067 // The event is never used
-        /// <summary>
-        /// Event fired when an error message should be sent to the algorithm
-        /// </summary>
-        public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
-
-        /// <summary>
-        /// Event fired when a debug message should be sent to the algorithm
-        /// </summary>
-        public event EventHandler<DebugMessageEventArgs> DebugMessage;
-
-        /// <summary>
-        /// Event fired when a runtime error should be sent to the algorithm
-        /// </summary>
-        public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
-#pragma warning restore CS0067
-
         /// <summary>
         /// Initializes this history provider to work for the specified job
         /// </summary>
         /// <param name="parameters">The initialization parameters</param>
-        public void Initialize(HistoryProviderInitializeParameters parameters)
+        public override void Initialize(HistoryProviderInitializeParameters parameters)
         {
         }
 
@@ -216,7 +195,7 @@ namespace QuantConnect.ToolBox.IQFeed
         /// <param name="requests">The historical data requests</param>
         /// <param name="sliceTimeZone">The time zone used when time stamping the slice instances</param>
         /// <returns>An enumerable of the slices of data covering the span specified in each request</returns>
-        public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+        public override IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
         {
             foreach (var request in requests)
             {

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -185,6 +185,23 @@ namespace QuantConnect.ToolBox.IQFeed
             }
         }
 
+#pragma warning disable CS0067 // The event is never used
+        /// <summary>
+        /// Event fired when an error message should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<ErrorMessageEventArgs> ErrorMessage;
+
+        /// <summary>
+        /// Event fired when a debug message should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<DebugMessageEventArgs> DebugMessage;
+
+        /// <summary>
+        /// Event fired when a runtime error should be sent to the algorithm
+        /// </summary>
+        public event EventHandler<RuntimeErrorEventArgs> RuntimeError;
+#pragma warning restore CS0067
+
         /// <summary>
         /// Initializes this history provider to work for the specified job
         /// </summary>

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using QuantConnect.Lean.Engine.HistoricalData;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 using Timer = System.Timers.Timer;
 


### PR DESCRIPTION
#### Description
- Removed `IResultHandler` dependency from `SubscriptionDataReader`
- Removed unused `IDataProvider` dependency from `SubscriptionDataReader`
- Removed `ResultHandlerStub` from `SubscriptionDataReaderHistoryProvider`
- Replaced `IHistoryProvider.Initialize` parameters with new `HistoryProviderInitializeParameters` class
- Added `InvalidConfigurationDetected`, `NumericalPrecisionLimited`, `DownloadFailed` and `ReaderErrorDetected` events to `SubscriptionDataReader` and `IHistoryProvider`

#### Related Issue
Closes #2601 

#### Motivation and Context
When custom data history requests fail to download error a remote file, the error message is not logged or displayed. The History call simply returns an empty result and we currently have no way to see the reason for the failure.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local and cloud testing using the algorithm included in #2601 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`