### PR TITLE
Update regression statistics for OptionExpiryDateOnHolidayCase

### DIFF
--- a/Algorithm.CSharp/OptionExpiryDateOnHolidayCase.cs
+++ b/Algorithm.CSharp/OptionExpiryDateOnHolidayCase.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 }
             }
 
-            Delisting delisting; 
+            Delisting delisting;
             if (slice.Delistings.TryGetValue(_optionContract.Symbol, out delisting))
             {
                 Log(delisting.ToString());
@@ -64,8 +64,8 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void OnEndOfAlgorithm()
         {
-            if (!(_delistings.Count == 2 && 
-                  _delistings.Any(d => d.Type == DelistingType.Warning) && 
+            if (!(_delistings.Count == 2 &&
+                  _delistings.Any(d => d.Type == DelistingType.Warning) &&
                   _delistings.Any(d => d.Type == DelistingType.Delisted)))
             {
                 throw new Exception($"Option contract {_optionContract.Symbol} was not correctly delisted.");
@@ -107,22 +107,22 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "2"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.54%"},
-            {"Compounding Annual Return", "23.199%"},
+            {"Compounding Annual Return", "23.156%"},
             {"Drawdown", "0.200%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "0.449%"},
-            {"Sharpe Ratio", "15.604"},
+            {"Net Profit", "0.448%"},
+            {"Sharpe Ratio", "15.59"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "0.172"},
-            {"Beta", "-0.683"},
+            {"Alpha", "0.171"},
+            {"Beta", "-0.65"},
             {"Annual Standard Deviation", "0.01"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "13.984"},
+            {"Information Ratio", "13.971"},
             {"Tracking Error", "0.01"},
-            {"Treynor Ratio", "-0.236"},
-            {"Total Fees", "$0.25"}
+            {"Treynor Ratio", "-0.248"},
+            {"Total Fees", "$1.00"}
         };
     }
 }


### PR DESCRIPTION

#### Description
The expected statistics for the `OptionExpiryDateOnHolidayCase` regression algorithm have been updated to reflect the changes in #2792. 

#### Related Issue
#2792 

#### Motivation and Context
Failing regression test.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Ran the test both locally and in the cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`