### PR TITLE
Support custom currency length

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1388,10 +1388,10 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Safely remove ending
+        /// Returns a new string in which specified ending in the current instance is removed.
         /// </summary>
-        /// <param name="s"></param>
-        /// <param name="ending"></param>
+        /// <param name="s">original string value</param>
+        /// <param name="ending">the string to be removed</param>
         /// <returns></returns>
         public static string RemoveFromEnd(this string s, string ending)
         {

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1386,5 +1386,23 @@ namespace QuantConnect
         {
             task.ConfigureAwait(false).GetAwaiter().GetResult();
         }
+
+        /// <summary>
+        /// Safely remove ending
+        /// </summary>
+        /// <param name="s"></param>
+        /// <param name="ending"></param>
+        /// <returns></returns>
+        public static string RemoveFromEnd(this string s, string ending)
+        {
+            if (s.EndsWith(ending))
+            {
+                return s.Substring(0, s.Length - ending.Length);
+            }
+            else
+            {
+                return s;
+            }
+        }
     }
 }

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -81,9 +81,9 @@ namespace QuantConnect.Securities
         /// <param name="conversionRate">The initial conversion rate of this currency into the <see cref="AccountCurrency"/></param>
         public Cash(string symbol, decimal amount, decimal conversionRate)
         {
-            if (symbol == null || symbol.Length != 3)
+            if (string.IsNullOrEmpty(symbol))
             {
-                throw new ArgumentException("Cash symbols must be exactly 3 characters.");
+                throw new ArgumentException("Cash symbols cannot be null or empty.");
             }
             Amount = amount;
             ConversionRate = conversionRate;

--- a/Common/Securities/Crypto/Crypto.cs
+++ b/Common/Securities/Crypto/Crypto.cs
@@ -19,6 +19,7 @@ using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Slippage;
 using QuantConnect.Securities.Forex;
+using System;
 
 namespace QuantConnect.Securities.Crypto
 {
@@ -58,9 +59,15 @@ namespace QuantConnect.Securities.Crypto
             Holdings = new CryptoHolding(this, currencyConverter);
 
             // decompose the symbol into each currency pair
-            string baseCurrencySymbol, quoteCurrencySymbol;
-            Forex.Forex.DecomposeCurrencyPair(config.Symbol.Value, out baseCurrencySymbol, out quoteCurrencySymbol);
-            BaseCurrencySymbol = baseCurrencySymbol;
+            string quoteCurrencySymbol = symbolProperties.QuoteCurrency;
+            if (config.Symbol.Value.EndsWith(quoteCurrencySymbol))
+            {
+                BaseCurrencySymbol = config.Symbol.Value.RemoveFromEnd(quoteCurrencySymbol);
+            }
+            else
+            {
+                throw new InvalidOperationException($"symbol doesn't end with {quoteCurrencySymbol}");
+            }
         }
 
         /// <summary>
@@ -93,9 +100,15 @@ namespace QuantConnect.Securities.Crypto
             Holdings = new CryptoHolding(this, currencyConverter);
 
             // decompose the symbol into each currency pair
-            string baseCurrencySymbol, quoteCurrencySymbol;
-            Forex.Forex.DecomposeCurrencyPair(symbol.Value, out baseCurrencySymbol, out quoteCurrencySymbol);
-            BaseCurrencySymbol = baseCurrencySymbol;
+            string quoteCurrencySymbol = symbolProperties.QuoteCurrency;
+            if (symbol.Value.EndsWith(quoteCurrencySymbol))
+            {
+                BaseCurrencySymbol = symbol.Value.RemoveFromEnd(quoteCurrencySymbol);
+            }
+            else
+            {
+                throw new InvalidOperationException($"symbol doesn't end with {quoteCurrencySymbol}");
+            }
         }
 
         /// <summary>

--- a/Common/Securities/Crypto/Crypto.cs
+++ b/Common/Securities/Crypto/Crypto.cs
@@ -59,15 +59,9 @@ namespace QuantConnect.Securities.Crypto
             Holdings = new CryptoHolding(this, currencyConverter);
 
             // decompose the symbol into each currency pair
-            string quoteCurrencySymbol = symbolProperties.QuoteCurrency;
-            if (config.Symbol.Value.EndsWith(quoteCurrencySymbol))
-            {
-                BaseCurrencySymbol = config.Symbol.Value.RemoveFromEnd(quoteCurrencySymbol);
-            }
-            else
-            {
-                throw new InvalidOperationException($"symbol doesn't end with {quoteCurrencySymbol}");
-            }
+            string quoteCurrencySymbol, baseCurrencySymbol;
+            DecomposeCurrencyPair(config.Symbol, symbolProperties, out baseCurrencySymbol, out quoteCurrencySymbol);
+            BaseCurrencySymbol = baseCurrencySymbol;
         }
 
         /// <summary>
@@ -100,15 +94,9 @@ namespace QuantConnect.Securities.Crypto
             Holdings = new CryptoHolding(this, currencyConverter);
 
             // decompose the symbol into each currency pair
-            string quoteCurrencySymbol = symbolProperties.QuoteCurrency;
-            if (symbol.Value.EndsWith(quoteCurrencySymbol))
-            {
-                BaseCurrencySymbol = symbol.Value.RemoveFromEnd(quoteCurrencySymbol);
-            }
-            else
-            {
-                throw new InvalidOperationException($"symbol doesn't end with {quoteCurrencySymbol}");
-            }
+            string quoteCurrencySymbol, baseCurrencySymbol;
+            DecomposeCurrencyPair(symbol, symbolProperties, out baseCurrencySymbol, out quoteCurrencySymbol);
+            BaseCurrencySymbol = baseCurrencySymbol;
         }
 
         /// <summary>
@@ -124,5 +112,25 @@ namespace QuantConnect.Securities.Crypto
         /// Get the current value of the security.
         /// </summary>
         public override decimal Price => Cache.GetData<TradeBar>()?.Close ?? Cache.Price;
+
+        /// <summary>
+        /// Decomposes the specified currency pair into a base and quote currency provided as out parameters
+        /// </summary>
+        /// <param name="symbol">The input symbol to be decomposed</param>
+        /// <param name="symbolProperties">The symbol properties for this security</param>
+        /// <param name="baseCurrency">The output base currency</param>
+        /// <param name="quoteCurrency">The output quote currency</param>
+        public static void DecomposeCurrencyPair(Symbol symbol, SymbolProperties symbolProperties, out string baseCurrency, out string quoteCurrency)
+        {
+            quoteCurrency = symbolProperties.QuoteCurrency;
+            if (symbol.Value.EndsWith(quoteCurrency))
+            {
+                baseCurrency = symbol.Value.RemoveFromEnd(quoteCurrency);
+            }
+            else
+            {
+                throw new InvalidOperationException($"symbol doesn't end with {quoteCurrency}");
+            }
+        }
     }
 }

--- a/Common/Securities/SecurityService.cs
+++ b/Common/Securities/SecurityService.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
+using System;
 
 namespace QuantConnect.Securities
 {
@@ -61,13 +62,17 @@ namespace QuantConnect.Securities
             var exchangeHours = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType).ExchangeHours;
 
             var defaultQuoteCurrency = _cashBook.AccountCurrency;
-            if (symbol.ID.SecurityType == SecurityType.Forex || symbol.ID.SecurityType == SecurityType.Crypto)
+            if (symbol.ID.SecurityType == SecurityType.Forex)
             {
                 defaultQuoteCurrency = symbol.Value.Substring(3);
             }
 
-            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
+            if (symbol.ID.SecurityType == SecurityType.Crypto && !_symbolPropertiesDatabase.ContainsKey(symbol.ID.Market, symbol, symbol.ID.SecurityType))
+            {
+                throw new ArgumentException($"symbol can't be found in csv: {symbol.Value}");
+            }
 
+            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);
             // add the symbol to our cache
             if (addToSymbolCache)
             {
@@ -85,7 +90,18 @@ namespace QuantConnect.Securities
             {
                 // decompose the symbol into each currency pair
                 string baseCurrency;
-                Forex.Forex.DecomposeCurrencyPair(symbol.Value, out baseCurrency, out quoteCurrency);
+                if (symbol.ID.SecurityType == SecurityType.Forex)
+                {
+                    Forex.Forex.DecomposeCurrencyPair(symbol.Value, out baseCurrency, out quoteCurrency);
+                }
+                else if (symbol.Value.EndsWith(quoteCurrency))
+                {
+                    baseCurrency = symbol.Value.RemoveFromEnd(quoteCurrency);
+                }
+                else
+                {
+                    throw new InvalidOperationException($"symbol doesn't end with {quoteCurrency}");
+                }
 
                 if (!_cashBook.ContainsKey(baseCurrency))
                 {

--- a/Common/Securities/SecurityService.cs
+++ b/Common/Securities/SecurityService.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Securities
 
             if (symbol.ID.SecurityType == SecurityType.Crypto && !_symbolPropertiesDatabase.ContainsKey(symbol.ID.Market, symbol, symbol.ID.SecurityType))
             {
-                throw new ArgumentException($"symbol can't be found in csv: {symbol.Value}");
+                throw new ArgumentException($"Symbol can't be found in the Symbol Properties Database: {symbol.Value}");
             }
 
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.ID.SecurityType, defaultQuoteCurrency);

--- a/Common/Securities/SecurityService.cs
+++ b/Common/Securities/SecurityService.cs
@@ -94,13 +94,9 @@ namespace QuantConnect.Securities
                 {
                     Forex.Forex.DecomposeCurrencyPair(symbol.Value, out baseCurrency, out quoteCurrency);
                 }
-                else if (symbol.Value.EndsWith(quoteCurrency))
-                {
-                    baseCurrency = symbol.Value.RemoveFromEnd(quoteCurrency);
-                }
                 else
                 {
-                    throw new InvalidOperationException($"symbol doesn't end with {quoteCurrency}");
+                    Crypto.Crypto.DecomposeCurrencyPair(symbol, symbolProperties, out baseCurrency, out quoteCurrency);
                 }
 
                 if (!_cashBook.ContainsKey(baseCurrency))

--- a/Common/Securities/SymbolPropertiesDatabase.cs
+++ b/Common/Securities/SymbolPropertiesDatabase.cs
@@ -35,6 +35,34 @@ namespace QuantConnect.Securities
         {
             _entries = entries.ToDictionary();
         }
+        
+        /// <summary>
+        /// Check whether symbol properties exists for the specified market/symbol/security-type
+        /// </summary>
+        /// <param name="market">The market the exchange resides in, i.e, 'usa', 'fxcm', ect...</param>
+        /// <param name="symbol">The particular symbol being traded</param>
+        /// <param name="securityType">The security type of the symbol</param>
+        public bool ContainsKey(string market, string symbol, SecurityType securityType)
+        {
+            var key = new SecurityDatabaseKey(market, symbol, securityType);
+            return _entries.ContainsKey(key);
+        }
+
+        /// <summary>
+        /// Check whether symbol properties exists for the specified market/symbol/security-type
+        /// </summary>
+        /// <param name="market">The market the exchange resides in, i.e, 'usa', 'fxcm', ect...</param>
+        /// <param name="symbol">The particular symbol being traded (Symbol class)</param>
+        /// <param name="securityType">The security type of the symbol</param>
+        public bool ContainsKey(string market, Symbol symbol, SecurityType securityType)
+        {
+            var stringSymbol = symbol == null ? string.Empty :
+                (symbol.ID.SecurityType == SecurityType.Option ? symbol.Underlying.Value :
+                (symbol.ID.SecurityType == SecurityType.Future ? symbol.ID.Symbol :
+                 symbol.Value));
+
+            return ContainsKey(market, stringSymbol, securityType);
+        }
 
         /// <summary>
         /// Gets the symbol properties for the specified market/symbol/security-type

--- a/Common/Securities/SymbolPropertiesDatabase.cs
+++ b/Common/Securities/SymbolPropertiesDatabase.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Securities
         {
             _entries = entries.ToDictionary();
         }
-        
+
         /// <summary>
         /// Check whether symbol properties exists for the specified market/symbol/security-type
         /// </summary>
@@ -56,12 +56,10 @@ namespace QuantConnect.Securities
         /// <param name="securityType">The security type of the symbol</param>
         public bool ContainsKey(string market, Symbol symbol, SecurityType securityType)
         {
-            var stringSymbol = symbol == null ? string.Empty :
-                (symbol.ID.SecurityType == SecurityType.Option ? symbol.Underlying.Value :
-                (symbol.ID.SecurityType == SecurityType.Future ? symbol.ID.Symbol :
-                 symbol.Value));
-
-            return ContainsKey(market, stringSymbol, securityType);
+            return ContainsKey(
+                market,
+                MarketHoursDatabase.GetDatabaseSymbolKey(symbol),
+                securityType);
         }
 
         /// <summary>
@@ -100,12 +98,11 @@ namespace QuantConnect.Securities
         /// <returns>The symbol properties matching the specified market/symbol/security-type or null if not found</returns>
         public SymbolProperties GetSymbolProperties(string market, Symbol symbol, SecurityType securityType, string defaultQuoteCurrency)
         {
-            var stringSymbol = symbol == null ? string.Empty :
-                (symbol.ID.SecurityType == SecurityType.Option ? symbol.Underlying.Value :
-                (symbol.ID.SecurityType == SecurityType.Future ? symbol.ID.Symbol :
-                 symbol.Value));
-
-            return GetSymbolProperties(market, stringSymbol, securityType, defaultQuoteCurrency);
+            return GetSymbolProperties(
+                market,
+                MarketHoursDatabase.GetDatabaseSymbolKey(symbol),
+                securityType,
+                defaultQuoteCurrency);
         }
 
         /// <summary>
@@ -167,12 +164,12 @@ namespace QuantConnect.Securities
             var csv = line.Split(',');
 
             key = new SecurityDatabaseKey(
-                market: csv[0], 
-                symbol: csv[1], 
+                market: csv[0],
+                symbol: csv[1],
                 securityType: (SecurityType)Enum.Parse(typeof(SecurityType), csv[2], true));
 
             return new SymbolProperties(
-                description: csv[3], 
+                description: csv[3],
                 quoteCurrency: csv[4],
                 contractMultiplier: csv[5].ToDecimal(),
                 minimumPriceVariation: csv[6].ToDecimal(),

--- a/Tests/Common/CurrenciesTests.cs
+++ b/Tests/Common/CurrenciesTests.cs
@@ -25,13 +25,24 @@ namespace QuantConnect.Tests.Common
         [Test]
         public void HasCurrencySymbolForEachPair()
         {
-            var allPairs = Currencies.CurrencyPairs.Concat(Currencies.CfdCurrencyPairs).Concat(Currencies.CryptoCurrencyPairs);
+            var allPairs = Currencies.CurrencyPairs.Concat(Currencies.CfdCurrencyPairs);
             foreach (var currencyPair in allPairs)
             {
                 string quotec, basec;
                 Forex.DecomposeCurrencyPair(currencyPair, out basec, out quotec);
                 Assert.IsTrue(Currencies.CurrencySymbols.ContainsKey(basec), "Missing currency symbol for: " + basec);
                 Assert.IsTrue(Currencies.CurrencySymbols.ContainsKey(quotec), "Missing currency symbol for: " + quotec);
+            }
+        }
+
+        [Test]
+        public void HasCryptoCurrencySymbolForEachPair()
+        {
+            var allPairs = Currencies.CryptoCurrencyPairs;
+            foreach (var currencyPair in allPairs)
+            {
+                Assert.IsTrue(Currencies.CurrencySymbols.Keys.Any(c => currencyPair.StartsWith(c)), "Missing currency symbol for: " + currencyPair);
+                Assert.IsTrue(Currencies.CurrencySymbols.Keys.Any(c => currencyPair.EndsWith(c)), "Missing currency symbol for: " + currencyPair);
             }
         }
     }

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -44,17 +44,20 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentException), MatchType = MessageMatch.Contains, ExpectedMessage = "Cash symbols must be exactly 3 characters")]
-        public void ConstructorThrowsOnSymbolTooLong()
+        [TestCase(null, ExpectedException = typeof(ArgumentException), MatchType = MessageMatch.Exact, ExpectedMessage = "Cash symbols cannot be null or empty.")]
+        [TestCase("", ExpectedException = typeof(ArgumentException), MatchType = MessageMatch.Exact, ExpectedMessage = "Cash symbols cannot be null or empty.")]
+        public void ConstructorThrowsOnEmptySymbol(string currency)
         {
-            var cash = new Cash("too long", 0, 0);
+            var cash = new Cash(currency, 0, 0);
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentException), MatchType = MessageMatch.Contains, ExpectedMessage = "Cash symbols must be exactly 3 characters")]
-        public void ConstructorThrowsOnSymbolTooShort()
+        [TestCase("too long")]
+        [TestCase("s")]
+        public void ConstructorOnCustomSymbolLength(string currency)
         {
-            var cash = new Cash("s", 0, 0);
+            var cash = new Cash(currency, 0, 0);
+            Assert.AreEqual(currency.ToUpper(), cash.Symbol);
         }
 
         [Test]
@@ -73,9 +76,9 @@ namespace QuantConnect.Tests.Common.Securities
         public void ComputesValueInBaseCurrency()
         {
             const int quantity = 100;
-            const decimal conversionRate = 1/100m;
+            const decimal conversionRate = 1 / 100m;
             var cash = new Cash("JPY", quantity, conversionRate);
-            Assert.AreEqual(quantity*conversionRate, cash.ValueInAccountCurrency);
+            Assert.AreEqual(quantity * conversionRate, cash.ValueInAccountCurrency);
         }
 
         [Test]
@@ -130,7 +133,7 @@ namespace QuantConnect.Tests.Common.Securities
                 )
             );
             var usdjpy = new Security(Symbols.USDJPY, SecurityExchangeHours, new Cash("JPY", 0, 0), SymbolProperties.GetDefault("JPY"), ErrorCurrencyConverter.Instance);
-            var changes = new SecurityChanges(new[] {usdjpy}, Enumerable.Empty<Security>());
+            var changes = new SecurityChanges(new[] { usdjpy }, Enumerable.Empty<Security>());
             var addedSecurity = cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, changes, dataManager.SecurityService, cashBook.AccountCurrency);
 
             // the security exists in SecurityChanges so it is NOT added to the security manager or subscriptions

--- a/Tests/Common/Securities/Cryptos/CryptoTests.cs
+++ b/Tests/Common/Securities/Cryptos/CryptoTests.cs
@@ -1,0 +1,75 @@
+﻿using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Crypto;
+using System;
+
+namespace QuantConnect.Tests.Common.Securities.Cryptos
+{
+    [TestFixture]
+    public class CryptoTests
+    {
+        private static TimeKeeper TimeKeeper
+        {
+            get { return new TimeKeeper(DateTime.Now, new[] { TimeZones.NewYork }); }
+        }
+
+        [Test]
+        [TestCase("BTCUSD", "USD")]
+        public void ConstructorParseBaseCurrencyBySymbolProps(string ticker, string quote)
+        {
+            var securities = new SecurityManager(TimeKeeper);
+            var transactions = new SecurityTransactionManager(null, securities);
+            var portfolio = new SecurityPortfolioManager(securities, transactions);
+            if (portfolio.CashBook.ContainsKey(quote))
+            {
+                portfolio.CashBook[quote].SetAmount(1000);
+            }
+            else
+            {
+                portfolio.CashBook.Add(quote, 0, 1000);
+            }
+            var cash = portfolio.CashBook[quote];
+            var symbol = Symbol.Create(ticker, SecurityType.Crypto, Market.GDAX);
+
+            var crypto = new Crypto(
+                symbol,
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                cash,
+                SymbolProperties.GetDefault(quote),
+                portfolio.CashBook
+            );
+
+            Assert.AreEqual(symbol.Value.RemoveFromEnd(quote), crypto.BaseCurrencySymbol);
+        }
+
+        [Test]
+        [TestCase("BTCEUR", "USD", ExpectedException = typeof(InvalidOperationException), MatchType = MessageMatch.Contains, ExpectedMessage = "symbol doesn't end with")]
+        public void ConstructorThrowOnWrongQuoteCurrency(string ticker, string quote)
+        {
+            var securities = new SecurityManager(TimeKeeper);
+            var transactions = new SecurityTransactionManager(null, securities);
+            var portfolio = new SecurityPortfolioManager(securities, transactions);
+            if (portfolio.CashBook.ContainsKey(quote))
+            {
+                portfolio.CashBook[quote].SetAmount(1000);
+            }
+            else
+            {
+                portfolio.CashBook.Add(quote, 0, 1000);
+            }
+            var cash = portfolio.CashBook[quote];
+            var symbol = Symbol.Create(ticker, SecurityType.Crypto, Market.GDAX);
+
+            var crypto = new Crypto(
+                symbol,
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                cash,
+                SymbolProperties.GetDefault(quote),
+                portfolio.CashBook
+            );
+
+            Assert.AreEqual(symbol.Value.RemoveFromEnd(quote), crypto.BaseCurrencySymbol);
+        }
+    }
+}

--- a/Tests/Common/Securities/Cryptos/CryptoTests.cs
+++ b/Tests/Common/Securities/Cryptos/CryptoTests.cs
@@ -16,6 +16,8 @@ namespace QuantConnect.Tests.Common.Securities.Cryptos
 
         [Test]
         [TestCase("BTCUSD", "USD")]
+        [TestCase("ETHBTC", "BTC")]
+        [TestCase("ETHUSDT", "USDT")]
         public void ConstructorParseBaseCurrencyBySymbolProps(string ticker, string quote)
         {
             var securities = new SecurityManager(TimeKeeper);

--- a/Tests/Common/Securities/SecurityServiceTests.cs
+++ b/Tests/Common/Securities/SecurityServiceTests.cs
@@ -116,7 +116,7 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentException), MatchType = MessageMatch.Contains, ExpectedMessage = "symbol can't be found in csv")]
+        [ExpectedException(typeof(ArgumentException), MatchType = MessageMatch.Contains, ExpectedMessage = "Symbol can't be found in the Symbol Properties Database")]
         public void ThrowOnCreateCryptoNotDescribedInCSV()
         {
             var symbol = Symbol.Create("ABCDEFG", SecurityType.Crypto, Market.GDAX);

--- a/Tests/Common/Securities/SecurityServiceTests.cs
+++ b/Tests/Common/Securities/SecurityServiceTests.cs
@@ -116,6 +116,16 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        [ExpectedException(typeof(ArgumentException), MatchType = MessageMatch.Contains, ExpectedMessage = "symbol can't be found in csv")]
+        public void ThrowOnCreateCryptoNotDescribedInCSV()
+        {
+            var symbol = Symbol.Create("ABCDEFG", SecurityType.Crypto, Market.GDAX);
+
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(typeof(QuoteBar), symbol, Resolution.Minute, false, false, false);
+            var actual = _securityService.CreateSecurity(symbol, configs, 1.0m, false);
+        }
+
+        [Test]
         public void CanCreate_ConcreteOptions_WithCorrectSubscriptions()
         {
             var underlying = SecurityIdentifier.GenerateEquity(new DateTime(1998, 01, 02), "SPY", Market.USA);

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Common\Orders\Fills\BackwardsCompatibilityFillModelsTests.cs" />
     <Compile Include="Common\Securities\CashAmountTests.cs" />
     <Compile Include="Common\Data\Custom\QuandlTests.cs" />
+    <Compile Include="Common\Securities\Cryptos\CryptoTests.cs" />
     <Compile Include="Common\Securities\ErrorCurrencyConverterTests.cs" />
     <Compile Include="Common\Securities\IdentityCurrencyConverterTests.cs" />
     <Compile Include="Common\Securities\AccountCurrencyImmediateSettlementModelTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Parse crypto symbols using symbol properties db. Using entries from this db we can identify base and quote currencies for each symbol.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #996
Closes #2874

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows us to support new brokerages with different currencies including stable coins that can have length different from 3 (i.e. USDT, USDC etc) 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Autotests; manual testing

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->