### PR TITLE
Composer will scan directory once

### DIFF
--- a/Tests/Common/Util/ComposerTests.cs
+++ b/Tests/Common/Util/ComposerTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.ComponentModel.Composition;
 using System.Linq;
 using NUnit.Framework;
@@ -45,14 +44,14 @@ namespace QuantConnect.Tests.Common.Util
         }
 
         [Test]
-        public void ResetsAndCreatesNewInstances()
+        public void ResetsReturnsSameInstances()
         {
             var composer = Composer.Instance;
             var export1 = composer.Single<IExport>(x => x.Id == 3);
             Assert.IsNotNull(export1);
             composer.Reset();
             var export2 = composer.Single<IExport>(x => x.Id == 3);
-            Assert.AreNotEqual(export1, export2);
+            Assert.AreEqual(export1, export2);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `Composer` will scan the specified directory for binaries only once.
This gives a performance improvement:
- Regression tests execution times (~1:30 improvement):
    - `master`: 11:11
    - `PR`: 9:56, 9:46
- Reverting the assert logic of a unit test
> We now have regression tests < 1 second, as low as 0.5s!
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2754
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Need for speed
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executed regression tests multiple times and unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->