### PR TITLE
Reduce ParallelRunnerController CPU usage

### DIFF
--- a/Common/Util/ParallelRunner.cs
+++ b/Common/Util/ParallelRunner.cs
@@ -131,6 +131,10 @@ namespace QuantConnect.Util
                     }
                     else
                     {
+                        if (!_holdQueue.Any(x => x.IsReady))
+                        {
+                            Thread.Sleep(5);
+                        }
                         _holdQueue.Add(workItem, token);
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding a 5ms sleep when there are no ready work items, reducing CPU
usage by the ParallelRunnerController thread.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2928
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`ParallelRunnerController` should not waste CPU time
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executing `HistoryRequestBenchmark` and `Empty400Daily10YearBenchmark` locally, showed Lean process **CPU usage went down from 25% to 15%** (see https://github.com/QuantConnect/Lean/issues/2928), having no real impact on execution times. Tested branch in the cloud too.

[PR C# HistoryRequestBenchmark]
57.08 seconds at 16k data points per second. Processing total of 904,955 data points.
54.53 seconds at 17k data points per second. Processing total of 904,955 data points.
53.51 seconds at 17k data points per second. Processing total of 904,955 data points.
51.26 seconds at 18k data points per second. Processing total of 904,955 data points.
51.51 seconds at 18k data points per second. Processing total of 904,955 data points.
51.24 seconds at 18k data points per second. Processing total of 904,955 data points.
[MASTER C# HistoryRequestBenchmark]
56.97 seconds at 16k data points per second. Processing total of 904,955 data points.
53.48 seconds at 17k data points per second. Processing total of 904,955 data points.
52.25 seconds at 17k data points per second. Processing total of 904,955 data points.
51.07 seconds at 18k data points per second. Processing total of 904,955 data points.
51.48 seconds at 18k data points per second. Processing total of 904,955 data points.
51.07 seconds at 18k data points per second. Processing total of 904,955 data points.

[PR Empty400Daily10YearBenchmark]
19.10 seconds at 44k data points per second. Processing total of 840,365 data points.
18.31 seconds at 46k data points per second. Processing total of 840,365 data points.
18.43 seconds at 46k data points per second. Processing total of 840,365 data points.
17.67 seconds at 48k data points per second. Processing total of 840,365 data points.
18.06 seconds at 47k data points per second. Processing total of 840,365 data points.
17.88 seconds at 47k data points per second. Processing total of 840,365 data points.
[MASTER Empty400Daily10YearBenchmark]
20.69 seconds at 41k data points per second. Processing total of 840,365 data points.
20.93 seconds at 40k data points per second. Processing total of 840,365 data points.
19.48 seconds at 43k data points per second. Processing total of 840,365 data points.
18.68 seconds at 45k data points per second. Processing total of 840,365 data points.
18.86 seconds at 45k data points per second. Processing total of 840,365 data points.
18.88 seconds at 45k data points per second. Processing total of 840,365 data points.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->