### PR TITLE
just a small fix. for LeanEngineSystemHandlers defaults

### DIFF
--- a/Configuration/Config.cs
+++ b/Configuration/Config.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Configuration
                     {"live-mode", false},
                     {"data-folder", "../../../Data/"},
                     {"messaging-handler", "QuantConnect.Messaging.Messaging"},
-                    {"queue-handler", "QuantConnect.Queues.Queues"},
+                    {"job-queue-handler", "QuantConnect.Queues.JobQueue"},
                     {"api-handler", "QuantConnect.Api.Api"},
                     {"setup-handler", "QuantConnect.Lean.Engine.Setup.ConsoleSetupHandler"},
                     {"result-handler", "QuantConnect.Lean.Engine.Results.BacktestingResultHandler"},


### PR DESCRIPTION
#### Description
I am working with genetic optimization for Lean at the moment. I have realized when launched the engine with no config file default ConfigFactory json object gives an error unless to have it explicitely load an existing queue-handler which is  {"job-queue-handler", "QuantConnect.Queues.JobQueue"}. despite I can set these properties manually by using Config.Set maybe I sould have also drawn your attention to this..

#### Related Issue
-

#### Motivation and Context
was working with genetic optimization and realized this might be little improved

#### Requires Documentation Change
-

#### How Has This Been Tested?
-

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [X ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [X ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->