### PR TITLE
Kaiko data converter able to process a single day

### DIFF
--- a/Configuration/ToolboxArgumentParser.cs
+++ b/Configuration/ToolboxArgumentParser.cs
@@ -35,15 +35,13 @@ namespace QuantConnect.Configuration
                                                                                 + "be used. --to-date=yyyyMMdd-HH:mm:ss"),
                 new CommandLineOption("exchange", CommandOptionType.SingleValue, "[REQUIRED for CryptoiqDownloader]"),
                 new CommandLineOption("api-key", CommandOptionType.SingleValue, "[REQUIRED for QuandlBitfinexDownloader]"),
-                new CommandLineOption("date", CommandOptionType.SingleValue, "[REQUIRED for AlgoSeekFuturesConverter, AlgoSeekOptionsConverter] "
+                new CommandLineOption("date", CommandOptionType.SingleValue, "[REQUIRED for AlgoSeekFuturesConverter, AlgoSeekOptionsConverter, KaikoDataConverter] "
                                                                              + "Date for the option bz files: --date=yyyyMMdd"),
                 new CommandLineOption("source-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter, KaikoDataConverter,"
                                                                                    + " NseMarketDataConverter, QuantQuoteConverter]"),
                 new CommandLineOption("destination-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter, "
                                                                                         + "NseMarketDataConverter, QuantQuoteConverter]"),
-                new CommandLineOption("source-meta-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter]"),
-                new CommandLineOption("market", CommandOptionType.SingleValue, "[REQUIRED for KaikoDataConverter]"),
-                new CommandLineOption("tick-type", CommandOptionType.SingleValue, "[REQUIRED for KaikoDataConverter] CASE INSENSITIVE: --tick-type=Quote/Trade")
+                new CommandLineOption("source-meta-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter]")
             };
 
         /// <summary>

--- a/ToolBox/KaikoDataConverter/KaikoCryptoReader.cs
+++ b/ToolBox/KaikoDataConverter/KaikoCryptoReader.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Ionic.Zlib;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using ZipEntry = Ionic.Zip.ZipEntry;
+
+namespace QuantConnect.ToolBox.KaikoDataConverter
+{
+    /// <summary>
+    /// Decompress single entry from Kaiko crypto raw data.
+    /// </summary>
+    public class KaikoCryptoReader
+    {
+        /// <summary>
+        /// Gets the raw data from entry.
+        /// </summary>
+        /// <param name="zipEntry">The zip entry.</param>
+        /// <returns>IEnumerable with the zip entry content.</returns>
+        public static IEnumerable<string> GetRawDataFromEntry(ZipEntry zipEntry)
+        {
+            using (var outerStream = new StreamReader(zipEntry.OpenReader()))
+            using (var innerStream = new GZipStream(outerStream.BaseStream, CompressionMode.Decompress))
+            {
+                var decompressed = Decompress(innerStream);
+                return Encoding.ASCII.GetString(decompressed).Split(new char[] { '\n' });
+            }
+        }
+
+        /// <summary>
+        /// Decompress the specified GZip stream.
+        /// </summary>
+        /// <param name="innerStream">The inner stream.</param>
+        /// <returns>Array of bytes with the decompressed data.</returns>
+        private static byte[] Decompress(GZipStream innerStream)
+        {
+            const int size = 4096;
+            byte[] buffer = new byte[size];
+            using (MemoryStream memory = new MemoryStream())
+            {
+                int count = 0;
+                do
+                {
+                    count = innerStream.Read(buffer, 0, size);
+                    if (count > 0)
+                    {
+                        memory.Write(buffer, 0, count);
+                    }
+                }
+                while (count > 0);
+                return memory.ToArray();
+            }
+        }
+    }
+}

--- a/ToolBox/KaikoDataConverter/KaikoCryptoReader.cs
+++ b/ToolBox/KaikoDataConverter/KaikoCryptoReader.cs
@@ -25,7 +25,7 @@ namespace QuantConnect.ToolBox.KaikoDataConverter
     /// <summary>
     /// Decompress single entry from Kaiko crypto raw data.
     /// </summary>
-    public class KaikoCryptoReader
+    public class EnumerableCompressedGz
     {
         /// <summary>
         /// Gets the raw data from entry.

--- a/ToolBox/KaikoDataConverter/KaikoCryptoReader.cs
+++ b/ToolBox/KaikoDataConverter/KaikoCryptoReader.cs
@@ -14,9 +14,16 @@
  * limitations under the License.
 */
 
+using Ionic.Zip;
 using Ionic.Zlib;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Logging;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using ZipEntry = Ionic.Zip.ZipEntry;
 
@@ -25,8 +32,225 @@ namespace QuantConnect.ToolBox.KaikoDataConverter
     /// <summary>
     /// Decompress single entry from Kaiko crypto raw data.
     /// </summary>
-    public class EnumerableCompressedGz
+    public class KaikoDataReader
     {
+        /// <summary>
+        /// Gets the ticks from Kaiko file zip entry.
+        /// </summary>
+        /// <param name="zipEntry">The zip entry.</param>
+        /// <param name="symbol">The symbol.</param>
+        /// <param name="tickType">Type of the tick.</param>
+        /// <returns></returns>
+        public static IEnumerable<BaseData> GetTicksFromZipEntry(ZipEntry zipEntry, Symbol symbol, TickType tickType)
+        {
+            var rawData = GetRawDataFromEntry(zipEntry);
+            return tickType == TickType.Trade ? ParseKaikoTradeFile(rawData, symbol) : ParseKaikoQuoteFile(rawData, symbol);
+        }
+
+        /// <summary>
+        /// Gets the raw data from entry.
+        /// </summary>
+        /// <param name="zipEntry">The zip entry.</param>
+        /// <returns>IEnumerable with the zip entry content.</returns>
+        private static IEnumerable<string> GetRawDataStreamFromEntry(ZipEntry zipEntry)
+        {
+            using (var outerStream = new StreamReader(zipEntry.OpenReader()))
+            using (var innerStream = new GZipStream(outerStream.BaseStream, CompressionMode.Decompress))
+            using (var outputStream = new StreamReader(innerStream))
+            {
+                string line;
+                while ((line = outputStream.ReadLine()) != null)
+                {
+                    yield return line;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parse order book information for Kaiko data files
+        /// </summary>
+        /// <param name="symbol">The symbol being converted</param>
+        /// <param name="unzippedFile">The path to the unzipped file</param>
+        /// <returns>Lean quote ticks representing the Kaiko data</returns>
+        private static IEnumerable<Tick> ParseKaikoQuoteFile(IEnumerable<string> rawDataLines, Symbol symbol)
+        {
+            var headerLine = rawDataLines.First();
+            var headerCsv = headerLine.ToCsv();
+            var typeColumn = headerCsv.FindIndex(x => x == "type");
+            var dateColumn = headerCsv.FindIndex(x => x == "date");
+            var priceColumn = headerCsv.FindIndex(x => x == "price");
+            var quantityColumn = headerCsv.FindIndex(x => x == "amount");
+
+            long currentEpoch = 0;
+            var currentEpochTicks = new List<KaikoTick>();
+
+            foreach (var line in rawDataLines.Skip(1))
+            {
+                if (line == null || line == string.Empty) continue;
+
+                var lineParts = line.Split(',');
+
+                var tickEpoch = Convert.ToInt64(lineParts[dateColumn]);
+
+                decimal quantity;
+                decimal price;
+
+                try
+                {
+                    quantity = ParseScientificNotationToDecimal(lineParts, quantityColumn);
+                    price = ParseScientificNotationToDecimal(lineParts, priceColumn);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"KaikoDataConverter.ParseKaikoQuoteFile(): Raw data corrupted. Line {string.Join(" ", lineParts)}, Exception {ex}");
+                    continue;
+                }
+
+                var currentTick = new KaikoTick
+                {
+                    TickType = TickType.Quote,
+                    Time = Time.UnixMillisecondTimeStampToDateTime(tickEpoch),
+                    Quantity = quantity,
+                    Value = price,
+                    OrderDirection = lineParts[typeColumn]
+                };
+
+                if (currentEpoch != tickEpoch)
+                {
+                    var quoteTick = CreateQuoteTick(symbol, Time.UnixMillisecondTimeStampToDateTime(currentEpoch), currentEpochTicks);
+
+                    if (quoteTick != null) yield return quoteTick;
+
+                    currentEpochTicks.Clear();
+                    currentEpoch = tickEpoch;
+                }
+
+                currentEpochTicks.Add(currentTick);
+            }
+        }
+
+        
+
+        /// <summary>
+        /// Take a minute snapshot of order book information and make a single Lean quote tick
+        /// </summary>
+        /// <param name="symbol">The symbol being processed</param>
+        /// <param name="date">The data being processed</param>
+        /// <param name="currentEpcohTicks">The snapshot of bid/ask Kaiko data</param>
+        /// <returns>A single Lean quote tick</returns>
+        private static Tick CreateQuoteTick(Symbol symbol, DateTime date, List<KaikoTick> currentEpcohTicks)
+        {
+            // lowest ask
+            var bestAsk = currentEpcohTicks.Where(x => x.OrderDirection == "a")
+                                        .OrderBy(x => x.Value)
+                                        .FirstOrDefault();
+
+            // highest bid
+            var bestBid = currentEpcohTicks.Where(x => x.OrderDirection == "b")
+                                        .OrderByDescending(x => x.Value)
+                                        .FirstOrDefault();
+
+            if (bestAsk == null && bestBid == null)
+            {
+                // Did not have enough data to create a tick
+                return null;
+            }
+
+            var tick = new Tick()
+            {
+                Symbol = symbol,
+                Time = date,
+                TickType = TickType.Quote
+            };
+
+            if (bestBid != null)
+            {
+                tick.BidPrice = bestBid.Price;
+                tick.BidSize = bestBid.Quantity;
+            }
+
+            if (bestAsk != null)
+            {
+                tick.AskPrice = bestAsk.Price;
+                tick.AskSize = bestAsk.Quantity;
+            }
+
+            return tick;
+        }
+
+        /// <summary>
+        /// Parse a kaiko trade file
+        /// </summary>
+        /// <param name="symbol">The symbol being processed</param>
+        /// <param name="unzippedFile">The path to the unzipped file</param>
+        /// <returns>Lean Ticks in the Kaiko file</returns>
+        private static IEnumerable<Tick> ParseKaikoTradeFile(IEnumerable<string> rawDataLines, Symbol symbol)
+        {
+            var headerLine = rawDataLines.First();
+            var headerCsv = headerLine.ToCsv();
+            var dateColumn = headerCsv.FindIndex(x => x == "date");
+            var priceColumn = headerCsv.FindIndex(x => x == "price");
+            var quantityColumn = headerCsv.FindIndex(x => x == "amount");
+
+            foreach (var line in rawDataLines.Skip(1))
+            {
+                if (line == null || line == string.Empty) continue;
+
+                var lineParts = line.Split(',');
+
+                decimal quantity;
+                decimal price;
+
+                try
+                {
+                    quantity = ParseScientificNotationToDecimal(lineParts, quantityColumn);
+                    price = ParseScientificNotationToDecimal(lineParts, priceColumn);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"KaikoDataConverter.ParseKaikoTradeFile(): Raw data corrupted. Line {string.Join(" ", lineParts)}, Exception {ex}");
+                    continue;
+                }
+
+                yield return new Tick
+                {
+                    Symbol = symbol,
+                    TickType = TickType.Trade,
+                    Time = Time.UnixMillisecondTimeStampToDateTime(Convert.ToInt64(lineParts[dateColumn])),
+                    Quantity = quantity,
+                    Value = price
+                };
+            }
+        }
+
+        /// <summary>
+        /// Parse the quantity field of the kaiko ticks - can sometimes be expressed in scientific notation
+        /// </summary>
+        /// <param name="lineParts">The line from the Kaiko file</param>
+        /// <param name="column">The index of the quantity column </param>
+        /// <returns>The quantity as a decimal</returns>
+        private static decimal ParseScientificNotationToDecimal(string[] lineParts, int column)
+        {
+            var value = lineParts[column];
+            if (value.Contains("e"))
+            {
+                return Decimal.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+            }
+
+            return Convert.ToDecimal(lineParts[column], CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Simple class to add order direction to Tick
+        /// used for aggregating Kaiko order book snapshots
+        /// </summary>
+        private class KaikoTick : Tick
+        {
+            public string OrderDirection { get; set; }
+        }
+
+        #region Vestigial Code (or better to say lazy developer implementation)
+
         /// <summary>
         /// Gets the raw data from entry.
         /// </summary>
@@ -66,5 +290,9 @@ namespace QuantConnect.ToolBox.KaikoDataConverter
                 return memory.ToArray();
             }
         }
+
+        
+
+        #endregion Vestigial Code (or better to say lazy developer implementation)
     }
 }

--- a/ToolBox/KaikoDataConverter/KaikoDataConverterProgram.cs
+++ b/ToolBox/KaikoDataConverter/KaikoDataConverterProgram.cs
@@ -72,7 +72,10 @@ namespace QuantConnect.ToolBox.KaikoDataConverter
                         Log.Trace($"KaikoDataConverter(): Processing {symbol.Value} {tickType}");
 
                         // Generate ticks from raw data and write them to disk
-                        var ticks = KaikoDataReader.GetTicksFromZipEntry(zipEntry, symbol, tickType);
+
+                        var reader = new KaikoDataReader(symbol, tickType);
+                        var ticks = reader.GetTicksFromZipEntry(zipEntry);
+
                         var writer = new LeanDataWriter(Resolution.Tick, symbol, Globals.DataFolder, tickType);
                         writer.Write(ticks);
 

--- a/ToolBox/Program.cs
+++ b/ToolBox/Program.cs
@@ -142,9 +142,8 @@ namespace QuantConnect.ToolBox
                         break;
                     case "kdc":
                     case "kaikodataconverter":
-                        KaikoDataConverterProgram.KaikoDataConverter(GetParameterOrExit(optionsObject, "market"),
-                                                                     GetParameterOrExit(optionsObject, "tick-type"),
-                                                                     GetParameterOrExit(optionsObject, "source-dir"));
+                        KaikoDataConverterProgram.KaikoDataConverter(GetParameterOrExit(optionsObject, "source-dir"),
+                                                                     GetParameterOrExit(optionsObject, "date"));
                         break;
                     case "nmdc":
                     case "nsemarketdataconverter":

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -263,6 +263,7 @@
     <None Include="IQFeed\IQFeed-symbol-map.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Compile Include="KaikoDataConverter\KaikoCryptoReader.cs" />
     <None Include="packages.config" />
     <Content Include="Visualizer\QuantConnect.Visualizer.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR implements many changes in the KaikoConverter logic:
- Process a single day of date instead of processing all available data every day.
- Big raw data files are not decompressed, only the needed entries are processed, aggregated into high resolutions (minute and second), and saved.
- Process every data available in the source directory, independently of exchanges and tick types.
- Kaiko raw data reading concerns moved into a new `KaikoDataReader` class.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2738 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The previous version was inefficient, it re-processed all available data every day. This process takes approximately  8 hs. for Coinbase (GDAX) and Bitinex for quotes and trades.
With this new implementation takes less than *1 minute* to process a single day of tick, second and minute data for Coinbase (GDAX) and Bitinex for quotes and trades.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local (Windows) and remote (Linux)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->