### PR TITLE
 Subscriptions will track Universe requests

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -186,6 +186,7 @@
     <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.cs" />
     <Compile Include="TimeInForceAlgorithm.cs" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.cs" />
+    <Compile Include="UniverseSharingSubscriptionRequestRegressionAlgorithm.cs" />
     <Compile Include="UserDefinedUniverseAlgorithm.cs" />
     <Compile Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs" />
     <Compile Include="WarmupAlgorithm.cs" />

--- a/Algorithm.CSharp/UniverseSharingSubscriptionRequestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UniverseSharingSubscriptionRequestRegressionAlgorithm.cs
@@ -1,0 +1,133 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This regression algorithm has two different Universe using the same SubscriptionDataConfig.
+    /// One of them will add and remove it in a toggle fashion but since it will still be consumed
+    /// by the other Universe it should not be removed.
+    /// </summary>
+    /// <meta name="tag" content="regression test" />
+    public class UniverseSharingSubscriptionRequestRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private readonly Symbol _spy = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+
+        private int _onDataCalls;
+        private bool _restOneDay;
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 01); //Set Start Date
+            SetEndDate(2013, 10, 30); //Set End Date
+            SetCash(100000); //Set Strategy Cash
+
+            AddEquity("SPY", Resolution.Daily);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            AddUniverse(SecurityType.Equity,
+                "SecondUniverse",
+                Resolution.Daily,
+                Market.USA,
+                UniverseSettings,
+                time => time.Day % 3 == 0 ? new[] { "SPY" } : Enumerable.Empty<string>()
+            );
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (data.Count != 1)
+            {
+                throw new Exception($"Unexpected data count {data.Count}");
+            }
+            Debug($"{data.Time}. Data count {data.Count}. Data {data.Bars.First().Value}");
+            _onDataCalls++;
+
+            if (_restOneDay)
+            {
+                // let a day pass before trading again, this will cause
+                // "SecondUniverse" remove request to be applied
+                _restOneDay = false;
+            }
+            else if(!Portfolio.Invested)
+            {
+                SetHoldings(_spy, 1);
+                Debug("Purchased Stock");
+            }
+            else
+            {
+                SetHoldings(_spy, 0);
+                Debug("Sell Stock");
+                _restOneDay = true;
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_onDataCalls != 23)
+            {
+                throw new Exception($"Unexpected OnData() calls count {_onDataCalls}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "15"},
+            {"Average Win", "0.68%"},
+            {"Average Loss", "-0.14%"},
+            {"Compounding Annual Return", "36.195%"},
+            {"Drawdown", "1.000%"},
+            {"Expectancy", "3.303"},
+            {"Net Profit", "2.572%"},
+            {"Sharpe Ratio", "3.185"},
+            {"Loss Rate", "29%"},
+            {"Win Rate", "71%"},
+            {"Profit-Loss Ratio", "5.02"},
+            {"Alpha", "0.411"},
+            {"Beta", "-11.173"},
+            {"Annual Standard Deviation", "0.075"},
+            {"Annual Variance", "0.006"},
+            {"Information Ratio", "2.981"},
+            {"Tracking Error", "0.075"},
+            {"Treynor Ratio", "-0.021"},
+            {"Total Fees", "$48.51"}
+        };
+    }
+}

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             var enqueueable = new EnqueueableEnumerator<SubscriptionData>(true);
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Security.Exchange.TimeZone, request.StartTimeUtc, request.EndTimeUtc);
-            var subscription = new Subscription(request.Universe, request.Security, request.Configuration, enqueueable, timeZoneOffsetProvider, request.StartTimeUtc, request.EndTimeUtc, false);
+            var subscription = new Subscription(request, enqueueable, timeZoneOffsetProvider);
 
             // add this enumerator to our exchange
             ScheduleEnumerator(subscription, enumerator, enqueueable, GetLowerThreshold(request.Configuration.Resolution), GetUpperThreshold(request.Configuration.Resolution));
@@ -204,7 +204,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             var enqueueable = new EnqueueableEnumerator<SubscriptionData>(true);
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Security.Exchange.TimeZone, request.StartTimeUtc, request.EndTimeUtc);
-            var subscription = new Subscription(request.Universe, request.Security, config, enqueueable, timeZoneOffsetProvider, request.StartTimeUtc, request.EndTimeUtc, true);
+            var subscription = new Subscription(request, enqueueable, timeZoneOffsetProvider);
 
             // add this enumerator to our exchange
             ScheduleEnumerator(subscription, enumerator, enqueueable, lowerThreshold, upperThreshold, firstLoopCount);

--- a/Engine/DataFeeds/IDataFeedSubscriptionManager.cs
+++ b/Engine/DataFeeds/IDataFeedSubscriptionManager.cs
@@ -38,8 +38,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// Removes the <see cref="Subscription"/>, if it exists
         /// </summary>
         /// <param name="configuration">The <see cref="SubscriptionDataConfig"/> of the subscription to remove</param>
+        /// <param name="universe">Universe requesting to remove <see cref="Subscription"/>.
+        /// Default value, null, will remove all universes</param>
         /// <returns>True if the subscription was successfully removed, false otherwise</returns>
-        bool RemoveSubscription(SubscriptionDataConfig configuration);
+        bool RemoveSubscription(SubscriptionDataConfig configuration, Universe universe = null);
 
         /// <summary>
         /// Adds a new <see cref="Subscription"/> to provide data for the specified security.

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -320,7 +320,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 enumerator = new FrontierAwareEnumerator(enumerator, _frontierTimeProvider, timeZoneOffsetProvider);
 
                 var subscriptionDataEnumerator = SubscriptionData.Enumerator(request.Configuration, request.Security, timeZoneOffsetProvider, enumerator);
-                subscription = new Subscription(request.Universe, request.Security, request.Configuration, subscriptionDataEnumerator, timeZoneOffsetProvider, request.StartTimeUtc, request.EndTimeUtc, false);
+                subscription = new Subscription(request, subscriptionDataEnumerator, timeZoneOffsetProvider);
             }
             catch (Exception err)
             {
@@ -460,7 +460,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             // create the subscription
             var subscriptionDataEnumerator = SubscriptionData.Enumerator(request.Configuration, request.Security, tzOffsetProvider, enumerator);
-            var subscription = new Subscription(request.Universe, request.Security, config, subscriptionDataEnumerator, tzOffsetProvider, request.StartTimeUtc, request.EndTimeUtc, true);
+            var subscription = new Subscription(request, subscriptionDataEnumerator, tzOffsetProvider);
 
             return subscription;
         }

--- a/Engine/DataFeeds/PendingRemovalsManager.cs
+++ b/Engine/DataFeeds/PendingRemovalsManager.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     /// </summary>
     public class PendingRemovalsManager
     {
-        private readonly Dictionary<Universe, List<Security>> _pendingRemovals = new Dictionary<Universe, List<Security>>();
+        private readonly Dictionary<Universe, List<Security>> _pendingRemovals;
         private readonly IOrderProvider _orderProvider;
 
         /// <summary>
@@ -41,6 +41,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public PendingRemovalsManager(IOrderProvider orderProvider)
         {
             _orderProvider = orderProvider;
+            _pendingRemovals = new Dictionary<Universe, List<Security>>();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/PendingRemovalsManager.cs
+++ b/Engine/DataFeeds/PendingRemovalsManager.cs
@@ -1,0 +1,150 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// Helper class used to managed pending security removals <see cref="UniverseSelection"/>
+    /// </summary>
+    public class PendingRemovalsManager
+    {
+        private readonly Dictionary<Universe, List<Security>> _pendingRemovals = new Dictionary<Universe, List<Security>>();
+        private readonly IOrderProvider _orderProvider;
+
+        /// <summary>
+        /// Current pending removals
+        /// </summary>
+        public IReadOnlyDictionary<Universe, List<Security>> PendingRemovals => _pendingRemovals;
+
+        /// <summary>
+        /// Create a new instance
+        /// </summary>
+        /// <param name="orderProvider">The order provider used to determine if it is safe to remove a security</param>
+        public PendingRemovalsManager(IOrderProvider orderProvider)
+        {
+            _orderProvider = orderProvider;
+        }
+
+        /// <summary>
+        /// Determines if we can safely remove the security member from a universe.
+        /// We must ensure that we have zero holdings, no open orders, and no existing portfolio targets
+        /// </summary>
+        private bool IsSafeToRemove(Security member)
+        {
+            // but don't physically remove it from the algorithm if we hold stock or have open orders against it or an open target
+            var openOrders = _orderProvider.GetOpenOrders(x => x.Symbol == member.Symbol);
+            if (!member.HoldStock && !openOrders.Any() && (member.Holdings.Target == null || member.Holdings.Target.Quantity == 0))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Will determine if the <see cref="Security"/> can be removed.
+        /// If it can be removed will add it to <see cref="PendingRemovals"/>
+        /// </summary>
+        /// <param name="member">The security to remove</param>
+        /// <param name="universe">The universe which the security is a member of</param>
+        /// <returns>The member to remove</returns>
+        public List<RemovedMember> TryRemoveMember(Security member, Universe universe)
+        {
+            if (IsSafeToRemove(member))
+            {
+                return new List<RemovedMember> {new RemovedMember(universe, member)};
+            }
+
+            if (_pendingRemovals.ContainsKey(universe))
+            {
+                if (!_pendingRemovals[universe].Contains(member))
+                {
+                    _pendingRemovals[universe].Add(member);
+                }
+            }
+            else
+            {
+                _pendingRemovals.Add(universe, new List<Security> { member });
+            }
+
+            return new List<RemovedMember>();
+        }
+
+        /// <summary>
+        /// Will check pending security removals
+        /// </summary>
+        /// <param name="selectedSymbols">Currently selected symbols</param>
+        /// <param name="currentUniverse">Current universe</param>
+        /// <returns>The members to be removed</returns>
+        public List<RemovedMember> CheckPendingRemovals(
+            HashSet<Symbol> selectedSymbols,
+            Universe currentUniverse)
+        {
+            var result = new List<RemovedMember>();
+            // remove previously deselected members which were kept in the universe because of holdings or open orders
+            foreach (var kvp in _pendingRemovals.ToList())
+            {
+                var universeRemoving = kvp.Key;
+                foreach (var security in kvp.Value.ToList())
+                {
+                    var isSafeToRemove = IsSafeToRemove(security);
+                    if (isSafeToRemove
+                        ||
+                        // if we are re selecting it we remove it as a pending removal
+                        // else we might remove it when we do not want to do so
+                        universeRemoving == currentUniverse
+                        && selectedSymbols.Contains(security.Symbol))
+                    {
+                        if (isSafeToRemove)
+                        {
+                            result.Add(new RemovedMember(universeRemoving, security));
+                        }
+
+                        _pendingRemovals[universeRemoving].Remove(security);
+
+                        // if there are no more pending removals for this universe lets remove it
+                        if (!_pendingRemovals[universeRemoving].Any())
+                        {
+                            _pendingRemovals.Remove(universeRemoving);
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Helper class used to report removed universe members
+        /// </summary>
+        public class RemovedMember
+        {
+            public Universe Universe { get; }
+            public Security Security { get; }
+
+            public RemovedMember(Universe universe, Security security)
+            {
+                Universe = universe;
+                Security = security;
+            }
+        }
+    }
+}

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                 : packetBaseDataCollection.Data;
 
                             BaseDataCollection collection;
-                            if (universeData.TryGetValue(subscription.Universe.First(), out collection))
+                            if (universeData.TryGetValue(subscription.Universes.Single(), out collection))
                             {
                                 collection.Data.AddRange(packetData);
                             }
@@ -169,17 +169,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                     collection = new BaseDataCollection(frontierUtc, subscription.Configuration.Symbol, packetData);
                                 }
 
-                                universeData[subscription.Universe.First()] = collection;
+                                universeData[subscription.Universes.Single()] = collection;
                             }
                         }
                     }
 
                     if (subscription.IsUniverseSelectionSubscription
-                        && subscription.Universe.First().DisposeRequested
+                        && subscription.Universes.Single().DisposeRequested
                         || delayedSubscriptionFinished)
                     {
                         delayedSubscriptionFinished = false;
-                        // we need to do this after all usages of subscription.Universe
+                        // we need to do this after all usages of subscription.Universes
                         OnSubscriptionFinished(subscription);
                     }
                 }

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NodaTime;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
@@ -34,7 +35,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private ManualTimeProvider _frontierTimeProvider;
 
         /// <summary>
-        /// Event fired when a subscription is finished
+        /// Event fired when a <see cref="Subscription"/> is finished
         /// </summary>
         public event EventHandler<Subscription> SubscriptionFinished;
 
@@ -86,6 +87,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="subscriptions">The subscriptions to sync</param>
         public TimeSlice Sync(IEnumerable<Subscription> subscriptions)
         {
+            var delayedSubscriptionFinished = false;
             var changes = SecurityChanges.None;
             var data = new List<DataFeedPacket>();
             // NOTE: Tight coupling in UniverseSelection.ApplyUniverseSelection
@@ -125,7 +127,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                         if (!subscription.MoveNext())
                         {
-                            OnSubscriptionFinished(subscription);
+                            delayedSubscriptionFinished = true;
                             break;
                         }
                     }
@@ -147,7 +149,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                 : packetBaseDataCollection.Data;
 
                             BaseDataCollection collection;
-                            if (universeData.TryGetValue(subscription.Universe, out collection))
+                            if (universeData.TryGetValue(subscription.Universe.First(), out collection))
                             {
                                 collection.Data.AddRange(packetData);
                             }
@@ -167,15 +169,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                     collection = new BaseDataCollection(frontierUtc, subscription.Configuration.Symbol, packetData);
                                 }
 
-                                universeData[subscription.Universe] = collection;
+                                universeData[subscription.Universe.First()] = collection;
                             }
                         }
                     }
 
-                    // remove subscription for universe data if disposal requested AFTER time sync
-                    // this ensures we get any security changes from removing the universe and its children
-                    if (subscription.IsUniverseSelectionSubscription && subscription.Universe.DisposeRequested)
+                    if (subscription.IsUniverseSelectionSubscription
+                        && subscription.Universe.First().DisposeRequested
+                        || delayedSubscriptionFinished)
                     {
+                        delayedSubscriptionFinished = false;
+                        // we need to do this after all usages of subscription.Universe
                         OnSubscriptionFinished(subscription);
                     }
                 }

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
@@ -121,7 +122,9 @@ namespace QuantConnect.Lean.Engine.HistoricalData
 
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(security.Exchange.TimeZone, start, end);
             var subscriptionDataEnumerator = SubscriptionData.Enumerator(config, security, timeZoneOffsetProvider, reader);
-            return new Subscription(null, security, config, subscriptionDataEnumerator, timeZoneOffsetProvider, start, end, false);
+
+            var subscriptionRequest = new SubscriptionRequest(false, null, security, config, start, end);
+            return new Subscription(subscriptionRequest, subscriptionDataEnumerator, timeZoneOffsetProvider);
         }
     }
 }

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -21,6 +21,7 @@ using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
@@ -153,7 +154,8 @@ namespace QuantConnect.Lean.Engine.HistoricalData
 
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(security.Exchange.TimeZone, start, end);
             var subscriptionDataEnumerator = SubscriptionData.Enumerator(config, security, timeZoneOffsetProvider, reader);
-            return new Subscription(null, security, config, subscriptionDataEnumerator, timeZoneOffsetProvider, start, end, false);
+            var subscriptionRequest = new SubscriptionRequest(false, null, security, config, start, end);
+            return new Subscription(subscriptionRequest, subscriptionDataEnumerator, timeZoneOffsetProvider);
         }
 
         private class FilterEnumerator<T> : IEnumerator<T>

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -161,6 +161,7 @@
     <Compile Include="DataFeeds\LiveFutureChainProvider.cs" />
     <Compile Include="DataFeeds\LiveOptionChainProvider.cs" />
     <Compile Include="DataFeeds\NullDataFeed.cs" />
+    <Compile Include="DataFeeds\PendingRemovalsManager.cs" />
     <Compile Include="DataFeeds\SubscriptionDataReaderEvents.cs" />
     <Compile Include="DataFeeds\SubscriptionFrontierTimeProvider.cs" />
     <Compile Include="DataFeeds\SingleEntryDataCacheProvider.cs" />

--- a/Tests/Common/Securities/FakeOrderProcessor.cs
+++ b/Tests/Common/Securities/FakeOrderProcessor.cs
@@ -90,5 +90,12 @@ namespace QuantConnect.Tests.Common.Securities
                     throw new NotImplementedException();
             }
         }
+
+        public void Clear()
+        {
+            _orders.Clear();
+            _tickets.Clear();
+            ProcessedOrdersRequests.Clear();
+        }
     }
 }

--- a/Tests/Common/Securities/SecurityTests.cs
+++ b/Tests/Common/Securities/SecurityTests.cs
@@ -255,7 +255,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(20, securityCache.Volume);
         }
 
-        private Security GetSecurity()
+        internal static Security GetSecurity()
         {
             return new Security(
                 SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
@@ -266,9 +266,9 @@ namespace QuantConnect.Tests.Common.Securities
             );
         }
 
-        private static SubscriptionDataConfig CreateTradeBarConfig()
+        internal static SubscriptionDataConfig CreateTradeBarConfig(Resolution resolution = Resolution.Minute)
         {
-            return new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
+            return new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, resolution, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
         }
     }
 }

--- a/Tests/Engine/DataFeeds/MockDataFeed.cs
+++ b/Tests/Engine/DataFeeds/MockDataFeed.cs
@@ -14,7 +14,6 @@
  *
 */
 
-using NodaTime;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;

--- a/Tests/Engine/DataFeeds/PendingRemovalsManagerTests.cs
+++ b/Tests/Engine/DataFeeds/PendingRemovalsManagerTests.cs
@@ -1,0 +1,202 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Orders;
+using QuantConnect.Tests.Common.Securities;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture]
+    public class PendingRemovalsManagerTests
+    {
+        [Test]
+        public void ReturnedRemoved_Add()
+        {
+            var orderProvider = new FakeOrderProcessor();
+            var pendingRemovals = new PendingRemovalsManager(orderProvider);
+            var security = SecurityTests.GetSecurity();
+            var universe = new TestUniverse();
+
+            var result = pendingRemovals.TryRemoveMember(security, universe);
+
+            Assert.IsTrue(result.Any());
+            Assert.AreEqual(universe, result.First().Universe);
+            Assert.AreEqual(security, result.First().Security);
+            Assert.IsFalse(pendingRemovals.CheckPendingRemovals(new HashSet<Symbol>(), universe).Any());
+            Assert.AreEqual(0, pendingRemovals.PendingRemovals.Keys.Count());
+            Assert.AreEqual(0, pendingRemovals.PendingRemovals.Values.Count());
+        }
+
+        [Test]
+        public void ReturnedRemoved_Check()
+        {
+            var orderProvider = new FakeOrderProcessor();
+            var pendingRemovals = new PendingRemovalsManager(orderProvider);
+            var security = SecurityTests.GetSecurity();
+            var universe = new TestUniverse();
+            orderProvider.AddOrder(new LimitOrder(security.Symbol, 1, 1, DateTime.UtcNow));
+            pendingRemovals.TryRemoveMember(security, universe);
+            orderProvider.Clear();
+
+            var result = pendingRemovals.CheckPendingRemovals(new HashSet<Symbol>(), universe);
+
+            Assert.IsTrue(result.Any());
+            Assert.AreEqual(universe, result.First().Universe);
+            Assert.AreEqual(security, result.First().Security);
+            Assert.IsFalse(pendingRemovals.CheckPendingRemovals(new HashSet<Symbol>(), universe).Any());
+            Assert.AreEqual(0, pendingRemovals.PendingRemovals.Keys.Count());
+            Assert.AreEqual(0, pendingRemovals.PendingRemovals.Values.Count());
+        }
+
+        [Test]
+        public void WontRemoveBecauseOpenOrder_Add()
+        {
+            var orderProvider = new FakeOrderProcessor();
+            var pendingRemovals = new PendingRemovalsManager(orderProvider);
+            var security = SecurityTests.GetSecurity();
+            var universe = new TestUniverse();
+            orderProvider.AddOrder(new LimitOrder(security.Symbol, 1, 1, DateTime.UtcNow));
+
+            Assert.IsFalse(pendingRemovals.TryRemoveMember(security, universe).Any());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Keys.Count());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Values.Count());
+            Assert.AreEqual(universe, pendingRemovals.PendingRemovals.Keys.First());
+            Assert.AreEqual(security, pendingRemovals.PendingRemovals.Values.First().First());
+        }
+
+        [Test]
+        public void WontRemoveBecauseOpenOrder_Check()
+        {
+            var orderProvider = new FakeOrderProcessor();
+            var pendingRemovals = new PendingRemovalsManager(orderProvider);
+            var security = SecurityTests.GetSecurity();
+            var universe = new TestUniverse();
+            orderProvider.AddOrder(new LimitOrder(security.Symbol, 1, 1, DateTime.UtcNow));
+
+            Assert.IsFalse(pendingRemovals.TryRemoveMember(security, universe).Any());
+            Assert.IsFalse(pendingRemovals.CheckPendingRemovals(new HashSet<Symbol>(), universe).Any());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Keys.Count());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Values.Count());
+            Assert.AreEqual(universe, pendingRemovals.PendingRemovals.Keys.First());
+            Assert.AreEqual(security, pendingRemovals.PendingRemovals.Values.First().First());
+        }
+
+        [Test]
+        public void WontRemoveBecauseHoldings_Add()
+        {
+            var orderProvider = new FakeOrderProcessor();
+            var pendingRemovals = new PendingRemovalsManager(orderProvider);
+            var security = SecurityTests.GetSecurity();
+            var universe = new TestUniverse();
+            security.Holdings.SetHoldings(10, 10);
+
+            Assert.IsFalse(pendingRemovals.TryRemoveMember(security, universe).Any());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Keys.Count());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Values.Count());
+            Assert.AreEqual(universe, pendingRemovals.PendingRemovals.Keys.First());
+            Assert.AreEqual(security, pendingRemovals.PendingRemovals.Values.First().First());
+        }
+
+        [Test]
+        public void WontRemoveBecauseHoldings_Check()
+        {
+            var orderProvider = new FakeOrderProcessor();
+            var pendingRemovals = new PendingRemovalsManager(orderProvider);
+            var security = SecurityTests.GetSecurity();
+            var universe = new TestUniverse();
+            security.Holdings.SetHoldings(10, 10);
+
+            Assert.IsFalse(pendingRemovals.TryRemoveMember(security, universe).Any());
+            Assert.IsFalse(pendingRemovals.CheckPendingRemovals(new HashSet<Symbol>(), universe).Any());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Keys.Count());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Values.Count());
+            Assert.AreEqual(universe, pendingRemovals.PendingRemovals.Keys.First());
+            Assert.AreEqual(security, pendingRemovals.PendingRemovals.Values.First().First());
+        }
+
+        [Test]
+        public void WontRemoveBecauseTarget_Add()
+        {
+            var orderProvider = new FakeOrderProcessor();
+            var pendingRemovals = new PendingRemovalsManager(orderProvider);
+            var security = SecurityTests.GetSecurity();
+            var universe = new TestUniverse();
+            security.Holdings.Target = new PortfolioTarget(security.Symbol, 10);
+
+            Assert.IsFalse(pendingRemovals.TryRemoveMember(security, universe).Any());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Keys.Count());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Values.Count());
+            Assert.AreEqual(universe, pendingRemovals.PendingRemovals.Keys.First());
+            Assert.AreEqual(security, pendingRemovals.PendingRemovals.Values.First().First());
+        }
+
+        [Test]
+        public void WontRemoveBecauseTarget_Check()
+        {
+            var orderProvider = new FakeOrderProcessor();
+            var pendingRemovals = new PendingRemovalsManager(orderProvider);
+            var security = SecurityTests.GetSecurity();
+            var universe = new TestUniverse();
+            security.Holdings.Target = new PortfolioTarget(security.Symbol, 10);
+
+            Assert.IsFalse(pendingRemovals.TryRemoveMember(security, universe).Any());
+            Assert.IsFalse(pendingRemovals.CheckPendingRemovals(new HashSet<Symbol>(), universe).Any());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Keys.Count());
+            Assert.AreEqual(1, pendingRemovals.PendingRemovals.Values.Count());
+            Assert.AreEqual(universe, pendingRemovals.PendingRemovals.Keys.First());
+            Assert.AreEqual(security, pendingRemovals.PendingRemovals.Values.First().First());
+        }
+
+        [Test]
+        public void WontBeReturnedBecauseReSelected()
+        {
+            var orderProvider = new FakeOrderProcessor();
+            var pendingRemovals = new PendingRemovalsManager(orderProvider);
+            var security = SecurityTests.GetSecurity();
+            var universe = new TestUniverse();
+            orderProvider.AddOrder(new LimitOrder(security.Symbol, 1, 1, DateTime.UtcNow));
+            pendingRemovals.TryRemoveMember(security, universe);
+
+            Assert.IsFalse(pendingRemovals.CheckPendingRemovals(
+                new HashSet<Symbol> { security.Symbol}, universe).Any());
+
+            // internally it was removed because it was reselected
+            Assert.AreEqual(0, pendingRemovals.PendingRemovals.Keys.Count());
+            Assert.AreEqual(0, pendingRemovals.PendingRemovals.Values.Count());
+        }
+
+        private class TestUniverse : Universe
+        {
+            public TestUniverse()
+                : base(SecurityTests.CreateTradeBarConfig())
+            {
+            }
+
+            public override UniverseSettings UniverseSettings { get; }
+            public override IEnumerable<Symbol> SelectSymbols(DateTime utcTime, BaseDataCollection data)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Tests/Engine/DataFeeds/SubscriptionCollectionTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionCollectionTests.cs
@@ -22,6 +22,7 @@ using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
 using QuantConnect.Securities;
@@ -54,7 +55,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(DateTimeZone.Utc, start, end);
             var enumerator = new EnqueueableEnumerator<BaseData>();
             var subscriptionDataEnumerator = SubscriptionData.Enumerator(config, security, timeZoneOffsetProvider, enumerator);
-            var subscription = new Subscription(null, security, config, subscriptionDataEnumerator, timeZoneOffsetProvider, start, end, false);
+            var subscriptionRequest = new SubscriptionRequest(false, null, security, config, start, end);
+            var subscription = new Subscription(subscriptionRequest, subscriptionDataEnumerator, timeZoneOffsetProvider);
 
             var addTask = new TaskFactory().StartNew(() =>
             {
@@ -363,7 +365,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(DateTimeZone.Utc, start, end);
             var enumerator = new EnqueueableEnumerator<BaseData>();
             var subscriptionDataEnumerator = SubscriptionData.Enumerator(config, security, timeZoneOffsetProvider, enumerator);
-            return new Subscription(null, security, config, subscriptionDataEnumerator, timeZoneOffsetProvider, start, end, false);
+            var subscriptionRequest = new SubscriptionRequest(false, null, security, config, start, end);
+            return new Subscription(subscriptionRequest, subscriptionDataEnumerator, timeZoneOffsetProvider);
         }
     }
 }

--- a/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
@@ -131,7 +131,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             .ToList();
 
             dataPointCount = data.Count;
-            return new Subscription(universe, security, config, data.GetEnumerator(), offsetProvider, endTimeUtc, endTimeUtc, false);
+            var subscriptionRequest = new SubscriptionRequest(false, universe, security, config, startTimeUtc, endTimeUtc);
+            return new Subscription(subscriptionRequest, data.GetEnumerator(), offsetProvider);
         }
 
         private class DataPoint : BaseData

--- a/Tests/Engine/DataFeeds/SubscriptionTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionTests.cs
@@ -40,8 +40,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 null,
                 new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
 
-            Assert.IsTrue(subscription.HasSubscriptionRequests);
-            Assert.IsFalse(subscription.Universe.Any());
+            Assert.IsFalse(subscription.Universes.Any());
             Assert.IsFalse(subscription.EndOfStream);
             Assert.AreEqual(_start, subscription.UtcStartTime);
             Assert.AreEqual(_end, subscription.UtcEndTime);
@@ -58,11 +57,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 null,
                 new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
 
-            Assert.IsTrue(subscription.HasSubscriptionRequests);
-            Assert.AreEqual(1, subscription.Universe.Count());
+            Assert.AreEqual(1, subscription.Universes.Count());
             Assert.AreEqual(_start, subscription.UtcStartTime);
             Assert.AreEqual(_end, subscription.UtcEndTime);
-            Assert.AreEqual(subscriptionRequest.Universe, subscription.Universe.First());
+            Assert.AreEqual(subscriptionRequest.Universe, subscription.Universes.First());
             Assert.IsFalse(subscription.EndOfStream);
             Assert.AreEqual(subscription.Configuration, subscriptionRequest.Configuration);
             Assert.IsFalse(subscription.IsUniverseSelectionSubscription);
@@ -77,13 +75,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 null,
                 new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
 
-            Assert.AreEqual(1, subscription.Universe.Count());
-            Assert.AreEqual(subscriptionRequest.Universe, subscription.Universe.First());
+            Assert.AreEqual(1, subscription.Universes.Count());
+            Assert.AreEqual(subscriptionRequest.Universe, subscription.Universes.First());
 
             subscription.AddSubscriptionRequest(subscriptionRequest);
 
-            Assert.AreEqual(1, subscription.Universe.Count());
-            Assert.AreEqual(subscriptionRequest.Universe, subscription.Universe.First());
+            Assert.AreEqual(1, subscription.Universes.Count());
+            Assert.AreEqual(subscriptionRequest.Universe, subscription.Universes.First());
         }
 
         [Test]
@@ -138,11 +136,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 null,
                 new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
 
-            var removedUniverse = subscription.RemoveSubscriptionRequest(subscriptionRequest.Universe);
-            Assert.IsTrue(removedUniverse.Contains(subscriptionRequest.Universe));
+            var emptySubscription = subscription.RemoveSubscriptionRequest(subscriptionRequest.Universe);
 
-            Assert.IsFalse(subscription.Universe.Any());
-            Assert.IsFalse(subscription.HasSubscriptionRequests);
+            Assert.IsTrue(emptySubscription);
+            Assert.IsFalse(subscription.Universes.Any());
         }
 
         [Test]
@@ -156,14 +153,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
 
             subscription.AddSubscriptionRequest(subscriptionRequest2);
-            Assert.AreEqual(2, subscription.Universe.Count());
-            var removedUniverses = subscription.RemoveSubscriptionRequest().ToList();
+            Assert.AreEqual(2, subscription.Universes.Count());
+            var emptySubscription = subscription.RemoveSubscriptionRequest();
 
-            Assert.IsTrue(removedUniverses.Contains(subscriptionRequest.Universe));
-            Assert.IsTrue(removedUniverses.Contains(subscriptionRequest2.Universe));
-
-            Assert.IsFalse(subscription.Universe.Any());
-            Assert.IsFalse(subscription.HasSubscriptionRequests);
+            Assert.IsTrue(emptySubscription);
+            Assert.IsFalse(subscription.Universes.Any());
         }
 
         [Test]
@@ -175,11 +169,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 null,
                 new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
 
-            var removedUniverses = subscription.RemoveSubscriptionRequest().ToList();
+            var emptySubscription = subscription.RemoveSubscriptionRequest();
 
-            Assert.IsFalse(removedUniverses.Any());
-            Assert.IsFalse(subscription.Universe.Any());
-            Assert.IsFalse(subscription.HasSubscriptionRequests);
+            Assert.IsTrue(emptySubscription);
+            Assert.IsFalse(subscription.Universes.Any());
         }
 
         private SubscriptionRequest GetSubscriptionRequest(

--- a/Tests/Engine/DataFeeds/SubscriptionTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionTests.cs
@@ -1,0 +1,200 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Tests.Common.Securities;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture]
+    public class SubscriptionTests
+    {
+        private readonly DateTime _start = DateTime.MinValue;
+        private readonly DateTime _end = DateTime.MinValue.AddDays(1);
+
+        [Test]
+        public void ConstructorNoUniverse()
+        {
+            var subscriptionRequest = GetSubscriptionRequest(false);
+            var subscription = new Subscription(
+                subscriptionRequest,
+                null,
+                new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
+
+            Assert.IsTrue(subscription.HasSubscriptionRequests);
+            Assert.IsFalse(subscription.Universe.Any());
+            Assert.IsFalse(subscription.EndOfStream);
+            Assert.AreEqual(_start, subscription.UtcStartTime);
+            Assert.AreEqual(_end, subscription.UtcEndTime);
+            Assert.AreEqual(subscription.Configuration, subscriptionRequest.Configuration);
+            Assert.IsFalse(subscription.IsUniverseSelectionSubscription);
+        }
+
+        [Test]
+        public void Constructor()
+        {
+            var subscriptionRequest = GetSubscriptionRequest();
+            var subscription = new Subscription(
+                subscriptionRequest,
+                null,
+                new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
+
+            Assert.IsTrue(subscription.HasSubscriptionRequests);
+            Assert.AreEqual(1, subscription.Universe.Count());
+            Assert.AreEqual(_start, subscription.UtcStartTime);
+            Assert.AreEqual(_end, subscription.UtcEndTime);
+            Assert.AreEqual(subscriptionRequest.Universe, subscription.Universe.First());
+            Assert.IsFalse(subscription.EndOfStream);
+            Assert.AreEqual(subscription.Configuration, subscriptionRequest.Configuration);
+            Assert.IsFalse(subscription.IsUniverseSelectionSubscription);
+        }
+
+        [Test]
+        public void AddSubscriptionRequestOncePerUniverse()
+        {
+            var subscriptionRequest = GetSubscriptionRequest();
+            var subscription = new Subscription(
+                subscriptionRequest,
+                null,
+                new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
+
+            Assert.AreEqual(1, subscription.Universe.Count());
+            Assert.AreEqual(subscriptionRequest.Universe, subscription.Universe.First());
+
+            subscription.AddSubscriptionRequest(subscriptionRequest);
+
+            Assert.AreEqual(1, subscription.Universe.Count());
+            Assert.AreEqual(subscriptionRequest.Universe, subscription.Universe.First());
+        }
+
+        [Test]
+        public void SubscriptionOnlyAcceptsOneUniverseSelection()
+        {
+            var subscriptionRequest = GetSubscriptionRequest(true, true);
+            var subscriptionRequest2 = GetSubscriptionRequest();
+            var subscription = new Subscription(
+                subscriptionRequest,
+                null,
+                new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
+
+            try
+            {
+                subscription.AddSubscriptionRequest(subscriptionRequest2);
+                Assert.Fail("Subscription should only accept one universe selection" +
+                    " subscription request.");
+            }
+            catch (Exception)
+            {
+                Assert.Pass();
+            }
+        }
+
+        [Test]
+        public void SubscriptionOnlyAcceptsSameConfiguration()
+        {
+            var subscriptionRequest = GetSubscriptionRequest();
+            var subscriptionRequest2 = GetSubscriptionRequest(resolution: Resolution.Second);
+            var subscription = new Subscription(
+                subscriptionRequest,
+                null,
+                new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
+
+            try
+            {
+                subscription.AddSubscriptionRequest(subscriptionRequest2);
+                Assert.Fail("Subscription should only accept the same configuration");
+            }
+            catch (Exception)
+            {
+                Assert.Pass();
+            }
+        }
+
+        [Test]
+        public void RemoveSubscriptionRequest()
+        {
+            var subscriptionRequest = GetSubscriptionRequest();
+            var subscription = new Subscription(
+                subscriptionRequest,
+                null,
+                new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
+
+            var removedUniverse = subscription.RemoveSubscriptionRequest(subscriptionRequest.Universe);
+            Assert.IsTrue(removedUniverse.Contains(subscriptionRequest.Universe));
+
+            Assert.IsFalse(subscription.Universe.Any());
+            Assert.IsFalse(subscription.HasSubscriptionRequests);
+        }
+
+        [Test]
+        public void RemoveAllSubscriptionRequest()
+        {
+            var subscriptionRequest = GetSubscriptionRequest();
+            var subscriptionRequest2 = GetSubscriptionRequest();
+            var subscription = new Subscription(
+                subscriptionRequest,
+                null,
+                new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
+
+            subscription.AddSubscriptionRequest(subscriptionRequest2);
+            Assert.AreEqual(2, subscription.Universe.Count());
+            var removedUniverses = subscription.RemoveSubscriptionRequest().ToList();
+
+            Assert.IsTrue(removedUniverses.Contains(subscriptionRequest.Universe));
+            Assert.IsTrue(removedUniverses.Contains(subscriptionRequest2.Universe));
+
+            Assert.IsFalse(subscription.Universe.Any());
+            Assert.IsFalse(subscription.HasSubscriptionRequests);
+        }
+
+        [Test]
+        public void RemoveAllSubscriptionRequestNoUniverse()
+        {
+            var subscriptionRequest = GetSubscriptionRequest(false);
+            var subscription = new Subscription(
+                subscriptionRequest,
+                null,
+                new TimeZoneOffsetProvider(DateTimeZone.Utc, _start, _end));
+
+            var removedUniverses = subscription.RemoveSubscriptionRequest().ToList();
+
+            Assert.IsFalse(removedUniverses.Any());
+            Assert.IsFalse(subscription.Universe.Any());
+            Assert.IsFalse(subscription.HasSubscriptionRequests);
+        }
+
+        private SubscriptionRequest GetSubscriptionRequest(
+            bool useUniverse = true,
+            bool isUniverseSelection = false,
+            Resolution resolution = Resolution.Minute)
+        {
+            var security = SecurityTests.GetSecurity();
+            var config = SecurityTests.CreateTradeBarConfig(resolution);
+            var universe = new ManualUniverse(
+                config,
+                new UniverseSettings(Resolution.Daily, 1, true, true, TimeSpan.FromDays(1)),
+                new[] {security.Symbol}
+            );
+            return new SubscriptionRequest(isUniverseSelection, useUniverse ? universe : null, security, config, _start, _end);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -171,7 +171,9 @@
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />
     <Compile Include="Engine\DataFeeds\DataManagerStub.cs" />
     <Compile Include="Engine\DataFeeds\MockDataFeed.cs" />
+    <Compile Include="Engine\DataFeeds\PendingRemovalsManagerTests.cs" />
     <Compile Include="Engine\DataFeeds\UniverseSelectionTests.cs" />
+    <Compile Include="Engine\DataFeeds\SubscriptionTests.cs" />
     <Compile Include="PythonSetup.cs" />
     <Compile Include="Algorithm\Framework\QCAlgorithmFrameworkTests.cs" />
     <Compile Include="Algorithm\Framework\Risk\MaximumDrawdownPercentPerSecurityTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- The class `Subscription` will internally track each `Universe`
`SubscriptionRequest` added or removed. **This PR is not updating the 'UtcStartTime' and 'UtcEndTime' of the `Subscription`**, they will maintain there initial value.
- Adding regression test in which two different `Universe` request the
same `SubscriptionDataConfig` and one of them removes/adds it in a
toggle fashion **(fails on current master)**
- `UniverseSelection` pending removals will also be tracked by
`Universe`
   - Extracting pending removals logic from `UniverseSelection` class into
a new helper class `PendingRemovalsManager`. This new class will keep
track of the `universes` requesting to remove a security. Adding unit tests
- `UniverseDecorator` will overwrite the `Universe` member of
`SubscriptionsRequests` at `GetSubscriptionRequests()`. This is due to
`this != this,Universe`. Behavior covered by existing regression tests.
- Adding `Subscription` unit tests covering expected behavior

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2616
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/5
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->