### PR TITLE
BacktestingResultHandler performance bug fixes

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -273,13 +273,20 @@ namespace QuantConnect.Lean.Engine.Results
                 if (progress > 0.999m) progress = 0.999m;
 
                 //1. Cloud Upload -> Upload the whole packet to S3  Immediately:
-                var completeResult = new BacktestResult(Algorithm.IsFrameworkAlgorithm, Charts, _transactionHandler.Orders, Algorithm.Transactions.TransactionRecord, new Dictionary<string, string>(), runtimeStatistics, new Dictionary<string, AlgorithmPerformance>());
-                var complete = new BacktestResultPacket(_job, completeResult, progress);
-
                 if (DateTime.UtcNow > _nextS3Update)
                 {
+                    var completeResult = new BacktestResult(
+                        Algorithm.IsFrameworkAlgorithm,
+                        Charts,
+                        _transactionHandler.Orders,
+                        Algorithm.Transactions.TransactionRecord,
+                        new Dictionary<string, string>(),
+                        runtimeStatistics,
+                        new Dictionary<string, AlgorithmPerformance>());
+
+                    StoreResult(new BacktestResultPacket(_job, completeResult, progress));
+
                     _nextS3Update = DateTime.UtcNow.AddSeconds(30);
-                    StoreResult(complete);
                 }
 
                 //2. Backtest Update -> Send the truncated packet to the backtester:

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -234,7 +234,7 @@ namespace QuantConnect.Lean.Engine.Results
                 {
                     _lastUpdate = Algorithm.UtcTime.Date;
                     _lastDaysProcessed = _daysProcessed;
-                    _nextUpdate = DateTime.UtcNow.AddSeconds(0.5);
+                    _nextUpdate = DateTime.UtcNow.AddSeconds(2);
                 }
                 catch (Exception err)
                 {


### PR DESCRIPTION

#### Description
This PR fixes a couple of bugs in `BacktestingResultHandler`:
- The time of the next storage update was being set **_before_** (instead of **_after_**) the `StoreResult` call.
- The `StoreResult` method was locking unnecessarily over the `SaveResults` method, causing the algo manager loop to wait for the operation to complete (and possibly time out), now we lock only for the time required to copy the charts dictionary.

#### Related Issue
Closes #2645 

#### Motivation and Context
Backtests of algorithms with thousands of orders would be terminated with timeout error.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local and cloud backtest with 500K orders.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`