### PR TITLE
Feature 2881 use brokerage fee

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -565,8 +565,12 @@ namespace QuantConnect.Brokerages.Bitfinex
                 if (fillQuantity != 0)
                 {
                     var security = _securityProvider.GetSecurity(order.Symbol);
-                    orderFee = security.FeeModel.GetOrderFee(
+                    var feeSize = security.FeeModel.GetOrderFee(
                         new OrderFeeParameters(security, order));
+                    orderFee = new OrderFee(new CashAmount(
+                            feeSize.Value.Amount * (Math.Abs(fillQuantity) / order.AbsoluteQuantity).Normalize(),
+                            feeSize.Value.Currency
+                        ));
                 }
 
                 OrderStatus status = OrderStatus.Filled;

--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -561,17 +561,10 @@ namespace QuantConnect.Brokerages.Bitfinex
                 var fillQuantity = decimal.Parse(entries[5], NumberStyles.Float, CultureInfo.InvariantCulture);
                 var direction = fillQuantity < 0 ? OrderDirection.Sell : OrderDirection.Buy;
                 var updTime = Time.UnixTimeStampToDateTime(double.Parse(entries[3], NumberStyles.Float, CultureInfo.InvariantCulture));
-                var orderFee = OrderFee.Zero;
-                if (fillQuantity != 0)
-                {
-                    var security = _securityProvider.GetSecurity(order.Symbol);
-                    var feeSize = security.FeeModel.GetOrderFee(
-                        new OrderFeeParameters(security, order));
-                    orderFee = new OrderFee(new CashAmount(
-                            feeSize.Value.Amount * (Math.Abs(fillQuantity) / order.AbsoluteQuantity).Normalize(),
-                            feeSize.Value.Currency
-                        ));
-                }
+                var orderFee = new OrderFee(new CashAmount(
+                        Math.Abs(decimal.Parse(entries[9], NumberStyles.Float, CultureInfo.InvariantCulture)),
+                        entries[10]
+                    ));
 
                 OrderStatus status = OrderStatus.Filled;
                 if (fillQuantity != order.Quantity)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Instead of using BitfinexFeeModel we can use fee information received from brokerage on trade update.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2881 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows to keep fee accurately. Even brokerage change their fee rates we still can have relevant information without FeeModel call update

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Order execution, compare "theirs" and "ours" values

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->