### PR TITLE
Refactor Fill Models - v2

### DIFF
--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
+using QuantConnect.Orders.Fills;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
 
@@ -318,34 +319,22 @@ namespace QuantConnect.Brokerages.Backtesting
                     {
                         //Model:
                         var model = security.FillModel;
-
                         //Based on the order type: refresh its model to get fill price and quantity
                         try
                         {
                             switch (order.Type)
                             {
                                 case OrderType.Limit:
-                                    fills = new[] { model.LimitFill(security, order as LimitOrder) };
-                                    break;
-
                                 case OrderType.StopMarket:
-                                    fills = new[] { model.StopMarketFill(security, order as StopMarketOrder) };
-                                    break;
-
                                 case OrderType.Market:
-                                    fills = new[] { model.MarketFill(security, order as MarketOrder) };
-                                    break;
-
                                 case OrderType.StopLimit:
-                                    fills = new[] { model.StopLimitFill(security, order as StopLimitOrder) };
-                                    break;
-
                                 case OrderType.MarketOnOpen:
-                                    fills = new[] { model.MarketOnOpenFill(security, order as MarketOnOpenOrder) };
-                                    break;
-
                                 case OrderType.MarketOnClose:
-                                    fills = new[] { model.MarketOnCloseFill(security, order as MarketOnCloseOrder) };
+                                    var context = new FillModelContext(
+                                        security,
+                                        order,
+                                        Algorithm.SubscriptionManager.SubscriptionDataConfigService);
+                                    fills = new[] { model.Fill(context) };
                                     break;
 
                                 case OrderType.OptionExercise:

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -322,25 +322,18 @@ namespace QuantConnect.Brokerages.Backtesting
                         //Based on the order type: refresh its model to get fill price and quantity
                         try
                         {
-                            switch (order.Type)
+                            if (order.Type == OrderType.OptionExercise)
                             {
-                                case OrderType.Limit:
-                                case OrderType.StopMarket:
-                                case OrderType.Market:
-                                case OrderType.StopLimit:
-                                case OrderType.MarketOnOpen:
-                                case OrderType.MarketOnClose:
-                                    var context = new FillModelContext(
-                                        security,
-                                        order,
-                                        Algorithm.SubscriptionManager.SubscriptionDataConfigService);
-                                    fills = new[] { model.Fill(context) };
-                                    break;
-
-                                case OrderType.OptionExercise:
-                                    var option = (Option)security;
-                                    fills = option.OptionExerciseModel.OptionExercise(option, order as OptionExerciseOrder).ToArray();
-                                    break;
+                                var option = (Option)security;
+                                fills = option.OptionExerciseModel.OptionExercise(option, order as OptionExerciseOrder).ToArray();
+                            }
+                            else
+                            {
+                                var context = new FillModelContext(
+                                    security,
+                                    order,
+                                    Algorithm.SubscriptionManager.SubscriptionDataConfigService);
+                                fills = new[] { model.Fill(context) };
                             }
 
                             // invoke fee models for completely filled order events

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -14,8 +14,6 @@
 */
 
 using System;
-using System.Linq;
-using QuantConnect.Data.Market;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Orders.Fills
@@ -23,6 +21,7 @@ namespace QuantConnect.Orders.Fills
     /// <summary>
     /// Provides a base class for all fill models
     /// </summary>
+    /// <remarks>Users FillModels should inherit IFillModel</remarks>
     public class FillModel : IFillModel
     {
         /// <summary>
@@ -31,41 +30,23 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Security asset we're filling</param>
         /// <param name="order">Order packet to model</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        /// <seealso cref="SecurityTransactionModel.StopMarketFill"/>
-        /// <seealso cref="SecurityTransactionModel.LimitFill"/>
+        [Obsolete("This was left for retro compatibility, see new MarketFill(FillModelContext context)")]
         public virtual OrderEvent MarketFill(Security asset, MarketOrder order)
         {
-            //Default order event to return.
-            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
-            var fill = new OrderEvent(order, utcTime, 0);
-
-            if (order.Status == OrderStatus.Canceled) return fill;
-
-            // make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
-
-            //Order [fill]price for a market order model is the current security price
-            fill.FillPrice = GetPrices(asset, order.Direction).Current;
-            fill.Status = OrderStatus.Filled;
-
-            //Calculate the model slippage: e.g. 0.01c
-            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
-
-            //Apply slippage
-            switch (order.Direction)
+            // The system will NOT call this method, but the user derivate might
+            // through base.xxxxFill(asset, order), in which case SDCProvider will be set
+            if (SubscriptionDataConfigProvider != null)
             {
-                case OrderDirection.Buy:
-                    fill.FillPrice += slip;
-                    break;
-                case OrderDirection.Sell:
-                    fill.FillPrice -= slip;
-                    break;
+                return MarketFillImplementation(
+                    new FillModelContext(
+                        asset,
+                        order,
+                        SubscriptionDataConfigProvider
+                    )
+                );
             }
-
-            // assume the order completely filled
-            fill.FillQuantity = order.Quantity;
-
-            return fill;
+            throw new NotImplementedException("Unexpected usage of IFillModel method. " +
+                "This was left just for retro compatibility.");
         }
 
         /// <summary>
@@ -74,59 +55,23 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Security asset we're filling</param>
         /// <param name="order">Order packet to model</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        /// <seealso cref="MarketFill(Security, MarketOrder)"/>
-        /// <seealso cref="SecurityTransactionModel.LimitFill"/>
+        [Obsolete("This was left for retro compatibility, see new StopMarketFill(FillModelContext context)")]
         public virtual OrderEvent StopMarketFill(Security asset, StopMarketOrder order)
         {
-            //Default order event to return.
-            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
-            var fill = new OrderEvent(order, utcTime, 0);
-
-            //If its cancelled don't need anymore checks:
-            if (order.Status == OrderStatus.Canceled) return fill;
-
-            // make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
-
-            //Get the range of prices in the last bar:
-            var prices = GetPrices(asset, order.Direction);
-            var pricesEndTime = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
-
-            // do not fill on stale data
-            if (pricesEndTime <= order.Time) return fill;
-
-            //Calculate the model slippage: e.g. 0.01c
-            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
-
-            //Check if the Stop Order was filled: opposite to a limit order
-            switch (order.Direction)
+            // The system will NOT call this method, but the user derivate might
+            // through base.xxxxFill(asset, order), in which case SDCProvider will be set
+            if (SubscriptionDataConfigProvider != null)
             {
-                case OrderDirection.Sell:
-                    //-> 1.1 Sell Stop: If Price below setpoint, Sell:
-                    if (prices.Low < order.StopPrice)
-                    {
-                        fill.Status = OrderStatus.Filled;
-                        // Assuming worse case scenario fill - fill at lowest of the stop & asset price.
-                        fill.FillPrice = Math.Min(order.StopPrice, prices.Current - slip);
-                        // assume the order completely filled
-                        fill.FillQuantity = order.Quantity;
-                    }
-                    break;
-
-                case OrderDirection.Buy:
-                    //-> 1.2 Buy Stop: If Price Above Setpoint, Buy:
-                    if (prices.High > order.StopPrice)
-                    {
-                        fill.Status = OrderStatus.Filled;
-                        // Assuming worse case scenario fill - fill at highest of the stop & asset price.
-                        fill.FillPrice = Math.Max(order.StopPrice, prices.Current + slip);
-                        // assume the order completely filled
-                        fill.FillQuantity = order.Quantity;
-                    }
-                    break;
+                return StopMarketFillImplementation(
+                    new FillModelContext(
+                        asset,
+                        order,
+                        SubscriptionDataConfigProvider
+                    )
+                );
             }
-
-            return fill;
+            throw new NotImplementedException("Unexpected usage of IFillModel method. " +
+                "This was left just for retro compatibility.");
         }
 
         /// <summary>
@@ -135,75 +80,23 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Security asset we're filling</param>
         /// <param name="order">Order packet to model</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        /// <seealso cref="StopMarketFill(Security, StopMarketOrder)"/>
-        /// <seealso cref="SecurityTransactionModel.LimitFill"/>
-        /// <remarks>
-        ///     There is no good way to model limit orders with OHLC because we never know whether the market has
-        ///     gapped past our fill price. We have to make the assumption of a fluid, high volume market.
-        ///
-        ///     Stop limit orders we also can't be sure of the order of the H - L values for the limit fill. The assumption
-        ///     was made the limit fill will be done with closing price of the bar after the stop has been triggered..
-        /// </remarks>
+        [Obsolete("This was left for retro compatibility, see new StopLimitFill(FillModelContext context)")]
         public virtual OrderEvent StopLimitFill(Security asset, StopLimitOrder order)
         {
-            //Default order event to return.
-            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
-            var fill = new OrderEvent(order, utcTime, 0);
-
-            //If its cancelled don't need anymore checks:
-            if (order.Status == OrderStatus.Canceled) return fill;
-
-            // make sure the exchange is open before filling -- allow pre/post market fills to occur
-            if (!IsExchangeOpen(asset, true)) return fill;
-
-            //Get the range of prices in the last bar:
-            var prices = GetPrices(asset, order.Direction);
-            var pricesEndTime = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
-
-            // do not fill on stale data
-            if (pricesEndTime <= order.Time) return fill;
-
-            //Check if the Stop Order was filled: opposite to a limit order
-            switch (order.Direction)
+            // The system will NOT call this method, but the user derivate might
+            // through base.xxxxFill(asset, order), in which case SDCProvider will be set
+            if (SubscriptionDataConfigProvider != null)
             {
-                case OrderDirection.Buy:
-                    //-> 1.2 Buy Stop: If Price Above Setpoint, Buy:
-                    if (prices.High > order.StopPrice || order.StopTriggered)
-                    {
-                        order.StopTriggered = true;
-
-                        // Fill the limit order, using closing price of bar:
-                        // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
-                        if (asset.Price < order.LimitPrice)
-                        {
-                            fill.Status = OrderStatus.Filled;
-                            fill.FillPrice = order.LimitPrice;
-                            // assume the order completely filled
-                            fill.FillQuantity = order.Quantity;
-                        }
-                    }
-                    break;
-
-                case OrderDirection.Sell:
-                    //-> 1.1 Sell Stop: If Price below setpoint, Sell:
-                    if (prices.Low < order.StopPrice || order.StopTriggered)
-                    {
-                        order.StopTriggered = true;
-
-                        // Fill the limit order, using minimum price of the bar
-                        // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
-                        if (asset.Price > order.LimitPrice)
-                        {
-                            fill.Status = OrderStatus.Filled;
-                            fill.FillPrice = order.LimitPrice; // Fill at limit price not asset price.
-                            // assume the order completely filled
-                            fill.FillQuantity = order.Quantity;
-                        }
-                    }
-                    break;
+                return StopLimitFillImplementation(
+                    new FillModelContext(
+                        asset,
+                        order,
+                        SubscriptionDataConfigProvider
+                    )
+                );
             }
-
-            return fill;
+            throw new NotImplementedException("Unexpected usage of IFillModel method. " +
+                "This was left just for retro compatibility.");
         }
 
         /// <summary>
@@ -214,56 +107,23 @@ namespace QuantConnect.Orders.Fills
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
         /// <seealso cref="StopMarketFill(Security, StopMarketOrder)"/>
         /// <seealso cref="MarketFill(Security, MarketOrder)"/>
+        [Obsolete("This was left for retro compatibility, see new LimitFill(FillModelContext context)")]
         public virtual OrderEvent LimitFill(Security asset, LimitOrder order)
         {
-            //Initialise;
-            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
-            var fill = new OrderEvent(order, utcTime, 0);
-
-            //If its cancelled don't need anymore checks:
-            if (order.Status == OrderStatus.Canceled) return fill;
-
-            // make sure the exchange is open before filling -- allow pre/post market fills to occur
-            if (!IsExchangeOpen(asset, true)) return fill;
-
-            //Get the range of prices in the last bar:
-            var prices = GetPrices(asset, order.Direction);
-            var pricesEndTime = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
-
-            // do not fill on stale data
-            if (pricesEndTime <= order.Time) return fill;
-
-            //-> Valid Live/Model Order:
-            switch (order.Direction)
+            // The system will NOT call this method, but the user derivate might
+            // through base.xxxxFill(asset, order), in which case SDCProvider will be set
+            if (SubscriptionDataConfigProvider != null)
             {
-                case OrderDirection.Buy:
-                    //Buy limit seeks lowest price
-                    if (prices.Low < order.LimitPrice)
-                    {
-                        //Set order fill:
-                        fill.Status = OrderStatus.Filled;
-                        // fill at the worse price this bar or the limit price, this allows far out of the money limits
-                        // to be executed properly
-                        fill.FillPrice = Math.Min(prices.High, order.LimitPrice);
-                        // assume the order completely filled
-                        fill.FillQuantity = order.Quantity;
-                    }
-                    break;
-                case OrderDirection.Sell:
-                    //Sell limit seeks highest price possible
-                    if (prices.High > order.LimitPrice)
-                    {
-                        fill.Status = OrderStatus.Filled;
-                        // fill at the worse price this bar or the limit price, this allows far out of the money limits
-                        // to be executed properly
-                        fill.FillPrice = Math.Max(prices.Low, order.LimitPrice);
-                        // assume the order completely filled
-                        fill.FillQuantity = order.Quantity;
-                    }
-                    break;
+                return LimitFillImplementation(
+                    new FillModelContext(
+                        asset,
+                        order,
+                        SubscriptionDataConfigProvider
+                    )
+                );
             }
-
-            return fill;
+            throw new NotImplementedException("Unexpected usage of IFillModel method. " +
+                "This was left just for retro compatibility.");
         }
 
         /// <summary>
@@ -272,55 +132,23 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Asset we're trading with this order</param>
         /// <param name="order">Order to be filled</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        [Obsolete("This was left for retro compatibility, see new MarketOnOpenFill(FillModelContext context)")]
         public OrderEvent MarketOnOpenFill(Security asset, MarketOnOpenOrder order)
         {
-            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
-            var fill = new OrderEvent(order, utcTime, 0);
-
-            if (order.Status == OrderStatus.Canceled) return fill;
-
-            // MOO should never fill on the same bar or on stale data
-            // Imagine the case where we have a thinly traded equity, ASUR, and another liquid
-            // equity, say SPY, SPY gets data every minute but ASUR, if not on fill forward, maybe
-            // have large gaps, in which case the currentBar.EndTime will be in the past
-            // ASUR  | | |      [order]        | | | | | | |
-            //  SPY  | | | | | | | | | | | | | | | | | | | |
-            var currentBar = asset.GetLastData();
-            var localOrderTime = order.Time.ConvertFromUtc(asset.Exchange.TimeZone);
-            if (currentBar == null || localOrderTime >= currentBar.EndTime) return fill;
-
-            // if the MOO was submitted during market the previous day, wait for a day to turn over
-            if (asset.Exchange.DateTimeIsOpen(localOrderTime) && localOrderTime.Date == asset.LocalTime.Date)
+            // The system will NOT call this method, but the user derivate might
+            // through base.xxxxFill(asset, order), in which case SDCProvider will be set
+            if (SubscriptionDataConfigProvider != null)
             {
-                return fill;
+                return MarketOnOpenFillImplementation(
+                    new FillModelContext(
+                        asset,
+                        order,
+                        SubscriptionDataConfigProvider
+                    )
+                );
             }
-
-            // wait until market open
-            // make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
-
-            fill.FillPrice = GetPrices(asset, order.Direction).Open;
-            fill.Status = OrderStatus.Filled;
-
-            //Calculate the model slippage: e.g. 0.01c
-            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
-
-            //Apply slippage
-            switch (order.Direction)
-            {
-                case OrderDirection.Buy:
-                    fill.FillPrice += slip;
-                    // assume the order completely filled
-                    fill.FillQuantity = order.Quantity;
-                    break;
-                case OrderDirection.Sell:
-                    fill.FillPrice -= slip;
-                    // assume the order completely filled
-                    fill.FillQuantity = order.Quantity;
-                    break;
-            }
-
-            return fill;
+            throw new NotImplementedException("Unexpected usage of IFillModel method. " +
+                "This was left just for retro compatibility.");
         }
 
         /// <summary>
@@ -329,155 +157,23 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Asset we're trading with this order</param>
         /// <param name="order">Order to be filled</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        [Obsolete("This was left for retro compatibility, see new MarketOnCloseFill(FillModelContext context)")]
         public OrderEvent MarketOnCloseFill(Security asset, MarketOnCloseOrder order)
         {
-            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
-            var fill = new OrderEvent(order, utcTime, 0);
-
-            if (order.Status == OrderStatus.Canceled) return fill;
-
-            var localOrderTime = order.Time.ConvertFromUtc(asset.Exchange.TimeZone);
-            var nextMarketClose = asset.Exchange.Hours.GetNextMarketClose(localOrderTime, false);
-
-            // wait until market closes after the order time
-            if (asset.LocalTime < nextMarketClose)
+            // The system will NOT call this method, but the user derivate might
+            // through base.xxxxFill(asset, order), in which case SDCProvider will be set
+            if (SubscriptionDataConfigProvider != null)
             {
-                return fill;
+                return MarketOnCloseFillImplementation(
+                    new FillModelContext(
+                        asset,
+                        order,
+                        SubscriptionDataConfigProvider
+                    )
+                );
             }
-            // make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
-
-            fill.FillPrice = GetPrices(asset, order.Direction).Close;
-            fill.Status = OrderStatus.Filled;
-
-            //Calculate the model slippage: e.g. 0.01c
-            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
-
-            //Apply slippage
-            switch (order.Direction)
-            {
-                case OrderDirection.Buy:
-                    fill.FillPrice += slip;
-                    // assume the order completely filled
-                    fill.FillQuantity = order.Quantity;
-                    break;
-                case OrderDirection.Sell:
-                    fill.FillPrice -= slip;
-                    // assume the order completely filled
-                    fill.FillQuantity = order.Quantity;
-                    break;
-            }
-
-            return fill;
-        }
-
-        /// <summary>
-        /// Get the minimum and maximum price for this security in the last bar:
-        /// </summary>
-        /// <param name="asset">Security asset we're checking</param>
-        /// <param name="direction">The order direction, decides whether to pick bid or ask</param>
-        protected virtual Prices GetPrices(Security asset, OrderDirection direction)
-        {
-            var low = asset.Low;
-            var high = asset.High;
-            var open = asset.Open;
-            var close = asset.Close;
-            var current = asset.Price;
-            var endTime = asset.Cache.GetData()?.EndTime ?? DateTime.MinValue;
-
-            if (direction == OrderDirection.Hold)
-            {
-                return new Prices(endTime, current, open, high, low, close);
-            }
-
-            // Only fill with data types we are subscribed to
-            var subscriptionTypes = asset.Subscriptions.Select(x => x.Type).ToList();
-
-            // Tick
-            var tick = asset.Cache.GetData<Tick>();
-            if (subscriptionTypes.Contains(typeof(Tick)) && tick != null)
-            {
-                var price = direction == OrderDirection.Sell ? tick.BidPrice : tick.AskPrice;
-                if (price != 0m)
-                {
-                    return new Prices(tick.EndTime, price, 0, 0, 0, 0);
-                }
-
-                // If the ask/bid spreads are not available for ticks, try the price
-                price = tick.Price;
-                if (price != 0m)
-                {
-                    return new Prices(tick.EndTime, price, 0, 0, 0, 0);
-                }
-            }
-
-            // Quote
-            var quoteBar = asset.Cache.GetData<QuoteBar>();
-            if (subscriptionTypes.Contains(typeof(QuoteBar)) && quoteBar != null)
-            {
-                var bar = direction == OrderDirection.Sell ? quoteBar.Bid : quoteBar.Ask;
-                if (bar != null)
-                {
-                    return new Prices(quoteBar.EndTime, bar);
-                }
-            }
-
-            // Trade
-            var tradeBar = asset.Cache.GetData<TradeBar>();
-            if (subscriptionTypes.Contains(typeof(TradeBar)) && tradeBar != null)
-            {
-                return new Prices(tradeBar);
-            }
-
-            return new Prices(endTime, current, open, high, low, close);
-        }
-
-        /// <summary>
-        /// Determines if the exchange is open using the current time of the asset
-        /// </summary>
-        private static bool IsExchangeOpen(Security asset, bool allowExtendedMarketHoursFills)
-        {
-            if (!asset.Exchange.DateTimeIsOpen(asset.LocalTime))
-            {
-                // if we're not open at the current time exactly, check the bar size, this handle large sized bars (hours/days)
-                var currentBar = asset.GetLastData();
-                var isExtendedMarketHours = allowExtendedMarketHoursFills && asset.IsExtendedMarketHours;
-                if (asset.LocalTime.Date != currentBar.EndTime.Date || !asset.Exchange.IsOpenDuringBar(currentBar.Time, currentBar.EndTime, isExtendedMarketHours))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        public class Prices
-        {
-            public readonly DateTime EndTime;
-            public readonly decimal Current;
-            public readonly decimal Open;
-            public readonly decimal High;
-            public readonly decimal Low;
-            public readonly decimal Close;
-
-            public Prices(IBaseDataBar bar)
-                : this(bar.EndTime, bar.Close, bar.Open, bar.High, bar.Low, bar.Close)
-            {
-            }
-
-            public Prices(DateTime endTime, IBar bar)
-                : this(endTime, bar.Close, bar.Open, bar.High, bar.Low, bar.Close)
-            {
-            }
-
-            public Prices(DateTime endTime, decimal current, decimal open, decimal high, decimal low, decimal close)
-            {
-                EndTime = endTime;
-                Current = current;
-                Open = open == 0 ? current : open;
-                High = high == 0 ? current : high;
-                Low = low == 0 ? current : low;
-                Close = close == 0 ? current : close;
-            }
+            throw new NotImplementedException("Unexpected usage of IFillModel method. " +
+                "This was left just for retro compatibility.");
         }
     }
 }

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -21,7 +21,6 @@ namespace QuantConnect.Orders.Fills
     /// <summary>
     /// Provides a base class for all fill models
     /// </summary>
-    /// <remarks>Users FillModels should inherit IFillModel</remarks>
     public class FillModel : IFillModel
     {
         /// <summary>

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Security asset we're filling</param>
         /// <param name="order">Order packet to model</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        [Obsolete("This was left for retro compatibility, see new MarketFill(FillModelContext context)")]
+        [Obsolete("This was left for backwards compatibility, see new MarketFill(FillModelContext context)")]
         public virtual OrderEvent MarketFill(Security asset, MarketOrder order)
         {
             // The system will NOT call this method, but the user derivate might
@@ -45,7 +45,7 @@ namespace QuantConnect.Orders.Fills
                 );
             }
             throw new NotImplementedException("Unexpected usage of IFillModel method. " +
-                "This was left just for retro compatibility.");
+                "This was left just for backwards compatibility.");
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Security asset we're filling</param>
         /// <param name="order">Order packet to model</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        [Obsolete("This was left for retro compatibility, see new StopMarketFill(FillModelContext context)")]
+        [Obsolete("This was left for backwards compatibility, see new StopMarketFill(FillModelContext context)")]
         public virtual OrderEvent StopMarketFill(Security asset, StopMarketOrder order)
         {
             // The system will NOT call this method, but the user derivate might
@@ -70,7 +70,7 @@ namespace QuantConnect.Orders.Fills
                 );
             }
             throw new NotImplementedException("Unexpected usage of IFillModel method. " +
-                "This was left just for retro compatibility.");
+                "This was left just for backwards compatibility.");
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Security asset we're filling</param>
         /// <param name="order">Order packet to model</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        [Obsolete("This was left for retro compatibility, see new StopLimitFill(FillModelContext context)")]
+        [Obsolete("This was left for backwards compatibility, see new StopLimitFill(FillModelContext context)")]
         public virtual OrderEvent StopLimitFill(Security asset, StopLimitOrder order)
         {
             // The system will NOT call this method, but the user derivate might
@@ -95,7 +95,7 @@ namespace QuantConnect.Orders.Fills
                 );
             }
             throw new NotImplementedException("Unexpected usage of IFillModel method. " +
-                "This was left just for retro compatibility.");
+                "This was left just for backwards compatibility.");
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace QuantConnect.Orders.Fills
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
         /// <seealso cref="StopMarketFill(Security, StopMarketOrder)"/>
         /// <seealso cref="MarketFill(Security, MarketOrder)"/>
-        [Obsolete("This was left for retro compatibility, see new LimitFill(FillModelContext context)")]
+        [Obsolete("This was left for backwards compatibility, see new LimitFill(FillModelContext context)")]
         public virtual OrderEvent LimitFill(Security asset, LimitOrder order)
         {
             // The system will NOT call this method, but the user derivate might
@@ -122,7 +122,7 @@ namespace QuantConnect.Orders.Fills
                 );
             }
             throw new NotImplementedException("Unexpected usage of IFillModel method. " +
-                "This was left just for retro compatibility.");
+                "This was left just for backwards compatibility.");
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Asset we're trading with this order</param>
         /// <param name="order">Order to be filled</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        [Obsolete("This was left for retro compatibility, see new MarketOnOpenFill(FillModelContext context)")]
+        [Obsolete("This was left for backwards compatibility, see new MarketOnOpenFill(FillModelContext context)")]
         public OrderEvent MarketOnOpenFill(Security asset, MarketOnOpenOrder order)
         {
             // The system will NOT call this method, but the user derivate might
@@ -147,7 +147,7 @@ namespace QuantConnect.Orders.Fills
                 );
             }
             throw new NotImplementedException("Unexpected usage of IFillModel method. " +
-                "This was left just for retro compatibility.");
+                "This was left just for backwards compatibility.");
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Asset we're trading with this order</param>
         /// <param name="order">Order to be filled</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        [Obsolete("This was left for retro compatibility, see new MarketOnCloseFill(FillModelContext context)")]
+        [Obsolete("This was left for backwards compatibility, see new MarketOnCloseFill(FillModelContext context)")]
         public OrderEvent MarketOnCloseFill(Security asset, MarketOnCloseOrder order)
         {
             // The system will NOT call this method, but the user derivate might
@@ -172,7 +172,7 @@ namespace QuantConnect.Orders.Fills
                 );
             }
             throw new NotImplementedException("Unexpected usage of IFillModel method. " +
-                "This was left just for retro compatibility.");
+                "This was left just for backwards compatibility.");
         }
     }
 }

--- a/Common/Orders/Fills/FillModelContext.cs
+++ b/Common/Orders/Fills/FillModelContext.cs
@@ -20,7 +20,7 @@ using QuantConnect.Securities;
 namespace QuantConnect.Orders.Fills
 {
     /// <summary>
-    /// Defines the parameters for the <see cref="InterfaceFillModel"/> methods
+    /// Defines the parameters for the <see cref="IFillModelInterface"/> methods
     /// </summary>
     public class FillModelContext
     {

--- a/Common/Orders/Fills/FillModelContext.cs
+++ b/Common/Orders/Fills/FillModelContext.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Orders.Fills
+{
+    /// <summary>
+    /// Defines the parameters for the <see cref="InterfaceFillModel"/> methods
+    /// </summary>
+    public class FillModelContext
+    {
+        /// <summary>
+        /// Gets the <see cref="Security"/>
+        /// </summary>
+        public Security Security { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Order"/>
+        /// </summary>
+        public Order Order { get; }
+
+        /// <summary>
+        /// Gets the <see cref="SubscriptionDataConfig"/> provider
+        /// </summary>
+        public ISubscriptionDataConfigProvider ConfigProvider { get; }
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="security">Security asset we're filling</param>
+        /// <param name="order">Order packet to model</param>
+        /// <param name="configProvider">The <see cref="ISubscriptionDataConfigProvider"/> to use</param>
+        public FillModelContext(
+            Security security,
+            Order order,
+            ISubscriptionDataConfigProvider configProvider)
+        {
+            Security = security;
+            Order = order;
+            ConfigProvider = configProvider;
+        }
+    }
+}

--- a/Common/Orders/Fills/IFillModel.cs
+++ b/Common/Orders/Fills/IFillModel.cs
@@ -13,61 +13,799 @@
  * limitations under the License.
 */
 
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Orders.Fills
 {
     /// <summary>
-    /// Represents a model that simulates order fill events
+    /// Represents a base model that simulates order fill events
     /// </summary>
-    public interface IFillModel
+    public abstract class IFillModel : InterfaceFillModel
     {
+        private readonly ConstantExpression _self;
+        private readonly ParameterExpression _securityParameter;
+        private bool _checkedMarketFill;
+        private bool _checkedStopMarketFill;
+        private bool _checkedStopLimitFill;
+        private bool _checkedLimitFill;
+        private bool _checkedMarketOnOpenFill;
+        private bool _checkedMarketOnCloseFill;
+        private Func<Security, MarketOrder, OrderEvent> _marketFill;
+        private Func<Security, StopMarketOrder, OrderEvent> _stopMarketFill;
+        private Func<Security, StopLimitOrder, OrderEvent> _stopLimitFill;
+        private Func<Security, LimitOrder, OrderEvent> _limitFill;
+        private Func<Security, MarketOnOpenOrder, OrderEvent> _marketOnOpenFill;
+        private Func<Security, MarketOnCloseOrder, OrderEvent> _marketOnCloseFill;
+
+        /// <summary>
+        /// The <see cref="SubscriptionDataConfig"/> provider to use
+        /// </summary>
+        protected ISubscriptionDataConfigProvider SubscriptionDataConfigProvider;
+
+        /// <summary>
+        /// Initializes and creates a new instance
+        /// </summary>
+        protected IFillModel()
+        {
+            _self = Expression.Constant(this);
+            _securityParameter = Expression.Parameter(typeof(Security), "security");
+        }
+
+        /// <summary>
+        /// Return an order event with the fill details
+        /// </summary>
+        /// <param name="context">A context object containing the security and order</param>
+        /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        public virtual OrderEvent Fill(FillModelContext context)
+        {
+            var order = context.Order;
+            SubscriptionDataConfigProvider = context.ConfigProvider;
+
+            switch (order.Type)
+            {
+                case OrderType.Market:
+                    return MarketFill(context);
+                case OrderType.Limit:
+                    return LimitFill(context);
+                case OrderType.StopMarket:
+                    return StopMarketFill(context);
+                case OrderType.StopLimit:
+                    return StopLimitFill(context);
+                case OrderType.MarketOnOpen:
+                    return MarketOnOpenFill(context);
+                case OrderType.MarketOnClose:
+                    return MarketOnCloseFill(context);
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
         /// <summary>
         /// Model the slippage on a market order: fixed percentage of order price
         /// </summary>
-        /// <param name="asset">Asset we're trading this order</param>
-        /// <param name="order">Order to update</param>
+        /// <param name="context">A context object containing the security and order</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        OrderEvent MarketFill(Security asset, MarketOrder order);
+        protected virtual OrderEvent MarketFill(FillModelContext context)
+        {
+            if (!_checkedMarketFill)
+            {
+                _checkedMarketFill = true;
+                SetFunctionCall(context.Order.Type);
+            }
+
+            if (_marketFill != null)
+            {
+                return  _marketFill(context.Security, context.Order as MarketOrder);
+            }
+
+            return MarketFillImplementation(context);
+        }
+
+        /// <summary>
+        /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
+        /// This was created to maintain retro compatibility allowing old user code
+        /// to access base.xxxxFill(asset, order) implementation
+        /// </summary>
+        protected OrderEvent MarketFillImplementation(FillModelContext context)
+        {
+            var asset = context.Security;
+            var order = context.Order as MarketOrder;
+
+            //Default order event to return.
+            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
+            var fill = new OrderEvent(order, utcTime, 0);
+
+            if (order.Status == OrderStatus.Canceled) return fill;
+
+            // make sure the exchange is open/normal market hours before filling
+            if (!IsExchangeOpen(asset, false)) return fill;
+
+            //Order [fill]price for a market order model is the current security price
+            fill.FillPrice = GetPrices(asset, order.Direction).Current;
+            fill.Status = OrderStatus.Filled;
+
+            //Calculate the model slippage: e.g. 0.01c
+            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
+
+            //Apply slippage
+            switch (order.Direction)
+            {
+                case OrderDirection.Buy:
+                    fill.FillPrice += slip;
+                    break;
+                case OrderDirection.Sell:
+                    fill.FillPrice -= slip;
+                    break;
+            }
+
+            // assume the order completely filled
+            fill.FillQuantity = order.Quantity;
+
+            return fill;
+        }
 
         /// <summary>
         /// Stop Market Fill Model. Return an order event with the fill details.
         /// </summary>
-        /// <param name="asset">Asset we're trading this order</param>
-        /// <param name="order">Stop Order to Check, return filled if true</param>
+        /// <param name="context">A context object containing the security and order</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        OrderEvent StopMarketFill(Security asset, StopMarketOrder order);
+        protected virtual OrderEvent StopMarketFill(FillModelContext context)
+        {
+            if (!_checkedStopMarketFill)
+            {
+                _checkedStopMarketFill = true;
+                SetFunctionCall(context.Order.Type);
+            }
+
+            if (_stopMarketFill != null)
+            {
+                return _stopMarketFill(context.Security, context.Order as StopMarketOrder);
+            }
+
+            return StopMarketFillImplementation(context);
+        }
+
+        /// <summary>
+        /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
+        /// This was created to maintain retro compatibility allowing old user code
+        /// to access base.xxxxFill(asset, order) implementation
+        /// </summary>
+        protected OrderEvent StopMarketFillImplementation(FillModelContext context)
+        {
+            var asset = context.Security;
+            var order = context.Order as StopMarketOrder;
+
+            //Default order event to return.
+            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
+            var fill = new OrderEvent(order, utcTime, 0);
+
+            //If its cancelled don't need anymore checks:
+            if (order.Status == OrderStatus.Canceled) return fill;
+
+            // make sure the exchange is open/normal market hours before filling
+            if (!IsExchangeOpen(asset, false)) return fill;
+
+            //Get the range of prices in the last bar:
+            var prices = GetPrices(asset, order.Direction);
+            var pricesEndTime = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
+
+            // do not fill on stale data
+            if (pricesEndTime <= order.Time) return fill;
+
+            //Calculate the model slippage: e.g. 0.01c
+            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
+
+            //Check if the Stop Order was filled: opposite to a limit order
+            switch (order.Direction)
+            {
+                case OrderDirection.Sell:
+                    //-> 1.1 Sell Stop: If Price below setpoint, Sell:
+                    if (prices.Low < order.StopPrice)
+                    {
+                        fill.Status = OrderStatus.Filled;
+                        // Assuming worse case scenario fill - fill at lowest of the stop & asset price.
+                        fill.FillPrice = Math.Min(order.StopPrice, prices.Current - slip);
+                        // assume the order completely filled
+                        fill.FillQuantity = order.Quantity;
+                    }
+                    break;
+
+                case OrderDirection.Buy:
+                    //-> 1.2 Buy Stop: If Price Above Setpoint, Buy:
+                    if (prices.High > order.StopPrice)
+                    {
+                        fill.Status = OrderStatus.Filled;
+                        // Assuming worse case scenario fill - fill at highest of the stop & asset price.
+                        fill.FillPrice = Math.Max(order.StopPrice, prices.Current + slip);
+                        // assume the order completely filled
+                        fill.FillQuantity = order.Quantity;
+                    }
+                    break;
+            }
+
+            return fill;
+        }
 
         /// <summary>
         /// Stop Limit Fill Model. Return an order event with the fill details.
         /// </summary>
-        /// <param name="asset">Asset we're trading this order</param>
-        /// <param name="order">Stop Limit Order to Check, return filled if true</param>
+        /// <param name="context">A context object containing the security and order</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        OrderEvent StopLimitFill(Security asset, StopLimitOrder order);
+        /// <remarks>
+        ///     There is no good way to model limit orders with OHLC because we never know whether the market has
+        ///     gapped past our fill price. We have to make the assumption of a fluid, high volume market.
+        ///
+        ///     Stop limit orders we also can't be sure of the order of the H - L values for the limit fill. The assumption
+        ///     was made the limit fill will be done with closing price of the bar after the stop has been triggered..
+        /// </remarks>
+        protected virtual OrderEvent StopLimitFill(FillModelContext context)
+        {
+            if (!_checkedStopLimitFill)
+            {
+                _checkedStopLimitFill = true;
+                SetFunctionCall(context.Order.Type);
+            }
+
+            if (_stopLimitFill != null)
+            {
+                return _stopLimitFill(context.Security, context.Order as StopLimitOrder);
+            }
+
+            return StopLimitFillImplementation(context);
+        }
+
+        /// <summary>
+        /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
+        /// This was created to maintain retro compatibility allowing old user code
+        /// to access base.xxxxFill(asset, order) implementation
+        /// </summary>
+        protected OrderEvent StopLimitFillImplementation(FillModelContext context)
+        {
+            var asset = context.Security;
+            var order = context.Order as StopLimitOrder;
+
+            //Default order event to return.
+            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
+            var fill = new OrderEvent(order, utcTime, 0);
+
+            //If its cancelled don't need anymore checks:
+            if (order.Status == OrderStatus.Canceled) return fill;
+
+            // make sure the exchange is open before filling -- allow pre/post market fills to occur
+            if (!IsExchangeOpen(
+                asset,
+                SubscriptionDataConfigProvider
+                    .GetSubscriptionDataConfigs(asset.Symbol)
+                    .IsExtendedMarketHours()))
+            {
+                return fill;
+            }
+
+            //Get the range of prices in the last bar:
+            var prices = GetPrices(asset, order.Direction);
+            var pricesEndTime = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
+
+            // do not fill on stale data
+            if (pricesEndTime <= order.Time) return fill;
+
+            //Check if the Stop Order was filled: opposite to a limit order
+            switch (order.Direction)
+            {
+                case OrderDirection.Buy:
+                    //-> 1.2 Buy Stop: If Price Above Setpoint, Buy:
+                    if (prices.High > order.StopPrice || order.StopTriggered)
+                    {
+                        order.StopTriggered = true;
+
+                        // Fill the limit order, using closing price of bar:
+                        // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
+                        if (asset.Price < order.LimitPrice)
+                        {
+                            fill.Status = OrderStatus.Filled;
+                            fill.FillPrice = order.LimitPrice;
+                            // assume the order completely filled
+                            fill.FillQuantity = order.Quantity;
+                        }
+                    }
+                    break;
+
+                case OrderDirection.Sell:
+                    //-> 1.1 Sell Stop: If Price below setpoint, Sell:
+                    if (prices.Low < order.StopPrice || order.StopTriggered)
+                    {
+                        order.StopTriggered = true;
+
+                        // Fill the limit order, using minimum price of the bar
+                        // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
+                        if (asset.Price > order.LimitPrice)
+                        {
+                            fill.Status = OrderStatus.Filled;
+                            fill.FillPrice = order.LimitPrice; // Fill at limit price not asset price.
+                            // assume the order completely filled
+                            fill.FillQuantity = order.Quantity;
+                        }
+                    }
+                    break;
+            }
+
+            return fill;
+        }
 
         /// <summary>
         /// Limit Fill Model. Return an order event with the fill details.
         /// </summary>
-        /// <param name="asset">Stock Object to use to help model limit fill</param>
-        /// <param name="order">Order to fill. Alter the values directly if filled.</param>
+        /// <param name="context">A context object containing the security and order</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        OrderEvent LimitFill(Security asset, LimitOrder order);
+        protected virtual OrderEvent LimitFill(FillModelContext context)
+        {
+            if (!_checkedLimitFill)
+            {
+                _checkedLimitFill = true;
+                SetFunctionCall(context.Order.Type);
+            }
+
+            if (_limitFill != null)
+            {
+                return _limitFill(context.Security, context.Order as LimitOrder);
+            }
+
+            return LimitFillImplementation(context);
+        }
+
+        /// <summary>
+        /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
+        /// This was created to maintain retro compatibility allowing old user code
+        /// to access base.xxxxFill(asset, order) implementation
+        /// </summary>
+        protected OrderEvent LimitFillImplementation(FillModelContext context)
+        {
+            var asset = context.Security;
+            var order = context.Order as LimitOrder;
+            //Initialise;
+            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
+            var fill = new OrderEvent(order, utcTime, 0);
+
+            //If its cancelled don't need anymore checks:
+            if (order.Status == OrderStatus.Canceled) return fill;
+
+            // make sure the exchange is open before filling -- allow pre/post market fills to occur
+            if (!IsExchangeOpen(asset,
+                SubscriptionDataConfigProvider
+                    .GetSubscriptionDataConfigs(asset.Symbol)
+                    .IsExtendedMarketHours()))
+            {
+                return fill;
+            }
+
+            //Get the range of prices in the last bar:
+            var prices = GetPrices(asset, order.Direction);
+            var pricesEndTime = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
+
+            // do not fill on stale data
+            if (pricesEndTime <= order.Time) return fill;
+
+            //-> Valid Live/Model Order:
+            switch (order.Direction)
+            {
+                case OrderDirection.Buy:
+                    //Buy limit seeks lowest price
+                    if (prices.Low < order.LimitPrice)
+                    {
+                        //Set order fill:
+                        fill.Status = OrderStatus.Filled;
+                        // fill at the worse price this bar or the limit price, this allows far out of the money limits
+                        // to be executed properly
+                        fill.FillPrice = Math.Min(prices.High, order.LimitPrice);
+                        // assume the order completely filled
+                        fill.FillQuantity = order.Quantity;
+                    }
+                    break;
+                case OrderDirection.Sell:
+                    //Sell limit seeks highest price possible
+                    if (prices.High > order.LimitPrice)
+                    {
+                        fill.Status = OrderStatus.Filled;
+                        // fill at the worse price this bar or the limit price, this allows far out of the money limits
+                        // to be executed properly
+                        fill.FillPrice = Math.Max(prices.Low, order.LimitPrice);
+                        // assume the order completely filled
+                        fill.FillQuantity = order.Quantity;
+                    }
+                    break;
+            }
+
+            return fill;
+        }
 
         /// <summary>
         /// Market on Open Fill Model. Return an order event with the fill details
         /// </summary>
-        /// <param name="asset">Asset we're trading with this order</param>
-        /// <param name="order">Order to be filled</param>
+        /// <param name="context">A context object containing the security and order</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        OrderEvent MarketOnOpenFill(Security asset, MarketOnOpenOrder order);
+        protected virtual OrderEvent MarketOnOpenFill(FillModelContext context)
+        {
+            if (!_checkedMarketOnOpenFill)
+            {
+                _checkedMarketOnOpenFill = true;
+                SetFunctionCall(context.Order.Type);
+            }
+
+            if (_marketOnOpenFill != null)
+            {
+                return _marketOnOpenFill(context.Security, context.Order as MarketOnOpenOrder);
+            }
+
+            return MarketOnOpenFillImplementation(context);
+        }
+
+        /// <summary>
+        /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
+        /// This was created to maintain retro compatibility allowing old user code
+        /// to access base.xxxxFill(asset, order) implementation
+        /// </summary>
+        protected OrderEvent MarketOnOpenFillImplementation(FillModelContext context)
+        {
+            var asset = context.Security;
+            var order = context.Order as MarketOnOpenOrder;
+
+            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
+            var fill = new OrderEvent(order, utcTime, 0);
+
+            if (order.Status == OrderStatus.Canceled) return fill;
+
+            // MOO should never fill on the same bar or on stale data
+            // Imagine the case where we have a thinly traded equity, ASUR, and another liquid
+            // equity, say SPY, SPY gets data every minute but ASUR, if not on fill forward, maybe
+            // have large gaps, in which case the currentBar.EndTime will be in the past
+            // ASUR  | | |      [order]        | | | | | | |
+            //  SPY  | | | | | | | | | | | | | | | | | | | |
+            var currentBar = asset.GetLastData();
+            var localOrderTime = order.Time.ConvertFromUtc(asset.Exchange.TimeZone);
+            if (currentBar == null || localOrderTime >= currentBar.EndTime) return fill;
+
+            // if the MOO was submitted during market the previous day, wait for a day to turn over
+            if (asset.Exchange.DateTimeIsOpen(localOrderTime) && localOrderTime.Date == asset.LocalTime.Date)
+            {
+                return fill;
+            }
+
+            // wait until market open
+            // make sure the exchange is open/normal market hours before filling
+            if (!IsExchangeOpen(asset, false)) return fill;
+
+            fill.FillPrice = GetPrices(asset, order.Direction).Open;
+            fill.Status = OrderStatus.Filled;
+
+            //Calculate the model slippage: e.g. 0.01c
+            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
+
+            //Apply slippage
+            switch (order.Direction)
+            {
+                case OrderDirection.Buy:
+                    fill.FillPrice += slip;
+                    // assume the order completely filled
+                    fill.FillQuantity = order.Quantity;
+                    break;
+                case OrderDirection.Sell:
+                    fill.FillPrice -= slip;
+                    // assume the order completely filled
+                    fill.FillQuantity = order.Quantity;
+                    break;
+            }
+
+            return fill;
+        }
 
         /// <summary>
         /// Market on Close Fill Model. Return an order event with the fill details
         /// </summary>
-        /// <param name="asset">Asset we're trading with this order</param>
-        /// <param name="order">Order to be filled</param>
+        /// <param name="context">A context object containing the security and order</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        OrderEvent MarketOnCloseFill(Security asset, MarketOnCloseOrder order);
+        protected virtual OrderEvent MarketOnCloseFill(FillModelContext context)
+        {
+            if (!_checkedMarketOnCloseFill)
+            {
+                _checkedMarketOnCloseFill = true;
+                SetFunctionCall(context.Order.Type);
+            }
+
+            if (_marketOnCloseFill != null)
+            {
+                return _marketOnCloseFill(context.Security, context.Order as MarketOnCloseOrder);
+            }
+
+            return MarketOnCloseFillImplementation(context);
+        }
+
+        /// <summary>
+        /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
+        /// This was created to maintain retro compatibility allowing old user code
+        /// to access base.xxxxFill(asset, order) implementation
+        /// </summary>
+        protected OrderEvent MarketOnCloseFillImplementation(FillModelContext context)
+        {
+            var asset = context.Security;
+            var order = context.Order as MarketOnCloseOrder;
+
+            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
+            var fill = new OrderEvent(order, utcTime, 0);
+
+            if (order.Status == OrderStatus.Canceled) return fill;
+
+            var localOrderTime = order.Time.ConvertFromUtc(asset.Exchange.TimeZone);
+            var nextMarketClose = asset.Exchange.Hours.GetNextMarketClose(localOrderTime, false);
+
+            // wait until market closes after the order time
+            if (asset.LocalTime < nextMarketClose)
+            {
+                return fill;
+            }
+            // make sure the exchange is open/normal market hours before filling
+            if (!IsExchangeOpen(asset, false)) return fill;
+
+            fill.FillPrice = GetPrices(asset, order.Direction).Close;
+            fill.Status = OrderStatus.Filled;
+
+            //Calculate the model slippage: e.g. 0.01c
+            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
+
+            //Apply slippage
+            switch (order.Direction)
+            {
+                case OrderDirection.Buy:
+                    fill.FillPrice += slip;
+                    // assume the order completely filled
+                    fill.FillQuantity = order.Quantity;
+                    break;
+                case OrderDirection.Sell:
+                    fill.FillPrice -= slip;
+                    // assume the order completely filled
+                    fill.FillQuantity = order.Quantity;
+                    break;
+            }
+
+            return fill;
+        }
+
+        /// <summary>
+        /// Get the minimum and maximum price for this security in the last bar:
+        /// </summary>
+        /// <param name="asset">Security asset we're checking</param>
+        /// <param name="direction">The order direction, decides whether to pick bid or ask</param>
+        protected virtual Prices GetPrices(Security asset, OrderDirection direction)
+        {
+            var low = asset.Low;
+            var high = asset.High;
+            var open = asset.Open;
+            var close = asset.Close;
+            var current = asset.Price;
+            var endTime = asset.Cache.GetData()?.EndTime ?? DateTime.MinValue;
+
+            if (direction == OrderDirection.Hold)
+            {
+                return new Prices(endTime, current, open, high, low, close);
+            }
+
+            // Only fill with data types we are subscribed to
+            var subscriptionTypes = SubscriptionDataConfigProvider
+                .GetSubscriptionDataConfigs(asset.Symbol)
+                .Select(x => x.Type).ToList();
+
+            // Tick
+            var tick = asset.Cache.GetData<Tick>();
+            if (subscriptionTypes.Contains(typeof(Tick)) && tick != null)
+            {
+                var price = direction == OrderDirection.Sell ? tick.BidPrice : tick.AskPrice;
+                if (price != 0m)
+                {
+                    return new Prices(tick.EndTime, price, 0, 0, 0, 0);
+                }
+
+                // If the ask/bid spreads are not available for ticks, try the price
+                price = tick.Price;
+                if (price != 0m)
+                {
+                    return new Prices(tick.EndTime, price, 0, 0, 0, 0);
+                }
+            }
+
+            // Quote
+            var quoteBar = asset.Cache.GetData<QuoteBar>();
+            if (subscriptionTypes.Contains(typeof(QuoteBar)) && quoteBar != null)
+            {
+                var bar = direction == OrderDirection.Sell ? quoteBar.Bid : quoteBar.Ask;
+                if (bar != null)
+                {
+                    return new Prices(quoteBar.EndTime, bar);
+                }
+            }
+
+            // Trade
+            var tradeBar = asset.Cache.GetData<TradeBar>();
+            if (subscriptionTypes.Contains(typeof(TradeBar)) && tradeBar != null)
+            {
+                return new Prices(tradeBar);
+            }
+
+            return new Prices(endTime, current, open, high, low, close);
+        }
+
+        /// <summary>
+        /// Determines if the exchange is open using the current time of the asset
+        /// </summary>
+        private static bool IsExchangeOpen(Security asset, bool isExtendedMarketHours)
+        {
+            if (!asset.Exchange.DateTimeIsOpen(asset.LocalTime))
+            {
+                // if we're not open at the current time exactly, check the bar size, this handle large sized bars (hours/days)
+                var currentBar = asset.GetLastData();
+                if (asset.LocalTime.Date != currentBar.EndTime.Date
+                    || !asset.Exchange.IsOpenDuringBar(currentBar.Time, currentBar.EndTime, isExtendedMarketHours))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public class Prices
+        {
+            public readonly DateTime EndTime;
+            public readonly decimal Current;
+            public readonly decimal Open;
+            public readonly decimal High;
+            public readonly decimal Low;
+            public readonly decimal Close;
+
+            public Prices(IBaseDataBar bar)
+                : this(bar.EndTime, bar.Close, bar.Open, bar.High, bar.Low, bar.Close)
+            {
+            }
+
+            public Prices(DateTime endTime, IBar bar)
+                : this(endTime, bar.Close, bar.Open, bar.High, bar.Low, bar.Close)
+            {
+            }
+
+            public Prices(DateTime endTime, decimal current, decimal open, decimal high, decimal low, decimal close)
+            {
+                EndTime = endTime;
+                Current = current;
+                Open = open == 0 ? current : open;
+                High = high == 0 ? current : high;
+                Low = low == 0 ? current : low;
+                Close = close == 0 ? current : close;
+            }
+        }
+
+        /// <summary>
+        /// Helper method that will set the retro compatible fill functions
+        /// </summary>
+        /// <param name="orderType">Used to determine the type of fill</param>
+        private void SetFunctionCall(OrderType orderType)
+        {
+            string methodName;
+            Type inputType;
+            switch (orderType)
+            {
+                case OrderType.Market:
+                    methodName = "MarketFill";
+                    inputType = typeof(MarketOrder);
+                    break;
+                case OrderType.Limit:
+                    methodName = "LimitFill";
+                    inputType = typeof(LimitOrder);
+                    break;
+                case OrderType.StopMarket:
+                    methodName = "StopMarketFill";
+                    inputType = typeof(StopMarketOrder);
+                    break;
+                case OrderType.StopLimit:
+                    methodName = "StopLimitFill";
+                    inputType = typeof(StopLimitOrder);
+                    break;
+                case OrderType.MarketOnOpen:
+                    methodName = "MarketOnOpenFill";
+                    inputType = typeof(MarketOnOpenOrder);
+                    break;
+                case OrderType.MarketOnClose:
+                    methodName = "MarketOnCloseFill";
+                    inputType = typeof(MarketOnCloseOrder);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            var method = GetMethod(GetType(),
+                methodName,
+                typeof(OrderEvent),
+                typeof(FillModel),
+                new[] { typeof(Security), inputType });
+
+            if (method != null)
+            {
+                // we've found the old method, now create a delegate so we can invoke it
+                var orderParameter = Expression.Parameter(inputType, "order");
+                var call = Expression.Call(_self, method, _securityParameter, orderParameter);
+                switch (orderType)
+                {
+                    case OrderType.Market:
+                        _marketFill = Expression.Lambda<Func<Security, MarketOrder, OrderEvent>>(
+                            call,
+                            _securityParameter,
+                            orderParameter).Compile();
+                        break;
+                    case OrderType.Limit:
+                        _limitFill = Expression.Lambda<Func<Security, LimitOrder, OrderEvent>>(
+                            call,
+                            _securityParameter,
+                            orderParameter).Compile();
+                        break;
+                    case OrderType.StopMarket:
+                        _stopMarketFill = Expression.Lambda<Func<Security, StopMarketOrder, OrderEvent>>(
+                            call,
+                            _securityParameter,
+                            orderParameter).Compile();
+                        break;
+                    case OrderType.StopLimit:
+                        _stopLimitFill = Expression.Lambda<Func<Security, StopLimitOrder, OrderEvent>>(
+                            call,
+                            _securityParameter,
+                            orderParameter).Compile();
+                        break;
+                    case OrderType.MarketOnOpen:
+                        _marketOnOpenFill = Expression.Lambda<Func<Security, MarketOnOpenOrder, OrderEvent>>(
+                            call,
+                            _securityParameter,
+                            orderParameter).Compile();
+                        break;
+                    case OrderType.MarketOnClose:
+                        _marketOnCloseFill = Expression.Lambda<Func<Security, MarketOnCloseOrder, OrderEvent>>(
+                            call,
+                            _securityParameter,
+                            orderParameter).Compile();
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper method to find a specific <see cref="MethodInfo"/> for a given Type
+        /// </summary>
+        /// <param name="type">The Type we want to search the method in</param>
+        /// <param name="methodName">The method name</param>
+        /// <param name="returnType">The return Type of the method to search</param>
+        /// <param name="nonDeclaringType">A Type how should not be the declaring Type of the method.
+        /// This is useful when wanting to detect if a method was overriden</param>
+        /// <param name="inputTypes">The input Types of the method</param>
+        /// <returns></returns>
+        private static MethodInfo GetMethod(
+            Type type,
+            string methodName,
+            Type returnType,
+            Type nonDeclaringType,
+            Type[] inputTypes
+            )
+        {
+            var parameterCount = inputTypes.Length;
+            var method = type.GetMethods()
+                .Where(m => m.Name == methodName)
+                .Where(m => m.ReturnType == returnType)
+                .Where(m => m.DeclaringType != nonDeclaringType)
+                .Where(m => m.GetParameters().Length == parameterCount)
+                .SingleOrDefault(m => m.GetParameters()
+                    .Select(x => x.ParameterType)
+                    .All(inputTypes.Contains));
+            return method;
+        }
     }
 }

--- a/Common/Orders/Fills/IFillModel.cs
+++ b/Common/Orders/Fills/IFillModel.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Orders.Fills
 
         /// <summary>
         /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
-        /// This was created to maintain retro compatibility allowing old user code
+        /// This was created to maintain backwards compatibility allowing old user code
         /// to access base.xxxxFill(asset, order) implementation
         /// </summary>
         protected OrderEvent MarketFillImplementation(FillModelContext context)
@@ -178,7 +178,7 @@ namespace QuantConnect.Orders.Fills
 
         /// <summary>
         /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
-        /// This was created to maintain retro compatibility allowing old user code
+        /// This was created to maintain backwards compatibility allowing old user code
         /// to access base.xxxxFill(asset, order) implementation
         /// </summary>
         protected OrderEvent StopMarketFillImplementation(FillModelContext context)
@@ -267,7 +267,7 @@ namespace QuantConnect.Orders.Fills
 
         /// <summary>
         /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
-        /// This was created to maintain retro compatibility allowing old user code
+        /// This was created to maintain backwards compatibility allowing old user code
         /// to access base.xxxxFill(asset, order) implementation
         /// </summary>
         protected OrderEvent StopLimitFillImplementation(FillModelContext context)
@@ -365,7 +365,7 @@ namespace QuantConnect.Orders.Fills
 
         /// <summary>
         /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
-        /// This was created to maintain retro compatibility allowing old user code
+        /// This was created to maintain backwards compatibility allowing old user code
         /// to access base.xxxxFill(asset, order) implementation
         /// </summary>
         protected OrderEvent LimitFillImplementation(FillModelContext context)
@@ -451,7 +451,7 @@ namespace QuantConnect.Orders.Fills
 
         /// <summary>
         /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
-        /// This was created to maintain retro compatibility allowing old user code
+        /// This was created to maintain backwards compatibility allowing old user code
         /// to access base.xxxxFill(asset, order) implementation
         /// </summary>
         protected OrderEvent MarketOnOpenFillImplementation(FillModelContext context)
@@ -531,7 +531,7 @@ namespace QuantConnect.Orders.Fills
 
         /// <summary>
         /// This method should only be called by <see cref="FillModel"/> and <see cref="IFillModel"/>.
-        /// This was created to maintain retro compatibility allowing old user code
+        /// This was created to maintain backwards compatibility allowing old user code
         /// to access base.xxxxFill(asset, order) implementation
         /// </summary>
         protected OrderEvent MarketOnCloseFillImplementation(FillModelContext context)
@@ -691,7 +691,7 @@ namespace QuantConnect.Orders.Fills
         }
 
         /// <summary>
-        /// Helper method that will set the retro compatible fill functions
+        /// Helper method that will set the backwards compatible fill functions
         /// </summary>
         /// <param name="orderType">Used to determine the type of fill</param>
         private Func<Security, T, OrderEvent> GetFunctionCall<T>(OrderType orderType)

--- a/Common/Orders/Fills/IFillModelInterface.cs
+++ b/Common/Orders/Fills/IFillModelInterface.cs
@@ -19,8 +19,8 @@ namespace QuantConnect.Orders.Fills
     /// <summary>
     /// Represents an interface that simulates order fill events
     /// </summary>
-    /// <remarks>Users should override base class <see cref="IFillModel"/></remarks>
-    public interface InterfaceFillModel
+    /// <remarks>Users should override base class <see cref="FillModel"/></remarks>
+    public interface IFillModelInterface
     {
         /// <summary>
         /// Return an order event with the fill details

--- a/Common/Orders/Fills/InterfaceFillModel.cs
+++ b/Common/Orders/Fills/InterfaceFillModel.cs
@@ -13,21 +13,20 @@
  * limitations under the License.
 */
 
-namespace QuantConnect.Securities.Future
+
+namespace QuantConnect.Orders.Fills
 {
     /// <summary>
-    /// Future holdings implementation of the base securities class
+    /// Represents an interface that simulates order fill events
     /// </summary>
-    /// <seealso cref="SecurityHolding"/>
-    public class FutureHolding : SecurityHolding
+    /// <remarks>Users should override base class <see cref="IFillModel"/></remarks>
+    public interface InterfaceFillModel
     {
         /// <summary>
-        /// Future Holding Class constructor
+        /// Return an order event with the fill details
         /// </summary>
-        /// <param name="security">The future security being held</param>
-        public FutureHolding(Security security)
-            : base(security)
-        {
-        }
+        /// <param name="context">A context object containing the security and order</param>
+        /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        OrderEvent Fill(FillModelContext context);
     }
 }

--- a/Common/Orders/Fills/LatestPriceFillModel.cs
+++ b/Common/Orders/Fills/LatestPriceFillModel.cs
@@ -48,8 +48,10 @@ namespace QuantConnect.Orders.Fills
                 return new Prices(endTime, current, open, high, low, close);
             }
 
+            var subscriptions = SubscriptionDataConfigProvider.GetSubscriptionDataConfigs(asset.Symbol);
+
             // Only fill with data types we are subscribed to
-            var subscriptionTypes = asset.Subscriptions.Select(x => x.Type).ToList();
+            var subscriptionTypes = subscriptions.Select(x => x.Type).ToList();
 
             // Tick
             var tick = asset.Cache.GetData<Tick>();

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -193,6 +193,8 @@
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />
     <Compile Include="IsolatorLimitResult.cs" />
+    <Compile Include="Orders\Fills\FillModelContext.cs" />
+    <Compile Include="Orders\Fills\InterfaceFillModel.cs" />
     <Compile Include="Python\BrokerageMessageHandlerPythonWrapper.cs" />
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Python\PythonInitializer.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -194,7 +194,7 @@
     <Compile Include="Interfaces\ITimeKeeper.cs" />
     <Compile Include="IsolatorLimitResult.cs" />
     <Compile Include="Orders\Fills\FillModelContext.cs" />
-    <Compile Include="Orders\Fills\InterfaceFillModel.cs" />
+    <Compile Include="Orders\Fills\IFillModelInterface.cs" />
     <Compile Include="Python\BrokerageMessageHandlerPythonWrapper.cs" />
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Python\PythonInitializer.cs" />

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -170,7 +170,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Fill model used to produce fill events for this security
         /// </summary>
-        public InterfaceFillModel FillModel
+        public IFillModelInterface FillModel
         {
             get;
             set;

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -170,7 +170,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Fill model used to produce fill events for this security
         /// </summary>
-        public IFillModel FillModel
+        public InterfaceFillModel FillModel
         {
             get;
             set;

--- a/Tests/Common/Data/MockSubscriptionDataConfigProvider.cs
+++ b/Tests/Common/Data/MockSubscriptionDataConfigProvider.cs
@@ -11,23 +11,27 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
 */
-
-namespace QuantConnect.Securities.Future
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+namespace QuantConnect.Tests.Common.Data
 {
-    /// <summary>
-    /// Future holdings implementation of the base securities class
-    /// </summary>
-    /// <seealso cref="SecurityHolding"/>
-    public class FutureHolding : SecurityHolding
+    internal class MockSubscriptionDataConfigProvider : ISubscriptionDataConfigProvider
     {
-        /// <summary>
-        /// Future Holding Class constructor
-        /// </summary>
-        /// <param name="security">The future security being held</param>
-        public FutureHolding(Security security)
-            : base(security)
+        public List<SubscriptionDataConfig> SubscriptionDataConfigs
+            = new List<SubscriptionDataConfig>();
+        public MockSubscriptionDataConfigProvider(SubscriptionDataConfig config = null)
         {
+            if (config != null)
+            {
+                SubscriptionDataConfigs.Add(config);
+            }
+        }
+        public List<SubscriptionDataConfig> GetSubscriptionDataConfigs(Symbol symbol)
+        {
+            return SubscriptionDataConfigs;
         }
     }
 }

--- a/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
+++ b/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
@@ -25,7 +25,7 @@ using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Orders.Fills
 {
-    public class RetroCompatibilityFillModelsTests
+    public class BackwardsCompatibilityFillModelsTests
     {
         private SubscriptionDataConfig _config;
         private Security _security;
@@ -54,10 +54,28 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             _security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
         }
 
-        #region RetroCompatibilityOldFillInterfaceModelTests
+        #region BackwardsCompatibilityInheritImmediateFillModel
 
         [Test]
-        public void RetroCompatibilityOldInterfaceWorks_MarketFill()
+        public void InheritImmediateFillModel_MarketFill()
+        {
+            var model = new TestFillModelInheritImmediateFillModel();
+            // IFillModel will detect and call users old implementation
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new MarketOrder(_security.Symbol, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.MarketFillWasCalled);
+            Assert.AreEqual(OrderStatus.Filled, result.Status);
+        }
+
+        #endregion
+
+        #region BackwardsCompatibilityOldFillInterfaceModelTests
+
+        [Test]
+        public void BackwardsCompatibilityOldInterfaceWorks_MarketFill()
         {
             var model = new TestFillModelInheritInterface();
             // IFillModel will detect and call users old implementation
@@ -71,7 +89,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldInterfaceWorks_StopMarketFill()
+        public void BackwardsCompatibilityOldInterfaceWorks_StopMarketFill()
         {
             var model = new TestFillModelInheritInterface();
             // IFillModel will detect and call users old implementation
@@ -85,7 +103,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldInterfaceWorks_StopLimitFill()
+        public void BackwardsCompatibilityOldInterfaceWorks_StopLimitFill()
         {
             var model = new TestFillModelInheritInterface();
             // IFillModel will detect and call users old implementation
@@ -99,7 +117,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldInterfaceWorks_LimitFill()
+        public void BackwardsCompatibilityOldInterfaceWorks_LimitFill()
         {
             var model = new TestFillModelInheritInterface();
             // IFillModel will detect and call users old implementation
@@ -113,7 +131,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldInterfaceWorks_MarketOnOpenFill()
+        public void BackwardsCompatibilityOldInterfaceWorks_MarketOnOpenFill()
         {
             var model = new TestFillModelInheritInterface();
             // IFillModel will detect and call users old implementation
@@ -127,7 +145,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldInterfaceWorks_MarketOnCloseFill()
+        public void BackwardsCompatibilityOldInterfaceWorks_MarketOnCloseFill()
         {
             var model = new TestFillModelInheritInterface();
             // IFillModel will detect and call users old implementation
@@ -142,10 +160,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
         #endregion
 
-        #region RetroCompatibilityOldBaseFillModelTests
+        #region BackwardsCompatibilityOldBaseFillModelTests
 
         [Test]
-        public void RetroCompatibilityOldBaseFillModelWorks_DoesNotOverride_MarketFill()
+        public void BackwardsCompatibilityOldBaseFillModelWorks_DoesNotOverride_MarketFill()
         {
             var model = new TestFillModelInheritBaseClassDoesNotOverride();
             // IFillModel will detect and call users old implementation
@@ -162,7 +180,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldBaseFillModelWorks_MarketFill()
+        public void BackwardsCompatibilityOldBaseFillModelWorks_MarketFill()
         {
             var model = new TestFillModelInheritBaseClass();
             // IFillModel will detect and call users old implementation
@@ -180,7 +198,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldBaseFillModelWorks_StopMarketFill()
+        public void BackwardsCompatibilityOldBaseFillModelWorks_StopMarketFill()
         {
             var model = new TestFillModelInheritBaseClass();
             // IFillModel will detect and call users old implementation
@@ -198,7 +216,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldBaseFillModelWorks_StopLimitFill()
+        public void BackwardsCompatibilityOldBaseFillModelWorks_StopLimitFill()
         {
             var model = new TestFillModelInheritBaseClass();
             // IFillModel will detect and call users old implementation
@@ -216,7 +234,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldBaseFillModelWorks_LimitFill()
+        public void BackwardsCompatibilityOldBaseFillModelWorks_LimitFill()
         {
             var model = new TestFillModelInheritBaseClass();
             // IFillModel will detect and call users old implementation
@@ -234,7 +252,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldBaseFillModelWorks_MarketOnOpenFill()
+        public void BackwardsCompatibilityOldBaseFillModelWorks_MarketOnOpenFill()
         {
             var model = new TestFillModelInheritBaseClass();
             _security.SetMarketPrice(new Tick(orderDateTime, _security.Symbol, 88, 88));
@@ -254,7 +272,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
-        public void RetroCompatibilityOldBaseFillModelWorks_MarketOnCloseFill()
+        public void BackwardsCompatibilityOldBaseFillModelWorks_MarketOnCloseFill()
         {
             var model = new TestFillModelInheritBaseClass();
             // IFillModel will detect and call users old implementation
@@ -398,6 +416,17 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 // call base.GetPrices() just to test it show its possible
                 base.GetPrices(asset, direction);
                 return new Prices(orderDateTime, 12345, 12345, 12345, 12345, 12345);
+            }
+        }
+
+        private class TestFillModelInheritImmediateFillModel : ImmediateFillModel
+        {
+            public bool MarketFillWasCalled;
+
+            public override OrderEvent MarketFill(Security asset, MarketOrder order)
+            {
+                MarketFillWasCalled = true;
+                return base.MarketFill(asset, order);
             }
         }
 

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -23,6 +23,7 @@ using QuantConnect.Orders;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Forex;
+using QuantConnect.Tests.Common.Data;
 using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Orders.Fills
@@ -49,7 +50,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.123m));
 
-            var fill = model.MarketFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(security.Price, fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
@@ -70,7 +74,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.123m));
 
-            var fill = model.MarketFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(security.Price, fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
@@ -92,7 +99,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 
-            var fill = model.LimitFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -100,7 +110,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 103m, 101m, 102.3m, 100));
 
-            fill = model.LimitFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             // this fills worst case scenario, so it's at the limit price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
@@ -124,7 +137,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
 
-            var fill = model.LimitFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -132,7 +148,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 103m, 101m, 102.3m, 100));
 
-            fill = model.LimitFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             // this fills worst case scenario, so it's at the limit price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
@@ -156,7 +175,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 100m));
 
-            var fill = model.StopLimitFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -164,7 +186,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 
-            fill = model.StopLimitFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -172,7 +197,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.66m));
 
-            fill = model.StopLimitFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             // this fills worst case scenario, so it's at the limit price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
@@ -196,7 +224,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 
-            var fill = model.StopLimitFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -204,7 +235,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
 
-            fill = model.StopLimitFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -212,7 +246,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.66m));
 
-            fill = model.StopLimitFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             // this fills worst case scenario, so it's at the limit price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
@@ -236,7 +273,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
 
-            var fill = model.StopMarketFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -244,7 +284,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102.5m));
 
-            fill = model.StopMarketFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             // this fills worst case scenario, so it's min of asset/stop price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
@@ -268,7 +311,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
 
-            var fill = model.StopMarketFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -276,7 +322,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
 
-            fill = model.StopMarketFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             // this fills worst case scenario, so it's min of asset/stop price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
@@ -303,7 +352,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
             security.SetMarketPrice(new TradeBar(time, Symbols.SPY, 1m, 2m, 0.5m, 1.33m, 100));
 
-            var fill = model.MarketOnOpenFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
             Assert.AreEqual(0, fill.FillQuantity);
 
             // market opens after 30min, so this is just before market open
@@ -311,7 +363,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
             security.SetMarketPrice(new TradeBar(time, Symbols.SPY, 1.33m, 2.75m, 1.15m, 1.45m, 100));
 
-            fill = model.MarketOnOpenFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
             Assert.AreEqual(0, fill.FillQuantity);
 
             // market opens after 30min
@@ -319,7 +374,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
             security.SetMarketPrice(new TradeBar(time, Symbols.SPY, 1.45m, 2.0m, 1.1m, 1.40m, 100));
 
-            fill = model.MarketOnOpenFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(security.Open, fill.FillPrice);
         }
@@ -343,7 +401,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
             security.SetMarketPrice(new TradeBar(time - config.Increment, Symbols.SPY, 1m, 2m, 0.5m, 1.33m, 100, config.Increment));
 
-            var fill = model.MarketOnCloseFill(security, order);
+            var fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
             Assert.AreEqual(0, fill.FillQuantity);
 
             // market closes after 60min, so this is just before market Close
@@ -351,7 +412,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
             security.SetMarketPrice(new TradeBar(time - config.Increment, Symbols.SPY, 1.33m, 2.75m, 1.15m, 1.45m, 100, config.Increment));
 
-            fill = model.MarketOnCloseFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
             Assert.AreEqual(0, fill.FillQuantity);
 
             // market closes
@@ -359,7 +423,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
             security.SetMarketPrice(new TradeBar(time - config.Increment, Symbols.SPY, 1.45m, 2.0m, 1.1m, 1.40m, 100, config.Increment));
 
-            fill = model.MarketOnCloseFill(security, order);
+            fill = model.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(security.Close, fill.FillPrice);
         }
@@ -390,7 +457,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             var quantity = direction == OrderDirection.Buy ? 1 : -1;
             var order = new MarketOrder(symbol, quantity, DateTime.Now);
-            var fill = fillModel.MarketFill(security, order);
+            var fill = fillModel.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             var expected = direction == OrderDirection.Buy ? askPrice : bidPrice;
             Assert.AreEqual(expected, fill.FillPrice);
@@ -421,7 +491,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             var fillModel = new ImmediateFillModel();
             var order = new MarketOrder(symbol, 1000, DateTime.Now);
-            var fill = fillModel.MarketFill(security, order);
+            var fill = fillModel.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             // The fill model should use the tick.Price
             Assert.AreEqual(fill.FillPrice, 100m);
@@ -453,7 +526,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             var fillModel = new ImmediateFillModel();
             var order = new MarketOrder(symbol, 1000, DateTime.Now);
-            var fill = fillModel.MarketFill(security, order);
+            var fill = fillModel.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             // The fill model should use the tick.Price
             Assert.AreEqual(fill.FillPrice, 1.0m);
@@ -490,7 +566,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fillModel = new ImmediateFillModel();
             var order = new LimitOrder(symbol, orderQuantity, limitPrice, time.ConvertToUtc(TimeZones.NewYork));
 
-            var fill = fillModel.LimitFill(security, order);
+            var fill = fillModel.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -502,7 +581,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             tradeBar = new TradeBar(time, symbol, 290m, 292m, 289m, 291m, 12345);
             security.SetMarketPrice(tradeBar);
 
-            fill = fillModel.LimitFill(security, order);
+            fill = fillModel.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(orderQuantity, fill.FillQuantity);
             Assert.AreEqual(limitPrice, fill.FillPrice);
@@ -540,7 +622,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fillModel = new ImmediateFillModel();
             var order = new StopMarketOrder(symbol, orderQuantity, stopPrice, time.ConvertToUtc(TimeZones.NewYork));
 
-            var fill = fillModel.StopMarketFill(security, order);
+            var fill = fillModel.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -552,7 +637,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             tradeBar = new TradeBar(time, symbol, 290m, 292m, 289m, 291m, 12345);
             security.SetMarketPrice(tradeBar);
 
-            fill = fillModel.StopMarketFill(security, order);
+            fill = fillModel.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(orderQuantity, fill.FillQuantity);
             Assert.AreEqual(stopPrice, fill.FillPrice);
@@ -590,7 +678,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fillModel = new ImmediateFillModel();
             var order = new StopLimitOrder(symbol, orderQuantity, stopPrice, limitPrice, time.ConvertToUtc(TimeZones.NewYork));
 
-            var fill = fillModel.StopLimitFill(security, order);
+            var fill = fillModel.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -602,7 +693,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             tradeBar = new TradeBar(time, symbol, 290m, 292m, 289m, 291m, 12345);
             security.SetMarketPrice(tradeBar);
 
-            fill = fillModel.StopLimitFill(security, order);
+            fill = fillModel.Fill(new FillModelContext(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config)));
 
             Assert.AreEqual(orderQuantity, fill.FillQuantity);
             Assert.AreEqual(limitPrice, fill.FillPrice);

--- a/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
@@ -6,7 +6,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Securities;
-using QuantConnect.Tests.Common.Securities;
+using QuantConnect.Tests.Common.Data;
 
 namespace QuantConnect.Tests.Common.Orders.Fills
 {
@@ -117,6 +117,11 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
         internal class TestableLatestFillModel : LatestPriceFillModel
         {
+            public TestableLatestFillModel()
+            {
+                // NOTE. GetPrices will no be called before SubscriptionDataConfigProvider is set by the system
+                SubscriptionDataConfigProvider = new MockSubscriptionDataConfigProvider();
+            }
             public new Prices GetPrices(Security asset, OrderDirection direction)
             {
                 return base.GetPrices(asset, direction);

--- a/Tests/Common/Orders/Fills/RetroCompatibilityFillModelsTests.cs
+++ b/Tests/Common/Orders/Fills/RetroCompatibilityFillModelsTests.cs
@@ -1,0 +1,415 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fills;
+using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Data;
+using QuantConnect.Tests.Common.Securities;
+
+namespace QuantConnect.Tests.Common.Orders.Fills
+{
+    public class RetroCompatibilityFillModelsTests
+    {
+        private SubscriptionDataConfig _config;
+        private Security _security;
+        private static OrderEvent orderEvent;
+        private static DateTime orderDateTime;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _config = SecurityTests.CreateTradeBarConfig();
+            _security = SecurityTests.GetSecurity();
+            orderDateTime = new DateTime(2017, 2, 2, 13, 0, 0);
+            orderEvent = new OrderEvent(
+                99,
+                _security.Symbol,
+                orderDateTime,
+                OrderStatus.Submitted,
+                OrderDirection.Buy,
+                1,
+                1,
+                1
+            );
+            var reference = DateTime.Now;
+            var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
+            var timeKeeper = new TimeKeeper(referenceUtc);
+            _security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+        }
+
+        #region RetroCompatibilityOldFillInterfaceModelTests
+
+        [Test]
+        public void RetroCompatibilityOldInterfaceWorks_MarketFill()
+        {
+            var model = new TestFillModelInheritInterface();
+            // IFillModel will detect and call users old implementation
+            var result = model.Fill(
+                new FillModelContext(_security,
+                new MarketOrder(_security.Symbol, 1, orderDateTime),
+                new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.MarketFillWasCalled);
+            Assert.AreEqual(orderEvent, result);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldInterfaceWorks_StopMarketFill()
+        {
+            var model = new TestFillModelInheritInterface();
+            // IFillModel will detect and call users old implementation
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new StopMarketOrder(_security.Symbol, 1, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.StopMarketFillWasCalled);
+            Assert.AreEqual(orderEvent, result);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldInterfaceWorks_StopLimitFill()
+        {
+            var model = new TestFillModelInheritInterface();
+            // IFillModel will detect and call users old implementation
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new StopLimitOrder(_security.Symbol, 1, 1, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.StopLimitFillWasCalled);
+            Assert.AreEqual(orderEvent, result);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldInterfaceWorks_LimitFill()
+        {
+            var model = new TestFillModelInheritInterface();
+            // IFillModel will detect and call users old implementation
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new LimitOrder(_security.Symbol, 1, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.LimitFillWasCalled);
+            Assert.AreEqual(orderEvent, result);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldInterfaceWorks_MarketOnOpenFill()
+        {
+            var model = new TestFillModelInheritInterface();
+            // IFillModel will detect and call users old implementation
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new MarketOnOpenOrder(_security.Symbol, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.MarketOnOpenFillWasCalled);
+            Assert.AreEqual(orderEvent, result);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldInterfaceWorks_MarketOnCloseFill()
+        {
+            var model = new TestFillModelInheritInterface();
+            // IFillModel will detect and call users old implementation
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new MarketOnCloseOrder(_security.Symbol, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.MarketOnCloseFillWasCalled);
+            Assert.AreEqual(orderEvent, result);
+        }
+
+        #endregion
+
+        #region RetroCompatibilityOldBaseFillModelTests
+
+        [Test]
+        public void RetroCompatibilityOldBaseFillModelWorks_DoesNotOverride_MarketFill()
+        {
+            var model = new TestFillModelInheritBaseClassDoesNotOverride();
+            // IFillModel will detect and call users old implementation
+            // which will call base.FillModel() implementation which will call
+            // core implementation at IFillModel
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new MarketOrder(_security.Symbol, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.IsNotNull(result);
+            Assert.True(model.GetPricesWasCalled);
+            Assert.AreEqual(12345, result.FillPrice);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldBaseFillModelWorks_MarketFill()
+        {
+            var model = new TestFillModelInheritBaseClass();
+            // IFillModel will detect and call users old implementation
+            // which will call base.FillModel() implementation which will call
+            // core implementation at IFillModel
+            var result = model.Fill(
+                new FillModelContext(_security,
+                new MarketOrder(_security.Symbol, 1, orderDateTime),
+                new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.MarketFillWasCalled);
+            Assert.IsNotNull(result);
+            Assert.True(model.GetPricesWasCalled);
+            Assert.AreEqual(12345, result.FillPrice);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldBaseFillModelWorks_StopMarketFill()
+        {
+            var model = new TestFillModelInheritBaseClass();
+            // IFillModel will detect and call users old implementation
+            // which will call base.FillModel() implementation which will call
+            // core implementation at IFillModel
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new StopMarketOrder(_security.Symbol, 1, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.StopMarketFillWasCalled);
+            Assert.IsNotNull(result);
+            Assert.True(model.GetPricesWasCalled);
+            Assert.AreEqual(12345, result.FillPrice);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldBaseFillModelWorks_StopLimitFill()
+        {
+            var model = new TestFillModelInheritBaseClass();
+            // IFillModel will detect and call users old implementation
+            // which will call base.FillModel() implementation which will call
+            // core implementation at IFillModel
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new StopLimitOrder(_security.Symbol, 1, 1, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.StopLimitFillWasCalled);
+            Assert.IsNotNull(result);
+            Assert.True(model.GetPricesWasCalled);
+            Assert.AreEqual(1, result.FillPrice);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldBaseFillModelWorks_LimitFill()
+        {
+            var model = new TestFillModelInheritBaseClass();
+            // IFillModel will detect and call users old implementation
+            // which will call base.FillModel() implementation which will call
+            // core implementation at IFillModel
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new LimitOrder(_security.Symbol, 1, 12346, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.LimitFillWasCalled);
+            Assert.IsNotNull(result);
+            Assert.True(model.GetPricesWasCalled);
+            Assert.AreEqual(12345, result.FillPrice);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldBaseFillModelWorks_MarketOnOpenFill()
+        {
+            var model = new TestFillModelInheritBaseClass();
+            _security.SetMarketPrice(new Tick(orderDateTime, _security.Symbol, 88, 88));
+
+            // IFillModel will detect and call users old implementation
+            // which will call base.FillModel() implementation which will call
+            // core implementation at IFillModel
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new MarketOnOpenOrder(_security.Symbol, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.MarketOnOpenFillWasCalled);
+            Assert.IsNotNull(result);
+            Assert.True(model.GetPricesWasCalled);
+            Assert.AreEqual(12345, result.FillPrice);
+        }
+
+        [Test]
+        public void RetroCompatibilityOldBaseFillModelWorks_MarketOnCloseFill()
+        {
+            var model = new TestFillModelInheritBaseClass();
+            // IFillModel will detect and call users old implementation
+            // which will call base.FillModel() implementation which will call
+            // core implementation at IFillModel
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new MarketOnCloseOrder(_security.Symbol, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.MarketOnCloseFillWasCalled);
+            Assert.IsNotNull(result);
+            Assert.True(model.GetPricesWasCalled);
+            Assert.AreEqual(12345, result.FillPrice);
+        }
+
+        #endregion
+
+        [Test]
+        public void NewFillModelInheritWorks()
+        {
+            var model = new NewFillModelInherit();
+            // IFillModel will detect and call users old implementation
+            // which will call base.FillModel() implementation which will call
+            // core implementation at IFillModel
+            var result = model.Fill(
+                new FillModelContext(_security,
+                    new MarketOrder(_security.Symbol, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config)));
+
+            Assert.True(model.MarketFillWasCalled);
+            Assert.IsNotNull(result);
+        }
+
+        private class TestFillModelInheritInterface : IFillModel
+        {
+            public bool MarketFillWasCalled;
+            public bool StopMarketFillWasCalled;
+            public bool StopLimitFillWasCalled;
+            public bool LimitFillWasCalled;
+            public bool MarketOnOpenFillWasCalled;
+            public bool MarketOnCloseFillWasCalled;
+
+            public OrderEvent MarketFill(Security asset, MarketOrder order)
+            {
+                MarketFillWasCalled = true;
+                return orderEvent;
+            }
+
+            public OrderEvent StopMarketFill(Security asset, StopMarketOrder order)
+            {
+                StopMarketFillWasCalled = true;
+                return orderEvent;
+            }
+
+            public OrderEvent StopLimitFill(Security asset, StopLimitOrder order)
+            {
+                StopLimitFillWasCalled = true;
+                return orderEvent;
+            }
+
+            public OrderEvent LimitFill(Security asset, LimitOrder order)
+            {
+                LimitFillWasCalled = true;
+                return orderEvent;
+            }
+
+            public OrderEvent MarketOnOpenFill(Security asset, MarketOnOpenOrder order)
+            {
+                MarketOnOpenFillWasCalled = true;
+                return orderEvent;
+            }
+
+            public OrderEvent MarketOnCloseFill(Security asset, MarketOnCloseOrder order)
+            {
+                MarketOnCloseFillWasCalled = true;
+                return orderEvent;
+            }
+        }
+
+        private class TestFillModelInheritBaseClass : FillModel
+        {
+            public bool MarketFillWasCalled;
+            public bool StopMarketFillWasCalled;
+            public bool StopLimitFillWasCalled;
+            public bool LimitFillWasCalled;
+            public bool MarketOnOpenFillWasCalled;
+            public bool MarketOnCloseFillWasCalled;
+            public bool GetPricesWasCalled;
+
+            public override OrderEvent MarketFill(Security asset, MarketOrder order)
+            {
+                MarketFillWasCalled = true;
+                return base.MarketFill(asset, order);
+            }
+
+            public override OrderEvent StopMarketFill(Security asset, StopMarketOrder order)
+            {
+                StopMarketFillWasCalled = true;
+                return base.StopMarketFill(asset, order);
+            }
+
+            public override OrderEvent StopLimitFill(Security asset, StopLimitOrder order)
+            {
+                StopLimitFillWasCalled = true;
+                return base.StopLimitFill(asset, order);
+            }
+
+            public override OrderEvent LimitFill(Security asset, LimitOrder order)
+            {
+                LimitFillWasCalled = true;
+                return base.LimitFill(asset, order);
+            }
+
+            public OrderEvent MarketOnOpenFill(Security asset, MarketOnOpenOrder order)
+            {
+                MarketOnOpenFillWasCalled = true;
+                return base.MarketOnOpenFill(asset, order);
+            }
+
+            public OrderEvent MarketOnCloseFill(Security asset, MarketOnCloseOrder order)
+            {
+                MarketOnCloseFillWasCalled = true;
+                return base.MarketOnCloseFill(asset, order);
+            }
+
+            protected override Prices GetPrices(Security asset, OrderDirection direction)
+            {
+                GetPricesWasCalled = true;
+                return new Prices(orderDateTime, 12345, 12345, 12345, 12345, 12345);
+            }
+        }
+
+        private class TestFillModelInheritBaseClassDoesNotOverride : FillModel
+        {
+            public bool GetPricesWasCalled;
+
+            protected override Prices GetPrices(Security asset, OrderDirection direction)
+            {
+                GetPricesWasCalled = true;
+                // call base.GetPrices() just to test it show its possible
+                base.GetPrices(asset, direction);
+                return new Prices(orderDateTime, 12345, 12345, 12345, 12345, 12345);
+            }
+        }
+
+        private class NewFillModelInherit : IFillModel
+        {
+            public bool MarketFillWasCalled;
+
+            protected override OrderEvent MarketFill(FillModelContext context)
+            {
+                MarketFillWasCalled = true;
+                return base.MarketFill(context);
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -161,7 +161,7 @@
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
     <Compile Include="Common\Data\Fundamental\MultiPeriodFieldTests.cs" />
     <Compile Include="Common\Data\MockSubscriptionDataConfigProvider.cs" />
-    <Compile Include="Common\Orders\Fills\RetroCompatibilityFillModelsTests.cs" />
+    <Compile Include="Common\Orders\Fills\BackwardsCompatibilityFillModelsTests.cs" />
     <Compile Include="Common\Securities\CashAmountTests.cs" />
     <Compile Include="Common\Data\Custom\QuandlTests.cs" />
     <Compile Include="Common\Securities\ErrorCurrencyConverterTests.cs" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -160,6 +160,8 @@
     <Compile Include="Common\Data\Auxiliary\FactorFileTests.cs" />
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
     <Compile Include="Common\Data\Fundamental\MultiPeriodFieldTests.cs" />
+    <Compile Include="Common\Data\MockSubscriptionDataConfigProvider.cs" />
+    <Compile Include="Common\Orders\Fills\RetroCompatibilityFillModelsTests.cs" />
     <Compile Include="Common\Securities\CashAmountTests.cs" />
     <Compile Include="Common\Data\Custom\QuandlTests.cs" />
     <Compile Include="Common\Securities\ErrorCurrencyConverterTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The objective of this PR is to remove usages of `Security.Subscriptions` and
`Security.IsExtendedMarketHours` properties by `FillModels` maintaining retro-compatibility.

System will always call new `Fill(FillModelContext context)` which will detect if the user is overriting old `xxxxFill(Security asset, MarketOrder order)` and call it insted. 
> If users fill model implementation inherited `FillModel` and calls `base.xxxxFill(Security asset, MarketOrder order)`, `FillModel` will now send the call to new `xxxxFillImplementation(FillModelContext context)`, not `Fill(FillModelContext context)` (else we would loop).

- Making `IFillModel` a class
- Adding new `FillModelContext` that will hold `Security`, `Order` and
`ISubscriptionDataConfigProvider`
- Adding new `InterfaceFillModel` who will replace old `IFillModel`.
New `Fill()` method will have new `FillModelContext` as only parameter
- Adding unit tests showcasing retro compatibility.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2634
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/5
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
yes, link https://www.quantconnect.com/docs/algorithm-reference/reality-modelling#Reality-Modelling-Fill-Models

> The Fill Models implement the `IFillModelInterface` interface. => `OrderEvent Fill(FillModelContext context)`

> Users are suggested to override base class `FillModel`, which allows users to overwrite a specific order type fill method, as `OrderEvent MarketFill(FillModelContext context)`. Versus having to handle all order types when directly implemeting `IFillModelInterface` interface, unless this is desired. => `OrderEvent Fill(FillModelContext context)`
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->