### PR TITLE
Adds is_finite to decimal.Decimal

### DIFF
--- a/Common/decimal.py
+++ b/Common/decimal.py
@@ -10,9 +10,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
 
 class Decimal(float):
     '''This is required for backwards compatibility with users performing operations over expected decimal types.
     NOTE: previously we converted C# decimal into python Decimal, but now its converted to python float due to performance.'''
     def __init__(self, obj):
         self = obj
+
+    def is_finite(self):
+        '''Return True if the argument is a finite number, and False if the argument
+        is infinite or a NaN.'''
+        return not self.is_infinite() and not self.is_nan()
+
+    def is_infinite(self):
+        '''Return True if the argument is either positive or negative infinity and
+        False otherwise.'''
+        return math.isinf(self)
+
+    def is_nan(self):
+        '''Return True if the argument is a (quiet or signaling) NaN and False
+        otherwise.'''
+        return math.isnan(self)


### PR DESCRIPTION
#### Description
Adds `is_finite`, `is_infinite` and `is_nan` methods.

#### Related Issue
Closes #2888 

#### Motivation and Context
`decimal.Decimal` class needs to implement `is_finite` for `parse` method from `dateutil.parser`.
Without this fix, jupyter/ipython would throw an exception in a string to datetime convertion.

#### How Has This Been Tested?
```python
from dateutil.parser import parse as _dateutil_parse
print(_dateutil_parse('2019-02-06T18:36:30.070106Z'))
```
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`