### PR TITLE
Logs Pandas and Numpy version

### DIFF
--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -16,6 +16,7 @@
 using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Indicators;
+using QuantConnect.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,6 +29,7 @@ namespace QuantConnect.Python
     public class PandasConverter
     {
         private static dynamic _pandas;
+        private readonly string _repr = "pandas module was not imported.";
 
         /// <summary>
         /// Creates an instance of <see cref="PandasConverter"/>.
@@ -38,7 +40,10 @@ namespace QuantConnect.Python
             {
                 using (Py.GIL())
                 {
+                    dynamic numpy = Py.Import("numpy");
                     _pandas = Py.Import("pandas");
+                    _repr = $"PandasConverter(): Pandas v{_pandas.__version__} Numpy v{numpy.__version__}";
+                    Log.Trace(_repr);
                 }
             }
         }
@@ -154,11 +159,6 @@ namespace QuantConnect.Python
         /// Returns a string that represent the current object
         /// </summary>
         /// <returns></returns>
-        public override string ToString()
-        {
-            return _pandas == null
-                ? "pandas module was not imported."
-                : _pandas.Repr();
-        }
+        public override string ToString() => _repr;
     }
 }


### PR DESCRIPTION
#### Description
Logs Pandas and Numpy version when an instance of PandasConverter is created.

#### Related Issue
Closes #2871 

#### Motivation and Context
Pandas and numpy are python libraries used to create pandas DataFrame of History Requests. It is useful to log their versions to track breaking changes.

#### How Has This Been Tested?
Executing BasicTemplateAlgorithm locally in Windows and QC cloud.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`