### PR TITLE
Changes the custom data type base class

### DIFF
--- a/Algorithm.Python/CustomDataRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataRegressionAlgorithm.py
@@ -44,6 +44,7 @@ class CustomDataRegressionAlgorithm(QCAlgorithm):
 
         resolution = Resolution.Second if self.LiveMode else Resolution.Daily
         self.AddData(Bitcoin, "BTC", resolution)
+        self.SetWarmup(1)
 
     def OnData(self, data):
         if not self.Portfolio.Invested:

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1002,7 +1002,7 @@ namespace QuantConnect.Algorithm
                 var typeBuilder = AppDomain.CurrentDomain
                     .DefineDynamicAssembly(an, AssemblyBuilderAccess.Run)
                     .DefineDynamicModule("MainModule")
-                    .DefineType(an.Name, TypeAttributes.Class, typeof(DynamicData));
+                    .DefineType(an.Name, TypeAttributes.Class, type);
 
                 pythonType = new PythonActivator(typeBuilder.CreateType(), pyObject);
 


### PR DESCRIPTION
#### Description
By using the python object parant class, which is either `PythonQuandl` or `PythonData`, instead of `DynamicData`, the `AlgorithmManager.Stream` method can find a matching subcription data configuration used to create a data feed packet.

#### Related Issue
Closes #2694

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
Unit and regression tests.
`self.SetWarmup(1)` was added to [CustomDataRegressionAlgorithm.Initialize](https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/CustomDataRegressionAlgorithm.py#L39) to test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`