### PR TITLE
BrokerageSetupHandler will not clear CashBook with BacktestingBrokerage

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -218,7 +218,7 @@ namespace QuantConnect.Lean.Engine.Setup
                                 "is only supported in backtesting for now.");
                         }
 
-                        if (liveJob.Brokerage != "PaperBrokerage")
+                        if (liveJob.Brokerage != "PaperBrokerage" && liveJob.Brokerage != "BacktestingBrokerage")
                         {
                             //Zero the CashBook - we'll populate directly from brokerage
                             foreach (var kvp in algorithm.Portfolio.CashBook)


### PR DESCRIPTION

#### Description
- `BrokerageSetupHandler.Setup` has been updated to **not** clear the `CashBook` when using `BacktestingBrokerage`

#### Related Issue
Closes #2912 

#### Motivation and Context
The algorithm was ignoring the starting cash set in the algorithm `Initialize` method

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local testing with custom configuration.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`