### PR TITLE
Adds Python Version of Latest Risk Management Model

### DIFF
--- a/Algorithm.CSharp/MaximumPortfolioDrawdownFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/MaximumPortfolioDrawdownFrameworkAlgorithm.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/TrailingStopRiskFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/TrailingStopRiskFrameworkAlgorithm.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp};
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -200,6 +200,9 @@
     <Content Include="Risk\CompositeRiskManagementModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Risk\MaximumDrawdownPercentPortfolio.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Risk\MaximumUnrealizedProfitPercentPerSecurity.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -200,6 +200,9 @@
     <Content Include="Risk\CompositeRiskManagementModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Risk\TrailingStopRiskManagementModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Risk\MaximumDrawdownPercentPortfolio.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -197,6 +197,12 @@
     <Content Include="Portfolio\EqualWeightingPortfolioConstructionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Risk\CompositeRiskManagementModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Risk\MaximumUnrealizedProfitPercentPerSecurity.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Risk\MaximumDrawdownPercentPerSecurity.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Algorithm.Framework/Risk/CompositeRiskManagementModel.py
+++ b/Algorithm.Framework/Risk/CompositeRiskManagementModel.py
@@ -1,0 +1,66 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Risk import RiskManagementModel
+
+class CompositeRiskManagementModel(RiskManagementModel):
+    '''Provides an implementation of IRiskManagementModel that combines multiple risk models
+    into a single risk management model and properly sets each insights 'SourceModel' property.'''
+
+    def __init__(self, *riskManagementModels):
+        '''Initializes a new instance of the CompositeRiskManagementModel class
+        Args:
+            riskManagementModels: The individual risk management models defining this composite model.'''
+        for model in riskManagementModels:
+            for attributeName in ['ManageRisk', 'OnSecuritiesChanged']:
+                if not hasattr(model, attributeName):
+                    raise Exception(f'IRiskManagementModel.{attributeName} must be implemented. Please implement this missing method on {model.__class__.__name__}')
+
+        self.riskManagementModels = riskManagementModels
+
+    def ManageRisk(self, algorithm, targets):
+        '''Manages the algorithm's risk at each time step
+        Args:
+            algorithm: The algorithm instance
+            targets: The current portfolio targets to be assessed for risk'''
+        for model in self.riskManagementModels:
+            # take into account the possibility of ManageRisk returning nothing
+            riskAdjusted = model.ManageRisk(algorithm, targets)
+
+            # produce a distinct set of new targets giving preference to newer targets
+            symbols = [x.Symbol for x in riskAdjusted]
+            for target in targets:
+                if target.Symbol not in symbols:
+                    riskAdjusted.append(target)
+
+            targets = riskAdjusted
+
+        return targets
+
+    def OnSecuritiesChanged(self, algorithm, changes):
+        '''Event fired each time the we add/remove securities from the data feed.
+        This method patches this call through the each of the wrapped models.
+        Args:
+            algorithm: The algorithm instance that experienced the change in securities
+            changes: The security additions and removals from the algorithm'''
+        for model in self.riskManagementModels:
+            model.OnSecuritiesChanged(algorithm, changes)

--- a/Algorithm.Framework/Risk/MaximumDrawdownPercentPortfolio.py
+++ b/Algorithm.Framework/Risk/MaximumDrawdownPercentPortfolio.py
@@ -1,0 +1,63 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget
+from QuantConnect.Algorithm.Framework.Risk import RiskManagementModel
+
+class MaximumDrawdownPercentPortfolio(RiskManagementModel):
+    '''Provides an implementation of IRiskManagementModel that limits the drawdown of the portfolio to the specified percentage.'''
+
+    def __init__(self, maximumDrawdownPercent = 0.05, isTrailing = False):
+        '''Initializes a new instance of the MaximumDrawdownPercentPortfolio class
+        Args:
+            maximumDrawdownPercent: The maximum percentage drawdown allowed for algorithm portfolio compared with starting value, defaults to 5% drawdown</param>
+            isTrailing: If "false", the drawdown will be relative to the starting value of the portfolio.
+                        If "true", the drawdown will be relative the last maximum portfolio value'''
+        self.maximumDrawdownPercent = -abs(maximumDrawdownPercent)
+        self.isTrailing = isTrailing
+        self.initialised = False
+        self.portfolioHigh = 0;
+
+    def ManageRisk(self, algorithm, targets):
+        '''Manages the algorithm's risk at each time step
+        Args:
+            algorithm: The algorithm instance
+            targets: The current portfolio targets to be assessed for risk'''
+        currentValue = algorithm.Portfolio.TotalPortfolioValue
+
+        if not self.initialised:
+            self.portfolioHigh = currentValue   # Set initial portfolio value
+            self.initialised = True
+
+        # Update trailing high value if in trailing mode
+        if self.isTrailing and self.portfolioHigh < currentValue:
+            self.portfolioHigh = currentValue
+            return []   # return if new high reached
+
+        pnl = self.GetTotalDrawdownPercent(currentValue)
+        if pnl < self.maximumDrawdownPercent:
+            return [ PortfolioTarget(target.Symbol, 0) for target in targets ]
+
+        return []
+
+    def GetTotalDrawdownPercent(self, currentValue):
+        return (float(currentValue) / float(self.portfolioHigh)) - 1.0

--- a/Algorithm.Framework/Risk/MaximumUnrealizedProfitPercentPerSecurity.py
+++ b/Algorithm.Framework/Risk/MaximumUnrealizedProfitPercentPerSecurity.py
@@ -23,14 +23,14 @@ from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget
 from QuantConnect.Algorithm.Framework.Risk import RiskManagementModel
 
-class MaximumDrawdownPercentPerSecurity(RiskManagementModel):
-    '''Provides an implementation of IRiskManagementModel that limits the drawdown per holding to the specified percentage'''
+class MaximumUnrealizedProfitPercentPerSecurity(RiskManagementModel):
+    '''Provides an implementation of IRiskManagementModel that limits the unrealized profit per holding to the specified percentage'''
 
-    def __init__(self, maximumDrawdownPercent = 0.05):
-        '''Initializes a new instance of the MaximumDrawdownPercentPerSecurity class
+    def __init__(self, maximumUnrealizedProfitPercent = 0.05):
+        '''Initializes a new instance of the MaximumUnrealizedProfitPercentPerSecurity class
         Args:
-            maximumDrawdownPercent: The maximum percentage drawdown allowed for any single security holding'''
-        self.maximumDrawdownPercent = -abs(maximumDrawdownPercent)
+            maximumUnrealizedProfitPercent: The maximum percentage unrealized profit allowed for any single security holding, defaults to 5% drawdown per security'''
+        self.maximumUnrealizedProfitPercent = abs(maximumUnrealizedProfitPercent)
 
     def ManageRisk(self, algorithm, targets):
         '''Manages the algorithm's risk at each time step
@@ -45,7 +45,7 @@ class MaximumDrawdownPercentPerSecurity(RiskManagementModel):
                 continue
 
             pnl = security.Holdings.UnrealizedProfitPercent
-            if pnl < self.maximumDrawdownPercent:
+            if pnl > self.maximumUnrealizedProfitPercent:
                 # liquidate
                 targets.append(PortfolioTarget(security.Symbol, 0))
 

--- a/Algorithm.Framework/Risk/RiskManagementModelPythonWrapper.cs
+++ b/Algorithm.Framework/Risk/RiskManagementModelPythonWrapper.cs
@@ -15,7 +15,7 @@
 
 using Python.Runtime;
 using QuantConnect.Data.UniverseSelection;
-using System;
+using QuantConnect.Python;
 using System.Collections.Generic;
 using QuantConnect.Algorithm.Framework.Portfolio;
 
@@ -34,16 +34,7 @@ namespace QuantConnect.Algorithm.Framework.Risk
         /// <param name="model">Model defining how risk is managed</param>
         public RiskManagementModelPythonWrapper(PyObject model)
         {
-            using (Py.GIL())
-            {
-                foreach (var attributeName in new[] { "ManageRisk", "OnSecuritiesChanged" })
-                {
-                    if (!model.HasAttr(attributeName))
-                    {
-                        throw new NotImplementedException($"IRiskManagementModel.{attributeName} must be implemented. Please implement this missing method on {model.GetPythonType()}");
-                    }
-                }
-            }
+            model.ValidateImplementationOf<IRiskManagementModel>();
             _model = model;
         }
 

--- a/Algorithm.Framework/Risk/TrailingStopRiskManagementModel.cs
+++ b/Algorithm.Framework/Risk/TrailingStopRiskManagementModel.cs
@@ -21,8 +21,8 @@ using QuantConnect.Algorithm.Framework.Portfolio;
 namespace QuantConnect.Algorithm.Framework.Risk
 {
     /// <summary>
-    /// Provides an implementation of <see cref="IRiskManagementModel"/> that limits the relative drawdown
-    /// per holding to the specified percentage
+    /// Provides an implementation of <see cref="IRiskManagementModel"/> that limits the maximum possible loss
+    /// measured from the highest unrealized profit
     /// </summary>
     public class TrailingStopRiskManagementModel : RiskManagementModel
     {
@@ -32,7 +32,7 @@ namespace QuantConnect.Algorithm.Framework.Risk
         /// <summary>
         /// Initializes a new instance of the <see cref="TrailingStopRiskManagementModel"/> class
         /// </summary>
-        /// <param name="maximumDrawdownPercent">The maximum percentage relative drawdown allowed for any single security holding, defaults to 5% drawdown per security</param>
+        /// <param name="maximumDrawdownPercent">The maximum percentage relative drawdown allowed for algorithm portfolio compared with the highest unrealized profit, defaults to 5% drawdown per security</param>
         public TrailingStopRiskManagementModel(decimal maximumDrawdownPercent = 0.05m)
         {
             _maximumDrawdownPercent = -Math.Abs(maximumDrawdownPercent);

--- a/Algorithm.Framework/Risk/TrailingStopRiskManagementModel.py
+++ b/Algorithm.Framework/Risk/TrailingStopRiskManagementModel.py
@@ -1,0 +1,70 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Portfolio import PortfolioTarget
+from QuantConnect.Algorithm.Framework.Risk import RiskManagementModel
+
+class TrailingStopRiskManagementModel(RiskManagementModel):
+    '''Provides an implementation of IRiskManagementModel that limits the maximum possible loss
+    measured from the highest unrealized profit'''
+    def __init__(self, maximumDrawdownPercent = 0.05):
+        '''Initializes a new instance of the TrailingStopRiskManagementModel class
+        Args:
+            maximumDrawdownPercent: The maximum percentage drawdown allowed for algorithm portfolio compared with the highest unrealized profit, defaults to 5% drawdown'''
+        self.maximumDrawdownPercent = -abs(maximumDrawdownPercent)
+        self.trailingHighs = dict()
+
+    def ManageRisk(self, algorithm, targets):
+        '''Manages the algorithm's risk at each time step
+        Args:
+            algorithm: The algorithm instance
+            targets: The current portfolio targets to be assessed for risk'''
+        riskAdjustedTargets = list()
+
+        for kvp in algorithm.Securities:
+            symbol = kvp.Key
+            security = kvp.Value
+
+            # Remove if not invested
+            if not security.Invested:
+                self.trailingHighs.pop(symbol, None)
+                continue
+
+            # Add newly invested securities
+            if symbol not in self.trailingHighs:
+                self.trailingHighs[symbol] = security.Holdings.AveragePrice   # Set to average holding cost
+                continue
+
+            # Check for new highs and update - set to tradebar high
+            if self.trailingHighs[symbol] < security.High:
+                self.trailingHighs[symbol] = security.High
+                continue
+
+            # Check for securities past the drawdown limit
+            securityHigh = self.trailingHighs[symbol]
+            drawdown = (security.Low / securityHigh) - 1
+
+            if drawdown < self.maximumDrawdownPercent:
+                # liquidate
+                riskAdjustedTargets.append(PortfolioTarget(symbol, 0))
+
+        return riskAdjustedTargets

--- a/Algorithm.Python/CompositeRiskManagementModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/CompositeRiskManagementModelFrameworkAlgorithm.py
@@ -23,9 +23,11 @@ from QuantConnect.Algorithm import *
 from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import *
 from QuantConnect.Algorithm.Framework.Execution import *
-from QuantConnect.Algorithm.Framework.Risk import *
 from QuantConnect.Algorithm.Framework.Selection import *
-from Portfolio.EqualWeightingPortfolioConstructionModel import EqualWeightingPortfolioConstructionModel
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from Risk.CompositeRiskManagementModel import CompositeRiskManagementModel
+from Risk.MaximumUnrealizedProfitPercentPerSecurity import MaximumUnrealizedProfitPercentPerSecurity
+from Risk.MaximumDrawdownPercentPerSecurity import MaximumDrawdownPercentPerSecurity
 from datetime import timedelta
 
 ### <summary>

--- a/Algorithm.Python/MaximumPortfolioDrawdownFrameworkAlgorithm.py
+++ b/Algorithm.Python/MaximumPortfolioDrawdownFrameworkAlgorithm.py
@@ -1,0 +1,57 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from Risk.CompositeRiskManagementModel import CompositeRiskManagementModel
+from Risk.MaximumDrawdownPercentPortfolio import MaximumDrawdownPercentPortfolio
+from datetime import timedelta
+import numpy as np
+
+
+class MaximumPortfolioDrawdownFrameworkAlgorithm(QCAlgorithmFramework):
+    '''Show example of how to use the MaximumDrawdownPercentPortfolio Risk Management Model'''
+
+    def Initialize(self):
+
+        # Set requested data resolution
+        self.UniverseSettings.Resolution = Resolution.Minute
+
+        self.SetStartDate(2013,10,7)   #Set Start Date
+        self.SetEndDate(2013,10,11)    #Set End Date
+        self.SetCash(100000)           #Set Strategy Cash
+
+        # set algorithm framework models
+        self.SetUniverseSelection(ManualUniverseSelectionModel([ Symbol.Create("SPY", SecurityType.Equity, Market.USA) ]))
+        self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(minutes = 20), 0.025, None))
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+
+        # define risk management model as a composite of several risk management models
+        self.SetRiskManagement(CompositeRiskManagementModel(
+            MaximumDrawdownPercentPortfolio(0.01),         # Avoid loss of initial capital
+            MaximumDrawdownPercentPortfolio(0.015, True)   # Avoid profit losses
+            ))

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -113,6 +113,7 @@
     <None Include="main.py" />
     <None Include="MarginCallEventsAlgorithm.py" />
     <None Include="MarketOnOpenOnCloseAlgorithm.py" />
+    <None Include="MaximumPortfolioDrawdownFrameworkAlgorithm.py" />
     <None Include="MeanVarianceOptimizationFrameworkAlgorithm.py" />
     <None Include="MovingAverageCrossAlgorithm.py" />
     <None Include="MultipleSymbolConsolidationAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -140,6 +140,7 @@
     <None Include="SectorExposureRiskFrameworkAlgorithm.py" />
     <None Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
     <None Include="TimeInForceAlgorithm.py" />
+    <None Include="TrailingStopRiskFrameworkAlgorithm.py" />
     <None Include="UniverseSelectionDefinitionsAlgorithm.py" />
     <None Include="UniverseSelectionRegressionAlgorithm.py" />
     <None Include="UpdateOrderRegressionAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -115,6 +115,7 @@
     <Compile Include="SectorExposureRiskFrameworkAlgorithm.py" />
     <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
     <Compile Include="TimeInForceAlgorithm.py" />
+    <Compile Include="TrailingStopRiskFrameworkAlgorithm.py" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.py" />
     <Compile Include="UniverseSelectionRegressionAlgorithm.py" />
     <Compile Include="UpdateOrderRegressionAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -87,6 +87,7 @@
     <Compile Include="main.py" />
     <Compile Include="MarginCallEventsAlgorithm.py" />
     <Compile Include="MarketOnOpenOnCloseAlgorithm.py" />
+    <Compile Include="MaximumPortfolioDrawdownFrameworkAlgorithm.py" />
     <Compile Include="MeanVarianceOptimizationFrameworkAlgorithm.py" />
     <Compile Include="MovingAverageCrossAlgorithm.py" />
     <Compile Include="MultipleSymbolConsolidationAlgorithm.py" />

--- a/Algorithm.Python/TrailingStopRiskFrameworkAlgorithm.py
+++ b/Algorithm.Python/TrailingStopRiskFrameworkAlgorithm.py
@@ -1,0 +1,54 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from Risk.TrailingStopRiskManagementModel import TrailingStopRiskManagementModel
+from datetime import timedelta
+
+
+class TrailingStopRiskFrameworkAlgorithm(QCAlgorithmFramework):
+    '''Show example of how to use the TrailingStopRiskManagementModel'''
+
+    def Initialize(self):
+
+        # Set requested data resolution
+        self.UniverseSettings.Resolution = Resolution.Minute
+
+        self.SetStartDate(2013,10,7)   #Set Start Date
+        self.SetEndDate(2013,10,11)    #Set End Date
+        self.SetCash(100000)           #Set Strategy Cash
+
+        # set algorithm framework models
+        self.SetUniverseSelection(ManualUniverseSelectionModel([ Symbol.Create("SPY", SecurityType.Equity, Market.USA) ]))
+        self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(minutes = 20), 0.025, None))
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+        self.SetRiskManagement(TrailingStopRiskManagementModel(0.01))
+
+    def OnOrderEvent(self, orderEvent):
+        if orderEvent.Status == OrderStatus.Filled:
+            self.Debug(f'Processed Order: {orderEvent.Symbol}, Quantity: {orderEvent.FillQuantity}')

--- a/Common/Python/PythonWrapper.cs
+++ b/Common/Python/PythonWrapper.cs
@@ -41,14 +41,16 @@ namespace QuantConnect.Python
 
             var missingMembers = new List<string>();
             var members = typeof(TInterface).GetMembers(BindingFlags.Public | BindingFlags.Instance);
-            foreach (var member in members)
+            using (Py.GIL())
             {
-                if (!model.HasAttr(member.Name))
+                foreach (var member in members)
                 {
-                    missingMembers.Add(member.Name);
+                    if (!model.HasAttr(member.Name))
+                    {
+                        missingMembers.Add(member.Name);
+                    }
                 }
             }
-
             if (missingMembers.Any())
             {
                 throw new NotImplementedException($"{nameof(TInterface)} must be fully implemented. Missing implementations: {string.Join(", ", missingMembers)}");


### PR DESCRIPTION
#### Description
- Use recently implemented `ValidateImplementationOf` extension method in `RiskManagementModelPythonWrapper`
- Adds python version CompositeRiskManagementModel
  The C# version was supposed to handle python modules, but when they inherit from a C# module, pythonnet send them as C# objects. Consequently, they are not wrapped and cannot be used. The python version of `CompositeRiskManagementModel` solves the issue.
- Implements python version of `MaximumUnrealizedProfitPercentPerSecurity`
- Updates `CompositeRiskManagementModelFrameworkAlgorithm` in order to use python risk model.
- Implements python version of `MaximumDrawdownPercentPortfolio`
- Implements python version of  `MaximumPortfolioDrawdownFrameworkAlgorithm`
- Implements python version of `TrailingStopRiskManagementModel`
- Implements python version of `TrailingStopRiskFrameworkAlgorithm`

#### Related Issue
Closes #2676 

#### Motivation and Context
Lean should have C# and python versions of all framework models. 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit and regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`