### PR TITLE
Adds "sort=True" argument to pandas.concat call in PandasConverter

### DIFF
--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -87,7 +87,7 @@ namespace QuantConnect.Python
                     return _pandas.DataFrame();
                 }
                 var dataFrames = sliceDataDict.Select(x => x.Value.ToPandasDataFrame(maxLevels));
-                return _pandas.concat(dataFrames.ToArray());
+                return _pandas.concat(dataFrames.ToArray(), Py.kw("sort", true));
             }
         }
 


### PR DESCRIPTION
#### Description
From [pandas-docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.concat.html):
> The current default of sorting is deprecated and will change to not-sorting in a future version of pandas.
>
> Explicitly pass sort=True to silence the warning and sort. 
> Explicitly pass sort=False to silence the warning and not sort.
#### Related Issue
Closes #2891 

#### Motivation and Context
Remove deprecation warning and keep current behaviour.

#### Requires Documentation Change
No, since we kept the current behaviour.

#### How Has This Been Tested?
in Research Environment: 
```python
qb = QuantBook()
es = qb.AddFuture("ES")
future_history = qb.GetFutureHistory(es.Symbol, datetime(2017, 1, 4))
print (future_history.GetExpiryDates())
h7 = future_history.GetAllData()
```
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`