### PR TITLE
Add IApi to HistoryProviderInitializeParameters

### DIFF
--- a/Common/Data/HistoryProviderInitializeParameters.cs
+++ b/Common/Data/HistoryProviderInitializeParameters.cs
@@ -30,6 +30,11 @@ namespace QuantConnect.Data
         public AlgorithmNodePacket Job { get; }
 
         /// <summary>
+        /// The API instance
+        /// </summary>
+        public IApi Api { get; }
+
+        /// <summary>
         /// The provider used to get data when it is not present on disk
         /// </summary>
         public IDataProvider DataProvider { get; }
@@ -58,6 +63,7 @@ namespace QuantConnect.Data
         /// Initializes a new instance of the <see cref="HistoryProviderInitializeParameters"/> class from the specified parameters
         /// </summary>
         /// <param name="job">The job</param>
+        /// <param name="api">The API instance</param>
         /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
         /// <param name="dataCacheProvider">Provider used to cache history data files</param>
         /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
@@ -65,6 +71,7 @@ namespace QuantConnect.Data
         /// <param name="statusUpdateAction">Function used to send status updates</param>
         public HistoryProviderInitializeParameters(
             AlgorithmNodePacket job,
+            IApi api,
             IDataProvider dataProvider,
             IDataCacheProvider dataCacheProvider,
             IMapFileProvider mapFileProvider,
@@ -72,6 +79,7 @@ namespace QuantConnect.Data
             Action<int> statusUpdateAction)
         {
             Job = job;
+            Api = api;
             DataProvider = dataProvider;
             DataCacheProvider = dataCacheProvider;
             MapFileProvider = mapFileProvider;

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -176,6 +176,7 @@ namespace QuantConnect.Lean.Engine
                     historyProvider.Initialize(
                         new HistoryProviderInitializeParameters(
                             job,
+                            _systemHandlers.Api,
                             _algorithmHandlers.DataProvider,
                             historyDataCacheProvider,
                             _algorithmHandlers.MapFileProvider,

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -83,6 +83,7 @@ namespace QuantConnect.Jupyter
                 HistoryProvider.Initialize(
                     new HistoryProviderInitializeParameters(
                         null,
+                        null,
                         algorithmHandlers.DataProvider,
                         _dataCacheProvider,
                         mapFileProvider,

--- a/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Tests.Brokerages.Alpaca
             {
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
 
                 var now = DateTime.UtcNow;
 

--- a/Tests/Brokerages/Bitfinex/BitfinexBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexBrokerageHistoryProviderTests.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
 
                 var now = DateTime.UtcNow;
 

--- a/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
 
                 var now = DateTime.UtcNow;
 
@@ -129,7 +129,7 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
 
             var historyProvider = new BrokerageHistoryProvider();
             historyProvider.SetBrokerage(brokerage);
-            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
 
             var stopwatch = Stopwatch.StartNew();
 

--- a/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
             var historyProvider = new BrokerageHistoryProvider();
             historyProvider.SetBrokerage(brokerage);
-            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
 
             var now = DateTime.UtcNow;
 

--- a/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Tests.Brokerages.Oanda
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
 
                 var now = DateTime.UtcNow;
 

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -68,6 +68,7 @@ namespace QuantConnect.Tests.Common.Securities
             historyProvider.Initialize(
                 new HistoryProviderInitializeParameters(
                     null,
+                    null,
                     new DefaultDataProvider(),
                     new SingleEntryDataCacheProvider(new DefaultDataProvider()),
                     new LocalDiskMapFileProvider(),

--- a/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
+++ b/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
@@ -254,7 +254,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void IEXCouldGetHistory(Symbol symbol, Resolution resolution, TimeSpan period, bool received)
         {
             var historyProvider = new IEXDataQueueHandler();
-            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null));
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
 
             var now = DateTime.UtcNow;
 


### PR DESCRIPTION

#### Description
- Added the `IApi` parameter to the `HistoryProviderInitializeParameters` class

#### Motivation and Context
Allows `IHistoryProvider` implementations to use the API in history requests.

#### Requires Documentation Change
No.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`