### PR TITLE
Fixes Plot(string, PyObject) handling of indicators.

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -396,29 +396,19 @@ namespace QuantConnect.Algorithm
         /// <seealso cref="Plot(string,decimal)"/>
         public void Plot(string series, PyObject pyObject)
         {
-            IIndicator<IndicatorDataPoint> indicator;
-
             using (Py.GIL())
             {
-                var pythonType = pyObject.GetPythonType();
-
                 try
                 {
-                    var type = pythonType.As<Type>();
-                    indicator = pyObject.AsManagedObject(type) as IIndicator<IndicatorDataPoint>;
-
-                    if (indicator == null)
-                    {
-                        throw new ArgumentException();
-                    }
+                    decimal value = ((dynamic)pyObject).Current.Value;
+                    Plot(series, value);
                 }
                 catch
                 {
-                    throw new ArgumentException($"QCAlgorithm.Plot(): The last argument should be a QuantConnect Indicator object, {pythonType.Repr()} was provided.");
+                    var pythonType = pyObject.GetPythonType().Repr();
+                    throw new ArgumentException($"QCAlgorithm.Plot(): The last argument should be a QuantConnect Indicator object, {pythonType} was provided.");
                 }
             }
-
-            Plot(series, indicator.Current.Value);
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
-        public void RegistersIndicatorProperlyPython()
+        public void PlotAndRegistersIndicatorProperlyPython()
         {
             var expected = 0;
             PyObject indicator;
@@ -111,6 +111,7 @@ namespace QuantConnect.Tests.Algorithm
                     throw new NotSupportedException($"RegistersIndicatorProperlyPython(): Unsupported indicator data type: {indicatorTest.GetType()}");
                 }
                 Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
+                Assert.DoesNotThrow(() => _algorithm.Plot(_spy.Value, indicator));
                 expected++;
 
                 var actual = _algorithm.SubscriptionManager.Subscriptions.FirstOrDefault().Consolidators.Count;


### PR DESCRIPTION
#### Description
`Plot(string, PyObject)` was not properly handling all types of indicators. With this fix, we capture the `.Current.Value` directly from the python object instead of converting it into an `IIndicator` object.

#### Related Issue
Closes #2771 

#### Motivation and Context
Bugfix.

#### How Has This Been Tested?
Manually using the snipped from the related issue.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests pass.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`