### PR TITLE
Implements indexer in DataDictionary derived classes

### DIFF
--- a/Algorithm.Python/DividendAlgorithm.py
+++ b/Algorithm.Python/DividendAlgorithm.py
@@ -55,22 +55,19 @@ class DividendAlgorithm(QCAlgorithm):
             self.SetHoldings("MSFT", .5)
             # place some orders that won't fill, when the split comes in they'll get modified to reflect the split
             quantity = self.CalculateOrderQuantity("MSFT", .25)
-            self.Debug("Purchased Stock: {0}".format(bar.Price))
+            self.Debug(f"Purchased Stock: {bar.Price}")
             self.StopMarketOrder("MSFT", -quantity, bar.Low/2)
             self.LimitOrder("MSFT", -quantity, bar.High*2)
 
-        for kvp in data.Dividends:   # update this to Dividends dictionary
-            symbol = kvp.Key
-            value = kvp.Value.Distribution
-            self.Log("{0} >> DIVIDEND >> {1} - {2} - {3} - {4}".format(self.Time, symbol, value, self.Portfolio.Cash, self.Portfolio["MSFT"].Price))
+        if data.Dividends.ContainsKey("MSFT"):
+            dividend = data.Dividends["MSFT"]
+            self.Log(f"{self.Time} >> DIVIDEND >> {dividend.Symbol} - {dividend.Distribution} - {self.Portfolio.Cash} - {self.Portfolio['MSFT'].Price}")
 
-        for kvp in data.Splits:      # update this to Splits dictionary
-            symbol = kvp.Key
-            value = kvp.Value.SplitFactor
-            self.Log("{0} >> SPLIT >> {1} - {2} - {3} - {4}".format(self.Time, symbol, value, self.Portfolio.Cash, self.Portfolio["MSFT"].Quantity))
-
+        if data.Splits.ContainsKey("MSFT"):
+            split = data.Splits["MSFT"]
+            self.Log(f"{self.Time} >> SPLIT >> {split.Symbol} - {split.SplitFactor} - {self.Portfolio.Cash} - {self.Portfolio['MSFT'].Price}")
 
     def OnOrderEvent(self, orderEvent):
         # orders get adjusted based on split events to maintain order value
         order = self.Transactions.GetOrderById(orderEvent.OrderId)
-        self.Log("{0} >> ORDER >> {1}".format(self.Time, order))
+        self.Log(f"{self.Time} >> ORDER >> {order}")

--- a/Common/Data/Market/Delistings.cs
+++ b/Common/Data/Market/Delistings.cs
@@ -38,5 +38,14 @@ namespace QuantConnect.Data.Market
             : base(frontier)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the Delisting with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The Delisting with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new Delisting this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/Delistings.cs
+++ b/Common/Data/Market/Delistings.cs
@@ -46,6 +46,7 @@ namespace QuantConnect.Data.Market
         /// The Delisting with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new Delisting this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/Dividends.cs
+++ b/Common/Data/Market/Dividends.cs
@@ -46,6 +46,7 @@ namespace QuantConnect.Data.Market
         /// The Dividend with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new Dividend this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/Dividends.cs
+++ b/Common/Data/Market/Dividends.cs
@@ -38,5 +38,14 @@ namespace QuantConnect.Data.Market
             : base(frontier)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the Dividend with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The Dividend with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new Dividend this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/FuturesChains.cs
+++ b/Common/Data/Market/FuturesChains.cs
@@ -36,5 +36,14 @@ namespace QuantConnect.Data.Market
             : base(time)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the FuturesChain with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The FuturesChain with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new FuturesChain this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/FuturesChains.cs
+++ b/Common/Data/Market/FuturesChains.cs
@@ -44,6 +44,7 @@ namespace QuantConnect.Data.Market
         /// The FuturesChain with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new FuturesChain this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/FuturesContracts.cs
+++ b/Common/Data/Market/FuturesContracts.cs
@@ -36,5 +36,14 @@ namespace QuantConnect.Data.Market
             : base(time)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the FuturesContract with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The FuturesContract with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new FuturesContract this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/FuturesContracts.cs
+++ b/Common/Data/Market/FuturesContracts.cs
@@ -44,6 +44,7 @@ namespace QuantConnect.Data.Market
         /// The FuturesContract with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new FuturesContract this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/OptionChains.cs
+++ b/Common/Data/Market/OptionChains.cs
@@ -44,6 +44,7 @@ namespace QuantConnect.Data.Market
         /// The OptionChain with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new OptionChain this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/OptionChains.cs
+++ b/Common/Data/Market/OptionChains.cs
@@ -36,5 +36,14 @@ namespace QuantConnect.Data.Market
             : base(time)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the OptionChain with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The OptionChain with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new OptionChain this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/OptionContracts.cs
+++ b/Common/Data/Market/OptionContracts.cs
@@ -36,5 +36,14 @@ namespace QuantConnect.Data.Market
             : base(time)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the OptionContract with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The OptionContract with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new OptionContract this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/OptionContracts.cs
+++ b/Common/Data/Market/OptionContracts.cs
@@ -44,6 +44,7 @@ namespace QuantConnect.Data.Market
         /// The OptionContract with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new OptionContract this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/QuoteBars.cs
+++ b/Common/Data/Market/QuoteBars.cs
@@ -36,5 +36,14 @@ namespace QuantConnect.Data.Market
             : base(time)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the QuoteBar with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The QuoteBar with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new QuoteBar this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/QuoteBars.cs
+++ b/Common/Data/Market/QuoteBars.cs
@@ -44,6 +44,7 @@ namespace QuantConnect.Data.Market
         /// The QuoteBar with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new QuoteBar this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/Splits.cs
+++ b/Common/Data/Market/Splits.cs
@@ -46,6 +46,7 @@ namespace QuantConnect.Data.Market
         /// The Split with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new Split this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/Splits.cs
+++ b/Common/Data/Market/Splits.cs
@@ -38,5 +38,14 @@ namespace QuantConnect.Data.Market
             : base(frontier)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the Split with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The Split with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new Split this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/SymbolChangedEvents.cs
+++ b/Common/Data/Market/SymbolChangedEvents.cs
@@ -46,6 +46,7 @@ namespace QuantConnect.Data.Market
         /// The SymbolChangedEvent with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new SymbolChangedEvent this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/SymbolChangedEvents.cs
+++ b/Common/Data/Market/SymbolChangedEvents.cs
@@ -24,19 +24,28 @@ namespace QuantConnect.Data.Market
     public class SymbolChangedEvents : DataDictionary<SymbolChangedEvent>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Delistings"/> dictionary
+        /// Initializes a new instance of the <see cref="SymbolChangedEvent"/> dictionary
         /// </summary>
         public SymbolChangedEvents()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Delistings"/> dictionary
+        /// Initializes a new instance of the <see cref="SymbolChangedEvent"/> dictionary
         /// </summary>
         /// <param name="frontier">The time associated with the data in this dictionary</param>
         public SymbolChangedEvents(DateTime frontier)
             : base(frontier)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the SymbolChangedEvent with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The SymbolChangedEvent with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new SymbolChangedEvent this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/Ticks.cs
+++ b/Common/Data/Market/Ticks.cs
@@ -47,6 +47,7 @@ namespace QuantConnect.Data.Market
         /// The list of Tick with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new List<Tick> this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/Ticks.cs
+++ b/Common/Data/Market/Ticks.cs
@@ -39,5 +39,14 @@ namespace QuantConnect.Data.Market
             : base(frontier)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the list of Tick with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The list of Tick with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new List<Tick> this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/TradeBars.cs
+++ b/Common/Data/Market/TradeBars.cs
@@ -45,6 +45,7 @@ namespace QuantConnect.Data.Market
         /// The TradeBar with the specified ticker.
         /// </returns>
         /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        /// <remarks>Wraps the base implementation to enable indexing in python algorithms due to pythonnet limitations</remarks>
         public new TradeBar this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }

--- a/Common/Data/Market/TradeBars.cs
+++ b/Common/Data/Market/TradeBars.cs
@@ -37,5 +37,14 @@ namespace QuantConnect.Data.Market
             : base(frontier)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the TradeBar with the specified ticker/Symbol.
+        /// </summary>
+        /// <returns>
+        /// The TradeBar with the specified ticker.
+        /// </returns>
+        /// <param name="ticker">The ticker/Symbol of the element to get or set.</param>
+        public new TradeBar this[string ticker] { get { return base[ticker]; } set { base[ticker] = value; } }
     }
 }


### PR DESCRIPTION
#### Description
Explicitly implements the indexer `this[string]` to all classed that inherit from `DataDictionary` since pythonnet was not able to access the indexer from the parent class.

- Changes DividentAlgorithm.py to test the fix.

#### Related Issue
Closes #2806

#### Motivation and Context
Lean API should be the same for C# and Python algorithm.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`