### PR TITLE
Fix AlphaRuntimeStatistics deserialization and missing null check

### DIFF
--- a/Common/AlphaRuntimeStatistics.cs
+++ b/Common/AlphaRuntimeStatistics.cs
@@ -42,6 +42,14 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <remarks>Required for proper deserialization</remarks>
+        public AlphaRuntimeStatistics()
+        {
+        }
+
+        /// <summary>
         /// Gets the mean scores for the entire population of insights
         /// </summary>
         public InsightScore MeanPopulationScore { get; } = new InsightScore();
@@ -113,7 +121,8 @@ namespace QuantConnect
         /// </summary>
         public Dictionary<string, string> ToDictionary()
         {
-            var accountCurrencySymbol = Currencies.GetCurrencySymbol(_accountCurrencyProvider.AccountCurrency);
+            var accountCurrencySymbol = Currencies.GetCurrencySymbol(_accountCurrencyProvider?.AccountCurrency ?? Currencies.USD);
+
             return new Dictionary<string, string>
             {
                 {"Total Insights Generated", $"{TotalInsightsGenerated}"},

--- a/Tests/Algorithm/Framework/Alphas/Serialization/AlphaRuntimeStatisticsTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/Serialization/AlphaRuntimeStatisticsTests.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
+{
+    [TestFixture]
+    public class AlphaRuntimeStatisticsTests
+    {
+        [Test]
+        public void HandlesSerializationRoundTrip()
+        {
+            var stats = new AlphaRuntimeStatistics
+            {
+                LongCount = 10,
+                ShortCount = 11,
+                TotalAccumulatedEstimatedAlphaValue = 100,
+                TotalInsightsAnalysisCompleted = 7,
+                TotalInsightsGenerated = 6,
+                TotalInsightsClosed = 5
+            };
+
+            var time = DateTime.UtcNow;
+            stats.MeanPopulationScore.SetScore(InsightScoreType.Direction, 0.5, time);
+            stats.MeanPopulationScore.SetScore(InsightScoreType.Magnitude, 0.6, time);
+            stats.RollingAveragedPopulationScore.SetScore(InsightScoreType.Direction, 0.55, time);
+            stats.RollingAveragedPopulationScore.SetScore(InsightScoreType.Magnitude, 0.66, time);
+
+            var json = JsonConvert.SerializeObject(stats);
+
+            var deserialized = JsonConvert.DeserializeObject<AlphaRuntimeStatistics>(json);
+
+            Assert.AreEqual(10, deserialized.LongCount);
+            Assert.AreEqual(11, deserialized.ShortCount);
+            Assert.AreEqual(100, deserialized.TotalAccumulatedEstimatedAlphaValue);
+            Assert.AreEqual(7, deserialized.TotalInsightsAnalysisCompleted);
+            Assert.AreEqual(6, deserialized.TotalInsightsGenerated);
+            Assert.AreEqual(5, deserialized.TotalInsightsClosed);
+
+            Assert.AreEqual(0.5, deserialized.MeanPopulationScore.Direction);
+            Assert.AreEqual(0.6, deserialized.MeanPopulationScore.Magnitude);
+            Assert.AreEqual(time, deserialized.MeanPopulationScore.UpdatedTimeUtc);
+            Assert.AreEqual(0.55, deserialized.RollingAveragedPopulationScore.Direction);
+            Assert.AreEqual(0.66, deserialized.RollingAveragedPopulationScore.Magnitude);
+            Assert.AreEqual(time, deserialized.RollingAveragedPopulationScore.UpdatedTimeUtc);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Algorithm\Framework\Alphas\MacdAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\BasePairsTradingAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\RsiAlphaModelTests.cs" />
+    <Compile Include="Algorithm\Framework\Alphas\Serialization\AlphaRuntimeStatisticsTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\Serialization\InsightJsonConverterTests.cs" />
     <Compile Include="Algorithm\Framework\Execution\VolumeWeightedAveragePriceExecutionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Execution\ImmediateExecutionModelTests.cs" />


### PR DESCRIPTION

#### Description
- Added parameterless constructor to `AlphaRuntimeStatistics`, required for JSON deserialization
- Added null check in `AlphaRuntimeStatistics.ToDictionary()`

#### Related Issue
Closes #2856 

#### Motivation and Context
- `MeanPopulationScore` and `RollingAveragedPopulationScore` values are zero after deserialization
- `NullReferenceException` is thrown when calling `ToDictionary` after deserialization

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test + regression tests in the cloud

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`