### PR TITLE
Update OandaBrokerage.GetCashBalance to include Currencies for Open Positions

### DIFF
--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -649,7 +649,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                     else
                     {
                         //Set the cash amount to zero if cash entry not found in the balances
-                        Log.LogHandler.Trace($"BrokerageTransactionHandler.PerformCashSync(): {cash.Symbol} was not found" +
+                        Log.LogHandler.Trace($"BrokerageTransactionHandler.PerformCashSync(): {cash.Symbol} was not found " +
                             "in brokerage cash balance, setting the amount to 0");
                         _algorithm.Portfolio.CashBook[cash.Symbol].SetAmount(0);
                     }


### PR DESCRIPTION

#### Description
The `GetCashBalance` method in `OandaBrokerage` has been updated to include currencies involved in open FX/CFD positions.

#### Related Issue
Closes #2933 

#### Motivation and Context
Some `CashBook` entries were being set to zero during the daily Cash sync process, causing equity jumps at this time (7:45 AM NY).

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included + live algorithm testing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`