### PR TITLE
Issue #2820: Daily and Hour Resolution History Requests Slow

### DIFF
--- a/Algorithm.CSharp/Benchmarks/HistoryRequestBenchmark.cs
+++ b/Algorithm.CSharp/Benchmarks/HistoryRequestBenchmark.cs
@@ -13,29 +13,38 @@
  * limitations under the License.
 */
 
+using System;
+using System.Diagnostics;
 using System.Linq;
+using QuantConnect.Data;
 
 namespace QuantConnect.Algorithm.CSharp.Benchmarks
 {
     public class HistoryRequestBenchmark : QCAlgorithm
     {
         private Symbol _symbol;
+        private Stopwatch _timer;
         public override void Initialize()
         {
-            SetStartDate(2010, 01, 01);
-            SetEndDate(2018, 01, 01);
+            SetStartDate(2010, 10, 07);
+            SetEndDate(2013, 10, 10);
             SetCash(10000);
-            _symbol = AddEquity("SPY").Symbol;
+            _symbol = AddEquity("SPY", Resolution.Minute).Symbol;
+            _timer = Stopwatch.StartNew();
         }
 
-        public override void OnEndOfDay()
+        public void OnData(Slice slice)
         {
-            var minuteHistory = History(_symbol, 60, Resolution.Minute);
+            long start = _timer.ElapsedTicks;
+
+            var minuteHistory = History(_symbol, 2, Resolution.Minute);
             var lastHourHigh = minuteHistory.Select(minuteBar => minuteBar.High).DefaultIfEmpty(0).Max();
-            var dailyHistory = History(_symbol, 1, Resolution.Daily).First();
-            var dailyHigh = dailyHistory.High;
-            var dailyLow = dailyHistory.Low;
-            var dailyOpen = dailyHistory.Open;
+            long minElapse = _timer.ElapsedTicks;
+            Debug($"Minute: #{minuteHistory.Count()} in {minElapse - start} ticks");
+
+            var dailyHistory = History(_symbol, 20, Resolution.Daily);
+            long dayElapse = _timer.ElapsedTicks;
+            Debug($"Daily: #{dailyHistory.Count()} in {dayElapse - minElapse} ticks");
         }
     }
 }

--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -266,7 +266,7 @@ namespace QuantConnect.Data.Market
                 Period = config.Increment
             };
 
-            var csv = line.ToCsv(6);
+            string[] csv = line.Split(',');
             if (config.Resolution == Resolution.Daily || config.Resolution == Resolution.Hour)
             {
                 // hourly and daily have different time format, and can use slow, robust c# parser.

--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -266,7 +266,7 @@ namespace QuantConnect.Data.Market
                 Period = config.Increment
             };
 
-            string[] csv = line.Split(',');
+            var csv = line.ToCsv(6);
             if (config.Resolution == Resolution.Daily || config.Resolution == Resolution.Hour)
             {
                 // hourly and daily have different time format, and can use slow, robust c# parser.

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -129,7 +129,17 @@ namespace QuantConnect.Data
         public readonly DateTimeZone ExchangeTimeZone;
 
         /// <summary>
-        /// Consolidators that are registred with this subscription
+        /// The start of history data range in exchange timezone
+        /// </summary>
+        public readonly DateTime? DataStartTime;
+
+        /// <summary>
+        /// The end of history data range in exchange timezone
+        /// </summary>
+        public readonly DateTime? DataEndTime;
+
+        /// <summary>
+        /// Consolidators that are registered with this subscription
         /// </summary>
         public readonly HashSet<IDataConsolidator> Consolidators;
 
@@ -155,6 +165,8 @@ namespace QuantConnect.Data
         /// <param name="tickType">Specifies if trade or quote data is subscribed</param>
         /// <param name="isFilteredSubscription">True if this subscription should have filters applied to it (market hours/user filters from security), false otherwise</param>
         /// <param name="dataNormalizationMode">Specifies normalization mode used for this subscription</param>
+        /// <param name="subscriptionDataStartDate">The start of subscribed data range</param>
+        /// <param name="subscriptionDataEndDate">The end of subscribed data range</param>
         public SubscriptionDataConfig(Type objectType,
             Symbol symbol,
             Resolution resolution,
@@ -166,7 +178,9 @@ namespace QuantConnect.Data
             bool isCustom = false,
             TickType? tickType = null,
             bool isFilteredSubscription = true,
-            DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted)
+            DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
+            DateTime? subscriptionDataStartDate = null,
+            DateTime? subscriptionDataEndDate = null)
         {
             if (objectType == null) throw new ArgumentNullException("objectType");
             if (symbol == null) throw new ArgumentNullException("symbol");
@@ -189,13 +203,14 @@ namespace QuantConnect.Data
             IsFilteredSubscription = isFilteredSubscription;
             Consolidators = new HashSet<IDataConsolidator>();
             DataNormalizationMode = dataNormalizationMode;
-
             TickType = tickType ?? LeanData.GetCommonTickTypeForCommonDataTypes(objectType, SecurityType);
+            DataStartTime = subscriptionDataStartDate;
+            DataEndTime = subscriptionDataEndDate;
 
             switch (resolution)
             {
                 case Resolution.Tick:
-                    //Ticks are individual sales and fillforward doesn't apply.
+                    //Ticks are individual sales and fill-forward doesn't apply.
                     Increment = TimeSpan.FromSeconds(0);
                     FillDataForward = false;
                     break;

--- a/Common/Interfaces/IDataCacheProvider.cs
+++ b/Common/Interfaces/IDataCacheProvider.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using QuantConnect.Data;
 
@@ -26,11 +27,25 @@ namespace QuantConnect.Interfaces
     public interface IDataCacheProvider : IDisposable
     {
         /// <summary>
-        /// Fetch data from the cache
+        /// Fetch data from the cache as stream
         /// </summary>
         /// <param name="key">A string representing the key of the cached data</param>
         /// <returns>An <see cref="Stream"/> of the cached data</returns>
-        Stream Fetch(string key);
+        Stream FetchStream(string key);
+
+        /// <summary>
+        /// Fetch data from the cache as enumerator
+        /// </summary>
+        /// <param name="key">A string representing the key of the cached data</param>
+        /// <param name="config">The subscription config</param>
+        /// <param name="startDate">Provide the start date of data to be fetched. Inclusive.</param>
+        /// <param name="endDate">Provide the end date of data to be fetched. Inclusive.</param>
+        /// <returns>An enumerator of the cached data</returns>
+        IEnumerator<string> FetchEnumerator(
+            string key,
+            SubscriptionDataConfig config,
+            DateTime? startDate = null,
+            DateTime? endDate = null);
 
         /// <summary>
         /// Store the data in the cache

--- a/Engine/DataFeeds/DataPointCacheProvider.cs
+++ b/Engine/DataFeeds/DataPointCacheProvider.cs
@@ -77,8 +77,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="dataProvider">The data provider</param>
         public DataPointCacheProvider(IDataProvider dataProvider)
         {
-            this._dataProvider = dataProvider;
-            this._dataPointCache = new MemoryCache(this.GetType().Name, new NameValueCollection()
+            _dataProvider = dataProvider;
+            _dataPointCache = new MemoryCache(GetType().Name, new NameValueCollection()
             {
                 { "CacheMemoryLimit", Config.Get("history-data-cache-size", DefaultCacheMemorySizeInMb.ToString()) },
                 { "PollingInterval", Config.Get("history-data-cache-polling-interval", DefaultCachePollingIntervalInSecond.ToString())},
@@ -101,28 +101,28 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             try
             {
-                this.TryExtractEntryName(key, out fileName, out entryName);
+                TryExtractEntryName(key, out fileName, out entryName);
                 if (!string.Equals(fileName.GetExtension(), ".zip", StringComparison.OrdinalIgnoreCase))
                 {
                     throw new InvalidOperationException($"Invalid file type. Only .zip is supported. Provided {fileName}");
                 }
 
                 // Create data point cache entry if not exists
-                if (!this._dataPointCache.Contains(fileName))
+                if (!_dataPointCache.Contains(fileName))
                 {
                     // handles zip files
-                    using (Stream fileStream = this.CreateStream(this._dataProvider.Fetch(fileName), entryName, fileName))
+                    using (Stream fileStream = CreateStream(_dataProvider.Fetch(fileName), entryName, fileName))
                     {
                         if (fileStream != null)
                         {
                             DataPointDictionary newItem = new DataPointDictionary(fileStream, fileName, config.Resolution);
-                            this._dataPointCache.Add(fileName, newItem, CachePolicy);
+                            _dataPointCache.Add(fileName, newItem, CachePolicy);
                         }
                     }
                 }
 
                 dataPointEnumerator = new DataPointEnumerator(
-                    this._dataPointCache.Get(fileName) as DataPointDictionary,
+                    _dataPointCache.Get(fileName) as DataPointDictionary,
                     config,
                     startDate,
                     endDate);
@@ -158,7 +158,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <filterpriority>2</filterpriority>
         public void Dispose()
         {
-            this._dataPointCache.DisposeSafely();
+            _dataPointCache.DisposeSafely();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/DataPointCacheProvider.cs
+++ b/Engine/DataFeeds/DataPointCacheProvider.cs
@@ -1,0 +1,218 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Runtime.Caching;
+
+using Ionic.Zip;
+using Ionic.Zlib;
+using QuantConnect.Configuration;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+using QuantConnect.Logging;
+using QuantConnect.Util;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// A cache provider that cache data points and serves with enumerator
+    /// </summary>
+    public class DataPointCacheProvider : IDataCacheProvider
+    {
+        /// <summary>
+        /// The cache memory limit. default 256 MBs
+        /// </summary>
+        private const long DefaultCacheMemorySizeInMb = 256;
+
+        /// <summary>
+        /// The cache scanning interval. default 3 seconds
+        /// </summary>
+        private const int DefaultCachePollingIntervalInSecond = 3;
+
+        /// <summary>
+        /// The lifespan of an entry in the cache. Default 10 seconds
+        /// </summary>
+        private const int DefaultCacheSlidingExpirationInSecond = 10;
+
+        /// <summary>
+        /// The cache for data points by file name
+        /// </summary>
+        private readonly MemoryCache _dataPointCache;
+
+        /// <summary>
+        /// The cache policy that controls behavior of each entry
+        /// </summary>
+        private static readonly CacheItemPolicy CachePolicy = new CacheItemPolicy()
+        {
+            // No need to eject entry until the cache hits size limit
+            // SlidingExpiration = TimeSpan.FromSeconds(Config.GetInt("history-data-cache-expiry", DefaultCacheSlidingExpirationInSecond)),
+        };
+
+        /// <summary>
+        /// The data provider
+        /// </summary>
+        private readonly IDataProvider _dataProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataPointCacheProvider"/> class.
+        /// </summary>
+        /// <param name="dataProvider">The data provider</param>
+        public DataPointCacheProvider(IDataProvider dataProvider)
+        {
+            this._dataProvider = dataProvider;
+            this._dataPointCache = new MemoryCache(this.GetType().Name, new NameValueCollection()
+            {
+                { "CacheMemoryLimit", Config.Get("history-data-cache-size", DefaultCacheMemorySizeInMb.ToString()) },
+                { "PollingInterval", Config.Get("history-data-cache-polling-interval", DefaultCachePollingIntervalInSecond.ToString())},
+            });
+        }
+
+        /// <summary>
+        /// Fetch data from the cache and return as an enumerator
+        /// </summary>
+        /// <param name="key">A string representing the key of the cached data</param>
+        /// <param name="config">The subscription config</param>
+        /// <param name="startDate">Provide the start date of data to be fetched. Inclusive.</param>
+        /// <param name="endDate">Provide the end date of data to be fetched. Inclusive.</param>
+        /// <returns>An enumerator of the cached data</returns>
+        public IEnumerator<string> FetchEnumerator(string key, SubscriptionDataConfig config, DateTime? startDate, DateTime? endDate)
+        {
+            string fileName = key;
+            string entryName = null; // Entry is not used
+            IEnumerator<string> dataPointEnumerator = default(IEnumerator<string>);
+
+            try
+            {
+                this.TryExtractEntryName(key, out fileName, out entryName);
+                if (!string.Equals(fileName.GetExtension(), ".zip", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"Invalid file type. Only .zip is supported. Provided {fileName}");
+                }
+
+                // Create data point cache entry if not exists
+                if (!this._dataPointCache.Contains(fileName))
+                {
+                    // handles zip files
+                    using (Stream fileStream = this.CreateStream(this._dataProvider.Fetch(fileName), entryName, fileName))
+                    {
+                        if (fileStream != null)
+                        {
+                            DataPointDictionary newItem = new DataPointDictionary(fileStream, fileName, config.Resolution);
+                            this._dataPointCache.Add(fileName, newItem, CachePolicy);
+                        }
+                    }
+                }
+
+                dataPointEnumerator = new DataPointEnumerator(
+                    this._dataPointCache.Get(fileName) as DataPointDictionary,
+                    config,
+                    startDate,
+                    endDate);
+            }
+            catch (Exception exception)
+            {
+                if (exception is ZipException || exception is ZlibException)
+                {
+                    Log.Error($"ZipDataCacheProvider.Fetch(): Corrupt zip file/entry: {fileName}#{entryName}; Error: {exception}");
+                }
+                else
+                {
+                    Log.Error($"Error occurs getting enumerator for {fileName}; Details: {exception.ToString()}");
+                }
+            }
+
+            return dataPointEnumerator;
+        }
+
+        /// <summary>
+        /// Store the data in the cache. Not implemented in this instance of the IDataCacheProvider
+        /// </summary>
+        /// <param name="key">The source of the data, used as a key to retrieve data in the cache</param>
+        /// <param name="data">The data as a byte array</param>
+        public void Store(string key, byte[] data)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <filterpriority>2</filterpriority>
+        public void Dispose()
+        {
+            this._dataPointCache.DisposeSafely();
+        }
+
+        /// <summary>
+        /// Try to extract the entry name if exists in key
+        /// </summary>
+        /// <param name="key">The input key with file name and entry key, separated by '#'</param>
+        /// <param name="fileName">The file name without entry name</param>
+        /// <param name="entryName">The entry name</param>
+        private void TryExtractEntryName(string key, out string fileName, out string entryName)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentNullException(key);
+            }
+
+            int splitPos = key.LastIndexOf("#", StringComparison.Ordinal);
+            entryName = (splitPos != -1) ? key.Substring(splitPos + 1) : string.Empty;
+            fileName = (splitPos != -1) ? key.Substring(0, splitPos) : key;
+        }
+
+        /// <summary>
+        /// Create a stream of a specific ZipEntry
+        /// </summary>
+        /// <param name="zipFileStream">The zip file stream containing ONLY one zipEntry</param>
+        /// <param name="entryName">The name of the entry</param>
+        /// <param name="fileName">The name of the zip file on disk</param>
+        /// <returns>A <see cref="Stream"/> of the appropriate zip entry</returns>
+        private Stream CreateStream(Stream zipFileStream, string entryName, string fileName)
+        {
+            if (zipFileStream == null || !zipFileStream.CanRead)
+            {
+                throw new ArgumentException($"{nameof(zipFileStream)} is broken. Cannot create stream.");
+            }
+
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentNullException($"fileName cannot be null or empty.");
+            }
+
+            ZipEntry entry = ZipFile.Read(zipFileStream).FirstOrDefault();
+            MemoryStream stream = new MemoryStream();
+            entry.OpenReader().CopyTo(stream);
+            stream.Position = 0;
+            return stream;
+        }
+
+        /// <summary>
+        /// Fetch data from the cache as stream
+        /// </summary>
+        /// <param name="key">A string representing the key of the cached data</param>
+        /// <returns>An <see cref="Stream"/> of the cached data</returns>
+        public Stream FetchStream(string key)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Engine/DataFeeds/DataPointDictionary.cs
+++ b/Engine/DataFeeds/DataPointDictionary.cs
@@ -61,14 +61,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="resolution">The resolution of data</param>
         public DataPointDictionary(Stream fileStream, string fileName, Resolution resolution)
         {
-            this._fileName = fileName;
-            this._resolution = resolution;
-            this._dataPoints = this.BuildDataPointDictionary(fileStream);
-            this._referenceArray = this.GetReferenceArray(this._dataPoints);
-            if (this._resolution != Resolution.Daily && this._resolution != Resolution.Hour)
+            _fileName = fileName;
+            _resolution = resolution;
+            _dataPoints = BuildDataPointDictionary(fileStream);
+            _referenceArray = GetReferenceArray(_dataPoints);
+            if (_resolution != Resolution.Daily && _resolution != Resolution.Hour)
             {
-                this._dateOfFileIfAny = DateTime.ParseExact(
-                    Path.GetFileNameWithoutExtension(this._fileName)
+                _dateOfFileIfAny = DateTime.ParseExact(
+                    Path.GetFileNameWithoutExtension(_fileName)
                         .Substring(0, DateFormat.EightCharacter.Length),
                     DateFormat.EightCharacter,
                     CultureInfo.InvariantCulture);
@@ -80,7 +80,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public int Count
         {
-            get { return this._dataPoints.Count; }
+            get { return _dataPoints.Count; }
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         continue;
                     }
 
-                    result[this.GetDateTime(line)] = line;
+                    result[GetDateTime(line)] = line;
                 }
                 catch (Exception ex)
                 {
@@ -131,7 +131,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 throw new ArgumentNullException(nameof(line), "Input cannot be null or empty.");
             }
 
-            switch (this._resolution)
+            switch (_resolution)
             {
                 case Resolution.Daily:
                 case Resolution.Hour:
@@ -140,7 +140,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         DateFormat.TwelveCharacter,
                         CultureInfo.InvariantCulture);
                 default:
-                    return this._dateOfFileIfAny +
+                    return _dateOfFileIfAny +
                         TimeSpan.FromMilliseconds(long.Parse(line.Split(new char[] { ',' })[0]));
             }
         }
@@ -175,7 +175,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             get
             {
-                return this._referenceArray[index];
+                return _referenceArray[index];
             }
         }
 
@@ -188,7 +188,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             get
             {
-                return this._dataPoints[key];
+                return _dataPoints[key];
             }
         }
 
@@ -198,7 +198,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>True if empty; False otherwise</returns>
         public bool IsEmpty()
         {
-            return this._dataPoints == null || this._dataPoints.Count == 0;
+            return _dataPoints == null || _dataPoints.Count == 0;
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>A KV pair of data point</returns>
         public KeyValuePair<DateTime, string> First(Func<KeyValuePair<DateTime, string>, bool> predicate)
         {
-            return this._dataPoints.FirstOrDefault(predicate);
+            return _dataPoints.FirstOrDefault(predicate);
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>A KV pair of data point</returns>
         public KeyValuePair<DateTime, string> Last(Func<KeyValuePair<DateTime, string>, bool> predicate)
         {
-            return this._dataPoints.LastOrDefault(predicate);
+            return _dataPoints.LastOrDefault(predicate);
         }
 
         /// <summary>
@@ -228,7 +228,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns></returns>
         public int IndexOfKey(DateTime key)
         {
-            return this._dataPoints.IndexOfKey(key);
+            return _dataPoints.IndexOfKey(key);
         }
     }
 }

--- a/Engine/DataFeeds/DataPointDictionary.cs
+++ b/Engine/DataFeeds/DataPointDictionary.cs
@@ -1,0 +1,234 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using QuantConnect.Logging;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// A wrapper class that keeps data points and provide high performance access
+    /// </summary>
+    public class DataPointDictionary
+    {
+        /// <summary>
+        /// The reference array for index-based enumeration
+        /// </summary>
+        private readonly IList<KeyValuePair<DateTime, string>> _referenceArray;
+
+        /// <summary>
+        /// A sorted list that maintain time orders of data points and provide time-based access
+        /// </summary>
+        private readonly SortedList<DateTime, string> _dataPoints;
+
+        /// <summary>
+        /// The source file name where the data is from in this class
+        /// </summary>
+        private readonly string _fileName;
+
+        /// <summary>
+        /// The resolution of the data
+        /// </summary>
+        private readonly Resolution _resolution;
+
+        /// <summary>
+        /// A property for fine granularity data. Available only when resolution is lower than Hour.
+        /// </summary>
+        private readonly DateTime _dateOfFileIfAny;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataPointCacheProvider"/> class.
+        /// </summary>
+        /// <param name="fileStream">The file stream to csv</param>
+        /// <param name="fileName">The source file name</param>
+        /// <param name="resolution">The resolution of data</param>
+        public DataPointDictionary(Stream fileStream, string fileName, Resolution resolution)
+        {
+            this._fileName = fileName;
+            this._resolution = resolution;
+            this._dataPoints = this.BuildDataPointDictionary(fileStream);
+            this._referenceArray = this.GetReferenceArray(this._dataPoints);
+            if (this._resolution != Resolution.Daily && this._resolution != Resolution.Hour)
+            {
+                this._dateOfFileIfAny = DateTime.ParseExact(
+                    Path.GetFileNameWithoutExtension(this._fileName)
+                        .Substring(0, DateFormat.EightCharacter.Length),
+                    DateFormat.EightCharacter,
+                    CultureInfo.InvariantCulture);
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of data points
+        /// </summary>
+        public int Count
+        {
+            get { return this._dataPoints.Count; }
+        }
+
+        /// <summary>
+        /// Extract <see cref="DataPointDictionary"/> from csv file stream
+        /// </summary>
+        /// <param name="fileStream">The csv file stream</param>
+        /// <returns>A sorted dictionary including all data points in ascending order</returns>
+        public SortedList<DateTime, string> BuildDataPointDictionary(Stream fileStream)
+        {
+            if (fileStream == null || !fileStream.CanRead)
+            {
+                throw new InvalidOperationException("Cannot read from the zip file stream. The stream is broken.");
+            }
+
+            StreamReader reader = new StreamReader(fileStream);
+            SortedList<DateTime, string> result = new SortedList<DateTime, string>();
+            string line = string.Empty;
+            do
+            {
+                try
+                {
+                    line = reader.ReadLine();
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    result[this.GetDateTime(line)] = line;
+                }
+                catch (Exception ex)
+                {
+                    Log.Trace($"DataPointDictionary was not able to parse/read below line: \"{line}\"; Details: {ex.ToString()}");
+                }
+            } while (!reader.EndOfStream);
+            return result;
+        }
+
+        /// <summary>
+        /// Extract datetime from a csv row
+        /// </summary>
+        /// <param name="line">The data row</param>
+        /// <returns>The datetime of the data point</returns>
+        public DateTime GetDateTime(string line)
+        {
+            // Get exchange timezone and the file name for date
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                throw new ArgumentNullException(nameof(line), "Input cannot be null or empty.");
+            }
+
+            switch (this._resolution)
+            {
+                case Resolution.Daily:
+                case Resolution.Hour:
+                    return DateTime.ParseExact(
+                        line.Split(new char[] { ',' })[0],
+                        DateFormat.TwelveCharacter,
+                        CultureInfo.InvariantCulture);
+                default:
+                    return this._dateOfFileIfAny +
+                        TimeSpan.FromMilliseconds(long.Parse(line.Split(new char[] { ',' })[0]));
+            }
+        }
+
+        /// <summary>
+        /// Generate reference array from sorted dictionary of data points for enumeration
+        /// </summary>
+        /// <param name="dataPoints">The data point dictionary</param>
+        /// <returns>A list of KV pairs in order</returns>
+        public IList<KeyValuePair<DateTime, string>> GetReferenceArray(SortedList<DateTime, string> dataPoints)
+        {
+            if (dataPoints == null || dataPoints.Count == 0)
+            {
+                return new List<KeyValuePair<DateTime, string>>(0);
+            }
+
+            List<KeyValuePair<DateTime, string>> result = new List<KeyValuePair<DateTime, string>>(dataPoints.Count);
+            foreach (KeyValuePair<DateTime, string> kv in dataPoints)
+            {
+                result.Add(kv);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Access data points by index. Equivalent to ElementAt()
+        /// </summary>
+        /// <param name="index">The index</param>
+        /// <returns>A kv pair at index</returns>
+        public KeyValuePair<DateTime, string> this[int index]
+        {
+            get
+            {
+                return this._referenceArray[index];
+            }
+        }
+
+        /// <summary>
+        /// Access data points by datetime(key)
+        /// </summary>
+        /// <param name="key">The key of the entry</param>
+        /// <returns>A data point in string</returns>
+        public string this[DateTime key]
+        {
+            get
+            {
+                return this._dataPoints[key];
+            }
+        }
+
+        /// <summary>
+        /// Whether the data point dictionary is empty
+        /// </summary>
+        /// <returns>True if empty; False otherwise</returns>
+        public bool IsEmpty()
+        {
+            return this._dataPoints == null || this._dataPoints.Count == 0;
+        }
+
+        /// <summary>
+        /// Return the first item of the list base on the predicate
+        /// </summary>
+        /// <param name="predicate">The selector</param>
+        /// <returns>A KV pair of data point</returns>
+        public KeyValuePair<DateTime, string> First(Func<KeyValuePair<DateTime, string>, bool> predicate)
+        {
+            return this._dataPoints.FirstOrDefault(predicate);
+        }
+
+        /// <summary>
+        /// Return the last item of the list base on the predicate
+        /// </summary>
+        /// <param name="predicate">The selector</param>
+        /// <returns>A KV pair of data point</returns>
+        public KeyValuePair<DateTime, string> Last(Func<KeyValuePair<DateTime, string>, bool> predicate)
+        {
+            return this._dataPoints.LastOrDefault(predicate);
+        }
+
+        /// <summary>
+        /// Get the index of the key
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public int IndexOfKey(DateTime key)
+        {
+            return this._dataPoints.IndexOfKey(key);
+        }
+    }
+}

--- a/Engine/DataFeeds/Enumerators/DataPointEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/DataPointEnumerator.cs
@@ -80,10 +80,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     $"data point to enumerate.");
             }
 
-            this._dataPointCache = dataPointDictionary;
-            this._config = config;
-            this.FindStartEndDateIndex(out this._startIndex, out this._endIndex, startDate, endDate);
-            this._position = this._startIndex - 1;
+            _dataPointCache = dataPointDictionary;
+            _config = config;
+            FindStartEndDateIndex(out _startIndex, out _endIndex, startDate, endDate);
+            _position = _startIndex - 1;
         }
 
         /// <summary>
@@ -93,12 +93,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         {
             get
             {
-                if (this._position < this._startIndex || this._position > this._endIndex)
+                if (_position < _startIndex || _position > _endIndex)
                 {
                     return null;
                 }
 
-                return this._dataPointCache[this._position].Value;
+                return _dataPointCache[_position].Value;
             }
         }
 
@@ -110,14 +110,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         {
             get
             {
-                return this._position > this._endIndex;
+                return _position > _endIndex;
             }
         }
 
         /// <summary>
         /// Return current value
         /// </summary>
-        object IEnumerator.Current => this.Current;
+        object IEnumerator.Current => Current;
 
         /// <summary>
         /// Dispose method for this enumerator
@@ -133,8 +133,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <returns>True if next element exists; Otherwise False.</returns>
         public bool MoveNext()
         {
-            this._position++;
-            if (this._position < this._startIndex || this._position > this._endIndex)
+            _position++;
+            if (_position < _startIndex || _position > _endIndex)
             {
                 return false;
             }
@@ -147,7 +147,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// </summary>
         public void Reset()
         {
-            this._position = this._startIndex - 1;
+            _position = _startIndex - 1;
         }
 
         /// <summary>
@@ -164,19 +164,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             DateTime? endDate = null)
         {
             startIndex = 0;
-            endIndex = this._dataPointCache.Count - 1;
+            endIndex = _dataPointCache.Count - 1;
 
-            if (this._config.Resolution == Resolution.Daily || this._config.Resolution == Resolution.Hour)
+            if (_config.Resolution == Resolution.Daily || _config.Resolution == Resolution.Hour)
             {
-                DateTime startKey = startDate.HasValue && (startDate >= this._dataPointCache[0].Key) ?
-                this._dataPointCache.First(k => k.Key >= startDate.Value).Key :  // Handle if start date is not trade day
-                this._dataPointCache[0].Key;
-                startIndex = this._dataPointCache.IndexOfKey(startKey);
+                DateTime startKey = startDate.HasValue && (startDate >= _dataPointCache[0].Key) ?
+                _dataPointCache.First(k => k.Key >= startDate.Value).Key :  // Handle if start date is not trade day
+                _dataPointCache[0].Key;
+                startIndex = _dataPointCache.IndexOfKey(startKey);
 
-                DateTime endKey = endDate.HasValue && (endDate > this._dataPointCache[this._dataPointCache.Count - 1].Key) ?
-                    this._dataPointCache.Last(k => k.Key <= endDate.Value).Key : // Handle if end date is not trade day
-                    this._dataPointCache[this._dataPointCache.Count - 1].Key;
-                endIndex = this._dataPointCache.IndexOfKey(endKey);
+                DateTime endKey = endDate.HasValue && (endDate > _dataPointCache[_dataPointCache.Count - 1].Key) ?
+                    _dataPointCache.Last(k => k.Key <= endDate.Value).Key : // Handle if end date is not trade day
+                    _dataPointCache[_dataPointCache.Count - 1].Key;
+                endIndex = _dataPointCache.IndexOfKey(endKey);
             }
         }
     }

--- a/Engine/DataFeeds/Enumerators/DataPointEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/DataPointEnumerator.cs
@@ -1,0 +1,183 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using QuantConnect.Data;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
+{
+    /// <summary>
+    /// A enumerator with range control
+    /// </summary>
+    public class DataPointEnumerator : IEnumerator<string>
+    {
+        /// <summary>
+        /// The data point cache sorted by time ascending
+        /// </summary>
+        private readonly DataPointDictionary _dataPointCache;
+
+        /// <summary>
+        /// The subscription data config
+        /// </summary>
+        private readonly SubscriptionDataConfig _config;
+
+        /// <summary>
+        /// The start index boundary of this enumerator. Inclusive.
+        /// </summary>
+        private readonly int _startIndex;
+
+        /// <summary>
+        /// The end index boundary of this enumerator. Inclusive.
+        /// </summary>
+        private readonly int _endIndex;
+
+        /// <summary>
+        /// The current position of this enumerator
+        /// </summary>
+        private int _position;
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="DataPointEnumerator"/>
+        /// </summary>
+        /// <param name="dataPointDictionary">The data point dictionary sorted by date</param>
+        /// <param name="config">The subscription config</param>
+        /// <param name="startDate">The start date of this enumerator. Inclusive.</param>
+        /// <param name="endDate">The end date of this enumerator. Inclusive.</param>
+        public DataPointEnumerator(
+            DataPointDictionary dataPointDictionary,
+            SubscriptionDataConfig config,
+            DateTime? startDate = null,
+            DateTime? endDate = null)
+        {
+            if (startDate.HasValue && endDate.HasValue && startDate > endDate)
+            {
+                throw new ArgumentException(
+                    $"Start date cannot be later than end date. Start date: " +
+                    $"{startDate.ToString()}; End date: {endDate.ToString()}");
+            }
+
+            if (dataPointDictionary.IsEmpty())
+            {
+                throw new ArgumentNullException(
+                    nameof(dataPointDictionary),
+                    $"{nameof(dataPointDictionary)} cannot be null. There is no " +
+                    $"data point to enumerate.");
+            }
+
+            this._dataPointCache = dataPointDictionary;
+            this._config = config;
+            this.FindStartEndDateIndex(out this._startIndex, out this._endIndex, startDate, endDate);
+            this._position = this._startIndex - 1;
+        }
+
+        /// <summary>
+        /// Get current value
+        /// </summary>
+        public string Current
+        {
+            get
+            {
+                if (this._position < this._startIndex || this._position > this._endIndex)
+                {
+                    return null;
+                }
+
+                return this._dataPointCache[this._position].Value;
+            }
+        }
+
+        /// <summary>
+        /// Return if this enumerator has next element
+        /// </summary>
+        /// <returns>True if there is more element. False otherwise.</returns>
+        public bool EndOfStream
+        {
+            get
+            {
+                return this._position > this._endIndex;
+            }
+        }
+
+        /// <summary>
+        /// Return current value
+        /// </summary>
+        object IEnumerator.Current => this.Current;
+
+        /// <summary>
+        /// Dispose method for this enumerator
+        /// </summary>
+        public void Dispose()
+        {
+            // Nothing to be disposed since cache is referenced.
+        }
+
+        /// <summary>
+        /// Move this enumerator to next available entry.
+        /// </summary>
+        /// <returns>True if next element exists; Otherwise False.</returns>
+        public bool MoveNext()
+        {
+            this._position++;
+            if (this._position < this._startIndex || this._position > this._endIndex)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Reset current position back to start index.
+        /// </summary>
+        public void Reset()
+        {
+            this._position = this._startIndex - 1;
+        }
+
+        /// <summary>
+        /// Calculate start and end index based on input dates and entries in the cache. StartIndex and EndIndex are inclusive.
+        /// </summary>
+        /// <param name="startIndex">The output start index</param>
+        /// <param name="endIndex">The output end index</param>
+        /// <param name="startDate">The input start date</param>
+        /// <param name="endDate">The input end date</param>
+        private void FindStartEndDateIndex(
+            out int startIndex,
+            out int endIndex,
+            DateTime? startDate = null,
+            DateTime? endDate = null)
+        {
+            startIndex = 0;
+            endIndex = this._dataPointCache.Count - 1;
+
+            if (this._config.Resolution == Resolution.Daily || this._config.Resolution == Resolution.Hour)
+            {
+                DateTime startKey = startDate.HasValue && (startDate >= this._dataPointCache[0].Key) ?
+                this._dataPointCache.First(k => k.Key >= startDate.Value).Key :  // Handle if start date is not trade day
+                this._dataPointCache[0].Key;
+                startIndex = this._dataPointCache.IndexOfKey(startKey);
+
+                DateTime endKey = endDate.HasValue && (endDate > this._dataPointCache[this._dataPointCache.Count - 1].Key) ?
+                    this._dataPointCache.Last(k => k.Key <= endDate.Value).Key : // Handle if end date is not trade day
+                    this._dataPointCache[this._dataPointCache.Count - 1].Key;
+                endIndex = this._dataPointCache.IndexOfKey(endKey);
+            }
+        }
+    }
+}

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -60,15 +60,15 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             Func<SubscriptionRequest, IEnumerable<DateTime>> tradableDaysProvider = null
             )
         {
-            this._resultHandler = resultHandler;
-            this._mapFileProvider = mapFileProvider;
-            this._factorFileProvider = factorFileProvider;
-            this._dataCacheProvider = (IDataCacheProvider)Activator.CreateInstance(
+            _resultHandler = resultHandler;
+            _mapFileProvider = mapFileProvider;
+            _factorFileProvider = factorFileProvider;
+            _dataCacheProvider = (IDataCacheProvider)Activator.CreateInstance(
                 Type.GetType(Config.Get("data-cache-provider", "QuantConnect.Lean.Engine.DataFeeds.ZipDataCacheProvider")),
                 dataProvider);
-            this._isLiveMode = isLiveMode;
-            this._includeAuxiliaryData = includeAuxiliaryData;
-            this._tradableDaysProvider = tradableDaysProvider ?? (request => request.TradableDays);
+            _isLiveMode = isLiveMode;
+            _includeAuxiliaryData = includeAuxiliaryData;
+            _tradableDaysProvider = tradableDaysProvider ?? (request => request.TradableDays);
         }
 
         /// <summary>
@@ -81,30 +81,30 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         {
             var mapFileResolver = request.Configuration.SecurityType == SecurityType.Equity ||
                                   request.Configuration.SecurityType == SecurityType.Option
-                                    ? this._mapFileProvider.Get(request.Security.Symbol.ID.Market)
+                                    ? _mapFileProvider.Get(request.Security.Symbol.ID.Market)
                                     : MapFileResolver.Empty;
 
             var dataReader = new SubscriptionDataReader(request.Configuration,
                 request.StartTimeLocal,
                 request.EndTimeLocal,
                 mapFileResolver,
-                this._factorFileProvider,
-                this._tradableDaysProvider(request),
-                this._isLiveMode,
-                 this._dataCacheProvider
+                _factorFileProvider,
+                _tradableDaysProvider(request),
+                _isLiveMode,
+                 _dataCacheProvider
                 );
 
-            dataReader.InvalidConfigurationDetected += (sender, args) => { this._resultHandler.ErrorMessage(args.Message); };
-            dataReader.NumericalPrecisionLimited += (sender, args) => { this._resultHandler.DebugMessage(args.Message); };
-            dataReader.DownloadFailed += (sender, args) => { this._resultHandler.ErrorMessage(args.Message, args.StackTrace); };
-            dataReader.ReaderErrorDetected += (sender, args) => { this._resultHandler.RuntimeError(args.Message, args.StackTrace); };
+            dataReader.InvalidConfigurationDetected += (sender, args) => { _resultHandler.ErrorMessage(args.Message); };
+            dataReader.NumericalPrecisionLimited += (sender, args) => { _resultHandler.DebugMessage(args.Message); };
+            dataReader.DownloadFailed += (sender, args) => { _resultHandler.ErrorMessage(args.Message, args.StackTrace); };
+            dataReader.ReaderErrorDetected += (sender, args) => { _resultHandler.RuntimeError(args.Message, args.StackTrace); };
 
             var enumerator = CorporateEventEnumeratorFactory.CreateEnumerators(
                 request.Configuration,
-                this._factorFileProvider,
+                _factorFileProvider,
                 dataReader,
                 mapFileResolver,
-                this._includeAuxiliaryData);
+                _includeAuxiliaryData);
 
             // has to be initialized after adding all the enumerators since it will execute a MoveNext
             dataReader.Initialize();
@@ -118,7 +118,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <filterpriority>2</filterpriority>
         public void Dispose()
         {
-            this._dataCacheProvider?.DisposeSafely();
+            _dataCacheProvider?.DisposeSafely();
         }
     }
 }

--- a/Engine/DataFeeds/SingleEntryDataCacheProvider.cs
+++ b/Engine/DataFeeds/SingleEntryDataCacheProvider.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public SingleEntryDataCacheProvider(IDataProvider dataProvider)
         {
-            this._dataProvider = dataProvider;
+            _dataProvider = dataProvider;
         }
 
         /// <summary>
@@ -50,17 +50,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>An <see cref="Stream"/> of the cached data</returns>
         public Stream FetchStream(string key)
         {
-            var stream = this._dataProvider.Fetch(key);
+            var stream = _dataProvider.Fetch(key);
 
             if (key.EndsWith(".zip") && stream != null)
             {
                 // get the first entry from the zip file
                 try
                 {
-                    var entryStream = Compression.UnzipStream(stream, out this._zipFile);
+                    var entryStream = Compression.UnzipStream(stream, out _zipFile);
 
                     // save the file stream so it can be disposed later
-                    this._zipFileStream = stream;
+                    _zipFileStream = stream;
 
                     return entryStream;
                 }
@@ -90,8 +90,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public void Dispose()
         {
-            this._zipFile?.DisposeSafely();
-            this._zipFileStream?.DisposeSafely();
+            _zipFile?.DisposeSafely();
+            _zipFileStream?.DisposeSafely();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/SingleEntryDataCacheProvider.cs
+++ b/Engine/DataFeeds/SingleEntryDataCacheProvider.cs
@@ -14,8 +14,11 @@
  *
 */
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using Ionic.Zip;
+using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Util;
@@ -37,7 +40,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public SingleEntryDataCacheProvider(IDataProvider dataProvider)
         {
-            _dataProvider = dataProvider;
+            this._dataProvider = dataProvider;
         }
 
         /// <summary>
@@ -45,19 +48,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         /// <param name="key">A string representing the key of the cached data</param>
         /// <returns>An <see cref="Stream"/> of the cached data</returns>
-        public Stream Fetch(string key)
+        public Stream FetchStream(string key)
         {
-            var stream = _dataProvider.Fetch(key);
+            var stream = this._dataProvider.Fetch(key);
 
             if (key.EndsWith(".zip") && stream != null)
             {
                 // get the first entry from the zip file
                 try
                 {
-                    var entryStream = Compression.UnzipStream(stream, out _zipFile);
+                    var entryStream = Compression.UnzipStream(stream, out this._zipFile);
 
                     // save the file stream so it can be disposed later
-                    _zipFileStream = stream;
+                    this._zipFileStream = stream;
 
                     return entryStream;
                 }
@@ -87,8 +90,21 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public void Dispose()
         {
-            _zipFile?.DisposeSafely();
-            _zipFileStream?.DisposeSafely();
+            this._zipFile?.DisposeSafely();
+            this._zipFileStream?.DisposeSafely();
+        }
+
+        /// <summary>
+        /// Fetch data from the cache as enumerator
+        /// </summary>
+        /// <param name="key">A string representing the key of the cached data</param>
+        /// <param name="config">The subscription config</param>
+        /// <param name="startDate">Provide the start date of data to be fetched. Inclusive.</param>
+        /// <param name="endDate">Provide the end date of data to be fetched. Inclusive.</param>
+        /// <returns>An enumerator of the cached data</returns>
+        public IEnumerator<string> FetchEnumerator(string key, SubscriptionDataConfig config, DateTime? startDate = null, DateTime? endDate = null)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -64,11 +64,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="isLiveMode">True if we're in live mode, false for backtesting</param>
         public TextSubscriptionDataSourceReader(IDataCacheProvider dataCacheProvider, SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
-            this._dataCacheProvider = dataCacheProvider;
-            this._date = date;
-            this._config = config;
-            this._isLiveMode = isLiveMode;
-            this._factory = (BaseData)ObjectActivator.GetActivator(config.Type).Invoke(new object[] { config.Type });
+            _dataCacheProvider = dataCacheProvider;
+            _date = date;
+            _config = config;
+            _isLiveMode = isLiveMode;
+            _factory = (BaseData)ObjectActivator.GetActivator(config.Type).Invoke(new object[] { config.Type });
         }
 
         /// <summary>
@@ -79,12 +79,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public IEnumerable<BaseData> Read(SubscriptionDataSource source)
         {
             string content = string.Empty;
-            using (var reader = this.CreateStreamReader(source))
+            using (var reader = CreateStreamReader(source))
             {
                 // if the reader doesn't have data then we're done with this subscription
                 if (reader == null || reader.EndOfStream)
                 {
-                    this.OnCreateStreamReaderError(this._date, source);
+                    OnCreateStreamReaderError(_date, source);
                     yield break;
                 }
 
@@ -96,11 +96,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     BaseData instance = null;
                     try
                     {
-                        instance = this._factory.Reader(this._config, line, this._date, this._isLiveMode);
+                        instance = _factory.Reader(_config, line, _date, _isLiveMode);
                     }
                     catch (Exception err)
                     {
-                        this.OnReaderError(line, err);
+                        OnReaderError(line, err);
                     }
 
                     if (instance != null && instance.EndTime != default(DateTime))
@@ -122,15 +122,15 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             switch (subscriptionDataSource.TransportMedium)
             {
                 case SubscriptionTransportMedium.LocalFile:
-                    reader = this.HandleLocalFileSource(subscriptionDataSource);
+                    reader = HandleLocalFileSource(subscriptionDataSource);
                     break;
 
                 case SubscriptionTransportMedium.RemoteFile:
-                    reader = this.HandleRemoteSourceFile(subscriptionDataSource);
+                    reader = HandleRemoteSourceFile(subscriptionDataSource);
                     break;
 
                 case SubscriptionTransportMedium.Rest:
-                    reader = new RestSubscriptionStreamReader(subscriptionDataSource.Source, subscriptionDataSource.Headers, this._isLiveMode);
+                    reader = new RestSubscriptionStreamReader(subscriptionDataSource.Source, subscriptionDataSource.Headers, _isLiveMode);
                     break;
 
                 default:
@@ -187,19 +187,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private IStreamReader HandleLocalFileSource(SubscriptionDataSource source)
         {
             // handles zip or text files
-            if (this._dataCacheProvider is DataPointCacheProvider)
+            if (_dataCacheProvider is DataPointCacheProvider)
             {
                 return new LocalFileSubscriptionEnumeratorReader(
-                    this._dataCacheProvider,
-                    this._config,
+                    _dataCacheProvider,
+                    _config,
                     source.Source,
                     null,
-                    this._config.DataStartTime,
-                    this._config.DataEndTime);
+                    _config.DataStartTime,
+                    _config.DataEndTime);
             }
 
             return new LocalFileSubscriptionStreamReader(
-                this._dataCacheProvider,
+                _dataCacheProvider,
                 source.Source,
                 null);
         }
@@ -214,11 +214,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             try
             {
                 // this will fire up a web client in order to download the 'source' file to the cache
-                return new RemoteFileSubscriptionStreamReader(this._dataCacheProvider, source.Source, Globals.Cache, source.Headers);
+                return new RemoteFileSubscriptionStreamReader(_dataCacheProvider, source.Source, Globals.Cache, source.Headers);
             }
             catch (Exception err)
             {
-                this.OnInvalidSource(source, err);
+                OnInvalidSource(source, err);
                 return null;
             }
         }

--- a/Engine/DataFeeds/Transport/LocalFileSubscriptionEnumeratorReader.cs
+++ b/Engine/DataFeeds/Transport/LocalFileSubscriptionEnumeratorReader.cs
@@ -54,9 +54,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
             DateTime? startDate = null,
             DateTime? endDate = null)
         {
-            this._config = config;
-            this._lineEnumerator = dataCacheProvider
-                .FetchEnumerator(source, this._config, startDate, endDate) as DataPointEnumerator;
+            _config = config;
+            _lineEnumerator = dataCacheProvider
+                .FetchEnumerator(source, _config, startDate, endDate) as DataPointEnumerator;
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         {
             get
             {
-                return this._lineEnumerator == null || this._lineEnumerator.EndOfStream;
+                return _lineEnumerator == null || _lineEnumerator.EndOfStream;
             }
         }
 
@@ -83,7 +83,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// </summary>
         public void Dispose()
         {
-            this._lineEnumerator?.Dispose();
+            _lineEnumerator?.Dispose();
         }
 
         /// <summary>
@@ -92,13 +92,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// <returns>A line of data point</returns>
         public string ReadLine()
         {
-            if (this.EndOfStream)
+            if (EndOfStream)
             {
                 throw new EndOfStreamException("Line enumerator is exhausted.");
             }
 
-            this._lineEnumerator.MoveNext();
-            return this._lineEnumerator.Current;
+            _lineEnumerator.MoveNext();
+            return _lineEnumerator.Current;
         }
     }
 }

--- a/Engine/DataFeeds/Transport/LocalFileSubscriptionEnumeratorReader.cs
+++ b/Engine/DataFeeds/Transport/LocalFileSubscriptionEnumeratorReader.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// <summary>
         /// The enumerator of data points
         /// </summary>
-        private DataPointEnumerator _lineEnumerator;
+        private readonly DataPointEnumerator _lineEnumerator;
 
         /// <summary>
         /// The subscription data config

--- a/Engine/DataFeeds/Transport/LocalFileSubscriptionEnumeratorReader.cs
+++ b/Engine/DataFeeds/Transport/LocalFileSubscriptionEnumeratorReader.cs
@@ -1,0 +1,104 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.IO;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.Transport
+{
+    /// <summary>
+    /// Implements a data point reader over local file subscription with enumerator
+    /// </summary>
+    public class LocalFileSubscriptionEnumeratorReader : IStreamReader
+    {
+        /// <summary>
+        /// The enumerator of data points
+        /// </summary>
+        private DataPointEnumerator _lineEnumerator;
+
+        /// <summary>
+        /// The subscription data config
+        /// </summary>
+        private readonly SubscriptionDataConfig _config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalFileSubscriptionEnumeratorReader"/> class.
+        /// </summary>
+        /// <param name="dataCacheProvider">The <see cref="IDataCacheProvider"/> used to retrieve a stream of data</param>
+        /// <param name="config">The subscription config</param>
+        /// <param name="source">The local file to be read</param>
+        /// <param name="entryName">Specifies the zip entry to be opened. Leave null if not applicable,
+        /// or to open the first zip entry found regardless of name</param>
+        /// <param name="startDate">The start of data range</param>
+        /// <param name="endDate">The end of data range</param>
+        public LocalFileSubscriptionEnumeratorReader(
+            IDataCacheProvider dataCacheProvider,
+            SubscriptionDataConfig config,
+            string source,
+            string entryName = null,
+            DateTime? startDate = null,
+            DateTime? endDate = null)
+        {
+            this._config = config;
+            this._lineEnumerator = dataCacheProvider
+                .FetchEnumerator(source, this._config, startDate, endDate) as DataPointEnumerator;
+        }
+
+        /// <summary>
+        /// Gets the transport medium of this subscription
+        /// </summary>
+        public SubscriptionTransportMedium TransportMedium
+        {
+            get { return SubscriptionTransportMedium.LocalFile; }
+        }
+
+        /// <summary>
+        /// Gets if it is end of stream(enumerator)
+        /// </summary>
+        public bool EndOfStream
+        {
+            get
+            {
+                return this._lineEnumerator == null || this._lineEnumerator.EndOfStream;
+            }
+        }
+
+        /// <summary>
+        /// Dispose the enumerator
+        /// </summary>
+        public void Dispose()
+        {
+            this._lineEnumerator?.Dispose();
+        }
+
+        /// <summary>
+        /// Wrapped enumerator as ReadLine() in stream
+        /// </summary>
+        /// <returns>A line of data point</returns>
+        public string ReadLine()
+        {
+            if (this.EndOfStream)
+            {
+                throw new EndOfStreamException("Line enumerator is exhausted.");
+            }
+
+            this._lineEnumerator.MoveNext();
+            return this._lineEnumerator.Current;
+        }
+    }
+}

--- a/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
@@ -41,10 +41,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// or to open the first zip entry found regardless of name</param>
         public LocalFileSubscriptionStreamReader(IDataCacheProvider dataCacheProvider, string source, string entryName = null)
         {
-            var stream = dataCacheProvider.Fetch(source);
-
-            if (stream != null)
+            var zipfileStream = dataCacheProvider.FetchStream(source);
+            if (zipfileStream != null)
             {
+                MemoryStream stream = new MemoryStream();
+                zipfileStream.CopyTo(stream);
+                stream.Position = 0;
                 _streamReader = new StreamReader(stream);
             }
         }
@@ -57,7 +59,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// <param name="startingPosition">The position in the stream from which to start reading</param>
         public LocalFileSubscriptionStreamReader(IDataCacheProvider dataCacheProvider, string source, long startingPosition)
         {
-            var stream = dataCacheProvider.Fetch(source);
+            var stream = dataCacheProvider.FetchStream(source);
 
             if (stream != null)
             {

--- a/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
@@ -14,13 +14,12 @@
  *
 */
 
-using System.IO;
-using Ionic.Zip;
-using System.IO.Compression;
-using QuantConnect.Interfaces;
-using System.Collections.Generic;
-using System.Linq;
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Ionic.Zip;
+using QuantConnect.Interfaces;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Transport
 {

--- a/Engine/DataFeeds/ZipDataCacheProvider.cs
+++ b/Engine/DataFeeds/ZipDataCacheProvider.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public ZipDataCacheProvider(IDataProvider dataProvider)
         {
-            this._dataProvider = dataProvider;
+            _dataProvider = dataProvider;
         }
 
         /// <summary>
@@ -67,26 +67,26 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 Stream stream = null;
 
                 // scan the cache once every 3 seconds
-                if (this._lastCacheScan == DateTime.MinValue || this._lastCacheScan < DateTime.Now.AddSeconds(-3))
+                if (_lastCacheScan == DateTime.MinValue || _lastCacheScan < DateTime.Now.AddSeconds(-3))
                 {
-                    this.CleanCache();
+                    CleanCache();
                 }
 
                 try
                 {
                     CachedZipFile existingEntry;
-                    if (!this._zipFileCache.TryGetValue(filename, out existingEntry))
+                    if (!_zipFileCache.TryGetValue(filename, out existingEntry))
                     {
-                        var dataStream = this._dataProvider.Fetch(filename);
+                        var dataStream = _dataProvider.Fetch(filename);
 
                         if (dataStream != null)
                         {
                             try
                             {
                                 var newItem = new CachedZipFile(dataStream, filename);
-                                stream = this.CreateStream(newItem, entryName, filename);
+                                stream = CreateStream(newItem, entryName, filename);
 
-                                if (!this._zipFileCache.TryAdd(filename, newItem))
+                                if (!_zipFileCache.TryAdd(filename, newItem))
                                 {
                                     newItem.Dispose();
                                 }
@@ -110,7 +110,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         {
                             lock (existingEntry)
                             {
-                                stream = this.CreateStream(existingEntry, entryName, filename);
+                                stream = CreateStream(existingEntry, entryName, filename);
                             }
                         }
                         catch (Exception exception)
@@ -138,7 +138,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             else
             {
                 // handles text files
-                return this._dataProvider.Fetch(filename);
+                return _dataProvider.Fetch(filename);
             }
         }
 
@@ -159,9 +159,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public void Dispose()
         {
             CachedZipFile zip;
-            foreach (var zipFile in this._zipFileCache)
+            foreach (var zipFile in _zipFileCache)
             {
-                if (this._zipFileCache.TryRemove(zipFile.Key, out zip))
+                if (_zipFileCache.TryRemove(zipFile.Key, out zip))
                 {
                     zip.Dispose();
                 }
@@ -176,13 +176,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var clearCacheIfOlderThan = DateTime.Now.AddSeconds(-CacheSeconds);
 
             // clean all items that that are older than CacheSeconds than the current date
-            foreach (var zip in this._zipFileCache)
+            foreach (var zip in _zipFileCache)
             {
                 if (zip.Value.Uncache(clearCacheIfOlderThan))
                 {
                     // removing it from the cache
                     CachedZipFile removed;
-                    if (this._zipFileCache.TryRemove(zip.Key, out removed))
+                    if (_zipFileCache.TryRemove(zip.Key, out removed))
                     {
                         // disposing zip archive
                         removed.Dispose();
@@ -190,7 +190,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
             }
 
-            this._lastCacheScan = DateTime.Now;
+            _lastCacheScan = DateTime.Now;
         }
 
         /// <summary>
@@ -310,14 +310,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="key">Key that represents the path to the data</param>
         public CachedZipFile(Stream dataStream, string key)
         {
-            this._dataStream = dataStream;
-            this._zipFile = ZipFile.Read(dataStream);
-            foreach (var entry in this._zipFile.Entries)
+            _dataStream = dataStream;
+            _zipFile = ZipFile.Read(dataStream);
+            foreach (var entry in _zipFile.Entries)
             {
-                this.EntryCache[entry.FileName] = entry;
+                EntryCache[entry.FileName] = entry;
             }
-            this.Key = key;
-            this._dateCached = DateTime.Now;
+            Key = key;
+            _dateCached = DateTime.Now;
         }
 
         /// <summary>
@@ -327,7 +327,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>Bool indicating whether this object is older than the specified time</returns>
         public bool Uncache(DateTime date)
         {
-            return this._dateCached < date;
+            return _dateCached < date;
         }
 
         /// <summary>
@@ -335,11 +335,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public void Dispose()
         {
-            this.EntryCache.Clear();
-            this._zipFile?.DisposeSafely();
-            this._dataStream?.DisposeSafely();
+            EntryCache.Clear();
+            _zipFile?.DisposeSafely();
+            _dataStream?.DisposeSafely();
 
-            this.Key = null;
+            Key = null;
         }
     }
 }

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Lean.Engine
         /// </summary>
         /// <param name="systemHandlers">The system handlers for controlling acquisition of jobs, messaging, and api calls</param>
         /// <param name="algorithmHandlers">The algorithm handlers for managing algorithm initialization, data, results, transaction, and real time events</param>
-        /// <param name="liveMode">True when running in live mode, false otherwises</param>
+        /// <param name="liveMode">True when running in live mode, false otherwise</param>
         public Engine(LeanEngineSystemHandlers systemHandlers, LeanEngineAlgorithmHandlers algorithmHandlers, bool liveMode)
         {
             _liveMode = liveMode;
@@ -173,7 +173,9 @@ namespace QuantConnect.Lean.Engine
                         (historyProvider as BrokerageHistoryProvider).SetBrokerage(brokerage);
                     }
 
-                    var historyDataCacheProvider = new ZipDataCacheProvider(_algorithmHandlers.DataProvider);
+                    IDataCacheProvider historyDataCacheProvider = (IDataCacheProvider)Activator.CreateInstance(
+                        Type.GetType(Config.Get("data-cache-provider", "QuantConnect.Lean.Engine.DataFeeds.ZipDataCacheProvider")),
+                        _algorithmHandlers.DataProvider);
                     historyProvider.Initialize(
                         new HistoryProviderInitializeParameters(
                             job,

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -164,9 +164,15 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             reader = new FilterEnumerator<BaseData>(reader, data =>
             {
                 // allow all ticks
-                if (config.Resolution == Resolution.Tick) return true;
+                if (config.Resolution == Resolution.Tick)
+                {
+                    return true;
+                }
                 // filter out future data
-                if (data.EndTime > endTimeAtExchange) return false;
+                if (data.EndTime > endTimeAtExchange)
+                {
+                    return false;
+                }
                 // filter out data before the start
                 return data.EndTime > startTimeAtExchange;
             });

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -83,19 +83,21 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             start = start.ConvertFromUtc(request.ExchangeHours.TimeZone);
             end = end.ConvertFromUtc(request.ExchangeHours.TimeZone);
 
-            var config = new SubscriptionDataConfig(request.DataType,
-                request.Symbol,
-                request.Resolution,
-                request.DataTimeZone,
-                request.ExchangeHours.TimeZone,
-                request.FillForwardResolution.HasValue,
-                request.IncludeExtendedMarketHours,
-                false,
-                request.IsCustomData,
-                request.TickType,
-                true,
-                request.DataNormalizationMode
-                );
+            var config = new SubscriptionDataConfig(
+                objectType: request.DataType,
+                symbol: request.Symbol,
+                resolution: request.Resolution,
+                dataTimeZone: request.DataTimeZone,
+                exchangeTimeZone: request.ExchangeHours.TimeZone,
+                fillForward: request.FillForwardResolution.HasValue,
+                extendedHours: request.IncludeExtendedMarketHours,
+                isInternalFeed: false,
+                isCustom: request.IsCustomData,
+                tickType: request.TickType,
+                isFilteredSubscription: true,
+                dataNormalizationMode: request.DataNormalizationMode,
+                subscriptionDataStartDate: request.StartTimeUtc,
+                subscriptionDataEndDate: request.EndTimeUtc);
 
             var security = new Security(
                 request.ExchangeHours,

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -135,6 +135,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -151,6 +152,8 @@
     <Compile Include="DataFeeds\CachingOptionChainProvider.cs" />
     <Compile Include="DataFeeds\CurrencySubscriptionDataConfigManager.cs" />
     <Compile Include="DataFeeds\DataManager.cs" />
+    <Compile Include="DataFeeds\DataPointDictionary.cs" />
+    <Compile Include="DataFeeds\Enumerators\DataPointEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\DelistingEventProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\DividendEventProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\Factories\CorporateEventEnumeratorFactory.cs" />
@@ -162,6 +165,7 @@
     <Compile Include="DataFeeds\Enumerators\LiveBaseDataSynchronizingEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\QuoteBarFillForwardEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\AuxiliaryDataEnumerator.cs" />
+    <Compile Include="DataFeeds\DataPointCacheProvider.cs" />
     <Compile Include="DataFeeds\IDataFeedSubscriptionManager.cs" />
     <Compile Include="DataFeeds\IDataFeedTimeProvider.cs" />
     <Compile Include="DataFeeds\IDataManager.cs" />
@@ -223,6 +227,7 @@
     <Compile Include="DataFeeds\SubscriptionDataReader.cs" />
     <Compile Include="DataFeeds\TimeSlice.cs" />
     <Compile Include="DataFeeds\TimeSliceFactory.cs" />
+    <Compile Include="DataFeeds\Transport\LocalFileSubscriptionEnumeratorReader.cs" />
     <Compile Include="DataFeeds\Transport\LocalFileSubscriptionStreamReader.cs" />
     <Compile Include="DataFeeds\Transport\RemoteFileSubscriptionStreamReader.cs" />
     <Compile Include="DataFeeds\Transport\RestSubscriptionStreamReader.cs" />

--- a/Engine/packages.config
+++ b/Engine/packages.config
@@ -7,4 +7,5 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
   <package id="RestSharp" version="105.2.3" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.Runtime.Caching" version="4.5.0" targetFramework="net452" />
 </packages>

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -13,6 +13,11 @@
  * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
 using Python.Runtime;
 using QuantConnect.Algorithm;
 using QuantConnect.Configuration;
@@ -28,11 +33,6 @@ using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Option;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
 
 namespace QuantConnect.Jupyter
 {
@@ -136,14 +136,20 @@ namespace QuantConnect.Jupyter
                 {
                     var symbol = QuantConnect.Symbol.Create(ticker.ToString(), SecurityType.Equity, Market.USA);
                     var dir = new DirectoryInfo(Path.Combine(Globals.DataFolder, "equity", symbol.ID.Market, "fundamental", "fine", symbol.Value.ToLower()));
-                    if (!dir.Exists) continue;
+                    if (!dir.Exists)
+                    {
+                        continue;
+                    }
 
                     var config = new SubscriptionDataConfig(typeof(FineFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
 
                     foreach (var fileName in dir.EnumerateFiles())
                     {
                         var date = DateTime.ParseExact(fileName.Name.Substring(0, 8), DateFormat.EightCharacter, CultureInfo.InvariantCulture);
-                        if (date < start || date > end) continue;
+                        if (date < start || date > end)
+                        {
+                            continue;
+                        }
 
                         var factory = new TextSubscriptionDataSourceReader(_dataCacheProvider, config, date, false);
                         var source = new SubscriptionDataSource(fileName.FullName, SubscriptionTransportMedium.LocalFile);
@@ -575,7 +581,10 @@ namespace QuantConnect.Jupyter
         {
             foreach (var name in fullName.Split('.'))
             {
-                if (baseData == null) return null;
+                if (baseData == null)
+                {
+                    return null;
+                }
 
                 var info = baseData.GetType().GetProperty(name);
 

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -66,8 +66,11 @@ namespace QuantConnect.Jupyter
                 // Initialize History Provider
                 var composer = new Composer();
                 var algorithmHandlers = LeanEngineAlgorithmHandlers.FromConfiguration(composer);
-                _dataCacheProvider = new ZipDataCacheProvider(algorithmHandlers.DataProvider);
 
+                // Select data reader
+                _dataCacheProvider = (IDataCacheProvider)Activator.CreateInstance(
+                    Type.GetType(Config.Get("data-cache-provider", "QuantConnect.Lean.Engine.DataFeeds.ZipDataCacheProvider")),
+                    algorithmHandlers.DataProvider);
                 var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
                 var securityService = new SecurityService(Portfolio.CashBook, MarketHoursDatabase, symbolPropertiesDataBase, this);
                 Securities.SetSecurityService(securityService);
@@ -405,7 +408,7 @@ namespace QuantConnect.Jupyter
                 var listBenchmark = CalculateDailyRateOfChange(dictBenchmark);
                 var listPerformance = CalculateDailyRateOfChange(dictEquity);
 
-                // Gets the startting capital
+                // Gets the starting capital
                 var startingCapital = Convert.ToDecimal(dictEquity.FirstOrDefault().Value);
 
                 // Compute portfolio statistics

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -69,8 +69,9 @@ namespace QuantConnect.Jupyter
 
                 // Select data reader
                 _dataCacheProvider = (IDataCacheProvider)Activator.CreateInstance(
-                    Type.GetType(Config.Get("data-cache-provider", "QuantConnect.Lean.Engine.DataFeeds.ZipDataCacheProvider")),
+                    Type.GetType($"{Config.Get("data-cache-provider", "QuantConnect.Lean.Engine.DataFeeds.ZipDataCacheProvider")}, QuantConnect.Lean.Engine"),
                     algorithmHandlers.DataProvider);
+
                 var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
                 var securityService = new SecurityService(Portfolio.CashBook, MarketHoursDatabase, symbolPropertiesDataBase, this);
                 Securities.SetSecurityService(securityService);

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -26,6 +26,7 @@
 
   // engine
   "data-folder": "../../../Data/",
+  //"data-folder": "..\\..\\..\\Data\\",
 
   // handlers
   "log-handler": "QuantConnect.Logging.CompositeLogHandler",
@@ -35,6 +36,7 @@
   "map-file-provider": "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider",
   "factor-file-provider": "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider",
   "data-provider": "QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider",
+  "data-cache-provider": "QuantConnect.Lean.Engine.DataFeeds.ZipDataCacheProvider",
   "alpha-handler": "QuantConnect.Lean.Engine.Alphas.DefaultAlphaHandler",
 
   // limits on number of symbols to allow

--- a/Tests/Engine/DataCacheProviders/SingleEntryDataCacheProviderTests.cs
+++ b/Tests/Engine/DataCacheProviders/SingleEntryDataCacheProviderTests.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Tests.Engine.DataCacheProviders
         [Test]
         public void SingleEntryDataCache_CanFetchDataThatExists()
         {
-            var stream = _singleEntryDataCacheProvider.Fetch("../../../Data/equity/usa/minute/aapl/20140606_trade.zip");
+            var stream = _singleEntryDataCacheProvider.FetchStream("../../../Data/equity/usa/minute/aapl/20140606_trade.zip");
 
             Assert.IsNotNull(stream);
         }
@@ -31,7 +31,7 @@ namespace QuantConnect.Tests.Engine.DataCacheProviders
         [Test]
         public void SingleEntryDataCache_CannotFetchDataThatDoesNotExist()
         {
-            var stream = _singleEntryDataCacheProvider.Fetch("../../../Data/equity/usa/minute/aapl/19980606_trade.zip");
+            var stream = _singleEntryDataCacheProvider.FetchStream("../../../Data/equity/usa/minute/aapl/19980606_trade.zip");
 
             Assert.IsNull(stream);
         }

--- a/Tests/Engine/DataCacheProviders/SingleEntryDataCacheProviderTests.cs
+++ b/Tests/Engine/DataCacheProviders/SingleEntryDataCacheProviderTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Ionic.Zip;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using QuantConnect.Lean.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Engine.DataCacheProviders


### PR DESCRIPTION
(Initial review of the new feature, more improvements to come.) 
Daily/Hour resolution history request is an order of magnitude slow than minute/second/ticks.
This change is based on the result of the performance profiling. 

#### Change Details
This PR is to address the problem where daily/hour history request is slow. After a couple of performance profiling, it shows there are a couple of performance hotpots:

1. Each history request unzips the zip file cached in ZipDataCacheProvider, which is computational expensive and unnecessary. Also, re-creating stream for each request is also contribute to the slow down.
2. There are multiple code paths isDailyOrHour also causes performance difference at scale.
3. Update the in-house cache to MemoryCache with capacity/time limit.
4. Include the benchmark algorithm to this PR
5. Flight this new feature. Based on config settings to select which cache provider to use.
6. Confirm UTC/Exchange Timezone align with history data.
7. (Todo) Unit tests
8. Provide baseline and improved performance profiles here. 
9. (Pending) Front-load data point conversion when caching (string->olchv) to avoid duplicate processing in every MoveNext(). 

#### Related Issue
https://github.com/QuantConnect/Lean/issues/2820

#### Motivation and Context
This is LEAN core engine performance improvement.

#### Requires Documentation Change
N/AP

#### How Has This Been Tested?
A new benchmark algorithm with History() in OnData().
Process profiling of each method call and timers.
Unit tests will come after.


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->