### PR TITLE
Increasing timer time step for Quandl unit test

### DIFF
--- a/Tests/Engine/DataFeeds/CustomLiveDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/CustomLiveDataFeedTests.cs
@@ -76,13 +76,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var lastFileWriteDate = DateTime.MinValue;
 
             // create a timer to advance time much faster than realtime and to simulate live Quandl data file updates
-            var timerInterval = TimeSpan.FromMilliseconds(10);
+            var timerInterval = TimeSpan.FromMilliseconds(20);
             var timer = Ref.Create<Timer>(null);
             timer.Value = new Timer(state =>
             {
-                // stop the timer to prevent reentrancy
-                timer.Value.Change(Timeout.Infinite, Timeout.Infinite);
-
                 var currentTime = timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork);
 
                 if (currentTime.Date > endDate.Date)
@@ -145,9 +142,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 //Log.Trace($"Time advanced to: {timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork)}");
 
                 // restart the timer
-                timer.Value.Change(timerInterval, timerInterval);
+                timer.Value.Change(timerInterval.Milliseconds, Timeout.Infinite);
 
-            }, null, TimeSpan.FromMilliseconds(50), timerInterval);
+            }, null, timerInterval.Milliseconds, Timeout.Infinite);
 
             try
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Increasing the timer time step for the
EmitsDailyQuandlFutureDataOverWeekends unit test.
- Now to avoid re entrancy I'm directly disabling it.
> Unit test now delays ~40 seconds vs ~20 seconds (today in master). As a reference, before https://github.com/QuantConnect/Lean/pull/2704 it took 3:30
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2726
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- There should be no intermittent failing test
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executed locally multiple times. 6 times on travis
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->