### PR TITLE
Fix incorrect symbol market used when loading holdings/open orders from brokerage

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -386,7 +386,7 @@ namespace QuantConnect.Lean.Engine.Setup
                 else
                 {
                     // for items not directly requested set leverage to 1 and at the min resolution
-                    algorithm.AddSecurity(symbol.SecurityType, symbol.Value, minResolution, null, true, 1.0m, false);
+                    algorithm.AddSecurity(symbol.SecurityType, symbol.Value, minResolution, symbol.ID.Market, true, 1.0m, false);
                 }
             }
         }

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -142,6 +142,51 @@ namespace QuantConnect.Tests.Engine.Setup
             }
         }
 
+        [Test]
+        public void LoadsHoldingsForExpectedMarket()
+        {
+            var symbol = Symbol.Create("AUDUSD", SecurityType.Forex, Market.Oanda);
+
+            var algorithm = new TestAlgorithm();
+            algorithm.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage);
+
+            algorithm.SetHistoryProvider(new BrokerageTransactionHandlerTests.BrokerageTransactionHandlerTests.EmptyHistoryProvider());
+            var job = new LiveNodePacket
+            {
+                UserId = 1,
+                ProjectId = 1,
+                DeployId = "1",
+                Brokerage = "PaperBrokerage",
+                DataQueueHandler = "none"
+            };
+            // Increasing RAM limit, else the tests fail. This is happening in master, when running all the tests together, locally (not travis).
+            job.Controls.RamAllocation = 1024 * 1024 * 1024;
+
+            var resultHandler = new Mock<IResultHandler>();
+            var transactionHandler = new Mock<ITransactionHandler>();
+            var realTimeHandler = new Mock<IRealTimeHandler>();
+            var brokerage = new Mock<IBrokerage>();
+
+            brokerage.Setup(x => x.IsConnected).Returns(true);
+            brokerage.Setup(x => x.GetCashBalance()).Returns(new List<Cash>());
+            brokerage.Setup(x => x.GetAccountHoldings()).Returns(new List<Holding>
+            {
+                new Holding { Symbol = symbol, Type = symbol.SecurityType, Quantity = 100 }
+            });
+            brokerage.Setup(x => x.GetOpenOrders()).Returns(new List<Order>());
+
+            var setupHandler = new BrokerageSetupHandler();
+
+            IBrokerageFactory factory;
+            setupHandler.CreateBrokerage(job, algorithm, out factory);
+
+            Assert.IsTrue(setupHandler.Setup(algorithm, brokerage.Object, job, resultHandler.Object, transactionHandler.Object, realTimeHandler.Object));
+
+            Security security;
+            Assert.IsTrue(algorithm.Portfolio.Securities.TryGetValue(symbol, out security));
+            Assert.AreEqual(symbol, security.Symbol);
+        }
+
         public TestCaseData[] GetExistingHoldingsAndOrdersTestCaseData()
         {
             return new[]


### PR DESCRIPTION

#### Description
In the `BrokerageSetupHandler`, after fetching holdings and/or open orders from a brokerage, the unrequested securities will now be added to the algorithm using the market included in the symbols.

#### Related Issue
Closes #2686 

#### Motivation and Context
An exception was thrown when deploying an algorithm with existing holdings, using a brokerage model different from the brokerage.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included + verified algorithm deployment to Oanda with existing holding and open order.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`