### PR TITLE
Fix parsing of crypto tick data with sub-millisecond timestamps

### DIFF
--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -265,7 +265,7 @@ namespace QuantConnect.Data.Market
                         if (TickType == TickType.Trade)
                         {
                             var csv = line.ToCsv(3);
-                            Time = date.Date.AddMilliseconds(csv[0].ToInt64())
+                            Time = date.Date.AddMilliseconds((double)csv[0].ToDecimal())
                                 .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
                             Value = csv[1].ToDecimal();
                             Quantity = csv[2].ToDecimal();
@@ -274,7 +274,7 @@ namespace QuantConnect.Data.Market
                         if (TickType == TickType.Quote)
                         {
                             var csv = line.ToCsv(6);
-                            Time = date.Date.AddMilliseconds(csv[0].ToInt64())
+                            Time = date.Date.AddMilliseconds((double)csv[0].ToDecimal())
                                 .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
                             BidPrice = csv[1].ToDecimal();
                             BidSize = csv[2].ToDecimal();

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -322,6 +322,9 @@ namespace QuantConnect
             int value = 0;
             for (var i = 0; i < str.Length; i++)
             {
+                if (str[i] == '.')
+                    break;
+
                 value = value * 10 + (str[i] - '0');
             }
             return value;
@@ -338,6 +341,9 @@ namespace QuantConnect
             long value = 0;
             for (var i = 0; i < str.Length; i++)
             {
+                if (str[i] == '.')
+                    break;
+
                 value = value * 10 + (str[i] - '0');
             }
             return value;

--- a/Tests/Common/Data/Market/TickTests.cs
+++ b/Tests/Common/Data/Market/TickTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,6 +39,26 @@ namespace QuantConnect.Tests.Common.Data.Market
             Assert.AreEqual("P", tick.Exchange);
             Assert.AreEqual("T", tick.SaleCondition);
             Assert.AreEqual(false, tick.Suspicious);
+        }
+
+        [Test]
+        public void ConstructsFromLineWithDecimalTimestamp()
+        {
+            const string line = "18000677.3,3669.12,0.0040077,3669.13,3.40618718";
+
+            var config = new SubscriptionDataConfig(
+                typeof(Tick), Symbols.BTCUSD, Resolution.Tick, TimeZones.Utc, TimeZones.Utc,
+                false, false, false, false, TickType.Quote);
+            var baseDate = new DateTime(2019, 1, 15);
+
+            var tick = new Tick(config, line, baseDate);
+
+            var ms = (tick.Time - baseDate).TotalMilliseconds;
+            Assert.AreEqual(18000677, ms);
+            Assert.AreEqual(3669.12, tick.BidPrice);
+            Assert.AreEqual(0.0040077, tick.BidSize);
+            Assert.AreEqual(3669.13, tick.AskPrice);
+            Assert.AreEqual(3.40618718, tick.AskSize);
         }
 
         [Test]

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -301,9 +301,25 @@ namespace QuantConnect.Tests.Common.Util
         }
 
         [Test]
+        public void ConvertsInt32FromStringWithDecimalTruncation()
+        {
+            const string input = "12345678.9";
+            var value = input.ToInt32();
+            Assert.AreEqual(12345678, value);
+        }
+
+        [Test]
         public void ConvertsInt64FromString()
         {
             const string input = "12345678900";
+            var value = input.ToInt64();
+            Assert.AreEqual(12345678900, value);
+        }
+
+        [Test]
+        public void ConvertsInt64FromStringWithDecimalTruncation()
+        {
+            const string input = "12345678900.12";
             var value = input.ToInt64();
             Assert.AreEqual(12345678900, value);
         }


### PR DESCRIPTION

#### Description
- The `Tick` constructor has been fixed to include parsing timestamps with decimals
- The extension methods `ToInt32` and `ToInt64` have been updated to support input strings with decimals

#### Related Issue
Closes #2844

#### Motivation and Context
Crypto Tick live history requests were returning empty results.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests + history calls with live algorithms.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`