### PR TITLE
Add StalePriceTimeSpan Algorithm Setting for Market Fill Warnings

### DIFF
--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -351,7 +351,8 @@ namespace QuantConnect.Brokerages.Backtesting
                                 var context = new FillModelParameters(
                                     security,
                                     order,
-                                    Algorithm.SubscriptionManager.SubscriptionDataConfigService);
+                                    Algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                                    Algorithm.Settings.StalePriceTimeSpan);
                                 fills = new[] { model.Fill(context).OrderEvent };
                             }
 

--- a/Common/AlgorithmSettings.cs
+++ b/Common/AlgorithmSettings.cs
@@ -13,7 +13,9 @@
  * limitations under the License.
 */
 
+using System;
 using QuantConnect.Interfaces;
+using QuantConnect.Orders.Fills;
 
 namespace QuantConnect
 {
@@ -43,6 +45,17 @@ namespace QuantConnect
         public bool LiquidateEnabled { get; set; }
 
         /// <summary>
+        /// Gets/sets the minimum time span elapsed to consider a market fill price as stale (defaults to one hour)
+        /// </summary>
+        /// <remarks>
+        /// In the default fill models, a warning message will be added to market order fills
+        /// if this time span (or more) has elapsed since the price was last updated.
+        /// </remarks>
+        /// <seealso cref="FillModel"/>
+        /// <seealso cref="ImmediateFillModel"/>
+        public TimeSpan StalePriceTimeSpan { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AlgorithmSettings"/> class
         /// </summary>
         public AlgorithmSettings()
@@ -51,6 +64,7 @@ namespace QuantConnect
             DataSubscriptionLimit = int.MaxValue;
             LiquidateEnabled = true;
             FreePortfolioValuePercentage = 0.0025m;
+            StalePriceTimeSpan = Time.OneHour;
         }
     }
 }

--- a/Common/Interfaces/IAlgorithmSettings.cs
+++ b/Common/Interfaces/IAlgorithmSettings.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System;
+
 namespace QuantConnect.Interfaces
 {
     /// <summary>
@@ -39,5 +41,10 @@ namespace QuantConnect.Interfaces
         /// with the exception of options and futures where every single contract in a chain counts as one.
         /// </remarks>
         int DataSubscriptionLimit { get; set; }
+
+        /// <summary>
+        /// Gets the minimum time span elapsed to consider a market fill price as stale (defaults to one hour)
+        /// </summary>
+        TimeSpan StalePriceTimeSpan { get; set; }
     }
 }

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -118,7 +118,7 @@ namespace QuantConnect.Orders.Fills
             var pricesEndTimeUtc = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
 
             // if the order is filled on stale (fill-forward) data, set a warning message on the order event
-            if (pricesEndTimeUtc < order.Time)
+            if (pricesEndTimeUtc.Add(Parameters.StalePriceTimeSpan) < order.Time)
             {
                 fill.Message = $"Warning: fill at stale price ({prices.EndTime} {asset.Exchange.TimeZone})";
             }

--- a/Common/Orders/Fills/FillModelParameters.cs
+++ b/Common/Orders/Fills/FillModelParameters.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
@@ -40,19 +41,27 @@ namespace QuantConnect.Orders.Fills
         public ISubscriptionDataConfigProvider ConfigProvider { get; }
 
         /// <summary>
+        /// Gets the minimum time span elapsed to consider a market fill price as stale (defaults to one hour)
+        /// </summary>
+        public TimeSpan StalePriceTimeSpan { get; }
+
+        /// <summary>
         /// Creates a new instance
         /// </summary>
         /// <param name="security">Security asset we're filling</param>
         /// <param name="order">Order packet to model</param>
         /// <param name="configProvider">The <see cref="ISubscriptionDataConfigProvider"/> to use</param>
+        /// <param name="stalePriceTimeSpan">The minimum time span elapsed to consider a fill price as stale</param>
         public FillModelParameters(
             Security security,
             Order order,
-            ISubscriptionDataConfigProvider configProvider)
+            ISubscriptionDataConfigProvider configProvider,
+            TimeSpan stalePriceTimeSpan)
         {
             Security = security;
             Order = order;
             ConfigProvider = configProvider;
+            StalePriceTimeSpan = stalePriceTimeSpan;
         }
     }
 }

--- a/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
+++ b/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
@@ -67,7 +67,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.MarketFillWasCalled);
             Assert.AreEqual(OrderStatus.Filled, result.OrderEvent.Status);
@@ -83,8 +84,9 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var model = new TestFillModelInheritInterface();
             var result = model.Fill(
                 new FillModelParameters(_security,
-                new MarketOrder(_security.Symbol, 1, orderDateTime),
-                new MockSubscriptionDataConfigProvider(_config)));
+                    new MarketOrder(_security.Symbol, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.MarketFillWasCalled);
             Assert.AreEqual(orderEvent, result.OrderEvent);
@@ -97,7 +99,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new StopMarketOrder(_security.Symbol, 1, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.StopMarketFillWasCalled);
             Assert.AreEqual(orderEvent, result.OrderEvent);
@@ -110,7 +113,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new StopLimitOrder(_security.Symbol, 1, 1, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.StopLimitFillWasCalled);
             Assert.AreEqual(orderEvent, result.OrderEvent);
@@ -123,7 +127,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new LimitOrder(_security.Symbol, 1, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.LimitFillWasCalled);
             Assert.AreEqual(orderEvent, result.OrderEvent);
@@ -136,7 +141,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new MarketOnOpenOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.MarketOnOpenFillWasCalled);
             Assert.AreEqual(orderEvent, result.OrderEvent);
@@ -149,7 +155,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new MarketOnCloseOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.MarketOnCloseFillWasCalled);
             Assert.AreEqual(orderEvent, result.OrderEvent);
@@ -166,7 +173,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.IsNotNull(result);
             Assert.True(model.GetPricesWasCalled);
@@ -179,8 +187,9 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var model = new TestFillModelInheritBaseClass();
             var result = model.Fill(
                 new FillModelParameters(_security,
-                new MarketOrder(_security.Symbol, 1, orderDateTime),
-                new MockSubscriptionDataConfigProvider(_config)));
+                    new MarketOrder(_security.Symbol, 1, orderDateTime),
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.MarketFillWasCalled);
             Assert.IsNotNull(result);
@@ -195,7 +204,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new StopMarketOrder(_security.Symbol, 1, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.StopMarketFillWasCalled);
             Assert.IsNotNull(result);
@@ -210,7 +220,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new StopLimitOrder(_security.Symbol, 1, 1, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.StopLimitFillWasCalled);
             Assert.IsNotNull(result);
@@ -225,7 +236,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new LimitOrder(_security.Symbol, 1, 12346, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.LimitFillWasCalled);
             Assert.IsNotNull(result);
@@ -242,7 +254,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new MarketOnOpenOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.MarketOnOpenFillWasCalled);
             Assert.IsNotNull(result);
@@ -257,7 +270,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var result = model.Fill(
                 new FillModelParameters(_security,
                     new MarketOnCloseOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)));
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour));
 
             Assert.True(model.MarketOnCloseFillWasCalled);
             Assert.IsNotNull(result);
@@ -291,7 +305,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 var result = wrapper.Fill(new FillModelParameters(
                         _security,
                         new MarketOrder(_security.Symbol, 1, orderDateTime),
-                        new MockSubscriptionDataConfigProvider(_config)
+                        new MockSubscriptionDataConfigProvider(_config),
+                        Time.OneHour
                     ));
 
                 bool called;
@@ -324,7 +339,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 var result = wrapper.Fill(new FillModelParameters(
                     _security,
                     new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour
                 ));
 
                 bool called;
@@ -357,7 +373,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 var result = wrapper.Fill(new FillModelParameters(
                     _security,
                     new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour
                 ));
 
                 bool called;
@@ -395,7 +412,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 var result = wrapper.Fill(new FillModelParameters(
                     _security,
                     new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour
                 ));
 
                 bool called;
@@ -436,7 +454,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 var result = wrapper.Fill(new FillModelParameters(
                     _security,
                     new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour
                 ));
 
                 bool called;
@@ -471,7 +490,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 var result = wrapper.Fill(new FillModelParameters(
                     _security,
                     new MarketOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config)
+                    new MockSubscriptionDataConfigProvider(_config),
+                    Time.OneHour
                 ));
 
                 bool called;

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -53,7 +53,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(security.Price, fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
@@ -78,7 +79,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(security.Price, fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
@@ -103,7 +105,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -138,7 +141,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -173,7 +177,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -184,7 +189,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -219,7 +225,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -230,7 +237,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -265,7 +273,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -276,7 +285,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             // this fills worst case scenario, so it's min of asset/stop price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
@@ -303,7 +313,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -314,7 +325,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             // this fills worst case scenario, so it's min of asset/stop price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
@@ -344,7 +356,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
             Assert.AreEqual(0, fill.FillQuantity);
 
             // market opens after 30min, so this is just before market open
@@ -355,7 +368,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
             Assert.AreEqual(0, fill.FillQuantity);
 
             // market opens after 30min
@@ -390,7 +404,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
             Assert.AreEqual(0, fill.FillQuantity);
 
             // market closes after 60min, so this is just before market Close
@@ -401,7 +416,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
             Assert.AreEqual(0, fill.FillQuantity);
 
             // market closes
@@ -443,7 +459,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = fillModel.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             var expected = direction == OrderDirection.Buy ? askPrice : bidPrice;
             Assert.AreEqual(expected, fill.FillPrice);
@@ -477,7 +494,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = fillModel.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             // The fill model should use the tick.Price
             Assert.AreEqual(fill.FillPrice, 100m);
@@ -512,7 +530,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = fillModel.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             // The fill model should use the tick.Price
             Assert.AreEqual(fill.FillPrice, 1.0m);
@@ -552,7 +571,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = fillModel.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -605,7 +625,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = fillModel.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -658,7 +679,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = fillModel.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
@@ -682,7 +704,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         public void MarketOrderFillWithStalePriceHasWarningMessage()
         {
             var model = new ImmediateFillModel();
-            var order = new MarketOrder(Symbols.SPY, -100, Noon.ConvertToUtc(TimeZones.NewYork).AddMinutes(30));
+            var order = new MarketOrder(Symbols.SPY, -100, Noon.ConvertToUtc(TimeZones.NewYork).AddMinutes(61));
             var config = CreateTradeBarConfig(Symbols.SPY);
             var security = new Security(
                 SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
@@ -697,7 +719,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config))).OrderEvent;
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
 
             Assert.IsTrue(fill.Message.Contains("Warning: fill at stale price"));
         }

--- a/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
@@ -136,7 +136,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             public TestableLatestFillModel()
             {
                 // NOTE. GetPrices will no be called before SubscriptionDataConfigProvider is set by the system
-                Parameters = new FillModelParameters(null, null, new MockSubscriptionDataConfigProvider());
+                Parameters = new FillModelParameters(null, null, new MockSubscriptionDataConfigProvider(), Time.OneHour);
             }
             public new Prices GetPrices(Security asset, OrderDirection direction)
             {


### PR DESCRIPTION

#### Description
The market fill warning introduced in #2869 was considering any price older than the fill time as stale (even if only a few seconds older), causing many false alerts.

This is being changed now by adding a new configurable algorithm setting: `StalePriceTimeSpan` (with a default value of **one hour**).

#### Related Issue
#2762 

#### Motivation and Context
Excessive stale price fill warnings.

#### Requires Documentation Change
A new algorithm setting has been added and can be set in `Initialize` to override the default 1hr value:

C#
``` C#
Settings.StalePriceTimeSpan = TimeSpan.FromMinutes(30)
```
Python
``` Python
self.Settings.StalePriceTimeSpan = timedelta(minutes=30)
```

#### How Has This Been Tested?
The unit test added in #2869 had to be updated to pass, confirming that the fill model is now using the new setting correctly.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`