### PR TITLE
BacktestingResultHandler speed improvement with many orders

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -274,10 +274,15 @@ namespace QuantConnect.Lean.Engine.Results
                 //1. Cloud Upload -> Upload the whole packet to S3  Immediately:
                 if (DateTime.UtcNow > _nextS3Update)
                 {
+                    // For intermediate backtesting results, we truncate the order list to include only the last 100 orders
+                    // The final packet will contain the full list of orders.
+                    const int maxOrders = 100;
+                    var orderCount = _transactionHandler.Orders.Count;
+
                     var completeResult = new BacktestResult(
                         Algorithm.IsFrameworkAlgorithm,
                         Charts,
-                        _transactionHandler.Orders,
+                        orderCount > maxOrders ? _transactionHandler.Orders.Skip(orderCount - maxOrders).ToDictionary() : _transactionHandler.Orders.ToDictionary(),
                         Algorithm.Transactions.TransactionRecord,
                         new Dictionary<string, string>(),
                         runtimeStatistics,

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -278,7 +278,6 @@ namespace QuantConnect.Lean.Engine.Results
                     if (utcNow > _nextChartsUpdate)
                     {
                         Log.Debug("LiveTradingResultHandler.Update(): Pre-store result");
-                        _nextChartsUpdate = DateTime.UtcNow.AddMinutes(1);
                         var chartComplete = new Dictionary<string, Chart>();
                         lock (_chartLock)
                         {
@@ -292,6 +291,7 @@ namespace QuantConnect.Lean.Engine.Results
                         var orders = new Dictionary<int, Order>(_transactionHandler.Orders);
                         var complete = new LiveResultPacket(_job, new LiveResult(_algorithm.IsFrameworkAlgorithm, chartComplete, orders, _algorithm.Transactions.TransactionRecord, holdings, _algorithm.Portfolio.CashBook, deltaStatistics, runtimeStatistics, serverStatistics));
                         StoreResult(complete);
+                        _nextChartsUpdate = DateTime.UtcNow.AddMinutes(1);
                         Log.Debug("LiveTradingResultHandler.Update(): End-store result");
                     }
 


### PR DESCRIPTION
#### Description
This is a continuation of PR #2646 for backtests with many orders: 
- When storing intermediate backtesting results, truncate the order list to 100 maximum

Also includes a minor fix in `LiveTradingResultHandler.Update`

#### Related Issue
Closes #2645 

#### Motivation and Context
Prevent large intermediate packet uploads, which would result in the Web IDE to freeze.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local and cloud backtest with 500K orders.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`