### PR TITLE
Contributing using the correct branch naming convention

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,6 @@
 - [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
 - [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
 - [ ] All new and existing tests passed.
-- [ ] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`
+- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
 
 <!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,11 +87,11 @@ Topic branches should exist in your **local** and **origin** repositories only. 
 
 ## Working on topic branches
 
-First create a new branch for the work you'd like to perform:
+First create a new branch for the work you'd like to perform. When naming your branch, please use the following convention: `bug-<issue#>-<description>` or `feature-<issue#>-<description>`:
 
 ```bash
-$ git checkout -b issue-123/short-issue-description
-Switched to a new branch 'issue-123/short-issue-description'
+$ git checkout -b bug-123-short-issue-description
+Switched to a new branch 'bug-123-short-issue-description'
 ```
 
 Now perform some work and commit changes. Always review your changes before committing
@@ -115,10 +115,10 @@ After performing some work you'll want to merge in changes from the **upstream/m
 
 ```bash
 $ git fetch upstream
-$ git rebase upstream/master issue-123/short-issue-description
+$ git rebase upstream/master bug-123-short-issue-description
 ```
 
-The `git fetch upstream` command will download the **upstream** repository to your computer but not merge it. The `rebase upstream/master issue-123/short-issue-description` command will [rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-commit--amend) your changes on top of **upstream/master**. This will make the review process easier for **collaborators**.
+The `git fetch upstream` command will download the **upstream** repository to your computer but not merge it. The `rebase upstream/master bug-123-short-issue-description` command will [rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-commit--amend) your changes on top of **upstream/master**. This will make the review process easier for **collaborators**.
 
 > CAUTION Please note that once you have pushed your branch remotely you MUST NOT rebase!
 
@@ -131,15 +131,15 @@ $ git pull upstream/master
 When topic branches are finished and ready for review, they should be pushed back to **origin**.
 
 ```bash
-$ git push origin issue-123/short-issue-description
+$ git push origin bug-123-short-issue-description
 To git@github.com:username/Lean.git
-    * [new branch]       issue-123/short-issue-description -> issue-123/short-issue-description
+    * [new branch]       bug-123-short-issue-description -> bug-123-short-issue-description
 ```
 
 Now you're ready to send a [pull request](https://help.github.com/articles/using-pull-requests/) from this branch to **upstream/master** and update the GitHub issue tracker to let a collaborator know that your branch is ready to be reviewed and merged.  If extra changes are required as part of the review process, make those changes on the topic branch and re-push. First re-checkout the topic branch you made your original changes on:
 
 ```bash
-$ git checkout issue-123/short-issue-description
+$ git checkout bug-123-short-issue-description
 ```
 
 Now make responses to the review comments, commit, and re-push your changes:


### PR DESCRIPTION
#### Description
CONTRIBUTING.md should propose a correct branch name for new users submitting PR's, i.e. the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`.

Currently, CONTRIBUTING.md proposes the following naming convention:
```bash
$ git checkout -b issue-123/short-issue-description
Switched to a new branch 'issue-123/short-issue-description'
```

This personally caught me out and forced me to make a new branch with the appropriate naming convention.

The file has been updated to reflect this convention, and also the GitHub PR template has been modified slightly as there was a `>` missing.

#### Related Issue
Closes #2967

#### Motivation and Context
Discussed above.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`