### PR TITLE
Fix QC500 bugs and inconsistencies

### DIFF
--- a/Algorithm.CSharp/ConstituentsQC500GeneratorAlgorithm.cs
+++ b/Algorithm.CSharp/ConstituentsQC500GeneratorAlgorithm.cs
@@ -111,12 +111,6 @@ namespace QuantConnect.Algorithm.CSharp
                  select new { g.Key, Value = y.Take(c) }
                  ).ToDictionary(x => x.Key, x => x.Value);
 
-            foreach (var kvp in topFineBySector)
-            {
-                var ordered = kvp.Value.OrderByDescending(x => _dollarVolumeBySymbol[x.Symbol]).Select(x => x.Symbol.Value).ToList();
-                Log($"{Time} :: {kvp.Key}-{ordered.Count}: {string.Join(",", ordered.Take(10))}");
-            }
-
             return topFineBySector.SelectMany(x => x.Value)
                 .OrderByDescending(x => _dollarVolumeBySymbol[x.Symbol])
                 .Take(_numberOfSymbolsFine)

--- a/Algorithm.Framework/Selection/QC500UniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/QC500UniverseSelectionModel.cs
@@ -111,12 +111,6 @@ namespace QuantConnect.Algorithm.Framework.Selection
                        x.EarningReports.BasicEPS.TwelveMonths * x.ValuationRatios.PERatio > 500000000m
                  select x).ToList();
 
-            if (filteredFine.Count == 0)
-            {
-                algorithm.Error($"QC500UniverseSelectionModel.SelectFine: fine universe filtering returned an empty list. fine.Count = {fine.Count()}");
-                return Universe.Unchanged;
-            }
-
             var percent = _numberOfSymbolsFine / (double)filteredFine.Count;
 
             // select stocks with top dollar volume in every single sector 

--- a/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
@@ -14,62 +14,45 @@
 from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Common")
-AddReference("QuantConnect.Indicators")
 AddReference("QuantConnect.Algorithm.Framework")
 
 from QuantConnect.Data.UniverseSelection import *
-from QuantConnect.Indicators import ExponentialMovingAverage
 from Selection.FundamentalUniverseSelectionModel import FundamentalUniverseSelectionModel
-from itertools import chain
+from itertools import groupby
 from math import ceil
 
 class QC500UniverseSelectionModel(FundamentalUniverseSelectionModel):
     '''Defines the QC500 universe as a universe selection model for framework algorithm
     For details: https://github.com/QuantConnect/Lean/pull/1663'''
 
-    def __init__(self,
-                 filterFineData = True,
-                 universeSettings = None, 
-                 securityInitializer = None):
+    def __init__(self, filterFineData = True, universeSettings = None, securityInitializer = None):
         '''Initializes a new default instance of the QC500UniverseSelectionModel'''
         super().__init__(filterFineData, universeSettings, securityInitializer)
-        self.NumberOfSymbolsCoarse = 1000
-        self.NumberOfSymbolsFine = 500
-        self.lastMonth = -1
+        self.numberOfSymbolsCoarse = 1000
+        self.numberOfSymbolsFine = 500
         self.dollarVolumeBySymbol = {}
         self.symbols = []
+        self.lastMonth = -1
 
     def SelectCoarse(self, algorithm, coarse):
         '''Performs coarse selection for the QC500 constituents.
         The stocks must have fundamental data
         The stock must have positive previous-day close price
         The stock must have positive volume on the previous trading day'''
-        coarse = list(coarse)
-
-        if len(coarse) == 0:
+        if algorithm.Time.month == self.lastMonth: 
             return self.symbols
 
-        month = coarse[0].EndTime.month
-        if month == self.lastMonth:
-            return self.symbols
+        filtered = [x for x in coarse if x.HasFundamentalData and x.Volume > 0 and x.Price > 0]
+        sortedByDollarVolume = sorted(filtered, key = lambda x: x.DollarVolume, reverse=True)[:self.numberOfSymbolsCoarse]
 
-        self.lastMonth = month
+        self.symbols.clear()
+        self.dollarVolumeBySymbol.clear()
+        for x in sortedByDollarVolume:
+            self.symbols.append(x.Symbol)
+            self.dollarVolumeBySymbol[x.Symbol] = x.DollarVolume
 
-        # The stocks must have fundamental data
-        # The stock must have positive previous-day close price
-        # The stock must have positive volume on the previous trading day
-        filtered = [x for x in coarse if x.HasFundamentalData
-                                      and x.Volume > 0
-                                      and x.Price > 0]
-        # sort the stocks by dollar volume and take the top 1000
-        top = sorted(filtered, key=lambda x: x.DollarVolume, reverse=True)[:self.NumberOfSymbolsCoarse]
-
-        self.dollarVolumeBySymbol = { i.Symbol: i.DollarVolume for i in top }
-
-        self.symbols = list(self.dollarVolumeBySymbol.keys())
-
+        # return the symbol objects our sorted collection
         return self.symbols
-
 
     def SelectFine(self, algorithm, fine):
         '''Performs fine selection for the QC500 constituents
@@ -77,28 +60,30 @@ class QC500UniverseSelectionModel(FundamentalUniverseSelectionModel):
         The stock must be traded on either the NYSE or NASDAQ
         At least half a year since its initial public offering
         The stock's market cap must be greater than 500 million'''
+        if algorithm.Time.month == self.lastMonth: 
+            return self.symbols
+        self.lastMonth = algorithm.Time.month
 
-        # The company's headquarter must in the U.S.
-        # The stock must be traded on either the NYSE or NASDAQ
-        # At least half a year since its initial public offering
-        # The stock's market cap must be greater than 500 million
         filteredFine = [x for x in fine if x.CompanyReference.CountryId == "USA"
                                         and (x.CompanyReference.PrimaryExchangeID == "NYS" or x.CompanyReference.PrimaryExchangeID == "NAS")
                                         and (algorithm.Time - x.SecurityReference.IPODate).days > 180
                                         and x.EarningReports.BasicAverageShares.ThreeMonths * x.EarningReports.BasicEPS.TwelveMonths * x.ValuationRatios.PERatio > 5e8]
-        count = len(filteredFine)
-        if count == 0: return []
 
-        myDict = dict()
-        percent = float(self.NumberOfSymbolsFine / count)
+        if len(filteredFine) == 0:
+            algorithm.Error(f"QC500UniverseSelectionModel.SelectFine: fine universe filtering returned an empty list. fine.Count = {fine.Count()}")
+            return self.symbols
+
+        sortedByDollarVolume = []
+        sortedBySector = sorted(filteredFine, key = lambda x: x.CompanyReference.IndustryTemplateCode)
+
+        percent = self.numberOfSymbolsFine/float(len(sortedBySector))
 
         # select stocks with top dollar volume in every single sector
-        for key in ["N", "M", "U", "T", "B", "I"]:
-            value = [x for x in filteredFine if x.CompanyReference.IndustryTemplateCode == key]
-            value = sorted(value, key=lambda x: self.dollarVolumeBySymbol[x.Symbol], reverse = True)
-            myDict[key] = value[:ceil(len(value) * percent)]
+        for code, g in groupby(sortedBySector, lambda x: x.CompanyReference.IndustryTemplateCode):
+            y = sorted(g, key = lambda x: self.dollarVolumeBySymbol[x.Symbol], reverse = True)
+            c = ceil(len(y) * percent)
+            sortedByDollarVolume.extend(y[:c])
 
-        topFine = list(chain.from_iterable(myDict.values()))[:self.NumberOfSymbolsFine]
-        self.symbols = [f.Symbol for f in topFine]
-
+        sortedByDollarVolume = sorted(sortedByDollarVolume, key = lambda x: self.dollarVolumeBySymbol[x.Symbol], reverse=True)
+        self.symbols = [x.Symbol for x in sortedByDollarVolume[:self.numberOfSymbolsFine]]
         return self.symbols

--- a/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
@@ -69,10 +69,6 @@ class QC500UniverseSelectionModel(FundamentalUniverseSelectionModel):
                                         and (algorithm.Time - x.SecurityReference.IPODate).days > 180
                                         and x.EarningReports.BasicAverageShares.ThreeMonths * x.EarningReports.BasicEPS.TwelveMonths * x.ValuationRatios.PERatio > 5e8]
 
-        if len(filteredFine) == 0:
-            algorithm.Error(f"QC500UniverseSelectionModel.SelectFine: fine universe filtering returned an empty list. fine.Count = {fine.Count()}")
-            return self.symbols
-
         sortedByDollarVolume = []
         sortedBySector = sorted(filteredFine, key = lambda x: x.CompanyReference.IndustryTemplateCode)
 

--- a/Algorithm.Python/ConstituentsQC500GeneratorAlgorithm.py
+++ b/Algorithm.Python/ConstituentsQC500GeneratorAlgorithm.py
@@ -13,19 +13,15 @@
 
 from clr import AddReference
 AddReference("System.Core")
-AddReference("System.Collections")
 AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Algorithm")
 
 from System import *
-from System.Collections.Generic import List
 from QuantConnect import *
 from QuantConnect.Algorithm import QCAlgorithm
 from QuantConnect.Data.UniverseSelection import *
 from math import ceil
-import numpy as np
-import pandas as pd
-import scipy as sp
+from itertools import groupby
 
 ### <summary>
 ### Demonstration of how to estimate constituents of QC500 index based on the company fundamentals
@@ -40,75 +36,69 @@ class ConstituentsQC500GeneratorAlgorithm(QCAlgorithm):
 
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
-
-        self.SetStartDate(2018, 1, 1) #Set Start Date
-        self.SetEndDate(2018, 1, 3) #Set End Date
-        self.SetCash(50000) #Set Strategy Cash
         self.UniverseSettings.Resolution = Resolution.Daily
+
+        self.SetStartDate(2018, 1, 1)   # Set Start Date
+        self.SetEndDate(2019, 1, 1)     # Set End Date
+        self.SetCash(100000)            # Set Strategy Cash
 
         # this add universe method accepts two parameters:
         # - coarse selection function: accepts an IEnumerable<CoarseFundamental> and returns an IEnumerable<Symbol>
         # - fine selection function: accepts an IEnumerable<FineFundamental> and returns an IEnumerable<Symbol>
         self.AddUniverse(self.CoarseSelectionFunction, self.FineSelectionFunction)
 
-        self.spy = self.AddEquity("SPY", Resolution.Daily)
-        self.Schedule.On(self.DateRules.MonthStart("SPY"), self.TimeRules.At(0, 0), self.monthly_rebalance)
-
-        self.num_coarse = 1000
-        self.num_fine = 500
-        self.dollar_volume = {}
-        self.rebalance = True
+        self.numberOfSymbolsCoarse = 1000
+        self.numberOfSymbolsFine = 500
+        self.dollarVolumeBySymbol = {}
+        self.symbols = []
+        self.lastMonth = -1
 
     def CoarseSelectionFunction(self, coarse):
-        if not self.rebalance: return []
+        if self.Time.month == self.lastMonth: 
+            return self.symbols
+
         # The stocks must have fundamental data
         # The stock must have positive previous-day close price
         # The stock must have positive volume on the previous trading day
-        filtered = [x for x in coarse if x.HasFundamentalData
-                                      and x.Volume > 0
-                                      and x.Price > 0]
-        # sort the stocks by dollar volume and take the top 1000
-        sort_filtered = sorted(filtered, key=lambda x: x.DollarVolume, reverse=True)[:self.num_coarse]
-        for i in sort_filtered:
-            self.dollar_volume[i.Symbol.Value] = i.DollarVolume
+        filtered = [x for x in coarse if x.HasFundamentalData and x.Volume > 0 and x.Price > 0]
+        sortedByDollarVolume = sorted(filtered, key = lambda x: x.DollarVolume, reverse=True)[:self.numberOfSymbolsCoarse]
+
+        self.symbols.clear()
+        self.dollarVolumeBySymbol.clear()
+        for x in sortedByDollarVolume:
+            self.symbols.append(x.Symbol)
+            self.dollarVolumeBySymbol[x.Symbol] = x.DollarVolume
 
         # return the symbol objects our sorted collection
-        return [x.Symbol for x in sort_filtered]
+        return self.symbols
 
     def FineSelectionFunction(self, fine):
-        if not self.rebalance: return []
-        self.rebalance = False
+        if self.Time.month == self.lastMonth: 
+            return self.symbols
+        self.lastMonth = self.Time.month
+
         # The company's headquarter must in the U.S.
         # The stock must be traded on either the NYSE or NASDAQ
         # At least half a year since its initial public offering
         # The stock's market cap must be greater than 500 million
-        filtered_fine = [x for x in fine if  (x.CompanyReference.CountryId == "USA")
-                                        and (x.CompanyReference.PrimaryExchangeID == "NYS" or x.CompanyReference.PrimaryExchangeID == "NAS")
-                                        and ((self.Time - x.SecurityReference.IPODate).days > 180)
-                                        and x.EarningReports.BasicAverageShares.ThreeMonths * (x.EarningReports.BasicEPS.TwelveMonths*x.ValuationRatios.PERatio) > 5e8]
+        filtered = [x for x in fine if x.CompanyReference.CountryId == "USA"
+                                    and (x.CompanyReference.PrimaryExchangeID == "NYS" or x.CompanyReference.PrimaryExchangeID == "NAS")
+                                    and (self.Time - x.SecurityReference.IPODate).days > 180
+                                    and x.EarningReports.BasicAverageShares.ThreeMonths * (x.EarningReports.BasicEPS.TwelveMonths*x.ValuationRatios.PERatio) > 5e8]
 
-        count = len(filtered_fine)
-        if count == 0: return []
-        
-        # select stocks with top dollar volume in every single sector
-        for i in filtered_fine:
-            i.DollarVolume = self.dollar_volume[i.Symbol.Value]
-        percent = float(self.num_fine/count)
-        group_by_code = {}
-        top_list = []
-        for code in ["N", "M", "U", "T", "B", "I"]:
-            group_by_code[code] = list(filter(lambda x: x.CompanyReference.IndustryTemplateCode == code, filtered_fine))
-            top = sorted(group_by_code[code], key=lambda x: x.DollarVolume, reverse = True)[:ceil(len(group_by_code[code])*percent)]
-            top_list.append(top)
-        joined_list = top_list[0]
-        for ls in top_list[1:]:
-            joined_list  += ls
-        self.symbols = [x.Symbol for x in joined_list][:self.num_fine]
-        self.Log(",".join(sorted(i.Value for i in self.symbols)))
+        sortedByDollarVolume = []
+        sortedBySector = sorted(filtered, key = lambda x: x.CompanyReference.IndustryTemplateCode)
+
+        percent = self.numberOfSymbolsFine/float(len(sortedBySector))
+
+        # select stocks with top dollar volume in every single sector 
+        for code, g in groupby(sortedBySector, lambda x: x.CompanyReference.IndustryTemplateCode):
+            y = sorted(g, key = lambda x: self.dollarVolumeBySymbol[x.Symbol], reverse = True)
+            c = ceil(len(y) * percent)
+            sortedByDollarVolume.extend(y[:c])
+
+            self.Log(f"{self.Time} :: {code}-{c}: {','.join([x.Symbol.Value for x in y[:10]])}")
+
+        sortedByDollarVolume = sorted(sortedByDollarVolume, key = lambda x: self.dollarVolumeBySymbol[x.Symbol], reverse=True)
+        self.symbols = [x.Symbol for x in sortedByDollarVolume[:self.numberOfSymbolsFine]]
         return self.symbols
-
-    def OnData(self, data):
-        pass
-
-    def monthly_rebalance(self):
-        self.rebalance = True

--- a/Algorithm.Python/ConstituentsQC500GeneratorAlgorithm.py
+++ b/Algorithm.Python/ConstituentsQC500GeneratorAlgorithm.py
@@ -97,8 +97,6 @@ class ConstituentsQC500GeneratorAlgorithm(QCAlgorithm):
             c = ceil(len(y) * percent)
             sortedByDollarVolume.extend(y[:c])
 
-            self.Log(f"{self.Time} :: {code}-{c}: {','.join([x.Symbol.Value for x in y[:10]])}")
-
         sortedByDollarVolume = sorted(sortedByDollarVolume, key = lambda x: self.dollarVolumeBySymbol[x.Symbol], reverse=True)
         self.symbols = [x.Symbol for x in sortedByDollarVolume[:self.numberOfSymbolsFine]]
         return self.symbols


### PR DESCRIPTION
#### Description
- ConstituentsQC500GeneratorAlgorithm:
  - Change monthly flag to be consistent with Selection Model that cannot use Schedule events.
  - Use a Dictionary keyed by `Symbol` instead of `string`.
  - Selector functions return `Universe.Unchanged` instead of an empty list;
  -Refactoring and more informative logging.
- QC500UniverseSelectionModel
  - SelectFine methods were performing all the logic every day and it should be only once per month
  - Log and return `Universe.Unchanged` before division by zero if the universe drops to zero members after filtering before selection by sector.
  - Refactoring

#### Related Issue
Closes #2994 

#### Motivation and Context
Bug fix and improving framework models.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Running algorithms and comparing universe output.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`