### PR TITLE
Will now delete removed universe subscriptions

### DIFF
--- a/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
@@ -34,6 +34,7 @@ namespace QuantConnect.Algorithm.CSharp
         private readonly HashSet<Symbol> _expectedSecurities = new HashSet<Symbol>();
         private readonly HashSet<Symbol> _expectedData = new HashSet<Symbol>();
         private readonly HashSet<Symbol> _expectedUniverses = new HashSet<Symbol>();
+        private bool _expectUniverseSubscription;
 
         // order of expected contract additions as price moves
         private int _expectedContractIndex;
@@ -61,6 +62,12 @@ namespace QuantConnect.Algorithm.CSharp
         public override void OnData(Slice data)
         {
             // verify expectations
+            if (SubscriptionManager.Subscriptions.Count(x => x.Symbol == OptionChainSymbol)
+                != (_expectUniverseSubscription ? 1 : 0))
+            {
+                Log($"SubscriptionManager.Subscriptions:  {string.Join(" -- ", SubscriptionManager.Subscriptions)}");
+                throw new Exception($"Unexpected {OptionChainSymbol} subscription presence");
+            }
             if (!data.ContainsKey(Underlying))
             {
                 // TODO : In fact, we're unable to properly detect whether or not we auto-added or it was manually added
@@ -111,6 +118,7 @@ namespace QuantConnect.Algorithm.CSharp
 
                 _expectedSecurities.Add(OptionChainSymbol);
                 _expectedUniverses.Add(OptionChainSymbol);
+                _expectUniverseSubscription = true;
             }
 
             // 11:30AM remove GOOG option chain
@@ -121,6 +129,8 @@ namespace QuantConnect.Algorithm.CSharp
                 _expectedData.RemoveWhere(s => _expectedContracts.Contains(s));
                 // remove option chain universe from expected universes
                 _expectedUniverses.Remove(OptionChainSymbol);
+                // OptionChainSymbol universe subscription should not be present
+                _expectUniverseSubscription = false;
             }
         }
 
@@ -203,7 +213,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "6"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.21%"},
-            {"Compounding Annual Return", "-96.657%"},
+            {"Compounding Annual Return", "-98.552%"},
             {"Drawdown", "0.600%"},
             {"Expectancy", "-1"},
             {"Net Profit", "-0.626%"},


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Previously when a user requested to remove a universe, they would call
`RemoveSecurity()`->`UniverseManager.Remove()`-> `Universe.Dispose()` ->
collection change notification would call `DataManager()` that would
call `RemoveSubscription()` that *would not perform any operation* since
it would return `false` through
`if(subscription.IsUniverseSelectionSubscription &&
subscription.Universe.DisposeRequested)`. Previous comment stated that
the `Subscription` would be removed by the `SubscriptionSynchronizer`
via `SubscriptionFinished()` but this call would also go through the same
`if` statemente as above, returning false and no performing any operation.
So the `Universe` `Subscription` was never removed.
See PR https://github.com/QuantConnect/Lean/pull/2039
- In this PR I'm removing the mentioned `if` statement and the call
relation between `UniverseManager.Remove()` and
`DataManager.RemoveSubscription()` since this will be covered by the
`SubscriptionSynchronizer` in the next loop.
- Modified regression test (originally added with these changes at
https://github.com/QuantConnect/Lean/pull/2039) to verify this issue (fails in `master`).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2478
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
-  Removed universe subscriptions are actually removed
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->