### PR TITLE
C# decimal to Python conversion

### DIFF
--- a/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.py
+++ b/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.py
@@ -47,7 +47,7 @@ class BasePairsTradingAlphaModel(AlphaModel):
         self.Securities = list()
 
         resolutionString = Extensions.GetEnumString(resolution, Resolution)
-        self.Name = f'{self.__class__.__name__}({self.lookback},{resolutionString},{Extensions.Normalize(threshold)})'
+        self.Name = f'{self.__class__.__name__}({self.lookback},{resolutionString},{Extensions.NormalizeToStr(threshold)})'
 
 
     def Update(self, algorithm, data):

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
@@ -80,8 +80,16 @@ class StandardDeviationExecutionModel(ExecutionModel):
                 maxOrderSize = OrderSizing.Value(data.Security, self.MaximumOrderValue)
                 orderSize = np.min([maxOrderSize, np.abs(unorderedQuantity)])
 
+                remainder = orderSize % data.Security.SymbolProperties.LotSize
+                missingForLotSize = data.Security.SymbolProperties.LotSize - remainder
+                # if the amount we are missing for +1 lot size is 1M part of a lot size
+                # we suppose its due to floating point error and round up
+                # Note: this is required to avoid a diff with C# equivalent
+                if missingForLotSize < (data.Security.SymbolProperties.LotSize / 1000000):
+                    remainder -= data.Security.SymbolProperties.LotSize
+
                 # round down to even lot size
-                orderSize -= orderSize % data.Security.SymbolProperties.LotSize
+                orderSize -= remainder
                 if orderSize != 0:
                     algorithm.MarketOrder(symbol, np.sign(unorderedQuantity) * orderSize)
 

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -41,6 +41,7 @@
     <Content Include="BasicTemplateFuturesFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateOptionsFrameworkAlgorithm.py" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Content Include="decimal.py" />
     <None Include="CompositeRiskManagementModelFrameworkAlgorithm.py" />
     <None Include="BlackLittermanPortfolioOptimizationFrameworkAlgorithm.py" />
     <None Include="packages.config" />

--- a/Algorithm.Python/decimal.py
+++ b/Algorithm.Python/decimal.py
@@ -1,0 +1,18 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Decimal(float):
+    '''This is required for backwards compatibility with users performing operations over expected decimal types.
+    NOTE: previously we converted C# decimal into python Decimal, but now its converted to python float due to performance.'''
+    def __init__(self, obj):
+        self = obj

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -235,10 +235,29 @@ namespace QuantConnect
             return (decimal) input;
         }
 
+        /// <summary>
+        /// Will remove any trailing zeros for the provided decimal input
+        /// </summary>
+        /// <param name="input">The <see cref="decimal"/> to remove trailing zeros from</param>
+        /// <returns>Provided input with no trailing zeros</returns>
+        /// <remarks>Will not have the expected behavior when called from Python,
+        /// since the returned <see cref="decimal"/> will be converted to python float,
+        /// <see cref="NormalizeToStr"/></remarks>
         public static decimal Normalize(this decimal input)
         {
             // http://stackoverflow.com/a/7983330/1582922
             return input / 1.000000000000000000000000000000000m;
+        }
+
+        /// <summary>
+        /// Will remove any trailing zeros for the provided decimal and convert to string.
+        /// Uses <see cref="Normalize"/>.
+        /// </summary>
+        /// <param name="input">The <see cref="decimal"/> to convert to <see cref="string"/></param>
+        /// <returns>Input converted to <see cref="string"/> with no trailing zeros</returns>
+        public static string NormalizeToStr(this decimal input)
+        {
+            return Normalize(input).ToString(CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/Tests/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreterTests.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Tests.Common.Exceptions
 
                 try
                 {
-                    // x = decimal.Decimal(1) * 1.1
+                    // x = None + "Pepe Grillo"
                     algorithm.unsupported_operand();
                 }
                 catch (PythonException pythonException)
@@ -80,7 +80,7 @@ namespace QuantConnect.Tests.Common.Exceptions
             var assembly = typeof(PythonExceptionInterpreter).Assembly;
             var interpreter = StackExceptionInterpreter.CreateFromAssemblies(new[] { assembly });
             exception = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
-            Assert.True(exception.Message.Contains("x = decimal.Decimal(1) * 1.1"));
+            Assert.True(exception.Message.Contains("x = None + \"Pepe Grillo\""));
         }
 
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -700,7 +700,7 @@ namespace QuantConnect.Tests.Common.Util
             }
             catch (PythonException e)
             {
-                Assert.AreEqual($"ValueError : {6}", e.Message);
+                Assert.AreEqual("ValueError : 6.0", e.Message);
             }
         }
 

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -38,7 +38,7 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
         self.SetCash('SPY')
 
     def unsupported_operand(self):
-        x = decimal.Decimal(1) * 1.1
+        x = None + "Pepe Grillo"
 
     def zero_division_error(self):
         x = 1 / 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- This PR is related to PR https://github.com/QuantConnect/pythonnet/pull/19 (but does not require it)
   > C# decimal will be cast to C# double and converted into python
   float
- Adding new `decimal.py` into the python algorithm project. This is
required for backwards compatibility with users performing operations over expected decimal types (like `Price`). `Decimal` class in `decimal.py` will cover the original `Decimal` with `float`.
- Updating two python regression test algorithms using python
execution models to be aware and ignore floating point precision errors
when handling order sizing.
- Adding new `NormalizeToStr()`. Required since now C# decimal will be converted to python float and trailing zeros were present after calling C# `Normalize()`

**Performance results with PythonNet of PR `QuantConnect/pythonnet/pull/19`**. ~15% improvement
>Master python_benchmark_algo
170.54 seconds at 42k data points per second. Processing total of 7,092,090 data points.
165.04 seconds at 43k data points per second. Processing total of 7,092,090 data points.
164.01 seconds at 43k data points per second. Processing total of 7,092,090 data points.
PR python_benchmark_algo
146.15 seconds at 49k data points per second. Processing total of 7,092,090 data points.
140.39 seconds at 51k data points per second. Processing total of 7,092,090 data points.
137.71 seconds at 51k data points per second. Processing total of 7,092,090 data points.

[python_benchmark_algo.txt](https://github.com/QuantConnect/Lean/files/2759935/python_benchmark_algo.txt)

>Master Py IndicatorRibbonBenchmark
339.04 seconds at 2k data points per second. Processing total of 782,223 data points.
335.39 seconds at 2k data points per second. Processing total of 782,223 data points.
307.85 seconds at 3k data points per second. Processing total of 782,223 data points.
PR Py IndicatorRibbonBenchmark -> **~45% improvement**
177.28 seconds at 4k data points per second. Processing total of 782,223 data points.
178.25 seconds at 4k data points per second. Processing total of 782,223 data points.
188.96 seconds at 4k data points per second. Processing total of 782,223 data points.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/Lean/issues/2825
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Python Execution Speed Improvement https://github.com/QuantConnect/Lean/projects/7
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->