### PR TITLE
Creating new ISecurityService

### DIFF
--- a/Algorithm.Framework/Selection/FutureUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/FutureUniverseSelectionModel.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
@@ -32,7 +33,6 @@ namespace QuantConnect.Algorithm.Framework.Selection
 
         private readonly TimeSpan _refreshInterval;
         private readonly UniverseSettings _universeSettings;
-        private readonly ISecurityInitializer _securityInitializer;
         private readonly Func<DateTime, IEnumerable<Symbol>> _futureChainSymbolSelector;
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="refreshInterval">Time interval between universe refreshes</param>
         /// <param name="futureChainSymbolSelector">Selects symbols from the provided future chain</param>
         public FutureUniverseSelectionModel(TimeSpan refreshInterval, Func<DateTime, IEnumerable<Symbol>> futureChainSymbolSelector)
-            : this(refreshInterval, futureChainSymbolSelector, null, null)
+            : this(refreshInterval, futureChainSymbolSelector, null)
         {
         }
 
@@ -57,17 +57,34 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="futureChainSymbolSelector">Selects symbols from the provided future chain</param>
         /// <param name="universeSettings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
         /// <param name="securityInitializer">Performs extra initialization (such as setting models) after we create a new security object</param>
-        public FutureUniverseSelectionModel(TimeSpan refreshInterval,
+        [Obsolete("This constructor is obsolete because SecurityInitializer is obsolete and will not be used.")]
+        public FutureUniverseSelectionModel(
+            TimeSpan refreshInterval,
             Func<DateTime, IEnumerable<Symbol>> futureChainSymbolSelector,
             UniverseSettings universeSettings,
             ISecurityInitializer securityInitializer
-        )
+            )
+            : this(refreshInterval, futureChainSymbolSelector, universeSettings)
+        {
+
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="FutureUniverseSelectionModel"/>
+        /// </summary>
+        /// <param name="refreshInterval">Time interval between universe refreshes</param>
+        /// <param name="futureChainSymbolSelector">Selects symbols from the provided future chain</param>
+        /// <param name="universeSettings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
+        public FutureUniverseSelectionModel(
+            TimeSpan refreshInterval,
+            Func<DateTime, IEnumerable<Symbol>> futureChainSymbolSelector,
+            UniverseSettings universeSettings
+            )
         {
             _nextRefreshTimeUtc = DateTime.MinValue;
 
             _refreshInterval = refreshInterval;
             _universeSettings = universeSettings;
-            _securityInitializer = securityInitializer;
             _futureChainSymbolSelector = futureChainSymbolSelector;
         }
 
@@ -104,20 +121,38 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="settings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
         /// <param name="initializer">Performs extra initialization (such as setting models) after we create a new security object</param>
         /// <returns><see cref="Future"/> for the given symbol</returns>
+        [Obsolete("This method is obsolete because SecurityInitializer is obsolete and will not be used.")]
         protected virtual Future CreateFutureChainSecurity(QCAlgorithmFramework algorithm, Symbol symbol, UniverseSettings settings, ISecurityInitializer initializer)
         {
-            var market = symbol.ID.Market;
+            return CreateFutureChainSecurity(
+                algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                symbol,
+                settings,
+                algorithm.Securities);
+        }
 
-            var marketHoursEntry = MarketHoursDatabase.FromDataFolder()
-                .GetEntry(market, symbol, SecurityType.Future);
-
-            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder()
-                .GetSymbolProperties(market, symbol, SecurityType.Future, CashBook.AccountCurrency);
-
-            return (Future)SecurityManager.CreateSecurity(typeof(ZipEntryName), algorithm.Portfolio,
-                algorithm.SubscriptionManager, marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties,
-                initializer, symbol, settings.Resolution, settings.FillForward, settings.Leverage, settings.ExtendedMarketHours,
-                false, false, algorithm.LiveMode, false, false);
+        /// <summary>
+        /// Creates the canonical <see cref="Future"/> chain security for a given symbol
+        /// </summary>
+        /// <param name="subscriptionDataConfigService">The service used to create new <see cref="SubscriptionDataConfig"/></param>
+        /// <param name="symbol">Symbol of the future</param>
+        /// <param name="settings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
+        /// <param name="securityService">The service used to create new <see cref="Security"/></param>
+        /// <returns><see cref="Future"/> for the given symbol</returns>
+        protected virtual Future CreateFutureChainSecurity(
+            ISubscriptionDataConfigService subscriptionDataConfigService,
+            Symbol symbol,
+            UniverseSettings settings,
+            ISecurityService securityService)
+        {
+            var config = subscriptionDataConfigService.Add(
+                typeof(ZipEntryName),
+                symbol,
+                settings.Resolution,
+                settings.FillForward,
+                settings.ExtendedMarketHours,
+                false);
+            return (Future)securityService.CreateSecurity(symbol, config, settings.Leverage, false);
         }
 
         /// <summary>
@@ -151,14 +186,17 @@ namespace QuantConnect.Algorithm.Framework.Selection
 
             // resolve defaults if not specified
             var settings = _universeSettings ?? algorithm.UniverseSettings;
-            var initializer = _securityInitializer ?? algorithm.SecurityInitializer;
 
             // create canonical security object, but don't duplicate if it already exists
             Security security;
             Future futureChain;
             if (!algorithm.Securities.TryGetValue(symbol, out security))
             {
-                futureChain = CreateFutureChainSecurity(algorithm, symbol, settings, initializer);
+                futureChain = CreateFutureChainSecurity(
+                    algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                    symbol,
+                    settings,
+                    algorithm.Securities);
             }
             else
             {
@@ -171,7 +209,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
             // force future chain security to not be directly tradable AFTER it's configured to ensure it's not overwritten
             futureChain.IsTradable = false;
 
-            return new FuturesChainUniverse(futureChain, settings, algorithm.SubscriptionManager, initializer);
+            return new FuturesChainUniverse(futureChain, settings);
         }
     }
 }

--- a/Algorithm.Framework/Selection/FutureUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/FutureUniverseSelectionModel.cs
@@ -137,13 +137,13 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="subscriptionDataConfigService">The service used to create new <see cref="SubscriptionDataConfig"/></param>
         /// <param name="symbol">Symbol of the future</param>
         /// <param name="settings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
-        /// <param name="securityService">The service used to create new <see cref="Security"/></param>
+        /// <param name="securityManager">Used to create new <see cref="Security"/></param>
         /// <returns><see cref="Future"/> for the given symbol</returns>
         protected virtual Future CreateFutureChainSecurity(
             ISubscriptionDataConfigService subscriptionDataConfigService,
             Symbol symbol,
             UniverseSettings settings,
-            ISecurityService securityService)
+            SecurityManager securityManager)
         {
             var config = subscriptionDataConfigService.Add(
                 typeof(ZipEntryName),
@@ -151,8 +151,8 @@ namespace QuantConnect.Algorithm.Framework.Selection
                 settings.Resolution,
                 settings.FillForward,
                 settings.ExtendedMarketHours,
-                false);
-            return (Future)securityService.CreateSecurity(symbol, config, settings.Leverage, false);
+                isFilteredSubscription: false);
+            return (Future)securityManager.CreateSecurity(symbol, config, settings.Leverage, false);
         }
 
         /// <summary>

--- a/Algorithm.Framework/Selection/FutureUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/FutureUniverseSelectionModel.py
@@ -29,14 +29,14 @@ class FutureUniverseSelectionModel(UniverseSelectionModel):
     def __init__(self,
                  refreshInterval,
                  futureChainSymbolSelector,
-                 universeSettings = None, 
+                 universeSettings = None,
                  securityInitializer = None):
         '''Creates a new instance of FutureUniverseSelectionModel
         Args:
             refreshInterval: Time interval between universe refreshes</param>
             futureChainSymbolSelector: Selects symbols from the provided future chain
             universeSettings: Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed
-            securityInitializer: Performs extra initialization (such as setting models) after we create a new security object'''
+            securityInitializer: [Obsolete, will not be used] Performs extra initialization (such as setting models) after we create a new security object'''
         self.nextRefreshTimeUtc = datetime.min
 
         self.refreshInterval = refreshInterval
@@ -105,18 +105,17 @@ class FutureUniverseSelectionModel(UniverseSelectionModel):
             algorithm: The algorithm instance to create universes for
             symbol: Symbol of the future
             settings: Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed
-            initializer: Performs extra initialization (such as setting models) after we create a new security object
+            initializer: [Obsolete, will not be used] Performs extra initialization (such as setting models) after we create a new security object
         Returns
             Future for the given symbol'''
-        market = symbol.ID.Market
+        config = algorithm.SubscriptionManager.SubscriptionDataConfigService.Add(typeof(ZipEntryName),
+                                                                                 symbol,
+                                                                                 settings.Resolution,
+                                                                                 settings.FillForward,
+                                                                                 settings.ExtendedMarketHours,
+                                                                                 False)
 
-        marketHoursEntry = MarketHoursDatabase.FromDataFolder().GetEntry(market, symbol, SecurityType.Future)
-        symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(market, symbol, SecurityType.Future, CashBook.AccountCurrency)
-
-        return SecurityManager.CreateSecurity(typeof(ZipEntryName), algorithm.Portfolio,
-                algorithm.SubscriptionManager, marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties,
-                initializer, symbol, settings.Resolution, settings.FillForward, settings.Leverage, settings.ExtendedMarketHours,
-                False, False, algorithm.LiveMode, False, False)
+        return algorithm.Securities.CreateSecurity(symbol, config, settings.Leverage, False)
 
     def Filter(self, filter):
         '''Defines the future chain universe filter'''

--- a/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
@@ -136,21 +136,22 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="subscriptionDataConfigService">The service used to create new <see cref="SubscriptionDataConfig"/></param>
         /// <param name="symbol">Symbol of the option</param>
         /// <param name="settings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
-        /// <param name="securityService">The service used to create new <see cref="Security"/></param>
+        /// <param name="securityManager">Used to create new <see cref="Security"/></param>
         /// <returns><see cref="Option"/> for the given symbol</returns>
         protected virtual Option CreateOptionChainSecurity(
             ISubscriptionDataConfigService subscriptionDataConfigService,
             Symbol symbol,
             UniverseSettings settings,
-            ISecurityService securityService)
+            SecurityManager securityManager)
         {
-            var config = subscriptionDataConfigService.Add(typeof(ZipEntryName),
+            var config = subscriptionDataConfigService.Add(
+                typeof(ZipEntryName),
                 symbol,
                 settings.Resolution,
                 settings.FillForward,
                 settings.ExtendedMarketHours,
                 false);
-            return (Option)securityService.CreateSecurity(symbol, config, settings.Leverage, false);
+            return (Option)securityManager.CreateSecurity(symbol, config, settings.Leverage, false);
         }
 
         /// <summary>

--- a/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/OptionUniverseSelectionModel.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
@@ -32,7 +33,6 @@ namespace QuantConnect.Algorithm.Framework.Selection
 
         private readonly TimeSpan _refreshInterval;
         private readonly UniverseSettings _universeSettings;
-        private readonly ISecurityInitializer _securityInitializer;
         private readonly Func<DateTime, IEnumerable<Symbol>> _optionChainSymbolSelector;
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="refreshInterval">Time interval between universe refreshes</param>
         /// <param name="optionChainSymbolSelector">Selects symbols from the provided option chain</param>
         public OptionUniverseSelectionModel(TimeSpan refreshInterval, Func<DateTime, IEnumerable<Symbol>> optionChainSymbolSelector)
-            : this(refreshInterval, optionChainSymbolSelector, null, null)
+            : this(refreshInterval, optionChainSymbolSelector, null)
         {
         }
 
@@ -57,17 +57,33 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="optionChainSymbolSelector">Selects symbols from the provided option chain</param>
         /// <param name="universeSettings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
         /// <param name="securityInitializer">Performs extra initialization (such as setting models) after we create a new security object</param>
-        public OptionUniverseSelectionModel(TimeSpan refreshInterval,
+        [Obsolete("This constructor is obsolete because SecurityInitializer is obsolete and will not be used.")]
+        public OptionUniverseSelectionModel(
+            TimeSpan refreshInterval,
             Func<DateTime, IEnumerable<Symbol>> optionChainSymbolSelector,
             UniverseSettings universeSettings,
             ISecurityInitializer securityInitializer
-        )
+            )
+            :this (refreshInterval,optionChainSymbolSelector,universeSettings)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="OptionUniverseSelectionModel"/>
+        /// </summary>
+        /// <param name="refreshInterval">Time interval between universe refreshes</param>
+        /// <param name="optionChainSymbolSelector">Selects symbols from the provided option chain</param>
+        /// <param name="universeSettings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
+        public OptionUniverseSelectionModel(
+            TimeSpan refreshInterval,
+            Func<DateTime, IEnumerable<Symbol>> optionChainSymbolSelector,
+            UniverseSettings universeSettings
+            )
         {
             _nextRefreshTimeUtc = DateTime.MinValue;
 
             _refreshInterval = refreshInterval;
             _universeSettings = universeSettings;
-            _securityInitializer = securityInitializer;
             _optionChainSymbolSelector = optionChainSymbolSelector;
         }
 
@@ -104,23 +120,37 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="settings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
         /// <param name="initializer">Performs extra initialization (such as setting models) after we create a new security object</param>
         /// <returns><see cref="Option"/> for the given symbol</returns>
+        [Obsolete("This method is obsolete because SecurityInitializer is obsolete and will not be used.")]
         protected virtual Option CreateOptionChainSecurity(QCAlgorithmFramework algorithm, Symbol symbol, UniverseSettings settings, ISecurityInitializer initializer)
         {
-            var market = symbol.ID.Market;
-            var underlying = symbol.Underlying;
+            return CreateOptionChainSecurity(
+                algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                symbol,
+                settings,
+                algorithm.Securities);
+        }
 
-            var marketHoursEntry = MarketHoursDatabase.FromDataFolder()
-                .GetEntry(market, underlying, SecurityType.Option);
-
-            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder()
-                .GetSymbolProperties(market, underlying, SecurityType.Option, CashBook.AccountCurrency);
-
-            var optionChain = (Option)SecurityManager.CreateSecurity(typeof(ZipEntryName), algorithm.Portfolio,
-                algorithm.SubscriptionManager, marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties,
-                initializer, symbol, settings.Resolution, settings.FillForward, settings.Leverage, settings.ExtendedMarketHours,
-                false, false, algorithm.LiveMode, false, false);
-
-            return optionChain;
+        /// <summary>
+        /// Creates the canonical <see cref="Option"/> chain security for a given symbol
+        /// </summary>
+        /// <param name="subscriptionDataConfigService">The service used to create new <see cref="SubscriptionDataConfig"/></param>
+        /// <param name="symbol">Symbol of the option</param>
+        /// <param name="settings">Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed</param>
+        /// <param name="securityService">The service used to create new <see cref="Security"/></param>
+        /// <returns><see cref="Option"/> for the given symbol</returns>
+        protected virtual Option CreateOptionChainSecurity(
+            ISubscriptionDataConfigService subscriptionDataConfigService,
+            Symbol symbol,
+            UniverseSettings settings,
+            ISecurityService securityService)
+        {
+            var config = subscriptionDataConfigService.Add(typeof(ZipEntryName),
+                symbol,
+                settings.Resolution,
+                settings.FillForward,
+                settings.ExtendedMarketHours,
+                false);
+            return (Option)securityService.CreateSecurity(symbol, config, settings.Leverage, false);
         }
 
         /// <summary>
@@ -156,14 +186,17 @@ namespace QuantConnect.Algorithm.Framework.Selection
 
             // resolve defaults if not specified
             var settings = _universeSettings ?? algorithm.UniverseSettings;
-            var initializer = _securityInitializer ?? algorithm.SecurityInitializer;
 
             // create canonical security object, but don't duplicate if it already exists
             Security security;
             Option optionChain;
             if (!algorithm.Securities.TryGetValue(symbol, out security))
             {
-                optionChain = CreateOptionChainSecurity(algorithm, symbol, settings, initializer);
+                optionChain = CreateOptionChainSecurity(
+                    algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                    symbol,
+                    settings,
+                    algorithm.Securities);
             }
             else
             {
@@ -176,7 +209,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
             // force option chain security to not be directly tradable AFTER it's configured to ensure it's not overwritten
             optionChain.IsTradable = false;
 
-            return new OptionChainUniverse(optionChain, settings, initializer, algorithm.LiveMode);
+            return new OptionChainUniverse(optionChain, settings, algorithm.LiveMode);
         }
     }
 }

--- a/Algorithm.Framework/Selection/OptionUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/OptionUniverseSelectionModel.py
@@ -29,14 +29,14 @@ class OptionUniverseSelectionModel(UniverseSelectionModel):
     def __init__(self,
                  refreshInterval,
                  optionChainSymbolSelector,
-                 universeSettings = None, 
+                 universeSettings = None,
                  securityInitializer = None):
         '''Creates a new instance of OptionUniverseSelectionModel
         Args:
             refreshInterval: Time interval between universe refreshes</param>
             optionChainSymbolSelector: Selects symbols from the provided option chain
             universeSettings: Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed
-            securityInitializer: Performs extra initialization (such as setting models) after we create a new security object'''
+            securityInitializer: [Obsolete, will not be used] Performs extra initialization (such as setting models) after we create a new security object'''
         self.nextRefreshTimeUtc = datetime.min
 
         self.refreshInterval = refreshInterval
@@ -107,19 +107,17 @@ class OptionUniverseSelectionModel(UniverseSelectionModel):
             algorithm: The algorithm instance to create universes for
             symbol: Symbol of the option
             settings: Universe settings define attributes of created subscriptions, such as their resolution and the minimum time in universe before they can be removed
-            initializer: Performs extra initialization (such as setting models) after we create a new security object
+            initializer: [Obsolete, will not be used] Performs extra initialization (such as setting models) after we create a new security object
         Returns
             Option for the given symbol'''
-        market = symbol.ID.Market
-        underlying = symbol.Underlying
+        config = algorithm.SubscriptionManager.SubscriptionDataConfigService.Add(typeof(ZipEntryName),
+                                                                                 symbol,
+                                                                                 settings.Resolution,
+                                                                                 settings.FillForward,
+                                                                                 settings.ExtendedMarketHours,
+                                                                                 False)
 
-        marketHoursEntry = MarketHoursDatabase.FromDataFolder().GetEntry(market, underlying, SecurityType.Option)
-        symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(market, underlying, SecurityType.Option, CashBook.AccountCurrency)
-
-        return SecurityManager.CreateSecurity(typeof(ZipEntryName), algorithm.Portfolio,
-                algorithm.SubscriptionManager, marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties,
-                initializer, symbol, settings.Resolution, settings.FillForward, settings.Leverage, settings.ExtendedMarketHours,
-                False, False, algorithm.LiveMode, False, False)
+        return algorithm.Securities.CreateSecurity(symbol, config, settings.Leverage, False)
 
     def Filter(self, filter):
         '''Defines the option chain universe filter'''

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -67,7 +67,6 @@ namespace QuantConnect.Algorithm
         //Error tracking to avoid message flooding:
         private string _previousDebugMessage = "";
         private string _previousErrorMessage = "";
-        private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase;
 
         /// <summary>
         /// Gets the market hours database in use by this algorithm
@@ -135,9 +134,6 @@ namespace QuantConnect.Algorithm
 
             // get exchange hours loaded from the market-hours-database.csv in /Data/market-hours
             MarketHoursDatabase = MarketHoursDatabase.FromDataFolder();
-
-            // get symbol properties loaded from the symbol-properties-database.csv in /Data/symbol-properties
-            _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
 
             // universe selection
             UniverseManager = new UniverseManager();
@@ -1342,7 +1338,7 @@ namespace QuantConnect.Algorithm
                 _liveMode = live;
                 Notify = new NotificationManager(live);
                 TradeBuilder.SetLiveMode(live);
-
+                Securities.SetLiveMode(live);
                 if (live)
                 {
                     _startDate = DateTime.Today;
@@ -1427,10 +1423,10 @@ namespace QuantConnect.Algorithm
                     symbolObject = QuantConnect.Symbol.Create(symbol, securityType, market);
                 }
 
-                var security = SecurityManager.CreateSecurity(Portfolio, SubscriptionManager, MarketHoursDatabase, _symbolPropertiesDatabase, SecurityInitializer,
-                    symbolObject, resolution, fillDataForward, leverage, extendedMarketHours, false, false, LiveMode);
+                var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbolObject, resolution, fillDataForward, extendedMarketHours);
+                var security = Securities.CreateSecurity(symbolObject, configs, leverage);
 
-                AddToUserDefinedUniverse(security, resolution, leverage, market, fillDataForward, extendedMarketHours, isInternalFeed: false);
+                AddToUserDefinedUniverse(security, configs);
                 return security;
             }
             catch (Exception err)
@@ -1481,11 +1477,13 @@ namespace QuantConnect.Algorithm
                 canonicalSymbol = QuantConnect.Symbol.Create(underlying, SecurityType.Option, market, alias);
             }
 
-            var marketHoursEntry = MarketHoursDatabase.GetEntry(market, underlying, SecurityType.Option);
-            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, underlying, SecurityType.Option, CashBook.AccountCurrency);
-            var canonicalSecurity = (Option) SecurityManager.CreateSecurity(typeof(ZipEntryName), Portfolio, SubscriptionManager,
-                marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties, SecurityInitializer, canonicalSymbol, resolution,
-                fillDataForward, leverage, false, false, false, LiveMode, true, false);
+            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(typeof(ZipEntryName),
+                canonicalSymbol,
+                resolution,
+                fillDataForward,
+                isFilteredSubscription: false);
+            var canonicalSecurity = (Option)Securities.CreateSecurity(canonicalSymbol, configs, leverage);
+
             canonicalSecurity.IsTradable = false;
             Securities.Add(canonicalSecurity);
 
@@ -1527,11 +1525,11 @@ namespace QuantConnect.Algorithm
                 canonicalSymbol = QuantConnect.Symbol.Create(symbol, SecurityType.Future, market, alias);
             }
 
-            var marketHoursEntry = MarketHoursDatabase.GetEntry(market, symbol, SecurityType.Future);
-            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, symbol, SecurityType.Future, CashBook.AccountCurrency);
-            var canonicalSecurity = (Future)SecurityManager.CreateSecurity(typeof(ZipEntryName), Portfolio, SubscriptionManager,
-                marketHoursEntry.ExchangeHours, marketHoursEntry.DataTimeZone, symbolProperties, SecurityInitializer, canonicalSymbol, resolution,
-                fillDataForward, leverage, false, false, false, LiveMode, true, false);
+            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(canonicalSymbol,
+                resolution,
+                fillDataForward,
+                isFilteredSubscription: false);
+            var canonicalSecurity = (Future)Securities.CreateSecurity(canonicalSymbol, configs, leverage);
             canonicalSecurity.IsTradable = false;
             Securities.Add(canonicalSecurity);
 
@@ -1557,10 +1555,10 @@ namespace QuantConnect.Algorithm
         /// <returns>The new <see cref="Future"/> security</returns>
         public Future AddFutureContract(Symbol symbol, Resolution resolution = Resolution.Minute, bool fillDataForward = true, decimal leverage = 0m)
         {
-            var future = (Future)SecurityManager.CreateSecurity(Portfolio, SubscriptionManager, MarketHoursDatabase, _symbolPropertiesDatabase, SecurityInitializer,
-                symbol, resolution, fillDataForward, leverage, false, false, false, LiveMode);
+            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward);
+            var future = (Future)Securities.CreateSecurity(symbol, configs, leverage);
 
-            AddToUserDefinedUniverse(future, resolution, leverage, symbol.ID.Market, fillDataForward, isExtendedMarketHours: false, isInternalFeed: false);
+            AddToUserDefinedUniverse(future, configs);
             return future;
         }
 
@@ -1574,8 +1572,8 @@ namespace QuantConnect.Algorithm
         /// <returns>The new <see cref="Option"/> security</returns>
         public Option AddOptionContract(Symbol symbol, Resolution resolution = Resolution.Minute, bool fillDataForward = true, decimal leverage = 0m)
         {
-            var option = (Option)SecurityManager.CreateSecurity(Portfolio, SubscriptionManager, MarketHoursDatabase, _symbolPropertiesDatabase, SecurityInitializer,
-                symbol, resolution, fillDataForward, leverage, false, false, false, LiveMode);
+            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward);
+            var option = (Option)Securities.CreateSecurity(symbol, configs, leverage);
 
             // add underlying if not present
             var underlying = option.Symbol.Underlying;
@@ -1595,7 +1593,7 @@ namespace QuantConnect.Algorithm
 
             option.Underlying = equity;
 
-            AddToUserDefinedUniverse(option, resolution, leverage, symbol.ID.Market, fillDataForward, isExtendedMarketHours: false, isInternalFeed: false);
+            AddToUserDefinedUniverse(option, configs);
 
             return option;
         }
@@ -1769,17 +1767,21 @@ namespace QuantConnect.Algorithm
             where T : IBaseData, new()
         {
             //Add this custom symbol to our market hours database
-            var marketHoursDbEntry = MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, symbol, SecurityType.Base, timeZone);
+            MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, symbol, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
             var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA), symbol);
-            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(Market.USA, symbol, SecurityType.Base, CashBook.AccountCurrency);
 
             //Add this new generic data as a tradeable security:
-            var security = SecurityManager.CreateSecurity(typeof(T), Portfolio, SubscriptionManager, marketHoursDbEntry.ExchangeHours, marketHoursDbEntry.DataTimeZone,
-                symbolProperties, SecurityInitializer, symbolObject, resolution, fillDataForward, leverage, true, false, true, LiveMode);
+            var config = SubscriptionManager.SubscriptionDataConfigService.Add(typeof(T),
+                symbolObject,
+                resolution,
+                fillDataForward,
+                extendedMarketHours: true,
+                isCustomData: true);
+            var security = Securities.CreateSecurity(symbolObject, config, leverage);
 
-            AddToUserDefinedUniverse(security, resolution, leverage, symbolObject.ID.Market, fillDataForward, isExtendedMarketHours: true, isInternalFeed: false);
+            AddToUserDefinedUniverse(security, new List<SubscriptionDataConfig>{ config });
             return security;
         }
 
@@ -1990,10 +1992,10 @@ namespace QuantConnect.Algorithm
                 symbol = QuantConnect.Symbol.Create(ticker, securityType, market);
             }
 
-            var security = SecurityManager.CreateSecurity(Portfolio, SubscriptionManager, MarketHoursDatabase, _symbolPropertiesDatabase, SecurityInitializer,
-                symbol, resolution, fillDataForward, leverage, extendedMarketHours, false, false, LiveMode);
+            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward, extendedMarketHours);
+            var security = Securities.CreateSecurity(symbol, configs, leverage);
 
-            AddToUserDefinedUniverse(security, resolution, leverage, market, fillDataForward, extendedMarketHours, isInternalFeed: false);
+            AddToUserDefinedUniverse(security, configs);
             return (T)security;
         }
 
@@ -2021,12 +2023,10 @@ namespace QuantConnect.Algorithm
                 resolution = hasNonAddSecurityUniverses ? UniverseSettings.Resolution : Resolution.Daily;
             }
 
-            var security = SecurityManager.CreateSecurity(Portfolio, SubscriptionManager, MarketHoursDatabase, _symbolPropertiesDatabase,
-                                                          SecurityInitializer, _benchmarkSymbol, resolution, fillDataForward: true,
-                                                          leverage: 1m, extendedMarketHours: false, isInternalFeed: true,
-                                                          isCustomData: false, isLiveMode: LiveMode);
+            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(_benchmarkSymbol, resolution, isInternalFeed:true);
+            var security = Securities.CreateSecurity(_benchmarkSymbol, configs, 1m);
 
-            AddToUserDefinedUniverse(security, resolution, 1m, security.Symbol.ID.Market, isFillDataForward: true, isExtendedMarketHours: false, isInternalFeed: true);
+            AddToUserDefinedUniverse(security, configs);
 
             return security;
         }

--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -215,10 +215,8 @@ namespace QuantConnect.Data.UniverseSelection
         [Obsolete("CreateSecurity is obsolete and will not be called. The system will create the required Securities based on selected symbols")]
         public virtual Security CreateSecurity(Symbol symbol, IAlgorithm algorithm, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase)
         {
-            // by default invoke the create security method to handle security initialization
-            return SecurityManager.CreateSecurity(algorithm.Portfolio, algorithm.SubscriptionManager, marketHoursDatabase, symbolPropertiesDatabase,
-                SecurityInitializer, symbol, UniverseSettings.Resolution, UniverseSettings.FillForward, UniverseSettings.Leverage,
-                UniverseSettings.ExtendedMarketHours, false, false, algorithm.LiveMode, symbol.ID.SecurityType == SecurityType.Option);
+            throw new Exception("CreateSecurity is obsolete and should not be called." +
+                "The system will create the required Securities based on selected symbols");
         }
 
         /// <summary>
@@ -231,16 +229,8 @@ namespace QuantConnect.Data.UniverseSelection
         [Obsolete("This overload is obsolete and will not be called. It was not capable of creating new SubscriptionDataConfig due to lack of information")]
         public virtual IEnumerable<SubscriptionRequest> GetSubscriptionRequests(Security security, DateTime currentTimeUtc, DateTime maximumEndTimeUtc)
         {
-            return security.Subscriptions.Select(config =>
-                new SubscriptionRequest(
-                    isUniverseSubscription: false,
-                    universe: this,
-                    security: security,
-                    configuration: new SubscriptionDataConfig(config),
-                    startTimeUtc: currentTimeUtc,
-                    endTimeUtc: maximumEndTimeUtc
-                    )
-                );
+            throw new Exception("This overload is obsolete and should not be called." +
+                "It was not capable of creating new SubscriptionDataConfig due to lack of information");
         }
 
 

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Interfaces
     /// Interface for QuantConnect algorithm implementations. All algorithms must implement these
     /// basic members to allow interaction with the Lean Backtesting Engine.
     /// </summary>
-    public interface IAlgorithm
+    public interface IAlgorithm : ISecurityInitializerProvider
     {
         /// <summary>
         /// Event fired when an algorithm generates a insight
@@ -292,14 +292,6 @@ namespace QuantConnect.Interfaces
         /// the value of the benchmark at a requested date/time
         /// </summary>
         IBenchmark Benchmark
-        {
-            get;
-        }
-
-        /// <summary>
-        /// Gets an instance that is to be used to initialize newly created securities.
-        /// </summary>
-        ISecurityInitializer SecurityInitializer
         {
             get;
         }

--- a/Common/Interfaces/ISecurityInitializerProvider.cs
+++ b/Common/Interfaces/ISecurityInitializerProvider.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Securities;
+
+namespace QuantConnect.Interfaces
+{
+    /// <summary>
+    /// Reduced interface which provides an instance which implements <see cref="ISecurityInitializer"/>
+    /// </summary>
+    public interface ISecurityInitializerProvider
+    {
+        /// <summary>
+        /// Gets an instance that is to be used to initialize newly created securities.
+        /// </summary>
+        ISecurityInitializer SecurityInitializer
+        {
+            get;
+        }
+    }
+}

--- a/Common/Interfaces/ISecurityService.cs
+++ b/Common/Interfaces/ISecurityService.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Interfaces
+{
+    /// <summary>
+    /// This interface exposes methods for creating a new <see cref="Security" />
+    /// </summary>
+    public interface ISecurityService
+    {
+        /// <summary>
+        /// Creates a new security
+        /// </summary>
+        /// <remarks>Following the obsoletion of Security.Subscriptions,
+        /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
+        Security CreateSecurity(Symbol symbol,
+            List<SubscriptionDataConfig> subscriptionDataConfigList,
+            decimal leverage = 0,
+            bool addToSymbolCache = true);
+
+        /// <summary>
+        /// Creates a new security
+        /// </summary>
+        /// <remarks>Following the obsoletion of Security.Subscriptions,
+        /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
+        Security CreateSecurity(Symbol symbol,
+            SubscriptionDataConfig subscriptionDataConfig,
+            decimal leverage = 0,
+            bool addToSymbolCache = true);
+    }
+}

--- a/Common/Interfaces/ISubscriptionDataConfigService.cs
+++ b/Common/Interfaces/ISubscriptionDataConfigService.cs
@@ -28,6 +28,22 @@ namespace QuantConnect.Interfaces
     {
         /// <summary>
         /// Creates and adds a list of <see cref="SubscriptionDataConfig" /> for a given symbol and configuration.
+        /// Can optionally pass in desired subscription data type to use.
+        /// If the config already existed will return existing instance instead
+        /// </summary>
+        SubscriptionDataConfig Add(
+            Type dataType,
+            Symbol symbol,
+            Resolution resolution,
+            bool fillForward = true,
+            bool extendedMarketHours = false,
+            bool isFilteredSubscription = true,
+            bool isInternalFeed = false,
+            bool isCustomData = false
+            );
+
+        /// <summary>
+        /// Creates and adds a list of <see cref="SubscriptionDataConfig" /> for a given symbol and configuration.
         /// Can optionally pass in desired subscription data types to use.
         /// If the config already existed will return existing instance instead
         /// </summary>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -185,6 +185,8 @@
     <Compile Include="Data\HistoryProviderInitializeParameters.cs" />
     <Compile Include="HistoryProviderEvents.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />
+    <Compile Include="Interfaces\ISecurityInitializerProvider.cs" />
+    <Compile Include="Interfaces\ISecurityService.cs" />
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />
     <Compile Include="IsolatorLimitResult.cs" />
@@ -201,6 +203,7 @@
     <Compile Include="Securities\IdentityCurrencyConverter.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPosition.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPositionContext.cs" />
+    <Compile Include="Securities\SecurityService.cs" />
     <Compile Include="Series.cs" />
     <Compile Include="Data\Custom\Intrinio\IntrinioConfig.cs" />
     <Compile Include="Data\Custom\Intrinio\IntrinioEconomicData.cs" />

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 
 namespace QuantConnect.Securities
@@ -135,23 +136,19 @@ namespace QuantConnect.Securities
 
         /// <summary>
         /// Ensures that we have a data feed to convert this currency into the base currency.
-        /// This will add a subscription at the lowest resolution if one is not found.
+        /// This will add a <see cref="SubscriptionDataConfig"/> and create a <see cref="Security"/> at the lowest resolution if one is not found.
         /// </summary>
         /// <param name="securities">The security manager</param>
         /// <param name="subscriptions">The subscription manager used for searching and adding subscriptions</param>
-        /// <param name="marketHoursDatabase">A security exchange hours provider instance used to resolve exchange hours for new subscriptions</param>
-        /// <param name="symbolPropertiesDatabase">A symbol properties database instance</param>
         /// <param name="marketMap">The market map that decides which market the new security should be in</param>
-        /// <param name="cashBook">The cash book - used for resolving quote currencies for created conversion securities</param>
-        /// <param name="changes"></param>
-        /// <returns>Returns the added currency security if needed, otherwise null</returns>
-        public Security EnsureCurrencyDataFeed(SecurityManager securities,
+        /// <param name="changes">Will be used to consume <see cref="SecurityChanges.AddedSecurities"/></param>
+        /// <param name="securityService">Will be used to create required new <see cref="Security"/></param>
+        /// <returns>Returns the added <see cref="SubscriptionDataConfig"/>, otherwise null</returns>
+        public SubscriptionDataConfig EnsureCurrencyDataFeed(SecurityManager securities,
             SubscriptionManager subscriptions,
-            MarketHoursDatabase marketHoursDatabase,
-            SymbolPropertiesDatabase symbolPropertiesDatabase,
             IReadOnlyDictionary<SecurityType, string> marketMap,
-            CashBook cashBook,
-            SecurityChanges changes
+            SecurityChanges changes,
+            ISecurityService securityService
             )
         {
             // this gets called every time we add securities using universe selection,
@@ -215,14 +212,6 @@ namespace QuantConnect.Securities
                 {
                     _invertRealTimePrice = symbol.Value == invert;
                     var securityType = symbol.ID.SecurityType;
-                    var symbolProperties = symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol.Value, securityType, Symbol);
-                    Cash quoteCash;
-                    if (!cashBook.TryGetValue(symbolProperties.QuoteCurrency, out quoteCash))
-                    {
-                        throw new Exception("Unable to resolve quote cash: " + symbolProperties.QuoteCurrency + ". This is required to add conversion feed: " + symbol.Value);
-                    }
-                    var marketHoursDbEntry = marketHoursDatabase.GetEntry(symbol.ID.Market, symbol.Value, symbol.ID.SecurityType);
-                    var exchangeHours = marketHoursDbEntry.ExchangeHours;
 
                     // use the first subscription defined in the subscription manager
                     var type = subscriptions.LookupSubscriptionConfigDataTypes(securityType, minimumResolution, false).First();
@@ -230,26 +219,19 @@ namespace QuantConnect.Securities
                     var tickType = type.Item2;
 
                     // set this as an internal feed so that the data doesn't get sent into the algorithm's OnData events
-                    var config = subscriptions.Add(objectType, tickType, symbol, minimumResolution, marketHoursDbEntry.DataTimeZone, exchangeHours.TimeZone, false, true, false, true);
+                    var config = subscriptions.SubscriptionDataConfigService.Add(symbol,
+                        minimumResolution,
+                        fillForward: true,
+                        extendedMarketHours: false,
+                        isInternalFeed: true,
+                        subscriptionDataTypes: new List<Tuple<Type, TickType>> { new Tuple<Type, TickType>(objectType, tickType) }).First();
 
-                    Security security;
-                    if (securityType == SecurityType.Cfd)
-                    {
-                        security = new Cfd.Cfd(exchangeHours, quoteCash, config, symbolProperties, cashBook);
-                    }
-                    else if (securityType == SecurityType.Crypto)
-                    {
-                        security = new Crypto.Crypto(exchangeHours, quoteCash, config, symbolProperties, cashBook);
-                    }
-                    else
-                    {
-                        security = new Forex.Forex(exchangeHours, quoteCash, config, symbolProperties, cashBook);
-                    }
+                    var security = securityService.CreateSecurity(symbol, config);
 
                     ConversionRateSecurity = security;
                     securities.Add(config.Symbol, security);
                     Log.Trace("Cash.EnsureCurrencyDataFeed(): Adding " + symbol.Value + " for cash " + Symbol + " currency feed");
-                    return security;
+                    return config;
                 }
             }
 

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -22,6 +22,7 @@ using System.Text;
 using QuantConnect.Data;
 using System.Collections.Concurrent;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 
 namespace QuantConnect.Securities
@@ -73,24 +74,28 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="securities">The SecurityManager for the algorithm</param>
         /// <param name="subscriptions">The SubscriptionManager for the algorithm</param>
-        /// <param name="marketHoursDatabase">A security exchange hours provider instance used to resolve exchange hours for new subscriptions</param>
-        /// <param name="symbolPropertiesDatabase">A symbol properties database instance</param>
         /// <param name="marketMap">The market map that decides which market the new security should be in</param>
-        /// <returns>Returns a list of added currency securities</returns>
-        public List<Security> EnsureCurrencyDataFeeds(SecurityManager securities, SubscriptionManager subscriptions, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase, IReadOnlyDictionary<SecurityType, string> marketMap, SecurityChanges changes)
+        /// <param name="changes">Will be used to consume <see cref="SecurityChanges.AddedSecurities"/></param>
+        /// <param name="securityService">Will be used to create required new <see cref="Security"/></param>
+        /// <returns>Returns a list of added currency <see cref="SubscriptionDataConfig"/></returns>
+        public List<SubscriptionDataConfig> EnsureCurrencyDataFeeds(SecurityManager securities,
+            SubscriptionManager subscriptions,
+            IReadOnlyDictionary<SecurityType, string> marketMap,
+            SecurityChanges changes,
+            ISecurityService securityService)
         {
-            var addedSecurities = new List<Security>();
+            var addedSubscriptionDataConfigs = new List<SubscriptionDataConfig>();
             foreach (var kvp in _currencies)
             {
                 var cash = kvp.Value;
 
-                var security = cash.EnsureCurrencyDataFeed(securities, subscriptions, marketHoursDatabase, symbolPropertiesDatabase, marketMap, this, changes);
-                if (security != null)
+                var subscriptionDataConfig = cash.EnsureCurrencyDataFeed(securities, subscriptions, marketMap, changes, securityService);
+                if (subscriptionDataConfig != null)
                 {
-                    addedSecurities.Add(security);
+                    addedSubscriptionDataConfigs.Add(subscriptionDataConfig);
                 }
             }
-            return addedSecurities;
+            return addedSubscriptionDataConfigs;
         }
 
         /// <summary>

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Securities
     /// Enumerable security management class for grouping security objects into an array and providing any common properties.
     /// </summary>
     /// <remarks>Implements IDictionary for the index searching of securities by symbol</remarks>
-    public class SecurityManager : IDictionary<Symbol, Security>, INotifyCollectionChanged, ISecurityService
+    public class SecurityManager : IDictionary<Symbol, Security>, INotifyCollectionChanged
     {
         /// <summary>
         /// Event fired when a security is added or removed from this collection

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -19,10 +19,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
-using QuantConnect.Util;
 
 namespace QuantConnect.Securities
 {
@@ -30,7 +28,7 @@ namespace QuantConnect.Securities
     /// Enumerable security management class for grouping security objects into an array and providing any common properties.
     /// </summary>
     /// <remarks>Implements IDictionary for the index searching of securities by symbol</remarks>
-    public class SecurityManager : IDictionary<Symbol, Security>, INotifyCollectionChanged
+    public class SecurityManager : IDictionary<Symbol, Security>, INotifyCollectionChanged, ISecurityService
     {
         /// <summary>
         /// Event fired when a security is added or removed from this collection
@@ -41,6 +39,7 @@ namespace QuantConnect.Securities
 
         //Internal dictionary implementation:
         private readonly ConcurrentDictionary<Symbol, Security> _securityManager;
+        private SecurityService _securityService;
 
         /// <summary>
         /// Gets the most recent time this manager was updated
@@ -294,205 +293,50 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Creates a security and matching configuration. This applies the default leverage if
-        /// leverage is less than or equal to zero.
-        /// This method also add the new symbol mapping to the <see cref="SymbolCache"/>
+        /// Sets the Security Service to be used
         /// </summary>
-        public static Security CreateSecurity(List<Tuple<Type, TickType>> subscriptionDataTypes,
-            SecurityPortfolioManager securityPortfolioManager,
-            SubscriptionManager subscriptionManager,
-            SecurityExchangeHours exchangeHours,
-            DateTimeZone dataTimeZone,
-            SymbolProperties symbolProperties,
-            ISecurityInitializer securityInitializer,
-            Symbol symbol,
-            Resolution resolution,
-            bool fillDataForward,
-            decimal leverage,
-            bool extendedMarketHours,
-            bool isInternalFeed,
-            bool isCustomData,
-            bool isLiveMode,
-            bool addToSymbolCache = true,
-            bool isFilteredSubscription = true)
+        public void SetSecurityService(SecurityService securityService)
         {
-            // add the symbol to our cache
-            if (addToSymbolCache) SymbolCache.Set(symbol.Value, symbol);
-
-            // Add the symbol to Data Manager -- generate unified data streams for algorithm events
-            var configs = subscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward,
-                                                                                extendedMarketHours, isFilteredSubscription, isInternalFeed,
-                                                                                isCustomData, subscriptionDataTypes);
-            var configList = new SubscriptionDataConfigList(symbol);
-            configList.AddRange(configs);
-
-            // verify the cash book is in a ready state
-            var quoteCurrency = symbolProperties.QuoteCurrency;
-            if (!securityPortfolioManager.CashBook.ContainsKey(quoteCurrency))
-            {
-                // since we have none it's safe to say the conversion is zero
-                securityPortfolioManager.CashBook.Add(quoteCurrency, 0, 0);
-            }
-            if (symbol.ID.SecurityType == SecurityType.Forex || symbol.ID.SecurityType == SecurityType.Crypto)
-            {
-                // decompose the symbol into each currency pair
-                string baseCurrency;
-                Forex.Forex.DecomposeCurrencyPair(symbol.Value, out baseCurrency, out quoteCurrency);
-
-                if (!securityPortfolioManager.CashBook.ContainsKey(baseCurrency))
-                {
-                    // since we have none it's safe to say the conversion is zero
-                    securityPortfolioManager.CashBook.Add(baseCurrency, 0, 0);
-                }
-                if (!securityPortfolioManager.CashBook.ContainsKey(quoteCurrency))
-                {
-                    // since we have none it's safe to say the conversion is zero
-                    securityPortfolioManager.CashBook.Add(quoteCurrency, 0, 0);
-                }
-            }
-
-            var quoteCash = securityPortfolioManager.CashBook[symbolProperties.QuoteCurrency];
-
-            Security security;
-            switch (symbol.ID.SecurityType)
-            {
-                case SecurityType.Equity:
-                    security = new Equity.Equity(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
-                    break;
-
-                case SecurityType.Option:
-                    if (addToSymbolCache) SymbolCache.Set(symbol.Underlying.Value, symbol.Underlying);
-                    security = new Option.Option(symbol, exchangeHours, securityPortfolioManager.CashBook[CashBook.AccountCurrency], new Option.OptionSymbolProperties(symbolProperties), securityPortfolioManager.CashBook);
-                    break;
-
-                case SecurityType.Future:
-                    security = new Future.Future(symbol, exchangeHours, securityPortfolioManager.CashBook[CashBook.AccountCurrency], symbolProperties, securityPortfolioManager.CashBook);
-                    break;
-
-                case SecurityType.Forex:
-                    security = new Forex.Forex(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
-                    break;
-
-                case SecurityType.Cfd:
-                    security = new Cfd.Cfd(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
-                    break;
-
-                case SecurityType.Crypto:
-                    security = new Crypto.Crypto(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
-                    break;
-
-                default:
-                case SecurityType.Base:
-                    security = new Security(symbol, exchangeHours, quoteCash, symbolProperties, securityPortfolioManager.CashBook);
-                    break;
-            }
-
-            // if we're just creating this security and it only has an internal
-            // feed, mark it as non-tradable since the user didn't request this data
-            if (!isInternalFeed)
-            {
-                security.IsTradable = true;
-            }
-
-            security.AddData(configList);
-
-            // invoke the security initializer
-            securityInitializer.Initialize(security);
-
-            // if leverage was specified then apply to security after the initializer has run, parameters of this
-            // method take precedence over the intializer
-            if (leverage > 0)
-            {
-                security.SetLeverage(leverage);
-            }
-
-            // In live mode, equity assumes specific price variation model
-            if (isLiveMode && security.Type == SecurityType.Equity)
-            {
-                security.PriceVariationModel = new EquityPriceVariationModel();
-            }
-
-            return security;
+            _securityService = securityService;
         }
 
         /// <summary>
-        /// Creates a security and matching configuration. This applies the default leverage if
-        /// leverage is less than or equal to zero.
-        /// This method also add the new symbol mapping to the <see cref="SymbolCache"/>
+        /// Creates a new security
         /// </summary>
-        public static Security CreateSecurity(Type dataType,
-            SecurityPortfolioManager securityPortfolioManager,
-            SubscriptionManager subscriptionManager,
-            SecurityExchangeHours exchangeHours,
-            DateTimeZone dataTimeZone,
-            SymbolProperties symbolProperties,
-            ISecurityInitializer securityInitializer,
+        /// <remarks>Following the obsoletion of Security.Subscriptions,
+        /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
+        public Security CreateSecurity(
             Symbol symbol,
-            Resolution resolution,
-            bool fillDataForward,
-            decimal leverage,
-            bool extendedMarketHours,
-            bool isInternalFeed,
-            bool isCustomData,
-            bool isLiveMode,
-            bool addToSymbolCache = true,
-            bool isFilteredSubscription = true)
+            List<SubscriptionDataConfig> subscriptionDataConfigList,
+            decimal leverage = 0,
+            bool addToSymbolCache = true)
         {
-            return CreateSecurity(
-                new List<Tuple<Type, TickType>>
-                {
-                    new Tuple<Type, TickType>(dataType, LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType))
-                },
-                securityPortfolioManager,
-                subscriptionManager,
-                exchangeHours,
-                dataTimeZone,
-                symbolProperties,
-                securityInitializer,
-                symbol,
-                resolution,
-                fillDataForward,
-                leverage,
-                extendedMarketHours,
-                isInternalFeed,
-                isCustomData,
-                isLiveMode,
-                addToSymbolCache,
-                isFilteredSubscription);
+            return _securityService.CreateSecurity(symbol, subscriptionDataConfigList, leverage, addToSymbolCache);
         }
 
+
         /// <summary>
-        /// Creates a security and matching configuration. This applies the default leverage if
-        /// leverage is less than or equal to zero.
-        /// This method also add the new symbol mapping to the <see cref="SymbolCache"/>
+        /// Creates a new security
         /// </summary>
-        public static Security CreateSecurity(SecurityPortfolioManager securityPortfolioManager,
-            SubscriptionManager subscriptionManager,
-            MarketHoursDatabase marketHoursDatabase,
-            SymbolPropertiesDatabase symbolPropertiesDatabase,
-            ISecurityInitializer securityInitializer,
+        /// <remarks>Following the obsoletion of Security.Subscriptions,
+        /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
+        public Security CreateSecurity(
             Symbol symbol,
-            Resolution resolution,
-            bool fillDataForward,
-            decimal leverage,
-            bool extendedMarketHours,
-            bool isInternalFeed,
-            bool isCustomData,
-            bool isLiveMode,
+            SubscriptionDataConfig subscriptionDataConfig,
+            decimal leverage = 0,
             bool addToSymbolCache = true
             )
         {
-            var marketHoursDbEntry = marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType);
-            var exchangeHours = marketHoursDbEntry.ExchangeHours;
+            return _securityService.CreateSecurity(symbol, subscriptionDataConfig, leverage, addToSymbolCache);
+        }
 
-            var defaultQuoteCurrency = CashBook.AccountCurrency;
-            if (symbol.ID.SecurityType == SecurityType.Forex || symbol.ID.SecurityType == SecurityType.Crypto) defaultQuoteCurrency = symbol.Value.Substring(3);
-            var symbolProperties = symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
-
-            var types = subscriptionManager.LookupSubscriptionConfigDataTypes(symbol.SecurityType, resolution, symbol.IsCanonical());
-
-            return CreateSecurity(types, securityPortfolioManager, subscriptionManager, exchangeHours, marketHoursDbEntry.DataTimeZone, symbolProperties, securityInitializer, symbol, resolution,
-                fillDataForward, leverage, extendedMarketHours, isInternalFeed, isCustomData, isLiveMode, addToSymbolCache);
+        /// <summary>
+        /// Set live mode state of the algorithm
+        /// </summary>
+        /// <param name="isLiveMode">True, live mode is enabled</param>
+        public void SetLiveMode(bool isLiveMode)
+        {
+            _securityService.SetLiveMode(isLiveMode);
         }
     }
 }

--- a/Common/Securities/SecurityService.cs
+++ b/Common/Securities/SecurityService.cs
@@ -1,0 +1,185 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// This class implements interface <see cref="ISecurityService"/> providing methods for creating new <see cref="Security"/>
+    /// </summary>
+    public class SecurityService : ISecurityService
+    {
+        private readonly CashBook _cashBook;
+        private readonly MarketHoursDatabase _marketHoursDatabase;
+        private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase;
+        private readonly ISecurityInitializerProvider _securityInitializerProvider;
+        private bool _isLiveMode;
+
+        /// <summary>
+        /// Creates a new instance of the SecurityService class
+        /// </summary>
+        public SecurityService(CashBook cashBook,
+            MarketHoursDatabase marketHoursDatabase,
+            SymbolPropertiesDatabase symbolPropertiesDatabase,
+            ISecurityInitializerProvider securityInitializerProvider)
+        {
+            _cashBook = cashBook;
+            _marketHoursDatabase = marketHoursDatabase;
+            _symbolPropertiesDatabase = symbolPropertiesDatabase;
+            _securityInitializerProvider = securityInitializerProvider;
+        }
+
+        /// <summary>
+        /// Creates a new security
+        /// </summary>
+        /// <remarks>Following the obsoletion of Security.Subscriptions,
+        /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
+        public Security CreateSecurity(Symbol symbol,
+            List<SubscriptionDataConfig> subscriptionDataConfigList,
+            decimal leverage = 0,
+            bool addToSymbolCache = true)
+        {
+            var configList = new SubscriptionDataConfigList(symbol);
+            configList.AddRange(subscriptionDataConfigList);
+
+            var exchangeHours = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType).ExchangeHours;
+
+            var defaultQuoteCurrency = CashBook.AccountCurrency;
+            if (symbol.ID.SecurityType == SecurityType.Forex || symbol.ID.SecurityType == SecurityType.Crypto)
+            {
+                defaultQuoteCurrency = symbol.Value.Substring(3);
+            }
+
+            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
+
+            // add the symbol to our cache
+            if (addToSymbolCache)
+            {
+                SymbolCache.Set(symbol.Value, symbol);
+            }
+
+            // verify the cash book is in a ready state
+            var quoteCurrency = symbolProperties.QuoteCurrency;
+            if (!_cashBook.ContainsKey(quoteCurrency))
+            {
+                // since we have none it's safe to say the conversion is zero
+                _cashBook.Add(quoteCurrency, 0, 0);
+            }
+            if (symbol.ID.SecurityType == SecurityType.Forex || symbol.ID.SecurityType == SecurityType.Crypto)
+            {
+                // decompose the symbol into each currency pair
+                string baseCurrency;
+                Forex.Forex.DecomposeCurrencyPair(symbol.Value, out baseCurrency, out quoteCurrency);
+
+                if (!_cashBook.ContainsKey(baseCurrency))
+                {
+                    // since we have none it's safe to say the conversion is zero
+                    _cashBook.Add(baseCurrency, 0, 0);
+                }
+                if (!_cashBook.ContainsKey(quoteCurrency))
+                {
+                    // since we have none it's safe to say the conversion is zero
+                    _cashBook.Add(quoteCurrency, 0, 0);
+                }
+            }
+
+            var quoteCash = _cashBook[symbolProperties.QuoteCurrency];
+
+            Security security;
+            switch (symbol.ID.SecurityType)
+            {
+                case SecurityType.Equity:
+                    security = new Equity.Equity(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    break;
+
+                case SecurityType.Option:
+                    if (addToSymbolCache) SymbolCache.Set(symbol.Underlying.Value, symbol.Underlying);
+                    security = new Option.Option(symbol, exchangeHours, _cashBook[CashBook.AccountCurrency], new Option.OptionSymbolProperties(symbolProperties), _cashBook);
+                    break;
+
+                case SecurityType.Future:
+                    security = new Future.Future(symbol, exchangeHours, _cashBook[CashBook.AccountCurrency], symbolProperties, _cashBook);
+                    break;
+
+                case SecurityType.Forex:
+                    security = new Forex.Forex(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    break;
+
+                case SecurityType.Cfd:
+                    security = new Cfd.Cfd(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    break;
+
+                case SecurityType.Crypto:
+                    security = new Crypto.Crypto(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    break;
+
+                default:
+                case SecurityType.Base:
+                    security = new Security(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    break;
+            }
+
+            // if we're just creating this security and it only has an internal
+            // feed, mark it as non-tradable since the user didn't request this data
+            if (!configList.IsInternalFeed)
+            {
+                security.IsTradable = true;
+            }
+
+            security.AddData(configList);
+
+            // invoke the security initializer
+            _securityInitializerProvider.SecurityInitializer.Initialize(security);
+
+            // if leverage was specified then apply to security after the initializer has run, parameters of this
+            // method take precedence over the intializer
+            if (leverage > 0)
+            {
+                security.SetLeverage(leverage);
+            }
+
+            // In live mode, equity assumes specific price variation model
+            if (_isLiveMode && security.Type == SecurityType.Equity)
+            {
+                security.PriceVariationModel = new EquityPriceVariationModel();
+            }
+
+            return security;
+        }
+
+        /// <summary>
+        /// Creates a new security
+        /// </summary>
+        /// <remarks>Following the obsoletion of Security.Subscriptions,
+        /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
+        public Security CreateSecurity(Symbol symbol, SubscriptionDataConfig subscriptionDataConfig, decimal leverage = 0, bool addToSymbolCache = true)
+        {
+            return CreateSecurity(symbol, new List<SubscriptionDataConfig> { subscriptionDataConfig }, leverage, addToSymbolCache);
+        }
+
+        /// <summary>
+        /// Set live mode state of the algorithm
+        /// </summary>
+        /// <param name="isLiveMode">True, live mode is enabled</param>
+        public void SetLiveMode(bool isLiveMode)
+        {
+            _isLiveMode = isLiveMode;
+        }
+    }
+}

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -124,9 +124,24 @@ namespace QuantConnect.Lean.Engine
                     IBrokerageFactory factory;
                     brokerage = _algorithmHandlers.Setup.CreateBrokerage(job, algorithm, out factory);
 
+                    var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+                    var symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
+
+                    var securityService = new SecurityService(algorithm.Portfolio.CashBook,
+                        marketHoursDatabase,
+                        symbolPropertiesDatabase,
+                        (ISecurityInitializerProvider)algorithm);
+
+                    algorithm.Securities.SetSecurityService(securityService);
+
                     dataManager = new DataManager(_algorithmHandlers.DataFeed,
-                                                  new UniverseSelection(_algorithmHandlers.DataFeed, algorithm),
-                                                  algorithm.Settings, algorithm.TimeKeeper);
+                        new UniverseSelection(
+                            _algorithmHandlers.DataFeed,
+                            algorithm,
+                            securityService),
+                        algorithm.Settings,
+                        algorithm.TimeKeeper,
+                        marketHoursDatabase);
 
                     algorithm.SubscriptionManager.SetDataManager(dataManager);
 

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -68,8 +68,16 @@ namespace QuantConnect.Jupyter
                 var algorithmHandlers = LeanEngineAlgorithmHandlers.FromConfiguration(composer);
                 _dataCacheProvider = new ZipDataCacheProvider(algorithmHandlers.DataProvider);
 
+                var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
                 var nullDataFeed = new NullDataFeed();
-                SubscriptionManager.SetDataManager(new DataManager(nullDataFeed, new UniverseSelection(nullDataFeed, this), Settings, TimeKeeper));
+                var securityService = new SecurityService(Portfolio.CashBook, MarketHoursDatabase, symbolPropertiesDataBase, this);
+                Securities.SetSecurityService(securityService);
+                SubscriptionManager.SetDataManager(
+                    new DataManager(nullDataFeed,
+                        new UniverseSelection(nullDataFeed, this, securityService),
+                        Settings,
+                        TimeKeeper,
+                        MarketHoursDatabase));
 
                 var mapFileProvider = algorithmHandlers.MapFileProvider;
                 HistoryProvider = composer.GetExportedValueByTypeName<IHistoryProvider>(Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider"));

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -158,12 +158,21 @@ AddReference('QuantConnect.Lean.Engine')
 
 from System import *
 from QuantConnect import *
+from QuantConnect.Securities import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Indicators import *
 from QuantConnect.Lean.Engine.DataFeeds import *
 
 algo = QCAlgorithm()
-algo.SubscriptionManager.SetDataManager(DataManager(None, UniverseSelection(None, algo), algo.Settings, algo.TimeKeeper))
+
+marketHoursDatabase = MarketHoursDatabase.FromDataFolder()
+symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder()
+securityService =  SecurityService(algo.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDatabase, algo)
+algo.Securities.SetSecurityService(securityService)
+dataManager = DataManager(None, UniverseSelection(None, algo, securityService), algo.Settings, algo.TimeKeeper, marketHoursDatabase)
+algo.SubscriptionManager.SetDataManager(dataManager)
+
+
 forex = algo.AddForex('EURUSD', Resolution.Daily)
 indicator = IchimokuKinkoHyo('EURUSD', 9, 26, 26, 52, 26, 26)
 algo.RegisterIndicator(forex.Symbol, indicator, Resolution.Daily)";

--- a/Tests/Algorithm/AlgorithmResolveConsolidatorTests.cs
+++ b/Tests/Algorithm/AlgorithmResolveConsolidatorTests.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Tests.Algorithm
         public void TradeBarToTradeBar()
         {
             var algorithm = new QCAlgorithm();
-            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub());
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
             var security = algorithm.AddEquity("SPY");
             var consolidator = algorithm.ResolveConsolidator("SPY", Resolution.Minute);
 
@@ -41,7 +41,7 @@ namespace QuantConnect.Tests.Algorithm
         public void QuoteBarToQuoteBar()
         {
             var algorithm = new QCAlgorithm();
-            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub());
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
             var security = algorithm.AddForex("EURUSD");
             var consolidator = algorithm.ResolveConsolidator("EURUSD", Resolution.Minute);
 
@@ -55,7 +55,7 @@ namespace QuantConnect.Tests.Algorithm
         public void TickTypeTradeToTradeBar()
         {
             var algorithm = new QCAlgorithm();
-            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub());
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
             var security = algorithm.AddEquity("SPY", Resolution.Tick);
             var consolidator = algorithm.ResolveConsolidator("SPY", Resolution.Minute);
 
@@ -70,7 +70,7 @@ namespace QuantConnect.Tests.Algorithm
         public void TickTypeQuoteToQuoteBar()
         {
             var algorithm = new QCAlgorithm();
-            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub());
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
             var security = algorithm.AddForex("EURUSD", Resolution.Tick);
             var consolidator = algorithm.ResolveConsolidator("EURUSD", Resolution.Minute);
 
@@ -85,7 +85,7 @@ namespace QuantConnect.Tests.Algorithm
         public void TickTypeTradeToTick()
         {
             var algorithm = new QCAlgorithm();
-            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub());
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
             var security = algorithm.AddEquity("SPY", Resolution.Tick);
             var consolidator = algorithm.ResolveConsolidator("SPY", Resolution.Tick);
 
@@ -101,7 +101,7 @@ namespace QuantConnect.Tests.Algorithm
         public void TickTypeQuoteToTick()
         {
             var algorithm = new QCAlgorithm();
-            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub());
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
             var security = algorithm.AddForex("EURUSD", Resolution.Tick);
             var consolidator = algorithm.ResolveConsolidator("EURUSD", Resolution.Tick);
 

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -35,7 +35,6 @@ namespace QuantConnect.Tests.Common.Securities
         private static readonly DateTimeZone TimeZone = TimeZones.NewYork;
         private static readonly SecurityExchangeHours SecurityExchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZone);
         private static readonly IReadOnlyDictionary<SecurityType, string> MarketMap = DefaultBrokerageModel.DefaultMarketMap;
-        private static readonly MarketHoursDatabase AlwaysOpenMarketHoursDatabase = MarketHoursDatabase.AlwaysOpen;
 
         [Test]
         public void ConstructorCapitalizedSymbol()
@@ -88,9 +87,11 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
+
             securities.Add(
                 Symbols.SPY,
                 new Security(
@@ -98,10 +99,9 @@ namespace QuantConnect.Tests.Common.Securities
                     abcConfig,
                     new Cash(CashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(CashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
-                )
-            );
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
+                    cashBook));
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
+
             Assert.AreEqual(1, subscriptions.Subscriptions.Count(x => x.Symbol == Symbols.USDJPY));
             Assert.AreEqual(1, securities.Values.Count(x => x.Symbol == Symbols.USDJPY));
         }
@@ -115,7 +115,8 @@ namespace QuantConnect.Tests.Common.Securities
             var cashBook = new CashBook();
             cashBook.Add("JPY", cash);
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(
@@ -130,7 +131,7 @@ namespace QuantConnect.Tests.Common.Securities
             );
             var usdjpy = new Security(Symbols.USDJPY, SecurityExchangeHours, new Cash("JPY", 0, 0), SymbolProperties.GetDefault("JPY"), ErrorCurrencyConverter.Instance);
             var changes = new SecurityChanges(new[] {usdjpy}, Enumerable.Empty<Security>());
-            var addedSecurity = cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, changes);
+            var addedSecurity = cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, changes, dataManager.SecurityService);
 
             // the security exists in SecurityChanges so it is NOT added to the security manager or subscriptions
             // this security will be added by the algorithm manager
@@ -148,7 +149,8 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add("JPY", cash);
 
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(
                 Symbols.SPY,
@@ -171,7 +173,7 @@ namespace QuantConnect.Tests.Common.Securities
                 )
             );
 
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
             Assert.AreEqual(minimumResolution, subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY).Resolution);
         }
 
@@ -185,7 +187,8 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add("JPY", cash);
 
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(
                 Symbols.EURUSD,
@@ -198,7 +201,7 @@ namespace QuantConnect.Tests.Common.Securities
                 )
             );
 
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
             var config = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY);
             Assert.IsTrue(config.IsInternalFeed);
         }
@@ -213,7 +216,8 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add("JPY", cash);
 
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(
                 Symbols.USDJPY,
@@ -226,7 +230,7 @@ namespace QuantConnect.Tests.Common.Securities
                 )
             );
 
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
             var config = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY);
             Assert.IsFalse(config.IsInternalFeed);
         }
@@ -245,7 +249,8 @@ namespace QuantConnect.Tests.Common.Securities
             var symbol = Symbol.Create("GBPJPY", SecurityType.Forex, Market.FXCM);
 
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(
                 symbol,
@@ -258,11 +263,11 @@ namespace QuantConnect.Tests.Common.Securities
                 )
             );
 
-            cashJPY.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
+            cashJPY.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
             var config1 = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.USDJPY);
             Assert.IsTrue(config1.IsInternalFeed);
 
-            cashGBP.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
+            cashGBP.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
             var config2 = subscriptions.Subscriptions.Single(x => x.Symbol == Symbols.GBPUSD);
             Assert.IsTrue(config2.IsInternalFeed);
         }
@@ -283,10 +288,11 @@ namespace QuantConnect.Tests.Common.Securities
             };
 
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
 
-            book.EnsureCurrencyDataFeeds(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, SecurityChanges.None);
+            book.EnsureCurrencyDataFeeds(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
 
             var symbols = subscriptions.Subscriptions.Select(sdc => sdc.Symbol).ToHashSet();
 
@@ -315,7 +321,8 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add("JPY", cash);
 
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(
                 Symbols.USDJPY,
@@ -329,7 +336,7 @@ namespace QuantConnect.Tests.Common.Securities
             );
 
             // we need to get subscription index
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
 
             var last = 120m;
             cash.Update(new Tick(DateTime.Now, Symbols.USDJPY, last, 119.95m, 120.05m));
@@ -348,7 +355,8 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add("GBP", cash);
 
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
             securities.Add(
                 Symbols.GBPUSD,
@@ -362,7 +370,7 @@ namespace QuantConnect.Tests.Common.Securities
             );
 
             // we need to get subscription index
-            cash.EnsureCurrencyDataFeed(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, cashBook, SecurityChanges.None);
+            cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
 
             var last = 1.5m;
             cash.Update(new Tick(DateTime.Now, Symbols.GBPUSD, last, last * 1.009m, last * 0.009m));
@@ -390,10 +398,11 @@ namespace QuantConnect.Tests.Common.Securities
                 {"EUR", new Cash("EUR", 100, 1.2m) }
             };
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
 
-            book.EnsureCurrencyDataFeeds(securities, subscriptions, AlwaysOpenMarketHoursDatabase, SymbolPropertiesDatabase.FromDataFolder(), MarketMap, SecurityChanges.None);
+            book.EnsureCurrencyDataFeeds(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
 
             Assert.DoesNotThrow(() => JsonConvert.SerializeObject(book, Formatting.Indented));
         }

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -14,29 +14,20 @@
 */
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data;
-using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
-using Bitcoin = QuantConnect.Algorithm.CSharp.LiveTradingFeaturesAlgorithm.Bitcoin;
 
 namespace QuantConnect.Tests.Common.Securities
 {
     [TestFixture]
     public class SecurityManagerTests
     {
-        private SecurityManager _securityManager;
-        private SecurityTransactionManager _securityTransactionManager;
-        private SecurityPortfolioManager _securityPortfolioManager;
         private SubscriptionManager _subscriptionManager;
-        private MarketHoursDatabase _marketHoursDatabase;
-        private SymbolPropertiesDatabase _symbolPropertiesDatabase;
-        private ISecurityInitializer _securityInitializer;
 
         [SetUp]
         public void Setup()
@@ -44,14 +35,8 @@ namespace QuantConnect.Tests.Common.Securities
             SymbolCache.Clear();
 
             var timeKeeper = new TimeKeeper(new DateTime(2015, 12, 07));
-            _securityManager = new SecurityManager(timeKeeper);
-            _securityTransactionManager = new SecurityTransactionManager(null, _securityManager);
-            _securityPortfolioManager = new SecurityPortfolioManager(_securityManager, _securityTransactionManager);
             _subscriptionManager = new SubscriptionManager();
             _subscriptionManager.SetDataManager(new DataManagerStub(timeKeeper));
-            _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
-            _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
-            _securityInitializer = SecurityInitializer.Null;
         }
 
         [Test]
@@ -142,231 +127,6 @@ namespace QuantConnect.Tests.Common.Securities
             manager.Remove(security.Symbol);
         }
 
-        [TestCase("EURUSD", SecurityType.Forex, Market.FXCM)]
-        [TestCase("EURUSD", SecurityType.Forex, Market.Oanda)]
-        [TestCase("BTCUSD", SecurityType.Crypto, Market.GDAX)]
-        public void SecurityManagerCanCreate_ForexOrCrypto_WithCorrectSubscriptions(string ticker, SecurityType type, string market)
-        {
-            var symbol = Symbol.Create(ticker, type, market);
-            var marketHoursDbEntry = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, type);
-            var defaultQuoteCurrency = symbol.Value.Substring(3);
-
-            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
-
-            var actual = SecurityManager.CreateSecurity(typeof(QuoteBar),
-                _securityPortfolioManager,
-                _subscriptionManager,
-                marketHoursDbEntry.ExchangeHours,
-                marketHoursDbEntry.DataTimeZone,
-                symbolProperties,
-                _securityInitializer,
-                symbol,
-                Resolution.Second,
-                false,
-                1.0m,
-                false,
-                false,
-                false,
-                false);
-            Assert.AreEqual(actual.Subscriptions.Count(), 1);
-            Assert.AreEqual(actual.Subscriptions.First().Type, typeof(QuoteBar));
-            Assert.AreEqual(actual.Subscriptions.First().TickType, TickType.Quote);
-        }
-
-        [Test]
-        public void SecurityManagerCanCreate_CanonicalOption_WithCorrectSubscriptions()
-        {
-            var optionSymbol = Symbol.Create("GOOG", SecurityType.Option, Market.USA);
-            var optionMarketHoursDbEntry = _marketHoursDatabase.GetEntry(optionSymbol.ID.Market, optionSymbol, SecurityType.Option);
-            var optionDefaultQuoteCurrency = CashBook.AccountCurrency;
-            var optionSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(optionSymbol.ID.Market, optionSymbol, optionSymbol.ID.SecurityType, optionDefaultQuoteCurrency);
-
-            var option = SecurityManager.CreateSecurity(typeof(ZipEntryName),
-                _securityPortfolioManager,
-                _subscriptionManager,
-                optionMarketHoursDbEntry.ExchangeHours,
-                optionMarketHoursDbEntry.DataTimeZone,
-                optionSymbolProperties,
-                _securityInitializer,
-                optionSymbol,
-                Resolution.Second,
-                false,
-                1.0m,
-                false,
-                false,
-                false,
-                false);
-
-            Assert.AreEqual(option.Subscriptions.Count(), 1);
-            Assert.AreEqual(option.Subscriptions.First().Type, typeof(ZipEntryName));
-            Assert.AreEqual(option.Subscriptions.First().TickType, TickType.Quote);
-        }
-
-
-        [Test]
-        public void SecurityManagerCanCreate_Equity_WithCorrectSubscriptions()
-        {
-            var equitySymbol = Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
-            var equityMarketHoursDbEntry = _marketHoursDatabase.GetEntry(equitySymbol.ID.Market, equitySymbol, SecurityType.Equity);
-            var equityDefaultQuoteCurrency = CashBook.AccountCurrency;
-            var equitySymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(equitySymbol.ID.Market, equitySymbol, equitySymbol.ID.SecurityType, equityDefaultQuoteCurrency);
-
-            var equity = SecurityManager.CreateSecurity(typeof(TradeBar),
-                _securityPortfolioManager,
-                _subscriptionManager,
-                equityMarketHoursDbEntry.ExchangeHours,
-                equityMarketHoursDbEntry.DataTimeZone,
-                equitySymbolProperties,
-                _securityInitializer,
-                equitySymbol,
-                Resolution.Second,
-                false,
-                1.0m,
-                false,
-                false,
-                false,
-                false);
-
-            Assert.AreEqual(equity.Subscriptions.Count(), 1);
-            Assert.AreEqual(equity.Subscriptions.First().Type, typeof(TradeBar));
-            Assert.AreEqual(equity.Subscriptions.First().TickType, TickType.Trade);
-        }
-
-        [Test]
-        public void SecurityManagerCanCreate_Cfd_WithCorrectSubscriptions()
-        {
-            var symbol = Symbol.Create("abc", SecurityType.Cfd, Market.USA);
-            var marketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "abc", SecurityType.Cfd, TimeZones.NewYork);
-            var defaultQuoteCurrency = CashBook.AccountCurrency;
-            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
-
-            var subscriptions = SecurityManager.CreateSecurity(typeof(QuoteBar),
-                _securityPortfolioManager,
-                _subscriptionManager,
-                marketHoursDbEntry.ExchangeHours,
-                marketHoursDbEntry.DataTimeZone,
-                symbolProperties,
-                _securityInitializer,
-                symbol,
-                Resolution.Second,
-                false,
-                1.0m,
-                false,
-                false,
-                false,
-                false);
-
-            Assert.AreEqual(subscriptions.Subscriptions.Count(), 1);
-            Assert.AreEqual(subscriptions.Subscriptions.First().Type, typeof(QuoteBar));
-            Assert.AreEqual(subscriptions.Subscriptions.First().TickType, TickType.Quote);
-        }
-
-        [Test]
-        public void SecurityManagerCanCreate_CustomSecurities_WithCorrectSubscriptions()
-        {
-            var equitySymbol = new Symbol(SecurityIdentifier.GenerateBase("BTC", Market.USA), "BTC");
-            var equityMarketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "BTC", SecurityType.Base, TimeZones.NewYork);
-            var equitySymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(equitySymbol.ID.Market, equitySymbol, equitySymbol.ID.SecurityType, CashBook.AccountCurrency);
-
-            var equity = SecurityManager.CreateSecurity(typeof(Bitcoin),
-                _securityPortfolioManager,
-                _subscriptionManager,
-                equityMarketHoursDbEntry.ExchangeHours,
-                equityMarketHoursDbEntry.DataTimeZone,
-                equitySymbolProperties,
-                _securityInitializer,
-                equitySymbol,
-                Resolution.Second,
-                false,
-                1.0m,
-                false,
-                false,
-                false,
-                false);
-
-            Assert.AreEqual(equity.Subscriptions.Count(), 1);
-            Assert.AreEqual(equity.Subscriptions.First().Type, typeof(Bitcoin));
-            Assert.AreEqual(equity.Subscriptions.First().TickType, TickType.Trade);
-        }
-
-        [Test]
-        public void SecurityManagerCanCreate_ConcreteOptions_WithCorrectSubscriptions()
-        {
-            var underlying = SecurityIdentifier.GenerateEquity(new DateTime(1998, 01, 02), "SPY", Market.USA);
-            var optionIdentifier = SecurityIdentifier.GenerateOption(new DateTime(2015, 09, 18), underlying, Market.USA, 195.50m, OptionRight.Put, OptionStyle.European);
-            var optionSymbol = new Symbol(optionIdentifier, "SPY", Symbol.Empty);
-            var optionMarketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "SPY", SecurityType.Equity, TimeZones.NewYork);
-            var optionSymbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(optionSymbol.ID.Market, "SPY", optionSymbol.ID.SecurityType, CashBook.AccountCurrency);
-
-            var subscriptionTypes = new List<Tuple<Type, TickType>>
-            {
-                new Tuple<Type, TickType>(typeof(TradeBar), TickType.Trade),
-                new Tuple<Type, TickType>(typeof(QuoteBar), TickType.Quote),
-                new Tuple<Type, TickType>(typeof(OpenInterest), TickType.OpenInterest)
-            };
-
-            var optionSubscriptions = SecurityManager.CreateSecurity(subscriptionTypes,
-                _securityPortfolioManager,
-                _subscriptionManager,
-                optionMarketHoursDbEntry.ExchangeHours,
-                optionMarketHoursDbEntry.DataTimeZone,
-                optionSymbolProperties,
-                _securityInitializer,
-                optionSymbol,
-                Resolution.Second,
-                false,
-                1.0m,
-                false,
-                false,
-                false,
-                false);
-
-            Assert.IsFalse(optionSymbol.IsCanonical());
-
-            Assert.AreEqual(optionSubscriptions.Subscriptions.Count(), 3);
-            Assert.IsTrue(optionSubscriptions.Subscriptions.Any(x => x.TickType == TickType.OpenInterest && x.Type == typeof(OpenInterest)));
-            Assert.IsTrue(optionSubscriptions.Subscriptions.Any(x => x.TickType == TickType.Quote && x.Type == typeof(QuoteBar)));
-            Assert.IsTrue(optionSubscriptions.Subscriptions.Any(x => x.TickType == TickType.Trade && x.Type == typeof(TradeBar)));
-        }
-
-        [Test]
-        public void SecurityManagerCanCreate_ConcreteFutures_WithCorrectSubscriptions()
-        {
-            var identifier = SecurityIdentifier.GenerateFuture(new DateTime(2020, 12, 15), "ED", Market.USA);
-            var symbol = new Symbol(identifier, "ED", Symbol.Empty);
-            var marketHoursDbEntry = _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "ED", SecurityType.Future, TimeZones.NewYork);
-            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, "ED", symbol.ID.SecurityType, CashBook.AccountCurrency);
-
-            var subscriptionTypes = new List<Tuple<Type, TickType>>
-            {
-                new Tuple<Type, TickType>(typeof(TradeBar), TickType.Trade),
-                new Tuple<Type, TickType>(typeof(QuoteBar), TickType.Quote),
-                new Tuple<Type, TickType>(typeof(OpenInterest), TickType.OpenInterest)
-            };
-
-            var subscriptions = SecurityManager.CreateSecurity(subscriptionTypes,
-                _securityPortfolioManager,
-                _subscriptionManager,
-                marketHoursDbEntry.ExchangeHours,
-                marketHoursDbEntry.DataTimeZone,
-                symbolProperties,
-                _securityInitializer,
-                symbol,
-                Resolution.Second,
-                false,
-                1.0m,
-                false,
-                false,
-                false,
-                false);
-
-            Assert.IsFalse(symbol.IsCanonical());
-
-            Assert.AreEqual(subscriptions.Subscriptions.Count(), 3);
-            Assert.IsTrue(subscriptions.Subscriptions.Any(x => x.TickType == TickType.OpenInterest && x.Type == typeof(OpenInterest)));
-            Assert.IsTrue(subscriptions.Subscriptions.Any(x => x.TickType == TickType.Quote && x.Type == typeof(QuoteBar)));
-            Assert.IsTrue(subscriptions.Subscriptions.Any(x => x.TickType == TickType.Trade && x.Type == typeof(TradeBar)));
-        }
 
         [Test]
         public void Option_SubscriptionDataConfigList_CanOnlyHave_RawDataNormalization()

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -33,6 +33,7 @@ using QuantConnect.Brokerages.Backtesting;
 using QuantConnect.Tests.Engine;
 using QuantConnect.Algorithm;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Common.Securities
@@ -157,7 +158,8 @@ namespace QuantConnect.Tests.Common.Securities
 
             // we're going to process fills and very our equity after each fill
             var subscriptions = new SubscriptionManager();
-            subscriptions.SetDataManager(new DataManagerStub(TimeKeeper));
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
             var transactions = new SecurityTransactionManager(null, securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
@@ -203,7 +205,9 @@ namespace QuantConnect.Tests.Common.Securities
             securities.Add(usdJwbSecurity);
             securities.Add(mchUsdSecurity);
 
-            portfolio.CashBook.EnsureCurrencyDataFeeds(securities, subscriptions, MarketHoursDatabase.FromDataFolder(), SymbolPropertiesDatabase.FromDataFolder(), DefaultBrokerageModel.DefaultMarketMap, SecurityChanges.None);
+            var securityService = new SecurityService(portfolio.CashBook, MarketHoursDatabase.FromDataFolder(), SymbolPropertiesDatabase.FromDataFolder(), dataManager.Algorithm);
+
+            portfolio.CashBook.EnsureCurrencyDataFeeds(securities, subscriptions, DefaultBrokerageModel.DefaultMarketMap, SecurityChanges.None, securityService);
 
             for (int i = 0; i < fills.Count; i++)
             {

--- a/Tests/Common/Securities/SecurityServiceTests.cs
+++ b/Tests/Common/Securities/SecurityServiceTests.cs
@@ -1,0 +1,168 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Algorithm.CSharp;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    public class SecurityServiceTests : ISecurityInitializerProvider
+    {
+        private ISecurityService _securityService;
+        private SubscriptionManager _subscriptionManager;
+        private MarketHoursDatabase _marketHoursDatabase;
+        public ISecurityInitializer SecurityInitializer => QuantConnect.Securities.SecurityInitializer.Null;
+
+        [SetUp]
+        public void Setup()
+        {
+            SymbolCache.Clear();
+            _subscriptionManager = new SubscriptionManager();
+            var dataManager = new DataManagerStub();
+            _subscriptionManager.SetDataManager(dataManager);
+            _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            _securityService = dataManager.SecurityService;
+        }
+
+        [TestCase("EURUSD", SecurityType.Forex, Market.FXCM)]
+        [TestCase("EURUSD", SecurityType.Forex, Market.Oanda)]
+        [TestCase("BTCUSD", SecurityType.Crypto, Market.GDAX)]
+        public void CanCreate_ForexOrCrypto_WithCorrectSubscriptions(string ticker, SecurityType type, string market)
+        {
+            var symbol = Symbol.Create(ticker, type, market);
+
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(typeof(QuoteBar), symbol, Resolution.Second, false, false, false);
+            var actual = _securityService.CreateSecurity(symbol, configs, 1.0m, false);
+
+            Assert.AreEqual(actual.Subscriptions.Count(), 1);
+            Assert.AreEqual(actual.Subscriptions.First().Type, typeof(QuoteBar));
+            Assert.AreEqual(actual.Subscriptions.First().TickType, TickType.Quote);
+        }
+
+        [Test]
+        public void CanCreate_CanonicalOption_WithCorrectSubscriptions()
+        {
+            var optionSymbol = Symbol.Create("GOOG", SecurityType.Option, Market.USA);
+
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(typeof(ZipEntryName), optionSymbol, Resolution.Second, false, false, false);
+            var option = _securityService.CreateSecurity(optionSymbol, configs, 1.0m, false);
+
+            Assert.AreEqual(option.Subscriptions.Count(), 1);
+            Assert.AreEqual(option.Subscriptions.First().Type, typeof(ZipEntryName));
+            Assert.AreEqual(option.Subscriptions.First().TickType, TickType.Quote);
+        }
+
+
+        [Test]
+        public void CanCreate_Equity_WithCorrectSubscriptions()
+        {
+            var equitySymbol = Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
+
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(typeof(TradeBar), equitySymbol, Resolution.Second, false, false, false);
+            var equity = _securityService.CreateSecurity(equitySymbol, configs, 1.0m, false);
+
+            Assert.AreEqual(equity.Subscriptions.Count(), 1);
+            Assert.AreEqual(equity.Subscriptions.First().Type, typeof(TradeBar));
+            Assert.AreEqual(equity.Subscriptions.First().TickType, TickType.Trade);
+        }
+
+        [Test]
+        public void CanCreate_Cfd_WithCorrectSubscriptions()
+        {
+            var symbol = Symbol.Create("abc", SecurityType.Cfd, Market.USA);
+            _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "abc", SecurityType.Cfd, TimeZones.NewYork);
+
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(typeof(QuoteBar), symbol, Resolution.Second, false, false, false);
+            var cfd = _securityService.CreateSecurity(symbol, configs, 1.0m, false);
+
+            Assert.AreEqual(cfd.Subscriptions.Count(), 1);
+            Assert.AreEqual(cfd.Subscriptions.First().Type, typeof(QuoteBar));
+            Assert.AreEqual(cfd.Subscriptions.First().TickType, TickType.Quote);
+        }
+
+        [Test]
+        public void CanCreate_CustomSecurities_WithCorrectSubscriptions()
+        {
+            var symbol = new Symbol(SecurityIdentifier.GenerateBase("BTC", Market.USA), "BTC");
+            _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "BTC", SecurityType.Base, TimeZones.NewYork);
+
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(typeof(LiveTradingFeaturesAlgorithm.Bitcoin), symbol, Resolution.Second, false, false, false);
+            var security = _securityService.CreateSecurity(symbol, configs, 1.0m, false);
+
+            Assert.AreEqual(security.Subscriptions.Count(), 1);
+            Assert.AreEqual(security.Subscriptions.First().Type, typeof(LiveTradingFeaturesAlgorithm.Bitcoin));
+            Assert.AreEqual(security.Subscriptions.First().TickType, TickType.Trade);
+        }
+
+        [Test]
+        public void CanCreate_ConcreteOptions_WithCorrectSubscriptions()
+        {
+            var underlying = SecurityIdentifier.GenerateEquity(new DateTime(1998, 01, 02), "SPY", Market.USA);
+            var optionIdentifier = SecurityIdentifier.GenerateOption(new DateTime(2015, 09, 18), underlying, Market.USA, 195.50m, OptionRight.Put, OptionStyle.European);
+            var optionSymbol = new Symbol(optionIdentifier, "SPY", Symbol.Empty);
+
+            var subscriptionTypes = new List<Tuple<Type, TickType>>
+            {
+                new Tuple<Type, TickType>(typeof(TradeBar), TickType.Trade),
+                new Tuple<Type, TickType>(typeof(QuoteBar), TickType.Quote),
+                new Tuple<Type, TickType>(typeof(OpenInterest), TickType.OpenInterest)
+            };
+
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(optionSymbol, Resolution.Second, false, false, false, false, false, subscriptionTypes);
+            var security = _securityService.CreateSecurity(optionSymbol, configs, 1.0m, false);
+
+            Assert.IsFalse(optionSymbol.IsCanonical());
+
+            Assert.AreEqual(security.Subscriptions.Count(), 3);
+            Assert.IsTrue(security.Subscriptions.Any(x => x.TickType == TickType.OpenInterest && x.Type == typeof(OpenInterest)));
+            Assert.IsTrue(security.Subscriptions.Any(x => x.TickType == TickType.Quote && x.Type == typeof(QuoteBar)));
+            Assert.IsTrue(security.Subscriptions.Any(x => x.TickType == TickType.Trade && x.Type == typeof(TradeBar)));
+        }
+
+        [Test]
+        public void CanCreate_ConcreteFutures_WithCorrectSubscriptions()
+        {
+            var identifier = SecurityIdentifier.GenerateFuture(new DateTime(2020, 12, 15), "ED", Market.USA);
+            var symbol = new Symbol(identifier, "ED", Symbol.Empty);
+            _marketHoursDatabase.SetEntryAlwaysOpen(Market.USA, "ED", SecurityType.Future, TimeZones.NewYork);
+
+            var subscriptionTypes = new List<Tuple<Type, TickType>>
+            {
+                new Tuple<Type, TickType>(typeof(TradeBar), TickType.Trade),
+                new Tuple<Type, TickType>(typeof(QuoteBar), TickType.Quote),
+                new Tuple<Type, TickType>(typeof(OpenInterest), TickType.OpenInterest)
+            };
+
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(symbol, Resolution.Second, false, false, false, false, false, subscriptionTypes);
+            var security = _securityService.CreateSecurity(symbol, configs, 1.0m, false);
+
+            Assert.IsFalse(symbol.IsCanonical());
+
+            Assert.AreEqual(security.Subscriptions.Count(), 3);
+            Assert.IsTrue(security.Subscriptions.Any(x => x.TickType == TickType.OpenInterest && x.Type == typeof(OpenInterest)));
+            Assert.IsTrue(security.Subscriptions.Any(x => x.TickType == TickType.Quote && x.Type == typeof(QuoteBar)));
+            Assert.IsTrue(security.Subscriptions.Any(x => x.TickType == TickType.Trade && x.Type == typeof(TradeBar)));
+        }
+    }
+}

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -54,7 +54,15 @@ namespace QuantConnect.Tests.Engine
             var algorithm = PerformanceBenchmarkAlgorithms.SingleSecurity_Second;
             var job = new BacktestNodePacket(1, 2, "3", null, 9m, $"{nameof(AlgorithmManagerTests)}.{nameof(TestAlgorithmManagerSpeed)}");
             var feed = new MockDataFeed();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings, algorithm.TimeKeeper);
+            var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
+            var dataManager = new DataManager(feed,
+                new UniverseSelection(feed,
+                    algorithm,
+                    new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm)),
+                algorithm.Settings,
+                algorithm.TimeKeeper,
+                marketHoursDatabase);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             var transactions = new BacktestingTransactionHandler();
             var results = new BacktestingResultHandler();

--- a/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
@@ -24,6 +24,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
 {
@@ -41,7 +42,15 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var algorithm = PerformanceBenchmarkAlgorithms.SingleSecurity_Second;
             var feed = new FileSystemDataFeed();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings, algorithm.TimeKeeper);
+            var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
+            var dataManager = new DataManager(feed,
+                new UniverseSelection(feed,
+                    algorithm,
+                    new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm)),
+                algorithm.Settings,
+                algorithm.TimeKeeper,
+                marketHoursDatabase);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
 
             feed.Initialize(algorithm, job, resultHandler, mapFileProvider, factorFileProvider, dataProvider, dataManager);

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -591,8 +591,19 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var resultHandler = new BacktestingResultHandler();
 
             var feed = new TestableLiveTradingDataFeed();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm),
-                algorithm.Settings, algorithm.TimeKeeper);
+            var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
+            var securityService = new SecurityService(
+                algorithm.Portfolio.CashBook,
+                marketHoursDatabase,
+                symbolPropertiesDataBase,
+                algorithm);
+            algorithm.Securities.SetSecurityService(securityService);
+            var dataManager = new DataManager(feed,
+                new UniverseSelection(feed, algorithm, securityService),
+                algorithm.Settings,
+                algorithm.TimeKeeper,
+                marketHoursDatabase);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             algorithm.AddSecurities(Resolution.Tick, Enumerable.Range(0, 20).Select(x => x.ToString()).ToList());
             var getNextTicksFunction = Enumerable.Range(0, 20).Select(x => new Tick { Symbol = SymbolCache.GetSymbol(x.ToString()) }).ToList();
@@ -655,8 +666,15 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var feed = new TestableLiveTradingDataFeed(dataQueueHandler, _manualTimeProvider);
             var mapFileProvider = new LocalDiskMapFileProvider();
             var fileProvider = new DefaultDataProvider();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, _algorithm),
-                _algorithm.Settings, _algorithm.TimeKeeper);
+            var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
+            var securityService = new SecurityService(_algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, _algorithm);
+            _algorithm.Securities.SetSecurityService(securityService);
+            var dataManager = new DataManager(feed,
+                new UniverseSelection(feed, _algorithm, securityService),
+                _algorithm.Settings,
+                _algorithm.TimeKeeper,
+                marketHoursDatabase);
             _algorithm.SubscriptionManager.SetDataManager(dataManager);
             _algorithm.AddSecurities(resolution, equities, forex);
 

--- a/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
@@ -49,7 +49,19 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         private void TestSubscriptionSynchronizerSpeed(QCAlgorithm algorithm)
         {
             var feed = new AlgorithmManagerTests.MockDataFeed();
-            var dataManager = new DataManager(feed, new UniverseSelection(feed, algorithm), algorithm.Settings, algorithm.TimeKeeper);
+            var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
+            var securityService = new SecurityService(
+                algorithm.Portfolio.CashBook,
+                marketHoursDatabase,
+                symbolPropertiesDataBase,
+                algorithm);
+            algorithm.Securities.SetSecurityService(securityService);
+            var dataManager = new DataManager(feed,
+                new UniverseSelection(feed, algorithm, securityService),
+                algorithm.Settings,
+                algorithm.TimeKeeper,
+                marketHoursDatabase);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
 
             algorithm.Initialize();

--- a/Tests/Engine/RealTimePriceUpdateTests.cs
+++ b/Tests/Engine/RealTimePriceUpdateTests.cs
@@ -60,8 +60,15 @@ namespace QuantConnect.Tests.Engine
             };
 
             var algo = new TestAlgorithm();
-            var dataManager = new DataManager(_liveTradingDataFeed, new UniverseSelection(_liveTradingDataFeed, algo),
-                algo.Settings, algo.TimeKeeper);
+            var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
+            var dataManager = new DataManager(_liveTradingDataFeed,
+                new UniverseSelection(_liveTradingDataFeed,
+                    algo,
+                    new SecurityService(algo.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algo)),
+                algo.Settings,
+                algo.TimeKeeper,
+                marketHoursDatabase);
             algo.SubscriptionManager.SetDataManager(dataManager);
 
             _liveTradingDataFeed.Initialize(algo, jobPacket, new LiveTradingResultHandler(), new LocalDiskMapFileProvider(),

--- a/Tests/Python/MethodOverloadTests.cs
+++ b/Tests/Python/MethodOverloadTests.cs
@@ -14,6 +14,7 @@
  *
 */
 
+using System;
 using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Python;
@@ -38,7 +39,9 @@ namespace QuantConnect.Tests.Python
             {
                 var module = Py.Import("Test_MethodOverload");
                 _algorithm = module.GetAttr("Test_MethodOverload").Invoke();
-                _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub());
+                // this is required else will get a 'RuntimeBinderException' because fails to match constructor method
+                dynamic algo = _algorithm.AsManagedObject((Type)_algorithm.GetPythonType().AsManagedObject(typeof(Type)));
+                _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algo));
                 _algorithm.Initialize();
             }
         }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Common\Securities\ErrorCurrencyConverterTests.cs" />
     <Compile Include="Common\Securities\IdentityCurrencyConverterTests.cs" />
     <Compile Include="Common\Securities\SecurityHoldingTests.cs" />
+    <Compile Include="Common\Securities\SecurityServiceTests.cs" />
     <Compile Include="Common\Util\SeriesJsonConverterTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />
     <Compile Include="Engine\DataFeeds\DataManagerStub.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding new ISecurityService and its implementation SecurityService.
This interface will expose a method for creating new securities.
- `SecurityManager` will inherite this new interface, calling _securityService
internally, so Future/OptionUniverseSelectionModel.cs can use it
- QCAlgorithm will no longer need `private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase;`
- Replacing all usages of SecurityManager.CreateSecurity for new
ISecurityService
- Modifying `Cash.cs` and `CashBook.cs` `EnsureCurrencyDataFeeds()` to
return newly added `SubscriptionDataConfig` instead of `Security`. This
will avoid using `Security.Subscriptions` at call site. They will still create the
Security internally, since it is used to set `ConversionRateSecurity`.
- Moving old SecurityManager.CreateSecurity into new
SecurityServiceTests.cs


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2593
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/5

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->