### PR TITLE
Fix Synchronizer live mode last empty error packet

### DIFF
--- a/Engine/DataFeeds/Synchronizer.cs
+++ b/Engine/DataFeeds/Synchronizer.cs
@@ -133,7 +133,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // send last empty packet list before terminating,
                 // so the algorithm manager has a chance to detect the runtime error
                 // and exit showing the correct error instead of a timeout
-                nextEmit = previousEmitTime.RoundDown(Time.OneSecond).Add(Time.OneSecond);
+                nextEmit = FrontierTimeProvider.GetUtcNow().RoundDown(Time.OneSecond);
                 if (!cancellationToken.IsCancellationRequested)
                 {
                     var timeSlice = _timeSliceFactory.Create(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- For the `Synchronizer` live mode, last empty packet sent after an exception,
will use the `FrontierTimeProvider.GetUtcNow()` as `TimeSlice` time.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2789
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix exception handling bug
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Live deployment, reproduced the reported issue and the exception (below) was correctly handled

> Runtime Error: The maximum number of concurrent market data subscriptions was exceeded (4).Please reduce the number of symbols requested or increase the limit using Settings.DataSubscriptionLimit. Stack Trace: System.Exception: The maximum number of concurrent market data subscriptions was exceeded (4).Please reduce the number of symbols requested or increase the limit using Settings.DataSubscriptionLimit.
  at QuantConnect.Lean.Engine.DataFeeds.DataManager.SubscriptionManagerGetOrAdd (QuantConnect.Data.SubscriptionDataConfig newConfig) [0x000c0] in <e2b0f86ae43b48608650acb1bc6e6edd>:0 
  at QuantConnect.Lean.Engine.DataFeeds.DataManager.Add (QuantConnect.Symbol symbol, QuantConnect.Resolution resolution, System.Boolean fillForward, System.Boolean extendedMarketHours, System.Boolean isFilteredSubscription, System.Boolean isInternalFeed, System.Boolean isCustomData, System.Collections.Generic.List`1[T] subscriptionDataTypes) [0x001c5] in <e2b0f86ae43b48608650acb1bc6e6edd>:0 
  at QuantConnect.Securities.Cash.EnsureCurrencyDataFeed (QuantConnect.Securities.SecurityManager securities, QuantConnect.Data.SubscriptionManager subscriptions, System.Collections.Generic.IReadOnlyDictionary`2[TKey,TValue] marketMap, QuantConnect.Data.UniverseSelection.SecurityChanges changes, QuantConnect.Interfaces.ISecurityService securityService, System.String accountCurrency) [0x003a8] in <4ec98f37c47d40bbac8ee68e0f21fb31>:0 
  at QuantConnect.Securities.CashBook.EnsureCurrencyDataFeeds (QuantConnect.Securities.SecurityManager securities, QuantConnect.Data.SubscriptionManager subscriptions, System.Collections.Generic.IReadOnlyDictionary`2[TKey,TValue] marketMap, QuantConnect.Data.UniverseSelection.SecurityChanges changes, QuantConnect.Interfaces.ISecurityService securityService) [0x00034] in <4ec98f37c47d40bbac8ee68e0f21fb31>:0 
  at QuantConnect.Lean.Engine.DataFeeds.CurrencySubscriptionDataConfigManager.EnsureCurrencySubscriptionDataConfigs (QuantConnect.Data.UniverseSelection.SecurityChanges securityChanges) [0x0004a] in <e2b0f86ae43b48608650acb1bc6e6edd>:0 
  at QuantConnect.Lean.Engine.DataFeeds.UniverseSelection.EnsureCurrencyDataFeeds (QuantConnect.Data.UniverseSelection.SecurityChanges securityChanges) [0x00001] in <e2b0f86ae43b48608650acb1bc6e6edd>:0 
  at QuantConnect.Lean.Engine.DataFeeds.UniverseSelection.ApplyUniverseSelection (QuantConnect.Data.UniverseSelection.Universe universe, System.DateTime dateTimeUtc, QuantConnect.Data.UniverseSelection.BaseDataCollection universeData) [0x006e6] in <e2b0f86ae43b48608650acb1bc6e6edd>:0 
  at QuantConnect.Lean.Engine.DataFeeds.SubscriptionSynchronizer.Sync (System.Collections.Generic.IEnumerable`1[T] subscriptions) [0x002ca] in <e2b0f86ae43b48608650acb1bc6e6edd>:0 
  at QuantConnect.Lean.Engine.DataFeeds.Synchronizer+<StreamData>d__13.MoveNext () [0x00086] in <e2b0f86ae43b48608650acb1bc6e6edd>:0

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->