### PR TITLE
RollingWindow Size does not capture read lock

### DIFF
--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,26 +50,13 @@ namespace QuantConnect.Indicators
                 throw new ArgumentException("RollingWindow must have size of at least 1.", "size");
             }
             _list = new List<T>(size);
+            Size = size;
         }
 
         /// <summary>
         ///     Gets the size of this window
         /// </summary>
-        public int Size
-        {
-            get
-            { 
-                try
-                {
-                    _listLock.EnterReadLock();
-                    return _list.Capacity;
-                }
-                finally
-                {
-                    _listLock.ExitReadLock();
-                }
-            }
-        }
+        public int Size { get; }
 
         /// <summary>
         ///     Gets the current number of elements in this window
@@ -77,7 +64,7 @@ namespace QuantConnect.Indicators
         public int Count
         {
             get
-            { 
+            {
                 try
                 {
                     _listLock.EnterReadLock();
@@ -96,7 +83,7 @@ namespace QuantConnect.Indicators
         public decimal Samples
         {
             get
-            { 
+            {
                 try
                 {
                     _listLock.EnterReadLock();
@@ -187,7 +174,7 @@ namespace QuantConnect.Indicators
         public bool IsReady
         {
             get
-            { 
+            {
                 try
                 {
                     _listLock.EnterReadLock();
@@ -196,7 +183,7 @@ namespace QuantConnect.Indicators
                 finally
                 {
                     _listLock.ExitReadLock();
-                } 
+                }
             }
         }
 
@@ -209,7 +196,7 @@ namespace QuantConnect.Indicators
         /// <filterpriority>1</filterpriority>
         public IEnumerator<T> GetEnumerator()
         {
-            // we make a copy on purpose so the enumerator isn't tied 
+            // we make a copy on purpose so the enumerator isn't tied
             // to a mutable object, well it is still mutable but out of scope
             var temp = new List<T>(Count);
             try


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Set `RollingWindow` `Size` int property at construction and avoid
capturing the read lock. * `int` are thread safe in C# https://docs.microsoft.com/en-us/dotnet/api/system.int32?view=netframework-4.7.2

[MASTER C# IndicatorRibbonBenchmark]
65.13 seconds at 12k data points per second. Processing total of 782,223 data points.
65.93 seconds at 12k data points per second. Processing total of 782,223 data points.
63.32 seconds at 12k data points per second. Processing total of 782,223 data points.
[PR C# IndicatorRibbonBenchmark]
63.74 seconds at 12k data points per second. Processing total of 782,223 data points.
62.55 seconds at 13k data points per second. Processing total of 782,223 data points.
60.75 seconds at 13k data points per second. Processing total of 782,223 data points.

[PR] has a ~5% speed improvement.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2926
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Faster is better
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit and regression tests

[C# IndicatorRibbonBenchmark MASTER]
Time improvement to be captured with PR:
![rollingwindowsizeperf](https://user-images.githubusercontent.com/18473240/53115074-fe6a0800-3523-11e9-86fb-1b88c0e2b3df.PNG)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->