### PR TITLE
BuyingPowerModel.GetInitialMarginRequiredForOrder will receive a Parameters object

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Python\BuyingPowerModelPythonWrapper.cs" />
     <Compile Include="Securities\CashAmount.cs" />
     <Compile Include="Securities\IdentityCurrencyConverter.cs" />
+    <Compile Include="Securities\InitialMarginRequiredForOrderParameters.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPosition.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPositionParameters.cs" />
     <Compile Include="Securities\SecurityService.cs" />

--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -130,16 +130,19 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Gets the total margin required to execute the specified order in units of the account currency including fees
         /// </summary>
-        /// <param name="security">The security to compute initial margin for</param>
-        /// <param name="order">The order to be executed</param>
+        /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        protected virtual decimal GetInitialMarginRequiredForOrder(Security security, Order order)
+        protected virtual decimal GetInitialMarginRequiredForOrder(
+            InitialMarginRequiredForOrderParameters parameters)
         {
             //Get the order value from the non-abstract order classes (MarketOrder, LimitOrder, StopMarketOrder)
             //Market order is approximated from the current security price and set in the MarketOrder Method in QCAlgorithm.
-            var orderFees = security.FeeModel.GetOrderFee(security, order);
+            var orderFees = parameters.Security.FeeModel.GetOrderFee(
+                parameters.Security,
+                parameters.Order);
 
-            var orderValue = order.GetValue(security) * GetInitialMarginRequirement(security);
+            var orderValue = parameters.Order.GetValue(parameters.Security)
+                * GetInitialMarginRequirement(parameters.Security);
             return orderValue + Math.Sign(orderValue) * orderFees;
         }
 
@@ -276,7 +279,10 @@ namespace QuantConnect.Securities
             }
 
             var freeMargin = GetMarginRemaining(parameters.Portfolio, parameters.Security, parameters.Order.Direction);
-            var initialMarginRequiredForOrder = GetInitialMarginRequiredForOrder(parameters.Security, parameters.Order);
+            var initialMarginRequiredForOrder = GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(parameters.Portfolio.CashBook,
+                    parameters.Security,
+                    parameters.Order));
 
             // pro-rate the initial margin required for order based on how much has already been filled
             var percentUnfilled = (Math.Abs(parameters.Order.Quantity) - Math.Abs(ticket.QuantityFilled)) / Math.Abs(parameters.Order.Quantity);

--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -70,16 +70,18 @@ namespace QuantConnect.Securities.Future
         /// <summary>
         /// Gets the total margin required to execute the specified order in units of the account currency including fees
         /// </summary>
-        /// <param name="security">The security to compute initial margin for</param>
-        /// <param name="order">The order to be executed</param>
+        /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        protected override decimal GetInitialMarginRequiredForOrder(Security security, Order order)
+        protected override decimal GetInitialMarginRequiredForOrder(
+            InitialMarginRequiredForOrderParameters parameters)
         {
             //Get the order value from the non-abstract order classes (MarketOrder, LimitOrder, StopMarketOrder)
             //Market order is approximated from the current security price and set in the MarketOrder Method in QCAlgorithm.
-            var orderFees = security.FeeModel.GetOrderFee(security, order);
-            var value = order.GetValue(security);
-            var orderValue = value * GetInitialMarginRequirement(security, value);
+            var orderFees = parameters.Security.FeeModel.GetOrderFee(
+                parameters.Security,
+                parameters.Order);
+            var value = parameters.Order.GetValue(parameters.Security);
+            var orderValue = value * GetInitialMarginRequirement(parameters.Security, value);
 
             return orderValue + Math.Sign(orderValue) * orderFees;
         }

--- a/Common/Securities/InitialMarginRequiredForOrderParameters.cs
+++ b/Common/Securities/InitialMarginRequiredForOrderParameters.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Orders;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Defines the parameters for <see cref="BuyingPowerModel.GetInitialMarginRequiredForOrder"/>
+    /// </summary>
+    public class InitialMarginRequiredForOrderParameters
+    {
+        /// <summary>
+        /// Gets the security
+        /// </summary>
+        public Security Security { get; }
+
+        /// <summary>
+        /// Gets the order
+        /// </summary>
+        public Order Order { get; }
+
+        /// <summary>
+        /// Gets the currency converter
+        /// </summary>
+        public ICurrencyConverter CurrencyConverter { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InitialMarginRequiredForOrderParameters"/> class
+        /// </summary>
+        /// <param name="currencyConverter">The currency converter</param>
+        /// <param name="security">The security</param>
+        /// <param name="order">The order</param>
+        public InitialMarginRequiredForOrderParameters(
+            ICurrencyConverter currencyConverter,
+            Security security,
+            Order order)
+        {
+            CurrencyConverter = currencyConverter;
+            Security = security;
+            Order = order;
+        }
+    }
+}

--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -66,16 +66,18 @@ namespace QuantConnect.Securities.Option
         /// <summary>
         /// Gets the total margin required to execute the specified order in units of the account currency including fees
         /// </summary>
-        /// <param name="security">The security to compute initial margin for</param>
-        /// <param name="order">The order to be executed</param>
+        /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        protected override decimal GetInitialMarginRequiredForOrder(Security security, Order order)
+        protected override decimal GetInitialMarginRequiredForOrder(
+            InitialMarginRequiredForOrderParameters parameters)
         {
             //Get the order value from the non-abstract order classes (MarketOrder, LimitOrder, StopMarketOrder)
             //Market order is approximated from the current security price and set in the MarketOrder Method in QCAlgorithm.
-            var orderFees = security.FeeModel.GetOrderFee(security, order);
-            var value = order.GetValue(security);
-            var orderValue = value * GetInitialMarginRequirement(security, value);
+            var orderFees = parameters.Security.FeeModel.GetOrderFee(
+                parameters.Security,
+                parameters.Order);
+            var value = parameters.Order.GetValue(parameters.Security);
+            var orderValue = value * GetInitialMarginRequirement(parameters.Security, value);
 
             return orderValue + Math.Sign(orderValue) * orderFees;
         }

--- a/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
+++ b/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
@@ -34,9 +34,10 @@ namespace QuantConnect.Tests.Algorithm
         {
             public TestSecurityMarginModel(decimal leverage) : base(leverage) { }
 
-            public new decimal GetInitialMarginRequiredForOrder(Security security, Order order)
+            public new decimal GetInitialMarginRequiredForOrder(
+                InitialMarginRequiredForOrderParameters parameters)
             {
-                return base.GetInitialMarginRequiredForOrder(security, order);
+                return base.GetInitialMarginRequiredForOrder(parameters);
             }
 
             public new decimal GetMarginRemaining(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)
@@ -166,7 +167,8 @@ namespace QuantConnect.Tests.Algorithm
                 orderQuantity = algorithm.CalculateOrderQuantity(_symbol, targetPercentage);
                 order = new MarketOrder(_symbol, orderQuantity, DateTime.UtcNow);
                 freeMargin = buyingPowerModel.GetMarginRemaining(algorithm.Portfolio, security, orderDirection);
-                requiredMargin = buyingPowerModel.GetInitialMarginRequiredForOrder(security, order);
+                requiredMargin = buyingPowerModel.GetInitialMarginRequiredForOrder(
+                    new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order));
 
                 //Console.WriteLine("Current price: " + security.Price);
                 //Console.WriteLine("Target percentage: " + targetPercentage);
@@ -209,7 +211,8 @@ namespace QuantConnect.Tests.Algorithm
             orderQuantity = algorithm.CalculateOrderQuantity(_symbol, targetPercentage);
             order = new MarketOrder(_symbol, orderQuantity, DateTime.UtcNow);
             freeMargin = buyingPowerModel.GetMarginRemaining(algorithm.Portfolio, security, orderDirection);
-            requiredMargin = buyingPowerModel.GetInitialMarginRequiredForOrder(security, order);
+            requiredMargin = buyingPowerModel.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order));
 
             //Console.WriteLine("Current price: " + security.Price);
             //Console.WriteLine("Target percentage: " + targetPercentage);

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -30,9 +30,10 @@ namespace QuantConnect.Tests.Common.Securities
         {
             public TestSecurityMarginModel(decimal leverage) : base(leverage) {}
 
-            public new decimal GetInitialMarginRequiredForOrder(Security security, Order order)
+            public new decimal GetInitialMarginRequiredForOrder(
+                InitialMarginRequiredForOrderParameters parameters)
             {
-                return base.GetInitialMarginRequiredForOrder(security, order);
+                return base.GetInitialMarginRequiredForOrder(parameters);
             }
 
             public new decimal GetMarginRemaining(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)
@@ -76,7 +77,8 @@ namespace QuantConnect.Tests.Common.Securities
             var buyingPowerModel = new TestSecurityMarginModel(2);
             security.BuyingPowerModel = buyingPowerModel;
             var order = new MarketOrder(security.Symbol, 100, DateTime.Now);
-            var actual = buyingPowerModel.GetInitialMarginRequiredForOrder(security, order);
+            var actual = buyingPowerModel.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order));
 
             Assert.AreEqual(0, actual);
         }

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -40,9 +40,10 @@ namespace QuantConnect.Tests.Common.Securities
             {
             }
 
-            public new decimal GetInitialMarginRequiredForOrder(Security security, Order order)
+            public new decimal GetInitialMarginRequiredForOrder(
+                InitialMarginRequiredForOrderParameters parameters)
             {
-                return base.GetInitialMarginRequiredForOrder(security, order);
+                return base.GetInitialMarginRequiredForOrder(parameters);
             }
 
             public new decimal GetMaintenanceMargin(Security security)
@@ -107,7 +108,8 @@ namespace QuantConnect.Tests.Common.Securities
             var order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
-            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(security, order), 1e-3);
+            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order)), 1e-3);
         }
 
         [Test]
@@ -123,7 +125,8 @@ namespace QuantConnect.Tests.Common.Securities
             var order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
-            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(security, order), 1e-3);
+            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order)), 1e-3);
         }
 
         [Test]
@@ -139,21 +142,24 @@ namespace QuantConnect.Tests.Common.Securities
             var order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
-            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(security, order), 1e-3);
+            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order)), 1e-3);
 
             // Market is Closed on Monday, Feb, 15th 2016 at Noon (US President Day)
             security = CreateSecurity(NoonHoliday);
             order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
-            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(security, order), 1e-3);
+            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order)), 1e-3);
 
             // Market is Closed on Sunday, Feb, 14th 2016 at Noon
             security = CreateSecurity(NoonWeekend);
             order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
-            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(security, order), 1e-3);
+            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order)), 1e-3);
         }
 
         [Test]
@@ -169,21 +175,24 @@ namespace QuantConnect.Tests.Common.Securities
             var order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
-            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(security, order), 1e-3);
+            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order)), 1e-3);
 
             // Market is Closed on Monday, Feb, 15th 2016 at Noon (US President Day)
             security = CreateSecurity(NoonHoliday);
             order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
-            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(security, order), 1e-3);
+            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order)), 1e-3);
 
             // Market is Closed on Sunday, Feb, 14th 2016 at Noon
             security = CreateSecurity(NoonWeekend);
             order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
-            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(security, order), 1e-3);
+            Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter("USD"), security, order)), 1e-3);
         }
 
         [Test]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `BuyingPowerModel.GetInitialMarginRequiredForOrder` will now receive
the new `InitialMarginRequiredForOrderParameters` object containing an
`ICurrencyConverter` instance.


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2728
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/6
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->