### PR TITLE
Adds matching version of C# and Python Alpha algorithms

### DIFF
--- a/Algorithm.CSharp/Alphas/GasAndCrudeOilEnergyCorrelationAlpha.cs
+++ b/Algorithm.CSharp/Alphas/GasAndCrudeOilEnergyCorrelationAlpha.cs
@@ -1,0 +1,315 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Accord.Math;
+using Accord.Statistics;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Indicators;
+using QuantConnect.Orders.Fees;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp.Alphas
+{
+    /// <summary>
+    /// Energy prices, especially Oil and Natural Gas, are in general fairly correlated,
+    /// meaning they typically move in the same direction as an overall trend.This Alpha
+    /// uses this idea and implements an Alpha Model that takes Natural Gas ETF price
+    /// movements as a leading indicator for Crude Oil ETF price movements.We take the
+    /// Natural Gas/Crude Oil ETF pair with the highest historical price correlation and
+    /// then create insights for Crude Oil depending on whether or not the Natural Gas ETF price change
+    /// is above/below a certain threshold that we set (arbitrarily).
+    ///
+    /// This alpha is part of the Benchmark Alpha Series created by QuantConnect which are open
+    /// sourced so the community and client funds can see an example of an alpha.
+    ///</summary>
+    public class GasAndCrudeOilEnergyCorrelationAlpha : QCAlgorithmFramework
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2018, 1, 1);
+            SetCash(100000);
+
+            // Set zero transaction fees
+            SetSecurityInitializer(security => security.FeeModel = new ConstantFeeModel(0));
+
+            Func<string, Symbol> ToSymbol = x => QuantConnect.Symbol.Create(x, SecurityType.Equity, Market.USA);
+            var naturalGas = new[] { "UNG", "BOIL", "FCG" }.Select(ToSymbol).ToArray();
+            var crudeOil = new[] { "USO", "UCO", "DBO" }.Select(ToSymbol).ToArray();
+
+            // Manually curated universe
+            UniverseSettings.Resolution = Resolution.Minute;
+            SetUniverseSelection(new ManualUniverseSelectionModel(naturalGas.Concat(crudeOil)));
+
+            // Use PairsAlphaModel to establish insights
+            SetAlpha(new PairsAlphaModel(naturalGas, crudeOil, 90, Resolution.Minute));
+
+            // Equally weigh securities in portfolio, based on insights
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+
+            // Set Custom Execution Model
+            SetExecution(new CustomExecutionModel());
+
+            // Set Null Risk Management Model
+            SetRiskManagement(new NullRiskManagementModel());
+        }
+
+        /// <summary>
+        /// This Alpha model assumes that the ETF for natural gas is a good leading-indicator
+        /// of the price of the crude oil ETF.The model will take in arguments for a threshold
+        /// at which the model triggers an insight, the length of the look-back period for evaluating
+        /// rate-of-change of UNG prices, and the duration of the insight
+        /// </summary>
+        private class PairsAlphaModel : AlphaModel
+        {
+            private readonly Symbol[] _leading;
+            private readonly Symbol[] _following;
+            private readonly int _historyDays;
+            private readonly int _lookback;
+            private readonly decimal _differenceTrigger = 0.75m;
+            private readonly Resolution _resolution;
+            private readonly TimeSpan _predictionInterval;
+            private readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol;
+            private Tuple<SymbolData, SymbolData> _pair;
+
+            private DateTime _nextUpdate;
+
+            public PairsAlphaModel(
+                Symbol[] naturalGas,
+                Symbol[] crudeOil,
+                int historyDays = 90,
+                Resolution resolution = Resolution.Hour,
+                int lookback = 5,
+                decimal differenceTrigger = 0.75m)
+            {
+                _leading = naturalGas;
+                _following = crudeOil;
+                _historyDays = historyDays;
+                _resolution = resolution;
+                _lookback = lookback;
+                _differenceTrigger = differenceTrigger;
+                _symbolDataBySymbol = new Dictionary<Symbol, SymbolData>();
+                _predictionInterval = resolution.ToTimeSpan().Multiply(lookback);
+            }
+
+            public override IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data)
+            {
+                if (_nextUpdate == DateTime.MinValue || algorithm.Time > _nextUpdate)
+                {
+                    CorrelationPairsSelection();
+                    _nextUpdate = algorithm.Time.AddDays(30);
+                }
+
+                var magnitude = (double)Math.Round(_pair.Item1.Return / 100, 6);
+
+                if (_pair.Item1.Return > _differenceTrigger)
+                {
+                    yield return Insight.Price(_pair.Item2.Symbol, _predictionInterval, InsightDirection.Up, magnitude);
+                }
+                if (_pair.Item1.Return < -_differenceTrigger)
+                {
+                    yield return Insight.Price(_pair.Item2.Symbol, _predictionInterval, InsightDirection.Down, magnitude);
+                }
+            }
+
+            public void CorrelationPairsSelection()
+            {
+                var maxCorrelation = -1.0;
+                var matrix = new double[_historyDays, _following.Length + 1];
+
+                // Get returns for each oil ETF
+                for (var j = 0; j < _following.Length; j++)
+                {
+                    SymbolData symbolData2;
+                    if (_symbolDataBySymbol.TryGetValue(_following[j], out symbolData2))
+                    {
+                        var dailyReturn2 = symbolData2.DailyReturnArray;
+                        for (var i = 0; i < _historyDays; i++)
+                        {
+                            matrix[i, j + 1] = symbolData2.DailyReturnArray[i];
+                        }
+                    }
+                }
+
+                // Get returns for each natural gas ETF
+                for (var j = 0; j < _leading.Length; j++)
+                {
+                    SymbolData symbolData1;
+                    if (_symbolDataBySymbol.TryGetValue(_leading[j], out symbolData1))
+                    {
+                        for (var i = 0; i < _historyDays; i++)
+                        {
+                            matrix[i, 0] = symbolData1.DailyReturnArray[i];
+                        }
+
+                        var column = matrix.Correlation().GetColumn(0);
+                        var correlation = column.RemoveAt(0).Max();
+
+                        // Calculate the pair with highest historical correlation
+                        if (correlation > maxCorrelation)
+                        {
+                            var maxIndex = column.IndexOf(correlation) - 1;
+                            if (maxIndex < 0) continue;
+                            var symbolData2 = _symbolDataBySymbol[_following[maxIndex]];
+                            _pair = Tuple.Create(symbolData1, symbolData2);
+                            maxCorrelation = correlation;
+                        }
+                    }
+                }
+            }
+
+            public override void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+            {
+                foreach (var removed in changes.RemovedSecurities)
+                {
+                    if (_symbolDataBySymbol.ContainsKey(removed.Symbol))
+                    {
+                        _symbolDataBySymbol[removed.Symbol].RemoveConsolidators(algorithm);
+                        _symbolDataBySymbol.Remove(removed.Symbol);
+                    }
+                }
+
+                // Initialize data for added securities
+                var symbols = changes.AddedSecurities.Select(x => x.Symbol);
+                var dailyHistory = algorithm.History(symbols, _historyDays + 1, Resolution.Daily);
+                if (symbols.Count() > 0 && dailyHistory.Count() == 0)
+                {
+                    algorithm.Debug($"{algorithm.Time} :: No daily data");
+                }
+
+                dailyHistory.PushThrough(bar =>
+                {
+                    SymbolData symbolData;
+                    if (!_symbolDataBySymbol.TryGetValue(bar.Symbol, out symbolData))
+                    {
+                        symbolData = new SymbolData(algorithm, bar.Symbol, _historyDays, _lookback, _resolution);
+                        _symbolDataBySymbol.Add(bar.Symbol, symbolData);
+                    }
+                    // Update daily rate of change indicator
+                    symbolData.UpdateDailyRateOfChange(bar);
+                });
+
+                algorithm.History(symbols, _lookback, _resolution).PushThrough(bar =>
+                {
+                    // Update rate of change indicator with given resolution
+                    if (_symbolDataBySymbol.ContainsKey(bar.Symbol))
+                    {
+                        _symbolDataBySymbol[bar.Symbol].UpdateRateOfChange(bar);
+                    }
+                });
+            }
+
+            /// <summary>
+            /// Contains data specific to a symbol required by this model
+            /// </summary>
+            private class SymbolData
+            {
+                private readonly RateOfChangePercent _dailyReturn;
+                private readonly IDataConsolidator _dailyConsolidator;
+                private readonly RollingWindow<IndicatorDataPoint> _dailyReturnHistory;
+                private readonly IDataConsolidator _consolidator;
+
+                public Symbol Symbol { get; }
+
+                public RateOfChangePercent Return { get; }
+
+                public double[] DailyReturnArray => _dailyReturnHistory
+                    .OrderBy(x => x.EndTime)
+                    .Select(x => (double)x.Value).ToArray();
+
+                public SymbolData(QCAlgorithm algorithm, Symbol symbol, int dailyLookback, int lookback, Resolution resolution)
+                {
+                    Symbol = symbol;
+
+                    _dailyReturn = new RateOfChangePercent($"{symbol}.DailyROCP(1)", 1);
+                    _dailyConsolidator = algorithm.ResolveConsolidator(symbol, Resolution.Daily);
+                    _dailyReturnHistory = new RollingWindow<IndicatorDataPoint>(dailyLookback);
+                    _dailyReturn.Updated += (s, e) => _dailyReturnHistory.Add(e);
+                    algorithm.RegisterIndicator(symbol, _dailyReturn, _dailyConsolidator);
+
+                    Return = new RateOfChangePercent($"{symbol}.ROCP({lookback})", lookback);
+                    _consolidator = algorithm.ResolveConsolidator(symbol, resolution);
+                    algorithm.RegisterIndicator(symbol, Return, _consolidator);
+                }
+
+                public void RemoveConsolidators(QCAlgorithm algorithm)
+                {
+                    algorithm.SubscriptionManager.RemoveConsolidator(Symbol, _consolidator);
+                    algorithm.SubscriptionManager.RemoveConsolidator(Symbol, _dailyConsolidator);
+                }
+
+                public void UpdateRateOfChange(BaseData data)
+                {
+                    Return.Update(data.EndTime, data.Value);
+                }
+
+                internal void UpdateDailyRateOfChange(BaseData data)
+                {
+                    _dailyReturn.Update(data.EndTime, data.Value);
+                }
+
+                public override string ToString() => Return.ToDetailedString();
+            }
+        }
+
+        /// <summary>
+        /// Provides an implementation of IExecutionModel that immediately submits market orders to achieve the desired portfolio targets
+        /// </summary>
+        private class CustomExecutionModel : ExecutionModel
+        {
+            private readonly PortfolioTargetCollection _targetsCollection = new PortfolioTargetCollection();
+            private Symbol _previousSymbol;
+
+            /// <summary>
+            /// Immediately submits orders for the specified portfolio targets.
+            /// </summary>
+            /// <param name="algorithm">The algorithm instance</param>
+            /// <param name="targets">The portfolio targets to be ordered</param>
+            public override void Execute(QCAlgorithmFramework algorithm, IPortfolioTarget[] targets)
+            {
+                _targetsCollection.AddRange(targets);
+
+                foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))
+                {
+                    var openQuantity = algorithm.Transactions.GetOpenOrders(target.Symbol)
+                        .Sum(x => x.Quantity);
+                    var existing = algorithm.Securities[target.Symbol].Holdings.Quantity + openQuantity;
+                    var quantity = target.Quantity - existing;
+
+                    // Liquidate positions in Crude Oil ETF that is no longer part of the highest-correlation pair
+                    if (_previousSymbol != null && target.Symbol != _previousSymbol)
+                    {
+                        algorithm.Liquidate(_previousSymbol);
+                    }
+                    if (quantity != 0)
+                    {
+                        algorithm.MarketOrder(target.Symbol, quantity);
+                        _previousSymbol = target.Symbol;
+                    }
+                }
+                _targetsCollection.ClearFulfilled(algorithm);
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/Alphas/GreenblattMagicFormulaAlpha.cs
+++ b/Algorithm.CSharp/Alphas/GreenblattMagicFormulaAlpha.cs
@@ -1,0 +1,291 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Indicators;
+using QuantConnect.Orders.Fees;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp.Alphas
+{
+    /// <summary>
+    /// This alpha picks stocks according to Joel Greenblatt's Magic Formula.
+    /// First, each stock is ranked depending on the relative value of the ratio EV/EBITDA. For example, a stock
+    /// that has the lowest EV/EBITDA ratio in the security universe receives a score of one while a stock that has 
+    /// the tenth lowest EV/EBITDA score would be assigned 10 points.
+    ///
+    /// Then, each stock is ranked and given a score for the second valuation ratio, Return on Capital (ROC).
+    /// Similarly, a stock that has the highest ROC value in the universe gets one score point.
+    /// The stocks that receive the lowest combined score are chosen for insights.
+    ///
+    /// Source: Greenblatt, J. (2010) The Little Book That Beats the Market
+    ///
+    /// This alpha is part of the Benchmark Alpha Series created by QuantConnect which are open
+    /// sourced so the community and client funds can see an example of an alpha.
+    ///</summary>
+    public class GreenblattMagicFormulaAlpha : QCAlgorithmFramework
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2018, 1, 1);
+            SetCash(100000);
+
+            // Set zero transaction fees
+            SetSecurityInitializer(security => security.FeeModel = new ConstantFeeModel(0));
+
+            // Select stocks using MagicFormulaUniverseSelectionModel
+            SetUniverseSelection(new GreenBlattMagicFormulaUniverseSelectionModel());
+
+            // Use RateOfChangeAlphaModel to establish insights
+            SetAlpha(new RateOfChangeAlphaModel());
+
+            // Equally weigh securities in portfolio, based on insights
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+
+            // Set Immediate Execution Model
+            SetExecution(new ImmediateExecutionModel());
+
+            // Set Null Risk Management Model
+            SetRiskManagement(new NullRiskManagementModel());
+        }
+
+        /// <summary>
+        /// Uses Rate of Change (ROC) to create magnitude prediction for insights.
+        /// </summary>
+        private class RateOfChangeAlphaModel : AlphaModel
+        {
+            private readonly int _lookback;
+            private readonly Resolution _resolution;
+            private readonly TimeSpan _predictionInterval;
+            private readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol;
+
+            public RateOfChangeAlphaModel(
+                int lookback = 1,
+                Resolution resolution = Resolution.Daily)
+            {
+                _lookback = lookback;
+                _resolution = resolution;
+                _predictionInterval = resolution.ToTimeSpan().Multiply(lookback);
+                _symbolDataBySymbol = new Dictionary<Symbol, SymbolData>();
+            }
+
+            public override IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data)
+            {
+                var insights = new List<Insight>();
+
+                foreach (var kvp in _symbolDataBySymbol)
+                {
+                    var symbolData = kvp.Value;
+                    if (symbolData.CanEmit)
+                    {
+                        var magnitude = Convert.ToDouble(Math.Abs(symbolData.Return));
+                        insights.Add(Insight.Price(kvp.Key, _predictionInterval, InsightDirection.Up, magnitude));
+                    }
+                }
+
+                return insights;
+            }
+
+            public override void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+            {
+                // Clean up data for removed securities
+                foreach (var removed in changes.RemovedSecurities)
+                {
+                    SymbolData symbolData;
+                    if (_symbolDataBySymbol.TryGetValue(removed.Symbol, out symbolData))
+                    {
+                        symbolData.RemoveConsolidators(algorithm);
+                        _symbolDataBySymbol.Remove(removed.Symbol);
+                    }
+                }
+
+                // Initialize data for added securities
+                var symbols = changes.AddedSecurities.Select(x => x.Symbol);
+                var history = algorithm.History(symbols, _lookback, _resolution);
+                if (symbols.Count() == 0 && history.Count() == 0)
+                {
+                    return;
+                }
+
+                history.PushThrough(bar =>
+                {
+                    SymbolData symbolData;
+                    if (!_symbolDataBySymbol.TryGetValue(bar.Symbol, out symbolData))
+                    {
+                        symbolData = new SymbolData(algorithm, bar.Symbol, _lookback, _resolution);
+                        _symbolDataBySymbol[bar.Symbol] = symbolData;
+                    }
+                    symbolData.WarmUpIndicators(bar);
+                });
+            }
+
+            /// <summary>
+            /// Contains data specific to a symbol required by this model
+            /// </summary>
+            private class SymbolData
+            {
+                private readonly Symbol _symbol;
+                private readonly IDataConsolidator _consolidator;
+                private long _previous = 0;
+
+                public RateOfChange Return { get; }
+
+                public bool CanEmit
+                {
+                    get
+                    {
+                        if (_previous == Return.Samples)
+                        {
+                            return false;
+                        }
+                        _previous = Return.Samples;
+                        return Return.IsReady;
+                    }
+                }
+
+                public SymbolData(QCAlgorithmFramework algorithm, Symbol symbol, int lookback, Resolution resolution)
+                {
+                    _symbol = symbol;
+                    Return = new RateOfChange($"{symbol}.ROC({lookback})", lookback);
+                    _consolidator = algorithm.ResolveConsolidator(symbol, resolution);
+                    algorithm.RegisterIndicator(symbol, Return, _consolidator);
+                }
+
+                internal void RemoveConsolidators(QCAlgorithmFramework algorithm)
+                {
+                    algorithm.SubscriptionManager.RemoveConsolidator(_symbol, _consolidator);
+                }
+
+                internal void WarmUpIndicators(BaseData bar)
+                {
+                    Return.Update(bar.EndTime, bar.Value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Defines a universe according to Joel Greenblatt's Magic Formula, as a universe selection model for the framework algorithm.
+        /// From the universe QC500, stocks are ranked using the valuation ratios, Enterprise Value to EBITDA(EV/EBITDA) and Return on Assets(ROA).
+        /// </summary>
+        private class GreenBlattMagicFormulaUniverseSelectionModel : FundamentalUniverseSelectionModel
+        {
+            private const int _numberOfSymbolsCoarse = 500;
+            private const int _numberOfSymbolsFine = 20;
+            private const int _numberOfSymbolsInPortfolio = 10;
+            private int _lastMonth = -1;
+            private Dictionary<Symbol, decimal> _dollarVolumeBySymbol;
+
+            public GreenBlattMagicFormulaUniverseSelectionModel() : base(true)
+            {
+                _dollarVolumeBySymbol = new Dictionary<Symbol, decimal>();
+            }
+
+            /// <summary>
+            /// Performs coarse selection for constituents.
+            /// The stocks must have fundamental data
+            /// The stock must have positive previous-day close price
+            /// The stock must have positive volume on the previous trading day
+            /// </summary>
+            public override IEnumerable<Symbol> SelectCoarse(QCAlgorithmFramework algorithm, IEnumerable<CoarseFundamental> coarse)
+            {
+                if (algorithm.Time.Month == _lastMonth)
+                {
+                    return algorithm.Universe.Unchanged;
+                }
+                _lastMonth = algorithm.Time.Month;
+
+                _dollarVolumeBySymbol = (
+                    from cf in coarse
+                    where cf.HasFundamentalData
+                    orderby cf.DollarVolume descending
+                    select new { cf.Symbol, cf.DollarVolume }
+                    )
+                    .Take(_numberOfSymbolsCoarse)
+                    .ToDictionary(x => x.Symbol, x => x.DollarVolume);
+
+                return _dollarVolumeBySymbol.Keys;
+            }
+
+            /// <summary>
+            /// QC500: Performs fine selection for the coarse selection constituents
+            /// The company's headquarter must in the U.S.
+            /// The stock must be traded on either the NYSE or NASDAQ
+            /// At least half a year since its initial public offering
+            /// The stock's market cap must be greater than 500 million
+            ///
+            /// Magic Formula: Rank stocks by Enterprise Value to EBITDA(EV/EBITDA)
+            /// Rank subset of previously ranked stocks(EV/EBITDA), using the valuation ratio Return on Assets(ROA)
+            /// </summary>
+            public override IEnumerable<Symbol> SelectFine(QCAlgorithmFramework algorithm, IEnumerable<FineFundamental> fine)
+            {
+                var filteredFine =
+                    from x in fine
+                    where x.CompanyReference.CountryId == "USA"
+                    where x.CompanyReference.PrimaryExchangeID == "NYS" || x.CompanyReference.PrimaryExchangeID == "NAS"
+                    where (algorithm.Time - x.SecurityReference.IPODate).TotalDays > 180
+                    where x.EarningReports.BasicAverageShares.ThreeMonths * x.EarningReports.BasicEPS.TwelveMonths * x.ValuationRatios.PERatio > 5e8m
+                    select x;
+
+                double count = filteredFine.Count();
+                if (count == 0)
+                {
+                    return Enumerable.Empty<Symbol>();
+                }
+
+                var percent = _numberOfSymbolsFine / count;
+
+                // Select stocks with top dollar volume in every single sector
+                var myDict = (
+                    from x in filteredFine
+                    group x by x.CompanyReference.IndustryTemplateCode into g
+                    let y = (
+                        from item in g
+                        orderby _dollarVolumeBySymbol[item.Symbol] descending
+                        select item
+                    )
+                    let c = (int)Math.Ceiling(y.Count() * percent)
+                    select new { g.Key, Value = y.Take(c) }
+                    )
+                    .ToDictionary(x => x.Key, x => x.Value);
+
+                // Stocks in QC500 universe
+                var topFine = myDict.Values.SelectMany(x => x);
+
+                // Magic Formula:
+                // Rank stocks by Enterprise Value to EBITDA (EV/EBITDA)
+                // Rank subset of previously ranked stocks (EV/EBITDA), using the valuation ratio Return on Assets (ROA)
+                return topFine
+                    // Sort stocks in the security universe of QC500 based on Enterprise Value to EBITDA valuation ratio
+                    .OrderByDescending(x => x.ValuationRatios.EVToEBITDA)
+                    .Take(_numberOfSymbolsFine)
+                    // sort subset of stocks that have been sorted by Enterprise Value to EBITDA, based on the valuation ratio Return on Assets (ROA)
+                    .OrderByDescending(x => x.ValuationRatios.ForwardROA)
+                    .Take(_numberOfSymbolsInPortfolio)
+                    .Select(x => x.Symbol);
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -122,6 +122,7 @@
     </Compile>
     <Compile Include="AddRemoveOptionUniverseRegressionAlgorithm.cs" />
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
+    <Compile Include="Alphas\GasAndCrudeOilEnergyCorrelationAlpha.cs" />
     <Compile Include="Alphas\GreenblattMagicFormulaAlpha.cs" />
     <Compile Include="Alphas\IntradayReversalCurrencyMarketsAlpha.cs" />
     <Compile Include="Alphas\ShareClassMeanReversionAlpha.cs" />

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -122,6 +122,7 @@
     </Compile>
     <Compile Include="AddRemoveOptionUniverseRegressionAlgorithm.cs" />
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />
+    <Compile Include="Alphas\GreenblattMagicFormulaAlpha.cs" />
     <Compile Include="Alphas\IntradayReversalCurrencyMarketsAlpha.cs" />
     <Compile Include="Alphas\ShareClassMeanReversionAlpha.cs" />
     <Compile Include="Alphas\SykesShortMicroCapAlpha.cs" />

--- a/Algorithm.Python/Alphas/GreenblattMagicFormulaAlpha.py
+++ b/Algorithm.Python/Alphas/GreenblattMagicFormulaAlpha.py
@@ -29,7 +29,7 @@ from datetime import timedelta, datetime
 from math import ceil
 from itertools import chain
 
-# 
+#
 # This alpha picks stocks according to Joel Greenblatt's Magic Formula.
 # First, each stock is ranked depending on the relative value of the ratio EV/EBITDA. For example, a stock
 # that has the lowest EV/EBITDA ratio in the security universe receives a score of one while a stock that has 
@@ -43,7 +43,7 @@ from itertools import chain
 #
 # This alpha is part of the Benchmark Alpha Series created by QuantConnect which are open
 # sourced so the community and client funds can see an example of an alpha.
-# 
+#
 
 class GreenblattMagicFormulaAlpha(QCAlgorithmFramework):
     ''' Alpha Streams: Benchmark Alpha: Pick stocks according to Joel Greenblatt's Magic Formula'''
@@ -52,7 +52,7 @@ class GreenblattMagicFormulaAlpha(QCAlgorithmFramework):
 
         self.SetStartDate(2018, 1, 1)
         self.SetCash(100000)
-        
+
         #Set zero transaction fees
         self.SetSecurityInitializer(lambda security: security.SetFeeModel(ConstantFeeModel(0)))
 
@@ -64,23 +64,22 @@ class GreenblattMagicFormulaAlpha(QCAlgorithmFramework):
 
         # Equally weigh securities in portfolio, based on insights
         self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
-        
+
         ## Set Immediate Execution Model
         self.SetExecution(ImmediateExecutionModel())
 
         ## Set Null Risk Management Model
         self.SetRiskManagement(NullRiskManagementModel())
-        
 
 class RateOfChangeAlphaModel(AlphaModel):
     '''Uses Rate of Change (ROC) to create magnitude prediction for insights.'''
 
     def __init__(self, *args, **kwargs): 
-        self.lookback = kwargs['lookback'] if 'lookback' in kwargs else 1
-        self.resolution = kwargs['resolution'] if 'resolution' in kwargs else Resolution.Daily
+        self.lookback = kwargs.get('lookback', 1)
+        self.resolution = kwargs.get('resolution', Resolution.Daily)
         self.predictionInterval = Time.Multiply(Extensions.ToTimeSpan(self.resolution), self.lookback)
         self.symbolDataBySymbol = {}
-        
+
     def Update(self, algorithm, data):
         insights = []
         for symbol, symbolData in self.symbolDataBySymbol.items():
@@ -89,7 +88,7 @@ class RateOfChangeAlphaModel(AlphaModel):
         return insights
 
     def OnSecuritiesChanged(self, algorithm, changes):
-        
+
         # clean up data for removed securities
         for removed in changes.RemovedSecurities:
             symbolData = self.symbolDataBySymbol.pop(removed.Symbol, None)
@@ -116,7 +115,7 @@ class SymbolData:
     '''Contains data specific to a symbol required by this model'''
     def __init__(self, symbol, lookback):
         self.Symbol = symbol
-        self.ROC = RateOfChange('{}.ROC({})'.format(symbol, lookback), lookback)
+        self.ROC = RateOfChange(f'{symbol}.ROC({lookback})', lookback)
         self.Consolidator = None
         self.previous = 0
 
@@ -146,7 +145,7 @@ class SymbolData:
 
     def __str__(self, **kwargs):
         return '{}: {:.2%}'.format(self.ROC.Name, (1 + self.Return)**252 - 1)
-        
+
 
 class GreenBlattMagicFormulaUniverseSelectionModel(FundamentalUniverseSelectionModel):
     '''Defines a universe according to Joel Greenblatt's Magic Formula, as a universe selection model for the framework algorithm. 
@@ -159,14 +158,14 @@ class GreenBlattMagicFormulaUniverseSelectionModel(FundamentalUniverseSelectionM
                  securityInitializer = None):
         '''Initializes a new default instance of the MagicFormulaUniverseSelectionModel'''
         super().__init__(filterFineData, universeSettings, securityInitializer)
-        
+
         # Number of stocks in Coarse Universe
         self.NumberOfSymbolsCoarse = 500
         # Number of sorted stocks in the fine selection subset using the valuation ratio, EV to EBITDA (EV/EBITDA)
         self.NumberOfSymbolsFine = 20
         # Final number of stocks in security list, after sorted by the valuation ratio, Return on Assets (ROA)
         self.NumberOfSymbolsInPortfolio = 10
-        
+
         self.lastMonth = -1
         self.dollarVolumeBySymbol = {}
         self.symbols = []
@@ -176,7 +175,6 @@ class GreenBlattMagicFormulaUniverseSelectionModel(FundamentalUniverseSelectionM
         The stocks must have fundamental data
         The stock must have positive previous-day close price
         The stock must have positive volume on the previous trading day'''
-        
         month = algorithm.Time.month
         if month == self.lastMonth:
             return self.symbols
@@ -186,9 +184,7 @@ class GreenBlattMagicFormulaUniverseSelectionModel(FundamentalUniverseSelectionM
         # The stocks must have fundamental data
         # The stock must have positive previous-day close price
         # The stock must have positive volume on the previous trading day
-        filtered = [x for x in coarse if x.HasFundamentalData
-                                      and x.Volume > 0
-                                      and x.Price > 0]
+        filtered = [x for x in coarse if x.HasFundamentalData]
         # sort the stocks by dollar volume and take the top 1000
         top = sorted(filtered, key=lambda x: x.DollarVolume, reverse=True)[:self.NumberOfSymbolsCoarse]
 
@@ -205,8 +201,7 @@ class GreenBlattMagicFormulaUniverseSelectionModel(FundamentalUniverseSelectionM
         The stock must be traded on either the NYSE or NASDAQ
         At least half a year since its initial public offering
         The stock's market cap must be greater than 500 million
-        
-        
+
         Magic Formula: Rank stocks by Enterprise Value to EBITDA (EV/EBITDA)
         Rank subset of previously ranked stocks (EV/EBITDA), using the valuation ratio Return on Assets (ROA)'''
 
@@ -231,24 +226,20 @@ class GreenBlattMagicFormulaUniverseSelectionModel(FundamentalUniverseSelectionM
             value = sorted(value, key=lambda x: self.dollarVolumeBySymbol[x.Symbol], reverse = True)
             myDict[key] = value[:ceil(len(value) * percent)]
 
-
         # stocks in QC500 universe 
-        topFine = list(chain.from_iterable(myDict.values()))[:self.NumberOfSymbolsCoarse]
-
+        topFine = chain.from_iterable(myDict.values())
 
         #  Magic Formula: 
         ## Rank stocks by Enterprise Value to EBITDA (EV/EBITDA)
         ## Rank subset of previously ranked stocks (EV/EBITDA), using the valuation ratio Return on Assets (ROA)
 
-        
         # sort stocks in the security universe of QC500 based on Enterprise Value to EBITDA valuation ratio
         sortedByEVToEBITDA = sorted(topFine, key=lambda x: x.ValuationRatios.EVToEBITDA , reverse=True)
 
         # sort subset of stocks that have been sorted by Enterprise Value to EBITDA, based on the valuation ratio Return on Assets (ROA)
         sortedByROA = sorted(sortedByEVToEBITDA[:self.NumberOfSymbolsFine], key=lambda x: x.ValuationRatios.ForwardROA, reverse=False)
-        
+
         # retrieve list of securites in portfolio
-        top = sortedByROA[:self.NumberOfSymbolsInPortfolio]
-        self.symbols = [f.Symbol for f in top]
-        
+        self.symbols = [f.Symbol for f in sortedByROA[:self.NumberOfSymbolsInPortfolio]]
+
         return self.symbols

--- a/Algorithm.Python/Alphas/VIXDualThrustAlpha.py
+++ b/Algorithm.Python/Alphas/VIXDualThrustAlpha.py
@@ -1,0 +1,198 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Indicators")
+AddReference("QuantConnect.Algorithm.Framework")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Data.UniverseSelection import *
+from QuantConnect.Data.Consolidators import TradeBarConsolidator
+from QuantConnect.Data.Market import TradeBar
+from QuantConnect.Indicators import RollingWindow
+from QuantConnect.Brokerages import BrokerageName
+from QuantConnect.Orders.Fees import ConstantFeeModel
+from QuantConnect.Algorithm.Framework import QCAlgorithmFramework
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Selection import ManualUniverseSelectionModel
+from QuantConnect.Algorithm.Framework.Portfolio import EqualWeightingPortfolioConstructionModel
+from QuantConnect.Algorithm.Framework.Execution import ImmediateExecutionModel
+from QuantConnect.Algorithm.Framework.Risk import MaximumDrawdownPercentPerSecurity
+from datetime import timedelta
+
+#
+# This is a demonstration algorithm. It trades UVXY.
+# Dual Thrust alpha model is used to produce insights. 
+# Those input parameters have been chosen that gave acceptable results on a series
+# of random backtests run for the period from Oct, 2016 till Feb, 2019.
+#
+
+class VIXDualThrustAlpha(QCAlgorithmFramework):
+
+    def Initialize(self):
+
+        # -- STRATEGY INPUT PARAMETERS --
+        self.k1 = 0.63
+        self.k2 = 0.63
+        self.rangePeriod = 20
+        self.consolidatorBars = 30
+
+        # Settings
+        self.SetStartDate(2018, 10, 1)
+        self.SetSecurityInitializer(lambda security: security.SetFeeModel(ConstantFeeModel(0)))
+        self.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Margin);
+
+        # Universe Selection
+        self.UniverseSettings.Resolution = Resolution.Minute   # it's minute by default, but lets leave this param here
+        symbols = [Symbol.Create("SPY", SecurityType.Equity, Market.USA)]
+        self.SetUniverseSelection(ManualUniverseSelectionModel(symbols))
+
+        # Warming up
+        resolutionInTimeSpan =  Extensions.ToTimeSpan(self.UniverseSettings.Resolution)
+        warmUpTimeSpan = Time.Multiply(resolutionInTimeSpan, self.consolidatorBars)
+        self.SetWarmUp(warmUpTimeSpan)
+
+        # Alpha Model
+        self.SetAlpha(DualThrustAlphaModel(self.k1, self.k2, self.rangePeriod, self.UniverseSettings.Resolution, self.consolidatorBars))
+
+        ## Portfolio Construction
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+
+        ## Execution
+        self.SetExecution(ImmediateExecutionModel())
+
+        ## Risk Management
+        self.SetRiskManagement(MaximumDrawdownPercentPerSecurity(0.03))
+
+
+class DualThrustAlphaModel(AlphaModel):
+    '''Alpha model that uses dual-thrust strategy to create insights
+    https://medium.com/@FMZ_Quant/dual-thrust-trading-strategy-2cc74101a626
+    or here:
+    https://www.quantconnect.com/tutorials/strategy-library/dual-thrust-trading-algorithm'''
+
+    def __init__(self,
+                 k1,
+                 k2,
+                 rangePeriod,
+                 resolution = Resolution.Daily,
+                 barsToConsolidate = 1):
+        '''Initializes a new instance of the class
+        Args:
+            k1: Coefficient for upper band
+            k2: Coefficient for lower band
+            rangePeriod: Amount of last bars to calculate the range
+            resolution: The resolution of data sent into the EMA indicators
+            barsToConsolidate: If we want alpha to work on trade bars whose length is different
+                from the standard resolution - 1m 1h etc. - we need to pass this parameters along
+                with proper data resolution'''
+
+        # coefficient that used to determinte upper and lower borders of a breakout channel
+        self.k1 = k1
+        self.k2 = k2
+
+        # period the range is calculated over
+        self.rangePeriod = rangePeriod
+
+        # initialize with empty dict.
+        self.symbolDataBySymbol = dict()
+
+        # time for bars we make the calculations on
+        resolutionInTimeSpan =  Extensions.ToTimeSpan(resolution)
+        self.consolidatorTimeSpan = Time.Multiply(resolutionInTimeSpan, barsToConsolidate)
+
+        # in 5 days after emission an insight is to be considered expired
+        self.period = timedelta(5)
+
+    def Update(self, algorithm, data):
+        insights = []
+
+        for symbol, symbolData in self.symbolDataBySymbol.items():
+            if not symbolData.IsReady:
+                continue
+
+            holding = algorithm.Portfolio[symbol]
+            price = algorithm.Securities[symbol].Price
+
+            # buying condition
+            # - (1) price is above upper line
+            # - (2) and we are not long. this is a first time we crossed the line lately
+            if price > symbolData.UpperLine and not holding.IsLong:
+                insightCloseTimeUtc = algorithm.UtcTime + self.period
+                insights.append(Insight.Price(symbol, insightCloseTimeUtc, InsightDirection.Up))
+
+            # selling condition
+            # - (1) price is lower that lower line
+            # - (2) and we are not short. this is a first time we crossed the line lately
+            if price < symbolData.LowerLine and not holding.IsShort:
+                insightCloseTimeUtc = algorithm.UtcTime + self.period
+                insights.append(Insight.Price(symbol, insightCloseTimeUtc, InsightDirection.Down))
+
+        return insights
+
+    def OnSecuritiesChanged(self, algorithm, changes):
+        # added
+        for symbol in [x.Symbol for x in changes.AddedSecurities]:
+            if symbol not in self.symbolDataBySymbol:
+                # add symbol/symbolData pair to collection
+                symbolData = self.SymbolData(symbol, self.k1, self.k2, self.rangePeriod, self.consolidatorTimeSpan)
+                self.symbolDataBySymbol[symbol] = symbolData
+                # register consolidator
+                algorithm.SubscriptionManager.AddConsolidator(symbol, symbolData.GetConsolidator())
+
+        # removed
+        for symbol in [x.Symbol for x in changes.RemovedSecurities]:
+            symbolData = self.symbolDataBySymbol.pop(symbol, None)
+            if symbolData is None:
+                algorithm.Error("Unable to remove data from collection: DualThrustAlphaModel")
+            else:
+                # unsubscribe consolidator from data updates
+                algorithm.SubscriptionManager.RemoveConsolidator(symbol, symbolData.GetConsolidator())
+
+
+    class SymbolData:
+        '''Contains data specific to a symbol required by this model'''
+        def __init__(self, symbol, k1, k2, rangePeriod, consolidatorResolution):
+
+            self.Symbol = symbol
+            self.rangeWindow = RollingWindow[TradeBar](rangePeriod)
+            self.consolidator = TradeBarConsolidator(consolidatorResolution);
+
+            def onDataConsolidated(sender, consolidated):
+                # add new tradebar to
+                self.rangeWindow.Add(consolidated)
+
+                if self.rangeWindow.IsReady:
+                    hh = max([x.High for x in self.rangeWindow])
+                    hc = max([x.Close for x in self.rangeWindow])
+                    lc = min([x.Close for x in self.rangeWindow])
+                    ll = min([x.Low for x in self.rangeWindow])
+
+                    range = max([hh - lc, hc - ll])
+                    self.UpperLine = consolidated.Close + k1 * range
+                    self.LowerLine = consolidated.Close - k2 * range
+
+            # event fired at new consolidated trade bar
+            self.consolidator.DataConsolidated += onDataConsolidated
+
+        # Returns the interior consolidator
+        def GetConsolidator(self):
+            return self.consolidator
+
+        @property
+        def IsReady(self):
+            return self.rangeWindow.IsReady

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -40,7 +40,7 @@
     <Content Include="Alphas\GasAndCrudeOilEnergyCorrelationAlpha.py" />
     <Content Include="Alphas\GlobalEquityMeanReversionIBSAlpha.py" />
     <Content Include="Alphas\IntradayReversalCurrencyMarketsAlpha.py" />
-    <Content Include="Alphas\GreenblattMagicFormulaAlgorithm.py" />
+    <Content Include="Alphas\GreenblattMagicFormulaAlpha.py" />
     <Content Include="Alphas\MeanReversionLunchBreakAlpha.py" />
     <Content Include="Alphas\SykesShortMicroCapAlpha.py" />
     <Content Include="Alphas\RebalancingLeveragedETFAlpha.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -47,6 +47,7 @@
     <Content Include="Alphas\TriangleExchangeRateArbitrageAlpha.py" />
     <Content Include="Alphas\ShareClassMeanReversionAlpha.py" />
     <Content Include="Alphas\TripleLeverageETFPairVolatilityDecayAlpha.py" />
+    <Content Include="Alphas\VIXDualThrustAlpha.py" />
     <Content Include="BasicSetAccountCurrencyAlgorithm.py" />
     <Content Include="BasicTemplateFuturesFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateOptionsFrameworkAlgorithm.py" />


### PR DESCRIPTION
#### Description
- Adds C# GreenblattMagicFormulaAlpha
- Adds C# GasAndCrudeOilEnergyCorrelationAlpha
- Adds Py VIXDualThrustAlpha

#### Related Issue
#2950

#### Motivation and Context
Have algorithms in both C# and Python.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Running the algorithms locally and in QuantConnect could

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests pass.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`