### PR TITLE
Cache raw data points

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -494,7 +494,7 @@ namespace QuantConnect.Algorithm
             var isExtendedMarketHours = configs.IsExtendedMarketHours();
 
             var startTime = _historyRequestFactory.GetStartTimeAlgoTz(security.Symbol, 1, resolution, security.Exchange.Hours);
-            var endTime   = Time.RoundDown(resolution.ToTimeSpan());
+            var endTime   = Time;
 
             // request QuoteBar for Options and Futures
             var dataType = typeof(BaseData);

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -23,7 +23,6 @@ using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Custom;
 using QuantConnect.Data.Custom.Tiingo;
-using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
 using QuantConnect.Logging;

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -155,7 +155,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     $"Type is: {cacheItem.Value.GetType()}");
             }
             // Find the first data point 10 days (just in case) before the desired date
-            // and subtract one item (just in case there wasn't a time gap and data.Time is after _date)
+            // and subtract one item (just in case there was a time gap and data.Time is after _date)
             var index = cache.FindIndex(data => data.Time.AddDays(10) > _date);
             index = index > 0 ? (index - 1) : 0;
             foreach (var data in cache.Skip(index))

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -15,11 +15,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds.Transport;
 using QuantConnect.Util;
+using System.Runtime.Caching;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.UniverseSelection;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -34,7 +39,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private readonly BaseData _factory;
         private readonly DateTime _date;
         private readonly SubscriptionDataConfig _config;
+        private bool _shouldCacheDataPoints;
         private readonly IDataCacheProvider _dataCacheProvider;
+        private static readonly MemoryCache BaseDataSourceCache = new MemoryCache("BaseDataSourceCache",
+            // Cache can use up to 70% of the installed physical memory
+            new NameValueCollection{ { "physicalMemoryLimitPercentage", "70"} });
+        private static readonly CacheItemPolicy CachePolicy = new CacheItemPolicy
+        {
+            // Cache entry should be evicted if it has not been accessed in given span of time:
+            SlidingExpiration = TimeSpan.FromMinutes(5)
+        };
 
         /// <summary>
         /// Event fired when the specified source is considered invalid, this may
@@ -69,6 +83,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _config = config;
             _isLiveMode = isLiveMode;
             _factory = (BaseData) ObjectActivator.GetActivator(config.Type).Invoke(new object[] { config.Type });
+            _shouldCacheDataPoints = !_config.IsCustomData && _config.Resolution >= Resolution.Hour
+                && _config.Type != typeof(FineFundamental) && _config.Type != typeof(CoarseFundamental);
         }
 
         /// <summary>
@@ -78,35 +94,75 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>An <see cref="IEnumerable{BaseData}"/> that contains the data in the source</returns>
         public IEnumerable<BaseData> Read(SubscriptionDataSource source)
         {
-            using (var reader = CreateStreamReader(source))
+            List<BaseData> cache;
+            _shouldCacheDataPoints = _shouldCacheDataPoints &&
+                // only cache local files
+                source.TransportMedium == SubscriptionTransportMedium.LocalFile;
+            var cacheItem = _shouldCacheDataPoints
+                ? BaseDataSourceCache.GetCacheItem(source.Source + _config.Type) : null;
+            if (cacheItem == null)
             {
-                // if the reader doesn't have data then we're done with this subscription
-                if (reader == null || reader.EndOfStream)
+                cache = new List<BaseData>();
+                using (var reader = CreateStreamReader(source))
                 {
-                    OnCreateStreamReaderError(_date, source);
+                    // if the reader doesn't have data then we're done with this subscription
+                    if (reader == null || reader.EndOfStream)
+                    {
+                        OnCreateStreamReaderError(_date, source);
+                        yield break;
+                    }
+                    // while the reader has data
+                    while (!reader.EndOfStream)
+                    {
+                        // read a line and pass it to the base data factory
+                        var line = reader.ReadLine();
+                        BaseData instance = null;
+                        try
+                        {
+                            instance = _factory.Reader(_config, line, _date, _isLiveMode);
+                        }
+                        catch (Exception err)
+                        {
+                            OnReaderError(line, err);
+                        }
+
+                        if (instance != null && instance.EndTime != default(DateTime))
+                        {
+                            if (_shouldCacheDataPoints)
+                            {
+                                cache.Add(instance);
+                            }
+                            else
+                            {
+                                yield return instance;
+                            }
+                        }
+                    }
+                }
+
+                if (!_shouldCacheDataPoints)
+                {
                     yield break;
                 }
 
-                // while the reader has data
-                while (!reader.EndOfStream)
-                {
-                    // read a line and pass it to the base data factory
-                    var line = reader.ReadLine();
-                    BaseData instance = null;
-                    try
-                    {
-                        instance = _factory.Reader(_config, line, _date, _isLiveMode);
-                    }
-                    catch (Exception err)
-                    {
-                        OnReaderError(line, err);
-                    }
-
-                    if (instance != null && instance.EndTime != default(DateTime))
-                    {
-                        yield return instance;
-                    }
-                }
+                cacheItem = new CacheItem(source.Source + _config.Type, cache);
+                BaseDataSourceCache.Add(cacheItem, CachePolicy);
+            }
+            cache = cacheItem.Value as List<BaseData>;
+            if (cache == null)
+            {
+                throw new InvalidOperationException("CacheItem can not be cast into expected type. " +
+                    $"Type is: {cacheItem.Value.GetType()}");
+            }
+            // Find the first data point 10 days (just in case) before the desired date
+            // and subtract one item (just in case there wasn't a time gap and data.Time is after _date)
+            var index = cache.FindIndex(data => data.Time.AddDays(10) > _date);
+            index = index > 0 ? (index - 1) : 0;
+            foreach (var data in cache.Skip(index))
+            {
+                var clone = data.Clone();
+                clone.Symbol = _config.Symbol;
+                yield return clone;
             }
         }
 

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -135,6 +135,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -51,8 +51,8 @@ namespace QuantConnect.Tests.Common.Securities
         private readonly SubscriptionDataConfig _quoteBarConfig = new SubscriptionDataConfig(typeof(QuoteBar),
                                                                                      Symbols.EURUSD,
                                                                                      Resolution.Second,
-                                                                                     TimeZones.NewYork,
-                                                                                     TimeZones.NewYork,
+                                                                                     DateTimeZone.ForOffset(Offset.FromHours(-5)),
+                                                                                     DateTimeZone.ForOffset(Offset.FromHours(-5)),
                                                                                      false,
                                                                                      false,
                                                                                      false,
@@ -80,7 +80,7 @@ namespace QuantConnect.Tests.Common.Securities
             _algo.HistoryProvider = historyProvider;
             _algo.SubscriptionManager.SetDataManager(new DataManagerStub(_algo));
             _tradeBarSecurity = new Security(
-                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
                 _tradeBarConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
@@ -88,7 +88,7 @@ namespace QuantConnect.Tests.Common.Securities
             );
 
             _quoteBarSecurity = new Security(
-                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.ForOffset(Offset.FromHours(-5))),
                 _quoteBarConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),

--- a/Tests/Engine/DataFeeds/TextSubscriptionDataSourceReaderTests.cs
+++ b/Tests/Engine/DataFeeds/TextSubscriptionDataSourceReaderTests.cs
@@ -1,0 +1,176 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using Accord.Math.Comparers;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture]
+    public class TextSubscriptionDataSourceReaderTests
+    {
+        private SubscriptionDataConfig _config;
+        private DateTime _initialDate;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _config = new SubscriptionDataConfig(
+                typeof(TestTradeBarFactory),
+                Symbols.SPY,
+                Resolution.Daily,
+                TimeZones.NewYork,
+                TimeZones.NewYork,
+                true,
+                true,
+                false);
+            _initialDate = new DateTime(2018, 1, 1);
+        }
+
+        [Test]
+        public void CachedDataIsReturnedAsClone()
+        {
+            var reader = new TextSubscriptionDataSourceReader(
+                new SingleEntryDataCacheProvider(new DefaultDataProvider()),
+                _config,
+                _initialDate,
+                false);
+            var source = (new TradeBar()).GetSource(_config, _initialDate, false);
+
+            var dataBars = reader.Read(source).First();
+            dataBars.Value = 0;
+            var dataBars2 = reader.Read(source).First();
+
+            Assert.AreNotEqual(dataBars.Price, dataBars2.Price);
+        }
+
+        [Test]
+        public void DataIsCachedCorrectly()
+        {
+            var reader = new TextSubscriptionDataSourceReader(
+                new SingleEntryDataCacheProvider(new DefaultDataProvider()),
+                _config,
+                _initialDate,
+                false);
+            var source = (new TradeBar()).GetSource(_config, _initialDate, false);
+
+            var dataBars = reader.Read(source).ToList();
+            var dataBars2 = reader.Read(source).ToList();
+
+            Assert.AreEqual(dataBars2.Count, dataBars.Count);
+            Assert.IsTrue(dataBars.SequenceEqual(dataBars2, new CustomComparer<BaseData>(
+                (data, baseData) =>
+                {
+                    if (data.EndTime == baseData.EndTime
+                        && data.Time == baseData.Time
+                        && data.Symbol == baseData.Symbol
+                        && data.Price == baseData.Price
+                        && data.DataType == baseData.DataType
+                        && data.Value == baseData.Value)
+                    {
+                        return 0;
+                    }
+                    return 1;
+                })));
+        }
+
+        [Test]
+        public void RespectsInitialDate()
+        {
+            var reader = new TextSubscriptionDataSourceReader(
+                new SingleEntryDataCacheProvider(new DefaultDataProvider()),
+                _config,
+                _initialDate,
+                false);
+            var source = (new TradeBar()).GetSource(_config, _initialDate, false);
+            var dataBars = reader.Read(source).First();
+
+            Assert.Less(dataBars.EndTime, _initialDate);
+
+            // 80 days after _initialDate
+            var initialDate2 = _initialDate.AddDays(80);
+            var reader2 = new TextSubscriptionDataSourceReader(
+                new SingleEntryDataCacheProvider(new DefaultDataProvider()),
+                _config,
+                initialDate2,
+                false);
+            var source2 = (new TradeBar()).GetSource(_config, initialDate2, false);
+            var dataBars2 = reader2.Read(source2).First();
+
+            Assert.Less(dataBars2.EndTime, initialDate2);
+
+            // 80 days before _initialDate
+            var initialDate3 = _initialDate.AddDays(-80);
+            var reader3 = new TextSubscriptionDataSourceReader(
+                new SingleEntryDataCacheProvider(new DefaultDataProvider()),
+                _config,
+                initialDate3,
+                false);
+            var source3 = (new TradeBar()).GetSource(_config, initialDate3, false);
+            var dataBars3 = reader3.Read(source3).First();
+
+            Assert.Less(dataBars3.EndTime, initialDate3);
+        }
+
+        [TestCase(Resolution.Daily, true)]
+        [TestCase(Resolution.Hour, true)]
+        [TestCase(Resolution.Minute, false)]
+        [TestCase(Resolution.Second, false)]
+        [TestCase(Resolution.Tick, false)]
+        public void CacheBehaviorDifferentResolutions(Resolution resolution, bool shouldBeCached)
+        {
+            _config = new SubscriptionDataConfig(
+                typeof(TestTradeBarFactory),
+                Symbols.SPY,
+                resolution,
+                TimeZones.NewYork,
+                TimeZones.NewYork,
+                true,
+                true,
+                false);
+            var reader = new TextSubscriptionDataSourceReader(
+                new SingleEntryDataCacheProvider(new DefaultDataProvider()),
+                _config,
+                new DateTime(2013, 10, 07),
+                false);
+            var source = (new TradeBar()).GetSource(_config, new DateTime(2013, 10, 07), false);
+
+            // first call should cache
+            reader.Read(source).First();
+            TestTradeBarFactory.ReaderWasCalled = false;
+            reader.Read(source).First();
+            Assert.AreEqual(!shouldBeCached, TestTradeBarFactory.ReaderWasCalled);
+        }
+
+        private class TestTradeBarFactory : TradeBar
+        {
+            /// <summary>
+            /// Will be true when data is created from a parsed file line
+            /// </summary>
+            public static bool ReaderWasCalled { get; set; }
+
+            public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
+            {
+                ReaderWasCalled = true;
+                return base.Reader(config, line, date, isLiveMode);
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Engine\DataFeeds\Enumerators\PriceScaleFactorEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\MockDataFeed.cs" />
     <Compile Include="Engine\DataFeeds\PendingRemovalsManagerTests.cs" />
+    <Compile Include="Engine\DataFeeds\TextSubscriptionDataSourceReaderTests.cs" />
     <Compile Include="Engine\DataFeeds\UniverseSelectionTests.cs" />
     <Compile Include="Engine\DataFeeds\SubscriptionTests.cs" />
     <Compile Include="PythonSetup.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `TextSubscriptionDataSourceReader` will now cache raw price mode data
points for each requested source file, per data type.
   - Caching will be handled by the `MemoryCache` class. Max physical memory usage will be 70%. 
Cache entry should be evicted if it has not been accessed in 5 minutes.
   - Adding unit tests
- `GetLastKnownPrice()` will not `RoundDown` end time. This was causing
it to fail to fetch any data point in some cases.

### CLOUD performance testing
```
        public override void Initialize()
        {
            SetStartDate(2016, 01, 01);
            SetEndDate(2018, 01, 01);
            SetCash(10000);
            _symbol = AddEquity("SPY").Symbol;
        }
        public override void OnEndOfDay()
        {
            var dailyHistory = History(_symbol, 1, Resolution.Daily/Hour).First();
        }
```

**PR Resolution.Hour**
4.62 seconds at 42k data points per second. Processing total of 196,141 data points.
4.38 seconds at 45k data points per second. Processing total of 196,141 data points.
4.86 seconds at 40k data points per second. Processing total of 196,141 data points.
**PR Resolution.Daily**
5.13 seconds at 38k data points per second. Processing total of 196,141 data points.
4.27 seconds at 46k data points per second. Processing total of 196,141 data points.
4.02 seconds at 49k data points per second. Processing total of 196,141 data points.
**MASTER Resolution.Hour**
82.92 seconds at 2k data points per second. Processing total of 196,141 data points.
82.48 seconds at 2k data points per second. Processing total of 196,141 data points.
85.68 seconds at 2k data points per second. Processing total of 196,141 data points.
**MASTER Resolution.Daily**
16.73 seconds at 12k data points per second. Processing total of 196,141 data points.
17.46 seconds at 11k data points per second. Processing total of 196,141 data points.
15.71 seconds at 12k data points per second. Processing total of 196,141 data points.

**Result: ~20x improvement for `Resolution.Hour`. ~4x `Resolution.Daily`**

### Performance Analysis
**MASTER Resolution.Daily**
![imagen](https://user-images.githubusercontent.com/18473240/53649574-31498580-3c21-11e9-92a9-d3829e6f2939.png)

**MASTER Resolution.Hour**
![imagen](https://user-images.githubusercontent.com/18473240/53649799-c51b5180-3c21-11e9-973e-f843a8e231e0.png)

Both `Resolution.Daily` and `Resolution.Hour` data files are organized in 1 zip file per symbol (for the entire data history). **Each** history request has to open, read and parse this only data file. The objective of this PR is to cache and reuse this raw data.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/2820
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Daily and Hour Resolution History Requests were adding significant overhead to overall performance.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests. Performance testing in the cloud. Live deployment. Local testing
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->