### PR TITLE
Fix BlackLittermanOptimizationPortfolio failing intermittently

### DIFF
--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -186,9 +186,17 @@ namespace QuantConnect.Indicators
             if (ReferenceEquals(obj, null)) return false;
             if (obj.GetType().IsSubclassOf(typeof (IndicatorBase<>))) return ReferenceEquals(this, obj);
 
-            // the obj is not an indicator, so let's check for value types, try converting to decimal
-            var converted = Convert.ToDecimal(obj);
-            return Current.Value == converted;
+            try
+            {
+                // the obj is not an indicator, so let's check for value types, try converting to decimal
+                var converted = Convert.ToDecimal(obj);
+                return Current.Value == converted;
+            }
+            catch (InvalidCastException)
+            {
+                // conversion failed, return false
+                return false;
+            }
         }
 
         /// <summary>

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -143,6 +143,22 @@ namespace QuantConnect.Tests.Indicators
             TestComparisonOperators<double>();
         }
 
+        [Test]
+        public void EqualsMethodShouldNotThrowExceptions()
+        {
+            var indicator = new TestIndicator();
+            var res = true;
+            try
+            {
+                res = indicator.Equals(new Exception(""));
+            }
+            catch (InvalidCastException)
+            {
+                Assert.Fail();
+            }
+            Assert.IsFalse(res);
+        }
+
         private static void TestComparisonOperators<TValue>()
         {
             var indicator = new TestIndicator();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding `try catch` statement in the `IndicatorBase.Equals()` method
when trying to convert `obj` to `decimal`. Adding unit test which reproduces original issue.

`PythonNet` is using the `IndicatorBase.Equals()` method in a `HashTable` with other objects types.
![imagen](https://user-images.githubusercontent.com/18473240/53431538-7f674a80-39cf-11e9-82ff-29e631d5ffdb.png)

I think this was happening intermittently because it depended on the calculated hash code, looking at the `HashTable` `Object this[Object key]` implementation https://referencesource.microsoft.com/#mscorlib/system/collections/hashtable.cs, called by `PythonNet` when getting an item:
```
if (((b.hash_coll & 0x7FFFFFFF) == hashcode) && 
    KeyEquals (b.key, key))
    return b.val;
```
It will only call `KeyEquals()` in the case that `(b.hash_coll & 0x7FFFFFFF) == hashcode) `

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2664
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix unit test that was failing intermittently.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->