### PR TITLE
Implements DataDictionary.GetValue

### DIFF
--- a/Algorithm.Python/BasicTemplateOptionsAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsAlgorithm.py
@@ -48,21 +48,21 @@ class BasicTemplateOptionsAlgorithm(QCAlgorithm):
     def OnData(self,slice):
         if self.Portfolio.Invested: return
 
-        for kvp in slice.OptionChains:
-            if kvp.Key != self.option_symbol: continue
-            chain = kvp.Value
+        chain = slice.OptionChains.GetValue(self.option_symbol)
+        if chain is None:
+            return
 
-            # we sort the contracts to find at the money (ATM) contract with farthest expiration
-            contracts = sorted(sorted(sorted(chain, \
-                key = lambda x: abs(chain.Underlying.Price - x.Strike)), \
-                key = lambda x: x.Expiry, reverse=True), \
-                key = lambda x: x.Right, reverse=True)
+        # we sort the contracts to find at the money (ATM) contract with farthest expiration
+        contracts = sorted(sorted(sorted(chain, \
+            key = lambda x: abs(chain.Underlying.Price - x.Strike)), \
+            key = lambda x: x.Expiry, reverse=True), \
+            key = lambda x: x.Right, reverse=True)
 
-            # if found, trade it
-            if len(contracts) == 0: continue
-            symbol = contracts[0].Symbol
-            self.MarketOrder(symbol, 1)
-            self.MarketOnCloseOrder(symbol, -1)
+        # if found, trade it
+        if len(contracts) == 0: return
+        symbol = contracts[0].Symbol
+        self.MarketOrder(symbol, 1)
+        self.MarketOnCloseOrder(symbol, -1)
 
     def OnOrderEvent(self, orderEvent):
         self.Log(str(orderEvent))

--- a/Common/Data/Market/DataDictionary.cs
+++ b/Common/Data/Market/DataDictionary.cs
@@ -272,6 +272,20 @@ namespace QuantConnect.Data.Market
         {
             get { return _data.Values; }
         }
+
+        /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key whose value to get.</param>
+        /// <returns>
+        /// The value associated with the specified key, if the key is found; otherwise, the default value for the type of the <see cref ="T"/> parameter.
+        /// </returns>
+        public virtual T GetValue(Symbol key)
+        {
+            T value;
+            TryGetValue(key, out value);
+            return value;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
#### Description
`DataDictionary.GetValue` is meant to be used as an alternative to `DataDictionary.TryGetValue`. It was created due to limitations to the python implementation.

#### Related Issue
Closes #2614 

#### Motivation and Context
Make Lean more user-friendly to python users.
In order to get the `OptionChain` of a given Option symbol, we need to loop through all the `OptionChains`, compare its key against the given Symbol and assign its value to a variable representing the `OptionChain`.

#### Requires Documentation Change
No, but we could add a code snippet to the [Using Options Data](https://www.quantconnect.com/docs/data-library/options#Options-Using-Options-Data) section.

#### How Has This Been Tested?
Regression test.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`