### PR TITLE
Move DataManager in front of DataFeed

### DIFF
--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -164,8 +164,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             Log.Debug($"DataManager.AddSubscription(): Added {request.Configuration}." +
                 $" Start: {request.StartTimeUtc}. End: {request.EndTimeUtc}");
-            DataFeedSubscriptions.TryAdd(subscription);
-            return true;
+            return DataFeedSubscriptions.TryAdd(subscription);
         }
 
         /// <summary>
@@ -206,9 +205,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
                 subscription.Dispose();
                 Log.Debug($"DataManager.RemoveSubscription(): Removed {configuration}");
+                return true;
             }
 
-            return true;
+            return false;
         }
 
         #endregion

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -17,9 +17,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Securities;
@@ -48,16 +50,66 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public DataManager(
             IDataFeed dataFeed,
             UniverseSelection universeSelection,
-            IAlgorithmSettings algorithmSettings,
+            IAlgorithm algorithm,
             ITimeKeeper timeKeeper,
             MarketHoursDatabase marketHoursDatabase)
         {
             _dataFeed = dataFeed;
             UniverseSelection = universeSelection;
-            _algorithmSettings = algorithmSettings;
+            UniverseSelection.SetDataManager(this);
+            _algorithmSettings = algorithm.Settings;
             AvailableDataTypes = SubscriptionManager.DefaultDataTypes();
             _timeKeeper = timeKeeper;
             _marketHoursDatabase = marketHoursDatabase;
+
+            var liveStart = DateTime.UtcNow;
+            // wire ourselves up to receive notifications when universes are added/removed
+            algorithm.UniverseManager.CollectionChanged += (sender, args) =>
+            {
+                switch (args.Action)
+                {
+                    case NotifyCollectionChangedAction.Add:
+                        foreach (var universe in args.NewItems.OfType<Universe>())
+                        {
+                            var config = universe.Configuration;
+                            var start = algorithm.LiveMode ? liveStart : algorithm.UtcTime;
+
+                            var end = algorithm.LiveMode ? Time.EndOfTime
+                                : algorithm.EndDate.ConvertToUtc(algorithm.TimeZone);
+
+                            Security security;
+                            if (!algorithm.Securities.TryGetValue(config.Symbol, out security))
+                            {
+                                // create a canonical security object if it doesn't exist
+                                security = new Security(
+                                    _marketHoursDatabase.GetExchangeHours(config),
+                                    config,
+                                    algorithm.Portfolio.CashBook[CashBook.AccountCurrency],
+                                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
+                                    algorithm.Portfolio.CashBook
+                                 );
+                            }
+                            AddSubscription(
+                                new SubscriptionRequest(true,
+                                    universe,
+                                    security,
+                                    config,
+                                    start,
+                                    end));
+                        }
+                        break;
+
+                    case NotifyCollectionChangedAction.Remove:
+                        foreach (var universe in args.OldItems.OfType<Universe>())
+                        {
+                            RemoveSubscription(universe.Configuration);
+                        }
+                        break;
+
+                    default:
+                        throw new NotImplementedException("The specified action is not implemented: " + args.Action);
+                }
+            };
         }
 
         #region IDataFeedSubscriptionManager
@@ -66,6 +118,98 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// Gets the data feed subscription collection
         /// </summary>
         public SubscriptionCollection DataFeedSubscriptions { get; } = new SubscriptionCollection();
+
+        /// <summary>
+        /// Will remove all current <see cref="Subscription"/>
+        /// </summary>
+        public void RemoveAllSubscriptions()
+        {
+            // remove each subscription from our collection
+            foreach (var subscription in DataFeedSubscriptions)
+            {
+                try
+                {
+                    RemoveSubscription(subscription.Configuration);
+                }
+                catch (Exception err)
+                {
+                    Log.Error(err, "DataManager.RemoveAllSubscriptions():" +
+                        $"Error removing: {subscription.Configuration}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds a new <see cref="Subscription"/> to provide data for the specified security.
+        /// </summary>
+        /// <param name="request">Defines the <see cref="SubscriptionRequest"/> to be added</param>
+        /// <returns>True if the subscription was created and added successfully, false otherwise</returns>
+        public bool AddSubscription(SubscriptionRequest request)
+        {
+            if (DataFeedSubscriptions.Contains(request.Configuration))
+            {
+                // duplicate subscription request
+                return false;
+            }
+
+            var subscription = _dataFeed.CreateSubscription(request);
+
+            if (subscription == null)
+            {
+                Log.Trace($"DataManager.AddSubscription(): Unable to add subscription for: {request.Configuration}");
+                // subscription will be null when there's no tradeable dates for the security between the requested times, so
+                // don't even try to load the data
+                return false;
+            }
+
+            Log.Debug($"DataManager.AddSubscription(): Added {request.Configuration}." +
+                $" Start: {request.StartTimeUtc}. End: {request.EndTimeUtc}");
+            DataFeedSubscriptions.TryAdd(subscription);
+            return true;
+        }
+
+        /// <summary>
+        /// Removes the <see cref="Subscription"/>, if it exists
+        /// </summary>
+        /// <param name="configuration">The <see cref="SubscriptionDataConfig"/> of the subscription to remove</param>
+        /// <returns>True if the subscription was successfully removed, false otherwise</returns>
+        public bool RemoveSubscription(SubscriptionDataConfig configuration)
+        {
+            // remove the subscription from our collection, if it exists
+            Subscription subscription;
+
+            if (DataFeedSubscriptions.TryGetValue(configuration, out subscription))
+            {
+                // don't remove universe subscriptions immediately, instead mark them as disposed
+                // so we can turn the crank one more time to ensure we emit security changes properly
+                if (subscription.IsUniverseSelectionSubscription && subscription.Universe.DisposeRequested)
+                {
+                    // subscription syncer will dispose the universe AFTER we've run selection a final time
+                    // and then will invoke SubscriptionFinished which will remove the universe subscription
+                    return false;
+                }
+
+                if (!DataFeedSubscriptions.TryRemove(configuration, out subscription))
+                {
+                    Log.Error($"DataManager.RemoveSubscription(): Unable to remove {configuration}");
+                    return false;
+                }
+
+                _dataFeed.RemoveSubscription(subscription);
+
+                // if the security is no longer a member of the universe, then mark the subscription properly
+                // universe may be null for internal currency conversion feeds
+                // TODO : Put currency feeds in their own internal universe
+                if (subscription.Universe != null && !subscription.Universe.Members.ContainsKey(configuration.Symbol))
+                {
+                    subscription.MarkAsRemovedFromUniverse();
+                }
+                subscription.Dispose();
+                Log.Debug($"DataManager.RemoveSubscription(): Removed {configuration}");
+            }
+
+            return true;
+        }
 
         #endregion
 

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _controller.Start(_cancellationTokenSource.Token);
         }
 
-        private Subscription InternalCreateSubscription(SubscriptionRequest request)
+        private Subscription CreateDataSubscription(SubscriptionRequest request)
         {
             // ReSharper disable once PossibleMultipleEnumeration
             if (!request.TradableDays.Any())
@@ -169,7 +169,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             return request.IsUniverseSubscription
                 ? CreateUniverseSubscription(request)
-                : InternalCreateSubscription(request);
+                : CreateDataSubscription(request);
         }
 
         /// <summary>

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -51,14 +51,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private SubscriptionDataReaderSubscriptionEnumeratorFactory _subscriptionFactory;
 
         /// <summary>
-        /// Gets all of the current subscriptions this data feed is processing
-        /// </summary>
-        public IEnumerable<Subscription> Subscriptions
-        {
-            get { return _subscriptions; }
-        }
-
-        /// <summary>
         /// Flag indicating the hander thread is completely finished and ready to dispose.
         /// </summary>
         public bool IsActive { get; private set; }
@@ -89,53 +81,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var threadCount = Math.Max(1, Math.Min(4, Environment.ProcessorCount - 3));
             _controller = new ParallelRunnerController(threadCount);
             _controller.Start(_cancellationTokenSource.Token);
-
-            // wire ourselves up to receive notifications when universes are added/removed
-            algorithm.UniverseManager.CollectionChanged += (sender, args) =>
-            {
-                switch (args.Action)
-                {
-                    case NotifyCollectionChangedAction.Add:
-                        foreach (var universe in args.NewItems.OfType<Universe>())
-                        {
-                            var config = universe.Configuration;
-                            var start = _algorithm.UtcTime;
-
-                            var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
-                            var exchangeHours = marketHoursDatabase.GetExchangeHours(config);
-
-                            Security security;
-                            if (!_algorithm.Securities.TryGetValue(config.Symbol, out security))
-                            {
-                                // create a canonical security object if it doesn't exist
-                                security = new Security(
-                                    exchangeHours,
-                                    config,
-                                    _algorithm.Portfolio.CashBook[CashBook.AccountCurrency],
-                                    SymbolProperties.GetDefault(CashBook.AccountCurrency),
-                                    _algorithm.Portfolio.CashBook
-                                );
-                            }
-
-                            var end = _algorithm.EndDate.ConvertToUtc(_algorithm.TimeZone);
-                            AddSubscription(new SubscriptionRequest(true, universe, security, config, start, end));
-                        }
-                        break;
-
-                    case NotifyCollectionChangedAction.Remove:
-                        foreach (var universe in args.OldItems.OfType<Universe>())
-                        {
-                            RemoveSubscription(universe.Configuration);
-                        }
-                        break;
-
-                    default:
-                        throw new NotImplementedException("The specified action is not implemented: " + args.Action);
-                }
-            };
         }
 
-        private Subscription CreateSubscription(SubscriptionRequest request)
+        private Subscription InternalCreateSubscription(SubscriptionRequest request)
         {
             // ReSharper disable once PossibleMultipleEnumeration
             if (!request.TradableDays.Any())
@@ -213,104 +161,23 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        /// Adds a new subscription to provide data for the specified security.
+        /// Creates a new subscription to provide data for the specified security.
         /// </summary>
         /// <param name="request">Defines the subscription to be added, including start/end times the universe and security</param>
-        /// <returns>True if the subscription was created and added successfully, false otherwise</returns>
-        public bool AddSubscription(SubscriptionRequest request)
+        /// <returns>The created <see cref="Subscription"/> if successful, null otherwise</returns>
+        public Subscription CreateSubscription(SubscriptionRequest request)
         {
-            if (_subscriptions.Contains(request.Configuration))
-            {
-                // duplicate subscription request
-                return false;
-            }
-
-            var subscription = request.IsUniverseSubscription
+            return request.IsUniverseSubscription
                 ? CreateUniverseSubscription(request)
-                : CreateSubscription(request);
-
-            if (subscription == null)
-            {
-                // subscription will be null when there's no tradeable dates for the security between the requested times, so
-                // don't even try to load the data
-                return false;
-            }
-
-            Log.Debug("FileSystemDataFeed.AddSubscription(): Added " + request.Configuration + " Start: " + request.StartTimeUtc + " End: " + request.EndTimeUtc);
-            _subscriptions.TryAdd(subscription);
-            return true;
+                : InternalCreateSubscription(request);
         }
 
         /// <summary>
         /// Removes the subscription from the data feed, if it exists
         /// </summary>
-        /// <param name="configuration">The configuration of the subscription to remove</param>
-        /// <returns>True if the subscription was successfully removed, false otherwise</returns>
-        public bool RemoveSubscription(SubscriptionDataConfig configuration)
+        /// <param name="subscription">The subscription to remove</param>
+        public void RemoveSubscription(Subscription subscription)
         {
-            // remove the subscription from our collection, if it exists
-            Subscription subscription;
-
-            if (_subscriptions.TryGetValue(configuration, out subscription))
-            {
-                // don't remove universe subscriptions immediately, instead mark them as disposed
-                // so we can turn the crank one more time to ensure we emit security changes properly
-                if (subscription.IsUniverseSelectionSubscription && subscription.Universe.DisposeRequested)
-                {
-                    // subscription syncer will dispose the universe AFTER we've run selection a final time
-                    // and then will invoke SubscriptionFinished which will remove the universe subscription
-                    return false;
-                }
-
-                if (!_subscriptions.TryRemove(configuration, out subscription))
-                {
-                    Log.Error("FileSystemDataFeed.RemoveSubscription(): Unable to remove: " + configuration);
-                    return false;
-                }
-
-                // if the security is no longer a member of the universe, then mark the subscription properly
-                // universe may be null for internal currency conversion feeds
-                // TODO : Put currency feeds in their own internal universe
-                if (subscription.Universe != null && !subscription.Universe.Members.ContainsKey(configuration.Symbol))
-                {
-                    subscription.MarkAsRemovedFromUniverse();
-                }
-                subscription.Dispose();
-                Log.Debug("FileSystemDataFeed.RemoveSubscription(): Removed " + configuration);
-            }
-
-            return true;
-        }
-
-        private DateTime GetInitialFrontierTime()
-        {
-            var frontier = DateTime.MaxValue;
-            foreach (var subscription in Subscriptions)
-            {
-                var current = subscription.Current;
-                if (current == null)
-                {
-                    continue;
-                }
-
-                // we need to initialize both the frontier time and the offset provider, in order to do
-                // this we'll first convert the current.EndTime to UTC time, this will allow us to correctly
-                // determine the offset in ticks using the OffsetProvider, we can then use this to recompute
-                // the UTC time. This seems odd, but is necessary given Noda time's lenient mapping, the
-                // OffsetProvider exists to give forward marching mapping
-
-                // compute the initial frontier time
-                if (current.EmitTimeUtc < frontier)
-                {
-                    frontier = current.EmitTimeUtc;
-                }
-            }
-
-            if (frontier == DateTime.MaxValue)
-            {
-                frontier = _algorithm.StartDate.ConvertToUtc(_algorithm.TimeZone);
-            }
-            return frontier;
         }
 
         /// <summary>
@@ -407,23 +274,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 _cancellationTokenSource.Cancel();
                 Log.Trace("FileSystemDataFeed.Exit(): Ending Thread...");
                 _controller?.DisposeSafely();
-
-                if (_subscriptions != null)
-                {
-                    // remove each subscription from our collection
-                    foreach (var subscription in Subscriptions)
-                    {
-                        try
-                        {
-                            RemoveSubscription(subscription.Configuration);
-                        }
-                        catch (Exception err)
-                        {
-                            Log.Error(err, "Error removing: " + subscription.Configuration);
-                        }
-                    }
-                }
-
                 _subscriptionFactory?.DisposeSafely();
                 Log.Trace("FileSystemDataFeed.Exit(): Exit Finished.");
             }

--- a/Engine/DataFeeds/IDataFeed.cs
+++ b/Engine/DataFeeds/IDataFeed.cs
@@ -14,9 +14,7 @@
  *
 */
 
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
@@ -30,14 +28,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     [InheritedExport(typeof(IDataFeed))]
     public interface IDataFeed
     {
-        /// <summary>
-        /// Gets all of the current subscriptions this data feed is processing
-        /// </summary>
-        IEnumerable<Subscription> Subscriptions
-        {
-            get;
-        }
-
         /// <summary>
         /// Public flag indicator that the thread is still busy.
         /// </summary>
@@ -59,18 +49,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             IDataFeedTimeProvider dataFeedTimeProvider);
 
         /// <summary>
-        /// Adds a new subscription to provide data for the specified security.
+        /// Creates a new subscription to provide data for the specified security.
         /// </summary>
         /// <param name="request">Defines the subscription to be added, including start/end times the universe and security</param>
-        /// <returns>True if the subscription was created and added successfully, false otherwise</returns>
-        bool AddSubscription(SubscriptionRequest request);
+        /// <returns>The created <see cref="Subscription"/> if successful, null otherwise</returns>
+        Subscription CreateSubscription(SubscriptionRequest request);
 
         /// <summary>
         /// Removes the subscription from the data feed, if it exists
         /// </summary>
-        /// <param name="configuration">The configuration of the subscription to remove</param>
-        /// <returns>True if the subscription was successfully removed, false otherwise</returns>
-        bool RemoveSubscription(SubscriptionDataConfig configuration);
+        /// <param name="subscription">The subscription to remove</param>
+        void RemoveSubscription(Subscription subscription);
 
         /// <summary>
         /// External controller calls to signal a terminate of the thread.

--- a/Engine/DataFeeds/IDataFeedSubscriptionManager.cs
+++ b/Engine/DataFeeds/IDataFeedSubscriptionManager.cs
@@ -14,6 +14,9 @@
  *
 */
 
+using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
+
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
     /// <summary>
@@ -30,5 +33,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// Get the universe selection instance
         /// </summary>
         UniverseSelection UniverseSelection { get; }
+
+        /// <summary>
+        /// Removes the <see cref="Subscription"/>, if it exists
+        /// </summary>
+        /// <param name="configuration">The <see cref="SubscriptionDataConfig"/> of the subscription to remove</param>
+        /// <returns>True if the subscription was successfully removed, false otherwise</returns>
+        bool RemoveSubscription(SubscriptionDataConfig configuration);
+
+        /// <summary>
+        /// Adds a new <see cref="Subscription"/> to provide data for the specified security.
+        /// </summary>
+        /// <param name="request">Defines the <see cref="SubscriptionRequest"/> to be added</param>
+        /// <returns>True if the subscription was created and added successfully, false otherwise</returns>
+        bool AddSubscription(SubscriptionRequest request);
     }
 }

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -118,7 +118,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // create and add the subscription to our collection
             var subscription = request.IsUniverseSubscription
                 ? CreateUniverseSubscription(request)
-                : InternalCreateSubscription(request);
+                : CreateDataSubscription(request);
 
             // check if we could create the subscription
             if (subscription != null)
@@ -187,7 +187,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         /// <param name="request">The subscription request</param>
         /// <returns>A new subscription instance of the specified security</returns>
-        protected Subscription InternalCreateSubscription(SubscriptionRequest request)
+        protected Subscription CreateDataSubscription(SubscriptionRequest request)
         {
             Subscription subscription = null;
             try

--- a/Engine/DataFeeds/Synchronizer.cs
+++ b/Engine/DataFeeds/Synchronizer.cs
@@ -35,7 +35,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private IAlgorithm _algorithm;
         private DateTimeZone _dateTimeZone;
         private CashBook _cashBook;
-        private IDataFeed _dataFeed;
         private bool _liveMode;
 
         /// <summary>
@@ -53,16 +52,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public void Initialize(
             IAlgorithm algorithm,
-            IDataFeedSubscriptionManager subscriptionManager,
-            IDataFeed dataFeed, // To be removed, when subscriptionManager is completely in front of the DF
+            IDataFeedSubscriptionManager dataFeedSubscriptionManager,
             bool liveMode,
             CashBook cashBook)
         {
-            _subscriptionManager = subscriptionManager;
+            _subscriptionManager = dataFeedSubscriptionManager;
             _algorithm = algorithm;
             _cashBook = cashBook;
             _liveMode = liveMode;
-            _dataFeed = dataFeed;
 
             _subscriptionSynchronizer = new SubscriptionSynchronizer(_subscriptionManager.UniverseSelection, _cashBook);
 
@@ -159,7 +156,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             _subscriptionSynchronizer.SubscriptionFinished += (sender, subscription) =>
             {
-                _dataFeed.RemoveSubscription(subscription.Configuration);
+                _subscriptionManager.RemoveSubscription(subscription.Configuration);
                 Log.Debug("Synchronizer.SubscriptionFinished(): Finished subscription:" +
                     $"{subscription.Configuration} at {FrontierTimeProvider.GetUtcNow()} UTC");
             };

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.Lean.Engine
                 _systemHandlers.Notify.SetAuthentication(job);
 
                 //-> Set the result handler type for this algorithm job, and launch the associated result thread.
-                _algorithmHandlers.Results.Initialize(job, _systemHandlers.Notify, _systemHandlers.Api, _algorithmHandlers.DataFeed, _algorithmHandlers.Setup, _algorithmHandlers.Transactions);
+                _algorithmHandlers.Results.Initialize(job, _systemHandlers.Notify, _systemHandlers.Api, _algorithmHandlers.Setup, _algorithmHandlers.Transactions);
 
                 threadResults = new Thread(_algorithmHandlers.Results.Run, 0) { IsBackground = true, Name = "Result Thread" };
                 threadResults.Start();
@@ -137,19 +137,18 @@ namespace QuantConnect.Lean.Engine
 
                     dataManager = new DataManager(_algorithmHandlers.DataFeed,
                         new UniverseSelection(
-                            _algorithmHandlers.DataFeed,
                             algorithm,
                             securityService),
-                        algorithm.Settings,
+                        algorithm,
                         algorithm.TimeKeeper,
                         marketHoursDatabase);
 
+                    _algorithmHandlers.Results.SetDataManager(dataManager);
                     algorithm.SubscriptionManager.SetDataManager(dataManager);
 
                     synchronizer.Initialize(
                         algorithm,
                         dataManager,
-                        _algorithmHandlers.DataFeed,
                         _liveMode,
                         algorithm.Portfolio.CashBook);
 
@@ -437,6 +436,7 @@ namespace QuantConnect.Lean.Engine
                     _algorithmHandlers.DataFeed.Exit();
                     _algorithmHandlers.RealTime.Exit();
                     _algorithmHandlers.Alphas.Exit();
+                    dataManager?.RemoveAllSubscriptions();
                 }
 
                 //Close result handler:

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -21,7 +21,6 @@ using System.Linq;
 using System.Threading;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
-using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.Setup;
 using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Logging;
@@ -30,6 +29,7 @@ using QuantConnect.Packets;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
 using System.IO;
+using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Lean.Engine.Results
@@ -129,10 +129,9 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="job">Algorithm job packet for this result handler</param>
         /// <param name="messagingHandler">The handler responsible for communicating messages to listeners</param>
         /// <param name="api">The api instance used for handling logs</param>
-        /// <param name="dataFeed"></param>
         /// <param name="setupHandler"></param>
         /// <param name="transactionHandler"></param>
-        public virtual void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, IDataFeed dataFeed, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
+        public virtual void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
         {
             _algorithmId = job.AlgorithmId;
             _projectId = job.ProjectId;

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
+using QuantConnect.Lean.Engine.DataFeeds;
 
 namespace QuantConnect.Lean.Engine.Results
 {
@@ -9,6 +10,8 @@ namespace QuantConnect.Lean.Engine.Results
     /// </summary>
     public class BaseResultsHandler
     {
+        protected IDataFeedSubscriptionManager DataManager;
+
         /// <summary>
         /// Gets or sets the current alpha runtime statistics
         /// </summary>
@@ -44,6 +47,14 @@ namespace QuantConnect.Lean.Engine.Results
         public virtual void SetAlphaRuntimeStatistics(AlphaRuntimeStatistics statistics)
         {
             AlphaRuntimeStatistics = statistics;
+        }
+
+        /// <summary>
+        /// Sets the current Data Manager instance
+        /// </summary>
+        public virtual void SetDataManager(IDataFeedSubscriptionManager dataManager)
+        {
+            DataManager = dataManager;
         }
     }
 }

--- a/Engine/Results/DesktopResultHandler.cs
+++ b/Engine/Results/DesktopResultHandler.cs
@@ -87,10 +87,9 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="job">Algorithm job packet for this result handler</param>
         /// <param name="messagingHandler"></param>
         /// <param name="api"></param>
-        /// <param name="dataFeed"></param>
         /// <param name="setupHandler"></param>
         /// <param name="transactionHandler"></param>
-        public void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, IDataFeed dataFeed, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
+        public void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
         {
             //Redirect the log messages here:
             _job = job;

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -87,10 +87,9 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="job">Algorithm job packet for this result handler</param>
         /// <param name="messagingHandler"></param>
         /// <param name="api"></param>
-        /// <param name="dataFeed"></param>
         /// <param name="setupHandler"></param>
         /// <param name="transactionHandler"></param>
-        void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, IDataFeed dataFeed, ISetupHandler setupHandler, ITransactionHandler transactionHandler);
+        void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, ISetupHandler setupHandler, ITransactionHandler transactionHandler);
 
         /// <summary>
         /// Primary result thread entry point to process the result message queue and send it to whatever endpoint is set.
@@ -273,5 +272,10 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="name">The name of the results</param>
         /// <param name="result">The results to save</param>
         void SaveResults(string name, Result result);
+
+        /// <summary>
+        /// Sets the current Data Manager instance
+        /// </summary>
+        void SetDataManager(IDataFeedSubscriptionManager dataManager);
     }
 }

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -73,7 +73,6 @@ namespace QuantConnect.Lean.Engine.Results
         private IMessagingHandler _messagingHandler;
         private IApi _api;
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-        private IDataFeed _dataFeed;
         private ISetupHandler _setupHandler;
         private ITransactionHandler _transactionHandler;
 
@@ -114,13 +113,11 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="job">Algorithm job packet for this result handler</param>
         /// <param name="messagingHandler"></param>
         /// <param name="api"></param>
-        /// <param name="dataFeed"></param>
         /// <param name="setupHandler"></param>
         /// <param name="transactionHandler"></param>
-        public virtual void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, IDataFeed dataFeed, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
+        public virtual void Initialize(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, ISetupHandler setupHandler, ITransactionHandler transactionHandler)
         {
             _api = api;
-            _dataFeed = dataFeed;
             _messagingHandler = messagingHandler;
             _setupHandler = setupHandler;
             _transactionHandler = transactionHandler;
@@ -1003,9 +1000,9 @@ namespace QuantConnect.Lean.Engine.Results
                 _nextSample = time.Add(ResamplePeriod);
 
                 //Update the asset prices to take a real time sample of the market price even though we're using minute bars
-                if (_dataFeed != null)
+                if (DataManager != null)
                 {
-                    foreach (var subscription in _dataFeed.Subscriptions)
+                    foreach (var subscription in DataManager.DataFeedSubscriptions)
                     {
                         var symbol = subscription.Configuration.Symbol;
                         var tickType = subscription.Configuration.TickType;

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -69,13 +69,12 @@ namespace QuantConnect.Jupyter
                 _dataCacheProvider = new ZipDataCacheProvider(algorithmHandlers.DataProvider);
 
                 var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
-                var nullDataFeed = new NullDataFeed();
                 var securityService = new SecurityService(Portfolio.CashBook, MarketHoursDatabase, symbolPropertiesDataBase, this);
                 Securities.SetSecurityService(securityService);
                 SubscriptionManager.SetDataManager(
-                    new DataManager(nullDataFeed,
-                        new UniverseSelection(nullDataFeed, this, securityService),
-                        Settings,
+                    new DataManager(new NullDataFeed(),
+                        new UniverseSelection(this, securityService),
+                        this,
                         TimeKeeper,
                         MarketHoursDatabase));
 

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -27,6 +27,7 @@ using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;
@@ -127,7 +128,7 @@ namespace QuantConnect.Tests.Algorithm
         public void OnEndOfTimeStepSeedsUnderlyingSecuritiesThatHaveNoData()
         {
             var qcAlgorithm = new QCAlgorithm();
-            qcAlgorithm.SubscriptionManager.SetDataManager(new DataManagerStub(qcAlgorithm));
+            qcAlgorithm.SubscriptionManager.SetDataManager(new DataManagerStub(qcAlgorithm, new MockDataFeed()));
             qcAlgorithm.SetLiveMode(true);
             var testHistoryProvider = new TestHistoryProvider();
             qcAlgorithm.HistoryProvider = testHistoryProvider;
@@ -149,7 +150,7 @@ namespace QuantConnect.Tests.Algorithm
         public void OnEndOfTimeStepDoesNotThrowWhenSeedsSameUnderlyingForTwoSecurities()
         {
             var qcAlgorithm = new QCAlgorithm();
-            qcAlgorithm.SubscriptionManager.SetDataManager(new DataManagerStub(qcAlgorithm));
+            qcAlgorithm.SubscriptionManager.SetDataManager(new DataManagerStub(qcAlgorithm, new MockDataFeed()));
             qcAlgorithm.SetLiveMode(true);
             var testHistoryProvider = new TestHistoryProvider();
             qcAlgorithm.HistoryProvider = testHistoryProvider;

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -169,7 +169,7 @@ marketHoursDatabase = MarketHoursDatabase.FromDataFolder()
 symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder()
 securityService =  SecurityService(algo.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDatabase, algo)
 algo.Securities.SetSecurityService(securityService)
-dataManager = DataManager(None, UniverseSelection(None, algo, securityService), algo.Settings, algo.TimeKeeper, marketHoursDatabase)
+dataManager = DataManager(None, UniverseSelection(algo, securityService), algo, algo.TimeKeeper, marketHoursDatabase)
 algo.SubscriptionManager.SetDataManager(dataManager)
 
 

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -39,7 +39,6 @@ using QuantConnect.Packets;
 using QuantConnect.Scheduling;
 using QuantConnect.Securities;
 using QuantConnect.Statistics;
-using QuantConnect.Tests.Engine.DataFeeds;
 using Log = QuantConnect.Logging.Log;
 
 namespace QuantConnect.Tests.Engine
@@ -57,10 +56,10 @@ namespace QuantConnect.Tests.Engine
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
             var dataManager = new DataManager(feed,
-                new UniverseSelection(feed,
+                new UniverseSelection(
                     algorithm,
                     new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm)),
-                algorithm.Settings,
+                algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
@@ -75,7 +74,7 @@ namespace QuantConnect.Tests.Engine
             algorithm.Initialize();
             algorithm.PostInitialize();
 
-            results.Initialize(job, new QuantConnect.Messaging.Messaging(), new Api.Api(), feed, new BacktestingSetupHandler(), transactions);
+            results.Initialize(job, new QuantConnect.Messaging.Messaging(), new Api.Api(), new BacktestingSetupHandler(), transactions);
             results.SetAlgorithm(algorithm);
             transactions.Initialize(algorithm, new BacktestingBrokerage(algorithm), results);
             feed.Initialize(algorithm, job, results, null, null, null, dataManager, null);
@@ -88,43 +87,6 @@ namespace QuantConnect.Tests.Engine
             var thousands = nullSynchronizer.Count / 1000d;
             var seconds = sw.Elapsed.TotalSeconds;
             Log.Trace("COUNT: " + nullSynchronizer.Count + "  KPS: " + thousands/seconds);
-        }
-
-        public class MockDataFeed : IDataFeed
-        {
-            public bool IsActive { get; }
-            public IEnumerable<Subscription> Subscriptions { get; }
-
-            public void Initialize(
-                IAlgorithm algorithm,
-                AlgorithmNodePacket job,
-                IResultHandler resultHandler,
-                IMapFileProvider mapFileProvider,
-                IFactorFileProvider factorFileProvider,
-                IDataProvider dataProvider,
-                IDataFeedSubscriptionManager subscriptionManager,
-                IDataFeedTimeProvider dataFeedTimeProvider
-                )
-            {
-            }
-
-            public bool AddSubscription(SubscriptionRequest request)
-            {
-                return true;
-            }
-
-            public bool RemoveSubscription(SubscriptionDataConfig configuration)
-            {
-                return true;
-            }
-
-            public void Run()
-            {
-            }
-
-            public void Exit()
-            {
-            }
         }
 
         public class NullAlphaHandler : IAlphaHandler
@@ -193,7 +155,6 @@ namespace QuantConnect.Tests.Engine
             public void Initialize(AlgorithmNodePacket job,
                 IMessagingHandler messagingHandler,
                 IApi api,
-                IDataFeed dataFeed,
                 ISetupHandler setupHandler,
                 ITransactionHandler transactionHandler)
             {
@@ -307,6 +268,10 @@ namespace QuantConnect.Tests.Engine
             }
 
             public void SaveResults(string name, Result result)
+            {
+            }
+
+            public void SetDataManager(IDataFeedSubscriptionManager dataManager)
             {
             }
         }

--- a/Tests/Engine/DataFeeds/AlgorithmStub.cs
+++ b/Tests/Engine/DataFeeds/AlgorithmStub.cs
@@ -30,10 +30,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public List<SecurityChanges> SecurityChangesRecord = new List<SecurityChanges>();
         public DataManager DataManager;
 
-        public AlgorithmStub()
+        public AlgorithmStub(bool createDataManager = true)
         {
-            DataManager = new DataManagerStub(this);
-            SubscriptionManager.SetDataManager(DataManager);
+            if (createDataManager)
+            {
+                DataManager = new DataManagerStub(this);
+                SubscriptionManager.SetDataManager(DataManager);
+            }
         }
 
         public AlgorithmStub(IDataFeed dataFeed)

--- a/Tests/Engine/DataFeeds/CustomLiveDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/CustomLiveDataFeedTests.cs
@@ -60,12 +60,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             }
 
             var algorithm = new QCAlgorithm();
-            var dataManager = new DataManagerStub(algorithm);
+            CreateDataFeed();
+            var dataManager = new DataManagerStub(algorithm, _feed);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
 
             var symbols = tickers.Select(ticker => algorithm.AddData<TestableQuandlFuture>(ticker, Resolution.Daily).Symbol).ToList();
-
-            algorithm.PostInitialize();
 
             var timeProvider = new ManualTimeProvider(TimeZones.NewYork);
             timeProvider.SetCurrentTime(startDate);
@@ -179,23 +178,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var startDate = new DateTime(2018, 4, 2);
             var endDate = new DateTime(2018, 4, 19);
             var algorithm = new QCAlgorithm();
-            var dataManager = new DataManagerStub(algorithm);
-            algorithm.SubscriptionManager.SetDataManager(dataManager);
-            var symbols = new List<Symbol>
-            {
-                algorithm.AddData<Quandl>("CBOE/VXV", Resolution.Daily).Symbol,
-                algorithm.AddData<QuandlVix>("CBOE/VIX", Resolution.Daily).Symbol,
-                algorithm.AddEquity("SPY", Resolution.Daily).Symbol,
-                algorithm.AddEquity("AAPL", Resolution.Daily).Symbol
-            };
-            algorithm.PostInitialize();
 
             var timeProvider = new ManualTimeProvider(TimeZones.NewYork);
             timeProvider.SetCurrentTime(startDate);
-            var cancellationTokenSource = new CancellationTokenSource();
-
-            var dataPointsEmitted = 0;
-            var slicesEmitted = 0;
             var dataQueueHandler = new FuncDataQueueHandler(fdqh =>
             {
                 var time = timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork);
@@ -209,8 +194,25 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 };
                 return new[] { tick, tick2 };
             });
+            CreateDataFeed(dataQueueHandler);
+            var dataManager = new DataManagerStub(algorithm, _feed);
 
-            RunLiveDataFeed(algorithm, startDate, symbols, timeProvider, dataManager, dataQueueHandler);
+            algorithm.SubscriptionManager.SetDataManager(dataManager);
+            var symbols = new List<Symbol>
+            {
+                algorithm.AddData<Quandl>("CBOE/VXV", Resolution.Daily).Symbol,
+                algorithm.AddData<QuandlVix>("CBOE/VIX", Resolution.Daily).Symbol,
+                algorithm.AddEquity("SPY", Resolution.Daily).Symbol,
+                algorithm.AddEquity("AAPL", Resolution.Daily).Symbol
+            };
+            algorithm.PostInitialize();
+
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            var dataPointsEmitted = 0;
+            var slicesEmitted = 0;
+
+            RunLiveDataFeed(algorithm, startDate, symbols, timeProvider, dataManager);
             Thread.Sleep(5000); // Give remote sources a handicap, so the data is available in time
 
             // create a timer to advance time much faster than realtime and to simulate live Quandl data file updates
@@ -262,16 +264,20 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.AreEqual(14 * symbols.Count, dataPointsEmitted);
         }
 
-        private IDataFeed RunLiveDataFeed(
+        private void CreateDataFeed(
+            FuncDataQueueHandler funcDataQueueHandler = null)
+        {
+            _feed = new TestableLiveTradingDataFeed(funcDataQueueHandler ?? new FuncDataQueueHandler(x => Enumerable.Empty<BaseData>()));
+        }
+
+        private void RunLiveDataFeed(
             IAlgorithm algorithm,
             DateTime startDate,
             IEnumerable<Symbol> symbols,
             ITimeProvider timeProvider,
-            DataManager dataManager,
-            FuncDataQueueHandler funcDataQueueHandler  = null)
+            DataManager dataManager)
         {
-            _feed = new TestableLiveTradingDataFeed(funcDataQueueHandler ?? new FuncDataQueueHandler(x => Enumerable.Empty<BaseData>()));
-            _synchronizer = new TestableSynchronizer(algorithm, dataManager, _feed, true, timeProvider);
+            _synchronizer = new TestableSynchronizer(algorithm, dataManager, true, timeProvider);
 
             var mapFileProvider = new LocalDiskMapFileProvider();
             _feed.Initialize(algorithm, new LiveNodePacket(), new BacktestingResultHandler(),
@@ -281,9 +287,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             {
                 var config = algorithm.Securities[symbol].SubscriptionDataConfig;
                 var request = new SubscriptionRequest(false, null, algorithm.Securities[symbol], config, startDate, Time.EndOfTime);
-                _feed.AddSubscription(request);
+                dataManager.AddSubscription(request);
             }
-            return _feed;
         }
 
         private static int _countFilesWritten;

--- a/Tests/Engine/DataFeeds/DataManagerStub.cs
+++ b/Tests/Engine/DataFeeds/DataManagerStub.cs
@@ -38,6 +38,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
         }
 
+        public DataManagerStub(IAlgorithm algorithm, IDataFeed dataFeed)
+            : this(dataFeed, algorithm, new TimeKeeper(DateTime.UtcNow, TimeZones.NewYork))
+        {
+
+        }
+
         public DataManagerStub(IAlgorithm algorithm)
             : this(new NullDataFeed(), algorithm, new TimeKeeper(DateTime.UtcNow, TimeZones.NewYork))
         {
@@ -73,8 +79,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
         public DataManagerStub(IDataFeed dataFeed, IAlgorithm algorithm, ITimeKeeper timeKeeper, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase, SecurityService securityService)
             : base(dataFeed,
-                new UniverseSelection(dataFeed, algorithm, securityService),
-                algorithm.Settings,
+                new UniverseSelection(algorithm, securityService),
+                algorithm,
                 timeKeeper,
                 marketHoursDatabase)
         {

--- a/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
@@ -46,15 +46,15 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
             var dataManager = new DataManager(feed,
-                new UniverseSelection(feed,
+                new UniverseSelection(
                     algorithm,
                     new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm)),
-                algorithm.Settings,
+                algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             var synchronizer = new Synchronizer();
-            synchronizer.Initialize(algorithm, dataManager, feed, false, algorithm.Portfolio.CashBook);
+            synchronizer.Initialize(algorithm, dataManager, false, algorithm.Portfolio.CashBook);
 
             feed.Initialize(algorithm, job, resultHandler, mapFileProvider, factorFileProvider, dataProvider, dataManager, synchronizer);
             algorithm.Initialize();
@@ -85,7 +85,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void TestDataFeedEnumeratorStackSpeed()
         {
             var algorithm = PerformanceBenchmarkAlgorithms.SingleSecurity_Second;
-            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
             algorithm.Initialize();
             algorithm.PostInitialize();
 

--- a/Tests/Engine/DataFeeds/MockDataFeed.cs
+++ b/Tests/Engine/DataFeeds/MockDataFeed.cs
@@ -14,7 +14,7 @@
  *
 */
 
-using System;
+using NodaTime;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
@@ -22,21 +22,10 @@ using QuantConnect.Packets;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
-    /// <summary>
-    /// Null data feed implementation. <seealso cref="DataManager"/>
-    /// </summary>
-    public class NullDataFeed : IDataFeed
+    public class MockDataFeed : IDataFeed
     {
-        /// <inheritdoc />
-        public bool IsActive
-        {
-            get
-            {
-                throw new NotImplementedException("Unexpected usage of null data feed implementation.");
-            }
-        }
+        public bool IsActive { get; }
 
-        /// <inheritdoc />
         public void Initialize(
             IAlgorithm algorithm,
             AlgorithmNodePacket job,
@@ -48,25 +37,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             IDataFeedTimeProvider dataFeedTimeProvider
             )
         {
-            throw new NotImplementedException("Unexpected usage of null data feed implementation.");
         }
 
-        /// <inheritdoc />
         public Subscription CreateSubscription(SubscriptionRequest request)
         {
-            throw new NotImplementedException("Unexpected usage of null data feed implementation.");
+            return null;
         }
 
-        /// <inheritdoc />
         public void RemoveSubscription(Subscription subscription)
         {
-            throw new NotImplementedException("Unexpected usage of null data feed implementation.");
         }
 
-        /// <inheritdoc />
         public void Exit()
         {
-            throw new NotImplementedException("Unexpected usage of null data feed implementation.");
         }
     }
 }

--- a/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
         private void TestSubscriptionSynchronizerSpeed(QCAlgorithm algorithm)
         {
-            var feed = new AlgorithmManagerTests.MockDataFeed();
+            var feed = new MockDataFeed();
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
             var securityService = new SecurityService(
@@ -58,8 +58,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 algorithm);
             algorithm.Securities.SetSecurityService(securityService);
             var dataManager = new DataManager(feed,
-                new UniverseSelection(feed, algorithm, securityService),
-                algorithm.Settings,
+                new UniverseSelection(algorithm, securityService),
+                algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase);
             algorithm.SubscriptionManager.SetDataManager(dataManager);

--- a/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
+++ b/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void CreatedEquityIsNotAddedToSymbolCache()
         {
             SymbolCache.Clear();
-            var algorithm = new AlgorithmStub(new TestDataFeed());
+            var algorithm = new AlgorithmStub(new MockDataFeed());
             algorithm.SetEndDate(Time.EndOfTime);
             algorithm.SetStartDate(DateTime.UtcNow.Subtract(TimeSpan.FromDays(10)));
             algorithm.AddUniverse(CoarseSelectionFunction, FineSelectionFunction);
@@ -68,39 +68,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         private IEnumerable<Symbol> FineSelectionFunction(IEnumerable<FineFundamental> fine)
         {
             return new[] { fine.First().Symbol };
-        }
-
-        private class TestDataFeed : IDataFeed
-        {
-            public IEnumerable<Subscription> Subscriptions { get; }
-            public bool IsActive { get; }
-
-            public void Initialize(
-                IAlgorithm algorithm,
-                AlgorithmNodePacket job,
-                IResultHandler resultHandler,
-                IMapFileProvider mapFileProvider,
-                IFactorFileProvider factorFileProvider,
-                IDataProvider dataProvider,
-                IDataFeedSubscriptionManager subscriptionManager,
-                IDataFeedTimeProvider dataFeedTimeProvider
-                )
-            {
-            }
-
-            public bool AddSubscription(SubscriptionRequest request)
-            {
-                return true;
-            }
-
-            public bool RemoveSubscription(SubscriptionDataConfig configuration)
-            {
-                return true;
-            }
-
-            public void Exit()
-            {
-            }
         }
     }
 }

--- a/Tests/Engine/PerformanceBenchmarkAlgorithms.cs
+++ b/Tests/Engine/PerformanceBenchmarkAlgorithms.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using QuantConnect.Algorithm;
+using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Engine
@@ -50,7 +51,7 @@ namespace QuantConnect.Tests.Engine
         {
             public SingleSecurity_Second_BenchmarkTest()
             {
-                SubscriptionManager.SetDataManager(new DataManagerStub(this));
+                SubscriptionManager.SetDataManager(new DataManagerStub(this, new MockDataFeed()));
             }
 
             public override void Initialize()

--- a/Tests/Engine/RealTimePriceUpdateTests.cs
+++ b/Tests/Engine/RealTimePriceUpdateTests.cs
@@ -62,15 +62,15 @@ namespace QuantConnect.Tests.Engine
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
             var dataManager = new DataManager(_liveTradingDataFeed,
-                new UniverseSelection(_liveTradingDataFeed,
+                new UniverseSelection(
                     algo,
                     new SecurityService(algo.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algo)),
-                algo.Settings,
+                algo,
                 algo.TimeKeeper,
                 marketHoursDatabase);
             algo.SubscriptionManager.SetDataManager(dataManager);
             var synchronizer = new Synchronizer();
-            synchronizer.Initialize(algo, dataManager, _liveTradingDataFeed, true, algo.Portfolio.CashBook);
+            synchronizer.Initialize(algo, dataManager, true, algo.Portfolio.CashBook);
             _liveTradingDataFeed.Initialize(algo, jobPacket, new LiveTradingResultHandler(), new LocalDiskMapFileProvider(),
                                             null, new DefaultDataProvider(), dataManager, synchronizer);
 

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -24,6 +24,7 @@ using QuantConnect.Algorithm;
 using QuantConnect.Brokerages;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.RealTime;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Lean.Engine.Setup;
@@ -281,7 +282,7 @@ namespace QuantConnect.Tests.Engine.Setup
         {
             public TestAlgorithm()
             {
-                SubscriptionManager.SetDataManager(new DataManagerStub(this));
+                SubscriptionManager.SetDataManager(new DataManagerStub(this, new MockDataFeed()));
             }
 
             public override void Initialize() { }

--- a/Tests/Engine/TestResultHandler.cs
+++ b/Tests/Engine/TestResultHandler.cs
@@ -79,7 +79,6 @@ namespace QuantConnect.Tests.Engine
         public void Initialize(AlgorithmNodePacket job,
             IMessagingHandler messagingHandler,
             IApi api,
-            IDataFeed dataFeed,
             ISetupHandler setupHandler,
             ITransactionHandler transactionHandler)
         {

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Common\Util\SeriesJsonConverterTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />
     <Compile Include="Engine\DataFeeds\DataManagerStub.cs" />
+    <Compile Include="Engine\DataFeeds\MockDataFeed.cs" />
     <Compile Include="Engine\DataFeeds\UniverseSelectionTests.cs" />
     <Compile Include="PythonSetup.cs" />
     <Compile Include="Algorithm\Framework\QCAlgorithmFrameworkTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Completly move `DataManager` in front of `DataFeed`. Specifically
`AddSubscription()` and `RemoveSubscription()` implementations. Also
moving `IDataFeed.Subscriptions`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2627
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Make IDataFeed implementation specific
- Avoid logic duplication, improvement can be seen deletions > additions
https://github.com/QuantConnect/Lean/projects/5
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression and live deployment tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->