### PR TITLE
Add new methods to MultiPeriodField class

### DIFF
--- a/Common/Data/Fundamental/MultiPeriodField.cs
+++ b/Common/Data/Fundamental/MultiPeriodField.cs
@@ -16,6 +16,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using QuantConnect.Util;
 
 namespace QuantConnect.Data.Fundamental
 {
@@ -32,20 +33,46 @@ namespace QuantConnect.Data.Fundamental
         /// <summary>
         /// Gets the default period for the field
         /// </summary>
-        protected virtual string DefaultPeriod
-        {
-            get { return Store.Keys.FirstOrDefault() ?? string.Empty; }
-        }
+        protected virtual string DefaultPeriod => Store.Keys.FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// Gets the value of the field for the requested period
         /// </summary>
         /// <param name="period">The requested period</param>
         /// <returns>The value for the period</returns>
-        protected decimal GetPeriodValue(string period)
+        public decimal GetPeriodValue(string period)
         {
             decimal value;
             return Store.TryGetValue(period, out value) ? value : 0m;
+        }
+
+        /// <summary>
+        /// Returns true if the field contains a value for the requested period
+        /// </summary>
+        /// <param name="period">The requested period</param>
+        public bool HasPeriodValue(string period) => Store.ContainsKey(period);
+
+        /// <summary>
+        /// Returns true if the field contains a value for the default period
+        /// </summary>
+        public bool HasValue => DefaultPeriod.Length > 0 && Store.ContainsKey(DefaultPeriod);
+
+        /// <summary>
+        /// Gets the list of available period names for the field
+        /// </summary>
+        /// <returns>The list of periods</returns>
+        public IEnumerable<string> GetPeriodNames()
+        {
+            return Store.Keys;
+        }
+
+        /// <summary>
+        /// Gets a dictionary of period names and values for the field
+        /// </summary>
+        /// <returns>The dictionary of period names and values</returns>
+        public IReadOnlyDictionary<string, decimal> GetPeriodValues()
+        {
+            return Store.ToReadOnlyDictionary();
         }
 
         /// <summary>

--- a/Tests/Common/Data/Fundamental/MultiPeriodFieldTests.cs
+++ b/Tests/Common/Data/Fundamental/MultiPeriodFieldTests.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Data.Fundamental;
+
+namespace QuantConnect.Tests.Common.Data.Fundamental
+{
+    [TestFixture]
+    public class MultiPeriodFieldTests
+    {
+        private NormalizedBasicEPSGrowth _field;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _field = new NormalizedBasicEPSGrowth();
+            _field.SetPeriodValue("3M", 1);
+            _field.SetPeriodValue("1Y", 5);
+            _field.SetPeriodValue("2Y", 2);
+        }
+
+        [Test]
+        public void ReturnsDefaultPeriod()
+        {
+            Assert.IsTrue(_field.HasValue);
+
+            Assert.AreEqual(5, _field);
+            Assert.AreEqual(5, _field.Value);
+        }
+
+        [Test]
+        public void ReturnsRequestedPeriodWithDataAvailable()
+        {
+            Assert.IsTrue(_field.HasPeriodValue("3M"));
+
+            Assert.AreEqual(1, _field.GetPeriodValue("3M"));
+            Assert.AreEqual(1, _field.ThreeMonths);
+        }
+
+        [Test]
+        public void ReturnsRequestedPeriodWithNoData()
+        {
+            Assert.IsFalse(_field.HasPeriodValue("3Y"));
+
+            Assert.AreEqual(0, _field.GetPeriodValue("3Y"));
+            Assert.AreEqual(0, _field.ThreeYears);
+        }
+
+        [Test]
+        public void ReturnsCorrectPeriodNamesAndValues()
+        {
+            Assert.AreEqual(new[] { "3M", "1Y", "2Y" }, _field.GetPeriodNames());
+
+            Assert.AreEqual(new[] { "3M", "1Y", "2Y" }, _field.GetPeriodValues().Keys);
+
+            Assert.AreEqual(new[] { 1, 5, 2 }, _field.GetPeriodValues().Values);
+        }
+
+        [Test]
+        public void ReturnsFirstPeriodIfNoDefaultAvailable()
+        {
+            var data = new Dictionary<string, decimal> { { "3M", 1 }, { "2Y", 2 } };
+            var field = new NormalizedBasicEPSGrowth(data);
+
+            Assert.IsFalse(field.HasValue);
+
+            Assert.AreEqual(1, field);
+            Assert.AreEqual(1, field.Value);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Brokerages\GDAX\GDAXBrokerageHistoryProviderTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileTests.cs" />
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
+    <Compile Include="Common\Data\Fundamental\MultiPeriodFieldTests.cs" />
     <Compile Include="Common\Securities\CashAmountTests.cs" />
     <Compile Include="Common\Data\Custom\QuandlTests.cs" />
     <Compile Include="Common\Securities\ErrorCurrencyConverterTests.cs" />


### PR DESCRIPTION
#### Description
- Added new methods to `MultiPeriodField` class:
  - `HasPeriodValue`
  - `HasValue`
  - `GetPeriodNames`
  - `GetPeriodValues`
- Made `GetPeriodValue` public
- Added unit tests for `MultiPeriodField` class

#### Related Issue
Closes #2660 

#### Motivation and Context
These changes will now allow users to perform the following operations on any multi-period field:
- check if a field has a value for the default period
- check if a field has a value for any requested period
- get the field value for any requested period
- get a list of available field period names
- get a read-only dictionary with the period names and values 

A few usage examples using C# LINQ queries/lambdas:
**Default period**
``` C#
    var queryDefaultPeriod =
        from f in fine
        let eps = f.EarningRatios.NormalizedBasicEPSGrowth
        where eps.HasValue && eps > 5m
        select f.Symbol;

    var lambdaDefaultPeriod1 = fine
        .Where(x => x.EarningRatios.NormalizedBasicEPSGrowth.HasValue &&
                    x.EarningRatios.NormalizedBasicEPSGrowth > 5m);

    var lambdaDefaultPeriod2 = fine
        .Where(x =>
        {
            var eps = x.EarningRatios.NormalizedBasicEPSGrowth;
            return eps.HasValue && eps > 5m;
        });
```
**Requested period**
``` C#
    var queryRequestedPeriod1 =
        from f in fine
        let eps = f.EarningRatios.NormalizedBasicEPSGrowth
        where eps.HasPeriodValue("3M") && eps.ThreeMonths > 5m
        select f.Symbol;

    var queryRequestedPeriod2 =
        from f in fine
        let eps = f.EarningRatios.NormalizedBasicEPSGrowth
        where eps.HasPeriodValue("3M") && eps.GetPeriodValue("3M") > 5m
        select f.Symbol;

    var lambdaRequestedPeriod1 = fine
        .Where(x => x.EarningRatios.NormalizedBasicEPSGrowth.HasPeriodValue("3M") &&
                    x.EarningRatios.NormalizedBasicEPSGrowth.GetPeriodValue("3M") > 5m);

    var lambdaRequestedPeriod2 = fine
        .Where(x => x.EarningRatios.NormalizedBasicEPSGrowth.HasPeriodValue(Data.Fundamental.Period.ThreeMonths) &&
                    x.EarningRatios.NormalizedBasicEPSGrowth.GetPeriodValue(Data.Fundamental.Period.ThreeMonths) > 5m);

    var lambdaRequestedPeriod3 = fine
        .Where(x =>
        {
            var eps = x.EarningRatios.NormalizedBasicEPSGrowth;
            return eps.HasPeriodValue("3M") && eps.GetPeriodValue("3M") > 5m;
        });
```

#### Requires Documentation Change
New methods will need to be documented, along with recommended usage examples.

#### How Has This Been Tested?
New unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`