### PR TITLE
Fix Cashbook Settlement for Oanda/FXCM CFD Trades

### DIFF
--- a/Common/Brokerages/FxcmBrokerageModel.cs
+++ b/Common/Brokerages/FxcmBrokerageModel.cs
@@ -191,6 +191,18 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
+        /// Gets a new settlement model for the security
+        /// </summary>
+        /// <param name="security">The security to get a settlement model for</param>
+        /// <returns>The settlement model for this brokerage</returns>
+        public override ISettlementModel GetSettlementModel(Security security)
+        {
+            return security.Type == SecurityType.Cfd
+                ? new AccountCurrencyImmediateSettlementModel() :
+                (ISettlementModel)new ImmediateSettlementModel();
+        }
+
+        /// <summary>
         /// Validates limit/stopmarket order prices, pass security.Price for limit/stop if n/a
         /// </summary>
         private static bool IsValidOrderPrices(Security security, OrderType orderType, OrderDirection orderDirection, decimal stopPrice, decimal limitPrice, ref BrokerageMessageEvent message)

--- a/Common/Brokerages/OandaBrokerageModel.cs
+++ b/Common/Brokerages/OandaBrokerageModel.cs
@@ -132,5 +132,17 @@ namespace QuantConnect.Brokerages
         {
             return new ConstantSlippageModel(0);
         }
+
+        /// <summary>
+        /// Gets a new settlement model for the security
+        /// </summary>
+        /// <param name="security">The security to get a settlement model for</param>
+        /// <returns>The settlement model for this brokerage</returns>
+        public override ISettlementModel GetSettlementModel(Security security)
+        {
+            return security.Type == SecurityType.Cfd
+                ? new AccountCurrencyImmediateSettlementModel() :
+                (ISettlementModel)new ImmediateSettlementModel();
+        }
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Python\BuyingPowerModelPythonWrapper.cs" />
     <Compile Include="Securities\CashAmount.cs" />
     <Compile Include="Securities\IdentityCurrencyConverter.cs" />
+    <Compile Include="Securities\AccountCurrencyImmediateSettlementModel.cs" />
     <Compile Include="Securities\InitialMarginRequiredForOrderParameters.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPosition.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPositionParameters.cs" />

--- a/Common/Securities/AccountCurrencyImmediateSettlementModel.cs
+++ b/Common/Securities/AccountCurrencyImmediateSettlementModel.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Represents the model responsible for applying cash settlement rules
+    /// </summary>
+    /// <remarks>This model converts the amount to the account currency and applies cash settlement immediately</remarks>
+    public class AccountCurrencyImmediateSettlementModel : ISettlementModel
+    {
+        /// <summary>
+        /// Applies cash settlement rules
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="security">The fill's security</param>
+        /// <param name="applicationTimeUtc">The fill time (in UTC)</param>
+        /// <param name="currency">The currency symbol</param>
+        /// <param name="amount">The amount of cash to apply</param>
+        public void ApplyFunds(SecurityPortfolioManager portfolio, Security security, DateTime applicationTimeUtc, string currency, decimal amount)
+        {
+            var amountInAccountCurrency = portfolio.CashBook.ConvertToAccountCurrency(amount, currency);
+
+            portfolio.CashBook[portfolio.CashBook.AccountCurrency].AddAmount(amountInAccountCurrency);
+        }
+    }
+}

--- a/Tests/Common/Securities/AccountCurrencyImmediateSettlementModelTests.cs
+++ b/Tests/Common/Securities/AccountCurrencyImmediateSettlementModelTests.cs
@@ -1,0 +1,114 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class AccountCurrencyImmediateSettlementModelTests
+    {
+        private static readonly DateTime Noon = new DateTime(2014, 6, 24, 12, 0, 0);
+        private static readonly TimeKeeper TimeKeeper = new TimeKeeper(Noon.ConvertToUtc(TimeZones.NewYork), new[] { TimeZones.NewYork });
+
+        [Test]
+        public void FundsAreSettledImmediately()
+        {
+            var securities = new SecurityManager(TimeKeeper);
+            var transactions = new SecurityTransactionManager(null, securities);
+            var portfolio = new SecurityPortfolioManager(securities, transactions);
+            var model = new AccountCurrencyImmediateSettlementModel();
+            var config = CreateTradeBarConfig(Symbols.SPY);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance
+            );
+
+            portfolio.SetCash(1000);
+            Assert.AreEqual(1000, portfolio.Cash);
+            Assert.AreEqual(0, portfolio.UnsettledCash);
+
+            var timeUtc = Noon.ConvertToUtc(TimeZones.NewYork);
+            model.ApplyFunds(portfolio, security, timeUtc, Currencies.USD, 1000);
+
+            Assert.AreEqual(2000, portfolio.Cash);
+            Assert.AreEqual(0, portfolio.UnsettledCash);
+
+            model.ApplyFunds(portfolio, security, timeUtc, Currencies.USD, -500);
+
+            Assert.AreEqual(1500, portfolio.Cash);
+            Assert.AreEqual(0, portfolio.UnsettledCash);
+
+            model.ApplyFunds(portfolio, security, timeUtc, Currencies.USD, 1000);
+
+            Assert.AreEqual(2500, portfolio.Cash);
+            Assert.AreEqual(0, portfolio.UnsettledCash);
+        }
+
+        [Test]
+        public void FundsAreSettledInAccountCurrency()
+        {
+            var securities = new SecurityManager(TimeKeeper);
+            var transactions = new SecurityTransactionManager(null, securities);
+            var portfolio = new SecurityPortfolioManager(securities, transactions);
+            var model = new AccountCurrencyImmediateSettlementModel();
+            portfolio.SetCash(1000);
+            portfolio.SetCash("EUR", 0, 1.1m);
+
+            var config = CreateTradeBarConfig(Symbols.DE30EUR);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                portfolio.CashBook["EUR"],
+                SymbolProperties.GetDefault("EUR"),
+                ErrorCurrencyConverter.Instance
+            );
+
+            Assert.AreEqual(1000, portfolio.Cash);
+            Assert.AreEqual(0, portfolio.UnsettledCash);
+
+            var timeUtc = Noon.ConvertToUtc(TimeZones.NewYork);
+            model.ApplyFunds(portfolio, security, timeUtc, "EUR", 1000);
+
+            // 1000 + 1000 * 1.1 = 2100
+            Assert.AreEqual(2100, portfolio.Cash);
+            Assert.AreEqual(0, portfolio.UnsettledCash);
+
+            model.ApplyFunds(portfolio, security, timeUtc, "EUR", -500);
+
+            // 2100 - 500 * 1.1 = 1550
+            Assert.AreEqual(1550, portfolio.Cash);
+            Assert.AreEqual(0, portfolio.UnsettledCash);
+
+            model.ApplyFunds(portfolio, security, timeUtc, "EUR", 1000);
+
+            // 1550 + 1000 * 1.1 = 2650
+            Assert.AreEqual(2650, portfolio.Cash);
+            Assert.AreEqual(0, portfolio.UnsettledCash);
+        }
+
+        private SubscriptionDataConfig CreateTradeBarConfig(Symbol symbol)
+        {
+            return new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
+        }
+    }
+}

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -589,10 +589,13 @@ namespace QuantConnect.Tests.Common.Securities
                     ErrorCurrencyConverter.Instance
                 )
             );
+            securities[Symbols.DE30EUR].SettlementModel = new AccountCurrencyImmediateSettlementModel();
 
             var fillBuy = new OrderEvent(1, Symbols.DE30EUR, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Buy, 10000, 5, OrderFee.Zero);
             portfolio.ProcessFill(fillBuy);
 
+            Assert.AreEqual(0, portfolio.CashBook["EUR"].Amount);
+            Assert.AreEqual(0, portfolio.CashBook["USD"].Amount);
             Assert.AreEqual(0, portfolio.Cash);
             Assert.AreEqual(5, securities[Symbols.DE30EUR].Holdings.Quantity);
 
@@ -600,6 +603,8 @@ namespace QuantConnect.Tests.Common.Securities
             portfolio.ProcessFill(fillSell);
 
             // PNL = (10100 - 10000) * 5 * 1.10 = 550 USD
+            Assert.AreEqual(0, portfolio.CashBook["EUR"].Amount);
+            Assert.AreEqual(550, portfolio.CashBook["USD"].Amount);
             Assert.AreEqual(550, portfolio.Cash);
             Assert.AreEqual(0, securities[Symbols.DE30EUR].Holdings.Quantity);
         }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Common\Data\Custom\QuandlTests.cs" />
     <Compile Include="Common\Securities\ErrorCurrencyConverterTests.cs" />
     <Compile Include="Common\Securities\IdentityCurrencyConverterTests.cs" />
+    <Compile Include="Common\Securities\AccountCurrencyImmediateSettlementModelTests.cs" />
     <Compile Include="Common\Securities\Options\OptionPortfolioModelTests.cs" />
     <Compile Include="Common\Securities\ProcessVolatilityHistoryRequirementsTests.cs" />
     <Compile Include="Common\Securities\SecurityHoldingTests.cs" />


### PR DESCRIPTION
#### Description
- Added new `AccountCurrencyImmediateSettlementModel` class to model CFD settlement for FXCM and Oanda brokerages (the settlement model is overridden in the brokerage models).

#### Related Issue
Closes #2955 

#### Motivation and Context
With Oanda and FXCM brokerages, profits for CFD trades were accrued to the cashbook in the asset's `Quote Currency` instead of the `Account Currency`.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New and updated unit tests + live CFD trades with Oanda and FXCM.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`