### PR TITLE
Adding new Alpha Model. DualThrust

### DIFF
--- a/Algorithm.Framework/Alphas/DualThrustAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/DualThrustAlphaModel.cs
@@ -1,0 +1,220 @@
+﻿using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Indicators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuantConnect.Algorithm.Framework.Alphas
+{
+    /// <summary>
+    /// Alpha model that uses dual-thrust strategy to create insights
+    /// https://medium.com/@FMZ_Quant/dual-thrust-trading-strategy-2cc74101a626
+    /// or here:
+    /// https://www.quantconnect.com/tutorials/strategy-library/dual-thrust-trading-algorithm
+    /// </summary>
+    public class DualThrustAlphaModel : AlphaModel
+    {
+        private readonly decimal _k1;
+        private readonly decimal _k2;
+        private readonly TimeSpan _consolidatorTimeSpan;
+        private readonly int _rangePeriod;
+        private readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol;
+
+        /// <summary>
+        /// Initializes a new instance of the  class
+        /// </summary>
+        /// <param name="k1">Coefficient for upper band</param>
+        /// <param name="k2">Coefficient for lower band</param>
+        /// <param name="rangePeriod">Amount of last bars to calculate the range</param>
+        /// <param name="resolution">The resolution of data sent into the EMA indicators</param>
+        /// <param name="barsToConsolidate">If we want alpha o work on trade bars whose length is
+        /// different from the standard resolution - 1m 1h etc. - we need to pass this parameters along
+        /// with proper data resolution</param>
+        public DualThrustAlphaModel(
+            decimal k1,
+            decimal k2,
+            int rangePeriod,
+            Resolution resolution = Resolution.Daily,
+            int barsToConsolidate = 1
+            )
+        {
+            // coefficient that used to determinte upper and lower borders of a breakout channel
+            _k1 = k1;
+            _k2 = k2;
+
+            // period the range is calculated over
+            _rangePeriod = rangePeriod;
+
+            // initialize with empty dict.
+            _symbolDataBySymbol = new Dictionary<Symbol, SymbolData>();
+
+            // time for bars we make the calculations on
+            _consolidatorTimeSpan = resolution.ToTimeSpan().Multiply(barsToConsolidate);
+        }
+
+        /// <summary>
+        /// Updates this alpha model with the latest data from the algorithm.
+        /// This is called each time the algorithm receives data for subscribed securities
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="data">The new data available</param>
+        /// <returns>The new insights generated</returns>
+        public override IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data)
+        {
+            var insights = new List<Insight>();
+
+            // in 5 days after emission an insight is to be considered expired
+            int insightCloseAddDays = 5;
+
+            foreach(var symbolData in _symbolDataBySymbol.Values)
+            {
+                var range = symbolData.Range;
+                var symbol = symbolData.Symbol;
+                var security = algorithm.Securities[symbol];
+
+                if (symbolData.IsReady)
+                {
+                    // buying condition
+                    // - (1) price is above upper line
+                    // - (2) and we are not long. this is a first time we crossed the line lately
+                    if (security.Price > symbolData.UpperLine && !algorithm.Portfolio[symbol].IsLong)
+                    {
+                        DateTime insightCloseTimeUtc = algorithm.UtcTime.AddDays(insightCloseAddDays);
+                        insights.Add(Insight.Price(symbolData.Symbol, insightCloseTimeUtc, InsightDirection.Up));
+                    }
+
+                    // selling condition
+                    // - (1) price is lower that lower line
+                    // - (2) and we are not short. this is a first time we crossed the line lately
+                    if (security.Price < symbolData.LowerLine && !algorithm.Portfolio[symbol].IsShort)
+                    {
+                        DateTime insightCloseTimeUtc = algorithm.UtcTime.AddDays(insightCloseAddDays);
+                        insights.Add(Insight.Price(symbolData.Symbol, insightCloseTimeUtc, InsightDirection.Down));
+                    }
+                }
+            }
+
+            return insights;
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
+        /// <param name="changes">The security additions and removals from the algorithm</param>
+        public override void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        {
+            // added
+            foreach (var added in changes.AddedSecurities)
+            {
+                SymbolData symbolData;
+                if (!_symbolDataBySymbol.TryGetValue(added.Symbol, out symbolData))
+                {
+                    // add symbol/symbolData pair to collection
+                    symbolData = new SymbolData(_rangePeriod, _consolidatorTimeSpan) {
+                        Symbol = added.Symbol, K1 = _k1, K2 = _k2
+                    };
+
+                    _symbolDataBySymbol[added.Symbol] = symbolData;
+
+                    //register consolidator
+                    algorithm.SubscriptionManager.AddConsolidator(added.Symbol, symbolData.GetConsolidator());
+                }
+            }
+
+            // removed
+            foreach(var removed in changes.RemovedSecurities)
+            {
+                SymbolData symbolData;
+                if (_symbolDataBySymbol.TryGetValue(removed.Symbol, out symbolData))
+                {
+                    // unsibscribe consolidator from data updates
+                    algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, symbolData.GetConsolidator());
+                    
+                    // remove item from dictionary collection
+                    if(!_symbolDataBySymbol.Remove(removed.Symbol))
+                    {
+                        algorithm.Error("Unable to remove data from collection: DualThrustAlphaModel");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Contains data specific to a symbol required by this model
+        /// </summary>
+        private class SymbolData
+        {
+            // rolling to contain items over the looking back period
+            private readonly RollingWindow<TradeBar> _rangeWindow;
+
+            // we calculate our logic on bars
+            private readonly TradeBarConsolidator _consolidator;
+
+            // current range value
+            public decimal Range { get; private set; }
+
+            // upper Line 
+            public decimal UpperLine { get; private set; }
+
+            // lower Line
+            public decimal LowerLine { get; private set; }
+
+            // symbol value
+            public Symbol Symbol { get; set; }
+
+            // k1
+            public decimal K1 { private get; set; }
+
+            // k2
+            public decimal K2 { private get; set; }
+
+            // data is ready when rolling window is ready
+            public bool IsReady => _rangeWindow.IsReady;
+
+            /// <summary>
+            /// Main constructor for the class
+            /// </summary>
+            /// <param name="rangePeriod">Range period</param>
+            /// <param name="consolidatorResolution">Time length of consolidator</param>
+            public SymbolData(int rangePeriod, TimeSpan consolidatorResolution)
+            {
+                _rangeWindow = new RollingWindow<TradeBar>(rangePeriod);
+                _consolidator = new TradeBarConsolidator(consolidatorResolution);
+
+                // event fired at new consolidated trade bar
+                _consolidator.DataConsolidated += (sender, consolidated) =>
+                {
+                    // add new tradebar to 
+                    _rangeWindow.Add(consolidated);
+
+                    if (IsReady)
+                    {
+                        var hh = _rangeWindow.Select(x => x.High).Max();
+                        var hc = _rangeWindow.Select(x => x.Close).Max();
+                        var lc = _rangeWindow.Select(x => x.Close).Min();
+                        var ll = _rangeWindow.Select(x => x.Low).Min();
+                        
+                        Range = Math.Max(hh - lc, hc - ll);
+
+                        UpperLine = consolidated.Close + K1 * Range;
+                        LowerLine = consolidated.Close - K2 * Range;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Returns the interior consolidator
+            /// </summary>
+            public TradeBarConsolidator GetConsolidator()
+            {
+                return _consolidator;
+            }
+        }
+    }
+}

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Alphas\AlphaModel.cs" />
     <Compile Include="Alphas\AlphaModelExtensions.cs" />
     <Compile Include="Alphas\AlphaModelPythonWrapper.cs" />
+    <Compile Include="Alphas\DualThrustAlphaModel.cs" />
     <Compile Include="Alphas\PearsonCorrelationPairsTradingAlphaModel.cs" />
     <Compile Include="Alphas\CompositeAlphaModel.cs" />
     <Compile Include="Alphas\EmaCrossAlphaModel.cs" />


### PR DESCRIPTION
#### Description
This commit publishes new alpha model into QuantConnect.Algorithm.Framework.Alphas namespace.
Written in C#.
Alpha model implements a widely known concept to generate trading singnals called Dual Thrust. https://www.quantconnect.com/tutorials/strategy-library/dual-thrust-trading-algorithm

#### Related Issue
NA

#### Motivation and Context
Add more alphas to an opensource. This model implements the basic idea and can be use in conjunction with other alpha models.

#### Requires Documentation Change
NA

#### How Has This Been Tested?
I have run it locally on custom data. It does work fine.

#### Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [X ] New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to change)
* [ ]  Non-functional change (xml comments/documentation/etc)

#### Checklist:
* [ X] My code follows the code style of this project.
* [ X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
* [ ]  I have added tests to cover my changes.
* [ ]  All new and existing tests passed.
* [X ] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`