### PR TITLE
 Fix Incorrect Portfolio.Cash with CFD Open Positions

### DIFF
--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -369,19 +369,26 @@ namespace QuantConnect.Securities
             get
             {
                 // we can't include forex in this calculation since we would be double accounting with respect to the cash book
-                // we exclude futures as they are calculated separately
-                decimal totalHoldingsValueWithoutForexAndCrypto = 0;
+                // we also exclude futures and CFD as they are calculated separately
+                decimal totalHoldingsValueWithoutForexCryptoFutureCfd = 0;
                 foreach (var kvp in Securities)
                 {
                     var position = kvp.Value;
                     if (position.Type != SecurityType.Forex && position.Type != SecurityType.Crypto &&
-                        position.Type != SecurityType.Future) totalHoldingsValueWithoutForexAndCrypto += position.Holdings.HoldingsValue;
+                        position.Type != SecurityType.Future && position.Type != SecurityType.Cfd)
+                    {
+                        totalHoldingsValueWithoutForexCryptoFutureCfd += position.Holdings.HoldingsValue;
+                    }
                 }
 
-                var totalFuturesHoldingsValue = Securities.Where(x => x.Value.Type == SecurityType.Future)
-                                                           .Sum(x => x.Value.Holdings.UnrealizedProfit);
+                var totalFuturesAndCfdHoldingsValue = Securities
+                    .Where(x => x.Value.Type == SecurityType.Future || x.Value.Type == SecurityType.Cfd)
+                    .Sum(x => x.Value.Holdings.UnrealizedProfit);
 
-                return CashBook.TotalValueInAccountCurrency + UnsettledCashBook.TotalValueInAccountCurrency + totalHoldingsValueWithoutForexAndCrypto + totalFuturesHoldingsValue;
+                return CashBook.TotalValueInAccountCurrency +
+                       UnsettledCashBook.TotalValueInAccountCurrency +
+                       totalHoldingsValueWithoutForexCryptoFutureCfd +
+                       totalFuturesAndCfdHoldingsValue;
             }
         }
 

--- a/Common/Securities/SecurityPortfolioModel.cs
+++ b/Common/Securities/SecurityPortfolioModel.cs
@@ -49,9 +49,9 @@ namespace QuantConnect.Securities
             try
             {
                 // apply sales value to holdings in the account currency
-                if (security.Type == SecurityType.Future)
+                if (security.Type == SecurityType.Future || security.Type == SecurityType.Cfd)
                 {
-                    // for futures, we measure volume of sales, not notionals
+                    // for futures/CFDs, we measure volume of sales, not notionals
                     var saleValueInQuoteCurrency = fill.FillPrice * Convert.ToDecimal(fill.AbsoluteFillQuantity);
                     var saleValue = saleValueInQuoteCurrency * quoteCash.ConversionRate;
                     security.Holdings.AddNewSale(saleValue);
@@ -77,8 +77,8 @@ namespace QuantConnect.Securities
                 }
 
                 // apply the funds using the current settlement model
-                // we dont adjust funds for futures: it is zero upfront payment derivative (margin applies though)
-                if (security.Type != SecurityType.Future)
+                // we dont adjust funds for futures and CFDs: it is zero upfront payment derivative (margin applies though)
+                if (security.Type != SecurityType.Future && security.Type != SecurityType.Cfd)
                 {
                     security.SettlementModel.ApplyFunds(portfolio, security, fill.UtcTime, quoteCash.Symbol, -fill.FillQuantity * fill.FillPrice * security.SymbolProperties.ContractMultiplier);
                 }
@@ -106,8 +106,8 @@ namespace QuantConnect.Securities
                         * security.SymbolProperties.ContractMultiplier;
                     var lastTradeProfitInAccountCurrency = lastTradeProfit * security.QuoteCurrency.ConversionRate;
 
-                    // Reflect account cash adjustment for futures position
-                    if (security.Type == SecurityType.Future)
+                    // Reflect account cash adjustment for futures/CFD position
+                    if (security.Type == SecurityType.Future || security.Type == SecurityType.Cfd)
                     {
                         security.SettlementModel.ApplyFunds(portfolio, security, fill.UtcTime, quoteCash.Symbol, lastTradeProfit);
                     }

--- a/Tests/Brokerages/Oanda/OandaBrokerageTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageTests.cs
@@ -293,9 +293,7 @@ namespace QuantConnect.Tests.Brokerages.Oanda
             }
             else if (securityType == SecurityType.Cfd)
             {
-                // quote currency
-                var quoteCurrencyCash = balances.Single(x => x.Currency == ticker.Substring(ticker.Length-3));
-                Assert.AreEqual(-Math.Sign(quantity), Math.Sign(quoteCurrencyCash.Amount));
+                Assert.AreEqual(1, balances.Count);
             }
         }
 


### PR DESCRIPTION

#### Description
- Updated `SecurityPortfolioModel.ProcessFill` to update the `CashBook` only when closing `CFD` positions (same as Futures)
- Updated `SecurityPortfolioManager.TotalPortfolioValue` to count only `UnrealizedProfit` for `CFD` positions (same as Futures)
- Updated `Oanda` and `FXCM` brokerages `GetCashBalance` to exclude currencies involved in `CFD` positions
- Added new portfolio manager and brokerage unit tests

#### Related Issue
Closes #2945 

#### Motivation and Context
Incorrect values for `Portfolio.Cash` with CFD open positions.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests + verified Portfolio and CashBook with live algorithms (Oanda and FXCM)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`