### PR TITLE
AlgoSeekFuturesConverter copies raw files locally before processing

### DIFF
--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
@@ -62,7 +62,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
         /// </summary>
         public void Convert()
         {
-
+            Log.Trace("AlgoSeekFuturesConverter.Convert(): Copying remote raw data files locally.");
             //Get the list of available raw files, copy from its remote location to a local folder and then for each file open a separate streamer.
             var files = _remote.EnumerateFiles("*")
                 .Where(f => (f.Extension == ".gz" || f.Extension == ".bz2") && !f.Name.Contains("option"))
@@ -82,8 +82,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
             var symbolMultipliers = LoadSymbolMultipliers();
 
             //Extract each file massively in parallel.
-            //Parallel.ForEach(files, file =>
-            foreach (var file in files)
+            Parallel.ForEach(files, file =>
             {
                 try
                 {
@@ -190,8 +189,7 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
                 {
                     Log.Error("Exception caught! File: {0} Err: {1} Source {2} Stack {3}", file, err.Message, err.Source, err.StackTrace);
                 }
-            }
-            //);
+            });
 
 
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Copies future raw data remote files into a temporal local folder before unzipping it. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improvement performance.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Full futures run for a single day.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)


#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->