### PR TITLE
Obsoleting Security: IsFillDataForward - Resolution - IsExtendedMarketHours

### DIFF
--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -78,16 +78,24 @@ namespace QuantConnect.Algorithm
                         ConfigureUnderlyingSecurity(security);
                     }
 
+                    var configs = SubscriptionManager.SubscriptionDataConfigService
+                        .GetSubscriptionDataConfigs(security.Symbol);
                     if (security.Symbol.HasUnderlying)
                     {
                         Security underlyingSecurity;
                         var underlyingSymbol = security.Symbol.Underlying;
+                        var resolution = configs.GetHighestResolution();
 
                         // create the underlying security object if it doesn't already exist
                         if (!Securities.TryGetValue(underlyingSymbol, out underlyingSecurity))
                         {
-                            underlyingSecurity = AddSecurity(underlyingSymbol.SecurityType, underlyingSymbol.Value, security.Resolution,
-                                underlyingSymbol.ID.Market, false, 0, security.IsExtendedMarketHours);
+                            underlyingSecurity = AddSecurity(underlyingSymbol.SecurityType,
+                                underlyingSymbol.Value,
+                                resolution,
+                                underlyingSymbol.ID.Market,
+                                false,
+                                0,
+                                configs.IsExtendedMarketHours());
                         }
 
                         // set data mode raw and default volatility model
@@ -100,14 +108,14 @@ namespace QuantConnect.Algorithm
                                 // lets request the higher resolution
                                 var currentResolutionRequest = requiredHistoryRequests[underlyingSecurity];
                                 if (currentResolutionRequest != Resolution.Minute  // Can not be less than Minute
-                                    && security.Resolution < currentResolutionRequest)
+                                    && resolution < currentResolutionRequest)
                                 {
-                                    requiredHistoryRequests[underlyingSecurity] = (Resolution)Math.Max((int)security.Resolution, (int)Resolution.Minute);
+                                    requiredHistoryRequests[underlyingSecurity] = (Resolution)Math.Max((int)resolution, (int)Resolution.Minute);
                                 }
                             }
                             else
                             {
-                                requiredHistoryRequests.Add(underlyingSecurity, (Resolution)Math.Max((int)security.Resolution, (int)Resolution.Minute));
+                                requiredHistoryRequests.Add(underlyingSecurity, (Resolution)Math.Max((int)resolution, (int)Resolution.Minute));
                             }
                         }
                         // set the underlying security on the derivative -- we do this in two places since it's possible

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1578,18 +1578,31 @@ namespace QuantConnect.Algorithm
             // add underlying if not present
             var underlying = option.Symbol.Underlying;
             Security equity;
+            List<SubscriptionDataConfig> underlyingConfigs;
             if (!Securities.TryGetValue(underlying, out equity))
             {
-                equity = AddEquity(underlying.Value, option.Resolution, underlying.ID.Market, false);
+                equity = AddEquity(underlying.Value, resolution, underlying.ID.Market, false);
+                underlyingConfigs = SubscriptionManager.SubscriptionDataConfigService
+                    .GetSubscriptionDataConfigs(underlying);
             }
-            else if (equity.DataNormalizationMode != DataNormalizationMode.Raw && _locked)
+            else
             {
-                // We check the "locked" flag here because during initialization we need to load existing open orders and holdings from brokerages.
-                // There is no data streaming yet, so it is safe to change the data normalization mode to Raw.
-                throw new ArgumentException($"The underlying equity asset ({underlying.Value}) is set to {equity.DataNormalizationMode}, " +
-                                            "please change this to DataNormalizationMode.Raw with the SetDataNormalization() method");
+                underlyingConfigs = SubscriptionManager.SubscriptionDataConfigService
+                    .GetSubscriptionDataConfigs(underlying);
+
+                var dataNormalizationMode = underlyingConfigs.DataNormalizationMode();
+                if (dataNormalizationMode != DataNormalizationMode.Raw && _locked)
+                {
+                    // We check the "locked" flag here because during initialization we need to load existing open orders and holdings from brokerages.
+                    // There is no data streaming yet, so it is safe to change the data normalization mode to Raw.
+                    throw new ArgumentException($"The underlying equity asset ({underlying.Value}) is set to {dataNormalizationMode}, " +
+                                                "please change this to DataNormalizationMode.Raw with the SetDataNormalization() method");
+                }
             }
-            equity.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            foreach (var config in underlyingConfigs)
+            {
+                config.DataNormalizationMode = DataNormalizationMode.Raw;
+            }
 
             option.Underlying = equity;
 

--- a/Common/Brokerages/DefaultBrokerageMessageHandler.cs
+++ b/Common/Brokerages/DefaultBrokerageMessageHandler.cs
@@ -17,6 +17,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Packets;
@@ -94,7 +95,12 @@ namespace QuantConnect.Brokerages
                                 where security.Type != SecurityType.Base
                                 let exchange = security.Exchange
                                 let localTime = _algorithm.UtcTime.ConvertFromUtc(exchange.TimeZone)
-                                where exchange.IsOpenDuringBar(localTime, localTime + _openThreshold, security.IsExtendedMarketHours)
+                                where exchange.IsOpenDuringBar(
+                                    localTime,
+                                    localTime + _openThreshold,
+                                    _algorithm.SubscriptionManager.SubscriptionDataConfigService
+                                        .GetSubscriptionDataConfigs(security.Symbol)
+                                        .IsExtendedMarketHours())
                                 select security).Any();
 
                     // if any are open then we need to kill the algorithm
@@ -118,7 +124,10 @@ namespace QuantConnect.Brokerages
                                                  where security.Type != SecurityType.Base
                                                  let exchange = security.Exchange
                                                  let localTime = _algorithm.UtcTime.ConvertFromUtc(exchange.TimeZone)
-                                                 let marketOpen = exchange.Hours.GetNextMarketOpen(localTime, security.IsExtendedMarketHours)
+                                                 let marketOpen = exchange.Hours.GetNextMarketOpen(localTime,
+                                                     _algorithm.SubscriptionManager.SubscriptionDataConfigService
+                                                         .GetSubscriptionDataConfigs(security.Symbol)
+                                                         .IsExtendedMarketHours())
                                                  let marketOpenUtc = marketOpen.ConvertToUtc(exchange.TimeZone)
                                                  select marketOpenUtc).Min();
                         }

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -86,16 +86,19 @@ namespace QuantConnect.Securities
         /// Resolution of data requested for this security.
         /// </summary>
         /// <remarks>Tick, second or minute resolution for QuantConnect assets.</remarks>
+        [Obsolete("This property is obsolete. Use the 'SubscriptionDataConfig' exposed by 'SubscriptionManager'")]
         public Resolution Resolution { get; private set; }
 
         /// <summary>
         /// Indicates the data will use previous bars when there was no trading in this time period. This was a configurable datastream setting set in initialization.
         /// </summary>
+        [Obsolete("This property is obsolete. Use the 'SubscriptionDataConfig' exposed by 'SubscriptionManager'")]
         public bool IsFillDataForward { get; private set; }
 
         /// <summary>
         /// Indicates the security will continue feeding data after the primary market hours have closed. This was a configurable setting set in initialization.
         /// </summary>
+        [Obsolete("This property is obsolete. Use the 'SubscriptionDataConfig' exposed by 'SubscriptionManager'")]
         public bool IsExtendedMarketHours { get; private set; }
 
         /// <summary>

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -115,10 +115,6 @@ namespace QuantConnect.Securities
         /// <returns>History request object list, or empty if no requirements</returns>
         public override IEnumerable<HistoryRequest> GetHistoryRequirements(Security security, DateTime utcTime)
         {
-            var barCount = _window.Size + 1;
-            var localStartTime = Time.GetStartTimeForTradeBars(security.Exchange.Hours, utcTime.ConvertFromUtc(security.Exchange.TimeZone), _periodSpan, barCount, security.IsExtendedMarketHours);
-            var utcStartTime = localStartTime.ConvertToUtc(security.Exchange.TimeZone);
-
             if (SubscriptionDataConfigProvider == null)
             {
                 throw new Exception(
@@ -126,9 +122,21 @@ namespace QuantConnect.Securities
                     "SubscriptionDataConfigProvider was not set."
                 );
             }
+
             var configurations = SubscriptionDataConfigProvider
                 .GetSubscriptionDataConfigs(security.Symbol)
                 .ToList();
+
+            var barCount = _window.Size + 1;
+            var extendedMarketHours = configurations.IsExtendedMarketHours();
+            var localStartTime = Time.GetStartTimeForTradeBars(
+                security.Exchange.Hours,
+                utcTime.ConvertFromUtc(security.Exchange.TimeZone),
+                _periodSpan,
+                barCount,
+                extendedMarketHours);
+
+            var utcStartTime = localStartTime.ConvertToUtc(security.Exchange.TimeZone);
             var configuration = configurations.First();
 
             return new[]
@@ -141,7 +149,7 @@ namespace QuantConnect.Securities
                                    security.Exchange.Hours,
                                    configuration.DataTimeZone,
                                    configurations.GetHighestResolution(),
-                                   configurations.IsExtendedMarketHours(),
+                                   extendedMarketHours,
                                    configurations.IsCustomData(),
                                    configurations.DataNormalizationMode(),
                                    LeanData.GetCommonTickTypeForCommonDataTypes(typeof(TradeBar), security.Type))

--- a/Common/Time.cs
+++ b/Common/Time.cs
@@ -389,7 +389,7 @@ namespace QuantConnect
             {
                 foreach (var security in securities)
                 {
-                    if (security.Exchange.IsOpenDuringBar(day.Date, day.Date.AddDays(1), security.IsExtendedMarketHours)) return true;
+                    if (security.Exchange.DateIsOpen(day.Date)) return true;
                 }
             }
             catch (Exception err)

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -1181,9 +1181,11 @@ namespace QuantConnect.Lean.Engine
                 var nextMarketClose = security.Exchange.Hours.GetNextMarketClose(security.LocalTime, false);
 
                 // determine the latest possible time we can submit a MOC order
-                var highestResolutionSubscription = security.Subscriptions.OrderBy(sub => sub.Resolution).First();
+                var configs = algorithm.SubscriptionManager.SubscriptionDataConfigService
+                    .GetSubscriptionDataConfigs(security.Symbol);
+
                 var latestMarketOnCloseTimeRoundedDownByResolution = nextMarketClose.Subtract(MarketOnCloseOrder.DefaultSubmissionTimeBuffer)
-                    .RoundDownInTimeZone(security.Resolution.ToTimeSpan(), security.Exchange.TimeZone, highestResolutionSubscription.DataTimeZone);
+                    .RoundDownInTimeZone(configs.GetHighestResolution().ToTimeSpan(), security.Exchange.TimeZone, configs.First().DataTimeZone);
 
                 // we don't need to do anyhing until the market closes
                 if (security.LocalTime < latestMarketOnCloseTimeRoundedDownByResolution) continue;

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -175,7 +175,10 @@ namespace QuantConnect.Jupyter
             }
 
             var option = Securities[symbol] as Option;
-            var underlying = AddEquity(symbol.Underlying.Value, option.Resolution);
+            var resolutionToUseForUnderlying = resolution ?? SubscriptionManager.SubscriptionDataConfigService
+                .GetSubscriptionDataConfigs(symbol)
+                .GetHighestResolution();
+            var underlying = AddEquity(symbol.Underlying.Value, resolutionToUseForUnderlying);
 
             var allSymbols = new List<Symbol>();
             for (var date = start; date < end; date = date.AddDays(1))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
> This PR is a mechanical refactor, no behavior changed. The rest of the configuration properties will be obsoleted in following PRs.

- Obsoleting `IsFillDataForward`, `Resolution`, `IsExtendedMarketHours`
`Security` configuration properties. Replacing there usages by
requesting the `SubscriptionDataConfigs` to the new
`SubscriptionDataConfigService`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Tackles part of https://github.com/QuantConnect/Lean/issues/2428
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/5
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
https://www.quantconnect.com/docs/algorithm-reference/securities-and-portfolio#Securities-and-Portfolio-Introduction 
>//Security object properties:
class Security {
    Resolution Resolution;...
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->