### PR TITLE
Fix to ensure proper function and match Python algo.

### DIFF
--- a/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
@@ -56,24 +56,23 @@ namespace QuantConnect.Algorithm.CSharp
         /// "Nifty" type below and fired into this event handler.
         /// </summary>
         /// <param name="data">One(1) Nifty Object, streamed into our algorithm synchronised in time with our other data streams</param>
-        public void OnData(DollarRupee data)
+        public void OnData(Slice data)
         {
-            _today = new CorrelationPair(data.Time) {CurrencyPrice = Convert.ToDouble(data.Close)};
-        }
+            if (data.ContainsKey("USDINR"))
+            {
+                _today = new CorrelationPair(Time) { CurrencyPrice = Convert.ToDouble(data["USDINR"].Close) };
+            }
 
-        /// <summary>
-        /// OnData is the primary entry point for youm algorithm. New data is piped into your algorithm here
-        /// via TradeBars objects.
-        /// </summary>
-        /// <param name="data">TradeBars IDictionary object</param>
-        public void OnData(Nifty data)
-        {
+            if (!data.ContainsKey("NIFTY"))
+            {
+                return;
+            }
             try
             {
-                var quantity = (int)(Portfolio.TotalPortfolioValue * 0.9m / data.Close);
 
-                _today.NiftyPrice = Convert.ToDouble(data.Close);
-                if (_today.Date == data.Time)
+
+                _today.NiftyPrice = Convert.ToDouble(data["NIFTY"].Close);
+                if (_today.Date == data["NIFTY"].EndTime)
                 {
                     _prices.Add(_today);
 
@@ -83,9 +82,12 @@ namespace QuantConnect.Algorithm.CSharp
                     }
                 }
 
+
                 //Strategy
+                var quantity = (int)(Portfolio.MarginRemaining * 0.9m / data["NIFTY"].Close);
                 var highestNifty = (from pair in _prices select pair.NiftyPrice).Max();
                 var lowestNifty = (from pair in _prices select pair.NiftyPrice).Min();
+                
                 if (Time.DayOfWeek == DayOfWeek.Wednesday) //prices.Count >= minimumCorrelationHistory &&
                 {
                     //List<double> niftyPrices = (from pair in prices select pair.NiftyPrice).ToList();
@@ -93,15 +95,15 @@ namespace QuantConnect.Algorithm.CSharp
                     //double correlation = Correlation.Pearson(niftyPrices, currencyPrices);
                     //double niftyFraction = (correlation)/2;
 
-                    if (Convert.ToDouble(data.Open) >= highestNifty)
+                    if (Convert.ToDouble(data["NIFTY"].Open) >= highestNifty)
                     {
                         var code = Order("NIFTY", quantity - Portfolio["NIFTY"].Quantity);
-                        Debug("LONG " + code + " Time: " + Time.ToShortDateString() + " Quantity: " + quantity + " Portfolio:" + Portfolio["NIFTY"].Quantity + " Nifty: " + data.Close + " Buying Power: " + Portfolio.TotalPortfolioValue);
+                        Debug("LONG " + code + " Time: " + Time.ToShortDateString() + " Quantity: " + quantity + " Portfolio:" + Portfolio["NIFTY"].Quantity + " Nifty: " + data["NIFTY"].Close + " Buying Power: " + Portfolio.TotalPortfolioValue);
                     }
-                    else if (Convert.ToDouble(data.Open) <= lowestNifty)
+                    else if (Convert.ToDouble(data["NIFTY"].Open) <= lowestNifty)
                     {
                         var code = Order("NIFTY", -quantity - Portfolio["NIFTY"].Quantity);
-                        Debug("SHORT " + code + " Time: " + Time.ToShortDateString() + " Quantity: " + quantity + " Portfolio:" + Portfolio["NIFTY"].Quantity + " Nifty: " + data.Close + " Buying Power: " + Portfolio.TotalPortfolioValue);
+                        Debug("SHORT " + code + " Time: " + Time.ToShortDateString() + " Quantity: " + quantity + " Portfolio:" + Portfolio["NIFTY"].Quantity + " Nifty: " + data["NIFTY"].Close + " Buying Power: " + Portfolio.TotalPortfolioValue);
                     }
                 }
             }

--- a/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
@@ -67,9 +67,9 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 return;
             }
+
             try
             {
-
 
                 _today.NiftyPrice = Convert.ToDouble(data["NIFTY"].Close);
                 if (_today.Date == data["NIFTY"].EndTime)
@@ -81,7 +81,6 @@ namespace QuantConnect.Algorithm.CSharp
                         _prices.RemoveAt(0);
                     }
                 }
-
 
                 //Strategy
                 var quantity = (int)(Portfolio.MarginRemaining * 0.9m / data["NIFTY"].Close);


### PR DESCRIPTION
Previous version entered Nifty OnData() method prior to initializing CorrelationPair in DollarRupee OnData() method and so it failed in evaluation later. Made this change to ensure that Correlation Pair object gets properly instantiated.

Also, the Python version of this algorithm used Portfolio.MarginRemaining to calculate quantity and so I changed this one to ensure they return the same results.

#### Motivation and Context
Solves error that is thrown when copy-and-pasting current C# version and ensures that both algorithms function identically.

#### How Has This Been Tested?
Tested locally and in the cloud, compared trade and other summary outcomes from Python and C# algorithms to ensure they match.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->