### PR TITLE
Adding Pandas MultiIndex cache

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -637,6 +637,7 @@
     <Compile Include="Util\IParallelRunnerWorkItem.cs" />
     <Compile Include="Util\LeanData.cs" />
     <Compile Include="Util\LeanDataPathComponents.cs" />
+    <Compile Include="Util\ListComparer.cs" />
     <Compile Include="Util\MarketHoursDatabaseJsonConverter.cs" />
     <Compile Include="Util\ParallelRunner.cs" />
     <Compile Include="Util\ParallelRunnerWorker.cs" />

--- a/Common/Util/ListComparer.cs
+++ b/Common/Util/ListComparer.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Util
+{
+    /// <summary>
+    /// An implementation of <see cref="IEqualityComparer{T}"/> for <see cref="List{T}"/>.
+    /// Useful when using a <see cref="List{T}"/> as the key of a collection.
+    /// </summary>
+    /// <typeparam name="T">The list type</typeparam>
+    public class ListComparer<T> : IEqualityComparer<List<T>>
+    {
+        /// <summary>Determines whether the specified objects are equal.</summary>
+        /// <returns>true if the specified objects are equal; otherwise, false.</returns>
+        public bool Equals(List<T> x, List<T> y)
+        {
+            return x.SequenceEqual(y);
+        }
+
+        /// <summary>Returns a hash code for the specified object.</summary>
+        /// <returns>A hash code for the specified object created from combining the hash
+        /// code of all the elements in the collection.</returns>
+        public int GetHashCode(List<T> obj)
+        {
+            var hashCode = 0;
+            foreach (var dateTime in obj)
+            {
+                hashCode = (hashCode * 397) ^ dateTime.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+}

--- a/Tests/Common/Util/ListComparerTests.cs
+++ b/Tests/Common/Util/ListComparerTests.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Common.Util
+{
+    [TestFixture]
+    public class ListComparerTests
+    {
+        [Test]
+        public void DateTimeEquals()
+        {
+            var comparer = new ListComparer<DateTime>();
+            var list1 = new List<DateTime> { new DateTime(2019) };
+            var list2 = new List<DateTime> { new DateTime(2019) };
+
+            Assert.IsTrue(comparer.Equals(list1, list2));
+            Assert.AreEqual(comparer.GetHashCode(list2), comparer.GetHashCode(list1));
+        }
+
+        [Test]
+        public void DateTimeDifferent()
+        {
+            var comparer = new ListComparer<DateTime>();
+            var list1 = new List<DateTime> { new DateTime(2019) };
+            var list2 = new List<DateTime> { new DateTime(2017) };
+
+            Assert.IsFalse(comparer.Equals(list1, list2));
+            Assert.AreNotEqual(comparer.GetHashCode(list2), comparer.GetHashCode(list1));
+        }
+
+        [Test]
+        public void EmptyLists()
+        {
+            var comparer = new ListComparer<DateTime>();
+            var list1 = new List<DateTime>();
+            var list2 = new List<DateTime>();
+
+            Assert.IsTrue(comparer.Equals(list1, list2));
+            Assert.AreEqual(comparer.GetHashCode(list2), comparer.GetHashCode(list1));
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Common\Securities\SecurityHoldingTests.cs" />
     <Compile Include="Common\Securities\SecurityServiceTests.cs" />
     <Compile Include="Common\Securities\TestAccountCurrencyProvider.cs" />
+    <Compile Include="Common\Util\ListComparerTests.cs" />
     <Compile Include="Common\Util\SeriesJsonConverterTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />
     <Compile Include="Engine\DataFeeds\DataManagerStub.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding a cache for the `Pandas.MultiIndex`, giving a significant
performance improvement: Python HistoryBenchmark ~30%, Python average use case Benchmark algorithm ~20%
   - Reverting changes from previous PR https://github.com/QuantConnect/Lean/pull/2812, since the cache will cover the same behavior, converting `DateTime` to python once and it requires calculating equality between the different `DateTime` instances.
- Adding new `ListComparer` class. Adding unit tests.

>- Master Python HistoryBenchmark
233.00 seconds at 0k data points per second. Processing total of 36,975 data points.
225.33 seconds at 0k data points per second. Processing total of 36,975 data points.
236.79 seconds at 0k data points per second. Processing total of 36,975 data points.
>- PR Python HistoryBenchmark
152.73 seconds at 0k data points per second. Processing total of 36,975 data points.
160.39 seconds at 0k data points per second. Processing total of 36,975 data points.
157.82 seconds at 0k data points per second. Processing total of 36,975 data points.
>- Master Python average use case Benchmark algorithm
183.78 seconds at 39k data points per second. Processing total of 7,092,090 data points.
180.41 seconds at 39k data points per second. Processing total of 7,092,090 data points.
187.89 seconds at 38k data points per second. Processing total of 7,092,090 data points.
>- PR Python average use case Benchmark algorithm
149.88 seconds at 47k data points per second. Processing total of 7,092,090 data points.
147.33 seconds at 48k data points per second. Processing total of 7,092,090 data points.
150.05 seconds at 47k data points per second. Processing total of 7,092,090 data points.

Python average use case Benchmark algorithm [python_benchmark_algo.txt](https://github.com/QuantConnect/Lean/files/2750585/python_benchmark_algo.txt)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2816
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Python Execution Speed Improvement https://github.com/QuantConnect/Lean/projects/7
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running mentioned python algorithms. Unit and regression tests.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->