### PR TITLE
Add FeeModel constructor parameter

### DIFF
--- a/Algorithm.CSharp/BrokerageModelAlgorithm.cs
+++ b/Algorithm.CSharp/BrokerageModelAlgorithm.cs
@@ -87,6 +87,7 @@ namespace QuantConnect.Algorithm.CSharp
             private readonly decimal _minimumAccountBalance;
 
             public MinimumAccountBalanceBrokerageModel(QCAlgorithm algorithm, decimal minimumAccountBalance)
+                : base(new BrokerageModelParameters(algorithm))
             {
                 _algorithm = algorithm;
                 _minimumAccountBalance = minimumAccountBalance;

--- a/Algorithm.CSharp/CustomModelsAlgorithm.cs
+++ b/Algorithm.CSharp/CustomModelsAlgorithm.cs
@@ -120,7 +120,7 @@ namespace QuantConnect.Algorithm.CSharp
             private readonly QCAlgorithm _algorithm;
 
             public CustomFeeModel(QCAlgorithm algorithm)
-                : base(new FeeModelParameters(algorithm.AccountCurrency))
+                : base(new FeeModelParameters(algorithm))
             {
                 _algorithm = algorithm;
             }

--- a/Algorithm.CSharp/CustomModelsAlgorithm.cs
+++ b/Algorithm.CSharp/CustomModelsAlgorithm.cs
@@ -120,6 +120,7 @@ namespace QuantConnect.Algorithm.CSharp
             private readonly QCAlgorithm _algorithm;
 
             public CustomFeeModel(QCAlgorithm algorithm)
+                : base(new FeeModelParameters(algorithm.AccountCurrency))
             {
                 _algorithm = algorithm;
             }
@@ -132,7 +133,8 @@ namespace QuantConnect.Algorithm.CSharp
                     parameters.Security.Price*parameters.Order.AbsoluteQuantity*0.00001m);
 
                 _algorithm.Log("CustomFeeModel: " + fee);
-                return new OrderFee(new CashAmount(fee, "USD"));
+                return new OrderFee(new CashAmount(fee,
+                    FeeModelParameters.AccountCurrency));
             }
         }
 

--- a/Algorithm.CSharp/FeeModelNotUsingAccountCurrency.cs
+++ b/Algorithm.CSharp/FeeModelNotUsingAccountCurrency.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.Algorithm.CSharp
             // Setting the cash allows the system to add a data subscription to fetch required conversion rates.
             SetCash("ETH", 0, 0m);
             _security.FeeModel = new NonAccountCurrencyCustomFeeModel(
-                new FeeModelParameters(AccountCurrency));
+                new FeeModelParameters(this));
         }
 
         /// <summary>

--- a/Algorithm.CSharp/FeeModelNotUsingAccountCurrency.cs
+++ b/Algorithm.CSharp/FeeModelNotUsingAccountCurrency.cs
@@ -59,7 +59,8 @@ namespace QuantConnect.Algorithm.CSharp
             // fees will be charged in ETH (not Base, nor Quote, not account currency).
             // Setting the cash allows the system to add a data subscription to fetch required conversion rates.
             SetCash("ETH", 0, 0m);
-            _security.FeeModel = new NonAccountCurrencyCustomFeeModel();
+            _security.FeeModel = new NonAccountCurrencyCustomFeeModel(
+                new FeeModelParameters(AccountCurrency));
         }
 
         /// <summary>
@@ -136,6 +137,11 @@ namespace QuantConnect.Algorithm.CSharp
             public override OrderFee GetOrderFee(OrderFeeParameters parameters)
             {
                 return new OrderFee(new CashAmount(1m, "ETH"));
+            }
+
+            public NonAccountCurrencyCustomFeeModel(FeeModelParameters feeModelParameters)
+                : base(feeModelParameters)
+            {
             }
         }
 

--- a/Algorithm.CSharp/ZeroFeeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ZeroFeeRegressionAlgorithm.cs
@@ -95,6 +95,10 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 return OrderFee.Zero;
             }
+
+            public ZeroFeeModel() : base(new FeeModelParameters(Currencies.NullCurrency))
+            {
+            }
         }
 
         /// <summary>

--- a/Algorithm.CSharp/ZeroFeeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ZeroFeeRegressionAlgorithm.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);             //Set Strategy Cash
 
             _security = AddEquity("SPY", Resolution.Minute);
-            _security.FeeModel = new ZeroFeeModel();
+            _security.FeeModel = new ZeroFeeModel(this);
         }
 
         /// <summary>
@@ -96,7 +96,8 @@ namespace QuantConnect.Algorithm.CSharp
                 return OrderFee.Zero;
             }
 
-            public ZeroFeeModel() : base(new FeeModelParameters(Currencies.NullCurrency))
+            public ZeroFeeModel(IAccountCurrencyProvider accountCurrencyProvider)
+                : base(new FeeModelParameters(accountCurrencyProvider))
             {
             }
         }

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -125,7 +125,8 @@ namespace QuantConnect.Algorithm
             Securities = new SecurityManager(_timeKeeper);
             Transactions = new SecurityTransactionManager(this, Securities);
             Portfolio = new SecurityPortfolioManager(Securities, Transactions, DefaultOrderProperties);
-            BrokerageModel = new DefaultBrokerageModel();
+            var brokerageModelParameters = new BrokerageModelParameters(this, AccountType.Margin);
+            BrokerageModel = new DefaultBrokerageModel(brokerageModelParameters);
             Notify = new NotificationManager(false); // Notification manager defaults to disabled.
 
             //Initialise Algorithm RunMode to Series - Parallel Mode deprecated:
@@ -148,7 +149,7 @@ namespace QuantConnect.Algorithm
             // initialize the trade builder
             TradeBuilder = new TradeBuilder(FillGroupingMethod.FillToFill, FillMatchingMethod.FIFO);
 
-            SecurityInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(AccountType.Margin), SecuritySeeder.Null);
+            SecurityInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(brokerageModelParameters), SecuritySeeder.Null);
 
             CandlestickPatterns = new CandlestickPatterns(this);
 
@@ -981,7 +982,8 @@ namespace QuantConnect.Algorithm
         /// <param name="accountType">The account type (Cash or Margin)</param>
         public void SetBrokerageModel(BrokerageName brokerage, AccountType accountType = AccountType.Margin)
         {
-            SetBrokerageModel(Brokerages.BrokerageModel.Create(brokerage, accountType));
+            SetBrokerageModel(Brokerages.BrokerageModel.Create(brokerage,
+                new BrokerageModelParameters(this, accountType)));
         }
 
         /// <summary>

--- a/Brokerages/Alpaca/AlpacaBrokerageFactory.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerageFactory.cs
@@ -59,7 +59,15 @@ namespace QuantConnect.Brokerages.Alpaca
         /// <summary>
         /// Gets a new instance of the <see cref="AlpacaBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new AlpacaBrokerageModel();
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public override IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider)
+        {
+            return new AlpacaBrokerageModel(
+                new BrokerageModelParameters(accountCurrencyProvider,
+                    AccountType.Cash));
+        }
 
         /// <summary>
         /// Creates a new <see cref="IBrokerage"/> instance

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -367,8 +367,7 @@ namespace QuantConnect.Brokerages.Backtesting
                                     {
                                         fill.OrderFee = security.FeeModel.GetOrderFee(
                                             new OrderFeeParameters(security,
-                                                order,
-                                                Algorithm.Portfolio.CashBook.AccountCurrency));
+                                                order));
                                     }
                                 }
                             }

--- a/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,9 +39,13 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public override IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider)
         {
-            get { return new InteractiveBrokersBrokerageModel(); }
+            return new InteractiveBrokersBrokerageModel(
+                new BrokerageModelParameters(accountCurrencyProvider));
         }
 
         /// <summary>
@@ -67,7 +71,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <summary>
         ///Initializes a new instance of the <see cref="BacktestingBrokerageFactory"/> class
         /// </summary>
-        public BacktestingBrokerageFactory() 
+        public BacktestingBrokerageFactory()
             : base(typeof(BacktestingBrokerage))
         {
         }

--- a/Brokerages/Backtesting/BasicOptionAssignmentSimulation.cs
+++ b/Brokerages/Backtesting/BasicOptionAssignmentSimulation.cs
@@ -179,7 +179,7 @@ namespace QuantConnect.Brokerages.Backtesting
             // Scenario 1 (base): we just close option position
             var marketOrder1 = new MarketOrder(option.Symbol, -holding.Quantity, option.LocalTime.ConvertToUtc(option.Exchange.TimeZone));
             var orderFee1 = currencyConverter.ConvertToAccountCurrency(option.FeeModel.GetOrderFee(
-                new OrderFeeParameters(option, marketOrder1, currencyConverter.AccountCurrency)).Value);
+                new OrderFeeParameters(option, marketOrder1)).Value);
 
             var basePnL = (optionPrice - holding.AveragePrice) * -holding.Quantity
                 * option.QuoteCurrency.ConversionRate
@@ -189,11 +189,11 @@ namespace QuantConnect.Brokerages.Backtesting
             // Scenario 2 (alternative): we exercise option and then close underlying position
             var optionExerciseOrder2 = new OptionExerciseOrder(option.Symbol, (int)holding.AbsoluteQuantity, option.LocalTime.ConvertToUtc(option.Exchange.TimeZone));
             var optionOrderFee2 = currencyConverter.ConvertToAccountCurrency(option.FeeModel.GetOrderFee(
-                new OrderFeeParameters(option, optionExerciseOrder2, currencyConverter.AccountCurrency)).Value);
+                new OrderFeeParameters(option, optionExerciseOrder2)).Value);
 
             var undelyingMarketOrder2 = new MarketOrder(underlying.Symbol, -underlyingQuantity, underlying.LocalTime.ConvertToUtc(underlying.Exchange.TimeZone));
             var undelyingOrderFee2 = currencyConverter.ConvertToAccountCurrency(underlying.FeeModel.GetOrderFee(
-                new OrderFeeParameters(underlying, undelyingMarketOrder2, currencyConverter.AccountCurrency)).Value);
+                new OrderFeeParameters(underlying, undelyingMarketOrder2)).Value);
 
             // calculating P/L of the two transactions (exercise option and then close underlying position)
             var altPnL = (underlyingPrice - option.StrikePrice) * underlyingQuantity * underlying.QuoteCurrency.ConversionRate * option.ContractUnitOfTrade

--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -574,7 +574,7 @@ namespace QuantConnect.Brokerages.Bitfinex
                 {
                     var security = _securityProvider.GetSecurity(order.Symbol);
                     orderFee = security.FeeModel.GetOrderFee(
-                        new OrderFeeParameters(security, order, _algorithm.Portfolio.CashBook.AccountCurrency));
+                        new OrderFeeParameters(security, order));
                 }
 
                 OrderStatus status = fillQuantity == order.Quantity ? OrderStatus.Filled : OrderStatus.PartiallyFilled;

--- a/Brokerages/Bitfinex/BitfinexBrokerageFactory.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerageFactory.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Util;
-using RestSharp;
 
 namespace QuantConnect.Brokerages.Bitfinex
 {
@@ -53,9 +52,16 @@ namespace QuantConnect.Brokerages.Bitfinex
         };
 
         /// <summary>
-        /// The brokerage model
+        /// Gets a new instance of the <see cref="BitfinexBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new BitfinexBrokerageModel();
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public override IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider)
+        {
+            return new BitfinexBrokerageModel(
+                new BrokerageModelParameters(accountCurrencyProvider));
+        }
 
         /// <summary>
         /// Create the Brokerage instance

--- a/Brokerages/BrokerageFactory.cs
+++ b/Brokerages/BrokerageFactory.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -54,7 +54,10 @@ namespace QuantConnect.Brokerages
         /// Gets a brokerage model that can be used to model this brokerage's unique
         /// behaviors
         /// </summary>
-        public abstract IBrokerageModel BrokerageModel { get; }
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public abstract IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider);
 
         /// <summary>
         /// Creates a new IBrokerage instance
@@ -80,11 +83,11 @@ namespace QuantConnect.Brokerages
         {
             _brokerageType = brokerageType;
         }
-        
+
         /// <summary>
         /// Reads a value from the brokerage data, adding an error if the key is not found
         /// </summary>
-        protected static T Read<T>(IReadOnlyDictionary<string, string> brokerageData, string key, ICollection<string> errors) 
+        protected static T Read<T>(IReadOnlyDictionary<string, string> brokerageData, string key, ICollection<string> errors)
             where T : IConvertible
         {
             string value;

--- a/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
@@ -421,7 +421,7 @@ namespace QuantConnect.Brokerages.Fxcm
                         {
                             var security = _securityProvider.GetSecurity(order.Symbol);
                             orderEvent.OrderFee = security.FeeModel.GetOrderFee(
-                                new OrderFeeParameters(security, order, _fxcmAccountCurrency));
+                                new OrderFeeParameters(security, order));
                         }
 
                         _orderEventQueue.Enqueue(orderEvent);

--- a/Brokerages/Fxcm/FxcmBrokerageFactory.cs
+++ b/Brokerages/Fxcm/FxcmBrokerageFactory.cs
@@ -63,9 +63,13 @@ namespace QuantConnect.Brokerages.Fxcm
         /// <summary>
         /// Gets a new instance of the <see cref="FxcmBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public override IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider)
         {
-            get { return new FxcmBrokerageModel(); }
+            return new FxcmBrokerageModel(
+                new BrokerageModelParameters(accountCurrencyProvider));
         }
 
         /// <summary>

--- a/Brokerages/GDAX/GDAXBrokerageFactory.cs
+++ b/Brokerages/GDAX/GDAXBrokerageFactory.cs
@@ -53,9 +53,17 @@ namespace QuantConnect.Brokerages.GDAX
         };
 
         /// <summary>
-        /// The brokerage model
+        /// Gets a new instance of the <see cref="GDAXBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new GDAXBrokerageModel();
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public override IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider)
+        {
+            return new GDAXBrokerageModel(
+                new BrokerageModelParameters(accountCurrencyProvider,
+                    AccountType.Cash));
+        }
 
         /// <summary>
         /// Create the Brokerage instance

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageFactory.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageFactory.cs
@@ -19,8 +19,6 @@ using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
 using QuantConnect.Util;
-using QuantConnect.Logging;
-using Newtonsoft.Json;
 
 namespace QuantConnect.Brokerages.InteractiveBrokers
 {
@@ -61,9 +59,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public override IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider)
         {
-            get { return new InteractiveBrokersBrokerageModel(); }
+            return new InteractiveBrokersBrokerageModel(
+                new BrokerageModelParameters(accountCurrencyProvider));
         }
 
         /// <summary>

--- a/Brokerages/Oanda/OandaBrokerageFactory.cs
+++ b/Brokerages/Oanda/OandaBrokerageFactory.cs
@@ -66,9 +66,13 @@ namespace QuantConnect.Brokerages.Oanda
         /// <summary>
         /// Gets a new instance of the <see cref="OandaBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public override IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider)
         {
-            get { return new OandaBrokerageModel(); }
+            return new OandaBrokerageModel(
+                new BrokerageModelParameters(accountCurrencyProvider));
         }
 
         /// <summary>

--- a/Brokerages/Paper/PaperBrokerageFactory.cs
+++ b/Brokerages/Paper/PaperBrokerageFactory.cs
@@ -34,9 +34,16 @@ namespace QuantConnect.Brokerages.Paper
         public override Dictionary<string, string> BrokerageData => new Dictionary<string, string>();
 
         /// <summary>
-        /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
+        /// Gets a new instance of the <see cref="DefaultBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new DefaultBrokerageModel();
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public override IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider)
+        {
+            return new DefaultBrokerageModel(
+                new BrokerageModelParameters(accountCurrencyProvider));
+        }
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -1353,7 +1353,7 @@ namespace QuantConnect.Brokerages.Tradier
                     cachedOrder.EmittedOrderFee = true;
                     var security = _securityProvider.GetSecurity(qcOrder.Symbol);
                     fill.OrderFee = security.FeeModel.GetOrderFee(
-                        new OrderFeeParameters(security, qcOrder, Currencies.USD));
+                        new OrderFeeParameters(security, qcOrder));
                 }
 
                 // if we filled the order and have another contingent order waiting, submit it

--- a/Brokerages/Tradier/TradierBrokerageFactory.cs
+++ b/Brokerages/Tradier/TradierBrokerageFactory.cs
@@ -141,9 +141,13 @@ namespace QuantConnect.Brokerages.Tradier
         /// <summary>
         /// Gets a new instance of the <see cref="TradierBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        public override IBrokerageModel GetBrokerageModel(
+            IAccountCurrencyProvider accountCurrencyProvider)
         {
-            get { return new TradierBrokerageModel(); }
+            return new TradierBrokerageModel(
+                new BrokerageModelParameters(accountCurrencyProvider));
         }
 
         /// <summary>

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -123,7 +123,7 @@ namespace QuantConnect.Brokerages
         public override IFeeModel GetFeeModel(Security security)
         {
             return new ConstantFeeModel(0m,
-                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider));
         }
 
         /// <summary>

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -46,12 +46,12 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to
-        /// <see cref="AccountType.Cash"/></param>
-        public AlpacaBrokerageModel(AccountType accountType = AccountType.Cash)
-            : base(accountType)
+        /// <param name="brokerageModelParameters">The brokerage model parameters
+        /// <see cref="BrokerageModelParameters"/></param>
+        public AlpacaBrokerageModel(BrokerageModelParameters brokerageModelParameters)
+            : base(brokerageModelParameters)
         {
-            if (accountType == AccountType.Margin)
+            if (brokerageModelParameters.AccountType == AccountType.Margin)
             {
                 throw new Exception("The Alpaca brokerage does not currently support Margin trading.");
             }
@@ -122,7 +122,8 @@ namespace QuantConnect.Brokerages
         /// <returns>The new fee model for this brokerage</returns>
         public override IFeeModel GetFeeModel(Security security)
         {
-            return new ConstantFeeModel(0m);
+            return new ConstantFeeModel(0m,
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
         }
 
         /// <summary>

--- a/Common/Brokerages/BitfinexBrokerageModel.cs
+++ b/Common/Brokerages/BitfinexBrokerageModel.cs
@@ -39,9 +39,10 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="BitfinexBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to <see cref="AccountType.Margin"/></param>
-        public BitfinexBrokerageModel(AccountType accountType = AccountType.Margin)
-            : base(accountType)
+        /// <param name="brokerageModelParameters">The brokerage model parameters
+        /// <see cref="BrokerageModelParameters"/></param>
+        public BitfinexBrokerageModel(BrokerageModelParameters brokerageModelParameters)
+            : base(brokerageModelParameters)
         {
         }
 
@@ -88,7 +89,8 @@ namespace QuantConnect.Brokerages
         /// <returns></returns>
         public override IFeeModel GetFeeModel(Security security)
         {
-            return new BitfinexFeeModel();
+            return new BitfinexFeeModel(
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
         }
 
         private static IReadOnlyDictionary<SecurityType, string> GetDefaultMarkets()

--- a/Common/Brokerages/BitfinexBrokerageModel.cs
+++ b/Common/Brokerages/BitfinexBrokerageModel.cs
@@ -15,11 +15,8 @@
 
 using System;
 using System.Collections.Generic;
-using QuantConnect.Orders;
 using QuantConnect.Securities;
-using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Fees;
-using System.Linq;
 using QuantConnect.Util;
 
 namespace QuantConnect.Brokerages
@@ -90,7 +87,7 @@ namespace QuantConnect.Brokerages
         public override IFeeModel GetFeeModel(Security security)
         {
             return new BitfinexFeeModel(
-                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider));
         }
 
         private static IReadOnlyDictionary<SecurityType, string> GetDefaultMarkets()

--- a/Common/Brokerages/BrokerageModelParameters.cs
+++ b/Common/Brokerages/BrokerageModelParameters.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Brokerages
+{
+    /// <summary>
+    /// Defines the parameters for a new <see cref="IBrokerageModel"/> instance
+    /// </summary>
+    public class BrokerageModelParameters
+    {
+        /// <summary>
+        /// The account type
+        /// </summary>
+        public AccountType AccountType { get; }
+
+        /// <summary>
+        /// The account currency provider
+        /// </summary>
+        public IAccountCurrencyProvider AccountCurrencyProvider { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="BrokerageModelParameters"/> instance
+        /// </summary>
+        /// <param name="accountCurrencyProvider"></param>
+        /// <param name="accountType">The type of account to be modeled, defaults to
+        /// <see cref="QuantConnect.AccountType.Margin"/></param>
+        public BrokerageModelParameters(
+            IAccountCurrencyProvider accountCurrencyProvider,
+            AccountType accountType = AccountType.Margin)
+        {
+            AccountCurrencyProvider = accountCurrencyProvider;
+            AccountType = accountType;
+        }
+    }
+}

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -35,6 +35,11 @@ namespace QuantConnect.Brokerages
     public class DefaultBrokerageModel : IBrokerageModel
     {
         /// <summary>
+        /// Gets the brokerage model parameters <see cref="BrokerageModelParameters"/>
+        /// </summary>
+        protected BrokerageModelParameters BrokerageModelParameters { get; }
+
+        /// <summary>
         /// The default markets for the backtesting brokerage
         /// </summary>
         public static readonly IReadOnlyDictionary<SecurityType, string> DefaultMarketMap = new Dictionary<SecurityType, string>
@@ -74,11 +79,11 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to
-        /// <see cref="QuantConnect.AccountType.Margin"/></param>
-        public DefaultBrokerageModel(AccountType accountType = AccountType.Margin)
+        /// <param name="brokerageModelParameters">The brokerage model parameters</param>
+        public DefaultBrokerageModel(BrokerageModelParameters brokerageModelParameters )
         {
-            AccountType = accountType;
+            AccountType = brokerageModelParameters.AccountType;
+            BrokerageModelParameters = brokerageModelParameters;
         }
 
         /// <summary>
@@ -203,16 +208,21 @@ namespace QuantConnect.Brokerages
                 case SecurityType.Forex:
                 case SecurityType.Cfd:
                 case SecurityType.Crypto:
-                    return new ConstantFeeModel(0m);
+                    return new ConstantFeeModel(0m,
+                        new FeeModelParameters(
+                            BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
 
                 case SecurityType.Equity:
                 case SecurityType.Option:
                 case SecurityType.Future:
-                    return new InteractiveBrokersFeeModel();
+                    return new InteractiveBrokersFeeModel(
+                        new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
 
                 case SecurityType.Commodity:
                 default:
-                    return new ConstantFeeModel(0m);
+                    return new ConstantFeeModel(0m,
+                        new FeeModelParameters(
+                            BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
             }
         }
 

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -210,19 +210,19 @@ namespace QuantConnect.Brokerages
                 case SecurityType.Crypto:
                     return new ConstantFeeModel(0m,
                         new FeeModelParameters(
-                            BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                            BrokerageModelParameters.AccountCurrencyProvider));
 
                 case SecurityType.Equity:
                 case SecurityType.Option:
                 case SecurityType.Future:
                     return new InteractiveBrokersFeeModel(
-                        new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                        new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider));
 
                 case SecurityType.Commodity:
                 default:
                     return new ConstantFeeModel(0m,
                         new FeeModelParameters(
-                            BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                            BrokerageModelParameters.AccountCurrencyProvider));
             }
         }
 

--- a/Common/Brokerages/FxcmBrokerageModel.cs
+++ b/Common/Brokerages/FxcmBrokerageModel.cs
@@ -49,10 +49,10 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to
-        /// <see cref="AccountType.Margin"/></param>
-        public FxcmBrokerageModel(AccountType accountType = AccountType.Margin)
-            : base(accountType)
+        /// <param name="brokerageModelParameters">The brokerage model parameters
+        /// <see cref="BrokerageModelParameters"/></param>
+        public FxcmBrokerageModel(BrokerageModelParameters brokerageModelParameters)
+            : base(brokerageModelParameters)
         {
         }
 
@@ -177,7 +177,8 @@ namespace QuantConnect.Brokerages
         /// <returns>The new fee model for this brokerage</returns>
         public override IFeeModel GetFeeModel(Security security)
         {
-            return new FxcmFeeModel();
+            return new FxcmFeeModel(
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
         }
 
         /// <summary>

--- a/Common/Brokerages/FxcmBrokerageModel.cs
+++ b/Common/Brokerages/FxcmBrokerageModel.cs
@@ -178,7 +178,7 @@ namespace QuantConnect.Brokerages
         public override IFeeModel GetFeeModel(Security security)
         {
             return new FxcmFeeModel(
-                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider));
         }
 
         /// <summary>

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.Brokerages
         public override IFeeModel GetFeeModel(Security security)
         {
             return new GDAXFeeModel(
-                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider));
         }
 
         /// <summary>

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -55,12 +55,12 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="GDAXBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to
-        /// <see cref="AccountType.Cash"/></param>
-        public GDAXBrokerageModel(AccountType accountType = AccountType.Cash)
-            : base(accountType)
+        /// <param name="brokerageModelParameters">The brokerage model parameters
+        /// <see cref="BrokerageModelParameters"/></param>
+        public GDAXBrokerageModel(BrokerageModelParameters brokerageModelParameters)
+            : base(brokerageModelParameters)
         {
-            if (accountType == AccountType.Margin)
+            if (brokerageModelParameters.AccountType == AccountType.Margin)
             {
                 throw new Exception("The GDAX brokerage does not currently support Margin trading.");
             }
@@ -84,7 +84,8 @@ namespace QuantConnect.Brokerages
         /// <returns></returns>
         public override IFeeModel GetFeeModel(Security security)
         {
-            return new GDAXFeeModel();
+            return new GDAXFeeModel(
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
         }
 
         /// <summary>

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -164,35 +164,36 @@ namespace QuantConnect.Brokerages
         /// Creates a new <see cref="IBrokerageModel"/> for the specified <see cref="BrokerageName"/>
         /// </summary>
         /// <param name="brokerage">The name of the brokerage</param>
-        /// <param name="accountType">The account type</param>
+        /// <param name="brokerageModelParameters">The brokerage model parameters</param>
         /// <returns>The model for the specified brokerage</returns>
-        public static IBrokerageModel Create(BrokerageName brokerage, AccountType accountType)
+        public static IBrokerageModel Create(BrokerageName brokerage,
+            BrokerageModelParameters brokerageModelParameters)
         {
             switch (brokerage)
             {
                 case BrokerageName.Default:
-                    return new DefaultBrokerageModel(accountType);
+                    return new DefaultBrokerageModel(brokerageModelParameters);
 
                 case BrokerageName.InteractiveBrokersBrokerage:
-                    return new InteractiveBrokersBrokerageModel(accountType);
+                    return new InteractiveBrokersBrokerageModel(brokerageModelParameters);
 
                 case BrokerageName.TradierBrokerage:
-                    return new TradierBrokerageModel(accountType);
+                    return new TradierBrokerageModel(brokerageModelParameters);
 
                 case BrokerageName.OandaBrokerage:
-                    return new OandaBrokerageModel(accountType);
+                    return new OandaBrokerageModel(brokerageModelParameters);
 
                 case BrokerageName.FxcmBrokerage:
-                    return new FxcmBrokerageModel(accountType);
+                    return new FxcmBrokerageModel(brokerageModelParameters);
 
                 case BrokerageName.Bitfinex:
-                    return new BitfinexBrokerageModel(accountType);
+                    return new BitfinexBrokerageModel(brokerageModelParameters);
 
                 case BrokerageName.GDAX:
-                    return new GDAXBrokerageModel(accountType);
+                    return new GDAXBrokerageModel(brokerageModelParameters);
 
                 case BrokerageName.Alpaca:
-                    return new AlpacaBrokerageModel(accountType);
+                    return new AlpacaBrokerageModel(brokerageModelParameters);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(brokerage), brokerage, null);

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -39,10 +39,10 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="InteractiveBrokersBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to
-        /// <see cref="AccountType.Margin"/></param>
-        public InteractiveBrokersBrokerageModel(AccountType accountType = AccountType.Margin)
-            : base(accountType)
+        /// <param name="brokerageModelParameters">The brokerage model parameters
+        /// <see cref="BrokerageModelParameters"/></param>
+        public InteractiveBrokersBrokerageModel(BrokerageModelParameters brokerageModelParameters)
+            : base(brokerageModelParameters)
         {
         }
 
@@ -53,7 +53,8 @@ namespace QuantConnect.Brokerages
         /// <returns>The new fee model for this brokerage</returns>
         public override IFeeModel GetFeeModel(Security security)
         {
-            return new InteractiveBrokersFeeModel();
+            return new InteractiveBrokersFeeModel(
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
         }
 
         /// <summary>

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Brokerages
         public override IFeeModel GetFeeModel(Security security)
         {
             return new InteractiveBrokersFeeModel(
-                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider));
         }
 
         /// <summary>

--- a/Common/Brokerages/OandaBrokerageModel.cs
+++ b/Common/Brokerages/OandaBrokerageModel.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.Brokerages
         public override IFeeModel GetFeeModel(Security security)
         {
             return new ConstantFeeModel(0m,
-                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider));
         }
 
         /// <summary>

--- a/Common/Brokerages/OandaBrokerageModel.cs
+++ b/Common/Brokerages/OandaBrokerageModel.cs
@@ -48,10 +48,10 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to
-        /// <see cref="AccountType.Margin"/></param>
-        public OandaBrokerageModel(AccountType accountType = AccountType.Margin)
-            : base(accountType)
+        /// <param name="brokerageModelParameters">The brokerage model parameters
+        /// <see cref="BrokerageModelParameters"/></param>
+        public OandaBrokerageModel(BrokerageModelParameters brokerageModelParameters)
+            : base(brokerageModelParameters)
         {
         }
 
@@ -120,7 +120,8 @@ namespace QuantConnect.Brokerages
         /// <returns>The new fee model for this brokerage</returns>
         public override IFeeModel GetFeeModel(Security security)
         {
-            return new ConstantFeeModel(0m);
+            return new ConstantFeeModel(0m,
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
         }
 
         /// <summary>

--- a/Common/Brokerages/TradierBrokerageModel.cs
+++ b/Common/Brokerages/TradierBrokerageModel.cs
@@ -177,7 +177,7 @@ namespace QuantConnect.Brokerages
         public override IFeeModel GetFeeModel(Security security)
         {
             return new ConstantFeeModel(1m,
-                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider));
         }
 
         /// <summary>

--- a/Common/Brokerages/TradierBrokerageModel.cs
+++ b/Common/Brokerages/TradierBrokerageModel.cs
@@ -35,10 +35,10 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to
-        /// <see cref="QuantConnect.AccountType.Margin"/></param>
-        public TradierBrokerageModel(AccountType accountType = AccountType.Margin)
-            : base(accountType)
+        /// <param name="brokerageModelParameters">The brokerage model parameters
+        /// <see cref="BrokerageModelParameters"/></param>
+        public TradierBrokerageModel(BrokerageModelParameters brokerageModelParameters)
+            : base(brokerageModelParameters)
         {
         }
 
@@ -176,7 +176,8 @@ namespace QuantConnect.Brokerages
         /// <returns>The new fee model for this brokerage</returns>
         public override IFeeModel GetFeeModel(Security security)
         {
-            return new ConstantFeeModel(1m);
+            return new ConstantFeeModel(1m,
+                new FeeModelParameters(BrokerageModelParameters.AccountCurrencyProvider.AccountCurrency));
         }
 
         /// <summary>

--- a/Common/Interfaces/IBrokerageFactory.cs
+++ b/Common/Interfaces/IBrokerageFactory.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,7 +45,9 @@ namespace QuantConnect.Interfaces
         /// Gets a brokerage model that can be used to model this brokerage's unique
         /// behaviors
         /// </summary>
-        IBrokerageModel BrokerageModel { get; }
+        /// <param name="accountCurrencyProvider">The account currency provider</param>
+        /// <returns>The new brokerage model</returns>
+        IBrokerageModel GetBrokerageModel(IAccountCurrencyProvider accountCurrencyProvider);
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Common/Orders/Fees/BitfinexFeeModel.cs
+++ b/Common/Orders/Fees/BitfinexFeeModel.cs
@@ -37,6 +37,23 @@ namespace QuantConnect.Orders.Fees
         public const decimal TakerFee = 0.002m;
 
         /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        public BitfinexFeeModel()
+            : this(new FeeModelParameters(Currencies.USD))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="feeModelParameters">The fee model parameters object to use</param>
+        public BitfinexFeeModel(FeeModelParameters feeModelParameters)
+            : base(feeModelParameters)
+        {
+        }
+
+        /// <summary>
         /// Get the fee for this order in quote currency
         /// </summary>
         /// <param name="parameters">A <see cref="OrderFeeParameters"/> object

--- a/Common/Orders/Fees/BitfinexFeeModel.cs
+++ b/Common/Orders/Fees/BitfinexFeeModel.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Orders.Fees
         /// Creates a new instance
         /// </summary>
         public BitfinexFeeModel()
-            : this(new FeeModelParameters(Currencies.USD))
+            : this(new FeeModelParameters(BackwardsCompatibleAccountCurrencyProvider.Instance))
         {
         }
 

--- a/Common/Orders/Fees/ConstantFeeModel.cs
+++ b/Common/Orders/Fees/ConstantFeeModel.cs
@@ -29,9 +29,20 @@ namespace QuantConnect.Orders.Fees
         /// Initializes a new instance of the <see cref="ConstantFeeModel"/> class with the specified <paramref name="fee"/>
         /// </summary>
         /// <param name="fee">The constant order fee used by the model</param>
-        public ConstantFeeModel(decimal fee)
+        /// <param name="feeModelParameters">The fee model parameters object to use</param>
+        public ConstantFeeModel(decimal fee, FeeModelParameters feeModelParameters)
+            : base(feeModelParameters)
         {
             _fee = Math.Abs(fee);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConstantFeeModel"/> class with the specified <paramref name="fee"/>
+        /// </summary>
+        /// <param name="fee">The constant order fee used by the model</param>
+        public ConstantFeeModel(decimal fee)
+            : this(fee, new FeeModelParameters(Currencies.USD))
+        {
         }
 
         /// <summary>
@@ -43,7 +54,7 @@ namespace QuantConnect.Orders.Fees
         public override OrderFee GetOrderFee(OrderFeeParameters parameters)
         {
             return new OrderFee(new CashAmount(_fee,
-                parameters.AccountCurrency));
+                FeeModelParameters.AccountCurrency));
         }
     }
 }

--- a/Common/Orders/Fees/ConstantFeeModel.cs
+++ b/Common/Orders/Fees/ConstantFeeModel.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Orders.Fees
         /// </summary>
         /// <param name="fee">The constant order fee used by the model</param>
         public ConstantFeeModel(decimal fee)
-            : this(fee, new FeeModelParameters(Currencies.USD))
+            : this(fee, new FeeModelParameters(BackwardsCompatibleAccountCurrencyProvider.Instance))
         {
         }
 

--- a/Common/Orders/Fees/FeeModel.cs
+++ b/Common/Orders/Fees/FeeModel.cs
@@ -25,6 +25,20 @@ namespace QuantConnect.Orders.Fees
     public class FeeModel : IFeeModel
     {
         /// <summary>
+        /// Gets the <see cref="FeeModelParameters"/> to use
+        /// </summary>
+        public FeeModelParameters FeeModelParameters { get; }
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="feeModelParameters"> The fee model parameters object to use</param>
+        public FeeModel(FeeModelParameters feeModelParameters)
+        {
+            FeeModelParameters = feeModelParameters;
+        }
+
+        /// <summary>
         /// Gets the order fee associated with the specified order.
         /// </summary>
         /// <param name="parameters">A <see cref="OrderFeeParameters"/> object
@@ -34,7 +48,7 @@ namespace QuantConnect.Orders.Fees
         {
             return new OrderFee(new CashAmount(
                 0,
-                parameters.AccountCurrency));
+                FeeModelParameters.AccountCurrency));
         }
     }
 }

--- a/Common/Orders/Fees/FeeModel.cs
+++ b/Common/Orders/Fees/FeeModel.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Orders.Fees
         /// <summary>
         /// Gets the <see cref="FeeModelParameters"/> to use
         /// </summary>
-        public FeeModelParameters FeeModelParameters { get; }
+        protected FeeModelParameters FeeModelParameters { get; }
 
         /// <summary>
         /// Creates a new instance
@@ -36,6 +36,14 @@ namespace QuantConnect.Orders.Fees
         public FeeModel(FeeModelParameters feeModelParameters)
         {
             FeeModelParameters = feeModelParameters;
+        }
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        public FeeModel()
+            : this(new FeeModelParameters(BackwardsCompatibleAccountCurrencyProvider.Instance))
+        {
         }
 
         /// <summary>

--- a/Common/Orders/Fees/FeeModelParameters.cs
+++ b/Common/Orders/Fees/FeeModelParameters.cs
@@ -12,33 +12,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-using QuantConnect.Securities;
+
+
 namespace QuantConnect.Orders.Fees
 {
     /// <summary>
-    /// Defines the parameters for <see cref="IFeeModel.GetOrderFee"/>
+    /// Parameters class used to construct a new <see cref="FeeModel"/>
+    /// and its derivatives.
     /// </summary>
-    public class OrderFeeParameters
+    public class FeeModelParameters
     {
         /// <summary>
-        /// Gets the security
+        /// Gets the account currency
         /// </summary>
-        public Security Security { get; }
+        public string AccountCurrency { get; }
 
         /// <summary>
-        /// Gets the order
+        /// Creates a new instance
         /// </summary>
-        public Order Order { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OrderFeeParameters"/> class
-        /// </summary>
-        /// <param name="security">The security</param>
-        /// <param name="order">The order</param>
-        public OrderFeeParameters(Security security, Order order)
+        /// <param name="accountCurrency">The current account currency</param>
+        public FeeModelParameters(string accountCurrency)
         {
-            Security = security;
-            Order = order;
+            AccountCurrency = accountCurrency;
         }
     }
 }

--- a/Common/Orders/Fees/FxcmFeeModel.cs
+++ b/Common/Orders/Fees/FxcmFeeModel.cs
@@ -36,6 +36,23 @@ namespace QuantConnect.Orders.Fees
         };
 
         /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        public FxcmFeeModel()
+            : this(new FeeModelParameters(Currencies.USD))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="feeModelParameters">The fee model parameters object to use</param>
+        public FxcmFeeModel(FeeModelParameters feeModelParameters)
+            : base(feeModelParameters)
+        {
+        }
+
+        /// <summary>
         /// Get the fee for this order in units of the account currency
         /// </summary>
         /// <param name="parameters">A <see cref="OrderFeeParameters"/> object
@@ -59,7 +76,7 @@ namespace QuantConnect.Orders.Fees
                 fee = Math.Abs(commissionRate * parameters.Order.AbsoluteQuantity / 1000);
             }
             return new OrderFee(new CashAmount(fee,
-                parameters.AccountCurrency));
+                FeeModelParameters.AccountCurrency));
         }
     }
 }

--- a/Common/Orders/Fees/FxcmFeeModel.cs
+++ b/Common/Orders/Fees/FxcmFeeModel.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Orders.Fees
         /// Creates a new instance
         /// </summary>
         public FxcmFeeModel()
-            : this(new FeeModelParameters(Currencies.USD))
+            : this(new FeeModelParameters(BackwardsCompatibleAccountCurrencyProvider.Instance))
         {
         }
 

--- a/Common/Orders/Fees/GDAXFeeModel.cs
+++ b/Common/Orders/Fees/GDAXFeeModel.cs
@@ -29,6 +29,23 @@ namespace QuantConnect.Orders.Fees
         public const decimal TakerFee = 0.003m;
 
         /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        public GDAXFeeModel()
+            : this(new FeeModelParameters(Currencies.USD))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="feeModelParameters">The fee model parameters object to use</param>
+        public GDAXFeeModel(FeeModelParameters feeModelParameters)
+            : base(feeModelParameters)
+        {
+        }
+
+        /// <summary>
         /// Get the fee for this order in quote currency
         /// </summary>
         /// <param name="parameters">A <see cref="OrderFeeParameters"/> object

--- a/Common/Orders/Fees/GDAXFeeModel.cs
+++ b/Common/Orders/Fees/GDAXFeeModel.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Orders.Fees
         /// Creates a new instance
         /// </summary>
         public GDAXFeeModel()
-            : this(new FeeModelParameters(Currencies.USD))
+            : this(new FeeModelParameters(BackwardsCompatibleAccountCurrencyProvider.Instance))
         {
         }
 

--- a/Common/Orders/Fees/IFeeModel.cs
+++ b/Common/Orders/Fees/IFeeModel.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Orders.Fees
         /// <returns>The cost of the order in units of the account currency</returns>
         public static decimal GetOrderFee(this IFeeModel model, Security security, Order order)
         {
-            var parameters = new OrderFeeParameters(security, order, security.QuoteCurrency.Symbol);
+            var parameters = new OrderFeeParameters(security, order);
             var fee = model.GetOrderFee(parameters);
 
             return fee.Value.Amount;

--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -14,7 +14,6 @@
 */
 
 using System;
-using QuantConnect.Orders.Fills;
 using QuantConnect.Securities;
 
 
@@ -37,7 +36,7 @@ namespace QuantConnect.Orders.Fees
         /// <param name="monthlyForexTradeAmountInUSDollars">Monthly FX dollar volume traded</param>
         /// <param name="monthlyOptionsTradeAmountInContracts">Monthly options contracts traded</param>
         public InteractiveBrokersFeeModel(decimal monthlyForexTradeAmountInUSDollars = 0, decimal monthlyOptionsTradeAmountInContracts = 0)
-            : this(new FeeModelParameters(Currencies.USD),
+            : this(new FeeModelParameters(BackwardsCompatibleAccountCurrencyProvider.Instance),
                 monthlyForexTradeAmountInUSDollars,
                 monthlyOptionsTradeAmountInContracts)
         {

--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -32,11 +32,27 @@ namespace QuantConnect.Orders.Fees
         private readonly Func<decimal, decimal, decimal>  _optionsCommissionFunc;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ImmediateFillModel"/>
+        /// Initializes a new instance of the <see cref="InteractiveBrokersFeeModel"/>
         /// </summary>
         /// <param name="monthlyForexTradeAmountInUSDollars">Monthly FX dollar volume traded</param>
         /// <param name="monthlyOptionsTradeAmountInContracts">Monthly options contracts traded</param>
         public InteractiveBrokersFeeModel(decimal monthlyForexTradeAmountInUSDollars = 0, decimal monthlyOptionsTradeAmountInContracts = 0)
+            : this(new FeeModelParameters(Currencies.USD),
+                monthlyForexTradeAmountInUSDollars,
+                monthlyOptionsTradeAmountInContracts)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InteractiveBrokersFeeModel"/>
+        /// </summary>
+        /// <param name="feeModelParameters">The fee model parameters object to use</param>
+        /// <param name="monthlyForexTradeAmountInUSDollars">Monthly FX dollar volume traded</param>
+        /// <param name="monthlyOptionsTradeAmountInContracts">Monthly options contracts traded</param>
+        public InteractiveBrokersFeeModel(FeeModelParameters feeModelParameters,
+            decimal monthlyForexTradeAmountInUSDollars = 0,
+            decimal monthlyOptionsTradeAmountInContracts = 0)
+            : base(feeModelParameters)
         {
             ProcessForexRateSchedule(monthlyForexTradeAmountInUSDollars, out _forexCommissionRate, out _forexMinimumOrderFee);
             ProcessOptionsRateSchedule(monthlyOptionsTradeAmountInContracts, out _optionsCommissionFunc);
@@ -64,7 +80,7 @@ namespace QuantConnect.Orders.Fees
                 {
                     return new OrderFee(new CashAmount(
                         0,
-                        parameters.AccountCurrency));
+                        FeeModelParameters.AccountCurrency));
                 }
             }
 
@@ -111,7 +127,7 @@ namespace QuantConnect.Orders.Fees
             // all other types default to zero fees
             return new OrderFee(new CashAmount(
                 feeResult,
-                parameters.AccountCurrency));
+                FeeModelParameters.AccountCurrency));
         }
 
         /// <summary>

--- a/Common/Orders/OrderJsonConverter.cs
+++ b/Common/Orders/OrderJsonConverter.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.Orders
             else
             {
                 //no data, use default
-                new DefaultBrokerageModel().DefaultMarkets.TryGetValue(securityType, out market);
+                DefaultBrokerageModel.DefaultMarketMap.TryGetValue(securityType, out market);
             }
 
             if (jObject.SelectTokens("Symbol.ID").Any())

--- a/Common/Python/FeeModelPythonWrapper.cs
+++ b/Common/Python/FeeModelPythonWrapper.cs
@@ -32,6 +32,7 @@ namespace QuantConnect.Python
         /// </summary>
         /// <param name="model">Represents a model that simulates order fees</param>
         public FeeModelPythonWrapper(PyObject model)
+            : base(new FeeModelParameters(Currencies.USD))
         {
             _model = model;
         }
@@ -58,7 +59,7 @@ namespace QuantConnect.Python
                     }
                 }
                 decimal fee = _model.GetOrderFee(parameters.Security, parameters.Order);
-                return new OrderFee(new CashAmount(fee, parameters.AccountCurrency));
+                return new OrderFee(new CashAmount(fee, FeeModelParameters.AccountCurrency));
             }
         }
     }

--- a/Common/Python/FeeModelPythonWrapper.cs
+++ b/Common/Python/FeeModelPythonWrapper.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Python
         /// </summary>
         /// <param name="model">Represents a model that simulates order fees</param>
         public FeeModelPythonWrapper(PyObject model)
-            : base(new FeeModelParameters(Currencies.USD))
+            : base(new FeeModelParameters(BackwardsCompatibleAccountCurrencyProvider.Instance))
         {
             _model = model;
         }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Python\PythonInitializer.cs" />
     <Compile Include="Python\PythonWrapper.cs" />
+    <Compile Include="Securities\BackwardsCompatibleAccountCurrencyProvider.cs" />
     <Compile Include="Securities\BuyingPower.cs" />
     <Compile Include="Securities\BuyingPowerParameters.cs" />
     <Compile Include="Securities\BuyingPowerModel.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Benchmarks\SecurityBenchmark.cs" />
     <Compile Include="Brokerages\AlpacaBrokerageModel.cs" />
     <Compile Include="Brokerages\BrokerageFactoryAttribute.cs" />
+    <Compile Include="Brokerages\BrokerageModelParameters.cs" />
     <Compile Include="Brokerages\BrokerageName.cs" />
     <Compile Include="Brokerages\DefaultBrokerageMessageHandler.cs" />
     <Compile Include="Brokerages\DefaultBrokerageModel.cs" />
@@ -198,6 +199,7 @@
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />
     <Compile Include="IsolatorLimitResult.cs" />
+    <Compile Include="Orders\Fees\FeeModelParameters.cs" />
     <Compile Include="Orders\Fills\Fill.cs" />
     <Compile Include="Orders\Fills\FillModelParameters.cs" />
     <Compile Include="Orders\Fees\FeeModel.cs" />

--- a/Common/Securities/BackwardsCompatibleAccountCurrencyProvider.cs
+++ b/Common/Securities/BackwardsCompatibleAccountCurrencyProvider.cs
@@ -13,31 +13,30 @@
  * limitations under the License.
 */
 
-
 using QuantConnect.Interfaces;
 
-namespace QuantConnect.Orders.Fees
+namespace QuantConnect.Securities
 {
     /// <summary>
-    /// Parameters class used to construct a new <see cref="FeeModel"/>
-    /// and its derivatives.
+    /// This class is a <see cref="IAccountCurrencyProvider"/> used
+    /// to maintain backwards compatibility.
+    /// It will always return <see cref="Currencies.USD"/>
     /// </summary>
-    public class FeeModelParameters
+    public class BackwardsCompatibleAccountCurrencyProvider : IAccountCurrencyProvider
     {
-        private readonly IAccountCurrencyProvider _accountCurrencyProvider;
-
         /// <summary>
-        /// Gets the account currency provider
+        /// Gets the account currency
         /// </summary>
-        public string AccountCurrency => _accountCurrencyProvider.AccountCurrency;
+        public string AccountCurrency => Currencies.USD;
 
-        /// <summary>
-        /// Creates a new instance
-        /// </summary>
-        /// <param name="accountCurrencyProvider">The account currency provider</param>
-        public FeeModelParameters(IAccountCurrencyProvider accountCurrencyProvider)
+        private BackwardsCompatibleAccountCurrencyProvider()
         {
-            _accountCurrencyProvider = accountCurrencyProvider;
         }
+
+        /// <summary>
+        /// Gets the static instance
+        /// </summary>
+        public static readonly BackwardsCompatibleAccountCurrencyProvider Instance
+            = new BackwardsCompatibleAccountCurrencyProvider();
     }
 }

--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -141,8 +141,7 @@ namespace QuantConnect.Securities
 
             var fees = parameters.Security.FeeModel.GetOrderFee(
                 new OrderFeeParameters(parameters.Security,
-                    parameters.Order,
-                    parameters.CurrencyConverter.AccountCurrency)).Value;
+                    parameters.Order)).Value;
             var feesInAccountCurrency = parameters.CurrencyConverter.
                 ConvertToAccountCurrency(fees).Amount;
 
@@ -395,8 +394,7 @@ namespace QuantConnect.Securities
 
                 var fees = parameters.Security.FeeModel.GetOrderFee(
                     new OrderFeeParameters(parameters.Security,
-                        order,
-                        parameters.Portfolio.CashBook.AccountCurrency)).Value;
+                        order)).Value;
                 orderFees = parameters.Portfolio.CashBook.ConvertToAccountCurrency(fees).Amount;
 
                 // The TPV, take out the fees(unscaled) => yields available value for trading(less fees)

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -129,8 +129,7 @@ namespace QuantConnect.Securities
             {
                 var fee = parameters.Security.FeeModel.GetOrderFee(
                     new OrderFeeParameters(parameters.Security,
-                        parameters.Order,
-                        parameters.Portfolio.CashBook.AccountCurrency)).Value;
+                        parameters.Order)).Value;
                 orderFee = parameters.Portfolio.CashBook.Convert(
                         fee.Amount,
                         fee.Currency,
@@ -269,8 +268,7 @@ namespace QuantConnect.Securities
 
                 var fees = parameters.Security.FeeModel.GetOrderFee(
                     new OrderFeeParameters(parameters.Security,
-                        order,
-                        parameters.Portfolio.CashBook.AccountCurrency)).Value;
+                        order)).Value;
                 orderFees = parameters.Portfolio.CashBook.ConvertToAccountCurrency(fees).Amount;
 
                 currentOrderValue = orderValue + orderFees;

--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -81,8 +81,7 @@ namespace QuantConnect.Securities.Future
 
             var fees = parameters.Security.FeeModel.GetOrderFee(
                 new OrderFeeParameters(parameters.Security,
-                    parameters.Order,
-                    parameters.CurrencyConverter.AccountCurrency)).Value;
+                    parameters.Order)).Value;
             var feesInAccountCurrency = parameters.CurrencyConverter.
                 ConvertToAccountCurrency(fees).Amount;
 

--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -77,8 +77,7 @@ namespace QuantConnect.Securities.Option
 
             var fees = parameters.Security.FeeModel.GetOrderFee(
                 new OrderFeeParameters(parameters.Security,
-                    parameters.Order,
-                    parameters.CurrencyConverter.AccountCurrency)).Value;
+                    parameters.Order)).Value;
             var feesInAccountCurrency = parameters.CurrencyConverter.
                 ConvertToAccountCurrency(fees).Amount;
 

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -434,7 +434,7 @@ namespace QuantConnect.Securities
             var marketOrder = new MarketOrder(_security.Symbol, -Quantity, _security.LocalTime.ConvertToUtc(_security.Exchange.TimeZone));
 
             var orderFee = _security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(_security, marketOrder, _currencyConverter.AccountCurrency)).Value;
+                new OrderFeeParameters(_security, marketOrder)).Value;
             var feesInAccountCurrency = _currencyConverter.
                 ConvertToAccountCurrency(orderFee).Amount;
 

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -175,7 +175,7 @@ namespace QuantConnect.Lean.Engine.Setup
                     try
                     {
                         //Set the default brokerage model before initialize
-                        algorithm.SetBrokerageModel(_factory.BrokerageModel);
+                        algorithm.SetBrokerageModel(_factory.GetBrokerageModel(algorithm));
 
                         //Margin calls are disabled by default in live mode
                         algorithm.Portfolio.MarginCallModel = MarginCallModel.Null;

--- a/Tests/Algorithm/AlgorithmInitializeTests.cs
+++ b/Tests/Algorithm/AlgorithmInitializeTests.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -65,7 +65,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -82,7 +82,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -100,7 +100,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -118,7 +118,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -139,7 +139,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -161,7 +161,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -183,7 +183,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -206,7 +206,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -229,7 +229,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -252,7 +252,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -275,7 +275,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -298,7 +298,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -321,7 +321,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -344,7 +344,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -367,7 +367,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -391,7 +391,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -415,7 +415,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -438,7 +438,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -461,7 +461,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -484,7 +484,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }

--- a/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
+++ b/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
@@ -182,7 +182,7 @@ namespace QuantConnect.Tests.Algorithm
                 Assert.That(Math.Abs(requiredMargin) <= freeMargin);
 
                 orderFee = security.FeeModel.GetOrderFee(
-                    new OrderFeeParameters(security, order, Currencies.USD));
+                    new OrderFeeParameters(security, order));
                 fill = new OrderEvent(order, DateTime.UtcNow, orderFee) { FillPrice = security.Price, FillQuantity = orderQuantity };
                 algorithm.Portfolio.ProcessFill(fill);
 
@@ -228,7 +228,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.That(Math.Abs(requiredMargin) <= freeMargin);
 
             orderFee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, order, Currencies.USD));
+                new OrderFeeParameters(security, order));
             fill = new OrderEvent(order, DateTime.UtcNow, orderFee) { FillPrice = security.Price, FillQuantity = orderQuantity };
             algorithm.Portfolio.ProcessFill(fill);
 

--- a/Tests/Brokerages/Bitfinex/BitfinexBrokerageTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexBrokerageTests.cs
@@ -43,7 +43,8 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
 
             var algorithm = new Mock<IAlgorithm>();
             algorithm.Setup(a => a.Transactions).Returns(transactions);
-            algorithm.Setup(a => a.BrokerageModel).Returns(new BitfinexBrokerageModel(AccountType.Margin));
+            algorithm.Setup(a => a.BrokerageModel).Returns(new BitfinexBrokerageModel(
+                new BrokerageModelParameters(new TestAccountCurrencyProvider(), AccountType.Margin)));
             algorithm.Setup(a => a.Portfolio).Returns(new SecurityPortfolioManager(securities, transactions));
 
             var priceProvider = new Mock<IPriceProvider>();

--- a/Tests/Brokerages/Bitfinex/BitfinexFeeModelTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexFeeModelTests.cs
@@ -21,6 +21,7 @@ using System;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Brokerages;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Brokerages.Bitfinex
 {
@@ -81,7 +82,8 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
         [Test]
         public void GetFeeModelTest()
         {
-            BitfinexBrokerageModel model = new BitfinexBrokerageModel();
+            BitfinexBrokerageModel model = new BitfinexBrokerageModel(
+                new BrokerageModelParameters(new TestAccountCurrencyProvider()));
             Assert.IsInstanceOf<BitfinexFeeModel>(model.GetFeeModel(Security));
         }
 
@@ -93,7 +95,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
 
             Order order = parameters.CreateShortOrder(Quantity);
             var price = order.Type == OrderType.Limit ? ((LimitOrder)order).LimitPrice : LowPrice;
-            var fee = feeModel.GetOrderFee(new OrderFeeParameters(Security, order, Currencies.USD));
+            var fee = feeModel.GetOrderFee(new OrderFeeParameters(Security, order));
 
             Assert.AreEqual(
                 BitfinexFeeModel.MakerFee * price * Math.Abs(Quantity), fee.Value.Amount);
@@ -109,7 +111,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
             Order order = parameters.CreateShortOrder(Quantity);
             var price = order.Type == OrderType.Limit ? ((LimitOrder)order).LimitPrice : LowPrice;
             var fee =
-                feeModel.GetOrderFee(new OrderFeeParameters(Security, order, Currencies.USD));
+                feeModel.GetOrderFee(new OrderFeeParameters(Security, order));
 
             Assert.AreEqual(
                 BitfinexFeeModel.TakerFee * price * Math.Abs(Quantity), fee.Value.Amount);
@@ -125,7 +127,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
             Order order = parameters.CreateLongOrder(Quantity);
             var price = order.Type == OrderType.Limit ? ((LimitOrder)order).LimitPrice : HighPrice;
             var fee =
-                feeModel.GetOrderFee(new OrderFeeParameters(Security, order, Currencies.USD));
+                feeModel.GetOrderFee(new OrderFeeParameters(Security, order));
 
             Assert.AreEqual(
                 BitfinexFeeModel.MakerFee * price * Math.Abs(Quantity), fee.Value.Amount);
@@ -141,7 +143,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
             Order order = parameters.CreateLongOrder(Quantity);
             var price = order.Type == OrderType.Limit ? ((LimitOrder)order).LimitPrice : HighPrice;
             var fee =
-                feeModel.GetOrderFee(new OrderFeeParameters(Security, order, Currencies.USD));
+                feeModel.GetOrderFee(new OrderFeeParameters(Security, order));
 
             Assert.AreEqual(
                 BitfinexFeeModel.TakerFee * price * Math.Abs(Quantity), fee.Value.Amount);

--- a/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageIntegrationTests.cs
@@ -21,6 +21,7 @@ using QuantConnect.Configuration;
 using QuantConnect.Orders;
 using Moq;
 using QuantConnect.Brokerages;
+using QuantConnect.Tests.Common.Securities;
 using RestSharp;
 
 namespace QuantConnect.Tests.Brokerages.GDAX
@@ -70,7 +71,8 @@ namespace QuantConnect.Tests.Brokerages.GDAX
             var webSocketClient = new WebSocketWrapper();
 
             var algorithm = new Mock<IAlgorithm>();
-            algorithm.Setup(a => a.BrokerageModel).Returns(new GDAXBrokerageModel(AccountType.Cash));
+            algorithm.Setup(a => a.BrokerageModel).Returns(new GDAXBrokerageModel(
+                new BrokerageModelParameters(new TestAccountCurrencyProvider(), AccountType.Cash)));
 
             var priceProvider = new ApiPriceProvider(Config.GetInt("job-user-id"), Config.Get("api-access-token"));
 

--- a/Tests/Common/Brokerages/BitfinexBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BitfinexBrokerageModelTests.cs
@@ -18,6 +18,7 @@ using QuantConnect.Brokerages;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
@@ -51,7 +52,8 @@ namespace QuantConnect.Tests.Common.Brokerages
         [Test]
         public void GetCashBuyingPowerModelTest()
         {
-            BitfinexBrokerageModel model = new BitfinexBrokerageModel(AccountType.Cash);
+            BitfinexBrokerageModel model = new BitfinexBrokerageModel(
+                new BrokerageModelParameters(new TestAccountCurrencyProvider(), AccountType.Cash));
             Assert.IsInstanceOf<CashBuyingPowerModel>(model.GetBuyingPowerModel(Security));
             Assert.AreEqual(1, model.GetLeverage(Security));
         }
@@ -59,7 +61,8 @@ namespace QuantConnect.Tests.Common.Brokerages
         [Test]
         public void GetSecurityMarginModelTest()
         {
-            BitfinexBrokerageModel model = new BitfinexBrokerageModel(AccountType.Margin);
+            BitfinexBrokerageModel model = new BitfinexBrokerageModel(
+                new BrokerageModelParameters(new TestAccountCurrencyProvider()));
             Assert.IsInstanceOf<SecurityMarginModel>(model.GetBuyingPowerModel(Security));
             Assert.AreEqual(3.3M, model.GetLeverage(Security));
         }

--- a/Tests/Common/Brokerages/FxcmBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/FxcmBrokerageModelTests.cs
@@ -44,7 +44,8 @@ namespace QuantConnect.Tests.Common.Brokerages
             var request = new SubmitOrderRequest(orderType, symbol.SecurityType, symbol, quantity, stopPrice, limitPrice, DateTime.UtcNow, "");
             var order = Order.CreateOrder(request);
 
-            var model = new FxcmBrokerageModel();
+            var model = new FxcmBrokerageModel(
+                    new BrokerageModelParameters(new TestAccountCurrencyProvider()));
 
             BrokerageMessageEvent messageEvent;
             Assert.AreEqual(isValid, model.CanSubmitOrder(security, order, out messageEvent));

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -23,13 +23,15 @@ using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
     [TestFixture]
     public class GDAXBrokerageModelTests
     {
-        private readonly GDAXBrokerageModel _unit = new GDAXBrokerageModel();
+        private readonly GDAXBrokerageModel _unit = new GDAXBrokerageModel(
+            new BrokerageModelParameters(new TestAccountCurrencyProvider(), AccountType.Cash));
 
         [Test]
         public void GetLeverageTest()
@@ -123,8 +125,7 @@ namespace QuantConnect.Tests.Common.Brokerages
             security.SetMarketPrice(new TradeBar { Symbol = security.Symbol, Close = 5000m });
             var orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
                 security,
-                new MarketOrder(security.Symbol, 1, DateTime.MinValue),
-                Currencies.USD));
+                new MarketOrder(security.Symbol, 1, DateTime.MinValue)));
 
             Assert.AreEqual(15m, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -141,7 +142,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 4999.99m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -151,7 +152,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5000m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -160,7 +161,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, -1, 5000.01m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -176,7 +177,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5000.01m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             // marketable buy limit fill at 5000
             Assert.AreEqual(15m, orderFee.Value.Amount);
@@ -187,7 +188,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5000.01m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             // marketable buy limit fill at 5000.01
             Assert.AreEqual(15.00003m, orderFee.Value.Amount);
@@ -197,7 +198,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, -1, 5000m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             // marketable sell limit fill at 5000
             Assert.AreEqual(15m, orderFee.Value.Amount);
@@ -217,7 +218,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 4999.99m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -226,7 +227,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, -1, 5000.01m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -245,7 +246,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5000m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(15m, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -254,7 +255,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5050m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(15m, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -263,7 +264,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, -1, 4950m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(15m, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -274,7 +275,8 @@ namespace QuantConnect.Tests.Common.Brokerages
         {
             Assert.Throws<Exception>(() =>
             {
-                new GDAXBrokerageModel(AccountType.Margin);
+                new GDAXBrokerageModel(
+                    new BrokerageModelParameters(new TestAccountCurrencyProvider()));
             }, "The GDAX brokerage does not currently support Margin trading.");
         }
     }

--- a/Tests/Common/Orders/Fees/BackwardsCompatibilityFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/BackwardsCompatibilityFeeModelTests.cs
@@ -63,8 +63,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
 
                 var result = wrapper.GetOrderFee(new OrderFeeParameters(
                     _security,
-                    new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    Currencies.USD
+                    new MarketOrder(_security.Symbol, 1, orderDateTime)
                 ));
 
                 bool called;
@@ -86,20 +85,20 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                     "AddReference(\"QuantConnect.Common\")\n" +
                     "from QuantConnect.Orders.Fees import *\n" +
                     "from QuantConnect.Securities import *\n" +
-                    "class CustomFeeModel(FeeModel):\n" +
+                    "class CustomFeeModel():\n" +
                     "   def __init__(self):\n" +
+                    "       self.__base = FeeModel(FeeModelParameters(\"EUR\"))\n" +
                     "       self.CalledGetOrderFee = False\n" +
                     "   def GetOrderFee(self, parameters):\n" +
                     "       self.CalledGetOrderFee = True\n" +
-                    "       return OrderFee(CashAmount(15, parameters.AccountCurrency))");
+                    "       return OrderFee(CashAmount(15, self.__base.FeeModelParameters.AccountCurrency))");
 
                 var customFeeModel = module.GetAttr("CustomFeeModel").Invoke();
                 var wrapper = new FeeModelPythonWrapper(customFeeModel);
 
                 var result = wrapper.GetOrderFee(new OrderFeeParameters(
                     _security,
-                    new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    Currencies.USD
+                    new MarketOrder(_security.Symbol, 1, orderDateTime)
                 ));
 
                 bool called;
@@ -107,7 +106,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 Assert.True(called);
                 Assert.IsNotNull(result);
                 Assert.AreEqual(15, result.Value.Amount);
-                Assert.AreEqual(Currencies.USD, result.Value.Currency);
+                Assert.AreEqual("EUR", result.Value.Currency);
             }
         }
         #endregion

--- a/Tests/Common/Orders/Fees/BitfinexFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/BitfinexFeeModelTests.cs
@@ -60,8 +60,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btcusd,
-                    new MarketOrder(_btcusd.Symbol, 1, DateTime.UtcNow),
-                    Currencies.USD
+                    new MarketOrder(_btcusd.Symbol, 1, DateTime.UtcNow)
                 )
             );
 
@@ -76,8 +75,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btceur,
-                    new MarketOrder(_btceur.Symbol, 1, DateTime.UtcNow),
-                    Currencies.USD
+                    new MarketOrder(_btceur.Symbol, 1, DateTime.UtcNow)
                 )
             );
 

--- a/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
@@ -60,8 +60,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btcusd,
-                    new MarketOrder(_btcusd.Symbol, 1, DateTime.UtcNow),
-                    Currencies.USD
+                    new MarketOrder(_btcusd.Symbol, 1, DateTime.UtcNow)
                 )
             );
 
@@ -76,8 +75,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btceur,
-                    new MarketOrder(_btceur.Symbol, 1, DateTime.UtcNow),
-                    Currencies.USD
+                    new MarketOrder(_btceur.Symbol, 1, DateTime.UtcNow)
                 )
             );
 

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -429,7 +429,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var timeKeeper = new TimeKeeper(referenceUtc);
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
-            var brokerageModel = new FxcmBrokerageModel();
+            var brokerageModel = new FxcmBrokerageModel(
+                new BrokerageModelParameters(new TestAccountCurrencyProvider()));
             var fillModel = brokerageModel.GetFillModel(security);
 
             const decimal bidPrice = 1.13739m;

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -95,8 +95,9 @@ namespace QuantConnect.Tests.Common.Securities
                 ErrorCurrencyConverter.Instance
             );
 
-            _brokerageInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(),
-                                                                          new FuncSecuritySeeder(_algo.GetLastKnownPrice));
+            _brokerageInitializer = new BrokerageModelSecurityInitializer(
+                new DefaultBrokerageModel(new BrokerageModelParameters(new TestAccountCurrencyProvider())),
+                new FuncSecuritySeeder(_algo.GetLastKnownPrice));
         }
 
         [Test]
@@ -154,7 +155,8 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void BrokerageModelSecurityInitializer_SetLeverageForBuyingPowerModel_Successfully()
         {
-            var brokerageModel = new DefaultBrokerageModel(AccountType.Cash);
+            var brokerageModel = new DefaultBrokerageModel(
+                new BrokerageModelParameters(_algo, AccountType.Cash));
             var localBrokerageInitializer = new BrokerageModelSecurityInitializer(brokerageModel,
                 new FuncSecuritySeeder(_algo.GetLastKnownPrice));
             Assert.AreEqual(1.0, _tradeBarSecurity.Leverage);

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -621,8 +621,7 @@ namespace QuantConnect.Tests.Common.Securities
             _btcusd = _algorithm.AddCrypto("BTCUSD");
             _btcusd.SetMarketPrice(new Tick { Value = 10000m, BidPrice = 9950, AskPrice = 10050, TickType = TickType.Quote });
             _algorithm.SetFinishedWarmingUp();
-            _btcusd.FeeModel = new NonAccountCurrencyCustomFeeModel(
-                new FeeModelParameters(_algorithm.AccountCurrency));
+            _btcusd.FeeModel = new NonAccountCurrencyCustomFeeModel(new FeeModelParameters(_algorithm));
             Assert.AreEqual(10000m, _portfolio.TotalPortfolioValue);
 
             // 0.24875621 * 100050 (ask price) + 0.5 (fee) * 15000 (conversion rate, because its BTC) = 9999.9999105

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -621,7 +621,8 @@ namespace QuantConnect.Tests.Common.Securities
             _btcusd = _algorithm.AddCrypto("BTCUSD");
             _btcusd.SetMarketPrice(new Tick { Value = 10000m, BidPrice = 9950, AskPrice = 10050, TickType = TickType.Quote });
             _algorithm.SetFinishedWarmingUp();
-            _btcusd.FeeModel = new NonAccountCurrencyCustomFeeModel();
+            _btcusd.FeeModel = new NonAccountCurrencyCustomFeeModel(
+                new FeeModelParameters(_algorithm.AccountCurrency));
             Assert.AreEqual(10000m, _portfolio.TotalPortfolioValue);
 
             // 0.24875621 * 100050 (ask price) + 0.5 (fee) * 15000 (conversion rate, because its BTC) = 9999.9999105
@@ -673,6 +674,11 @@ namespace QuantConnect.Tests.Common.Securities
             public override OrderFee GetOrderFee(OrderFeeParameters parameters)
             {
                 return new OrderFee(new CashAmount(FeeAmount, FeeCurrency));
+            }
+
+            public NonAccountCurrencyCustomFeeModel(FeeModelParameters feeModelParameters)
+                : base(feeModelParameters)
+            {
             }
         }
     }

--- a/Tests/Common/Securities/SecurityMarginModelTests.cs
+++ b/Tests/Common/Securities/SecurityMarginModelTests.cs
@@ -376,7 +376,8 @@ namespace QuantConnect.Tests.Common.Securities
             var algo = GetAlgorithm();
             var security = InitAndGetSecurity(algo, 0);
             algo.SetCash("EUR", 0, 100);
-            security.FeeModel = new NonAccountCurrencyCustomFeeModel();
+            security.FeeModel = new NonAccountCurrencyCustomFeeModel(
+                new FeeModelParameters(algo.AccountCurrency));
 
             // ((100000 - 100 * 100) * 2 * 0.9975 / (25)
             var actual = algo.CalculateOrderQuantity(_symbol, 1m * security.BuyingPowerModel.GetLeverage(security));
@@ -461,6 +462,11 @@ namespace QuantConnect.Tests.Common.Securities
             public override OrderFee GetOrderFee(OrderFeeParameters parameters)
             {
                 return new OrderFee(new CashAmount(FeeAmount, FeeCurrency));
+            }
+
+            public NonAccountCurrencyCustomFeeModel(FeeModelParameters feeModelParameters)
+                : base(feeModelParameters)
+            {
             }
         }
     }

--- a/Tests/Common/Securities/SecurityMarginModelTests.cs
+++ b/Tests/Common/Securities/SecurityMarginModelTests.cs
@@ -376,8 +376,7 @@ namespace QuantConnect.Tests.Common.Securities
             var algo = GetAlgorithm();
             var security = InitAndGetSecurity(algo, 0);
             algo.SetCash("EUR", 0, 100);
-            security.FeeModel = new NonAccountCurrencyCustomFeeModel(
-                new FeeModelParameters(algo.AccountCurrency));
+            security.FeeModel = new NonAccountCurrencyCustomFeeModel(new FeeModelParameters(algo));
 
             // ((100000 - 100 * 100) * 2 * 0.9975 / (25)
             var actual = algo.CalculateOrderQuantity(_symbol, 1m * security.BuyingPowerModel.GetLeverage(security));

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -642,7 +642,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(1000, portfolio.Cash);
 
             var orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
-                security, new MarketOrder(Symbols.EURUSD, 100, DateTime.MinValue), Currencies.USD));
+                security, new MarketOrder(Symbols.EURUSD, 100, DateTime.MinValue)));
             var fill = new OrderEvent(1, Symbols.EURUSD, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Buy, 1.1000m, 100, orderFee);
             portfolio.ProcessFill(fill);
             Assert.AreEqual(100, security.Holdings.Quantity);
@@ -678,7 +678,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(10000, portfolio.Cash);
 
             var orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
-                security, new MarketOrder(Symbols.BTCUSD, 2, DateTime.MinValue), Currencies.USD));
+                security, new MarketOrder(Symbols.BTCUSD, 2, DateTime.MinValue)));
             var fill = new OrderEvent(1, Symbols.BTCUSD, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Buy, 4000.01m, 2, OrderFee.Zero);
             portfolio.ProcessFill(fill);
             Assert.AreEqual(2, security.Holdings.Quantity);
@@ -714,7 +714,7 @@ namespace QuantConnect.Tests.Common.Securities
             // Buy on Monday
             var timeUtc = new DateTime(2015, 10, 26, 15, 30, 0);
             var orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
-                security, new MarketOrder(Symbols.AAPL, 10, timeUtc), Currencies.USD));
+                security, new MarketOrder(Symbols.AAPL, 10, timeUtc)));
             var fill = new OrderEvent(1, Symbols.AAPL, timeUtc, OrderStatus.Filled, OrderDirection.Buy, 100, 10, orderFee);
             portfolio.ProcessFill(fill);
             Assert.AreEqual(10, security.Holdings.Quantity);            Assert.AreEqual(-1, portfolio.Cash);
@@ -723,7 +723,7 @@ namespace QuantConnect.Tests.Common.Securities
             // Sell on Tuesday, cash unsettled
             timeUtc = timeUtc.AddDays(1);
             orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
-                security, new MarketOrder(Symbols.AAPL, 10, timeUtc), Currencies.USD));
+                security, new MarketOrder(Symbols.AAPL, 10, timeUtc)));
             fill = new OrderEvent(2, Symbols.AAPL, timeUtc, OrderStatus.Filled, OrderDirection.Sell, 100, -10, orderFee);
             portfolio.ProcessFill(fill);
             Assert.AreEqual(0, security.Holdings.Quantity);

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -330,7 +330,8 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             // Initializes the transaction handler
             var transactionHandler = new BrokerageTransactionHandler();
             transactionHandler.Initialize(_algorithm, new BacktestingBrokerage(_algorithm), new BacktestingResultHandler());
-            _algorithm.SetBrokerageModel(new TestBrokerageModel());
+            _algorithm.SetBrokerageModel(new TestBrokerageModel(
+                new BrokerageModelParameters(_algorithm)));
             // Creates a limit order
             var security = _algorithm.Securities[Ticker];
             var price = 1.12m;
@@ -904,6 +905,11 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             {
                 message = new BrokerageMessageEvent(0, 0, "");
                 return false;
+            }
+
+            public TestBrokerageModel(BrokerageModelParameters brokerageModelParameters)
+                : base(brokerageModelParameters)
+            {
             }
         }
 

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactoryTests.cs
@@ -24,6 +24,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories;
 using QuantConnect.Logging;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
 {
@@ -45,7 +46,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             );
 
             var universeSettings = new UniverseSettings(Resolution.Daily, 2m, true, false, TimeSpan.FromDays(1));
-            var securityInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(), SecuritySeeder.Null);
+            var securityInitializer = new BrokerageModelSecurityInitializer(
+                new DefaultBrokerageModel(new BrokerageModelParameters(
+                    new TestAccountCurrencyProvider())),
+                SecuritySeeder.Null);
             var universe = new CoarseFundamentalUniverse(universeSettings, securityInitializer, x => new List<Symbol>{ Symbols.AAPL });
 
             var fileProvider = new DefaultDataProvider();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding new `FeeModel` constructor parameter that will hold the account
currency. This is to avoid having to send it in through the
`OrderFeeParameter` in each `GetOrderFee` call.
- Adding new `BrokerageModelParameters` constructor parameter that will
hold the account currency provider and the account type. This is required for the
account currency to reach the `FeeModel`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2758
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/6
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->