### PR TITLE
Moving price scale factoring to new enumerator

### DIFF
--- a/Common/Data/Market/QuoteBar.cs
+++ b/Common/Data/Market/QuoteBar.cs
@@ -473,10 +473,10 @@ namespace QuantConnect.Data.Market
             {
                 quoteBar.Bid = new Bar
                 {
-                    Open = config.GetNormalizedPrice(csv[1].ToDecimal() * scaleFactor),
-                    High = config.GetNormalizedPrice(csv[2].ToDecimal() * scaleFactor),
-                    Low = config.GetNormalizedPrice(csv[3].ToDecimal() * scaleFactor),
-                    Close = config.GetNormalizedPrice(csv[4].ToDecimal() * scaleFactor)
+                    Open = csv[1].ToDecimal() * scaleFactor,
+                    High = csv[2].ToDecimal() * scaleFactor,
+                    Low = csv[3].ToDecimal() * scaleFactor,
+                    Close = csv[4].ToDecimal() * scaleFactor
                 };
                 quoteBar.LastBidSize = csv[5].ToDecimal();
             }
@@ -490,10 +490,10 @@ namespace QuantConnect.Data.Market
             {
                 quoteBar.Ask = new Bar
                 {
-                    Open = config.GetNormalizedPrice(csv[6].ToDecimal() * scaleFactor),
-                    High = config.GetNormalizedPrice(csv[7].ToDecimal() * scaleFactor),
-                    Low = config.GetNormalizedPrice(csv[8].ToDecimal() * scaleFactor),
-                    Close = config.GetNormalizedPrice(csv[9].ToDecimal() * scaleFactor)
+                    Open = csv[6].ToDecimal() * scaleFactor,
+                    High = csv[7].ToDecimal() * scaleFactor,
+                    Low = csv[8].ToDecimal() * scaleFactor,
+                    Close = csv[9].ToDecimal() * scaleFactor
                 };
                 quoteBar.LastAskSize = csv[10].ToDecimal();
             }

--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -229,7 +229,7 @@ namespace QuantConnect.Data.Market
                         var csv = line.ToCsv(6);
                         Symbol = config.Symbol;
                         Time = date.Date.AddMilliseconds(csv[0].ToInt64()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
-                        Value = config.GetNormalizedPrice(csv[1].ToDecimal() / scaleFactor);
+                        Value = csv[1].ToDecimal() / scaleFactor;
                         TickType = TickType.Trade;
                         Quantity = csv[2].ToDecimal();
                         if (csv.Count > 3)
@@ -295,7 +295,7 @@ namespace QuantConnect.Data.Market
 
                         if (TickType == TickType.Trade)
                         {
-                            Value = config.GetNormalizedPrice(csv[1].ToDecimal()/scaleFactor);
+                            Value = csv[1].ToDecimal()/scaleFactor;
                             Quantity = csv[2].ToDecimal();
                             Exchange = csv[3];
                             SaleCondition = csv[4];
@@ -309,12 +309,12 @@ namespace QuantConnect.Data.Market
                         {
                             if (csv[1].Length != 0)
                             {
-                                BidPrice = config.GetNormalizedPrice(csv[1].ToDecimal()/scaleFactor);
+                                BidPrice = csv[1].ToDecimal()/scaleFactor;
                                 BidSize = csv[2].ToDecimal();
                             }
                             if (csv[3].Length != 0)
                             {
-                                AskPrice = config.GetNormalizedPrice(csv[3].ToDecimal()/scaleFactor);
+                                AskPrice = csv[3].ToDecimal()/scaleFactor;
                                 AskSize = csv[4].ToDecimal();
                             }
                             Exchange = csv[5];

--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -278,10 +278,10 @@ namespace QuantConnect.Data.Market
                 tradeBar.Time = date.Date.AddMilliseconds(csv[0].ToInt32()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
             }
 
-            tradeBar.Open = config.GetNormalizedPrice(csv[1].ToDecimal()*_scaleFactor);
-            tradeBar.High = config.GetNormalizedPrice(csv[2].ToDecimal()*_scaleFactor);
-            tradeBar.Low = config.GetNormalizedPrice(csv[3].ToDecimal()*_scaleFactor);
-            tradeBar.Close = config.GetNormalizedPrice(csv[4].ToDecimal()*_scaleFactor);
+            tradeBar.Open = csv[1].ToDecimal()*_scaleFactor;
+            tradeBar.High = csv[2].ToDecimal()*_scaleFactor;
+            tradeBar.Low = csv[3].ToDecimal()*_scaleFactor;
+            tradeBar.Close = csv[4].ToDecimal()*_scaleFactor;
             tradeBar.Volume = csv[5].ToDecimal();
 
             return tradeBar;
@@ -441,10 +441,10 @@ namespace QuantConnect.Data.Market
                 tradeBar.Time = date.Date.AddMilliseconds(csv[0].ToInt32()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
             }
 
-            tradeBar.Open = config.GetNormalizedPrice(csv[1].ToDecimal() * _scaleFactor);
-            tradeBar.High = config.GetNormalizedPrice(csv[2].ToDecimal() * _scaleFactor);
-            tradeBar.Low = config.GetNormalizedPrice(csv[3].ToDecimal() * _scaleFactor);
-            tradeBar.Close = config.GetNormalizedPrice(csv[4].ToDecimal() * _scaleFactor);
+            tradeBar.Open = csv[1].ToDecimal() * _scaleFactor;
+            tradeBar.High = csv[2].ToDecimal() * _scaleFactor;
+            tradeBar.Low = csv[3].ToDecimal() * _scaleFactor;
+            tradeBar.Close = csv[4].ToDecimal() * _scaleFactor;
             tradeBar.Volume = csv[5].ToDecimal();
 
             return tradeBar;
@@ -479,10 +479,10 @@ namespace QuantConnect.Data.Market
                 tradeBar.Time = date.Date.AddMilliseconds(csv[0].ToInt32()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
             }
 
-            tradeBar.Open = config.GetNormalizedPrice(csv[1].ToDecimal());
-            tradeBar.High = config.GetNormalizedPrice(csv[2].ToDecimal());
-            tradeBar.Low = config.GetNormalizedPrice(csv[3].ToDecimal());
-            tradeBar.Close = config.GetNormalizedPrice(csv[4].ToDecimal());
+            tradeBar.Open = csv[1].ToDecimal();
+            tradeBar.High = csv[2].ToDecimal();
+            tradeBar.Low = csv[3].ToDecimal();
+            tradeBar.Close = csv[4].ToDecimal();
             tradeBar.Volume = csv[5].ToDecimal();
 
             return tradeBar;

--- a/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
@@ -35,6 +35,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// Creates a new <see cref="AuxiliaryDataEnumerator"/> that will hold the
         /// corporate event providers
         /// </summary>
+        /// <param name="rawDataEnumerator">The underlying raw data enumerator</param>
         /// <param name="config">The <see cref="SubscriptionDataConfig"/></param>
         /// <param name="factorFileProvider">Used for getting factor files</param>
         /// <param name="tradableDayNotifier">Tradable dates provider</param>
@@ -42,6 +43,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <param name="includeAuxiliaryData">True to emit auxiliary data</param>
         /// <returns>The new auxiliary data enumerator</returns>
         public static IEnumerator<BaseData> CreateEnumerators(
+            IEnumerator<BaseData> rawDataEnumerator,
             SubscriptionDataConfig config,
             IFactorFileProvider factorFileProvider,
             ITradableDatesNotifier tradableDayNotifier,
@@ -65,7 +67,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 tradableDayNotifier,
                 includeAuxiliaryData);
 
-            return enumerator;
+            var priceScaleFactorEnumerator = new PriceScaleFactorEnumerator(
+                rawDataEnumerator,
+                config,
+                factorFile);
+
+            return new SynchronizingEnumerator(priceScaleFactorEnumerator, enumerator);
         }
 
         private static MapFile GetMapFileToUse(

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -96,7 +96,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             dataReader.DownloadFailed += (sender, args) => { _resultHandler.ErrorMessage(args.Message, args.StackTrace); };
             dataReader.ReaderErrorDetected += (sender, args) => { _resultHandler.RuntimeError(args.Message, args.StackTrace); };
 
-            var enumerator = CorporateEventEnumeratorFactory.CreateEnumerators(
+            var result = CorporateEventEnumeratorFactory.CreateEnumerators(
+                dataReader,
                 request.Configuration,
                 _factorFileProvider,
                 dataReader,
@@ -106,7 +107,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             // has to be initialized after adding all the enumerators since it will execute a MoveNext
             dataReader.Initialize();
 
-            return new SynchronizingEnumerator(dataReader, enumerator);
+            return result;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/Enumerators/PriceScaleFactorEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/PriceScaleFactorEnumerator.cs
@@ -1,0 +1,216 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
+{
+    /// <summary>
+    /// This enumerator will update the <see cref="SubscriptionDataConfig.PriceScaleFactor"/> when required
+    /// and adjust the raw <see cref="BaseData"/> prices based on the provided <see cref="SubscriptionDataConfig"/>.
+    /// Assumes the prices of the provided <see cref="IEnumerator"/> are in raw mode.
+    /// </summary>
+    public class PriceScaleFactorEnumerator : IEnumerator<BaseData>
+    {
+        private readonly IEnumerator<BaseData> _rawDataEnumerator;
+        private readonly SubscriptionDataConfig _config;
+        private readonly FactorFile _factorFile;
+        private DateTime _lastTradableDate;
+
+        /// <summary>
+        /// Explicit interface implementation for <see cref="Current"/>
+        /// </summary>
+        object IEnumerator.Current => Current;
+
+        /// <summary>
+        /// Last read <see cref="BaseData"/> object from this type and source
+        /// </summary>
+        public BaseData Current
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="PriceScaleFactorEnumerator"/>.
+        /// </summary>
+        /// <param name="rawDataEnumerator">The underlying raw data enumerator</param>
+        /// <param name="config">The <see cref="SubscriptionDataConfig"/> to enumerate for.
+        /// Will determine the <see cref="DataNormalizationMode"/> to use.</param>
+        /// <param name="factorFile">The <see cref="FactorFile"/> instance to use</param>
+        public PriceScaleFactorEnumerator(
+            IEnumerator<BaseData> rawDataEnumerator,
+            SubscriptionDataConfig config,
+            FactorFile factorFile)
+        {
+            _lastTradableDate = DateTime.MinValue;
+            _config = config;
+            _rawDataEnumerator = rawDataEnumerator;
+            _factorFile = factorFile;
+        }
+
+        /// <summary>
+        /// Dispose of the underlying enumerator.
+        /// </summary>
+        public void Dispose()
+        {
+            _rawDataEnumerator.Dispose();
+        }
+
+        /// <summary>
+        /// Advances the enumerator to the next element of the collection.
+        /// </summary>
+        /// <returns>
+        /// True if the enumerator was successfully advanced to the next element;
+        /// False if the enumerator has passed the end of the collection.
+        /// </returns>
+        public bool MoveNext()
+        {
+            var underlyingReturnValue = _rawDataEnumerator.MoveNext();
+            Current = _rawDataEnumerator.Current;
+
+            if (underlyingReturnValue
+                && Current != null
+                && _factorFile != null)
+            {
+                if (Current.Time.Date > _lastTradableDate)
+                {
+                    _lastTradableDate = Current.Time.Date;
+                    UpdateScaleFactor(_lastTradableDate);
+                }
+
+                var securityType = Current.Symbol.SecurityType;
+                switch (Current.DataType)
+                {
+                    case MarketDataType.TradeBar:
+                        var tradeBar = Current as TradeBar;
+                        if (tradeBar != null)
+                        {
+                            tradeBar.Open = _config.GetNormalizedPrice(tradeBar.Open);
+                            tradeBar.High = _config.GetNormalizedPrice(tradeBar.High);
+                            tradeBar.Low = _config.GetNormalizedPrice(tradeBar.Low);
+                            tradeBar.Close = _config.GetNormalizedPrice(tradeBar.Close);
+                        }
+                        break;
+                    case MarketDataType.Tick:
+                        var tick = Current as Tick;
+                        if (tick != null)
+                        {
+                            if (securityType == SecurityType.Equity)
+                            {
+                                tick.Value = _config.GetNormalizedPrice(tick.Value);
+                            }
+                            if (securityType == SecurityType.Option
+                                || securityType == SecurityType.Future)
+                            {
+                                if (tick.TickType == TickType.Trade)
+                                {
+                                    tick.Value = _config.GetNormalizedPrice(tick.Value);
+                                }
+                                else if (tick.TickType != TickType.OpenInterest)
+                                {
+                                    tick.BidPrice = tick.BidPrice != 0 ? _config.GetNormalizedPrice(tick.BidPrice) : 0;
+                                    tick.AskPrice = tick.AskPrice != 0 ?_config.GetNormalizedPrice(tick.AskPrice) : 0;
+
+                                    if (tick.BidPrice != 0)
+                                    {
+                                        if (tick.AskPrice != 0)
+                                        {
+                                            tick.Value = (tick.BidPrice + tick.AskPrice) / 2m;
+                                        }
+                                        else
+                                        {
+                                            tick.Value = tick.BidPrice;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        tick.Value = tick.AskPrice;
+                                    }
+                                }
+                            }
+                        }
+                        break;
+                    case MarketDataType.QuoteBar:
+                        var quoteBar = Current as QuoteBar;
+                        if (quoteBar != null)
+                        {
+                            if (quoteBar.Ask != null)
+                            {
+                                quoteBar.Ask.Open = _config.GetNormalizedPrice(quoteBar.Ask.Open);
+                                quoteBar.Ask.High = _config.GetNormalizedPrice(quoteBar.Ask.High);
+                                quoteBar.Ask.Low = _config.GetNormalizedPrice(quoteBar.Ask.Low);
+                                quoteBar.Ask.Close = _config.GetNormalizedPrice(quoteBar.Ask.Close);
+                            }
+                            if (quoteBar.Bid != null)
+                            {
+                                quoteBar.Bid.Open = _config.GetNormalizedPrice(quoteBar.Bid.Open);
+                                quoteBar.Bid.High = _config.GetNormalizedPrice(quoteBar.Bid.High);
+                                quoteBar.Bid.Low = _config.GetNormalizedPrice(quoteBar.Bid.Low);
+                                quoteBar.Bid.Close = _config.GetNormalizedPrice(quoteBar.Bid.Close);
+                            }
+                            quoteBar.Value = quoteBar.Close;
+                        }
+                        break;
+                    case MarketDataType.Auxiliary:
+                    case MarketDataType.Base:
+                    case MarketDataType.OptionChain:
+                    case MarketDataType.FuturesChain:
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            return underlyingReturnValue;
+        }
+
+        /// <summary>
+        /// Reset the IEnumeration
+        /// </summary>
+        /// <remarks>Not used</remarks>
+        public void Reset()
+        {
+            throw new NotImplementedException("Reset method not implemented. Assumes loop will only be used once.");
+        }
+
+        private void UpdateScaleFactor(DateTime date)
+        {
+            switch (_config.DataNormalizationMode)
+            {
+                case DataNormalizationMode.Raw:
+                    return;
+
+                case DataNormalizationMode.TotalReturn:
+                case DataNormalizationMode.SplitAdjusted:
+                    _config.PriceScaleFactor = _factorFile.GetSplitFactor(date);
+                    break;
+
+                case DataNormalizationMode.Adjusted:
+                    _config.PriceScaleFactor = _factorFile.GetPriceScaleFactor(date);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -375,7 +375,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // as updating factors and symbol mapping
                     if (instance.EndTime.Date > _tradeableDates.Current)
                     {
-                        var currentPriceScaleFactor = _config.PriceScaleFactor;
                         // this is fairly hacky and could be solved by removing the aux data from this class
                         // the case is with coarse data files which have many daily sized data points for the
                         // same date,
@@ -384,32 +383,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             // this will advance the date enumerator and determine if a new
                             // instance of the subscription enumerator is required
                             _subscriptionFactoryEnumerator = ResolveDataEnumerator(false);
-                        }
-
-                        // TODO: we should be able to remove this `if` once the underlying data
-                        // scale process is performed later in the enumerator stack and in its own
-                        // enumerator.
-                        // with hourly resolution the first bar for the new date is received
-                        // before the price scale factor is updated by ResolveDataEnumerator,
-                        // so we have to 'rescale' prices before emitting the bar
-                        if (currentPriceScaleFactor != _config.PriceScaleFactor)
-                        {
-                            if ((_config.Resolution == Resolution.Hour
-                                || (_config.Resolution == Resolution.Daily
-                                    && instance.EndTime.Date > _tradeableDates.Current))
-                                && (_config.SecurityType == SecurityType.Equity
-                                || _config.SecurityType == SecurityType.Option))
-                            {
-                                var tradeBar = instance as TradeBar;
-                                if (tradeBar != null)
-                                {
-                                    var bar = tradeBar;
-                                    bar.Open = _config.GetNormalizedPrice(GetRawValue(bar.Open, _config.SumOfDividends, currentPriceScaleFactor));
-                                    bar.High = _config.GetNormalizedPrice(GetRawValue(bar.High, _config.SumOfDividends, currentPriceScaleFactor));
-                                    bar.Low = _config.GetNormalizedPrice(GetRawValue(bar.Low, _config.SumOfDividends, currentPriceScaleFactor));
-                                    bar.Close = _config.GetNormalizedPrice(GetRawValue(bar.Close, _config.SumOfDividends, currentPriceScaleFactor));
-                                }
-                            }
                         }
                     }
 
@@ -579,8 +552,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     continue;
                 }
 
-                UpdateScaleFactors(date);
-
                 // we've passed initial checks,now go get data for this date!
                 return true;
             }
@@ -591,68 +562,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        /// For backwards adjusted data the price is adjusted by a scale factor which is a combination of splits and dividends.
-        /// This backwards adjusted price is used by default and fed as the current price.
-        /// </summary>
-        /// <param name="date">Current date of the backtest.</param>
-        private void UpdateScaleFactors(DateTime date)
-        {
-            if (_hasScaleFactors)
-            {
-                switch (_config.DataNormalizationMode)
-                {
-                    case DataNormalizationMode.Raw:
-                        return;
-
-                    case DataNormalizationMode.TotalReturn:
-                    case DataNormalizationMode.SplitAdjusted:
-                        _config.PriceScaleFactor = _factorFile.GetSplitFactor(date);
-                        break;
-
-                    case DataNormalizationMode.Adjusted:
-                        _config.PriceScaleFactor = _factorFile.GetPriceScaleFactor(date);
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
-        }
-
-        /// <summary>
         /// Reset the IEnumeration
         /// </summary>
         /// <remarks>Not used</remarks>
         public void Reset()
         {
             throw new NotImplementedException("Reset method not implemented. Assumes loop will only be used once.");
-        }
-
-        /// <summary>
-        /// Un-normalizes a price
-        /// </summary>
-        private decimal GetRawValue(decimal price, decimal sumOfDividends, decimal priceScaleFactor)
-        {
-            switch (_config.DataNormalizationMode)
-            {
-                case DataNormalizationMode.Raw:
-                    break;
-
-                case DataNormalizationMode.SplitAdjusted:
-                case DataNormalizationMode.Adjusted:
-                    // we need to 'unscale' the price
-                    price = price / priceScaleFactor;
-                    break;
-
-                case DataNormalizationMode.TotalReturn:
-                    // we need to remove the dividends since we've been accumulating them in the price
-                    price = (price - sumOfDividends) / priceScaleFactor;
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-            return price;
         }
 
         /// <summary>

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -129,13 +129,13 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             dataReader.DownloadFailed += (sender, args) => { OnDownloadFailed(new DownloadFailedEventArgs(args.Message, args.StackTrace)); };
             dataReader.ReaderErrorDetected += (sender, args) => { OnReaderErrorDetected(new ReaderErrorDetectedEventArgs(args.Message, args.StackTrace)); };
 
-            var enumerator = CorporateEventEnumeratorFactory.CreateEnumerators(
+            var reader = CorporateEventEnumeratorFactory.CreateEnumerators(
+                dataReader,
                 config,
                 _factorFileProvider,
                 dataReader,
                 mapFileResolver,
                 false);
-            IEnumerator<BaseData> reader = new SynchronizingEnumerator(dataReader, enumerator);
 
             // has to be initialized after adding all the enumerators since it will execute a MoveNext
             dataReader.Initialize();

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -157,6 +157,7 @@
     <Compile Include="DataFeeds\Enumerators\ITradableDateEventProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\ITradableDatesNotifier.cs" />
     <Compile Include="DataFeeds\Enumerators\MappingEventProvider.cs" />
+    <Compile Include="DataFeeds\Enumerators\PriceScaleFactorEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\SplitEventProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\Factories\LiveCustomDataSubscriptionEnumeratorFactory.cs" />
     <Compile Include="DataFeeds\Enumerators\LiveBaseDataSynchronizingEnumerator.cs" />

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -900,7 +900,15 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             algorithm.Transactions.SetOrderProcessor(transactionHandler);
 
-            Task.Run(() => transactionHandler.Run());
+            var task = Task.Run(() => transactionHandler.Run());
+
+            while (task.Status != TaskStatus.Running
+                && task.Status != TaskStatus.Faulted
+                && task.Status != TaskStatus.RanToCompletion)
+            {
+                // wait for the task to start
+                Thread.Sleep(5);
+            }
 
             var ticket = algorithm.LimitOrder(security.Symbol, 1, 100);
 

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -900,15 +900,14 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             algorithm.Transactions.SetOrderProcessor(transactionHandler);
 
-            var task = Task.Run(() => transactionHandler.Run());
-
-            while (task.Status != TaskStatus.Running
-                && task.Status != TaskStatus.Faulted
-                && task.Status != TaskStatus.RanToCompletion)
-            {
-                // wait for the task to start
-                Thread.Sleep(5);
-            }
+            var flag = new ManualResetEvent(false);
+            Task.Run(() =>
+                {
+                    flag.Set();
+                    transactionHandler.Run();
+                });
+            // lets wait until the task starts running
+            flag.WaitOne();
 
             var ticket = algorithm.LimitOrder(security.Symbol, 1, 100);
 

--- a/Tests/Engine/DataFeeds/Enumerators/PriceScaleFactorEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/PriceScaleFactorEnumeratorTests.cs
@@ -1,0 +1,273 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+using Tick = QuantConnect.Data.Market.Tick;
+
+namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
+{
+    [TestFixture]
+    public class PriceScaleFactorEnumeratorTests
+    {
+        private SubscriptionDataConfig _config;
+        private FactorFile _factorFile;
+        private RawDataEnumerator _rawDataEnumerator;
+
+        [SetUp]
+        public void Setup()
+        {
+            _config = new SubscriptionDataConfig(typeof(TradeBar),
+                Symbols.SPY,
+                Resolution.Daily,
+                TimeZones.NewYork,
+                TimeZones.NewYork,
+                true,
+                true,
+                false);
+            _factorFile = FactorFile.Read(
+                _config.Symbol.Value, _config.Symbol.ID.Market);
+            _rawDataEnumerator = new RawDataEnumerator();
+        }
+
+        [Test]
+        public void EquityTradeBar()
+        {
+            var enumerator = new PriceScaleFactorEnumerator(
+                _rawDataEnumerator,
+                _config,
+                _factorFile);
+            _rawDataEnumerator.CurrentValue = new TradeBar(
+                new DateTime(2018, 1, 1),
+                _config.Symbol,
+                10,
+                10,
+                10,
+                10,
+                100);
+            Assert.IsTrue(enumerator.MoveNext());
+            var tradeBar = enumerator.Current as TradeBar;
+            var expectedValue = 10 * _config.PriceScaleFactor;
+
+            Assert.Less(expectedValue, 10);
+            Assert.AreEqual(expectedValue, tradeBar.Price);
+            Assert.AreEqual(expectedValue, tradeBar.Open);
+            Assert.AreEqual(expectedValue, tradeBar.Close);
+            Assert.AreEqual(expectedValue, tradeBar.High);
+            Assert.AreEqual(expectedValue, tradeBar.Low);
+            Assert.AreEqual(expectedValue, tradeBar.Value);
+        }
+
+        [Test]
+        public void EquityQuoteBar()
+        {
+            var enumerator = new PriceScaleFactorEnumerator(
+                _rawDataEnumerator,
+                _config,
+                _factorFile);
+            _rawDataEnumerator.CurrentValue = new QuoteBar(
+                new DateTime(2018, 1, 1),
+                _config.Symbol,
+                new Bar(10, 10, 10, 10),
+                100,
+                new Bar(10, 10, 10, 10),
+                100);
+            Assert.IsTrue(enumerator.MoveNext());
+            var quoteBar = enumerator.Current as QuoteBar;
+            var expectedValue = 10 * _config.PriceScaleFactor;
+
+            Assert.Less(expectedValue, 10);
+
+            Assert.AreEqual(expectedValue, quoteBar.Price);
+            Assert.AreEqual(expectedValue, quoteBar.Value);
+            Assert.AreEqual(expectedValue, quoteBar.Open);
+            Assert.AreEqual(expectedValue, quoteBar.Close);
+            Assert.AreEqual(expectedValue, quoteBar.High);
+            Assert.AreEqual(expectedValue, quoteBar.Low);
+            // bid
+            Assert.AreEqual(expectedValue, quoteBar.Bid.Open);
+            Assert.AreEqual(expectedValue, quoteBar.Bid.Close);
+            Assert.AreEqual(expectedValue, quoteBar.Bid.High);
+            Assert.AreEqual(expectedValue, quoteBar.Bid.Low);
+            // ask
+            Assert.AreEqual(expectedValue, quoteBar.Ask.Open);
+            Assert.AreEqual(expectedValue, quoteBar.Ask.Close);
+            Assert.AreEqual(expectedValue, quoteBar.Ask.High);
+            Assert.AreEqual(expectedValue, quoteBar.Ask.Low);
+        }
+
+        [Test]
+        public void EquityTick()
+        {
+            var enumerator = new PriceScaleFactorEnumerator(
+                _rawDataEnumerator,
+                _config,
+                _factorFile);
+            _rawDataEnumerator.CurrentValue = new Tick(
+                new DateTime(2018, 1, 1),
+                _config.Symbol,
+                10,
+                10,
+                10);
+            Assert.IsTrue(enumerator.MoveNext());
+            var tick = enumerator.Current as Tick;
+            var expectedValue = 10 * _config.PriceScaleFactor;
+
+            Assert.Less(expectedValue, 10);
+            Assert.AreEqual(expectedValue, tick.Price);
+            Assert.AreEqual(expectedValue, tick.Value);
+        }
+
+        [Test]
+        public void FactorFileIsNull()
+        {
+            var enumerator = new PriceScaleFactorEnumerator(
+                _rawDataEnumerator,
+                _config,
+                null);
+            _rawDataEnumerator.CurrentValue = new Tick(
+                new DateTime(2018, 1, 1),
+                _config.Symbol,
+                10,
+                10,
+                10);
+            Assert.IsTrue(enumerator.MoveNext());
+            var tick = enumerator.Current as Tick;
+            Assert.AreEqual(10, tick.Price);
+            Assert.AreEqual(10, tick.Value);
+        }
+
+        [Test]
+        public void RawEnumeratorReturnsFalse()
+        {
+            var enumerator = new PriceScaleFactorEnumerator(
+                _rawDataEnumerator,
+                _config,
+                _factorFile);
+            _rawDataEnumerator.CurrentValue = new Tick(
+                new DateTime(2018, 1, 1),
+                _config.Symbol,
+                10,
+                10,
+                10);
+            _rawDataEnumerator.MoveNextReturnValue = false;
+            Assert.IsFalse(enumerator.MoveNext());
+            Assert.AreEqual(_rawDataEnumerator.CurrentValue, enumerator.Current);
+        }
+
+        [Test]
+        public void RawEnumeratorCurrentIsNull()
+        {
+            var enumerator = new PriceScaleFactorEnumerator(
+                _rawDataEnumerator,
+                _config,
+                _factorFile);
+            _rawDataEnumerator.CurrentValue = null;
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+        }
+
+        [Test]
+        public void UpdatesFactorFileCorrectly()
+        {
+            var dateBeforeUpadate = new DateTime(2018, 3, 14);
+            var dateAtUpadate = new DateTime(2018, 3, 15);
+            var dateAfterUpadate = new DateTime(2018, 3, 16);
+
+            var enumerator = new PriceScaleFactorEnumerator(
+                _rawDataEnumerator,
+                _config,
+                _factorFile);
+
+            // Before factor file update date (2018, 3, 15)
+            _rawDataEnumerator.CurrentValue = new Tick(
+                dateBeforeUpadate,
+                _config.Symbol,
+                10,
+                10,
+                10);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            var expectedFactor = _factorFile.GetPriceScaleFactor(dateBeforeUpadate);
+            var tick = enumerator.Current as Tick;
+            Assert.AreEqual(expectedFactor, _config.PriceScaleFactor);
+            Assert.AreEqual(10 * expectedFactor, tick.Price);
+            Assert.AreEqual(10 * expectedFactor, tick.Value);
+
+            // At factor file update date (2018, 3, 15)
+            _rawDataEnumerator.CurrentValue = new Tick(
+                dateAtUpadate,
+                _config.Symbol,
+                10,
+                10,
+                10);
+            Assert.IsTrue(enumerator.MoveNext());
+            var expectedFactor2 = _factorFile.GetPriceScaleFactor(dateAtUpadate);
+            var tick2 = enumerator.Current as Tick;
+            Assert.AreEqual(expectedFactor2, _config.PriceScaleFactor);
+            Assert.AreEqual(10 * expectedFactor2, tick2.Price);
+            Assert.AreEqual(10 * expectedFactor2, tick2.Value);
+
+            // After factor file update date (2018, 3, 15)
+            _rawDataEnumerator.CurrentValue = new Tick(
+                dateAfterUpadate,
+                _config.Symbol,
+                10,
+                10,
+                10);
+            Assert.IsTrue(enumerator.MoveNext());
+            var expectedFactor3 = _factorFile.GetPriceScaleFactor(dateAfterUpadate);
+            var tick3 = enumerator.Current as Tick;
+            Assert.AreEqual(expectedFactor3, _config.PriceScaleFactor);
+            Assert.AreEqual(10 * expectedFactor3, tick3.Price);
+            Assert.AreEqual(10 * expectedFactor3, tick3.Value);
+        }
+
+        private class RawDataEnumerator : IEnumerator<BaseData>
+        {
+            public bool MoveNextReturnValue { get; set; }
+            public BaseData CurrentValue { get; set; }
+
+            public BaseData Current => CurrentValue;
+
+            object IEnumerator.Current => CurrentValue;
+
+            public RawDataEnumerator()
+            {
+                MoveNextReturnValue = true;
+            }
+            public bool MoveNext()
+            {
+                return MoveNextReturnValue;
+            }
+
+            public void Reset()
+            {
+                throw new NotImplementedException();
+            }
+            public void Dispose()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Engine\DataFeeds\Enumerators\DelistingEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\Factories\FuturesChainUniverseSubscriptionEnumeratorFactoryTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\AuxiliaryDataEnumeratorTests.cs" />
+    <Compile Include="Engine\DataFeeds\Enumerators\PriceScaleFactorEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\MockDataFeed.cs" />
     <Compile Include="Engine\DataFeeds\PendingRemovalsManagerTests.cs" />
     <Compile Include="Engine\DataFeeds\UniverseSelectionTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding new `PriceScaleFactorEnumerator` that will scale raw prices
based on a provided `SubscriptionDataConfig` and update the
`SubscriptionDataConfig.PriceScaleFactor`. Adding unit tests.
- `BaseData` factories (`TradeBar.cs`, `QuoteBar.cs`, `Tick.cs`) will
no longer scale factor prices, they will generate data points in raw
mode.
- `SubscriptionDataReader` will no longer update the
`SuscriptionDataConfig.PriceScaleFactor`
- Fix `BrokerageTransactionHandlerTests` unit test that was having a
race condition.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2961
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Will allow us to add a raw data cache. Also will fix dependency issues between the `SubscriptionDataReader` updating the `SubscriptionDataConfig.PriceScaleFactor` and the underlying `BaseData` factories.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests. In the cloud 10 year back test, `Daily`, `Hour`, `Minute`, `Second` and `Tick` Resolution for "SPY", "AAPL", "UPRO"
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->