### PR TITLE
Remove OrderFeeParameters.AccountCurrency

### DIFF
--- a/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
@@ -213,10 +213,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "6"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.21%"},
-            {"Compounding Annual Return", "-98.552%"},
+            {"Compounding Annual Return", "-98.595%"},
             {"Drawdown", "0.600%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "-0.626%"},
+            {"Net Profit", "-0.631%"},
             {"Sharpe Ratio", "0"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
@@ -228,7 +228,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$1.50"}
+            {"Total Fees", "$6.00"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
@@ -115,9 +115,9 @@ namespace QuantConnect.Algorithm.CSharp
             {"Average Win", "0%"},
             {"Average Loss", "-0.02%"},
             {"Compounding Annual Return", "-100%"},
-            {"Drawdown", "6.800%"},
+            {"Drawdown", "6.900%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "-6.821%"},
+            {"Net Profit", "-6.860%"},
             {"Sharpe Ratio", "0"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
@@ -129,7 +129,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$389.00"}
+            {"Total Fees", "$778.00"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
@@ -111,10 +111,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "2"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.28%"},
-            {"Compounding Annual Return", "-78.105%"},
+            {"Compounding Annual Return", "-78.282%"},
             {"Drawdown", "0.300%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "-0.280%"},
+            {"Net Profit", "-0.282%"},
             {"Sharpe Ratio", "0"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
@@ -126,7 +126,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$0.50"}
+            {"Total Fees", "$2.00"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -21,9 +21,7 @@ using QuantConnect.Algorithm.Framework.Execution;
 using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Algorithm.Framework.Risk;
 using QuantConnect.Algorithm.Framework.Selection;
-using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
-using QuantConnect.Orders;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Algorithm.CSharp
@@ -144,22 +142,22 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "4"},
             {"Average Win", "0.14%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "72.420%"},
+            {"Compounding Annual Return", "71.396%"},
             {"Drawdown", "0.700%"},
             {"Expectancy", "0"},
-            {"Net Profit", "0.274%"},
+            {"Net Profit", "0.271%"},
             {"Sharpe Ratio", "9.165"},
             {"Loss Rate", "0%"},
             {"Win Rate", "100%"},
             {"Profit-Loss Ratio", "0"},
             {"Alpha", "0"},
-            {"Beta", "25.02"},
+            {"Beta", "24.746"},
             {"Annual Standard Deviation", "0.025"},
             {"Annual Variance", "0.001"},
-            {"Information Ratio", "8.886"},
+            {"Information Ratio", "8.883"},
             {"Tracking Error", "0.025"},
             {"Treynor Ratio", "0.009"},
-            {"Total Fees", "$1.00"},
+            {"Total Fees", "$4.00"},
             {"Total Insights Generated", "26"},
             {"Total Insights Closed", "24"},
             {"Total Insights Analysis Completed", "24"},

--- a/Algorithm.CSharp/OptionChainConsistencyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainConsistencyRegressionAlgorithm.cs
@@ -121,11 +121,11 @@ namespace QuantConnect.Algorithm.CSharp
         {
             {"Total Trades", "2"},
             {"Average Win", "0%"},
-            {"Average Loss", "-3.86%"},
+            {"Average Loss", "-3.87%"},
             {"Compounding Annual Return", "-100.000%"},
             {"Drawdown", "3.900%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "-3.855%"},
+            {"Net Profit", "-3.870%"},
             {"Sharpe Ratio", "0"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
@@ -137,7 +137,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$0.50"}
+            {"Total Fees", "$2.00"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionChainProviderAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainProviderAlgorithm.cs
@@ -100,10 +100,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "2"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "3.198%"},
+            {"Compounding Annual Return", "2.775%"},
             {"Drawdown", "0.200%"},
             {"Expectancy", "0"},
-            {"Net Profit", "0.006%"},
+            {"Net Profit", "0.005%"},
             {"Sharpe Ratio", "0"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
@@ -115,7 +115,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$1.25"},
+            {"Total Fees", "$2.00"},
         };
     }
 }

--- a/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
@@ -125,10 +125,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "4"},
             {"Average Win", "0.30%"},
             {"Average Loss", "-0.33%"},
-            {"Compounding Annual Return", "-85.023%"},
+            {"Compounding Annual Return", "-85.144%"},
             {"Drawdown", "0.400%"},
             {"Expectancy", "-0.358"},
-            {"Net Profit", "-0.350%"},
+            {"Net Profit", "-0.352%"},
             {"Sharpe Ratio", "0"},
             {"Loss Rate", "67%"},
             {"Win Rate", "33%"},
@@ -140,7 +140,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$0.50"}
+            {"Total Fees", "$2.00"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
@@ -107,7 +107,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "2"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.01%"},
-            {"Compounding Annual Return", "-2.042%"},
+            {"Compounding Annual Return", "-2.072%"},
             {"Drawdown", "0.000%"},
             {"Expectancy", "-1"},
             {"Net Profit", "-0.010%"},
@@ -122,7 +122,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-11.225"},
             {"Tracking Error", "0.033"},
             {"Treynor Ratio", "0.355"},
-            {"Total Fees", "$0.50"}
+            {"Total Fees", "$2.00"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
@@ -139,11 +139,11 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "4"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.02%"},
-            {"Compounding Annual Return", "-0.472%"},
+            {"Compounding Annual Return", "-0.484%"},
             {"Drawdown", "0.000%"},
             {"Expectancy", "-1"},
             {"Net Profit", "-0.006%"},
-            {"Sharpe Ratio", "-3.344"},
+            {"Sharpe Ratio", "-3.415"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
@@ -153,8 +153,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Annual Variance", "0"},
             {"Information Ratio", "10.014"},
             {"Tracking Error", "0.877"},
-            {"Treynor Ratio", "4.212"},
-            {"Total Fees", "$2.50"}
+            {"Treynor Ratio", "4.289"},
+            {"Total Fees", "$4.00"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
@@ -129,7 +129,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "2"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.02%"},
-            {"Compounding Annual Return", "-1.564%"},
+            {"Compounding Annual Return", "-1.578%"},
             {"Drawdown", "0.000%"},
             {"Expectancy", "-1"},
             {"Net Profit", "-0.017%"},
@@ -144,7 +144,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "7.935"},
             {"Tracking Error", "6.786"},
             {"Treynor Ratio", "161.568"},
-            {"Total Fees", "$0.50"}
+            {"Total Fees", "$2.00"}
         };
     }
 }

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -367,8 +367,7 @@ namespace QuantConnect.Brokerages.Backtesting
                                     {
                                         fill.OrderFee = security.FeeModel.GetOrderFee(
                                             new OrderFeeParameters(security,
-                                                order,
-                                                Algorithm.Portfolio.CashBook.AccountCurrency));
+                                                order));
                                     }
                                 }
                             }

--- a/Brokerages/Backtesting/BasicOptionAssignmentSimulation.cs
+++ b/Brokerages/Backtesting/BasicOptionAssignmentSimulation.cs
@@ -179,7 +179,7 @@ namespace QuantConnect.Brokerages.Backtesting
             // Scenario 1 (base): we just close option position
             var marketOrder1 = new MarketOrder(option.Symbol, -holding.Quantity, option.LocalTime.ConvertToUtc(option.Exchange.TimeZone));
             var orderFee1 = currencyConverter.ConvertToAccountCurrency(option.FeeModel.GetOrderFee(
-                new OrderFeeParameters(option, marketOrder1, currencyConverter.AccountCurrency)).Value);
+                new OrderFeeParameters(option, marketOrder1)).Value);
 
             var basePnL = (optionPrice - holding.AveragePrice) * -holding.Quantity
                 * option.QuoteCurrency.ConversionRate
@@ -189,11 +189,11 @@ namespace QuantConnect.Brokerages.Backtesting
             // Scenario 2 (alternative): we exercise option and then close underlying position
             var optionExerciseOrder2 = new OptionExerciseOrder(option.Symbol, (int)holding.AbsoluteQuantity, option.LocalTime.ConvertToUtc(option.Exchange.TimeZone));
             var optionOrderFee2 = currencyConverter.ConvertToAccountCurrency(option.FeeModel.GetOrderFee(
-                new OrderFeeParameters(option, optionExerciseOrder2, currencyConverter.AccountCurrency)).Value);
+                new OrderFeeParameters(option, optionExerciseOrder2)).Value);
 
             var undelyingMarketOrder2 = new MarketOrder(underlying.Symbol, -underlyingQuantity, underlying.LocalTime.ConvertToUtc(underlying.Exchange.TimeZone));
             var undelyingOrderFee2 = currencyConverter.ConvertToAccountCurrency(underlying.FeeModel.GetOrderFee(
-                new OrderFeeParameters(underlying, undelyingMarketOrder2, currencyConverter.AccountCurrency)).Value);
+                new OrderFeeParameters(underlying, undelyingMarketOrder2)).Value);
 
             // calculating P/L of the two transactions (exercise option and then close underlying position)
             var altPnL = (underlyingPrice - option.StrikePrice) * underlyingQuantity * underlying.QuoteCurrency.ConversionRate * option.ContractUnitOfTrade

--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -574,7 +574,7 @@ namespace QuantConnect.Brokerages.Bitfinex
                 {
                     var security = _securityProvider.GetSecurity(order.Symbol);
                     orderFee = security.FeeModel.GetOrderFee(
-                        new OrderFeeParameters(security, order, _algorithm.Portfolio.CashBook.AccountCurrency));
+                        new OrderFeeParameters(security, order));
                 }
 
                 OrderStatus status = fillQuantity == order.Quantity ? OrderStatus.Filled : OrderStatus.PartiallyFilled;

--- a/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
@@ -30,7 +30,6 @@ using QuantConnect.Data.Market;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
-using QuantConnect.Securities;
 
 namespace QuantConnect.Brokerages.Fxcm
 {
@@ -398,7 +397,7 @@ namespace QuantConnect.Brokerages.Fxcm
                         {
                             var security = _securityProvider.GetSecurity(order.Symbol);
                             orderEvent.OrderFee = security.FeeModel.GetOrderFee(
-                                new OrderFeeParameters(security, order, _fxcmAccountCurrency));
+                                new OrderFeeParameters(security, order));
                         }
 
                         _orderEventQueue.Enqueue(orderEvent);

--- a/Brokerages/Tradier/TradierBrokerage.cs
+++ b/Brokerages/Tradier/TradierBrokerage.cs
@@ -1353,7 +1353,7 @@ namespace QuantConnect.Brokerages.Tradier
                     cachedOrder.EmittedOrderFee = true;
                     var security = _securityProvider.GetSecurity(qcOrder.Symbol);
                     fill.OrderFee = security.FeeModel.GetOrderFee(
-                        new OrderFeeParameters(security, qcOrder, Currencies.USD));
+                        new OrderFeeParameters(security, qcOrder));
                 }
 
                 // if we filled the order and have another contingent order waiting, submit it

--- a/Common/Orders/Fees/ConstantFeeModel.cs
+++ b/Common/Orders/Fees/ConstantFeeModel.cs
@@ -24,14 +24,17 @@ namespace QuantConnect.Orders.Fees
     public class ConstantFeeModel : FeeModel
     {
         private readonly decimal _fee;
+        private readonly string _currency;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstantFeeModel"/> class with the specified <paramref name="fee"/>
         /// </summary>
         /// <param name="fee">The constant order fee used by the model</param>
-        public ConstantFeeModel(decimal fee)
+        /// <param name="currency">The currency of the order fee</param>
+        public ConstantFeeModel(decimal fee, string currency = "USD")
         {
             _fee = Math.Abs(fee);
+            _currency = currency;
         }
 
         /// <summary>
@@ -42,8 +45,7 @@ namespace QuantConnect.Orders.Fees
         /// <returns>The cost of the order in units of the account currency</returns>
         public override OrderFee GetOrderFee(OrderFeeParameters parameters)
         {
-            return new OrderFee(new CashAmount(_fee,
-                parameters.AccountCurrency));
+            return new OrderFee(new CashAmount(_fee, _currency));
         }
     }
 }

--- a/Common/Orders/Fees/FeeModel.cs
+++ b/Common/Orders/Fees/FeeModel.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Orders.Fees
         {
             return new OrderFee(new CashAmount(
                 0,
-                parameters.AccountCurrency));
+                "USD"));
         }
     }
 }

--- a/Common/Orders/Fees/FxcmFeeModel.cs
+++ b/Common/Orders/Fees/FxcmFeeModel.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Orders.Fees
     /// </summary>
     public class FxcmFeeModel : FeeModel
     {
+        private readonly string _currency;
+
         private readonly HashSet<Symbol> _groupCommissionSchedule1 = new HashSet<Symbol>
         {
             Symbol.Create("EURUSD", SecurityType.Forex, Market.FXCM),
@@ -34,6 +36,15 @@ namespace QuantConnect.Orders.Fees
             Symbol.Create("EURJPY", SecurityType.Forex, Market.FXCM),
             Symbol.Create("GBPJPY", SecurityType.Forex, Market.FXCM),
         };
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="currency">The currency of the order fee, for FXCM this is the account currency</param>
+        public FxcmFeeModel(string currency = "USD")
+        {
+            _currency = currency;
+        }
 
         /// <summary>
         /// Get the fee for this order in units of the account currency
@@ -59,7 +70,7 @@ namespace QuantConnect.Orders.Fees
                 fee = Math.Abs(commissionRate * parameters.Order.AbsoluteQuantity / 1000);
             }
             return new OrderFee(new CashAmount(fee,
-                parameters.AccountCurrency));
+                _currency));
         }
     }
 }

--- a/Common/Orders/Fees/IFeeModel.cs
+++ b/Common/Orders/Fees/IFeeModel.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Orders.Fees
@@ -50,7 +49,7 @@ namespace QuantConnect.Orders.Fees
         /// <returns>The cost of the order in units of the account currency</returns>
         public static decimal GetOrderFee(this IFeeModel model, Security security, Order order)
         {
-            var parameters = new OrderFeeParameters(security, order, security.QuoteCurrency.Symbol);
+            var parameters = new OrderFeeParameters(security, order);
             var fee = model.GetOrderFee(parameters);
 
             return fee.Value.Amount;

--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -62,13 +62,12 @@ namespace QuantConnect.Orders.Fees
                 if (optionOrder.Symbol.ID.SecurityType == SecurityType.Option &&
                     optionOrder.Symbol.ID.Underlying.SecurityType == SecurityType.Equity)
                 {
-                    return new OrderFee(new CashAmount(
-                        0,
-                        parameters.AccountCurrency));
+                    return OrderFee.Zero;
                 }
             }
 
             decimal feeResult = 0;
+            string feeCurrency = security.QuoteCurrency.Symbol;
             switch (security.Type)
             {
                 case SecurityType.Forex:
@@ -76,6 +75,8 @@ namespace QuantConnect.Orders.Fees
                     var totalOrderValue = order.GetValue(security);
                     var fee = Math.Abs(_forexCommissionRate*totalOrderValue);
                     feeResult = Math.Max(_forexMinimumOrderFee, fee);
+                    // IB Forex fees are all in USD
+                    feeCurrency = "USD";
                     break;
                 case SecurityType.Option:
                     // applying commission function to the order
@@ -111,7 +112,7 @@ namespace QuantConnect.Orders.Fees
             // all other types default to zero fees
             return new OrderFee(new CashAmount(
                 feeResult,
-                parameters.AccountCurrency));
+                feeCurrency));
         }
 
         /// <summary>

--- a/Common/Orders/Fees/OrderFeeParameters.cs
+++ b/Common/Orders/Fees/OrderFeeParameters.cs
@@ -31,21 +31,14 @@ namespace QuantConnect.Orders.Fees
         public Order Order { get; }
 
         /// <summary>
-        /// Gets account currency
-        /// </summary>
-        public string AccountCurrency { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="OrderFeeParameters"/> class
         /// </summary>
         /// <param name="security">The security</param>
         /// <param name="order">The order</param>
-        /// <param name="accountCurrency">The account currency</param>
-        public OrderFeeParameters(Security security, Order order, string accountCurrency)
+        public OrderFeeParameters(Security security, Order order)
         {
             Security = security;
             Order = order;
-            AccountCurrency = accountCurrency;
         }
     }
 }

--- a/Common/Python/FeeModelPythonWrapper.cs
+++ b/Common/Python/FeeModelPythonWrapper.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.Python
                     }
                 }
                 decimal fee = _model.GetOrderFee(parameters.Security, parameters.Order);
-                return new OrderFee(new CashAmount(fee, parameters.AccountCurrency));
+                return new OrderFee(new CashAmount(fee, "USD"));
             }
         }
     }

--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -141,8 +141,7 @@ namespace QuantConnect.Securities
 
             var fees = parameters.Security.FeeModel.GetOrderFee(
                 new OrderFeeParameters(parameters.Security,
-                    parameters.Order,
-                    parameters.CurrencyConverter.AccountCurrency)).Value;
+                    parameters.Order)).Value;
             var feesInAccountCurrency = parameters.CurrencyConverter.
                 ConvertToAccountCurrency(fees).Amount;
 
@@ -395,8 +394,7 @@ namespace QuantConnect.Securities
 
                 var fees = parameters.Security.FeeModel.GetOrderFee(
                     new OrderFeeParameters(parameters.Security,
-                        order,
-                        parameters.Portfolio.CashBook.AccountCurrency)).Value;
+                        order)).Value;
                 orderFees = parameters.Portfolio.CashBook.ConvertToAccountCurrency(fees).Amount;
 
                 // The TPV, take out the fees(unscaled) => yields available value for trading(less fees)

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -129,8 +129,7 @@ namespace QuantConnect.Securities
             {
                 var fee = parameters.Security.FeeModel.GetOrderFee(
                     new OrderFeeParameters(parameters.Security,
-                        parameters.Order,
-                        parameters.Portfolio.CashBook.AccountCurrency)).Value;
+                        parameters.Order)).Value;
                 orderFee = parameters.Portfolio.CashBook.Convert(
                         fee.Amount,
                         fee.Currency,
@@ -269,8 +268,7 @@ namespace QuantConnect.Securities
 
                 var fees = parameters.Security.FeeModel.GetOrderFee(
                     new OrderFeeParameters(parameters.Security,
-                        order,
-                        parameters.Portfolio.CashBook.AccountCurrency)).Value;
+                        order)).Value;
                 orderFees = parameters.Portfolio.CashBook.ConvertToAccountCurrency(fees).Amount;
 
                 currentOrderValue = orderValue + orderFees;

--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -81,8 +81,7 @@ namespace QuantConnect.Securities.Future
 
             var fees = parameters.Security.FeeModel.GetOrderFee(
                 new OrderFeeParameters(parameters.Security,
-                    parameters.Order,
-                    parameters.CurrencyConverter.AccountCurrency)).Value;
+                    parameters.Order)).Value;
             var feesInAccountCurrency = parameters.CurrencyConverter.
                 ConvertToAccountCurrency(fees).Amount;
 

--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -77,8 +77,7 @@ namespace QuantConnect.Securities.Option
 
             var fees = parameters.Security.FeeModel.GetOrderFee(
                 new OrderFeeParameters(parameters.Security,
-                    parameters.Order,
-                    parameters.CurrencyConverter.AccountCurrency)).Value;
+                    parameters.Order)).Value;
             var feesInAccountCurrency = parameters.CurrencyConverter.
                 ConvertToAccountCurrency(fees).Amount;
 

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -434,7 +434,7 @@ namespace QuantConnect.Securities
             var marketOrder = new MarketOrder(_security.Symbol, -Quantity, _security.LocalTime.ConvertToUtc(_security.Exchange.TimeZone));
 
             var orderFee = _security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(_security, marketOrder, _currencyConverter.AccountCurrency)).Value;
+                new OrderFeeParameters(_security, marketOrder)).Value;
             var feesInAccountCurrency = _currencyConverter.
                 ConvertToAccountCurrency(orderFee).Amount;
 

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -94,8 +94,7 @@ namespace QuantConnect.Lean.Engine.Setup
                 }
             });
 
-            Log.Trace("BaseSetupHandler.SetupCurrencyConversions(): " +
-                $"{string.Join(" | ", algorithm.Portfolio.CashBook.Values.Select(x => x.ToString()))}");
+            Log.Trace($"BaseSetupHandler.SetupCurrencyConversions(): {algorithm.Portfolio.CashBook}");
         }
     }
 }

--- a/Tests/Algorithm/AlgorithmInitializeTests.cs
+++ b/Tests/Algorithm/AlgorithmInitializeTests.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -65,7 +65,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -82,7 +82,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -100,7 +100,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -118,7 +118,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -139,7 +139,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -161,7 +161,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -183,7 +183,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -206,7 +206,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -229,7 +229,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -252,7 +252,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -275,7 +275,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(100, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -298,7 +298,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -321,7 +321,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -344,7 +344,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(50, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -367,7 +367,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -391,7 +391,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -415,7 +415,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(InteractiveBrokersFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(2, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -438,7 +438,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -461,7 +461,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(ConstantFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }
@@ -484,7 +484,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(25, Math.Round(security.Leverage, RoundingPrecision));
             Assert.IsInstanceOf(typeof(FxcmFeeModel), security.FeeModel);
             var fee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, _order, Currencies.USD));
+                new OrderFeeParameters(security, _order));
             Assert.AreEqual(0.04, fee.Value.Amount);
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
         }

--- a/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
+++ b/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
@@ -182,7 +182,7 @@ namespace QuantConnect.Tests.Algorithm
                 Assert.That(Math.Abs(requiredMargin) <= freeMargin);
 
                 orderFee = security.FeeModel.GetOrderFee(
-                    new OrderFeeParameters(security, order, Currencies.USD));
+                    new OrderFeeParameters(security, order));
                 fill = new OrderEvent(order, DateTime.UtcNow, orderFee) { FillPrice = security.Price, FillQuantity = orderQuantity };
                 algorithm.Portfolio.ProcessFill(fill);
 
@@ -228,7 +228,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.That(Math.Abs(requiredMargin) <= freeMargin);
 
             orderFee = security.FeeModel.GetOrderFee(
-                new OrderFeeParameters(security, order, Currencies.USD));
+                new OrderFeeParameters(security, order));
             fill = new OrderEvent(order, DateTime.UtcNow, orderFee) { FillPrice = security.Price, FillQuantity = orderQuantity };
             algorithm.Portfolio.ProcessFill(fill);
 

--- a/Tests/Brokerages/Bitfinex/BitfinexFeeModelTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexFeeModelTests.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
 
             Order order = parameters.CreateShortOrder(Quantity);
             var price = order.Type == OrderType.Limit ? ((LimitOrder)order).LimitPrice : LowPrice;
-            var fee = feeModel.GetOrderFee(new OrderFeeParameters(Security, order, Currencies.USD));
+            var fee = feeModel.GetOrderFee(new OrderFeeParameters(Security, order));
 
             Assert.AreEqual(
                 BitfinexFeeModel.MakerFee * price * Math.Abs(Quantity), fee.Value.Amount);
@@ -109,7 +109,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
             Order order = parameters.CreateShortOrder(Quantity);
             var price = order.Type == OrderType.Limit ? ((LimitOrder)order).LimitPrice : LowPrice;
             var fee =
-                feeModel.GetOrderFee(new OrderFeeParameters(Security, order, Currencies.USD));
+                feeModel.GetOrderFee(new OrderFeeParameters(Security, order));
 
             Assert.AreEqual(
                 BitfinexFeeModel.TakerFee * price * Math.Abs(Quantity), fee.Value.Amount);
@@ -125,7 +125,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
             Order order = parameters.CreateLongOrder(Quantity);
             var price = order.Type == OrderType.Limit ? ((LimitOrder)order).LimitPrice : HighPrice;
             var fee =
-                feeModel.GetOrderFee(new OrderFeeParameters(Security, order, Currencies.USD));
+                feeModel.GetOrderFee(new OrderFeeParameters(Security, order));
 
             Assert.AreEqual(
                 BitfinexFeeModel.MakerFee * price * Math.Abs(Quantity), fee.Value.Amount);
@@ -141,7 +141,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
             Order order = parameters.CreateLongOrder(Quantity);
             var price = order.Type == OrderType.Limit ? ((LimitOrder)order).LimitPrice : HighPrice;
             var fee =
-                feeModel.GetOrderFee(new OrderFeeParameters(Security, order, Currencies.USD));
+                feeModel.GetOrderFee(new OrderFeeParameters(Security, order));
 
             Assert.AreEqual(
                 BitfinexFeeModel.TakerFee * price * Math.Abs(Quantity), fee.Value.Amount);

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -123,8 +123,7 @@ namespace QuantConnect.Tests.Common.Brokerages
             security.SetMarketPrice(new TradeBar { Symbol = security.Symbol, Close = 5000m });
             var orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
                 security,
-                new MarketOrder(security.Symbol, 1, DateTime.MinValue),
-                Currencies.USD));
+                new MarketOrder(security.Symbol, 1, DateTime.MinValue)));
 
             Assert.AreEqual(15m, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -141,7 +140,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 4999.99m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -151,7 +150,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5000m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -160,7 +159,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, -1, 5000.01m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -176,7 +175,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5000.01m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             // marketable buy limit fill at 5000
             Assert.AreEqual(15m, orderFee.Value.Amount);
@@ -187,7 +186,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5000.01m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             // marketable buy limit fill at 5000.01
             Assert.AreEqual(15.00003m, orderFee.Value.Amount);
@@ -197,7 +196,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, -1, 5000m, DateTime.MinValue)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             // marketable sell limit fill at 5000
             Assert.AreEqual(15m, orderFee.Value.Amount);
@@ -217,7 +216,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 4999.99m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -226,7 +225,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, -1, 5000.01m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(0, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -245,7 +244,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5000m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(15m, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -254,7 +253,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, 1, 5050m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(15m, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);
@@ -263,7 +262,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                 security, new LimitOrder(security.Symbol, -1, 4950m, time)
                 {
                     OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Price)
-                }, Currencies.USD));
+                }));
 
             Assert.AreEqual(15m, orderFee.Value.Amount);
             Assert.AreEqual(Currencies.USD, orderFee.Value.Currency);

--- a/Tests/Common/Orders/Fees/BackwardsCompatibilityFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/BackwardsCompatibilityFeeModelTests.cs
@@ -63,8 +63,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
 
                 var result = wrapper.GetOrderFee(new OrderFeeParameters(
                     _security,
-                    new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    Currencies.USD
+                    new MarketOrder(_security.Symbol, 1, orderDateTime)
                 ));
 
                 bool called;
@@ -91,15 +90,14 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                     "       self.CalledGetOrderFee = False\n" +
                     "   def GetOrderFee(self, parameters):\n" +
                     "       self.CalledGetOrderFee = True\n" +
-                    "       return OrderFee(CashAmount(15, parameters.AccountCurrency))");
+                    "       return OrderFee(CashAmount(15, \"USD\"))");
 
                 var customFeeModel = module.GetAttr("CustomFeeModel").Invoke();
                 var wrapper = new FeeModelPythonWrapper(customFeeModel);
 
                 var result = wrapper.GetOrderFee(new OrderFeeParameters(
                     _security,
-                    new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    Currencies.USD
+                    new MarketOrder(_security.Symbol, 1, orderDateTime)
                 ));
 
                 bool called;

--- a/Tests/Common/Orders/Fees/BitfinexFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/BitfinexFeeModelTests.cs
@@ -60,8 +60,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btcusd,
-                    new MarketOrder(_btcusd.Symbol, 1, DateTime.UtcNow),
-                    Currencies.USD
+                    new MarketOrder(_btcusd.Symbol, 1, DateTime.UtcNow)
                 )
             );
 
@@ -76,8 +75,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btceur,
-                    new MarketOrder(_btceur.Symbol, 1, DateTime.UtcNow),
-                    Currencies.USD
+                    new MarketOrder(_btceur.Symbol, 1, DateTime.UtcNow)
                 )
             );
 

--- a/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
@@ -60,8 +60,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btcusd,
-                    new MarketOrder(_btcusd.Symbol, 1, DateTime.UtcNow),
-                    Currencies.USD
+                    new MarketOrder(_btcusd.Symbol, 1, DateTime.UtcNow)
                 )
             );
 
@@ -76,8 +75,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btceur,
-                    new MarketOrder(_btceur.Symbol, 1, DateTime.UtcNow),
-                    Currencies.USD
+                    new MarketOrder(_btceur.Symbol, 1, DateTime.UtcNow)
                 )
             );
 

--- a/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
@@ -21,6 +21,7 @@ using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Forex;
+using QuantConnect.Securities.Future;
 using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Orders.Fees
@@ -31,7 +32,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
         private readonly IFeeModel _feeModel = new InteractiveBrokersFeeModel();
 
         [Test]
-        public void ReturnsMinimumFeeInQuoteCurrency_USD()
+        public void USAEquityMinimumFeeInUSD()
         {
             var security = SecurityTests.GetSecurity();
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
@@ -48,7 +49,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
         }
 
         [Test]
-        public void ReturnsFeeInQuoteCurrency_USD()
+        public void USAEquityFeeInUSD()
         {
             var security = SecurityTests.GetSecurity();
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
@@ -62,6 +63,29 @@ namespace QuantConnect.Tests.Common.Orders.Fees
 
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
             Assert.AreEqual(5m, fee.Value.Amount);
+        }
+
+        [Test]
+        public void USAFutureFee()
+        {
+            var tz = TimeZones.NewYork;
+            var security = new Future(Symbols.Fut_SPY_Feb19_2016,
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("USD", 0, 0),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+                );
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1000, DateTime.UtcNow)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            Assert.AreEqual(1000 * 1.85m, fee.Value.Amount);
         }
 
         [Test]

--- a/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
@@ -22,6 +22,7 @@ using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Forex;
 using QuantConnect.Securities.Future;
+using QuantConnect.Securities.Option;
 using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Common.Orders.Fees
@@ -86,6 +87,52 @@ namespace QuantConnect.Tests.Common.Orders.Fees
 
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
             Assert.AreEqual(1000 * 1.85m, fee.Value.Amount);
+        }
+
+        [Test]
+        public void USAOptionFee()
+        {
+            var tz = TimeZones.NewYork;
+            var security = new Option(Symbols.SPY_C_192_Feb19_2016,
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("USD", 0, 0),
+                new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
+                ErrorCurrencyConverter.Instance
+            );
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1000, DateTime.UtcNow)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            Assert.AreEqual(250m, fee.Value.Amount);
+        }
+
+        [Test]
+        public void USAOptionMinimumFee()
+        {
+            var tz = TimeZones.NewYork;
+            var security = new Option(Symbols.SPY_C_192_Feb19_2016,
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("USD", 0, 0),
+                new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
+                ErrorCurrencyConverter.Instance
+            );
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1, DateTime.UtcNow)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            Assert.AreEqual(1m, fee.Value.Amount);
         }
 
         [Test]

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -642,7 +642,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(1000, portfolio.Cash);
 
             var orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
-                security, new MarketOrder(Symbols.EURUSD, 100, DateTime.MinValue), Currencies.USD));
+                security, new MarketOrder(Symbols.EURUSD, 100, DateTime.MinValue)));
             var fill = new OrderEvent(1, Symbols.EURUSD, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Buy, 1.1000m, 100, orderFee);
             portfolio.ProcessFill(fill);
             Assert.AreEqual(100, security.Holdings.Quantity);
@@ -678,7 +678,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(10000, portfolio.Cash);
 
             var orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
-                security, new MarketOrder(Symbols.BTCUSD, 2, DateTime.MinValue), Currencies.USD));
+                security, new MarketOrder(Symbols.BTCUSD, 2, DateTime.MinValue)));
             var fill = new OrderEvent(1, Symbols.BTCUSD, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Buy, 4000.01m, 2, OrderFee.Zero);
             portfolio.ProcessFill(fill);
             Assert.AreEqual(2, security.Holdings.Quantity);
@@ -714,7 +714,7 @@ namespace QuantConnect.Tests.Common.Securities
             // Buy on Monday
             var timeUtc = new DateTime(2015, 10, 26, 15, 30, 0);
             var orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
-                security, new MarketOrder(Symbols.AAPL, 10, timeUtc), Currencies.USD));
+                security, new MarketOrder(Symbols.AAPL, 10, timeUtc)));
             var fill = new OrderEvent(1, Symbols.AAPL, timeUtc, OrderStatus.Filled, OrderDirection.Buy, 100, 10, orderFee);
             portfolio.ProcessFill(fill);
             Assert.AreEqual(10, security.Holdings.Quantity);            Assert.AreEqual(-1, portfolio.Cash);
@@ -723,7 +723,7 @@ namespace QuantConnect.Tests.Common.Securities
             // Sell on Tuesday, cash unsettled
             timeUtc = timeUtc.AddDays(1);
             orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(
-                security, new MarketOrder(Symbols.AAPL, 10, timeUtc), Currencies.USD));
+                security, new MarketOrder(Symbols.AAPL, 10, timeUtc)));
             fill = new OrderEvent(2, Symbols.AAPL, timeUtc, OrderStatus.Filled, OrderDirection.Sell, 100, -10, orderFee);
             portfolio.ProcessFill(fill);
             Assert.AreEqual(0, security.Holdings.Quantity);

--- a/Tests/Engine/BasicOptionAssignmentSimulationTests.cs
+++ b/Tests/Engine/BasicOptionAssignmentSimulationTests.cs
@@ -139,15 +139,15 @@ namespace QuantConnect.Tests.Engine
 
             // we define option chain with expected results for each contract (if it is optimal to exercise it or not)
             var optionChain = new[] { new { Right = OptionRight.Call, StrikePrice = 190.0m, BidPrice = 27.81m, AskPrice = 28.01m, Exercise = true },
-                                    new { Right = OptionRight.Call, StrikePrice = 193.0m, BidPrice = 24.87m, AskPrice = 24.99m, Exercise = false },
+                                    new { Right = OptionRight.Call, StrikePrice = 193.0m, BidPrice = 24.87m, AskPrice = 24.99m, Exercise = true },
                                     new { Right = OptionRight.Call, StrikePrice = 196.0m, BidPrice = 21.50m, AskPrice = 21.63m, Exercise = true },
                                     new { Right = OptionRight.Call, StrikePrice = 198.0m, BidPrice = 18.79m, AskPrice = 18.96m, Exercise = true },
                                     new { Right = OptionRight.Call, StrikePrice = 200.0m, BidPrice = 17.77m, AskPrice = 17.96m, Exercise = true },
                                     new { Right = OptionRight.Call, StrikePrice = 202.0m, BidPrice = 15.31m, AskPrice = 15.47m, Exercise = true },
 
-                                    new { Right = OptionRight.Put, StrikePrice = 225.0m, BidPrice = 7.071m, AskPrice = 7.26m, Exercise = false },
-                                    new { Right = OptionRight.Put, StrikePrice = 226.0m, BidPrice = 8.07m, AskPrice = 8.24m, Exercise = false },
-                                    new { Right = OptionRight.Put, StrikePrice = 227.0m, BidPrice = 9.59m, AskPrice = 9.77m, Exercise = false },
+                                    new { Right = OptionRight.Put, StrikePrice = 225.0m, BidPrice = 7.071m, AskPrice = 7.26m, Exercise = true },
+                                    new { Right = OptionRight.Put, StrikePrice = 226.0m, BidPrice = 8.07m, AskPrice = 8.24m, Exercise = true },
+                                    new { Right = OptionRight.Put, StrikePrice = 227.0m, BidPrice = 9.59m, AskPrice = 9.77m, Exercise = true },
                                     new { Right = OptionRight.Put, StrikePrice = 230.0m, BidPrice = 12.01m, AskPrice = 12.34m, Exercise = true },
                                     new { Right = OptionRight.Put, StrikePrice = 240.0m, BidPrice = 22.01m, AskPrice = 22.32m, Exercise = true } };
 

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Common\Orders\Fees\BackwardsCompatibilityFeeModelTests.cs" />
     <Compile Include="Common\Orders\Fees\BitfinexFeeModelTests.cs" />
     <Compile Include="Common\Orders\Fees\GDAXFeeModelTests.cs" />
+    <Compile Include="Common\Orders\Fees\InteractiveBrokersFeeModelTests.cs" />
     <Compile Include="Common\Orders\Fees\OrderFeesTests.cs" />
     <Compile Include="Common\Orders\Fills\BackwardsCompatibilityFillModelsTests.cs" />
     <Compile Include="Common\Securities\CashAmountTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Removing `OrderFeeParameters.AccountCurrency`. Where required replacing
for constructor parameter defaulting to USD.
- Updating IB fee model to use to correct fee currency and fee rates based on the security Market.
    - Adding new IB fee model unit tests
- Fixing IB FeeModel for options. Adding unit tests. Updating regression and unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2791
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/QuantConnect/Lean/projects/6
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->