### PR TITLE
Adds ContainsKey check in MacdAlphaModel

### DIFF
--- a/Algorithm.Framework/Alphas/MacdAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/MacdAlphaModel.cs
@@ -111,6 +111,10 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         {
             foreach (var added in changes.AddedSecurities)
             {
+                if (_symbolData.ContainsKey(added.Symbol))
+                {
+                    continue;
+                }
                 _symbolData.Add(added.Symbol, new SymbolData(algorithm, added, _fastPeriod, _slowPeriod, _signalPeriod, _movingAverageType, _resolution));
             }
 
@@ -121,6 +125,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 {
                     // clean up our consolidator
                     algorithm.SubscriptionManager.RemoveConsolidator(data.Security.Symbol, data.Consolidator);
+                    _symbolData.Remove(removed.Symbol);
                 }
             }
         }


### PR DESCRIPTION
#### Description
In `MacdAlphaModel.OnSecuritiesChanged`, a missing `ContainsKey` is not preventing a second key addition to a dictionary.

#### Related Issue
Closes #2656

#### Motivation and Context
Framework models should not throw.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Executes `CustomFrameworkModelsAlgorithm` in the cloud with a different `EndDate`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`