### PR TITLE
Fix DowngradeErrorCodeToWarningBrokerageMessageHandler for Python compatibility

### DIFF
--- a/Common/Brokerages/DowngradeErrorCodeToWarningBrokerageMessageHandler.cs
+++ b/Common/Brokerages/DowngradeErrorCodeToWarningBrokerageMessageHandler.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Brokerages
         /// </summary>
         /// <param name="brokerageMessageHandler">The brokerage message handler to be wrapped</param>
         /// <param name="errorCodesToIgnore">The error codes to convert to warning messages</param>
-        public DowngradeErrorCodeToWarningBrokerageMessageHandler(IBrokerageMessageHandler brokerageMessageHandler, List<string> errorCodesToIgnore)
+        public DowngradeErrorCodeToWarningBrokerageMessageHandler(IBrokerageMessageHandler brokerageMessageHandler, string[] errorCodesToIgnore)
         {
             _brokerageMessageHandler = brokerageMessageHandler;
             _errorCodesToIgnore = errorCodesToIgnore.ToHashSet();

--- a/Tests/Brokerages/DowngradeErrorCodeToWarningBrokerageMessageHandlerTests.cs
+++ b/Tests/Brokerages/DowngradeErrorCodeToWarningBrokerageMessageHandlerTests.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
 using QuantConnect.Brokerages;
@@ -33,7 +32,7 @@ namespace QuantConnect.Tests.Brokerages
             var wrapped = new Mock<IBrokerageMessageHandler>();
             wrapped.Setup(bmh => bmh.Handle(It.IsAny<BrokerageMessageEvent>())).Verifiable();
 
-            var downgrader = new DowngradeErrorCodeToWarningBrokerageMessageHandler(wrapped.Object, new List<string>{"code"});
+            var downgrader = new DowngradeErrorCodeToWarningBrokerageMessageHandler(wrapped.Object, new[] { "code" });
             var message = new BrokerageMessageEvent(type, "code", "message");
             downgrader.Handle(message);
 
@@ -46,7 +45,7 @@ namespace QuantConnect.Tests.Brokerages
             var wrapped = new Mock<IBrokerageMessageHandler>();
             wrapped.Setup(bmh => bmh.Handle(It.IsAny<BrokerageMessageEvent>())).Verifiable();
 
-            var downgrader = new DowngradeErrorCodeToWarningBrokerageMessageHandler(wrapped.Object, new List<string> { "code" });
+            var downgrader = new DowngradeErrorCodeToWarningBrokerageMessageHandler(wrapped.Object, new[] { "code" });
             var message = new BrokerageMessageEvent(BrokerageMessageType.Error, "not-code", "message");
             downgrader.Handle(message);
 
@@ -59,7 +58,7 @@ namespace QuantConnect.Tests.Brokerages
             var wrapped = new Mock<IBrokerageMessageHandler>();
             wrapped.Setup(bmh => bmh.Handle(It.IsAny<BrokerageMessageEvent>())).Verifiable();
 
-            var downgrader = new DowngradeErrorCodeToWarningBrokerageMessageHandler(wrapped.Object, new List<string> { "code" });
+            var downgrader = new DowngradeErrorCodeToWarningBrokerageMessageHandler(wrapped.Object, new[] { "code" });
             var message = new BrokerageMessageEvent(BrokerageMessageType.Error, "code", "message");
             downgrader.Handle(message);
 


### PR DESCRIPTION
#### Description
Constructor argument has been changed from C# generic list type to array type. Thanks @AlexCatarino 

#### Related Issue
Closes #2690 

#### Motivation and Context
The `DowngradeErrorCodeToWarningBrokerageMessageHandler` (added in PR #2610) was not usable in Python algorithms.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
This example code can now be used in a Python algorithm:
```
AddReference("QuantConnect.Brokerages")
from QuantConnect.Brokerages import DowngradeErrorCodeToWarningBrokerageMessageHandler

self.SetBrokerageMessageHandler( DowngradeErrorCodeToWarningBrokerageMessageHandler(self.BrokerageMessageHandler, ["200"]))
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`