### PR TITLE
Implements IndexUniverseDefinitions

### DIFF
--- a/Algorithm.CSharp/ConstituentsQC500GeneratorAlgorithm.cs
+++ b/Algorithm.CSharp/ConstituentsQC500GeneratorAlgorithm.cs
@@ -39,10 +39,5 @@ namespace QuantConnect.Algorithm.CSharp
             // Add QC500 Universe
             AddUniverse(Universe.Index.QC500);
         }
-
-        public override void OnSecuritiesChanged(SecurityChanges changes)
-        {
-            Log($"{Time} :: {changes}");
-        }
     }
 }

--- a/Algorithm.CSharp/ConstituentsQC500GeneratorAlgorithm.cs
+++ b/Algorithm.CSharp/ConstituentsQC500GeneratorAlgorithm.cs
@@ -13,11 +13,7 @@
  * limitations under the License.
 */
 
-using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -32,12 +28,6 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="fine universes" />
     public class ConstituentsQC500GeneratorAlgorithm : QCAlgorithm
     {
-        private const int _numberOfSymbolsCoarse = 1000;
-        private const int _numberOfSymbolsFine = 500;
-
-        private readonly Dictionary<Symbol, decimal> _dollarVolumeBySymbol = new Dictionary<Symbol, decimal>();
-        private int _lastMonth = -1;
-
         public override void Initialize()
         {
             UniverseSettings.Resolution = Resolution.Daily;
@@ -46,75 +36,13 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2019, 1, 1);     // Set End Date
             SetCash(100000);            // Set Strategy Cash
 
-            // this add universe method accepts two parameters:
-            // - coarse selection function: accepts an IEnumerable<CoarseFundamental> and returns an IEnumerable<Symbol>
-            // - fine selection function: accepts an IEnumerable<FineFundamental> and returns an IEnumerable<Symbol>
-            AddUniverse(CoarseSelectionFunction, FineSelectionFunction);
+            // Add QC500 Universe
+            AddUniverse(Universe.Index.QC500);
         }
 
-        public IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
+        public override void OnSecuritiesChanged(SecurityChanges changes)
         {
-            if (Time.Month == _lastMonth)
-            {
-                return Universe.Unchanged;
-            }
-
-            // The stocks must have fundamental data
-            // The stock must have positive previous-day close price
-            // The stock must have positive volume on the previous trading day
-            var sortedByDollarVolume =
-                (from x in coarse
-                 where x.HasFundamentalData && x.Volume > 0 && x.Price > 0
-                 orderby x.DollarVolume descending
-                 select x).Take(_numberOfSymbolsCoarse).ToList();
-
-            _dollarVolumeBySymbol.Clear();
-            foreach (var i in sortedByDollarVolume)
-            {
-                _dollarVolumeBySymbol[i.Symbol] = i.DollarVolume;
-            }
-            return _dollarVolumeBySymbol.Keys;
-        }
-
-        public IEnumerable<Symbol> FineSelectionFunction(IEnumerable<FineFundamental> fine)
-        {
-            if (Time.Month == _lastMonth)
-            {
-                return Universe.Unchanged;
-            }
-            _lastMonth = Time.Month;
-
-            // The company's headquarter must in the U.S.
-            // The stock must be traded on either the NYSE or NASDAQ 
-            // At least half a year since its initial public offering
-            // The stock's market cap must be greater than 500 million
-            var filteredFine =
-                (from x in fine
-                 where x.CompanyReference.CountryId == "USA" &&
-                       (x.CompanyReference.PrimaryExchangeID == "NYS" || x.CompanyReference.PrimaryExchangeID == "NAS") &&
-                       (Time - x.SecurityReference.IPODate).Days > 180 &&
-                       x.EarningReports.BasicAverageShares.ThreeMonths *
-                       x.EarningReports.BasicEPS.TwelveMonths * x.ValuationRatios.PERatio > 500000000m
-                 select x).ToList();
-
-            var percent = _numberOfSymbolsFine / (double)filteredFine.Count;
-
-            // select stocks with top dollar volume in every single sector 
-            var topFineBySector =
-                (from x in filteredFine
-                 // Group by sector
-                 group x by x.CompanyReference.IndustryTemplateCode into g
-                 let y = from item in g
-                         orderby _dollarVolumeBySymbol[item.Symbol] descending
-                         select item
-                 let c = (int)Math.Ceiling(y.Count() * percent)
-                 select new { g.Key, Value = y.Take(c) }
-                 ).ToDictionary(x => x.Key, x => x.Value);
-
-            return topFineBySector.SelectMany(x => x.Value)
-                .OrderByDescending(x => _dollarVolumeBySymbol[x.Symbol])
-                .Take(_numberOfSymbolsFine)
-                .Select(x => x.Symbol);
+            Log($"{Time} :: {changes}");
         }
     }
 }

--- a/Algorithm.Python/ConstituentsQC500GeneratorAlgorithm.py
+++ b/Algorithm.Python/ConstituentsQC500GeneratorAlgorithm.py
@@ -20,8 +20,6 @@ from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import QCAlgorithm
 from QuantConnect.Data.UniverseSelection import *
-from math import ceil
-from itertools import groupby
 
 ### <summary>
 ### Demonstration of how to estimate constituents of QC500 index based on the company fundamentals
@@ -42,61 +40,8 @@ class ConstituentsQC500GeneratorAlgorithm(QCAlgorithm):
         self.SetEndDate(2019, 1, 1)     # Set End Date
         self.SetCash(100000)            # Set Strategy Cash
 
-        # this add universe method accepts two parameters:
-        # - coarse selection function: accepts an IEnumerable<CoarseFundamental> and returns an IEnumerable<Symbol>
-        # - fine selection function: accepts an IEnumerable<FineFundamental> and returns an IEnumerable<Symbol>
-        self.AddUniverse(self.CoarseSelectionFunction, self.FineSelectionFunction)
+        # Add QC500 Universe
+        self.AddUniverse(self.Universe.Index.QC500)
 
-        self.numberOfSymbolsCoarse = 1000
-        self.numberOfSymbolsFine = 500
-        self.dollarVolumeBySymbol = {}
-        self.symbols = []
-        self.lastMonth = -1
-
-    def CoarseSelectionFunction(self, coarse):
-        if self.Time.month == self.lastMonth: 
-            return self.symbols
-
-        # The stocks must have fundamental data
-        # The stock must have positive previous-day close price
-        # The stock must have positive volume on the previous trading day
-        filtered = [x for x in coarse if x.HasFundamentalData and x.Volume > 0 and x.Price > 0]
-        sortedByDollarVolume = sorted(filtered, key = lambda x: x.DollarVolume, reverse=True)[:self.numberOfSymbolsCoarse]
-
-        self.symbols.clear()
-        self.dollarVolumeBySymbol.clear()
-        for x in sortedByDollarVolume:
-            self.symbols.append(x.Symbol)
-            self.dollarVolumeBySymbol[x.Symbol] = x.DollarVolume
-
-        # return the symbol objects our sorted collection
-        return self.symbols
-
-    def FineSelectionFunction(self, fine):
-        if self.Time.month == self.lastMonth: 
-            return self.symbols
-        self.lastMonth = self.Time.month
-
-        # The company's headquarter must in the U.S.
-        # The stock must be traded on either the NYSE or NASDAQ
-        # At least half a year since its initial public offering
-        # The stock's market cap must be greater than 500 million
-        filtered = [x for x in fine if x.CompanyReference.CountryId == "USA"
-                                    and (x.CompanyReference.PrimaryExchangeID == "NYS" or x.CompanyReference.PrimaryExchangeID == "NAS")
-                                    and (self.Time - x.SecurityReference.IPODate).days > 180
-                                    and x.EarningReports.BasicAverageShares.ThreeMonths * (x.EarningReports.BasicEPS.TwelveMonths*x.ValuationRatios.PERatio) > 5e8]
-
-        sortedByDollarVolume = []
-        sortedBySector = sorted(filtered, key = lambda x: x.CompanyReference.IndustryTemplateCode)
-
-        percent = self.numberOfSymbolsFine/float(len(sortedBySector))
-
-        # select stocks with top dollar volume in every single sector 
-        for code, g in groupby(sortedBySector, lambda x: x.CompanyReference.IndustryTemplateCode):
-            y = sorted(g, key = lambda x: self.dollarVolumeBySymbol[x.Symbol], reverse = True)
-            c = ceil(len(y) * percent)
-            sortedByDollarVolume.extend(y[:c])
-
-        sortedByDollarVolume = sorted(sortedByDollarVolume, key = lambda x: self.dollarVolumeBySymbol[x.Symbol], reverse=True)
-        self.symbols = [x.Symbol for x in sortedByDollarVolume[:self.numberOfSymbolsFine]]
-        return self.symbols
+    def OnSecuritiesChanged(self, changes):
+        self.Log(f"{Time} :: {changes}")

--- a/Algorithm.Python/ConstituentsQC500GeneratorAlgorithm.py
+++ b/Algorithm.Python/ConstituentsQC500GeneratorAlgorithm.py
@@ -42,6 +42,3 @@ class ConstituentsQC500GeneratorAlgorithm(QCAlgorithm):
 
         # Add QC500 Universe
         self.AddUniverse(self.Universe.Index.QC500)
-
-    def OnSecuritiesChanged(self, changes):
-        self.Log(f"{Time} :: {changes}")

--- a/Algorithm/IndexUniverseDefinitions.cs
+++ b/Algorithm/IndexUniverseDefinitions.cs
@@ -1,0 +1,129 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Data.UniverseSelection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm
+{
+    /// <summary>
+    /// Provides helpers for defining universes based on index definitions
+    /// </summary>
+    public class IndexUniverseDefinitions
+    {
+        private readonly QCAlgorithm _algorithm;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IndexUniverseDefinitions"/> class
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance, used for obtaining the default <see cref="UniverseSettings"/></param>
+        public IndexUniverseDefinitions(QCAlgorithm algorithm)
+        {
+            _algorithm = algorithm;
+        }
+
+        /// <summary>
+        /// Creates a new fine universe that contains the constituents of QC500 index based onthe company fundamentals
+        /// The algorithm creates a default tradable and liquid universe containing 500 US equities
+        /// which are chosen at the first trading day of each month.
+        /// </summary>
+        /// <returns>A new coarse universe for the top count of stocks by dollar volume</returns>
+        public Universe QC500
+        {
+            get
+            {
+                var lastMonth = -1;
+                var numberOfSymbolsCoarse = 1000;
+                var numberOfSymbolsFine = 500;
+                var dollarVolumeBySymbol = new Dictionary<Symbol, decimal>();
+                var symbol = Symbol.Create("qc-500", SecurityType.Equity, Market.USA);
+
+                var coarseUniverse = new CoarseFundamentalUniverse(
+                    symbol,
+                    _algorithm.UniverseSettings,
+                    _algorithm.SecurityInitializer,
+                    coarse =>
+                    {
+                        if (_algorithm.Time.Month == lastMonth)
+                        {
+                            return Universe.Unchanged;
+                        }
+
+                        // The stocks must have fundamental data
+                        // The stock must have positive previous-day close price
+                        // The stock must have positive volume on the previous trading day
+                        var sortedByDollarVolume =
+                                (from x in coarse
+                                 where x.HasFundamentalData && x.Volume > 0 && x.Price > 0
+                                 orderby x.DollarVolume descending
+                                 select x).Take(numberOfSymbolsCoarse).ToList();
+
+                        dollarVolumeBySymbol.Clear();
+                        foreach (var i in sortedByDollarVolume)
+                        {
+                            dollarVolumeBySymbol[i.Symbol] = i.DollarVolume;
+                        }
+                        return dollarVolumeBySymbol.Keys;
+                    });
+
+                return new FineFundamentalFilteredUniverse(
+                    coarseUniverse,
+                    fine =>
+                    {
+                        if (_algorithm.Time.Month == lastMonth)
+                        {
+                            return Universe.Unchanged;
+                        }
+                        lastMonth = _algorithm.Time.Month;
+
+                        // The company's headquarter must in the U.S.
+                        // The stock must be traded on either the NYSE or NASDAQ 
+                        // At least half a year since its initial public offering
+                        // The stock's market cap must be greater than 500 million
+                        var filteredFine =
+                                (from x in fine
+                                 where x.CompanyReference.CountryId == "USA" &&
+                                       (x.CompanyReference.PrimaryExchangeID == "NYS" || x.CompanyReference.PrimaryExchangeID == "NAS") &&
+                                       (_algorithm.Time - x.SecurityReference.IPODate).Days > 180 &&
+                                       x.EarningReports.BasicAverageShares.ThreeMonths *
+                                       x.EarningReports.BasicEPS.TwelveMonths * x.ValuationRatios.PERatio > 500000000m
+                                 select x).ToList();
+
+                        var percent = numberOfSymbolsFine / (double)filteredFine.Count;
+
+                        // select stocks with top dollar volume in every single sector 
+                        var topFineBySector =
+                                (from x in filteredFine
+                                 // Group by sector
+                                 group x by x.CompanyReference.IndustryTemplateCode into g
+                                 let y = from item in g
+                                         orderby dollarVolumeBySymbol[item.Symbol] descending
+                                         select item
+                                 let c = (int)Math.Ceiling(y.Count() * percent)
+                                 select new { g.Key, Value = y.Take(c) }
+                                 ).ToDictionary(x => x.Key, x => x.Value);
+
+                        return topFineBySector.SelectMany(x => x.Value)
+                            .OrderByDescending(x => dollarVolumeBySymbol[x.Symbol])
+                            .Take(numberOfSymbolsFine)
+                            .Select(x => x.Symbol);
+                    });
+            }
+        }
+    }
+}

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -124,6 +124,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="CandlestickPatterns.cs" />
+    <Compile Include="IndexUniverseDefinitions.cs" />
     <Compile Include="DollarVolumeUniverseDefinitions.cs" />
     <Compile Include="QCAlgorithm.cs" />
     <Compile Include="QCAlgorithm.History.cs" />

--- a/Algorithm/UniverseDefinitions.cs
+++ b/Algorithm/UniverseDefinitions.cs
@@ -26,18 +26,17 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// Specifies that universe selection should not make changes on this iteration
         /// </summary>
-        public Universe.UnchangedUniverse Unchanged
-        {
-            get { return Universe.Unchanged; }
-        }
+        public Universe.UnchangedUniverse Unchanged => Universe.Unchanged;
 
         /// <summary>
         /// Gets a helper that provides methods for creating universes based on daily dollar volumes
         /// </summary>
-        public DollarVolumeUniverseDefinitions DollarVolume
-        {
-            get; private set;
-        }
+        public DollarVolumeUniverseDefinitions DollarVolume { get; private set; }
+
+        /// <summary>
+        /// Gets a helper that provides methods for creating universes based on index definitions
+        /// </summary>
+        public IndexUniverseDefinitions Index { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UniverseDefinitions"/> class
@@ -46,6 +45,7 @@ namespace QuantConnect.Algorithm
         public UniverseDefinitions(QCAlgorithm algorithm)
         {
             DollarVolume = new DollarVolumeUniverseDefinitions(algorithm);
+            Index = new IndexUniverseDefinitions(algorithm);
         }
     }
 }


### PR DESCRIPTION
#### Description
In this new `UniverseDefintions`, a member defines the QC500 Universe. This helper can be used to add that custom universe to the user algorithm (both in C# and Python).

#### Related Issue
#2994 

#### Motivation and Context
In the sequence of the work on issue #2994 and pull request #2995, we propose a new UniverseDefintions member that creates a helper to create QC500 algorithms.

#### Requires Documentation Change
We could include a note in the Universe section.

#### How Has This Been Tested?
Regression test in QC cloud.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`