### PR TITLE
Prevents negative Variance

### DIFF
--- a/Indicators/Variance.cs
+++ b/Indicators/Variance.cs
@@ -78,7 +78,8 @@ namespace QuantConnect.Indicators
                 _rollingSumOfSquares -= removedValue * removedValue;
             }
 
-            return meanValue2 - meanValue1 * meanValue1;
+            // Ensure non-negative variance
+            return System.Math.Max(0m, meanValue2 - meanValue1 * meanValue1);
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description
Prevents negative variance (mathematically impossible) in `Variance` indicator.
Since variance is used to calculate standard deviation, we found that negative variance yield `double.NaN` and, consequently, an arithmetic overflow when we convert `NaN` into `decimal`.

#### Related Issue
Closes #2672

#### Motivation and Context
Fix bugs in indicators 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Existing unit and regression tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`