### PR TITLE
Adds an Overload to DateRules.Every Method that Accepts a Single DayOfWeek Object

### DIFF
--- a/Algorithm.CSharp/ScheduledEventsAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledEventsAlgorithm.cs
@@ -61,6 +61,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Log("EveryDay.SPY 10 min before close: Fired at: " + Time);
             });
 
+            // schedule an event to fire on a single day of the week
+            Schedule.On(DateRules.Every(DayOfWeek.Wednesday), TimeRules.At(12, 0), () =>
+            {
+                Log("Wed at 12pm: Fired at: " + Time);
+            });
+
             // schedule an event to fire on certain days of the week
             Schedule.On(DateRules.Every(DayOfWeek.Monday, DayOfWeek.Friday), TimeRules.At(12, 0), () =>
             {

--- a/Algorithm.Python/ScheduledEventsAlgorithm.py
+++ b/Algorithm.Python/ScheduledEventsAlgorithm.py
@@ -54,6 +54,9 @@ class ScheduledEventsAlgorithm(QCAlgorithm):
         # time rule here tells it to fire 10 minutes before SPY's market close
         self.Schedule.On(self.DateRules.EveryDay("SPY"), self.TimeRules.BeforeMarketClose("SPY", 10), self.EveryDayAfterMarketClose)
 
+        # schedule an event to fire on a single day of the week
+        self.Schedule.On(self.DateRules.Every(DayOfWeek.Wednesday), self.TimeRules.At(12, 0), self.EveryWedAtNoon)
+
         # schedule an event to fire on certain days of the week
         self.Schedule.On(self.DateRules.Every(DayOfWeek.Monday, DayOfWeek.Friday), self.TimeRules.At(12, 0), self.EveryMonFriAtNoon)
 
@@ -74,25 +77,29 @@ class ScheduledEventsAlgorithm(QCAlgorithm):
 
 
     def SpecificTime(self):
-        self.Log("SpecificTime: Fired at : {0}".format(self.Time))
+        self.Log(f"SpecificTime: Fired at : {self.Time}")
 
 
     def EveryDayAfterMarketOpen(self):
-        self.Log("EveryDay.SPY 10 min after open: Fired at: {0}".format(self.Time))
+        self.Log(f"EveryDay.SPY 10 min after open: Fired at: {self.Time}")
 
 
     def EveryDayAfterMarketClose(self):
-        self.Log("EveryDay.SPY 10 min before close: Fired at: {0}".format(self.Time))
+        self.Log(f"EveryDay.SPY 10 min before close: Fired at: {self.Time}")
+
+
+    def EveryWedAtNoon(self):
+        self.Log(f"Wed at 12pm: Fired at: {self.Time}")
 
 
     def EveryMonFriAtNoon(self):
-        self.Log("Mon/Fri at 12pm: Fired at: {0}".format(self.Time))
+        self.Log(f"Mon/Fri at 12pm: Fired at: {self.Time}")
 
 
     def LiquidateUnrealizedLosses(self):
         ''' if we have over 1000 dollars in unrealized losses, liquidate'''
         if self.Portfolio.TotalUnrealizedProfit < -1000:
-            self.Log("Liquidated due to unrealized losses at: {0}".format(self.Time))
+            self.Log(f"Liquidated due to unrealized losses at: {self.Time}")
             self.Liquidate()
 
 

--- a/Common/Scheduling/DateRules.cs
+++ b/Common/Scheduling/DateRules.cs
@@ -67,6 +67,13 @@ namespace QuantConnect.Scheduling
         /// <summary>
         /// Specifies an event should fire on each of the specified days of week
         /// </summary>
+        /// <param name="day">The day the event shouls fire</param>
+        /// <returns>A date rule that fires on every specified day of week</returns>
+        public IDateRule Every(DayOfWeek day) => Every(new[] { day });
+
+        /// <summary>
+        /// Specifies an event should fire on each of the specified days of week
+        /// </summary>
         /// <param name="days">The days the event shouls fire</param>
         /// <returns>A date rule that fires on every specified day of week</returns>
         public IDateRule Every(params DayOfWeek[] days)


### PR DESCRIPTION
#### Description
Adds an overload to `DateRules.Every` method that accepts a single `DayOfWeek` object.

#### Related Issue
Closes #2963 

#### Motivation and Context
C# and Python API consistency.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added a new Scheduled Event to `ScheduledEventsAlgorithm` (C# and Python).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`