### PR TITLE
Fix SubscriptionManager.AddConsolidator for Resolution.Tick

### DIFF
--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -164,7 +164,7 @@ namespace QuantConnect.Data
             foreach (var subscription in subscriptions)
             {
                 // we need to be able to pipe data directly from the data feed into the consolidator
-                if (consolidator.InputType.IsAssignableFrom(subscription.Type))
+                if (IsSubscriptionValidForConsolidator(subscription, consolidator))
                 {
                     subscription.Consolidators.Add(consolidator);
                     return;
@@ -241,6 +241,23 @@ namespace QuantConnect.Data
         public void SetDataManager(IAlgorithmSubscriptionManager subscriptionManager)
         {
             _subscriptionManager = subscriptionManager;
+        }
+
+        /// <summary>
+        /// Checks if the subscription is valid for the consolidator
+        /// </summary>
+        /// <param name="subscription">The subscription configuration</param>
+        /// <param name="consolidator">The consolidator</param>
+        /// <returns>true if the subscription is valid for the consolidator</returns>
+        public static bool IsSubscriptionValidForConsolidator(SubscriptionDataConfig subscription, IDataConsolidator consolidator)
+        {
+            if (subscription.Type == typeof(Tick))
+            {
+                var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(consolidator.OutputType, subscription.Symbol.SecurityType);
+                return subscription.TickType == tickType;
+            }
+
+            return consolidator.InputType.IsAssignableFrom(subscription.Type);
         }
     }
 }


### PR DESCRIPTION

#### Description
Since subscriptions are enumerated in a non-deterministic order, tick consolidators for multi-tick-type security types (such as `Crypto`, `Future` and `Option`) could end up being added to the wrong subscription, e.g. `QuoteBarTickConsolidator` added to a tick subscription with `TickType.Trade`. This was causing the `DataConsolidated` event handler to never be called.
The `Resolution.Tick` case is now handled properly, checking the subscription tick type.

#### Related Issue
Closes #2764 

#### Motivation and Context
Consolidator event handlers for tick consolidators not firing.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests included + verified the example algorithm in #2764 is now firing events.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`