### PR TITLE
Bug 2878 bitfinex partially filled problem

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -633,7 +633,7 @@ namespace QuantConnect.Brokerages.Bitfinex
         /// </summary>
         public void LockStream()
         {
-            Log.Trace("BItfinexBrokerage.Messaging.LockStream(): Locking Stream");
+            Log.Trace("BitfinexBrokerage.Messaging.LockStream(): Locking Stream");
             _streamLocked = true;
         }
 
@@ -642,14 +642,14 @@ namespace QuantConnect.Brokerages.Bitfinex
         /// </summary>
         public void UnlockStream()
         {
-            Log.Trace("BItfinexBrokerage.Messaging.UnlockStream(): Processing Backlog...");
+            Log.Trace("BitfinexBrokerage.Messaging.UnlockStream(): Processing Backlog...");
             while (_messageBuffer.Any())
             {
                 WebSocketMessage e;
                 _messageBuffer.TryDequeue(out e);
                 OnMessageImpl(this, e);
             }
-            Log.Trace("BItfinexBrokerage.Messaging.UnlockStream(): Stream Unlocked.");
+            Log.Trace("BitfinexBrokerage.Messaging.UnlockStream(): Stream Unlocked.");
             // Once dequeued in order; unlock stream.
             _streamLocked = false;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
In order to Lean could handle order filling properly it's necessary to pass Filled status for the last trade update. As Bitfinex doesn't send us Filled Size within each trade update we have to track it manually

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2878 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
LEAN can't handle order filled by multiple trades if no Filled status was passed in event

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run brokerage based algorithm and check all executed orders including fully or in multiple pieces.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->