### PR TITLE
Update FillModel.MarketFill to prevent fills at stale prices

### DIFF
--- a/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
@@ -156,6 +156,8 @@ namespace QuantConnect.Algorithm.CSharp
             }
             else if (Time.Hour > 13)
             {
+                if (Transactions.GetOpenOrders("LTCUSD").Count > 0) return;
+
                 // To include any initial holdings, we read the LTC amount from the cashbook
                 // instead of using Portfolio["LTCUSD"].Quantity
 
@@ -212,19 +214,19 @@ namespace QuantConnect.Algorithm.CSharp
             {"Compounding Annual Return", "-99.992%"},
             {"Drawdown", "3.800%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "-2.545%"},
-            {"Sharpe Ratio", "-16.028"},
+            {"Net Profit", "-2.546%"},
+            {"Sharpe Ratio", "-16.255"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "-5.47"},
-            {"Beta", "326.536"},
-            {"Annual Standard Deviation", "0.201"},
-            {"Annual Variance", "0.04"},
-            {"Information Ratio", "-16.112"},
-            {"Tracking Error", "0.2"},
+            {"Alpha", "-5.442"},
+            {"Beta", "322.169"},
+            {"Annual Standard Deviation", "0.198"},
+            {"Annual Variance", "0.039"},
+            {"Information Ratio", "-16.34"},
+            {"Tracking Error", "0.197"},
             {"Treynor Ratio", "-0.01"},
-            {"Total Fees", "$85.27"}
+            {"Total Fees", "$85.26"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -68,6 +68,8 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="slice">The current slice of data keyed by symbol string</param>
         public override void OnData(Slice slice)
         {
+            if (Transactions.GetOpenOrders().Count > 0) return;
+
             if (!Portfolio.Invested)
             {
                 foreach(var chain in slice.FutureChains)
@@ -117,25 +119,25 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "8220"},
+            {"Total Trades", "7964"},
             {"Average Win", "0.00%"},
             {"Average Loss", "0.00%"},
             {"Compounding Annual Return", "-100.000%"},
-            {"Drawdown", "13.500%"},
-            {"Expectancy", "-0.818"},
-            {"Net Profit", "-13.517%"},
-            {"Sharpe Ratio", "-29.354"},
+            {"Drawdown", "13.000%"},
+            {"Expectancy", "-0.807"},
+            {"Net Profit", "-12.980%"},
+            {"Sharpe Ratio", "-30.984"},
             {"Loss Rate", "89%"},
             {"Win Rate", "11%"},
-            {"Profit-Loss Ratio", "0.69"},
-            {"Alpha", "-7.746"},
-            {"Beta", "-0.859"},
-            {"Annual Standard Deviation", "0.305"},
-            {"Annual Variance", "0.093"},
-            {"Information Ratio", "-24.985"},
-            {"Tracking Error", "0.414"},
-            {"Treynor Ratio", "10.413"},
-            {"Total Fees", "$15207.00"}
+            {"Profit-Loss Ratio", "0.74"},
+            {"Alpha", "-7.572"},
+            {"Beta", "-0.719"},
+            {"Annual Standard Deviation", "0.277"},
+            {"Annual Variance", "0.077"},
+            {"Information Ratio", "-26.012"},
+            {"Tracking Error", "0.384"},
+            {"Treynor Ratio", "11.933"},
+            {"Total Fees", "$14733.40"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
@@ -59,6 +59,8 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void OnData(Slice slice)
         {
+            if (Transactions.GetOpenOrders().Count > 0) return;
+
             if (!Portfolio.Invested)
             {
                 OptionChain chain;
@@ -111,13 +113,13 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "778"},
+            {"Total Trades", "404"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.02%"},
-            {"Compounding Annual Return", "-100%"},
-            {"Drawdown", "6.800%"},
+            {"Compounding Annual Return", "-100.000%"},
+            {"Drawdown", "4.400%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "-6.821%"},
+            {"Net Profit", "-4.388%"},
             {"Sharpe Ratio", "0"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
@@ -129,7 +131,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$389.00"}
+            {"Total Fees", "$202.00"}
         };
     }
 }

--- a/Algorithm.CSharp/CustomModelsAlgorithm.cs
+++ b/Algorithm.CSharp/CustomModelsAlgorithm.cs
@@ -171,24 +171,24 @@ namespace QuantConnect.Algorithm.CSharp
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "62"},
-            {"Average Win", "0.11%"},
+            {"Average Win", "0.10%"},
             {"Average Loss", "-0.06%"},
-            {"Compounding Annual Return", "-7.582%"},
+            {"Compounding Annual Return", "-7.408%"},
             {"Drawdown", "2.400%"},
-            {"Expectancy", "-0.193"},
-            {"Net Profit", "-0.660%"},
-            {"Sharpe Ratio", "-1.563"},
-            {"Loss Rate", "70%"},
-            {"Win Rate", "30%"},
-            {"Profit-Loss Ratio", "1.71"},
-            {"Alpha", "-0.174"},
-            {"Beta", "5.695"},
+            {"Expectancy", "-0.186"},
+            {"Net Profit", "-0.645%"},
+            {"Sharpe Ratio", "-1.52"},
+            {"Loss Rate", "69%"},
+            {"Win Rate", "31%"},
+            {"Profit-Loss Ratio", "1.62"},
+            {"Alpha", "-0.171"},
+            {"Beta", "5.636"},
             {"Annual Standard Deviation", "0.046"},
             {"Annual Variance", "0.002"},
-            {"Information Ratio", "-1.959"},
+            {"Information Ratio", "-1.914"},
             {"Tracking Error", "0.046"},
-            {"Treynor Ratio", "-0.013"},
-            {"Total Fees", "$62.24"}
+            {"Treynor Ratio", "-0.012"},
+            {"Total Fees", "$62.23"}
         };
     }
 }

--- a/Algorithm.CSharp/MarketFillOnNextBarRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketFillOnNextBarRegressionAlgorithm.cs
@@ -1,0 +1,131 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This algorithm is a test case for market orders not being filled on fill-forward bars (stale prices),
+    /// but filled at the open price of the next bar.
+    /// </summary>
+    public class MarketFillOnNextBarRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 11);
+            SetCash(10000);
+
+            _symbol = AddEquity("AAPL", Resolution.Hour, Market.USA, true, 1).Symbol;
+            AddEquity("SPY", Resolution.Minute, Market.USA, true, 1);
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (Time.Day != 8) return;
+
+            if (Time.Hour == 9 && Time.Minute == 45)
+            {
+                var lastData = Securities[_symbol].GetLastData();
+
+                // log price from market close of 10/7/2013 at 4 PM
+                Log($"{Time} - latest price: {lastData.EndTime} - {lastData.Price}");
+
+                // this market order will be filled at the open of the next hourly bar (10:00 AM)
+                SetHoldings(_symbol, 0.85);
+
+                if (Portfolio.Invested)
+                {
+                    // order filled at price of last market close
+                    throw new Exception("Unexpected fill on fill-forward bar with stale price.");
+                }
+            }
+            if (Time.Hour == 9 && Time.Minute == 50)
+            {
+                var openOrders = Transactions.GetOpenOrders(_symbol);
+                if (openOrders.Count == 0)
+                {
+                    throw new Exception("Pending market order was expected on current bar.");
+                }
+            }
+            else if (Time.Hour == 10 && Time.Minute == 0)
+            {
+                if (!Portfolio.Invested)
+                {
+                    throw new Exception("Order fill was expected on current bar.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Order fill event handler. On an order fill update the resulting information is passed to this method.
+        /// </summary>
+        /// <param name="orderEvent">Order event details containing details of the event</param>
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Log($"{Time} - OnOrderEvent: {orderEvent}");
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "54.968%"},
+            {"Drawdown", "1.600%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0.562%"},
+            {"Sharpe Ratio", "1.894"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "26.43"},
+            {"Annual Standard Deviation", "0.154"},
+            {"Annual Variance", "0.024"},
+            {"Information Ratio", "1.823"},
+            {"Tracking Error", "0.154"},
+            {"Treynor Ratio", "0.011"},
+            {"Total Fees", "$1.00"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -90,6 +90,7 @@
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
     <Compile Include="Alphas\ForexCalendarAlpha.cs" />
     <Compile Include="Alphas\RebalancingLeveragedETFAlpha.cs" />
+    <Compile Include="MarketFillOnNextBarRegressionAlgorithm.cs" />
     <Compile Include="FeeModelNotUsingAccountCurrency.cs" />
     <Compile Include="MaximumPortfolioDrawdownFrameworkAlgorithm.cs" />
     <Compile Include="CompositeRiskManagementModelFrameworkAlgorithm.cs" />

--- a/Algorithm.CSharp/RegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionAlgorithm.cs
@@ -59,6 +59,8 @@ namespace QuantConnect.Algorithm.CSharp
                     continue;
                 }
 
+                if (Transactions.GetOpenOrders(symbol).Count > 0) return;
+
                 var holdings = Portfolio[symbol];
                 if (!holdings.Invested)
                 {
@@ -86,25 +88,25 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "5433"},
+            {"Total Trades", "161"},
             {"Average Win", "0.00%"},
             {"Average Loss", "0.00%"},
-            {"Compounding Annual Return", "-3.894%"},
-            {"Drawdown", "0.100%"},
-            {"Expectancy", "-0.993"},
-            {"Net Profit", "-0.054%"},
-            {"Sharpe Ratio", "-30.322"},
-            {"Loss Rate", "100%"},
-            {"Win Rate", "0%"},
-            {"Profit-Loss Ratio", "2.23"},
-            {"Alpha", "-0.019"},
-            {"Beta", "-0.344"},
-            {"Annual Standard Deviation", "0.001"},
+            {"Compounding Annual Return", "-0.117%"},
+            {"Drawdown", "0.000%"},
+            {"Expectancy", "-0.832"},
+            {"Net Profit", "-0.002%"},
+            {"Sharpe Ratio", "-17.638"},
+            {"Loss Rate", "94%"},
+            {"Win Rate", "6%"},
+            {"Profit-Loss Ratio", "1.69"},
+            {"Alpha", "-0.001"},
+            {"Beta", "0.059"},
+            {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-38.881"},
-            {"Tracking Error", "0.001"},
-            {"Treynor Ratio", "0.066"},
-            {"Total Fees", "$5433.00"}
+            {"Information Ratio", "-36.312"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "-0.011"},
+            {"Total Fees", "$161.00"}
         };
     }
 }

--- a/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
@@ -78,7 +78,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "394"},
             {"Average Win", "0.03%"},
             {"Average Loss", "0.00%"},
-            {"Compounding Annual Return", "608.511%"},
+            {"Compounding Annual Return", "608.520%"},
             {"Drawdown", "1.000%"},
             {"Expectancy", "5.981"},
             {"Net Profit", "2.535%"},

--- a/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateCryptoAlgorithm.py
@@ -141,6 +141,9 @@ class BasicTemplateCryptoAlgorithm(QCAlgorithm):
             self.Transactions.CancelOpenOrders("BTCEUR")
 
         elif self.Time.hour > 13:
+            if len(self.Transactions.GetOpenOrders("LTCUSD")) > 0:
+                return
+
             # To include any initial holdings, we read the LTC amount from the cashbook
             # instead of using Portfolio["LTCUSD"].Quantity
 

--- a/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
@@ -49,6 +49,9 @@ class BasicTemplateFuturesAlgorithm(QCAlgorithm):
 
 
     def OnData(self,slice):
+        if len(self.Transactions.GetOpenOrders()) > 0:
+            return
+
         if not self.Portfolio.Invested:
             for chain in slice.FutureChains:
                  # Get contracts expiring no earlier than in 90 days

--- a/Algorithm.Python/BasicTemplateOptionStrategyAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionStrategyAlgorithm.py
@@ -52,6 +52,9 @@ class BasicTemplateOptionStrategyAlgorithm(QCAlgorithm):
         self.SetBenchmark("GOOG")
 
     def OnData(self,slice):
+        if len(self.Transactions.GetOpenOrders()) > 0:
+            return
+
         if not self.Portfolio.Invested:
             for kvp in slice.OptionChains:
                 chain = kvp.Value

--- a/Algorithm.Python/RegressionAlgorithm.py
+++ b/Algorithm.Python/RegressionAlgorithm.py
@@ -58,6 +58,10 @@ class RegressionAlgorithm(QCAlgorithm):
                 pass
 
             symbol = kvp.Key
+
+            if len(self.Transactions.GetOpenOrders(symbol)) > 0:
+                return
+
             holdings = self.Portfolio[symbol]
 
             if not holdings.Invested:

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -58,6 +58,8 @@ namespace QuantConnect.Securities
 
             //Internal storage for transaction records:
             _transactionRecord = new Dictionary<DateTime, decimal>();
+
+            _marketOrderFillTimeout = TimeSpan.FromSeconds(algorithm != null && algorithm.LiveMode ? 5 : 0.5);
         }
 
         /// <summary>
@@ -257,7 +259,7 @@ namespace QuantConnect.Securities
 
             if (!orderTicket.OrderClosed.WaitOne(_marketOrderFillTimeout))
             {
-                Log.Error("SecurityTransactionManager.WaitForOrder(): Order did not fill within {0} seconds.", _marketOrderFillTimeout.TotalSeconds);
+                Log.Error($"SecurityTransactionManager.WaitForOrder(): Order {orderId} did not fill within {_marketOrderFillTimeout.TotalSeconds} seconds.");
                 return false;
             }
 

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -453,7 +453,9 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         public void ImmediateFillModelUsesPriceForTicksWhenBidAskSpreadsAreNotAvailable()
         {
             var noon = new DateTime(2014, 6, 24, 12, 0, 0);
-            var timeKeeper = new TimeKeeper(noon.ConvertToUtc(TimeZones.NewYork), new[] { TimeZones.NewYork });
+            var noonUtc = noon.ConvertToUtc(TimeZones.NewYork);
+
+            var timeKeeper = new TimeKeeper(noonUtc, new[] { TimeZones.NewYork });
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
             var config = new SubscriptionDataConfig(typeof(Tick), Symbols.SPY, Resolution.Tick, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
             var security = new Security(
@@ -468,11 +470,11 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
             // Add both a tradebar and a tick to the security cache
             // This is the case when a tick is seeded with minute data in an algorithm
-            security.Cache.AddData(new TradeBar(DateTime.MinValue, symbol, 1.0m, 1.0m, 1.0m, 1.0m, 1.0m));
-            security.Cache.AddData(new Tick(config, "42525000,1000000,100,A,@,0", DateTime.MinValue));
+            security.Cache.AddData(new TradeBar(noon, symbol, 1.0m, 1.0m, 1.0m, 1.0m, 1.0m));
+            security.Cache.AddData(new Tick(config, "57600000,1000000,100,A,@,0", noon));
 
             var fillModel = new ImmediateFillModel();
-            var order = new MarketOrder(symbol, 1000, DateTime.Now);
+            var order = new MarketOrder(symbol, 1000, noonUtc);
             var fill = fillModel.Fill(new FillModelParameters(
                 security,
                 order,
@@ -487,7 +489,9 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         public void ImmediateFillModelDoesNotUseTicksWhenThereIsNoTickSubscription()
         {
             var noon = new DateTime(2014, 6, 24, 12, 0, 0);
-            var timeKeeper = new TimeKeeper(noon.ConvertToUtc(TimeZones.NewYork), new[] { TimeZones.NewYork });
+            var noonUtc = noon.ConvertToUtc(TimeZones.NewYork);
+
+            var timeKeeper = new TimeKeeper(noonUtc, new[] { TimeZones.NewYork });
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
             // Minute subscription
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
@@ -501,13 +505,12 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, noon, 101.123m));
 
-
             // This is the case when a tick is seeded with minute data in an algorithm
-            security.Cache.AddData(new TradeBar(DateTime.MinValue, symbol, 1.0m, 1.0m, 1.0m, 1.0m, 1.0m));
-            security.Cache.AddData(new Tick(config, "42525000,1000000,100,A,@,0", DateTime.MinValue));
+            security.Cache.AddData(new TradeBar(noon, symbol, 1.0m, 1.0m, 1.0m, 1.0m, 1.0m));
+            security.Cache.AddData(new Tick(config, "57600000,1000000,100,A,@,0", noon));
 
             var fillModel = new ImmediateFillModel();
-            var order = new MarketOrder(symbol, 1000, DateTime.Now);
+            var order = new MarketOrder(symbol, 1000, noonUtc);
             var fill = fillModel.Fill(new FillModelParameters(
                 security,
                 order,

--- a/Tests/Common/Securities/DelayedSettlementModelTests.cs
+++ b/Tests/Common/Securities/DelayedSettlementModelTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using NUnit.Framework;
+using QuantConnect.Algorithm;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
@@ -31,7 +32,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SellOnMondaySettleOnThursday()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(null, securities);
+            var transactions = new SecurityTransactionManager(new QCAlgorithm(), securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             // settlement at T+3, 8:00 AM
             var model = new DelayedSettlementModel(3, TimeSpan.FromHours(8));
@@ -84,7 +85,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void SellOnThursdaySettleOnTuesday()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(null, securities);
+            var transactions = new SecurityTransactionManager(new QCAlgorithm(), securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             // settlement at T+3, 8:00 AM
             var model = new DelayedSettlementModel(3, TimeSpan.FromHours(8));

--- a/Tests/Common/Securities/ImmediateSettlementModelTests.cs
+++ b/Tests/Common/Securities/ImmediateSettlementModelTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using NUnit.Framework;
+using QuantConnect.Algorithm;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
@@ -31,7 +32,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void FundsAreSettledImmediately()
         {
             var securities = new SecurityManager(TimeKeeper);
-            var transactions = new SecurityTransactionManager(null, securities);
+            var transactions = new SecurityTransactionManager(new QCAlgorithm(), securities);
             var portfolio = new SecurityPortfolioManager(securities, transactions);
             var model = new ImmediateSettlementModel();
             var config = CreateTradeBarConfig();

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using NUnit.Framework;
+using QuantConnect.Algorithm;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
@@ -226,7 +227,7 @@ namespace QuantConnect.Tests.Common.Securities
         private SecurityPortfolioManager GetPortfolio(IOrderProcessor orderProcessor, int quantity)
         {
             var securities = new SecurityManager(new TimeKeeper(DateTime.Now, new[] { TimeZones.NewYork }));
-            var transactions = new SecurityTransactionManager(null, securities);
+            var transactions = new SecurityTransactionManager(new QCAlgorithm(), securities);
             transactions.SetOrderProcessor(orderProcessor);
 
             var portfolio = new SecurityPortfolioManager(securities, transactions);

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using QuantConnect.Algorithm;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
@@ -278,7 +279,7 @@ namespace QuantConnect.Tests.Common.Securities
         private SecurityPortfolioManager GetPortfolio(IOrderProcessor orderProcessor, int quantity)
         {
             var securities = new SecurityManager(new TimeKeeper(DateTime.Now, new[] { TimeZones.NewYork }));
-            var transactions = new SecurityTransactionManager(null, securities);
+            var transactions = new SecurityTransactionManager(new QCAlgorithm(), securities);
             transactions.SetOrderProcessor(orderProcessor);
 
             var portfolio = new SecurityPortfolioManager(securities, transactions);


### PR DESCRIPTION
#### Description
- The default fill model for market orders has been updated to never return fills on stale data (e.g. fill-forward bars). Orders submitted after the latest data point will be filled at the open price of the next bar.
- The new MarketFillOnNextBarRegressionAlgorithm regression algorithm has been added.
- Some regression algorithms with frequent trading have been slightly changed to check for pending market orders and expected statistics have been updated.
- The default MarketFillTimeout has also been lowered from 5 seconds to 0.5 seconds (only for backtesting).

#### Related Issue
Closes #2762 

#### Motivation and Context
Market orders can be filled at stale prices in the following cases:
- using multiple assets at different resolutions and submitting a market order for the lower resolution symbol
- submitting market orders from scheduled events at times not aligned with the asset resolution

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New regression test + existing unit and regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`