### PR TITLE
Update GDAXFeeModel and GDAXBrokerageModel

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -421,7 +421,7 @@ namespace QuantConnect.Brokerages.GDAX
                 : order.PriceCurrency;
 
             var orderFee = new OrderFee(new CashAmount(
-                GetFillFee(symbol, fillPrice, fillQuantity, isMaker),
+                GetFillFee(_algorithm.UtcTime, fillPrice, fillQuantity, isMaker),
                 currency));
 
             var orderEvent = new OrderEvent
@@ -629,14 +629,11 @@ namespace QuantConnect.Brokerages.GDAX
         /// <summary>
         /// Returns the fee paid for a total or partial order fill
         /// </summary>
-        public static decimal GetFillFee(Symbol symbol, decimal fillPrice, decimal fillQuantity, bool isMaker)
+        public static decimal GetFillFee(DateTime utcTime, decimal fillPrice, decimal fillQuantity, bool isMaker)
         {
-            if (isMaker)
-            {
-                return 0;
-            }
+            var feePercentage = GDAXFeeModel.GetFeePercentage(utcTime, isMaker);
 
-            return fillPrice * Math.Abs(fillQuantity) * GDAXFeeModel.TakerFee;
+            return fillPrice * Math.Abs(fillQuantity) * feePercentage;
         }
     }
 }

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Brokerages
     /// </summary>
     public class GDAXBrokerageModel : DefaultBrokerageModel
     {
-        private static BrokerageMessageEvent _message = new BrokerageMessageEvent(BrokerageMessageType.Warning, 0, "Brokerage does not support update. You must cancel and re-create instead.");
+        private readonly BrokerageMessageEvent _message = new BrokerageMessageEvent(BrokerageMessageType.Warning, 0, "Brokerage does not support update. You must cancel and re-create instead.");
 
         // https://support.gdax.com/customer/portal/articles/2725970-trading-rules
         private static readonly Dictionary<string, decimal> MinimumOrderSizes = new Dictionary<string, decimal>
@@ -51,6 +51,9 @@ namespace QuantConnect.Brokerages
             { "LTCGBP", 0.1m },
             { "LTCBTC", 0.1m }
         };
+
+        // https://blog.coinbase.com/coinbase-pro-market-structure-update-fbd9d49f43d7
+        private readonly DateTime _stopMarketOrderSupportEndDate = new DateTime(2019, 3, 23, 1, 0, 0);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GDAXBrokerageModel"/> class
@@ -140,6 +143,15 @@ namespace QuantConnect.Brokerages
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     $"The {nameof(GDAXBrokerageModel)} does not support {order.Type} order type."
+                );
+
+                return false;
+            }
+
+            if (order.Type == OrderType.StopMarket && order.Time >= _stopMarketOrderSupportEndDate)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    $"Stop Market orders are no longer supported since {_stopMarketOrderSupportEndDate}."
                 );
 
                 return false;

--- a/Common/Orders/Fees/GDAXFeeModel.cs
+++ b/Common/Orders/Fees/GDAXFeeModel.cs
@@ -14,7 +14,6 @@
 */
 
 using System;
-using System.Collections.Generic;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Orders.Fees
@@ -24,17 +23,6 @@ namespace QuantConnect.Orders.Fees
     /// </summary>
     public class GDAXFeeModel : FeeModel
     {
-        /// <summary>
-        /// Tier 1 taker fees
-        /// https://pro.coinbase.com/orders/fees
-        /// https://blog.coinbase.com/coinbase-pro-market-structure-update-fbd9d49f43d7
-        /// </summary>
-        private static readonly List<FeeHistoryEntry> FeeHistory = new List<FeeHistoryEntry>
-        {
-            new FeeHistoryEntry(DateTime.MinValue, 0m, 0.003m),
-            new FeeHistoryEntry(new DateTime(2019, 3, 23, 1, 30, 0), 0.0015m, 0.0025m)
-        };
-
         /// <summary>
         /// Get the fee for this order in quote currency
         /// </summary>
@@ -70,50 +58,14 @@ namespace QuantConnect.Orders.Fees
         /// <returns>The fee percentage effective at the requested date</returns>
         public static decimal GetFeePercentage(DateTime utcTime, bool isMaker)
         {
-            for (var index = FeeHistory.Count - 1; index >= 0; index--)
-            {
-                var entry = FeeHistory[index];
-                if (utcTime >= entry.EffectiveDateTime)
-                {
-                    return isMaker ? entry.MakerFeePercentage : entry.TakerFeePercentage;
-                }
-            }
+            // Tier 1 fees
+            // https://pro.coinbase.com/orders/fees
+            // https://blog.coinbase.com/coinbase-pro-market-structure-update-fbd9d49f43d7
 
-            return 0m;
-        }
+            if (utcTime < new DateTime(2019, 3, 23, 1, 30, 0))
+                return isMaker ? 0m : 0.003m;
 
-        /// <summary>
-        /// Represents an entry in the list of historical fee changes.
-        /// </summary>
-        public class FeeHistoryEntry
-        {
-            /// <summary>
-            /// The date/time (UTC) when the new fees go into effect.
-            /// </summary>
-            public DateTime EffectiveDateTime { get; set; }
-
-            /// <summary>
-            /// The maker fee percentage.
-            /// </summary>
-            public decimal MakerFeePercentage { get; set; }
-
-            /// <summary>
-            /// The taker fee percentage.
-            /// </summary>
-            public decimal TakerFeePercentage { get; set; }
-
-            /// <summary>
-            /// Creates an instance of the <see cref="FeeHistoryEntry"/> class.
-            /// </summary>
-            /// <param name="effectiveDateTime">The date/time (UTC) when the new fees go into effect.</param>
-            /// <param name="makerFeePercentage">The maker fee percentage.</param>
-            /// <param name="takerFeePercentage">The taker fee percentage.</param>
-            public FeeHistoryEntry(DateTime effectiveDateTime, decimal makerFeePercentage, decimal takerFeePercentage)
-            {
-                EffectiveDateTime = effectiveDateTime;
-                MakerFeePercentage = makerFeePercentage;
-                TakerFeePercentage = takerFeePercentage;
-            }
+            return isMaker ? 0.0015m : 0.0025m;
         }
     }
 }

--- a/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/GDAXBrokerageModelTests.cs
@@ -100,17 +100,21 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.AreEqual(isValidSecurityType, _unit.CanSubmitOrder(GDAXTestsHelpers.GetSecurity(1.0m, securityType), order.Object, out message));
         }
 
-        [TestCase(OrderType.Market, true)]
-        [TestCase(OrderType.Limit, true)]
-        [TestCase(OrderType.MarketOnClose, false)]
-        [TestCase(OrderType.MarketOnOpen, false)]
-        [TestCase(OrderType.StopLimit, false)]
-        [TestCase(OrderType.StopMarket, true)]
-        public void CanSubmit_CertainOrderTypes(OrderType orderType, bool isValidOrderType)
+        [TestCase(OrderType.Market, 2019, 2, 1, 0, 0, 0, true)]
+        [TestCase(OrderType.Limit, 2019, 2, 1, 0, 0, 0, true)]
+        [TestCase(OrderType.MarketOnClose, 2019, 2, 1, 0, 0, 0, false)]
+        [TestCase(OrderType.MarketOnOpen, 2019, 2, 1, 0, 0, 0, false)]
+        [TestCase(OrderType.StopLimit, 2019, 2, 1, 0, 0, 0, false)]
+        [TestCase(OrderType.StopMarket, 2019, 2, 1, 0, 0, 0, true)]
+        [TestCase(OrderType.StopMarket, 2019, 3, 23, 0, 59, 59, true)]
+        [TestCase(OrderType.StopMarket, 2019, 3, 23, 1, 0, 0, false)]
+        public void CanSubmit_CertainOrderTypes(OrderType orderType, int year, int month, int day, int hour, int minute, int second, bool isValidOrderType)
         {
+            var utcTime = new DateTime(year, month, day, hour, minute, second);
+
             BrokerageMessageEvent message;
             var security = GDAXTestsHelpers.GetSecurity();
-            var order = Order.CreateOrder(new SubmitOrderRequest(orderType, SecurityType.Crypto, security.Symbol, 10.0m, 1.0m, 10.0m, DateTime.Now, "Test Order"));
+            var order = Order.CreateOrder(new SubmitOrderRequest(orderType, SecurityType.Crypto, security.Symbol, 10.0m, 1.0m, 10.0m, utcTime, "Test Order"));
 
             Assert.AreEqual(isValidOrderType, _unit.CanSubmitOrder(security, order, out message));
         }

--- a/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
@@ -57,10 +57,11 @@ namespace QuantConnect.Tests.Common.Orders.Fees
         [Test]
         public void ReturnsFeeInQuoteCurrencyInAccountCurrency()
         {
+            var time = new DateTime(2019, 2, 1);
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btcusd,
-                    new MarketOrder(_btcusd.Symbol, 1, DateTime.UtcNow)
+                    new MarketOrder(_btcusd.Symbol, 1, time)
                 )
             );
 
@@ -72,16 +73,36 @@ namespace QuantConnect.Tests.Common.Orders.Fees
         [Test]
         public void ReturnsFeeInQuoteCurrencyInOtherCurrency()
         {
+            var time = new DateTime(2019, 2, 1);
             var fee = _feeModel.GetOrderFee(
                 new OrderFeeParameters(
                     _btceur,
-                    new MarketOrder(_btceur.Symbol, 1, DateTime.UtcNow)
+                    new MarketOrder(_btceur.Symbol, 1, time)
                 )
             );
 
             Assert.AreEqual("EUR", fee.Value.Currency);
             // 100 (price) * 0.003 (taker fee)
             Assert.AreEqual(0.3m, fee.Value.Amount);
+        }
+
+        [TestCase(2019, 2, 1, 0, 0, 0, 0.3)]
+        [TestCase(2019, 3, 23, 1, 29, 59, 0.3)]
+        [TestCase(2019, 3, 23, 1, 30, 0, 0.25)]
+        [TestCase(2019, 4, 1, 0, 0, 0, 0.25)]
+        public void FeeChangesOverTime(int year, int month, int day, int hour, int minute, int second, decimal expectedFee)
+        {
+            var time = new DateTime(year, month, day, hour, minute, second);
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    _btcusd,
+                    new MarketOrder(_btcusd.Symbol, 1, time)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            // 100 (price) * fee (taker fee)
+            Assert.AreEqual(expectedFee, fee.Value.Amount);
         }
     }
 }


### PR DESCRIPTION

#### Description
- `GDAXFeeModel` has been updated to the new fee structure effective March 22nd, 2019
- `GDAXBrokerageModel` has been updated to deprecate `StopMarket` orders effective March 22nd, 2019

#### Related Issue
Closes #3006 

#### Motivation and Context
Coinbase Pro updates:
https://blog.coinbase.com/coinbase-pro-market-structure-update-fbd9d49f43d7

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New and updated unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`