### PR TITLE
#2824 Add ToolBox RandomDataGenerator

### DIFF
--- a/Common/Data/Consolidators/FilteredIdentityDataConsolidator.cs
+++ b/Common/Data/Consolidators/FilteredIdentityDataConsolidator.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Data.Consolidators
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IDataConsolidator"/> that preserve the input
+    /// data unmodified. The input data is filtering by the specified predicate function
+    /// </summary>
+    /// <typeparam name="T">The type of data</typeparam>
+    public class FilteredIdentityDataConsolidator<T> : IdentityDataConsolidator<T>
+        where T : IBaseData
+    {
+        private readonly Func<T, bool> _predicate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilteredIdentityDataConsolidator{T}"/> class
+        /// </summary>
+        /// <param name="predicate">The predicate function, returning true to accept data and false to reject data</param>
+        public FilteredIdentityDataConsolidator(Func<T, bool> predicate)
+        {
+            this._predicate = predicate;
+        }
+
+        /// <summary>
+        /// Updates this consolidator with the specified data
+        /// </summary>
+        /// <param name="data">The new data for the consolidator</param>
+        public override void Update(T data)
+        {
+            // only permit data that passes our predicate function to be passed through
+            if (_predicate(data))
+            {
+                base.Update(data);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Provides factory methods for creating instances of <see cref="FilteredIdentityDataConsolidator{T}"/>
+    /// </summary>
+    public static class FilteredIdentityDataConsolidator
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="FilteredIdentityDataConsolidator{T}"/> that filters ticks
+        /// based on the specified <see cref="TickType"/>
+        /// </summary>
+        /// <param name="tickType">The tick type of data to accept</param>
+        /// <returns>A new <see cref="FilteredIdentityDataConsolidator{T}"/> that filters based on the provided tick type</returns>
+        public static FilteredIdentityDataConsolidator<Tick> ForTickType(TickType tickType)
+        {
+            return new FilteredIdentityDataConsolidator<Tick>(tick => tick.TickType == tickType);
+        }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Brokerages\GDAXBrokerageModel.cs" />
     <Compile Include="Chart.cs" />
     <Compile Include="ChartPoint.cs" />
+    <Compile Include="Data\Consolidators\FilteredIdentityDataConsolidator.cs" />
     <Compile Include="Data\HistoryProviderBase.cs" />
     <Compile Include="Data\HistoryProviderInitializeParameters.cs" />
     <Compile Include="Data\HistoryRequestFactory.cs" />

--- a/Configuration/ToolboxArgumentParser.cs
+++ b/Configuration/ToolboxArgumentParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.CommandLineUtils;
 
 namespace QuantConnect.Configuration
@@ -23,13 +24,16 @@ namespace QuantConnect.Configuration
                                                      + "/YahooDownloader or YDL/AlgoSeekFuturesConverter or ASFC/AlgoSeekOptionsConverter or ASOC"
                                                      + "/IVolatilityEquityConverter or IVEC/KaikoDataConverter or KDC/NseMarketDataConverter or NMDC"
                                                      + "/QuantQuoteConverter or QQC/CoarseUniverseGenerator or CUG\n"
+                                                     + "RandomDataGenerator or RDG"
                                                      + "Example 1: --app=DDL\n"
-                                                     + "Example 2: --app=NseMarketDataConverter\n"),
+                                                     + "Example 2: --app=NseMarketDataConverter\n"
+                                                     + "Example 3: --app=RDG"),
                 new CommandLineOption("tickers", CommandOptionType.MultipleValue, "[REQUIRED ALL downloaders (except QBDL)] "
                                                                                   + "--tickers=SPY,AAPL,etc"),
                 new CommandLineOption("resolution", CommandOptionType.SingleValue, "[REQUIRED ALL downloaders (except QBDL, CDL) and IVolatilityEquityConverter,"
                                                                                    + " QuantQuoteConverter] *Not all downloaders support all resolutions. Send empty for more information.*"
-                                                                                   + " CASE SENSITIVE: --resolution=Tick/Second/Minute/Hour/Daily/All"),
+                                                                                   + " CASE SENSITIVE: --resolution=Tick/Second/Minute/Hour/Daily/All" +Environment.NewLine+
+                                                                                   "[OPTIONAL for RandomDataGenerator - same format as downloaders, Options only support Minute"),
                 new CommandLineOption("from-date", CommandOptionType.SingleValue, "[REQUIRED ALL downloaders] --from-date=yyyyMMdd-HH:mm:ss"),
                 new CommandLineOption("to-date", CommandOptionType.SingleValue, "[OPTIONAL for downloaders] If not provided 'DateTime.UtcNow' will "
                                                                                 + "be used. --to-date=yyyyMMdd-HH:mm:ss"),
@@ -41,7 +45,14 @@ namespace QuantConnect.Configuration
                                                                                    + " NseMarketDataConverter, QuantQuoteConverter]"),
                 new CommandLineOption("destination-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter, "
                                                                                         + "NseMarketDataConverter, QuantQuoteConverter]"),
-                new CommandLineOption("source-meta-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter]")
+                new CommandLineOption("source-meta-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter]"),
+                new CommandLineOption("start", CommandOptionType.SingleValue, "[REQUIRED for RandomDataGenerator. Format yyyyMMdd Example: --start=20010101]"),
+                new CommandLineOption("end", CommandOptionType.SingleValue, "[REQUIRED for RandomDataGenerator. Format yyyyMMdd Example: --end=20020101]"),
+                new CommandLineOption("market", CommandOptionType.SingleValue, "[OPTIONAL for RandomDataGenerator. Market of generated symbols. Defaults to default market for security type: Example: --market=usa]"),
+                new CommandLineOption("symbol-count", CommandOptionType.SingleValue, "[REQUIRED for RandomDataGenerator. Number of symbols to generate data for: Example: --symbol-count=10]"),
+                new CommandLineOption("security-type", CommandOptionType.SingleValue, "[OPTIONAL for RandomDataGenerator. Security type of generated symbols, defaults to Equity: Example: --security-type=Equity/Option/Forex/Future/Cfd/Crypto]"),
+                new CommandLineOption("data-density", CommandOptionType.SingleValue, "[OPTIONAL for RandomDataGenerator. Valid values: --data-density=Dense/Sparse/VerySparse ]"),
+                new CommandLineOption("include-coarse", CommandOptionType.SingleValue, "[OPTIONAL for RandomDataGenerator. Only used for Equity, defaults to true: Example: --include-coarse=true"),
             };
 
         /// <summary>

--- a/QuantConnect.Lean.sln.DotSettings
+++ b/QuantConnect.Lean.sln.DotSettings
@@ -1,8 +1,9 @@
-<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
     <s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_INVOCATION_PARS/@EntryValue">INSIDE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_INVOCATION_RPAR/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Quant/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -437,6 +437,7 @@
     <Compile Include="ToolBox\ForexVolume\FxcmVolumeDownloaderTest.cs" />
     <Compile Include="ToolBox\LeanDataReaderTests.cs" />
     <Compile Include="ToolBox\LeanDataWriterTests.cs" />
+    <Compile Include="ToolBox\RandomDataGenerator\RandomValueGeneratorTests.cs" />
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>

--- a/Tests/ToolBox/RandomDataGenerator/RandomValueGeneratorTests.cs
+++ b/Tests/ToolBox/RandomDataGenerator/RandomValueGeneratorTests.cs
@@ -1,0 +1,350 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Securities;
+using QuantConnect.ToolBox.RandomDataGenerator;
+
+namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
+{
+    [TestFixture]
+    public class RandomValueGeneratorTests
+    {
+        private const int Seed = 123456789;
+        private RandomValueGenerator randomValueGenerator;
+
+        [SetUp]
+        public void Setup()
+        {
+            // initialize using a seed for deterministic tests
+            randomValueGenerator = new RandomValueGenerator(Seed);
+        }
+
+        [Test]
+        [TestCase(2,5)]
+        [TestCase(3,3)]
+        [TestCase(1,4)]
+        public void NextUpperCaseString_CreatesString_WithinSpecifiedMinMaxLength(int min, int max)
+        {
+            var str = randomValueGenerator.NextUpperCaseString(min, max);
+            Assert.LessOrEqual(min, str.Length);
+            Assert.GreaterOrEqual(max, str.Length);
+        }
+
+        [Test]
+        public void NextUpperCaseString_CreatesUpperCaseString()
+        {
+            var str = randomValueGenerator.NextUpperCaseString(10, 10);
+            Assert.IsTrue(str.All(char.IsUpper));
+        }
+
+        [Test]
+        public void NextDateTime_CreatesDateTime_WithinSpecifiedMinMax()
+        {
+            var min = new DateTime(2000, 01, 01);
+            var max = new DateTime(2001, 01, 01);
+            var dateTime = randomValueGenerator.NextDate(min, max, dayOfWeek: null);
+
+            Assert.LessOrEqual(min, dateTime);
+            Assert.GreaterOrEqual(max, dateTime);
+        }
+
+        [Test]
+        [TestCase(DayOfWeek.Sunday)]
+        [TestCase(DayOfWeek.Monday)]
+        [TestCase(DayOfWeek.Tuesday)]
+        [TestCase(DayOfWeek.Wednesday)]
+        [TestCase(DayOfWeek.Thursday)]
+        [TestCase(DayOfWeek.Friday)]
+        [TestCase(DayOfWeek.Saturday)]
+        public void NextDateTime_CreatesDateTime_OnSpecifiedDayOfWeek(DayOfWeek dayOfWeek)
+        {
+            var min = new DateTime(2000, 01, 01);
+            var max = new DateTime(2001, 01, 01);
+            var dateTime = randomValueGenerator.NextDate(min, max, dayOfWeek);
+
+            Assert.AreEqual(dayOfWeek, dateTime.DayOfWeek);
+        }
+
+        [Test]
+        public void NextDateTime_ThrowsArgumentException_WhenMaxIsLessThanMin()
+        {
+            var min = new DateTime(2000, 01, 01);
+            var max = min.AddDays(-1);
+            Assert.Throws<ArgumentException>(() =>
+                randomValueGenerator.NextDate(min, max, dayOfWeek: null)
+            );
+        }
+
+        [Test]
+        public void NextDateTime_ThrowsArgumentException_WhenRangeIsTooSmallToProduceDateTimeOnRequestedDayOfWeek()
+        {
+            var min = new DateTime(2019, 01, 15);
+            var max = new DateTime(2019, 01, 20);
+            Assert.Throws<ArgumentException>(() =>
+                // no monday between these dates, so impossible to fulfill request
+                randomValueGenerator.NextDate(min, max, DayOfWeek.Monday)
+            );
+        }
+
+        [Test]
+        [TestCase(SecurityType.Option)]
+        [TestCase(SecurityType.Future)]
+        public void NextSymbol_ThrowsArgumentException_ForDerivativeSymbols(SecurityType securityType)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                randomValueGenerator.NextSymbol(securityType, Market.USA)
+            );
+        }
+
+        [Test]
+        [TestCase(SecurityType.Cfd, Market.FXCM)]
+        [TestCase(SecurityType.Base, Market.USA)]
+        [TestCase(SecurityType.Forex, Market.FXCM)]
+        [TestCase(SecurityType.Equity, Market.USA)]
+        [TestCase(SecurityType.Crypto, Market.GDAX)]
+        public void NextSymbol_CreatesSymbol_WithRequestedSecurityTypeAndMarket(SecurityType securityType, string market)
+        {
+            var symbol = randomValueGenerator.NextSymbol(securityType, market);
+
+            Assert.AreEqual(securityType, symbol.SecurityType);
+            Assert.AreEqual(market, symbol.ID.Market);
+        }
+
+        [Test]
+        [TestCase(SecurityType.Cfd)]
+        [TestCase(SecurityType.Base)]
+        [TestCase(SecurityType.Forex)]
+        [TestCase(SecurityType.Equity)]
+        [TestCase(SecurityType.Crypto)]
+        public void NextSymbol_CreatesSymbol_WithThreeCharacterTicker(SecurityType securityType)
+        {
+            var defaultMarket = DefaultBrokerageModel.DefaultMarketMap[securityType];
+            var symbol = randomValueGenerator.NextSymbol(securityType, defaultMarket);
+
+            // for derivatives, check the underlying ticker
+            if (securityType == SecurityType.Option || securityType == SecurityType.Future)
+            {
+                symbol = symbol.Underlying;
+            }
+
+            Assert.AreEqual(3, symbol.Value.Length);
+        }
+
+        [Test]
+        public void NextOptionSymbol_CreatesOptionSymbol_WithCorrectSecurityTypeAndEquitUnderlying()
+        {
+            var minExpiry = new DateTime(2000, 01, 01);
+            var maxExpiry = new DateTime(2001, 01, 01);
+            var symbol = randomValueGenerator.NextOption(Market.USA, minExpiry, maxExpiry, 100m, 50);
+
+            Assert.AreEqual(SecurityType.Option, symbol.SecurityType);
+
+            var underlying = symbol.Underlying;
+            Assert.AreEqual(Market.USA, underlying.ID.Market);
+            Assert.AreEqual(SecurityType.Equity, underlying.SecurityType);
+        }
+
+        [Test]
+        public void NextOptionSymbol_CreatesOptionSymbol_WithinSpecifiedExpiration_OnFriday()
+        {
+            var minExpiry = new DateTime(2000, 01, 01);
+            var maxExpiry = new DateTime(2001, 01, 01);
+            var symbol = randomValueGenerator.NextOption(Market.USA, minExpiry, maxExpiry, 100m, 50);
+
+            var expiration = symbol.ID.Date;
+            Assert.LessOrEqual(minExpiry, expiration);
+            Assert.GreaterOrEqual(maxExpiry, expiration);
+        }
+
+        [Test]
+        public void NextOptionSymbol_CreatesOptionSymbol_WithRequestedMarket()
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                var minExpiry = new DateTime(2000, 01, 01);
+                var maxExpiry = new DateTime(2001, 01, 01);
+                var price = randomValueGenerator.NextPrice(SecurityType.Equity, Market.USA, 100m, 100m);
+                var symbol = randomValueGenerator.NextOption(Market.USA, minExpiry, maxExpiry, price, 50);
+
+                Assert.AreEqual(Market.USA, symbol.ID.Market);
+            }
+        }
+
+        [Test]
+        public void NextOptionSymbol_CreatesOptionSymbol_WithinSpecifiedStrikePriceDeviation()
+        {
+            var underlyingPrice = 100m;
+            var maximumStrikePriceDeviation = 50m;
+            var minExpiry = new DateTime(2000, 01, 01);
+            var maxExpiry = new DateTime(2001, 01, 01);
+            var symbol = randomValueGenerator.NextOption(Market.USA, minExpiry, maxExpiry, underlyingPrice, maximumStrikePriceDeviation);
+
+            var strikePrice = symbol.ID.StrikePrice;
+            var maximumDeviation = underlyingPrice * (maximumStrikePriceDeviation / 100m);
+            Assert.LessOrEqual(underlyingPrice - maximumDeviation, strikePrice);
+            Assert.GreaterOrEqual(underlyingPrice + maximumDeviation, strikePrice);
+        }
+
+        [Test]
+        public void NextTick_CreatesTradeTick_WithPriceAndQuantity()
+        {
+            var dateTime = new DateTime(2000, 01, 01);
+            var symbol = randomValueGenerator.NextSymbol(SecurityType.Equity, Market.USA);
+            var tick = randomValueGenerator.NextTick(symbol, dateTime, TickType.Trade, 100m, 1m);
+
+            Assert.AreEqual(symbol, tick.Symbol);
+            Assert.AreEqual(dateTime, tick.Time);
+            Assert.AreEqual(TickType.Trade, tick.TickType);
+            Assert.LessOrEqual(99m, tick.Value);
+            Assert.GreaterOrEqual(101m, tick.Value);
+
+            Assert.Greater(tick.Quantity, 0);
+            Assert.LessOrEqual(tick.Quantity, 1500);
+        }
+
+        [Test]
+        public void NextTick_CreatesQuoteTick_WithCommonValues()
+        {
+            var dateTime = new DateTime(2000, 01, 01);
+            var symbol = randomValueGenerator.NextSymbol(SecurityType.Equity, Market.USA);
+            var tick = randomValueGenerator.NextTick(symbol, dateTime, TickType.Quote, 100m, 1m);
+
+            Assert.AreEqual(symbol, tick.Symbol);
+            Assert.AreEqual(dateTime, tick.Time);
+            Assert.AreEqual(TickType.Quote, tick.TickType);
+            Assert.GreaterOrEqual(tick.Value, 99m);
+            Assert.LessOrEqual(tick.Value, 101m);
+        }
+
+        [Test]
+        public void NextTick_CreatesQuoteTick_WithBidData()
+        {
+            var dateTime = new DateTime(2000, 01, 01);
+            var symbol = randomValueGenerator.NextSymbol(SecurityType.Equity, Market.USA);
+            var tick = randomValueGenerator.NextTick(symbol, dateTime, TickType.Quote, 100m, 1m);
+
+            Assert.Greater(tick.BidSize, 0);
+            Assert.LessOrEqual(tick.BidSize, 1500);
+            Assert.GreaterOrEqual(tick.BidPrice, 98.9m);
+            Assert.LessOrEqual(tick.BidPrice, 100.9m);
+            Assert.GreaterOrEqual(tick.Value, tick.BidPrice);
+        }
+
+        [Test]
+        public void NextTick_CreatesQuoteTick_WithAskData()
+        {
+            var dateTime = new DateTime(2000, 01, 01);
+            var symbol = randomValueGenerator.NextSymbol(SecurityType.Equity, Market.USA);
+            var tick = randomValueGenerator.NextTick(symbol, dateTime, TickType.Quote, 100m, 1m);
+
+            Assert.GreaterOrEqual(tick.AskSize, 0);
+            Assert.LessOrEqual(tick.AskSize, 1500);
+            Assert.GreaterOrEqual(tick.AskPrice, 99.1m);
+            Assert.LessOrEqual(tick.AskPrice, 101.1m);
+            Assert.LessOrEqual(tick.Value, tick.AskPrice);
+        }
+
+        [Test]
+        public void NextTick_CreatesOpenInterestTick()
+        {
+            var dateTime = new DateTime(2000, 01, 01);
+            var symbol = randomValueGenerator.NextSymbol(SecurityType.Equity, Market.USA);
+            var tick = randomValueGenerator.NextTick(symbol, dateTime, TickType.OpenInterest, 10000m, 10m);
+
+            Assert.AreEqual(dateTime, tick.Time);
+            Assert.AreEqual(TickType.OpenInterest, tick.TickType);
+            Assert.AreEqual(symbol, tick.Symbol);
+            Assert.GreaterOrEqual(tick.Quantity, 9000);
+            Assert.LessOrEqual(tick.Quantity, 11000);
+            Assert.AreEqual(tick.Value, tick.Quantity);
+        }
+
+        [Test]
+        [TestCase(Resolution.Tick, DataDensity.Dense)]
+        [TestCase(Resolution.Second, DataDensity.Dense)]
+        [TestCase(Resolution.Minute, DataDensity.Dense)]
+        [TestCase(Resolution.Hour, DataDensity.Dense)]
+        [TestCase(Resolution.Daily, DataDensity.Dense)]
+        [TestCase(Resolution.Tick, DataDensity.Sparse)]
+        [TestCase(Resolution.Second, DataDensity.Sparse)]
+        [TestCase(Resolution.Minute, DataDensity.Sparse)]
+        [TestCase(Resolution.Hour, DataDensity.Sparse)]
+        [TestCase(Resolution.Daily, DataDensity.Sparse)]
+        [TestCase(Resolution.Tick, DataDensity.VerySparse)]
+        [TestCase(Resolution.Second, DataDensity.VerySparse)]
+        [TestCase(Resolution.Minute, DataDensity.VerySparse)]
+        [TestCase(Resolution.Hour, DataDensity.VerySparse)]
+        [TestCase(Resolution.Daily, DataDensity.VerySparse)]
+        public void NextTickTime_CreatesTimes(Resolution resolution, DataDensity density)
+        {
+            var count = 100;
+            var deltaSum = TimeSpan.Zero;
+            var previous = new DateTime(2019, 01, 14, 9, 30, 0);
+            var increment = resolution.ToTimeSpan();
+            if (increment == TimeSpan.Zero)
+            {
+                increment = TimeSpan.FromMilliseconds(500);
+            }
+            var symbol = randomValueGenerator.NextSymbol(SecurityType.Equity, Market.USA);
+            var marketHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+            for (int i = 0; i < count; i++)
+            {
+                var next = randomValueGenerator.NextTickTime(symbol, previous, resolution, density);
+                var barStart = next.Subtract(increment);
+                Assert.Less(previous, next);
+                Assert.IsTrue(marketHours.IsOpen(barStart, next, false));
+
+                var delta = next - previous;
+                deltaSum += delta;
+
+                previous = next;
+            }
+
+            var avgDelta = TimeSpan.FromTicks(deltaSum.Ticks / count);
+            switch (density)
+            {
+                case DataDensity.Dense:
+                    // more frequent than once an increment
+                    Assert.Less(avgDelta, increment);
+                    break;
+
+                case DataDensity.Sparse:
+                    // less frequent that once an increment
+                    Assert.Greater(avgDelta, increment);
+                    break;
+
+                case DataDensity.VerySparse:
+                    // less frequent than one every 10 increments
+                    Assert.Greater(avgDelta, TimeSpan.FromTicks(increment.Ticks * 10));
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(density), density, null);
+            }
+        }
+
+        [Test]
+        public void NextFuture_CreatesSymbol_WithFutureSecurityTypeAndRequestedMarket()
+        {
+            var minExpiry = new DateTime(2000, 01, 01);
+            var maxExpiry = new DateTime(2001, 01, 01);
+            var symbol = randomValueGenerator.NextFuture(Market.USA, minExpiry, maxExpiry);
+
+            Assert.AreEqual(Market.USA, symbol.ID.Market);
+            Assert.AreEqual(SecurityType.Future, symbol.SecurityType);
+        }
+        [Test]
+        public void NextFuture_CreatesSymbol_WithFutureWithValidFridayExpiry()
+        {
+            var minExpiry = new DateTime(2000, 01, 01);
+            var maxExpiry = new DateTime(2001, 01, 01);
+            var symbol = randomValueGenerator.NextFuture(Market.USA, minExpiry, maxExpiry);
+
+            var expiry = symbol.ID.Date;
+            Assert.Greater(expiry, minExpiry);
+            Assert.LessOrEqual(expiry, maxExpiry);
+            Assert.AreEqual(DayOfWeek.Friday, expiry.DayOfWeek);
+        }
+    }
+}

--- a/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
+++ b/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
@@ -107,7 +107,7 @@ namespace QuantConnect.ToolBox.CoarseUniverseGenerator
         /// </summary>
         /// <param name="dataDirectory">The Lean /Data directory</param>
         /// <param name="ignoreMaplessSymbols">Ignore symbols without a QuantQuote map file.</param>
-        public static void ProcessEquityDirectories(string dataDirectory, bool ignoreMaplessSymbols, DateTime? startDate)
+        public static IEnumerable<string> ProcessEquityDirectories(string dataDirectory, bool ignoreMaplessSymbols, DateTime? startDate)
         {
             var exclusions = ReadExclusionsFile(ExclusionsFile);
 
@@ -123,7 +123,11 @@ namespace QuantConnect.ToolBox.CoarseUniverseGenerator
                 }
 
                 var lastProcessedDate = startDate ?? GetLastProcessedDate(coarseFolder);
-                ProcessDailyFolder(dailyFolder, coarseFolder, MapFileResolver.Create(mapFileFolder), exclusions, ignoreMaplessSymbols, lastProcessedDate);
+                var files = ProcessDailyFolder(dailyFolder, coarseFolder, MapFileResolver.Create(mapFileFolder), exclusions, ignoreMaplessSymbols, lastProcessedDate);
+                foreach (var file in files)
+                {
+                    yield return file;
+                }
             }
         }
 

--- a/ToolBox/Program.cs
+++ b/ToolBox/Program.cs
@@ -36,6 +36,7 @@ using QuantConnect.ToolBox.NseMarketDataConverter;
 using QuantConnect.ToolBox.OandaDownloader;
 using QuantConnect.ToolBox.QuandlBitfinexDownloader;
 using QuantConnect.ToolBox.QuantQuoteConverter;
+using QuantConnect.ToolBox.RandomDataGenerator;
 using QuantConnect.ToolBox.YahooDownloader;
 using QuantConnect.Util;
 
@@ -160,6 +161,19 @@ namespace QuantConnect.ToolBox
                     case "coarseuniversegenerator":
                         CoarseUniverseGeneratorProgram.CoarseUniverseGenerator();
                         break;
+                    case "rdg":
+                    case "randomdatagenerator":
+                        RandomDataGeneratorProgram.RandomDataGenerator(
+                            GetParameterOrExit(optionsObject, "start"),
+                            GetParameterOrExit(optionsObject, "end"),
+                            GetParameterOrExit(optionsObject, "symbol-count"),
+                            GetParameterOrDefault(optionsObject, "market", null),
+                            GetParameterOrDefault(optionsObject, "security-type", "Equity"),
+                            GetParameterOrDefault(optionsObject, "resolution", "Minute"),
+                            GetParameterOrDefault(optionsObject, "data-density", "Dense"),
+                            GetParameterOrDefault(optionsObject, "include-coarse", "true")
+                        );
+                        break;
                     default:
                         PrintMessageAndExit(1, "ERROR: Unrecognized --app value");
                         break;
@@ -186,6 +200,18 @@ namespace QuantConnect.ToolBox
                 PrintMessageAndExit(1, "ERROR: REQUIRED parameter --" + parameter + "= is missing");
             }
             return optionsObject[parameter].ToString();
+        }
+
+        private static string GetParameterOrDefault(IReadOnlyDictionary<string, object> optionsObject, string parameter, string defaultValue)
+        {
+            object value;
+            if (!optionsObject.TryGetValue(parameter, out value))
+            {
+                Console.WriteLine($"'{parameter}' was not specified. Using default value: '{defaultValue}'");
+                return defaultValue;
+            }
+
+            return value.ToString();
         }
     }
 }

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -181,6 +181,11 @@
     <Compile Include="IEX\IEXDownloaderProgram.cs" />
     <Compile Include="IVolatilityEquityConverter\IVolatilityEquityConverterProgram.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="RandomDataGenerator\DataDensity.cs" />
+    <Compile Include="RandomDataGenerator\IRandomValueGenerator.cs" />
+    <Compile Include="RandomDataGenerator\RandomValueGenerator.cs" />
+    <Compile Include="RandomDataGenerator\RandomValueGeneratorException.cs" />
+    <Compile Include="RandomDataGenerator\TooManyFailedAttemptsException.cs" />
     <Compile Include="TickAggregator.cs" />
     <Compile Include="AlgoSeekFuturesConverter\AlgoSeekFuturesConverter.cs" />
     <Compile Include="AlgoSeekFuturesConverter\AlgoSeekFuturesProcessor.cs" />

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -181,10 +181,15 @@
     <Compile Include="IEX\IEXDownloaderProgram.cs" />
     <Compile Include="IVolatilityEquityConverter\IVolatilityEquityConverterProgram.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="RandomDataGenerator\ConsoleLeveledOutput.cs" />
     <Compile Include="RandomDataGenerator\DataDensity.cs" />
+    <Compile Include="RandomDataGenerator\RandomDataGeneratorSettings.cs" />
     <Compile Include="RandomDataGenerator\IRandomValueGenerator.cs" />
+    <Compile Include="RandomDataGenerator\RandomDataGeneratorProgram.cs" />
     <Compile Include="RandomDataGenerator\RandomValueGenerator.cs" />
     <Compile Include="RandomDataGenerator\RandomValueGeneratorException.cs" />
+    <Compile Include="RandomDataGenerator\SymbolGenerator.cs" />
+    <Compile Include="RandomDataGenerator\TickGenerator.cs" />
     <Compile Include="RandomDataGenerator\TooManyFailedAttemptsException.cs" />
     <Compile Include="TickAggregator.cs" />
     <Compile Include="AlgoSeekFuturesConverter\AlgoSeekFuturesConverter.cs" />

--- a/ToolBox/RandomDataGenerator/ConsoleLeveledOutput.cs
+++ b/ToolBox/RandomDataGenerator/ConsoleLeveledOutput.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using QuantConnect.Util;
+
+namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    public class ConsoleLeveledOutput
+    {
+        public TextWriter Info { get; }
+        public TextWriter Warn { get; }
+        public TextWriter Error { get; }
+        public bool ErrorMessageWritten { get; private set; }
+
+        public ConsoleLeveledOutput()
+        {
+            Info = Console.Out;
+            Warn = new FuncTextWriter(line =>
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine(line);
+                Console.ResetColor();
+            });
+            Error = new FuncTextWriter(line =>
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine(line);
+                Console.ResetColor();
+                ErrorMessageWritten = true;
+            });
+        }
+
+        public ConsoleLeveledOutput(TextWriter info, TextWriter warn, TextWriter error)
+        {
+            Info = info;
+            Warn = warn;
+            Error = error;
+        }
+    }
+}

--- a/ToolBox/RandomDataGenerator/DataDensity.cs
+++ b/ToolBox/RandomDataGenerator/DataDensity.cs
@@ -1,0 +1,23 @@
+﻿namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    /// <summary>
+    /// Specifies how dense data should be generated
+    /// </summary>
+    public enum DataDensity
+    {
+        /// <summary>
+        /// At least once per resolution step
+        /// </summary>
+        Dense,
+
+        /// <summary>
+        /// At least once per 5 resolution steps
+        /// </summary>
+        Sparse,
+
+        /// <summary>
+        /// At least once per 50 resolution steps
+        /// </summary>
+        VerySparse
+    }
+}

--- a/ToolBox/RandomDataGenerator/IRandomValueGenerator.cs
+++ b/ToolBox/RandomDataGenerator/IRandomValueGenerator.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+
+namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    /// <summary>
+    /// Defines a type capable of producing random values for use in random data generation
+    /// </summary>
+    public interface IRandomValueGenerator
+    {
+        /// <summary>
+        /// Generates a random <see cref="string"/> within the specified lengths.
+        /// </summary>
+        /// <param name="minLength">The minimum length, inclusive</param>
+        /// <param name="maxLength">The maximum length, inclusive</param>
+        /// <returns>A new upper case string within the specified lengths</returns>
+        string NextUpperCaseString(int minLength, int maxLength);
+
+        /// <summary>
+        /// Generates a random <see cref="decimal"/> suitable as a price. This should observe minimum price
+        /// variations if available in <see cref="SymbolPropertiesDatabase"/>, and if not, truncating to 2
+        /// decimal places.
+        /// </summary>
+        /// <exception cref="ArgumentException">Throw when the <paramref name="referencePrice"/> or <paramref name="maximumPercentDeviation"/>
+        /// is less than or equal to zero.</exception>
+        /// <param name="securityType"></param>
+        /// <param name="market"></param>
+        /// <param name="referencePrice">The reference price used as the mean of random price generation</param>
+        /// <param name="maximumPercentDeviation">The maximum percent deviation. This value is in percent space,
+        ///     so a value of 1m is equal to 1%.</param>
+        /// <returns>A new decimal suitable for usage as price within the specified deviation from the reference price</returns>
+        decimal NextPrice(SecurityType securityType, string market, decimal referencePrice, decimal maximumPercentDeviation);
+
+        /// <summary>
+        /// Generates a random <see cref="DateTime"/> between the specified <paramref name="minDateTime"/> and
+        /// <paramref name="maxDateTime"/>. <paramref name="dayOfWeek"/> is optionally specified to force the
+        /// result to a particular day of the week
+        /// </summary>
+        /// <param name="minDateTime">The minimum date time, inclusive</param>
+        /// <param name="maxDateTime">The maximum date time, inclusive</param>
+        /// <param name="dayOfWeek">Optional. The day of week to force</param>
+        /// <returns>A new <see cref="DateTime"/> within the specified range and optionally of the specified day of week</returns>
+        DateTime NextDate(DateTime minDateTime, DateTime maxDateTime, DayOfWeek? dayOfWeek);
+
+        /// <summary>
+        /// Generates a random <see cref="DateTime"/> suitable for use as a tick's emit time.
+        /// If the density provided is <see cref="DataDensity.Dense"/>, then at least one tick will be generated per <paramref name="resolution"/> step.
+        /// If the density provided is <see cref="DataDensity.Sparse"/>, then at least one tick will be generated every 5 <paramref name="resolution"/> steps.
+        /// if the density provided is <see cref="DataDensity.VerySparse"/>, then at least one tick will be generated every 50 <paramref name="resolution"/> steps.
+        /// Times returned are guaranteed to be within market hours for the specified symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to generate a new tick time for</param>
+        /// <param name="previous">The previous tick time</param>
+        /// <param name="resolution">The requested resolution of data</param>
+        /// <param name="density">The requested data density</param>
+        /// <returns>A new <see cref="DateTime"/> that is after <paramref name="previous"/> according to the specified <paramref name="resolution"/>
+        /// and <paramref name="density"/> specified</returns>
+        DateTime NextTickTime(Symbol symbol, DateTime previous, Resolution resolution, DataDensity density);
+
+        /// <summary>
+        /// Generates a random <see cref="Tick"/> that is at most the specified <paramref name="maximumPercentDeviation"/> away from the
+        /// <paramref name="previousValue"/> and is of the requested <paramref name="tickType"/>
+        /// </summary>
+        /// <param name="symbol">The symbol of the generated tick</param>
+        /// <param name="dateTime">The time of the generated tick</param>
+        /// <param name="tickType">The type of <see cref="Tick"/> to be generated</param>
+        /// <param name="previousValue">The previous price, used as a reference for generating
+        /// new random prices for the next time step</param>
+        /// <param name="maximumPercentDeviation">The maximum percentage to deviate from the
+        /// <paramref name="previousValue"/>, for example, 1 would indicate a maximum of 1% deviation from the
+        /// <paramref name="previousValue"/>. For a previous price of 100, this would yield a price between 99 and 101 inclusive</param>
+        /// <returns>A random <see cref="Tick"/> value that is within the specified <paramref name="maximumPercentDeviation"/>
+        /// from the <paramref name="previousValue"/></returns>
+        Tick NextTick(Symbol symbol, DateTime dateTime, TickType tickType, decimal previousValue, decimal maximumPercentDeviation);
+
+        /// <summary>
+        /// Generates a new random <see cref="Symbol"/> object of the specified security type.
+        /// </summary>
+        /// <remarks>
+        /// A valid implementation will keep track of generated symbol objects to ensure duplicates
+        /// are not generated.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Throw when specifying <see cref="SecurityType.Option"/> or
+        /// <see cref="SecurityType.Future"/>. To generate symbols for the derivative security types, please
+        /// use <see cref="NextOption"/> and <see cref="NextFuture"/> respectively</exception>
+        /// <param name="securityType">The security type of the generated symbol</param>
+        /// <param name="market"></param>
+        /// <returns>A new symbol object of the specified security type</returns>
+        Symbol NextSymbol(SecurityType securityType, string market);
+
+        /// <summary>
+        /// Generates a new random option <see cref="Symbol"/>. The generated option contract symbol will have an
+        /// expiry between the specified <paramref name="minExpiry"/> and <paramref name="maxExpiry"/>. The strike
+        /// price will be within the specified <paramref name="maximumStrikePriceDeviation"/> of the <paramref name="underlyingPrice"/>
+        /// and should be rounded to reasonable value for the given price. For example, a price of 100 dollars would round
+        /// to 5 dollar increments and a price of 5 dollars would round to 50 cent increments
+        /// </summary>
+        /// <remarks>
+        /// Standard contracts expiry on the third Friday.
+        /// Weekly contracts expiry every week on Friday
+        /// </remarks>
+        /// <param name="market"></param>
+        /// <param name="minExpiry">The minimum expiry date, inclusive</param>
+        /// <param name="maxExpiry">The maximum expiry date, inclusive</param>
+        /// <param name="underlyingPrice">The option's current underlying price</param>
+        /// <param name="maximumStrikePriceDeviation">The strike price's maximum percent deviation from the underlying price</param>
+        /// <returns>A new option contract symbol within the specified expiration and strike price parameters</returns>
+        Symbol NextOption(string market, DateTime minExpiry, DateTime maxExpiry, decimal underlyingPrice, decimal maximumStrikePriceDeviation);
+
+        /// <summary>
+        /// Generates a new random future <see cref="Symbol"/>. The generates future contract symbol will have an
+        /// expiry between the specified <paramref name="minExpiry"/> and <paramref name="maxExpiry"/>.
+        /// </summary>
+        /// <param name="market"></param>
+        /// <param name="minExpiry">The minimum expiry date, inclusive</param>
+        /// <param name="maxExpiry">The maximum expiry date, inclusive</param>
+        /// <returns>A new future contract symbol with the specified expiration parameters</returns>
+        Symbol NextFuture(string market, DateTime minExpiry, DateTime maxExpiry);
+    }
+}

--- a/ToolBox/RandomDataGenerator/RandomDataGeneratorProgram.cs
+++ b/ToolBox/RandomDataGenerator/RandomDataGeneratorProgram.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+using QuantConnect.Util;
+
+namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    public class RandomDataGeneratorProgram
+    {
+        public static void RandomDataGenerator(
+            string startDateString,
+            string endDateString,
+            string symbolCountString,
+            string market,
+            string securityTypeString,
+            string resolutionString,
+            string dataDensityString,
+            string includeCoarseString
+            )
+        {
+            var output = new ConsoleLeveledOutput();
+            var settings = RandomDataGeneratorSettings.FromCommandLineArguments(
+                startDateString,
+                endDateString,
+                symbolCountString,
+                market,
+                securityTypeString,
+                resolutionString,
+                dataDensityString,
+                includeCoarseString,
+                output
+            );
+
+            GenerateRandomData(settings, output);
+
+            if (settings.IncludeCoarse && settings.SecurityType == SecurityType.Equity)
+            {
+                output.Info.WriteLine("Launching coarse data generator...");
+                var coarseFiles = CoarseUniverseGenerator.CoarseUniverseGeneratorProgram.ProcessEquityDirectories(
+                    Globals.DataFolder,
+                    false,
+                    settings.Start
+                ).ToList();
+                output.Info.WriteLine("Coarse data generation completed. Produced the following files:");
+                foreach (var coarseFile in coarseFiles)
+                {
+                    output.Info.WriteLine($"Generated coarse file: {coarseFile}");
+                }
+            }
+
+            output.Info.WriteLine("Press any key to exit...");
+            Console.ReadKey();
+        }
+
+        public static void GenerateRandomData(RandomDataGeneratorSettings settings, ConsoleLeveledOutput output)
+        {
+            // can specify a seed value in this ctor if determinism is desired
+            var randomValueGenerator = new RandomValueGenerator();
+            var symbolGenerator = new SymbolGenerator(settings, randomValueGenerator);
+            var tickGenerator = new TickGenerator(settings, randomValueGenerator);
+
+            output.Warn.WriteLine($"Begin data generation of {settings.SymbolCount} randomly generated {settings.SecurityType} assets...");
+
+            // iterate over our randomly generated symbols
+            var count = 0;
+            var progress = 0d;
+            var previousMonth = -1;
+            foreach (var symbol in symbolGenerator.GenerateRandomSymbols())
+            {
+                output.Warn.WriteLine($"\tSymbol[{++count}]: {symbol} Progress: {progress:0.0}% - Generating data...");
+
+                // define consolidators via settings
+                var consolidators = settings.CreateConsolidators().ToList();
+
+                // generate and consolidate data
+                foreach (var tick in tickGenerator.GenerateTicks(symbol))
+                {
+                    if (tick.Time.Month != previousMonth)
+                    {
+                        output.Info.WriteLine($"\tMonth: {tick.Time:MMMM}");
+                        previousMonth = tick.Time.Month;
+                    }
+
+                    foreach (var item in consolidators)
+                    {
+                        item.Consolidator.Update(tick);
+                    }
+                }
+
+                var min = consolidators[0].Data[0];
+                var max = consolidators[0].Data.Last();
+
+                // count each stage as a point, so total points is 2*symbol-count
+                // and the current progress is twice the current, but less one because we haven't finished writing data yet
+                progress = 100*(2 * count - 1) / (2.0 * settings.SymbolCount);
+                output.Warn.WriteLine($"\tSymbol[{count}]: {symbol} Progress: {progress:0.0}% - Saving data in LEAN format");
+
+                // persist consolidated data to disk
+                foreach (var item in consolidators)
+                {
+                    var writer = new LeanDataWriter(item.Resolution, symbol, Globals.DataFolder, item.TickType);
+
+                    // IDataConsolidator defines its output as IBaseData, but they're all derived from BaseData,
+                    // so this OfType<BaseData> is safe and will not filter any items out of the result set
+                    writer.Write(item.Data.OfType<BaseData>());
+                }
+
+                // update progress
+                progress = 100 * (2 * count) / (2.0 * settings.SymbolCount);
+                output.Warn.WriteLine($"\tSymbol[{count}]: {symbol} Progress: {progress:0.0}% - Symbol data generation and output completed");
+            }
+
+            output.Info.WriteLine("Random data generation has completed.");
+        }
+    }
+}

--- a/ToolBox/RandomDataGenerator/RandomDataGeneratorSettings.cs
+++ b/ToolBox/RandomDataGenerator/RandomDataGeneratorSettings.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    public class RandomDataGeneratorSettings
+    {
+        private static int MarketCode = 100;
+        private static readonly string[] DateFormats = {DateFormat.EightCharacter, DateFormat.YearMonth, "yyyy-MM-dd"};
+
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
+        public SecurityType SecurityType { get; set; } = SecurityType.Equity;
+        public DataDensity DataDensity { get; set; } = DataDensity.Dense;
+        public Resolution Resolution { get; set; } = Resolution.Minute;
+        public string Market { get; set; }
+        public bool IncludeCoarse { get; set; } = true;
+        public int SymbolCount { get; set; }
+        public TickType[] TickTypes { get; set; }
+
+        public static RandomDataGeneratorSettings FromCommandLineArguments(
+            string startDateString,
+            string endDateString,
+            string symbolCountString,
+            string market,
+            string securityTypeString,
+            string resolutionString,
+            string dataDensityString,
+            string includeCoarseString,
+            ConsoleLeveledOutput output
+            )
+        {
+            int symbolCount;
+            bool includeCoarse;
+            TickType[] tickTypes;
+            Resolution resolution;
+            DataDensity dataDensity;
+            SecurityType securityType;
+            DateTime startDate, endDate;
+
+            // --start
+            if (!DateTime.TryParseExact(startDateString, DateFormats, null, DateTimeStyles.None, out startDate))
+            {
+                output.Error.WriteLine($"Required parameter --start was incorrectly formatted. Please specify in yyyyMMdd format. Value provided: '{startDateString}'");
+            }
+
+            // --end
+            if (!DateTime.TryParseExact(endDateString, DateFormats, null, DateTimeStyles.None, out endDate))
+            {
+                output.Error.WriteLine($"Required parameter --end was incorrectly formatted. Please specify in yyyyMMdd format. Value provided: '{endDateString}'");
+            }
+
+            // --symbol-count
+            if (!int.TryParse(symbolCountString, out symbolCount))
+            {
+                output.Error.WriteLine($"Required parameter --symbol-count was incorrectly formatted. Please specify a valid integer greater than zero. Value provided: '{symbolCountString}'");
+            }
+
+            // --resolution
+            if (string.IsNullOrEmpty(resolutionString))
+            {
+                resolution = Resolution.Minute;
+                output.Info.WriteLine($"Using default value of '{resolution}' for --resolution");
+            }
+            else if (!Enum.TryParse(resolutionString, true, out resolution))
+            {
+                var validValues = string.Join(", ", Enum.GetValues(typeof(Resolution)).Cast<Resolution>());
+                output.Error.WriteLine($"Optional parameter --resolution was incorrectly formatted. Default is Minute. Please specify a valid Resolution. Value provided: '{resolutionString}' Valid values: {validValues}");
+            }
+
+            // --security-type
+            if (string.IsNullOrEmpty(securityTypeString))
+            {
+                securityType = SecurityType.Equity;
+                output.Info.WriteLine($"Using default value of '{securityType}' for --security-type");
+            }
+            else if (!Enum.TryParse(securityTypeString, true, out securityType))
+            {
+                var validValues = string.Join(", ", Enum.GetValues(typeof(SecurityType)).Cast<SecurityType>());
+                output.Error.WriteLine($"Optional parameter --security-type is invalid. Default is Equity. Please specify a valid SecurityType. Value provided: '{securityTypeString}' Valid values: {validValues}");
+            }
+
+            if (securityType == SecurityType.Option && resolution != Resolution.Minute)
+            {
+                output.Error.WriteLine($"When using --security-type=Option you must specify --resolution=Minute");
+            }
+
+            // --market
+            if (string.IsNullOrEmpty(market))
+            {
+                market = DefaultBrokerageModel.DefaultMarketMap[securityType];
+                output.Info.WriteLine($"Using default value of '{market}' for --market and --security-type={securityType}");
+            }
+            else if (QuantConnect.Market.Encode(market) == null)
+            {
+                // be sure to add a reference to the unknown market, otherwise we won't be able to decode it coming out
+                QuantConnect.Market.Add(market, Interlocked.Increment(ref MarketCode));
+                output.Warn.WriteLine($"Please verify that the specified market value is correct: '{market}'   This value is not known has been added to the market value map. If this is an error, stop the application immediately using Ctrl+C");
+            }
+
+            // --include-coarse
+            if (string.IsNullOrEmpty(includeCoarseString))
+            {
+                includeCoarse = securityType == SecurityType.Equity;
+                if (securityType != SecurityType.Equity)
+                {
+                    output.Info.WriteLine($"Using default value of '{includeCoarse}' for --security-type={securityType}");
+                }
+            }
+            else if (!bool.TryParse(includeCoarseString, out includeCoarse))
+            {
+                output.Error.WriteLine($"Optional parameter --include-coarse was incorrectly formated. Please specify a valid boolean. Value provided: '{includeCoarseString}'. Valid values: 'true' or 'false'");
+            }
+            else if (includeCoarse && securityType != SecurityType.Equity)
+            {
+                output.Warn.WriteLine("Optional parameter --include-coarse will be ignored because it only applies to --security-type=Equity");
+            }
+
+            // --data-density
+            if (string.IsNullOrEmpty(dataDensityString))
+            {
+                dataDensity = DataDensity.Dense;
+                output.Info.WriteLine($"Using default value of '{dataDensity}' for --data-density");
+            }
+            else if (!Enum.TryParse(dataDensityString, true, out dataDensity))
+            {
+                var validValues = string.Join(", ", Enum.GetValues(typeof(DataDensity))).Cast<DataDensity>();
+                output.Error.WriteLine($"Optional parameter --data-density was incorrectly formated. Please specify a valid DataDensity. Value provided: '{dataDensityString}'. Valid values: {validValues}");
+            }
+
+            if (output.ErrorMessageWritten)
+            {
+                output.Error.WriteLine("Please address the errors and run the application again.");
+                Environment.Exit(-1);
+            }
+
+            switch (securityType)
+            {
+                case SecurityType.Base:
+                case SecurityType.Equity:
+                    tickTypes = new[] { TickType.Trade };
+                    break;
+
+                case SecurityType.Forex:
+                case SecurityType.Cfd:
+                    tickTypes = new[] { TickType.Quote };
+                    break;
+
+                case SecurityType.Option:
+                case SecurityType.Future:
+                    tickTypes = new[] { TickType.Trade, TickType.Quote, TickType.OpenInterest };
+                    break;
+
+                case SecurityType.Crypto:
+                    tickTypes = new[] { TickType.Trade, TickType.Quote };
+                    break;
+
+                case SecurityType.Commodity:
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            output.Info.WriteLine($"Selected tick types for {securityType}: {string.Join(", ", tickTypes)}");
+
+            return new RandomDataGeneratorSettings
+            {
+                End = endDate,
+                Start = startDate,
+
+                Market = market,
+                SymbolCount = symbolCount,
+                SecurityType = securityType,
+
+                TickTypes = tickTypes,
+                Resolution = resolution,
+
+                DataDensity = dataDensity,
+                IncludeCoarse = includeCoarse,
+            };
+        }
+
+        public IEnumerable<ConsolidatorTickTypeData> CreateConsolidators()
+        {
+            if (Resolution == Resolution.Tick)
+            {
+                // to maintain 'likeness' w/ non-tick resolutions, we'll use identity here
+                foreach (var tickType in TickTypes)
+                {
+                    if (tickType == TickType.OpenInterest)
+                    {
+                        yield return new ConsolidatorTickTypeData(Resolution.Daily, TickType.OpenInterest, new OpenInterestConsolidator(Time.OneDay));
+                    }
+                    else
+                    {
+                        yield return new ConsolidatorTickTypeData(Resolution, tickType, new IdentityDataConsolidator<Tick>());
+                    }
+                }
+
+                yield break;
+            }
+
+            var increment = Resolution.ToTimeSpan();
+            if (TickTypes.Contains(TickType.Trade))
+            {
+                yield return new ConsolidatorTickTypeData(Resolution, TickType.Trade, new TickConsolidator(increment));
+            }
+
+            if (TickTypes.Contains(TickType.Quote))
+            {
+                yield return new ConsolidatorTickTypeData(Resolution, TickType.Quote, new TickQuoteBarConsolidator(increment));
+            }
+
+            if (TickTypes.Contains(TickType.OpenInterest))
+            {
+                yield return new ConsolidatorTickTypeData(Resolution.Daily, TickType.OpenInterest, new OpenInterestConsolidator(Time.OneDay));
+            }
+
+            // ensure we have a daily consolidator when coarse is enabled
+            if (IncludeCoarse && Resolution != Resolution.Daily)
+            {
+                // prefer trades for coarse - in practice equity only does trades, but leaving this as configurable
+                if (TickTypes.Contains(TickType.Trade))
+                {
+                    yield return new ConsolidatorTickTypeData(Resolution.Daily, TickType.Trade, new TickConsolidator(Time.OneDay));
+                }
+                else
+                {
+                    yield return new ConsolidatorTickTypeData(Resolution.Daily, TickType.Quote, new TickQuoteBarConsolidator(Time.OneDay));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Provides a small layer to maintain a cache of consolidated data
+        /// </summary>
+        public class ConsolidatorTickTypeData
+        {
+            private List<IBaseData> _data;
+            public Resolution Resolution { get; }
+            public IReadOnlyList<IBaseData> Data { get { return _data; } }
+            public TickType TickType { get; }
+            public IDataConsolidator Consolidator { get; }
+
+            public ConsolidatorTickTypeData(Resolution resolution, TickType tickType, IDataConsolidator consolidator)
+            {
+                Resolution = resolution;
+                TickType = tickType;
+                Consolidator = consolidator;
+                _data = new List<IBaseData>();
+
+                // cache consolidated data, we'll write to disk after data is generated per symbol
+                Consolidator.DataConsolidated += (sender, args) => _data.Add(args);
+            }
+        }
+    }
+}

--- a/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
+++ b/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
@@ -1,0 +1,336 @@
+﻿using System;
+using System.Linq;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+using QuantConnect.Util;
+
+namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IRandomValueGenerator"/> that uses
+    /// <see cref="Random"/> to generate random values
+    /// </summary>
+    public class RandomValueGenerator : IRandomValueGenerator
+    {
+        private readonly Random _random;
+        private readonly MarketHoursDatabase _marketHoursDatabase;
+        private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase;
+
+        // used to prevent generating duplicates, but also caps
+        // the memory allocated to checking for duplicates
+        private readonly FixedSizeHashQueue<Symbol> symbols;
+
+        public RandomValueGenerator()
+        {
+            _random = new Random();
+            symbols = new FixedSizeHashQueue<Symbol>(1000);
+            _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
+        }
+
+        public RandomValueGenerator(int seed)
+        {
+            _random = new Random(seed);
+            symbols = new FixedSizeHashQueue<Symbol>(1000);
+            _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
+        }
+
+        public RandomValueGenerator(int seed, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase)
+        {
+            _random = new Random(seed);
+            _marketHoursDatabase = marketHoursDatabase;
+            symbols = new FixedSizeHashQueue<Symbol>(1000);
+            _symbolPropertiesDatabase = symbolPropertiesDatabase;
+        }
+
+        public virtual string NextUpperCaseString(int minLength, int maxLength)
+        {
+            var str = string.Empty;
+            var length = _random.Next(minLength, maxLength);
+            for (int i = 0; i < length; i++)
+            {
+                // A=65, Z=90
+                var c = (char)_random.Next(65, 90);
+                str += c;
+            }
+
+            return str;
+        }
+
+        public virtual decimal NextPrice(SecurityType securityType, string market, decimal referencePrice, decimal maximumPercentDeviation)
+        {
+            if (referencePrice <= 0)
+            {
+                throw new ArgumentException("The provided reference price must be a positive number.");
+            }
+
+            if (maximumPercentDeviation <= 0)
+            {
+                throw new ArgumentException("The provided maximum percent deviation must be a postive number");
+            }
+
+            // convert from percent space to decimal space
+            maximumPercentDeviation /= 100m;
+
+            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, (string) null, securityType, "USD");
+            var minimumPriceVariation = symbolProperties.MinimumPriceVariation;
+
+            decimal price;
+            var attempts = 0;
+            do
+            {
+                // what follows is a simple model of browning motion that
+                // limits the walk to the specified percent deviation
+
+                var deviation = referencePrice * maximumPercentDeviation * (decimal) (_random.NextDouble() - 0.5);
+                price = referencePrice + deviation;
+                price = RoundPrice(price, minimumPriceVariation);
+
+                attempts++;
+            } while (price <= 0 && attempts < 10);
+
+            if (price <= 0)
+            {
+                // if still invalid, bail
+                throw new TooManyFailedAttemptsException(nameof(NextPrice), attempts);
+            }
+
+            return price;
+        }
+
+        public virtual DateTime NextDate(DateTime minDateTime, DateTime maxDateTime, DayOfWeek? dayOfWeek)
+        {
+            if (maxDateTime < minDateTime)
+            {
+                throw new ArgumentException(
+                    "The maximum date time must be less than or equal to the minimum date time specified"
+                );
+            }
+
+            // compute a random date time value
+            var rangeInDays = (int) maxDateTime.Subtract(minDateTime).TotalDays;
+            var daysOffsetFromMin = _random.Next(0, rangeInDays);
+            var dateTime = minDateTime.AddDays(daysOffsetFromMin);
+
+            var currentDayOfWeek = dateTime.DayOfWeek;
+            if (!dayOfWeek.HasValue || currentDayOfWeek == dayOfWeek.Value)
+            {
+                // either DOW wasn't specified or we got REALLY lucky, although, I suppose it'll happen 1/7 (~14%) of the time
+                return dateTime;
+            }
+
+            var nextDayOfWeek = Enumerable.Range(0, 7)
+                .Select(i => dateTime.AddDays(i))
+                .First(dt => dt.DayOfWeek == dayOfWeek.Value);
+
+            var previousDayOfWeek = Enumerable.Range(0, 7)
+                .Select(i => dateTime.AddDays(-i))
+                .First(dt => dt.DayOfWeek == dayOfWeek.Value);
+
+            // both are valid dates, so chose one randomly
+            if (IsWithinRange(nextDayOfWeek, minDateTime, maxDateTime) &&
+                IsWithinRange(previousDayOfWeek, minDateTime, maxDateTime)
+            )
+            {
+                return _random.Next(0, 1) == 0
+                    ? previousDayOfWeek
+                    : nextDayOfWeek;
+            }
+
+            if (IsWithinRange(nextDayOfWeek, minDateTime, maxDateTime))
+            {
+                return nextDayOfWeek;
+            }
+
+            if (IsWithinRange(previousDayOfWeek, minDateTime, maxDateTime))
+            {
+                return previousDayOfWeek;
+            }
+
+            throw new ArgumentException("The provided min and max dates do not have the requested day of week between them");
+        }
+
+        public virtual DateTime NextTickTime(Symbol symbol, DateTime previous, Resolution resolution, DataDensity density)
+        {
+            var increment = resolution.ToTimeSpan();
+            if (increment == TimeSpan.Zero)
+            {
+                increment = TimeSpan.FromMilliseconds(500);
+            }
+
+            double steps;
+            switch (density)
+            {
+                case DataDensity.Dense:
+                    steps = 0.5 * _random.NextDouble();
+                    break;
+
+                case DataDensity.Sparse:
+                    steps = 5 * _random.NextDouble();
+                    break;
+
+                case DataDensity.VerySparse:
+                    steps = 50 * _random.NextDouble();
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(density), density, null);
+            }
+
+            var delta = TimeSpan.FromTicks((long) (steps * increment.Ticks));
+            var tickTime = previous.Add(delta);
+            if (tickTime == previous)
+            {
+                tickTime = tickTime.Add(increment);
+            }
+
+            var barStart = tickTime.Subtract(increment);
+            var marketHours = _marketHoursDatabase.GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+            if (!marketHours.IsDateOpen(tickTime) || !marketHours.IsOpen(barStart, tickTime, false))
+            {
+                // we ended up outside of market hours, emit a new tick at market open
+                var nextMarketOpen = marketHours.GetNextMarketOpen(tickTime, false);
+                if (resolution == Resolution.Tick)
+                {
+                    resolution = Resolution.Second;
+                }
+
+                // emit a new tick somewhere in the next trading day at a step lower resolution to guarantee a hit
+                return NextTickTime(symbol, nextMarketOpen, resolution - 1, density);
+            }
+
+            return tickTime;
+        }
+
+        public virtual Tick NextTick(Symbol symbol, DateTime dateTime, TickType tickType, decimal previousValue, decimal maximumPercentDeviation)
+        {
+            var next = NextPrice(symbol.SecurityType, symbol.ID.Market, previousValue, maximumPercentDeviation);
+            var tick = new Tick
+            {
+                Time = dateTime,
+                Symbol = symbol,
+                TickType = tickType,
+                Value = next
+            };
+
+            switch (tickType)
+            {
+                case TickType.Trade:
+                    tick.Quantity = _random.Next(1, 1500);
+                    return tick;
+
+                case TickType.Quote:
+                    var quoteDeviation = Math.Max(0.1m, maximumPercentDeviation / 10m);
+                    var bid = NextPrice(symbol.SecurityType, symbol.ID.Market, tick.Value, quoteDeviation);
+                    if (bid > tick.Value)
+                    {
+                        bid = tick.Value - (bid - tick.Value);
+                    }
+                    var ask = NextPrice(symbol.SecurityType, symbol.ID.Market, tick.Value, quoteDeviation);
+                    if (ask < tick.Value)
+                    {
+                        ask = tick.Value + (tick.Value - ask);
+                    }
+
+                    tick.BidPrice = bid;
+                    tick.BidSize = _random.Next(1, 1500);
+                    tick.AskPrice = ask;
+                    tick.AskSize = _random.Next(1, 1500);
+                    return tick;
+
+                case TickType.OpenInterest:
+                    tick.Value = (long) tick.Value;
+                    tick.Quantity = tick.Value;
+                    return tick;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(tickType), tickType, null);
+            }
+        }
+
+        public virtual Symbol NextSymbol(SecurityType securityType, string market)
+        {
+            if (securityType == SecurityType.Option || securityType == SecurityType.Future)
+            {
+                throw new ArgumentException("Please use NextOption or NextFuture for SecurityType.Option and SecurityType.Future respectively.");
+            }
+
+            // let's make symbols all have 3 chars as it's acceptable for all permitted security types in this method
+            var ticker = NextUpperCaseString(3, 3);
+
+            // by chance we may generate a ticker that actually exists, and if map files exist that match this
+            // ticker then we'll end up resolving the first trading date for use in the SID, otherwise, all
+            // generated symbol will have a date equal to SecurityIdentifier.DefaultDate
+            var symbol = Symbol.Create(ticker, securityType, market);
+            if (symbols.Add(symbol))
+            {
+                return symbol;
+            }
+
+            // lo' and behold, we created a duplicate --recurse to find a unique value
+            // this is purposefully done as the last statement to enable the compiler to
+            // unroll this method into a tail-recursion loop :)
+            return NextSymbol(securityType, market);
+        }
+
+        public virtual Symbol NextOption(string market, DateTime minExpiry, DateTime maxExpiry, decimal underlyingPrice, decimal maximumStrikePriceDeviation)
+        {
+            // first generate the underlying
+            var underlying = NextSymbol(SecurityType.Equity, market);
+
+            var marketHours = _marketHoursDatabase.GetExchangeHours(market, underlying, SecurityType.Equity);
+            var expiry = GetRandomExpiration(marketHours, minExpiry, maxExpiry);
+
+            // generate a random strike while respecting the maximum deviation from the underlying's price
+            // since these are underlying prices, use Equity as the security type
+            var strike = NextPrice(SecurityType.Equity, market, underlyingPrice, maximumStrikePriceDeviation);
+
+            // round the strike price to something reasonable
+            var order = 1 + Math.Log10((double) strike);
+            strike = strike.RoundToSignificantDigits((int) order);
+
+            var optionRight = (OptionRight) _random.Next(0, 1);
+
+            // when providing a null option w/ an expiry, it will automatically create the OSI ticker string for the Value
+            return Symbol.CreateOption(underlying, market, OptionStyle.American, optionRight, strike, expiry);
+        }
+
+        public virtual Symbol NextFuture(string market, DateTime minExpiry, DateTime maxExpiry)
+        {
+            // futures are usually two characters
+            var ticker = NextUpperCaseString(2, 2);
+
+            var marketHours = _marketHoursDatabase.GetExchangeHours(market, null, SecurityType.Future);
+            var expiry = GetRandomExpiration(marketHours, minExpiry, maxExpiry);
+
+            return Symbol.CreateFuture(ticker, market, expiry);
+        }
+
+        private bool IsWithinRange(DateTime value, DateTime min, DateTime max)
+        {
+            return value >= min && value <= max;
+        }
+
+        private static decimal RoundPrice(decimal price, decimal minimumPriceVariation)
+        {
+            if (minimumPriceVariation == 0) return minimumPriceVariation;
+            return Math.Round(price / minimumPriceVariation) * minimumPriceVariation;
+        }
+
+        private DateTime GetRandomExpiration(SecurityExchangeHours marketHours, DateTime minExpiry, DateTime maxExpiry)
+        {
+            // generate a random expiration date on a friday
+            var expiry = NextDate(minExpiry, maxExpiry, DayOfWeek.Friday);
+
+            // check to see if we're open on this date and if not, back track until we are
+            // we're using the equity market hours as a proxy since we haven't generated the option symbol yet
+            while (!marketHours.IsDateOpen(expiry))
+            {
+                expiry = expiry.AddDays(-1);
+            }
+
+            return expiry;
+        }
+    }
+}

--- a/ToolBox/RandomDataGenerator/RandomValueGeneratorException.cs
+++ b/ToolBox/RandomDataGenerator/RandomValueGeneratorException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    /// <summary>
+    /// Provides a base class for exceptions thrown by implementations of <see cref="IRandomValueGenerator"/>
+    /// </summary>
+    public class RandomValueGeneratorException : ApplicationException
+    {
+        public RandomValueGeneratorException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/ToolBox/RandomDataGenerator/SymbolGenerator.cs
+++ b/ToolBox/RandomDataGenerator/SymbolGenerator.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    public class SymbolGenerator
+    {
+        private readonly IRandomValueGenerator _random;
+        private readonly RandomDataGeneratorSettings _settings;
+
+        public SymbolGenerator(RandomDataGeneratorSettings settings, IRandomValueGenerator random)
+        {
+            _settings = settings;
+            _random = random;
+        }
+
+        public IEnumerable<Symbol> GenerateRandomSymbols()
+        {
+            for (int i = 0; i < _settings.SymbolCount; i++)
+            {
+                switch (_settings.SecurityType)
+                {
+                    case SecurityType.Option:
+                        yield return _random.NextOption(_settings.Market, _settings.Start, _settings.End, 100m, 75m);
+                        break;
+
+                    case SecurityType.Future:
+                        yield return _random.NextFuture(_settings.Market, _settings.Start, _settings.End);
+                        break;
+
+                    default:
+                        yield return _random.NextSymbol(_settings.SecurityType, _settings.Market);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/ToolBox/RandomDataGenerator/TickGenerator.cs
+++ b/ToolBox/RandomDataGenerator/TickGenerator.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    /// <summary>
+    /// Generates random tick data according to the settings provided
+    /// </summary>
+    public class TickGenerator
+    {
+        private readonly RandomDataGeneratorSettings _settings;
+        private readonly IRandomValueGenerator _random;
+
+        public TickGenerator(RandomDataGeneratorSettings settings)
+        {
+            _settings = settings;
+            _random = new RandomValueGenerator();
+        }
+
+        public TickGenerator(RandomDataGeneratorSettings settings, IRandomValueGenerator random)
+        {
+            _random = random;
+            _settings = settings;
+        }
+
+        public IEnumerable<Tick> GenerateTicks(Symbol symbol)
+        {
+            var previousValues = new Dictionary<TickType, decimal>
+            {
+                {TickType.Trade, 100m},
+                {TickType.Quote, 100m},
+                {TickType.OpenInterest, 10000m}
+            };
+
+            var current = _settings.Start;
+            // create deviations like 0.025 for tick and
+            var deviation = GetMaximumDeviation(_settings.Resolution);
+            while (current <= _settings.End)
+            {
+                var next = _random.NextTickTime(symbol, current, _settings.Resolution, _settings.DataDensity);
+                if (_settings.TickTypes.Contains(TickType.OpenInterest))
+                {
+                    if (next.Date != current.Date)
+                    {
+                        // 5% deviation in daily OI
+                        var previous = previousValues[TickType.OpenInterest];
+                        var openInterest = _random.NextTick(symbol, next.Date, TickType.OpenInterest, previous, 5m);
+                        previousValues[TickType.OpenInterest] = openInterest.Value;
+                        yield return openInterest;
+                    }
+                }
+
+                // keeps quotes close to the trades for consistency
+                if (_settings.TickTypes.Contains(TickType.Trade) &&
+                    _settings.TickTypes.Contains(TickType.Quote))
+                {
+                    var nextTrade = _random.NextTick(symbol, next, TickType.Trade, previousValues[TickType.Trade], deviation);
+                    previousValues[TickType.Trade] = nextTrade.Value;
+                    yield return nextTrade;
+
+                    // specify 0 to bind the mean to the previous trade for consistency
+                    var nextQuote = _random.NextTick(symbol, next, TickType.Quote, nextTrade.Value, 0m);
+                    previousValues[TickType.Quote] = nextQuote.Value;
+                    yield return nextQuote;
+                }
+                else if(_settings.TickTypes.Contains(TickType.Trade))
+                {
+                    var nextTrade = _random.NextTick(symbol, next, TickType.Trade, previousValues[TickType.Trade], deviation);
+                    previousValues[TickType.Trade] = nextTrade.Value;
+                    yield return nextTrade;
+                }
+                else if (_settings.TickTypes.Contains(TickType.Quote))
+                {
+                    // specify 0 to bind the mean to the previous trade for consistency
+                    var nextQuote = _random.NextTick(symbol, next, TickType.Quote, previousValues[TickType.Quote], deviation);
+                    previousValues[TickType.Quote] = nextQuote.Value;
+                    yield return nextQuote;
+                }
+
+                // advance to the next time step
+                current = next;
+            }
+        }
+
+        private decimal GetMaximumDeviation(Resolution resolution)
+        {
+            var incr = ((int) resolution) + 0.15m;
+            var deviation = incr * incr * 0.1m;
+            return deviation;
+        }
+    }
+}

--- a/ToolBox/RandomDataGenerator/TooManyFailedAttemptsException.cs
+++ b/ToolBox/RandomDataGenerator/TooManyFailedAttemptsException.cs
@@ -1,0 +1,13 @@
+﻿namespace QuantConnect.ToolBox.RandomDataGenerator
+{
+    /// <summary>
+    /// Exception thrown when multiple attempts to generate a valid random value end in failure
+    /// </summary>
+    public class TooManyFailedAttemptsException : RandomValueGeneratorException
+    {
+        public TooManyFailedAttemptsException(string method, int attempts)
+            : base($"Failed to generate a valid value for '{method}' after {attempts} attempts.")
+        {
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Creates a new toolbox project: `RandomDataGenerator` which satisfies the requirements as laid out in #2824. A piece missing from those requirements is properly emitting underlying equity data in tandem with options data. I've defined an `IRandomValueDataGenerator` which produces all of the random values and it supports specifying a seed value  to permit deterministic results between multiple runs. I added an enum, `DataDensity` with values `Dense`, `Sparse` and `VerySparse`. I felt the need for `VerySparse` was large given how thin some options and even some equities can trade, plus having less than a trade tick a day is an important test case for `Lean`. The `RandomValueGenerator` as implemented uses a simplified model of [Browning motion](https://en.wikipedia.org/wiki/Brownian_motion) where we simply advance the current value by +/- random value. Also, too keep the ticks more realistic, they too are advanced at random values capped by the `DataDensity` parameter. All settings are configurable via command line and extensive output is provided for users to help make using the program easier, including solid reporting of parse errors and invalid configuration values. I also threw in some color on the command line to keep your eyes pleased :)

A note on performance: The generation of data is 100% lazy-fed into consolidators where it is _non_ lazily aggregated into lists per consolidator. These consolidated lists are then passed off to the `LeanDataWriter` to produce the correct output files in `Lean` format. While it _isn't_ parallelized, it would be very easy to make it parallel as the processing of each `symbol` does not share any mutable state with the processing of other symbols, so we could simply throw it in a `Parallel.ForEach` and it'll be happy (be sure to use things like `Interlocked.Increment` when updating the `count` for progress) I didn't want to make this PR more complicated than necessary, but if desired, I'm happy to add it -- would only take a few minutes.

A note on options data -- this PR has a _serious_ shortcoming that I raised but did not address here, although it shouldn't take too much time to remedy, and that's when producing `Option` data we should be producing the `Equity` data at the same time, or perhaps, produce the equity data, and then use those prices to guide the options prices... this may require just a tad more though, since if we want it to be realistic we should probably be running black scholes on the equity data to resolve volatility, etc and back-compute realistic options prices instead of _randomized_ prices for options -- that way we don't get wierd/nan values for the greeks.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #2824 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#2824 aims to democratize the testing of `Lean` by empowering the open source community to generate large test data sets that are realistic enough to perform performance benchmarking of `Lean` while not requiring any data licenses, etc.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Documentation _could_ be added regarding usage of the application, although I'm not sure if it's standard practice to add usage documentation for the `ToolBox` projects -- I'll defer to @jaredbroad on this one.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The `RandomValueGenerator` is _extensively_ tested by units tests with almost 100% test coverage. Since this is the meat of the application, I felt it necessary to provide confidence that the generated data is consistent with the various data types used and that the generated data meets the specifications outlined in #2824 .

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

#### Sample Data Output
![image](https://user-images.githubusercontent.com/531416/51182105-130b0e80-189b-11e9-8186-9da073e4aabe.png)


<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->