### PR TITLE
Update BrokerageTransactionHandler.AddOrder to wait for order to be processed

### DIFF
--- a/Common/Orders/OrderTicket.cs
+++ b/Common/Orders/OrderTicket.cs
@@ -43,6 +43,7 @@ namespace QuantConnect.Orders
         private readonly SubmitOrderRequest _submitRequest;
         private readonly ManualResetEvent _orderStatusClosedEvent;
         private readonly List<UpdateOrderRequest> _updateRequests;
+        private readonly ManualResetEvent _orderSetEvent;
 
         // we pull this in to provide some behavior/simplicity to the ticket API
         private readonly SecurityTransactionManager _transactionManager;
@@ -194,6 +195,16 @@ namespace QuantConnect.Orders
         }
 
         /// <summary>
+        /// Returns true if the order has been set for this ticket
+        /// </summary>
+        public bool HasOrder => _order != null;
+
+        /// <summary>
+        /// Gets a wait handle that can be used to wait until the order has been set
+        /// </summary>
+        public WaitHandle OrderSet => _orderSetEvent;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="OrderTicket"/> class
         /// </summary>
         /// <param name="transactionManager">The transaction manager used for submitting updates and cancels for this ticket</param>
@@ -207,6 +218,7 @@ namespace QuantConnect.Orders
             _orderEvents = new List<OrderEvent>();
             _updateRequests = new List<UpdateOrderRequest>();
             _orderStatusClosedEvent = new ManualResetEvent(false);
+            _orderSetEvent = new ManualResetEvent(false);
         }
 
         /// <summary>
@@ -356,6 +368,8 @@ namespace QuantConnect.Orders
             }
 
             _order = order;
+
+            _orderSetEvent.Set();
         }
 
         /// <summary>


### PR DESCRIPTION

#### Description
- `BrokerageTransactionHandler.AddOrder` calls are now synchronized with the brokerage transaction handler thread to prevent returning a ticket for an unprocessed order.

#### Related Issue
Closes #2920 

#### Motivation and Context
Currently, `GetOpenOrders` does not always return orders submitted immediately before the call.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`