### PR TITLE
AlgoSeekConverter process all futures and VIX in a single run

### DIFF
--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
@@ -36,7 +36,6 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
         private const int ExecTimeout = 60;// sec
         private readonly string _source;
         private readonly string _remote;
-        private readonly string _remoteMask;
         private readonly string _destination;
         private readonly List<Resolution> _resolutions;
         private readonly DateTime _referenceDate;
@@ -49,11 +48,10 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
         /// <param name="remote">Remote directory of the .bz algoseek files</param>
         /// <param name="source">Source directory of the .csv algoseek files</param>
         /// <param name="destination">Destination directory of the processed future files</param>
-        public AlgoSeekFuturesConverter(List<Resolution> resolutions, DateTime referenceDate, string remote, string remoteMask, string source, string destination)
+        public AlgoSeekFuturesConverter(List<Resolution> resolutions, DateTime referenceDate, string remote, string source, string destination)
         {
             _source = source;
             _remote = remote;
-            _remoteMask = remoteMask;
             _referenceDate = referenceDate;
             _destination = destination;
             _resolutions = resolutions;
@@ -65,8 +63,10 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
         public void Convert()
         {
             //Get the list of all the files, then for each file open a separate streamer.
-            var files = Directory.EnumerateFiles(_remote, _remoteMask);
-            files = files.Where(x => Path.GetFileNameWithoutExtension(x).ToLower().IndexOf("option") == -1);
+            var files = Directory.EnumerateFiles(_remote);
+
+            files = files.Where(x => (Path.GetExtension(x) == ".gz" || Path.GetExtension(x) == ".bz2") &&
+                !Path.GetFileNameWithoutExtension(x).ToLower().Contains("option"));
 
             Log.Trace("AlgoSeekFuturesConverter.Convert(): Loading {0} AlgoSeekFuturesReader for {1} ", files.Count(), _referenceDate);
 

--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesProgram.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesProgram.cs
@@ -36,7 +36,6 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
             Log.LogHandler = new CompositeLogHandler(new ILogHandler[] { new ConsoleLogHandler(), new FileLogHandler("log.txt") });
 
             // Directory for the data, output and processed cache:
-            var remoteMask = Config.Get("futures-remote-file-mask", "*.bz2").Replace("{0}", date);
             var remoteDirectory = Config.Get("futures-remote-directory").Replace("{0}", date);
             var sourceDirectory = Config.Get("futures-source-directory").Replace("{0}", date);
             var dataDirectory = Config.Get("data-directory").Replace("{0}", date);
@@ -77,7 +76,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
 
             // Convert the date:
             var timer = Stopwatch.StartNew();
-            var converter = new AlgoSeekFuturesConverter(resolutionList.ToList() , referenceDate, remoteDirectory, remoteMask, sourceDirectory, dataDirectory);
+            var converter = new AlgoSeekFuturesConverter(resolutionList.ToList() , referenceDate, remoteDirectory, sourceDirectory, dataDirectory);
             converter.Convert();
             Log.Trace(string.Format("AlgoSeekFuturesConverter.Main(): {0} Conversion finished in time: {1}", referenceDate, timer.Elapsed));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR removes the use of a single file mask. Instead, it uses a hard-coded filter to get both VIX and the rest of the futures symbols.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/!.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This implementation allows processing all futures + VIX if all raw data files are in a single folder.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Complete run locally and comparison of values against existent data.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->