### PR TITLE
Fix generic Slice.Get to handle TradeBar and QuoteBar for the same symbol

### DIFF
--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -252,6 +252,18 @@ namespace QuantConnect.Data
                 {
                     dictionary = new Lazy<object>(() => new DataDictionary<T>(_data.Value.Values.SelectMany<dynamic, dynamic>(x => x.GetData()).OfType<T>(), x => x.Symbol));
                 }
+                else if (typeof(T) == typeof(TradeBar))
+                {
+                    dictionary = new Lazy<object>(() => new DataDictionary<TradeBar>(
+                        _data.Value.Values.Where(x => x.TradeBar != null).Select(x => x.TradeBar),
+                        x => x.Symbol));
+                }
+                else if (typeof(T) == typeof(QuoteBar))
+                {
+                    dictionary = new Lazy<object>(() => new DataDictionary<QuoteBar>(
+                        _data.Value.Values.Where(x => x.QuoteBar != null).Select(x => x.QuoteBar),
+                        x => x.Symbol));
+                }
                 else
                 {
                     dictionary = new Lazy<object>(() => new DataDictionary<T>(_data.Value.Values.Select(x => x.GetData()).OfType<T>(), x => x.Symbol));

--- a/Tests/Common/Data/SliceTests.cs
+++ b/Tests/Common/Data/SliceTests.cs
@@ -145,5 +145,36 @@ namespace QuantConnect.Tests.Common.Data
 
             Assert.AreEqual(4, slice.Count());
         }
+
+        [Test]
+        public void AccessesTradeBarAndQuoteBarForSameSymbol()
+        {
+            var tradeBar = new TradeBar(DateTime.Now, Symbols.BTCUSD,
+                3000, 3000, 3000, 3000, 100, Time.OneMinute);
+
+            var quoteBar = new QuoteBar(DateTime.Now, Symbols.BTCUSD,
+                    new Bar(3100, 3100, 3100, 3100), 0,
+                    new Bar(3101, 3101, 3101, 3101), 0,
+                    Time.OneMinute);
+
+            var tradeBars = new TradeBars { { Symbols.BTCUSD, tradeBar } };
+            var quoteBars = new QuoteBars { { Symbols.BTCUSD, quoteBar } };
+
+            var slice = new Slice(DateTime.Now, new BaseData[] { tradeBar, quoteBar }, tradeBars, quoteBars, null, null, null, null, null, null, null);
+
+            var tradeBarData = slice.Get<TradeBar>();
+            Assert.AreEqual(1, tradeBarData.Count);
+
+            var quoteBarData = slice.Get<QuoteBar>();
+            Assert.AreEqual(1, quoteBarData.Count);
+
+            slice = new Slice(DateTime.Now, new BaseData[] { tradeBar, quoteBar });
+
+            tradeBarData = slice.Get<TradeBar>();
+            Assert.AreEqual(1, tradeBarData.Count);
+
+            quoteBarData = slice.Get<QuoteBar>();
+            Assert.AreEqual(1, quoteBarData.Count);
+        }
     }
 }

--- a/Tests/Common/Data/SliceTests.cs
+++ b/Tests/Common/Data/SliceTests.cs
@@ -164,17 +164,23 @@ namespace QuantConnect.Tests.Common.Data
 
             var tradeBarData = slice.Get<TradeBar>();
             Assert.AreEqual(1, tradeBarData.Count);
+            Assert.AreEqual(3000, tradeBarData[Symbols.BTCUSD].Close);
 
             var quoteBarData = slice.Get<QuoteBar>();
             Assert.AreEqual(1, quoteBarData.Count);
+            Assert.AreEqual(3100, quoteBarData[Symbols.BTCUSD].Bid.Close);
+            Assert.AreEqual(3101, quoteBarData[Symbols.BTCUSD].Ask.Close);
 
             slice = new Slice(DateTime.Now, new BaseData[] { tradeBar, quoteBar });
 
             tradeBarData = slice.Get<TradeBar>();
             Assert.AreEqual(1, tradeBarData.Count);
+            Assert.AreEqual(3000, tradeBarData[Symbols.BTCUSD].Close);
 
             quoteBarData = slice.Get<QuoteBar>();
             Assert.AreEqual(1, quoteBarData.Count);
+            Assert.AreEqual(3100, quoteBarData[Symbols.BTCUSD].Bid.Close);
+            Assert.AreEqual(3101, quoteBarData[Symbols.BTCUSD].Ask.Close);
         }
     }
 }


### PR DESCRIPTION

#### Description
The generic `Slice.Get<T>` method has been updated to handle the case the inclusion of both `TradeBar` and `QuoteBar` for the same symbol

#### Related Issue
Closes #2849 

#### Motivation and Context
This method is called internally by some `QCAlgorithm.History` overloads and this issue was causing only one data type to be returned.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test + history regression tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`