### PR TITLE
Remove unused SubscriptionDataConfig

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -186,6 +186,7 @@
     <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.cs" />
     <Compile Include="TimeInForceAlgorithm.cs" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.cs" />
+    <Compile Include="UniverseSharingSecurityDifferentSubscriptionRequestRegressionAlgorithm.cs" />
     <Compile Include="UniverseSharingSubscriptionRequestRegressionAlgorithm.cs" />
     <Compile Include="UserDefinedUniverseAlgorithm.cs" />
     <Compile Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs" />

--- a/Algorithm.CSharp/UniverseSharingSecurityDifferentSubscriptionRequestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UniverseSharingSecurityDifferentSubscriptionRequestRegressionAlgorithm.cs
@@ -1,0 +1,157 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This regression algorithm has two different Universe using the same Security but with
+    /// different SubscriptionDataConfig. One of them will add and remove it in a toggle fashion and it should also remove the
+    /// corresponding SubscriptionDataConfig.
+    /// Also will test manually adding and removing a security.
+    /// </summary>
+    /// <meta name="tag" content="regression test" />
+    public class UniverseSharingSecurityDifferentSubscriptionRequestRegressionAlgorithm
+        : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private readonly Symbol _spy = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+        private readonly Symbol _aig = QuantConnect.Symbol.Create("AIG", SecurityType.Equity, Market.USA);
+        private int _onDataCalls;
+        private bool _alreadyRemoved;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 08);  //Set Start Date
+            SetEndDate(2013, 10, 11);    //Set End Date
+            SetCash(100000); //Set Strategy Cash
+
+            AddEquity("SPY");
+            AddEquity("AIG");
+
+            UniverseSettings.Resolution = Resolution.Minute;
+            UniverseSettings.ExtendedMarketHours = true;
+            AddUniverse(SecurityType.Equity,
+                "SecondUniverse",
+                Resolution.Daily,
+                Market.USA,
+                UniverseSettings,
+                time => time.Day % 2 == 0 ? new[] { "SPY" } : Enumerable.Empty<string>()
+            );
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            _onDataCalls++;
+
+            if (!_alreadyRemoved)
+            {
+                _alreadyRemoved = true;
+                var config = SubscriptionManager
+                    .SubscriptionDataConfigService
+                    .GetSubscriptionDataConfigs(_aig);
+                if (!config.Any())
+                {
+                    throw new Exception("Expecting to find a SubscriptionDataConfig for AIG");
+                }
+                RemoveSecurity(_aig);
+
+                config = SubscriptionManager
+                    .SubscriptionDataConfigService
+                    .GetSubscriptionDataConfigs(_aig);
+                if (config.Any())
+                {
+                    throw new Exception($"Unexpected SubscriptionDataConfig: {config}");
+                }
+            }
+
+            var isExtendedMarketHours = SubscriptionManager
+                .SubscriptionDataConfigService
+                .GetSubscriptionDataConfigs(_spy)
+                .IsExtendedMarketHours();
+
+            if (Time.Day % 2 == 0)
+            {
+                if (!isExtendedMarketHours)
+                {
+                    throw new Exception($"Unexpected isExtendedMarketHours value: {false}");
+                }
+            }
+            else
+            {
+                if (isExtendedMarketHours)
+                {
+                    throw new Exception($"Unexpected isExtendedMarketHours value: {true}");
+                }
+
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_onDataCalls == 0)
+            {
+                throw new Exception($"Unexpected OnData() calls count {_onDataCalls}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"}
+        };
+    }
+}

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1711,8 +1711,6 @@ namespace QuantConnect.Algorithm
 
                         security = CreateBenchmarkSecurity();
                     }
-
-                    SubscriptionManager.HasCustomData = universe.Members.Any(x => x.Value.Subscriptions.Any(y => y.IsCustomData));
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- After removing a `Subscription` entirely, we will now also remove the
matching `SubscriptionDataConfig` from the `SubscriptionManager`
- Adding a new regression test, which fails in `master`
- Fixing previous PR change that reduced log level from `Trace` to `Debug` when adding
and removing a `Subscription`, for live mode
- Fixing a bug in the `UserDefinedUniverse` where calling `RemoveMember`
would cause the `SubscriptionDataConfig` to be re added to the
`SubscriptionManager` (not the `DF`). Found this through added
regression test. Fixed by calling new `private RemoveAndKeepTrack()` from both
 `RemoveMember()` and `Remove()` (has no impact today in `master`)
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2635
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/5
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->