### PR TITLE
Fix incorrect return value in Compression.GetBytes

### DIFF
--- a/Compression/Compression.cs
+++ b/Compression/Compression.cs
@@ -252,7 +252,8 @@ namespace QuantConnect
                     entryStream.Write(bytes, 0, bytes.Length);
                 }
             }
-            return memoryStream.GetBuffer();
+
+            return memoryStream.ToArray();
         }
 
         /// <summary>

--- a/Tests/Compression/CompressionTests.cs
+++ b/Tests/Compression/CompressionTests.cs
@@ -53,6 +53,16 @@ namespace QuantConnect.Tests.Compression
         }
 
         [Test]
+        public void ZipBytesReturnsByteArrayWithCorrectLength()
+        {
+            const string file = "../../../Data/equity/usa/tick/spy/20131007_trade.zip";
+            var fileBytes = File.ReadAllBytes(file);
+            var zippedBytes = QuantConnect.Compression.ZipBytes(fileBytes, "entry");
+
+            Assert.AreEqual(612631, zippedBytes.Length);
+        }
+
+        [Test]
         public void ExtractsZipEntryByName()
         {
             var zip = Path.Combine("TestData", "multizip.zip");

--- a/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
+++ b/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
@@ -199,7 +199,7 @@ namespace QuantConnect.ToolBox.DukascopyDownloader
                 {
                     SevenZipExtractor.DecompressStream(inStream, outStream, (int)inStream.Length, null);
 
-                    byte[] bytes = outStream.GetBuffer();
+                    byte[] bytes = outStream.ToArray();
                     int count = bytes.Length / DukascopyTickLength;
 
                     // Numbers are big-endian


### PR DESCRIPTION

#### Description
- `Compression.GetBytes` was returning the internal buffer with `MemoryStream.GetBuffer` instead of returning the actual bytes using `MemoryStream.ToArray`
- The same issue was also fixed in `DukascopyDataDownloader`

#### Motivation and Context
The return value for the method was a byte array larger than expected.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.