### PR TITLE
Adds missing Py.GIL() in VolatilityModelPythonWrapper.Volatility

### DIFF
--- a/Common/Python/VolatilityModelPythonWrapper.cs
+++ b/Common/Python/VolatilityModelPythonWrapper.cs
@@ -36,6 +36,16 @@ namespace QuantConnect.Python
         /// <param name="model"> Represents a model that computes the volatility of a security</param>
         public VolatilityModelPythonWrapper(PyObject model)
         {
+            using (Py.GIL())
+            {
+                foreach (var attributeName in new[] { "Volatility", "Update", "GetHistoryRequirements" })
+                {
+                    if (!model.HasAttr(attributeName))
+                    {
+                        throw new NotImplementedException($"IVolatilityModel.{attributeName} must be implemented. Please implement this missing method on {model.GetPythonType()}");
+                    }
+                }
+            }
             _model = model;
         }
 
@@ -46,7 +56,10 @@ namespace QuantConnect.Python
         {
             get
             {
-                return _model.Volatility;
+                using (Py.GIL())
+                {
+                    return (decimal)_model.Volatility;
+                }
             }
         }
 


### PR DESCRIPTION
#### Description
Adds missing `Py.GIL()` in `VolatilityModelPythonWrapper.Volatility`.
Adds a check for the minimum methods/members that must be implemented.

#### Related Issue
Closes #2907 

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
Running CustomVolatilityModelAlgorithm.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests pass.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`