### PR TITLE
Fix conversion error in VolatilityModelPythonWrapper.Volatility

### DIFF
--- a/Common/Python/VolatilityModelPythonWrapper.cs
+++ b/Common/Python/VolatilityModelPythonWrapper.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.Python
             {
                 using (Py.GIL())
                 {
-                    return (decimal)_model.Volatility;
+                    return (decimal)(double)_model.Volatility;
                 }
             }
         }


### PR DESCRIPTION

#### Description
- A `PyObject` to `decimal` conversion has been fixed in the `Volatility` getter in the `VolatilityModelPythonWrapper` class

#### Related Issue
Closes #2918 

#### Motivation and Context
The `Volatility` getter was throwing the following error:
```
Cannot convert type 'Python.Runtime.PyObject' to 'decimal'
```

#### Requires Documentation Change
No

#### How Has This Been Tested?
Verified the issue was resolved with an algorithm in the cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`