### PR TITLE
Market order fill stale price warning

### DIFF
--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -114,8 +114,17 @@ namespace QuantConnect.Orders.Fills
             // make sure the exchange is open/normal market hours before filling
             if (!IsExchangeOpen(asset, false)) return fill;
 
+            var prices = GetPricesCheckingPythonWrapper(asset, order.Direction);
+            var pricesEndTimeUtc = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
+
+            // if the order is filled on stale (fill-forward) data, set a warning message on the order event
+            if (pricesEndTimeUtc < order.Time)
+            {
+                fill.Message = $"Warning: fill at stale price ({prices.EndTime} {asset.Exchange.TimeZone})";
+            }
+
             //Order [fill]price for a market order model is the current security price
-            fill.FillPrice = GetPricesCheckingPythonWrapper(asset, order.Direction).Current;
+            fill.FillPrice = prices.Current;
             fill.Status = OrderStatus.Filled;
 
             //Calculate the model slippage: e.g. 0.01c

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1023,6 +1023,19 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                     case OrderStatus.PartiallyFilled:
                     case OrderStatus.Filled:
                         order.LastFillTime = fill.UtcTime;
+
+                        // append fill message to order tag, for additional information
+                        if (fill.Status == OrderStatus.Filled && !string.IsNullOrWhiteSpace(fill.Message))
+                        {
+                            if (string.IsNullOrWhiteSpace(order.Tag))
+                            {
+                                order.Tag = fill.Message;
+                            }
+                            else
+                            {
+                                order.Tag += " - " + fill.Message;
+                            }
+                        }
                         break;
 
                     case OrderStatus.Submitted:


### PR DESCRIPTION

#### Description
- A warning message has been added to market order fill events when the order is being filled with stale prices (e.g. fill-forward bars), which can happen in backtesting with multiple symbols at different resolutions
- The order tag is also updated to include the warning, so it can be displayed in the QC IDE trade list.

#### Related Issue
#2762 

#### Motivation and Context
This is useful to let users know about the issue, by showing the warning message both in the order event and in the order tag.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Example test algorithm:
``` C#
    public class StalePriceFillAlgorithm : QCAlgorithm
    {
        private Symbol _symbol;

        public override void Initialize()
        {
            SetStartDate(2013, 10, 7);
            SetEndDate(2013, 10, 11);
            SetCash(10000);

            _symbol = AddEquity("AAPL", Resolution.Hour, Market.USA, true, 1).Symbol;
            AddEquity("SPY", Resolution.Minute, Market.USA, true, 1);
        }

        public override void OnData(Slice data)
        {
            if (Time.Day == 8 && Time.Hour == 9 && Time.Minute == 45)
            {
                var lastData = Securities[_symbol].GetLastData();

                // log price from market close of 10/7/2013 at 4 PM
                Debug($"{Time} - latest price: {lastData.EndTime} - {lastData.Price}");

                // this market order will be filled at a stale price
                MarketOrder(_symbol, 1, false, "Test");
            }
        }

        public override void OnOrderEvent(OrderEvent orderEvent)
        {
            Debug($"{Time} - OnOrderEvent(): {orderEvent}");

            var order = Transactions.GetOrderById(orderEvent.OrderId);
            Debug($"{Time} - OnOrderEvent(): order.Tag: {order.Tag}");
        }
    }
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`