### PR TITLE
Fix potential endless loop in BrokerageSetupHandler daily cash sync

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -462,7 +462,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 Connect();
             }
 
-            return _accountData.CashBalances.Select(x => new Cash(x.Key, x.Value, GetUsdConversion(x.Key))).ToList();
+            var balances = _accountData.CashBalances.Select(x => new Cash(x.Key, x.Value, GetUsdConversion(x.Key))).ToList();
+
+            if (balances.Count == 0)
+            {
+                Log.Trace($"InteractiveBrokersBrokerage.GetCashBalance(): no balances found, IsConnected: {IsConnected}");
+            }
+
+            return balances;
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description
- added tracking of failed cash sync attempts and throw if maximum reached
- added extra log traces in IB `GetCashBalance` and in `BrokerageTransactionHandler`
- added endless loop unit tests for both `BrokerageTransactionHandler` and `InteractiveBrokersBrokerage`

#### Related Issue
Closes #2668 

#### Motivation and Context
This fix will prevent an endless loop during the daily cash sync. 
Additional logging has been included to help diagnose the source of the problem (IB occasionally not being able to connect before `GetCashBalance`).

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`