### PR TITLE
 #2715: Fixes CustomModelsAlgorithm.py making wrong trades.

### DIFF
--- a/Algorithm.CSharp/CustomModelsAlgorithm.cs
+++ b/Algorithm.CSharp/CustomModelsAlgorithm.cs
@@ -163,7 +163,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.Python/CustomModelsAlgorithm.py
+++ b/Algorithm.Python/CustomModelsAlgorithm.py
@@ -71,15 +71,19 @@ class CustomFillModel(ImmediateFillModel):
     def __init__(self, algorithm):
         self.algorithm = algorithm
         self.absoluteRemainingByOrderId = {}
-        random.seed(100)
+        self.random = Random(387510346)
 
     def MarketFill(self, asset, order):
-        #if not _absoluteRemainingByOrderId.TryGetValue(order.Id, absoluteRemaining):
         absoluteRemaining = order.AbsoluteQuantity
-        self.absoluteRemainingByOrderId[order.Id] = order.AbsoluteQuantity
+
+        if order.Id in self.absoluteRemainingByOrderId.keys():
+            absoluteRemaining = self.absoluteRemainingByOrderId[order.Id]
+            self.absoluteRemainingByOrderId[order.Id] = order.AbsoluteQuantity
+
         fill = super().MarketFill(asset, order)
-        absoluteFillQuantity = int(min(absoluteRemaining, random.randint(0, 2*int(order.AbsoluteQuantity))))
+        absoluteFillQuantity = int(min(absoluteRemaining, self.random.Next(0, 2*int(order.AbsoluteQuantity))))
         fill.FillQuantity = np.sign(order.Quantity) * absoluteFillQuantity
+        
         if absoluteRemaining == absoluteFillQuantity:
             fill.Status = OrderStatus.Filled
             if self.absoluteRemainingByOrderId.get(order.Id):

--- a/Algorithm.Python/CustomModelsAlgorithm.py
+++ b/Algorithm.Python/CustomModelsAlgorithm.py
@@ -78,7 +78,6 @@ class CustomFillModel(ImmediateFillModel):
 
         if order.Id in self.absoluteRemainingByOrderId.keys():
             absoluteRemaining = self.absoluteRemainingByOrderId[order.Id]
-            self.absoluteRemainingByOrderId[order.Id] = order.AbsoluteQuantity
 
         fill = super().MarketFill(asset, order)
         absoluteFillQuantity = int(min(absoluteRemaining, self.random.Next(0, 2*int(order.AbsoluteQuantity))))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
`CustomModelsAlgorithm.py` summary statistics now matches `CustomModelsAlgorithm.cs` statistics. Example output:

**C#**
```
20190116 13:35:04.392 Trace:: STATISTICS:: Total Trades 62
20190116 13:35:04.400 Trace:: STATISTICS:: Average Win 0.11%
20190116 13:35:04.405 Trace:: STATISTICS:: Average Loss -0.06%
20190116 13:35:04.406 Trace:: STATISTICS:: Compounding Annual Return -7.582%
20190116 13:35:04.407 Trace:: STATISTICS:: Drawdown 2.400%
20190116 13:35:04.410 Trace:: STATISTICS:: Expectancy -0.193
20190116 13:35:04.410 Trace:: STATISTICS:: Net Profit -0.660%
20190116 13:35:04.412 Trace:: STATISTICS:: Sharpe Ratio -1.563
20190116 13:35:04.413 Trace:: STATISTICS:: Loss Rate 70%
20190116 13:35:04.413 Trace:: STATISTICS:: Win Rate 30%
20190116 13:35:04.419 Trace:: STATISTICS:: Profit-Loss Ratio 1.71
20190116 13:35:04.424 Trace:: STATISTICS:: Alpha -0.174
20190116 13:35:04.425 Trace:: STATISTICS:: Beta 5.695
20190116 13:35:04.434 Trace:: STATISTICS:: Annual Standard Deviation 0.046
20190116 13:35:04.434 Trace:: STATISTICS:: Annual Variance 0.002
20190116 13:35:04.435 Trace:: STATISTICS:: Information Ratio -1.959
20190116 13:35:04.436 Trace:: STATISTICS:: Tracking Error 0.046
20190116 13:35:04.437 Trace:: STATISTICS:: Treynor Ratio -0.013
20190116 13:35:04.438 Trace:: STATISTICS:: Total Fees $62.24
```

**Python**
```
20190116 13:33:25.270 Trace:: STATISTICS:: Total Trades 62
20190116 13:33:25.271 Trace:: STATISTICS:: Average Win 0.11%
20190116 13:33:25.271 Trace:: STATISTICS:: Average Loss -0.06%
20190116 13:33:25.272 Trace:: STATISTICS:: Compounding Annual Return -7.582%
20190116 13:33:25.273 Trace:: STATISTICS:: Drawdown 2.400%
20190116 13:33:25.279 Trace:: STATISTICS:: Expectancy -0.193
20190116 13:33:25.282 Trace:: STATISTICS:: Net Profit -0.660%
20190116 13:33:25.283 Trace:: STATISTICS:: Sharpe Ratio -1.563
20190116 13:33:25.284 Trace:: STATISTICS:: Loss Rate 70%
20190116 13:33:25.285 Trace:: STATISTICS:: Win Rate 30%
20190116 13:33:25.292 Trace:: STATISTICS:: Profit-Loss Ratio 1.71
20190116 13:33:25.293 Trace:: STATISTICS:: Alpha -0.174
20190116 13:33:25.294 Trace:: STATISTICS:: Beta 5.695
20190116 13:33:25.306 Trace:: STATISTICS:: Annual Standard Deviation 0.046
20190116 13:33:25.307 Trace:: STATISTICS:: Annual Variance 0.002
20190116 13:33:25.308 Trace:: STATISTICS:: Information Ratio -1.959
20190116 13:33:25.309 Trace:: STATISTICS:: Tracking Error 0.046
20190116 13:33:25.311 Trace:: STATISTICS:: Treynor Ratio -0.013
20190116 13:33:25.317 Trace:: STATISTICS:: Total Fees $62.24
```

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2715 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows CustomModelsAlgorithm to be included in the regression tests

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Backtests ran on different symbols yield identical results

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->