### PR TITLE
Fix IB Tick History Requests Returning Second Bars

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2602,6 +2602,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 yield break;
             }
 
+            // tick resolution not supported for now
+            if (request.Resolution == Resolution.Tick)
+            {
+                // TODO: upgrade IB C# API DLL
+                // In IB API version 973.04, the reqHistoricalTicks function has been added,
+                // which would now enable us to support history requests at Tick resolution.
+                yield break;
+            }
+
             // preparing the data for IB request
             var contract = CreateContract(request.Symbol);
             var resolution = ConvertResolution(request.Resolution);


### PR DESCRIPTION
#### Description
Currently, tick resolution history requests are returning second bars instead of returning ticks.

IB recently added a new `reqHistoricalTicks` API function for tick historical data:
https://interactivebrokers.github.io/tws-api/historical_time_and_sales.html

We recently upgraded the IB Gateway client in the cloud to the latest version, so we can now implement historical tick requests properly.

In this PR, for now, we return an empty result for Tick history requests, as returning second bars instead causes a runtime error in warmup (as reported in #1837).
In another PR, we will upgrade the IB C# API DLL and support Tick history requests.


#### Related Issue
#1837

#### Motivation and Context
Runtime error in warmup at Tick resolution with any asset type:
```
Runtime Error: A data subscription for type 'TradeBar' was not found.
```

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Run this algorithm with the IB brokerage using the `BrokerageHistoryProvider`:
``` C#
    public class BasicTemplateAlgorithm : QCAlgorithm
    {
        public override void Initialize()
        {
            SetStartDate(2013, 10, 07);  //Set Start Date
            SetEndDate(2013, 10, 11);    //Set End Date
            SetCash(100000);             //Set Strategy Cash

            AddEquity("SPY", Resolution.Tick);
            SetWarmup(TimeSpan.FromHours(1));
        }
    }
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`