### PR TITLE
Add Insight optional Weight

### DIFF
--- a/Algorithm.CSharp/InsightWeightingFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/InsightWeightingFrameworkAlgorithm.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using QuantConnect.Algorithm.Framework;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Algorithm.Framework.Execution;
 using QuantConnect.Algorithm.Framework.Portfolio;
@@ -28,7 +27,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// Test algorithm using <see cref="InsightWeightingPortfolioConstructionModel"/> and <see cref="ConstantAlphaModel"/>
     /// generating a constant <see cref="Insight"/> with a 0.25 weight
     /// </summary>
-    public class InsightWeightingFrameworkAlgorithm : QCAlgorithmFramework, IRegressionAlgorithmDefinition
+    public class InsightWeightingFrameworkAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
@@ -52,9 +51,9 @@ namespace QuantConnect.Algorithm.CSharp
         public override void OnEndOfAlgorithm()
         {
             if (// holdings value should be 0.25 - to avoid price fluctuation issue we compare with 0.28 and 0.23
-                (Portfolio.TotalHoldingsValue > Portfolio.TotalPortfolioValue * 0.28m
+                Portfolio.TotalHoldingsValue > Portfolio.TotalPortfolioValue * 0.28m
                 ||
-                Portfolio.TotalHoldingsValue < Portfolio.TotalPortfolioValue * 0.23m))
+                Portfolio.TotalHoldingsValue < Portfolio.TotalPortfolioValue * 0.23m)
             {
                 throw new Exception($"Unexpected Total Holdings Value: {Portfolio.TotalHoldingsValue}");
             }
@@ -68,7 +67,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/InsightWeightingFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/InsightWeightingFrameworkAlgorithm.cs
@@ -49,10 +49,9 @@ namespace QuantConnect.Algorithm.CSharp
             SetExecution(new ImmediateExecutionModel());
         }
 
-        public override void OnEndOfDay()
+        public override void OnEndOfAlgorithm()
         {
-            if (Portfolio.Invested &&
-                // holdings value should be 0.25 - to avoid price fluctuation issue we compare with 0.28 and 0.23
+            if (// holdings value should be 0.25 - to avoid price fluctuation issue we compare with 0.28 and 0.23
                 (Portfolio.TotalHoldingsValue > Portfolio.TotalPortfolioValue * 0.28m
                 ||
                 Portfolio.TotalHoldingsValue < Portfolio.TotalPortfolioValue * 0.23m))

--- a/Algorithm.CSharp/InsightWeightingFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/InsightWeightingFrameworkAlgorithm.cs
@@ -1,0 +1,113 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Test algorithm using <see cref="InsightWeightingPortfolioConstructionModel"/> and <see cref="ConstantAlphaModel"/>
+    /// generating a constant <see cref="Insight"/> with a 0.25 weight
+    /// </summary>
+    public class InsightWeightingFrameworkAlgorithm : QCAlgorithmFramework, IRegressionAlgorithmDefinition
+    {
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            // Set requested data resolution
+            UniverseSettings.Resolution = Resolution.Minute;
+
+            SetStartDate(2013, 10, 07);  //Set Start Date
+            SetEndDate(2013, 10, 11);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+
+            // set algorithm framework models
+            SetUniverseSelection(new ManualUniverseSelectionModel(QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)));
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromMinutes(20), 0.025, null, 0.25));
+            SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+        }
+
+        public override void OnEndOfDay()
+        {
+            if (Portfolio.Invested &&
+                // holdings value should be 0.25 - to avoid price fluctuation issue we compare with 0.28 and 0.23
+                (Portfolio.TotalHoldingsValue > Portfolio.TotalPortfolioValue * 0.28m
+                ||
+                Portfolio.TotalHoldingsValue < Portfolio.TotalPortfolioValue * 0.23m))
+            {
+                throw new Exception($"Unexpected Total Holdings Value: {Portfolio.TotalHoldingsValue}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "6"},
+            {"Average Win", "0.00%"},
+            {"Average Loss", "0.00%"},
+            {"Compounding Annual Return", "37.905%"},
+            {"Drawdown", "0.600%"},
+            {"Expectancy", "-0.495"},
+            {"Net Profit", "0.412%"},
+            {"Sharpe Ratio", "4.344"},
+            {"Loss Rate", "67%"},
+            {"Win Rate", "33%"},
+            {"Profit-Loss Ratio", "0.52"},
+            {"Alpha", "0.001"},
+            {"Beta", "18.742"},
+            {"Annual Standard Deviation", "0.048"},
+            {"Annual Variance", "0.002"},
+            {"Information Ratio", "4.118"},
+            {"Tracking Error", "0.048"},
+            {"Treynor Ratio", "0.011"},
+            {"Total Fees", "$6.00"},
+            {"Total Insights Generated", "100"},
+            {"Total Insights Closed", "99"},
+            {"Total Insights Analysis Completed", "99"},
+            {"Long Insight Count", "100"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$158418.3850"},
+            {"Total Accumulated Estimated Alpha Value", "$25522.9620"},
+            {"Mean Population Estimated Insight Value", "$257.8077"},
+            {"Mean Population Direction", "54.5455%"},
+            {"Mean Population Magnitude", "54.5455%"},
+            {"Rolling Averaged Population Direction", "59.8056%"},
+            {"Rolling Averaged Population Magnitude", "59.8056%"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -153,6 +153,7 @@
     <Compile Include="HistoryWithSymbolChangesRegressionAlgorithm.cs" />
     <Compile Include="FeeModelNotUsingAccountCurrency.cs" />
     <Compile Include="InvalidEmitInsightsAlgorithm.cs" />
+    <Compile Include="InsightWeightingFrameworkAlgorithm.cs" />
     <Compile Include="MaximumPortfolioDrawdownFrameworkAlgorithm.cs" />
     <Compile Include="CompositeRiskManagementModelFrameworkAlgorithm.cs" />
     <Compile Include="OrderBasedInsightGeneratedAlgorithm.cs" />

--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
@@ -31,6 +31,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private readonly TimeSpan _period;
         private readonly double? _magnitude;
         private readonly double? _confidence;
+        private readonly double? _weight;
         private readonly HashSet<Security> _securities;
         private readonly Dictionary<Symbol, DateTime> _insightsTimeBySymbol;
 
@@ -53,7 +54,8 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="period">The period over which the insight with come to fruition</param>
         /// <param name="magnitude">The predicted change in magnitude as a +- percentage</param>
         /// <param name="confidence">The confidence in the insight</param>
-        public ConstantAlphaModel(InsightType type, InsightDirection direction, TimeSpan period, double? magnitude, double? confidence)
+        /// <param name="weight">The portfolio weight of the insights</param>
+        public ConstantAlphaModel(InsightType type, InsightDirection direction, TimeSpan period, double? magnitude, double? confidence, double? weight = null)
         {
             _type = type;
             _direction = direction;
@@ -62,6 +64,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             // Optional
             _magnitude = magnitude;
             _confidence = confidence;
+            _weight = weight;
 
             _securities = new HashSet<Security>();
             _insightsTimeBySymbol = new Dictionary<Symbol, DateTime>();
@@ -92,7 +95,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             {
                 if (ShouldEmitInsight(algorithm.UtcTime, security.Symbol))
                 {
-                    yield return new Insight(security.Symbol, _period, _type, _direction, _magnitude, _confidence);
+                    yield return new Insight(security.Symbol, _period, _type, _direction, _magnitude, _confidence, weight: _weight);
                 }
             }
         }

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -45,6 +45,36 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         }
 
         /// <summary>
+        /// Method that will determine if the portfolio construction model should create a
+        /// target for this insight
+        /// </summary>
+        /// <param name="insight">The insight to create a target for</param>
+        /// <returns>True if the portfolio should create a target for the insight</returns>
+        public virtual bool ShouldCreateTargetForInsight(Insight insight)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Will determine the target percent for each insight
+        /// </summary>
+        /// <param name="activeInsights">The active insights to generate a target for</param>
+        /// <returns>A target percent for each insight</returns>
+        public virtual Dictionary<Insight, double> DetermineTargetPercent(ICollection<Insight> activeInsights)
+        {
+            var result = new Dictionary<Insight, double>();
+
+            // give equal weighting to each security
+            var count = activeInsights.Count(x => x.Direction != InsightDirection.Flat);
+            var percent = count == 0 ? 0 : 1m / count;
+            foreach (var insight in activeInsights)
+            {
+                result[insight] = (double)((int)insight.Direction * percent);
+            }
+            return result;
+        }
+
+        /// <summary>
         /// Create portfolio targets from the specified insights
         /// </summary>
         /// <param name="algorithm">The algorithm instance</param>
@@ -62,7 +92,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 return targets;
             }
 
-            _insightCollection.AddRange(insights);
+            // Validate we should create a target for this insight
+            _insightCollection.AddRange(insights.Where(ShouldCreateTargetForInsight));
 
             // Create flatten target for each security that was removed from the universe
             if (_removedSymbols != null)
@@ -76,19 +107,18 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             var activeInsights = _insightCollection.GetActiveInsights(algorithm.UtcTime);
 
             // Get the last generated active insight for each symbol
-            var lastActiveInsights = from insight in activeInsights
-                                     group insight by insight.Symbol into g
-                                     select g.OrderBy(x => x.GeneratedTimeUtc).Last();
-
-            // give equal weighting to each security
-            var count = lastActiveInsights.Count(x => x.Direction != InsightDirection.Flat);
-            var percent = count == 0 ? 0 : 1m / count;
+            var lastActiveInsights = (from insight in activeInsights
+                                      group insight by insight.Symbol into g
+                                      select g.OrderBy(x => x.GeneratedTimeUtc).Last()).ToList();
 
             var errorSymbols = new HashSet<Symbol>();
 
+            // Determine target percent for the given insights
+            var percents = DetermineTargetPercent(lastActiveInsights);
+
             foreach (var insight in lastActiveInsights)
             {
-                var target = PortfolioTarget.Percent(algorithm, insight.Symbol, (int) insight.Direction * percent);
+                var target = PortfolioTarget.Percent(algorithm, insight.Symbol, percents[insight]);
                 if (target != null)
                 {
                     targets.Add(target);

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
@@ -13,11 +13,9 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Algorithm.Framework.Alphas;
-using QuantConnect.Data.UniverseSelection;
 
 namespace QuantConnect.Algorithm.Framework.Portfolio
 {
@@ -31,109 +29,48 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
     /// percent holdings proportionally so the sum is 1.
     /// It will ignore <see cref="Insight"/> that have no <see cref="Insight.Weight"/> value.
     /// </summary>
-    public class InsightWeightingPortfolioConstructionModel : PortfolioConstructionModel
+    public class InsightWeightingPortfolioConstructionModel : EqualWeightingPortfolioConstructionModel
     {
-        private DateTime _rebalancingTime;
-        private readonly TimeSpan _rebalancingPeriod;
-        private List<Symbol> _removedSymbols;
-        private readonly InsightCollection _insightCollection = new InsightCollection();
-        private DateTime? _nextExpiryTime;
-
         /// <summary>
         /// Initialize a new instance of <see cref="InsightWeightingPortfolioConstructionModel"/>
         /// </summary>
         /// <param name="resolution">Rebalancing frequency</param>
         public InsightWeightingPortfolioConstructionModel(Resolution resolution = Resolution.Daily)
+            : base(resolution)
         {
-            _rebalancingPeriod = resolution.ToTimeSpan();
         }
 
         /// <summary>
-        /// Create portfolio targets from the specified insights
+        /// Method that will determine if the portfolio construction model should create a
+        /// target for this insight
         /// </summary>
-        /// <param name="algorithm">The algorithm instance</param>
-        /// <param name="insights">The insights to create portoflio targets from</param>
-        /// <returns>An enumerable of portfolio targets to be sent to the execution model</returns>
-        public override IEnumerable<IPortfolioTarget> CreateTargets(QCAlgorithmFramework algorithm, Insight[] insights)
+        /// <param name="insight">The insight to create a target for</param>
+        /// <returns>True if the portfolio should create a target for the insight</returns>
+        public override bool ShouldCreateTargetForInsight(Insight insight)
         {
-            var targets = new List<IPortfolioTarget>();
+            return insight.Weight.HasValue;
+        }
 
-            if (algorithm.UtcTime <= _nextExpiryTime &&
-                algorithm.UtcTime <= _rebalancingTime &&
-                insights.Length == 0 &&
-                _removedSymbols == null)
-            {
-                return targets;
-            }
-
-            // Ignore insights that don't have Weight value
-            _insightCollection.AddRange(insights.Where(insight => insight.Weight.HasValue));
-
-            // Create flatten target for each security that was removed from the universe
-            if (_removedSymbols != null)
-            {
-                var universeDeselectionTargets = _removedSymbols.Select(symbol => new PortfolioTarget(symbol, 0));
-                targets.AddRange(universeDeselectionTargets);
-                _removedSymbols = null;
-            }
-
-            // Get insight that haven't expired of each symbol that is still in the universe
-            var activeInsights = _insightCollection.GetActiveInsights(algorithm.UtcTime);
-
-            // Get the last generated active insight for each symbol
-            var lastActiveInsights = (from insight in activeInsights
-                                    group insight by insight.Symbol into g
-                                    select g.OrderBy(x => x.GeneratedTimeUtc).Last()).ToList();
-
+        /// <summary>
+        /// Will determine the target percent for each insight
+        /// </summary>
+        /// <param name="activeInsights">The active insights to generate a target for</param>
+        /// <returns>A target percent for each insight</returns>
+        public override Dictionary<Insight, double> DetermineTargetPercent(ICollection<Insight> activeInsights)
+        {
+            var result = new Dictionary<Insight, double>();
             // We will adjust weights proportionally in case the sum is > 1 so it sums to 1.
-            var weightSums = lastActiveInsights.Sum(insight => insight.Weight.Value);
+            var weightSums = activeInsights.Sum(insight => insight.Weight.Value);
             var weightFactor = 1.0;
             if (weightSums > 1)
             {
                 weightFactor = 1 / weightSums;
             }
-
-            var errorSymbols = new HashSet<Symbol>();
-
-            foreach (var insight in lastActiveInsights)
+            foreach (var insight in activeInsights)
             {
-                var target = PortfolioTarget.Percent(algorithm, insight.Symbol, (int)insight.Direction * insight.Weight.Value * weightFactor);
-                if (target != null)
-                {
-                    targets.Add(target);
-                }
-                else
-                {
-                    errorSymbols.Add(insight.Symbol);
-                }
+                result[insight] = (int)insight.Direction * insight.Weight.Value * weightFactor;
             }
-
-            // Get expired insights and create flatten targets for each symbol
-            var expiredInsights = _insightCollection.RemoveExpiredInsights(algorithm.UtcTime);
-
-            var expiredTargets = from insight in expiredInsights
-                                 group insight.Symbol by insight.Symbol into g
-                                 where !_insightCollection.HasActiveInsights(g.Key, algorithm.UtcTime) && !errorSymbols.Contains(g.Key)
-                                 select new PortfolioTarget(g.Key, 0);
-
-            targets.AddRange(expiredTargets);
-
-            _nextExpiryTime = _insightCollection.GetNextExpiryTime();
-            _rebalancingTime = algorithm.UtcTime.Add(_rebalancingPeriod);
-
-            return targets;
-        }
-
-        /// <summary>
-        /// Event fired each time the we add/remove securities from the data feed
-        /// </summary>
-        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
-        /// <param name="changes">The security additions and removals from the algorithm</param>
-        public override void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
-        {
-            // Get removed symbol and invalidate them in the insight collection
-            _removedSymbols = changes.RemovedSecurities.Select(x => x.Symbol).ToList();
-            _insightCollection.Clear(_removedSymbols.ToArray());
+            return result;
         }
     }
 }

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
@@ -1,0 +1,139 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Algorithm.Framework.Portfolio
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IPortfolioConstructionModel"/> that generates percent targets based on the
+    /// <see cref="Insight.Weight"/>. The target percent holdings of each Symbol is given by the <see cref="Insight.Weight"/>
+    /// from the last active <see cref="Insight"/> for that symbol.
+    /// For insights of direction <see cref="InsightDirection.Up"/>, long targets are returned and for insights of direction
+    /// <see cref="InsightDirection.Down"/>, short targets are returned.
+    /// If the sum of all the last active <see cref="Insight"/> per symbol is bigger than 1, it will factor down each target
+    /// percent holdings proportionally so the sum is 1.
+    /// It will ignore <see cref="Insight"/> that have no <see cref="Insight.Weight"/> value.
+    /// </summary>
+    public class InsightWeightingPortfolioConstructionModel : PortfolioConstructionModel
+    {
+        private DateTime _rebalancingTime;
+        private readonly TimeSpan _rebalancingPeriod;
+        private List<Symbol> _removedSymbols;
+        private readonly InsightCollection _insightCollection = new InsightCollection();
+        private DateTime? _nextExpiryTime;
+
+        /// <summary>
+        /// Initialize a new instance of <see cref="InsightWeightingPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="resolution">Rebalancing frequency</param>
+        public InsightWeightingPortfolioConstructionModel(Resolution resolution = Resolution.Daily)
+        {
+            _rebalancingPeriod = resolution.ToTimeSpan();
+        }
+
+        /// <summary>
+        /// Create portfolio targets from the specified insights
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="insights">The insights to create portoflio targets from</param>
+        /// <returns>An enumerable of portfolio targets to be sent to the execution model</returns>
+        public override IEnumerable<IPortfolioTarget> CreateTargets(QCAlgorithmFramework algorithm, Insight[] insights)
+        {
+            var targets = new List<IPortfolioTarget>();
+
+            if (algorithm.UtcTime <= _nextExpiryTime &&
+                algorithm.UtcTime <= _rebalancingTime &&
+                insights.Length == 0 &&
+                _removedSymbols == null)
+            {
+                return targets;
+            }
+
+            // Ignore insights that don't have Weight value
+            _insightCollection.AddRange(insights.Where(insight => insight.Weight.HasValue));
+
+            // Create flatten target for each security that was removed from the universe
+            if (_removedSymbols != null)
+            {
+                var universeDeselectionTargets = _removedSymbols.Select(symbol => new PortfolioTarget(symbol, 0));
+                targets.AddRange(universeDeselectionTargets);
+                _removedSymbols = null;
+            }
+
+            // Get insight that haven't expired of each symbol that is still in the universe
+            var activeInsights = _insightCollection.GetActiveInsights(algorithm.UtcTime);
+
+            // Get the last generated active insight for each symbol
+            var lastActiveInsights = (from insight in activeInsights
+                                    group insight by insight.Symbol into g
+                                    select g.OrderBy(x => x.GeneratedTimeUtc).Last()).ToList();
+
+            // We will adjust weights proportionally in case the sum is > 1 so it sums to 1.
+            var weightSums = lastActiveInsights.Sum(insight => insight.Weight.Value);
+            var weightFactor = 1.0;
+            if (weightSums > 1)
+            {
+                weightFactor = 1 / weightSums;
+            }
+
+            var errorSymbols = new HashSet<Symbol>();
+
+            foreach (var insight in lastActiveInsights)
+            {
+                var target = PortfolioTarget.Percent(algorithm, insight.Symbol, (int)insight.Direction * insight.Weight.Value * weightFactor);
+                if (target != null)
+                {
+                    targets.Add(target);
+                }
+                else
+                {
+                    errorSymbols.Add(insight.Symbol);
+                }
+            }
+
+            // Get expired insights and create flatten targets for each symbol
+            var expiredInsights = _insightCollection.RemoveExpiredInsights(algorithm.UtcTime);
+
+            var expiredTargets = from insight in expiredInsights
+                                 group insight.Symbol by insight.Symbol into g
+                                 where !_insightCollection.HasActiveInsights(g.Key, algorithm.UtcTime) && !errorSymbols.Contains(g.Key)
+                                 select new PortfolioTarget(g.Key, 0);
+
+            targets.AddRange(expiredTargets);
+
+            _nextExpiryTime = _insightCollection.GetNextExpiryTime();
+            _rebalancingTime = algorithm.UtcTime.Add(_rebalancingPeriod);
+
+            return targets;
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
+        /// <param name="changes">The security additions and removals from the algorithm</param>
+        public override void OnSecuritiesChanged(QCAlgorithmFramework algorithm, SecurityChanges changes)
+        {
+            // Get removed symbol and invalidate them in the insight collection
+            _removedSymbols = changes.RemovedSecurities.Select(x => x.Symbol).ToList();
+            _insightCollection.Clear(_removedSymbols.ToArray());
+        }
+    }
+}

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
@@ -61,7 +61,7 @@ class InsightWeightingPortfolioConstructionModel(PortfolioConstructionModel):
 
         # Ignore insights that don't have Weight value
         for insight in insights:
-            if insight.Weight:
+            if insight.Weight is not None:
                 self.insightCollection.Add(insight)
 
         # Create flatten target for each security that was removed from the universe

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
@@ -17,13 +17,13 @@ AddReference("QuantConnect.Algorithm.Framework")
 
 from QuantConnect import Resolution, Extensions
 from QuantConnect.Algorithm.Framework.Alphas import *
-from QuantConnect.Algorithm.Framework.Portfolio import *
 from itertools import groupby
 from datetime import datetime, timedelta
 from pytz import utc
 UTCMIN = datetime.min.replace(tzinfo=utc)
+from EqualWeightingPortfolioConstructionModel import EqualWeightingPortfolioConstructionModel
 
-class InsightWeightingPortfolioConstructionModel(PortfolioConstructionModel):
+class InsightWeightingPortfolioConstructionModel(EqualWeightingPortfolioConstructionModel):
     '''Provides an implementation of IPortfolioConstructionModel that generates percent targets based on the
     Insight.Weight. The target percent holdings of each Symbol is given by the Insight.Weight from the last
     active Insight for that symbol.
@@ -37,86 +37,26 @@ class InsightWeightingPortfolioConstructionModel(PortfolioConstructionModel):
         '''Initialize a new instance of InsightWeightingPortfolioConstructionModel
         Args:
             resolution: Rebalancing frequency'''
-        self.insightCollection = InsightCollection()
-        self.removedSymbols = []
-        self.nextExpiryTime = UTCMIN
-        self.rebalancingTime = UTCMIN
-        self.rebalancingPeriod = Extensions.ToTimeSpan(resolution)
+        super().__init__(resolution)
 
-    def CreateTargets(self, algorithm, insights):
-        '''Create portfolio targets from the specified insights
+    def ShouldCreateTargetForInsight(self, insight):
+        '''Method that will determine if the portfolio construction model should create a
+        target for this insight
         Args:
-            algorithm: The algorithm instance
-            insights: The insights to create portoflio targets from
-        Returns:
-            An enumerable of portoflio targets to be sent to the execution model'''
-
-        targets = []
-
-        if (algorithm.UtcTime <= self.nextExpiryTime and
-            algorithm.UtcTime <= self.rebalancingTime and
-            len(insights) == 0 and
-            self.removedSymbols is None):
-            return targets
-
+            insight: The insight to create a target for'''
         # Ignore insights that don't have Weight value
-        for insight in insights:
-            if insight.Weight is not None:
-                self.insightCollection.Add(insight)
+        return insight.Weight is not None
 
-        # Create flatten target for each security that was removed from the universe
-        if self.removedSymbols is not None:
-            universeDeselectionTargets = [ PortfolioTarget(symbol, 0) for symbol in self.removedSymbols ]
-            targets.extend(universeDeselectionTargets)
-            self.removedSymbols = None
-
-        # Get insight that haven't expired of each symbol that is still in the universe
-        activeInsights = self.insightCollection.GetActiveInsights(algorithm.UtcTime)
-
-        # Get the last generated active insight for each symbol
-        lastActiveInsights = []
-        for symbol, g in groupby(activeInsights, lambda x: x.Symbol):
-            lastActiveInsights.append(sorted(g, key = lambda x: x.GeneratedTimeUtc)[-1])
-
+    def DetermineTargetPercent(self, activeInsights):
+        '''Will determine the target percent for each insight
+        Args:
+            activeInsights: The active insights to generate a target for'''
+        result = {}
         # We will adjust weights proportionally in case the sum is > 1 so it sums to 1.
-        weightSums = sum(insight.Weight for insight in lastActiveInsights)
+        weightSums = sum(insight.Weight for insight in activeInsights)
         weightFactor = 1.0
         if weightSums > 1:
             weightFactor = 1 / weightSums
-
-        errorSymbols = {}
-        for insight in lastActiveInsights:
-            target = PortfolioTarget.Percent(algorithm, insight.Symbol, insight.Direction * insight.Weight * weightFactor)
-            if not target is None:
-                targets.append(target)
-            else:
-                errorSymbols[insight.Symbol] = insight.Symbol
-
-        # Get expired insights and create flatten targets for each symbol
-        expiredInsights = self.insightCollection.RemoveExpiredInsights(algorithm.UtcTime)
-
-        expiredTargets = []
-        for symbol, f in groupby(expiredInsights, lambda x: x.Symbol):
-            if not self.insightCollection.HasActiveInsights(symbol, algorithm.UtcTime) and not symbol in errorSymbols:
-                expiredTargets.append(PortfolioTarget(symbol, 0))
-                continue
-
-        targets.extend(expiredTargets)
-
-        self.nextExpiryTime = self.insightCollection.GetNextExpiryTime()
-        if self.nextExpiryTime is None:
-            self.nextExpiryTime = UTCMIN
-
-        self.rebalancingTime = algorithm.UtcTime + self.rebalancingPeriod
-
-        return targets
-
-    def OnSecuritiesChanged(self, algorithm, changes):
-        '''Event fired each time the we add/remove securities from the data feed
-        Args:
-            algorithm: The algorithm instance that experienced the change in securities
-            changes: The security additions and removals from the algorithm'''
-
-        # Get removed symbol and invalidate them in the insight collection
-        self.removedSymbols = [x.Symbol for x in changes.RemovedSecurities]
-        self.insightCollection.Clear(self.removedSymbols)
+        for insight in activeInsights:
+            result[insight] = insight.Direction * insight.Weight * weightFactor
+        return result

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
@@ -1,0 +1,122 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm.Framework")
+
+from QuantConnect import Resolution, Extensions
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from itertools import groupby
+from datetime import datetime, timedelta
+from pytz import utc
+UTCMIN = datetime.min.replace(tzinfo=utc)
+
+class InsightWeightingPortfolioConstructionModel(PortfolioConstructionModel):
+    '''Provides an implementation of IPortfolioConstructionModel that generates percent targets based on the
+    Insight.Weight. The target percent holdings of each Symbol is given by the Insight.Weight from the last
+    active Insight for that symbol.
+    For insights of direction InsightDirection.Up, long targets are returned and for insights of direction
+    InsightDirection.Down, short targets are returned.
+    If the sum of all the last active Insight per symbol is bigger than 1, it will factor down each target
+    percent holdings proportionally so the sum is 1.
+    It will ignore Insight that have no Insight.Weight value.'''
+
+    def __init__(self, resolution = Resolution.Daily):
+        '''Initialize a new instance of InsightWeightingPortfolioConstructionModel
+        Args:
+            resolution: Rebalancing frequency'''
+        self.insightCollection = InsightCollection()
+        self.removedSymbols = []
+        self.nextExpiryTime = UTCMIN
+        self.rebalancingTime = UTCMIN
+        self.rebalancingPeriod = Extensions.ToTimeSpan(resolution)
+
+    def CreateTargets(self, algorithm, insights):
+        '''Create portfolio targets from the specified insights
+        Args:
+            algorithm: The algorithm instance
+            insights: The insights to create portoflio targets from
+        Returns:
+            An enumerable of portoflio targets to be sent to the execution model'''
+
+        targets = []
+
+        if (algorithm.UtcTime <= self.nextExpiryTime and
+            algorithm.UtcTime <= self.rebalancingTime and
+            len(insights) == 0 and
+            self.removedSymbols is None):
+            return targets
+
+        # Ignore insights that don't have Weight value
+        for insight in insights:
+            if insight.Weight:
+                self.insightCollection.Add(insight)
+
+        # Create flatten target for each security that was removed from the universe
+        if self.removedSymbols is not None:
+            universeDeselectionTargets = [ PortfolioTarget(symbol, 0) for symbol in self.removedSymbols ]
+            targets.extend(universeDeselectionTargets)
+            self.removedSymbols = None
+
+        # Get insight that haven't expired of each symbol that is still in the universe
+        activeInsights = self.insightCollection.GetActiveInsights(algorithm.UtcTime)
+
+        # Get the last generated active insight for each symbol
+        lastActiveInsights = []
+        for symbol, g in groupby(activeInsights, lambda x: x.Symbol):
+            lastActiveInsights.append(sorted(g, key = lambda x: x.GeneratedTimeUtc)[-1])
+
+        # We will adjust weights proportionally in case the sum is > 1 so it sums to 1.
+        weightSums = sum(insight.Weight for insight in lastActiveInsights)
+        weightFactor = 1.0
+        if weightSums > 1:
+            weightFactor = 1 / weightSums
+
+        errorSymbols = {}
+        for insight in lastActiveInsights:
+            target = PortfolioTarget.Percent(algorithm, insight.Symbol, insight.Direction * insight.Weight * weightFactor)
+            if not target is None:
+                targets.append(target)
+            else:
+                errorSymbols[insight.Symbol] = insight.Symbol
+
+        # Get expired insights and create flatten targets for each symbol
+        expiredInsights = self.insightCollection.RemoveExpiredInsights(algorithm.UtcTime)
+
+        expiredTargets = []
+        for symbol, f in groupby(expiredInsights, lambda x: x.Symbol):
+            if not self.insightCollection.HasActiveInsights(symbol, algorithm.UtcTime) and not symbol in errorSymbols:
+                expiredTargets.append(PortfolioTarget(symbol, 0))
+                continue
+
+        targets.extend(expiredTargets)
+
+        self.nextExpiryTime = self.insightCollection.GetNextExpiryTime()
+        if self.nextExpiryTime is None:
+            self.nextExpiryTime = UTCMIN
+
+        self.rebalancingTime = algorithm.UtcTime + self.rebalancingPeriod
+
+        return targets
+
+    def OnSecuritiesChanged(self, algorithm, changes):
+        '''Event fired each time the we add/remove securities from the data feed
+        Args:
+            algorithm: The algorithm instance that experienced the change in securities
+            changes: The security additions and removals from the algorithm'''
+
+        # Get removed symbol and invalidate them in the insight collection
+        self.removedSymbols = [x.Symbol for x in changes.RemovedSecurities]
+        self.insightCollection.Clear(self.removedSymbols)

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -113,6 +113,9 @@
     <Compile Include="Execution\VolumeWeightedAveragePriceExecutionModel.cs" />
     <Compile Include="NotifiedSecurityChanges.cs" />
     <Compile Include="Portfolio\BlackLittermanOptimizationPortfolioConstructionModel.cs" />
+    <Compile Include="Portfolio\InsightWeightingPortfolioConstructionModel.cs" />
+    <Compile Include="Portfolio\IPortfolioConstructionModel.cs" />
+    <Compile Include="Portfolio\IPortfolioOptimizer.cs" />
     <Compile Include="Portfolio\UnconstrainedMeanVariancePortfolioOptimizer.cs" />
     <Compile Include="Portfolio\MaximumSharpeRatioPortfolioOptimizer.cs" />
     <Compile Include="Portfolio\MeanVarianceOptimizationPortfolioConstructionModel.cs" />
@@ -154,6 +157,9 @@
   <ItemGroup>
     <None Include="packages.config" />
     <Content Include="Portfolio\BlackLittermanOptimizationPortfolioConstructionModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Portfolio\InsightWeightingPortfolioConstructionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Portfolio\UnconstrainedMeanVariancePortfolioOptimizer.py">

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -114,8 +114,6 @@
     <Compile Include="NotifiedSecurityChanges.cs" />
     <Compile Include="Portfolio\BlackLittermanOptimizationPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\InsightWeightingPortfolioConstructionModel.cs" />
-    <Compile Include="Portfolio\IPortfolioConstructionModel.cs" />
-    <Compile Include="Portfolio\IPortfolioOptimizer.cs" />
     <Compile Include="Portfolio\UnconstrainedMeanVariancePortfolioOptimizer.cs" />
     <Compile Include="Portfolio\MaximumSharpeRatioPortfolioOptimizer.cs" />
     <Compile Include="Portfolio\MeanVarianceOptimizationPortfolioConstructionModel.cs" />

--- a/Algorithm.Python/InsightWeightingFrameworkAlgorithm.py
+++ b/Algorithm.Python/InsightWeightingFrameworkAlgorithm.py
@@ -1,0 +1,59 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from datetime import timedelta
+
+### <summary>
+### Test algorithm using 'InsightWeightingPortfolioConstructionModel' and 'ConstantAlphaModel'
+### generating a constant 'Insight' with a 0.25 weight
+### </summary>
+class InsightWeightingFrameworkAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        ''' Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        # Set requested data resolution
+        self.UniverseSettings.Resolution = Resolution.Minute
+
+        self.SetStartDate(2013,10,7)   #Set Start Date
+        self.SetEndDate(2013,10,11)    #Set End Date
+        self.SetCash(100000)           #Set Strategy Cash
+
+        symbols = [ Symbol.Create("SPY", SecurityType.Equity, Market.USA) ]
+
+        # set algorithm framework models
+        self.SetUniverseSelection(ManualUniverseSelectionModel(symbols))
+        self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(minutes = 20), 0.025, None, 0.25))
+        self.SetPortfolioConstruction(InsightWeightingPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+
+    def OnEndOfAlgorithm(self):
+        # holdings value should be 0.25 - to avoid price fluctuation issue we compare with 0.28 and 0.23
+        if (self.Portfolio.TotalHoldingsValue > self.Portfolio.TotalPortfolioValue * 0.28
+            or self.Portfolio.TotalHoldingsValue < self.Portfolio.TotalPortfolioValue * 0.23):
+            raise ValueError("Unexpected Total Holdings Value: " + str(self.Portfolio.TotalHoldingsValue))

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -64,6 +64,7 @@
     <Content Include="BasicTemplateFuturesFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateOptionsFrameworkAlgorithm.py" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Content Include="InsightWeightingFrameworkAlgorithm.py" />
     <None Include="CompositeRiskManagementModelFrameworkAlgorithm.py" />
     <None Include="BlackLittermanPortfolioOptimizationFrameworkAlgorithm.py" />
     <None Include="packages.config" />

--- a/Common/Algorithm/Framework/Alphas/Insight.cs
+++ b/Common/Algorithm/Framework/Alphas/Insight.cs
@@ -102,6 +102,11 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         public double? Confidence { get; private set; }
 
         /// <summary>
+        /// Gets the portfolio weight of this insight
+        /// </summary>
+        public double? Weight { get; private set; }
+
+        /// <summary>
         /// Gets the most recent scores for this insight
         /// </summary>
         public InsightScore Score { get; private set; }
@@ -153,7 +158,8 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="magnitude">The predicted magnitude as a percentage change</param>
         /// <param name="confidence">The confidence in this insight</param>
         /// <param name="sourceModel">An identifier defining the model that generated this insight</param>
-        public Insight(Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence, string sourceModel = null)
+        /// <param name="weight">The portfolio weight of this insight</param>
+        public Insight(Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence, string sourceModel = null, double? weight = null)
         {
             Id = Guid.NewGuid();
             Score = new InsightScore();
@@ -167,6 +173,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             // Optional
             Magnitude = magnitude;
             Confidence = confidence;
+            Weight = weight;
 
             _periodSpecification = new TimeSpanPeriodSpecification(period);
         }
@@ -211,8 +218,9 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="magnitude">The predicted magnitude as a percentage change</param>
         /// <param name="confidence">The confidence in this insight</param>
         /// <param name="sourceModel">An identifier defining the model that generated this insight</param>
-        public Insight(DateTime generatedTimeUtc, Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence, string sourceModel = null)
-            : this(symbol, period, type, direction, magnitude, confidence, sourceModel)
+        /// <param name="weight">The portfolio weight of this insight</param>
+        public Insight(DateTime generatedTimeUtc, Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, double? magnitude, double? confidence, string sourceModel = null, double? weight = null)
+            : this(symbol, period, type, direction, magnitude, confidence, sourceModel, weight)
         {
             GeneratedTimeUtc = generatedTimeUtc;
             CloseTimeUtc = generatedTimeUtc + period;
@@ -228,7 +236,8 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="magnitude">The predicted magnitude as a percentage change</param>
         /// <param name="confidence">The confidence in this insight</param>
         /// <param name="sourceModel">An identifier defining the model that generated this insight</param>
-        private Insight(Symbol symbol, IPeriodSpecification periodSpec, InsightType type, InsightDirection direction, double? magnitude, double? confidence, string sourceModel = null)
+        /// <param name="weight">The portfolio weight of this insight</param>
+        private Insight(Symbol symbol, IPeriodSpecification periodSpec, InsightType type, InsightDirection direction, double? magnitude, double? confidence, string sourceModel = null, double? weight = null)
         {
             Id = Guid.NewGuid();
             Score = new InsightScore();
@@ -241,6 +250,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             // Optional
             Magnitude = magnitude;
             Confidence = confidence;
+            Weight = weight;
 
             _periodSpecification = periodSpec;
 
@@ -273,7 +283,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <returns>A new insight with identical values, but new instances</returns>
         public Insight Clone()
         {
-            return new Insight(Symbol, Period, Type, Direction, Magnitude, Confidence)
+            return new Insight(Symbol, Period, Type, Direction, Magnitude, Confidence, weight:Weight)
             {
                 GeneratedTimeUtc = GeneratedTimeUtc,
                 CloseTimeUtc = CloseTimeUtc,
@@ -296,8 +306,9 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="magnitude">The predicted magnitude as a percent change</param>
         /// <param name="confidence">The confidence in this insight</param>
         /// <param name="sourceModel">The model generating this insight</param>
+        /// <param name="weight">The portfolio weight of this insight</param>
         /// <returns>A new insight object for the specified parameters</returns>
-        public static Insight Price(Symbol symbol, Resolution resolution, int barCount, InsightDirection direction, double? magnitude = null, double? confidence = null, string sourceModel = null)
+        public static Insight Price(Symbol symbol, Resolution resolution, int barCount, InsightDirection direction, double? magnitude = null, double? confidence = null, string sourceModel = null, double? weight = null)
         {
             if (barCount < 1)
             {
@@ -305,7 +316,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             }
 
             var spec = new ResolutionBarCountPeriodSpecification(resolution, barCount);
-            return new Insight(symbol, spec, InsightType.Price, direction, magnitude, confidence, sourceModel);
+            return new Insight(symbol, spec, InsightType.Price, direction, magnitude, confidence, sourceModel, weight);
         }
 
         /// <summary>
@@ -317,12 +328,13 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="magnitude">The predicted magnitude as a percent change</param>
         /// <param name="confidence">The confidence in this insight</param>
         /// <param name="sourceModel">The model generating this insight</param>
+        /// <param name="weight">The portfolio weight of this insight</param>
         /// <returns>A new insight object for the specified parameters</returns>
-        public static Insight Price(Symbol symbol, DateTime closeTimeLocal, InsightDirection direction, double? magnitude = null, double? confidence = null, string sourceModel = null)
+        public static Insight Price(Symbol symbol, DateTime closeTimeLocal, InsightDirection direction, double? magnitude = null, double? confidence = null, string sourceModel = null, double? weight = null)
         {
             var spec = closeTimeLocal == Time.EndOfTime ? (IPeriodSpecification)
                 new EndOfTimeCloseTimePeriodSpecification() : new CloseTimePeriodSpecification(closeTimeLocal);
-            return new Insight(symbol, spec, InsightType.Price, direction, magnitude, confidence, sourceModel);
+            return new Insight(symbol, spec, InsightType.Price, direction, magnitude, confidence, sourceModel, weight);
         }
 
         /// <summary>
@@ -334,8 +346,9 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="magnitude">The predicted magnitude as a percent change</param>
         /// <param name="confidence">The confidence in this insight</param>
         /// <param name="sourceModel">The model generating this insight</param>
+        /// <param name="weight">The portfolio weight of this insight</param>
         /// <returns>A new insight object for the specified parameters</returns>
-        public static Insight Price(Symbol symbol, TimeSpan period, InsightDirection direction, double? magnitude = null, double? confidence = null, string sourceModel = null)
+        public static Insight Price(Symbol symbol, TimeSpan period, InsightDirection direction, double? magnitude = null, double? confidence = null, string sourceModel = null, double? weight = null)
         {
             if (period < Time.OneSecond)
             {
@@ -344,7 +357,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
 
             var spec = period == Time.EndOfTimeTimeSpan ? (IPeriodSpecification)
                 new EndOfTimeCloseTimePeriodSpecification() : new TimeSpanPeriodSpecification(period);
-            return new Insight(symbol, spec, InsightType.Price, direction, magnitude, confidence, sourceModel);
+            return new Insight(symbol, spec, InsightType.Price, direction, magnitude, confidence, sourceModel, weight);
         }
 
         /// <summary>
@@ -407,7 +420,8 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 serializedInsight.Direction,
                 serializedInsight.Magnitude,
                 serializedInsight.Confidence,
-                serializedInsight.SourceModel
+                serializedInsight.SourceModel,
+                serializedInsight.Weight
             )
             {
                 Id = Guid.Parse(serializedInsight.Id),
@@ -587,6 +601,10 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             if (Confidence.HasValue)
             {
                 str += $" with {Math.Round(100 * Confidence.Value, 1)}% confidence";
+            }
+            if (Weight.HasValue)
+            {
+                str += $" and {Math.Round(100 * Weight.Value, 1)}% weight";
             }
 
             return str;

--- a/Common/Algorithm/Framework/Alphas/Serialization/InsightJsonConverter.cs
+++ b/Common/Algorithm/Framework/Alphas/Serialization/InsightJsonConverter.cs
@@ -14,7 +14,6 @@
  *
 */
 
-using System;
 using QuantConnect.Util;
 
 namespace QuantConnect.Algorithm.Framework.Alphas.Serialization

--- a/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
+++ b/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using Newtonsoft.Json;
 
 namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
@@ -106,6 +105,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
         public double? Confidence { get; set; }
 
         /// <summary>
+        /// See <see cref="Insight.Weight"/>
+        /// </summary>
+        [JsonProperty("weight", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public double? Weight { get; set; }
+
+        /// <summary>
         /// See <see cref="InsightScore.IsFinalScore"/>
         /// </summary>
         [JsonProperty("score-final", DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -159,6 +164,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
             ScoreMagnitude = insight.Score.Magnitude;
             ScoreDirection = insight.Score.Direction;
             EstimatedValue = insight.EstimatedValue;
+            Weight = insight.Weight;
         }
     }
 }

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
         public void SurvivesRoundTripSerializationUsingJsonConvert()
         {
             var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);
-            var insight = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2, "source-model");
+            var insight = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2, "source-model", 1);
             Insight.Group(insight);
             var serialized = JsonConvert.SerializeObject(insight);
             var deserialized = JsonConvert.DeserializeObject<Insight>(serialized);
@@ -61,13 +61,14 @@ namespace QuantConnect.Tests.Algorithm.Framework
             Assert.AreEqual(insight.Score.IsFinalScore, deserialized.Score.IsFinalScore);
             Assert.AreEqual(insight.Symbol, deserialized.Symbol);
             Assert.AreEqual(insight.Type, deserialized.Type);
+            Assert.AreEqual(insight.Weight, deserialized.Weight);
         }
 
         [Test]
         public void SurvivesRoundTripCopy()
         {
             var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);
-            var original = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2, "source-model");
+            var original = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2, "source-model", 1);
             Insight.Group(original);
 
             var copy = original.Clone();
@@ -88,6 +89,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
             Assert.AreEqual(original.Score.IsFinalScore, copy.Score.IsFinalScore);
             Assert.AreEqual(original.Symbol, copy.Symbol);
             Assert.AreEqual(original.Type, copy.Type);
+            Assert.AreEqual(original.Weight, copy.Weight);
         }
 
         [Test]

--- a/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
@@ -19,7 +19,7 @@ using System.Linq;
 using NodaTime;
 using NUnit.Framework;
 using Python.Runtime;
-using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Data.Market;
@@ -34,14 +34,14 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
     [TestFixture]
     public class InsightWeightingPortfolioConstructionModelTests
     {
-        private QCAlgorithmFramework _algorithm;
+        private QCAlgorithm _algorithm;
         private const decimal _startingCash = 100000;
         private const double Weight = 0.01;
 
         [TestFixtureSetUp]
         public void SetUp()
         {
-            _algorithm = new QCAlgorithmFramework();
+            _algorithm = new QCAlgorithm();
             _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
 
             var prices = new Dictionary<Symbol, decimal>
@@ -375,7 +375,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             return insight;
         }
 
-        private void SetPortfolioConstruction(Language language, QCAlgorithmFramework algorithm)
+        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm)
         {
             algorithm.SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel());
             if (language == Language.Python)

--- a/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
@@ -330,7 +330,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
             var insights = new[]
             {
-                Insight.Price(Symbols.SPY, TimeSpan.FromDays(1), InsightDirection.Down)
+                GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime, weight:null)
             };
 
             var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
@@ -366,7 +366,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             );
         }
 
-        private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double weight = Weight)
+        private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? weight = Weight)
         {
             period = period ?? TimeSpan.FromDays(1);
             var insight = Insight.Price(symbol, period.Value, direction, weight: weight);

--- a/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
@@ -321,6 +321,39 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             AssertTargets(expectedTargets, actualTargets);
         }
 
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void GeneratesNoTargetsForInsightsWithNoWeight(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var insights = new[]
+            {
+                Insight.Price(Symbols.SPY, TimeSpan.FromDays(1), InsightDirection.Down)
+            };
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            Assert.AreEqual(0, actualTargets.Count);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void GeneratesZeroTargetForZeroInsightWeight(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var insights = new[]
+            {
+                GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime, weight:0)
+            };
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            Assert.AreEqual(1, actualTargets.Count);
+            AssertTargets(actualTargets, new[] {new PortfolioTarget(Symbols.SPY, 0)});
+        }
+
         private Security GetSecurity(Symbol symbol)
         {
             var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);

--- a/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
@@ -1,0 +1,388 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NodaTime;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Equity;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
+{
+    [TestFixture]
+    public class InsightWeightingPortfolioConstructionModelTests
+    {
+        private QCAlgorithmFramework _algorithm;
+        private const decimal _startingCash = 100000;
+        private const double Weight = 0.01;
+
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            _algorithm = new QCAlgorithmFramework();
+            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
+
+            var prices = new Dictionary<Symbol, decimal>
+            {
+                { Symbol.Create("AIG", SecurityType.Equity, Market.USA), 55.22m },
+                { Symbol.Create("IBM", SecurityType.Equity, Market.USA), 145.17m },
+                { Symbol.Create("SPY", SecurityType.Equity, Market.USA), 281.79m },
+            };
+
+            foreach (var kvp in prices)
+            {
+                var symbol = kvp.Key;
+                var security = GetSecurity(symbol);
+                security.SetMarketPrice(new Tick(_algorithm.Time, symbol, kvp.Value, kvp.Value));
+                _algorithm.Securities.Add(symbol, security);
+            }
+        }
+
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void EmptyInsightsReturnsEmptyTargets(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
+
+            Assert.AreEqual(0, actualTargets.Count());
+        }
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)Weight;
+            var expectedTargets = _algorithm.Securities
+                .Select(x => new PortfolioTarget(x.Key, (int)direction
+                                                        * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
+                                                                     / x.Value.Price)));
+
+            var insights = _algorithm.Securities.Keys.Select(x => GetInsight(x, direction, _algorithm.UtcTime));
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public void FlatDirectionNotAccountedToAllocation(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            // Modifying fee model for a constant one so numbers are simplified
+            foreach (var security in _algorithm.Securities)
+            {
+                security.Value.FeeModel = new ConstantFeeModel(1);
+            }
+
+            // Equity, minus $1 for fees
+            var amount = (_algorithm.Portfolio.TotalPortfolioValue - 1 * (_algorithm.Securities.Count - 1)) * (decimal)Weight;
+            var expectedTargets = _algorithm.Securities.Select(x =>
+            {
+                // Expected target quantity for SPY is zero, since its insight will have flat direction
+                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction
+                                                          * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
+                                                                       / x.Value.Price);
+                return new PortfolioTarget(x.Key, quantity);
+            });
+
+            var insights = _algorithm.Securities.Keys.Select(x =>
+            {
+                // SPY insight direction is flat
+                var actualDirection = x.Value == "SPY" ? InsightDirection.Flat : direction;
+                return GetInsight(x, actualDirection, _algorithm.UtcTime);
+            });
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public void AutomaticallyRemoveInvestedWithNewInsights(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            // Let's create a position for SPY
+            var insights = new[] { GetInsight(Symbols.SPY, direction, _algorithm.UtcTime) };
+
+            foreach (var target in _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights))
+            {
+                var holding = _algorithm.Portfolio[target.Symbol];
+                holding.SetHoldings(holding.Price, target.Quantity);
+                _algorithm.Portfolio.SetCash(_startingCash - holding.HoldingsValue);
+            }
+
+            SetUtcTime(_algorithm.UtcTime.AddDays(2));
+
+            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)Weight;
+            var expectedTargets = _algorithm.Securities.Select(x =>
+            {
+                // Expected target quantity for SPY is zero, since it will be removed
+                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction
+                                                          * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
+                                                                       / x.Value.Price);
+                return new PortfolioTarget(x.Key, quantity);
+            });
+
+            // Do no include SPY in the insights
+            insights = _algorithm.Securities.Keys.Where(x => x.Value != "SPY")
+                .Select(x => GetInsight(x, direction, _algorithm.UtcTime)).ToArray();
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void AutomaticallyRemoveInvestedWithoutNewInsights(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            // Let's create a position for SPY
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, _algorithm.UtcTime) };
+
+            foreach (var target in _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights))
+            {
+                var holding = _algorithm.Portfolio[target.Symbol];
+                holding.SetHoldings(holding.Price, target.Quantity);
+                _algorithm.Portfolio.SetCash(_startingCash - holding.HoldingsValue);
+            }
+
+            SetUtcTime(_algorithm.UtcTime.AddDays(2));
+
+            var expectedTargets = new List<IPortfolioTarget> { new PortfolioTarget(Symbols.SPY, 0) };
+
+            // Create target from an empty insights array
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void LongTermInsightPreservesPosition(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            // First emit long term insight
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
+            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            Assert.AreEqual(1, targets.Count);
+
+            // One minute later, emits short term insight
+            SetUtcTime(_algorithm.UtcTime.AddMinutes(1));
+            insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, _algorithm.UtcTime, Time.OneMinute) };
+            targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            Assert.AreEqual(1, targets.Count);
+
+            // One minute later, emit empty insights array
+            SetUtcTime(_algorithm.UtcTime.AddMinutes(1.1));
+
+            var expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, -1m * (decimal)Weight) };
+
+            // Create target from an empty insights array
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void DelistedSecurityEmitsFlatTargetWithoutNewInsights(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
+            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            Assert.AreEqual(1, targets.Count);
+
+            var changes = SecurityChanges.Removed(_algorithm.Securities[Symbols.SPY]);
+            _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+
+            var expectedTargets = new List<IPortfolioTarget> { new PortfolioTarget(Symbols.SPY, 0) };
+
+            // Create target from an empty insights array
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public void DelistedSecurityEmitsFlatTargetWithNewInsights(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
+            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            Assert.AreEqual(1, targets.Count);
+
+            // Removing SPY should clear the key in the insight collection
+            var changes = SecurityChanges.Removed(_algorithm.Securities[Symbols.SPY]);
+            _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+
+            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)Weight;
+            var expectedTargets = _algorithm.Securities.Select(x =>
+            {
+                // Expected target quantity for SPY is zero, since it will be removed
+                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction
+                                                          * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
+                                                                       / x.Value.Price);
+                return new PortfolioTarget(x.Key, quantity);
+            });
+
+            // Do no include SPY in the insights
+            insights = _algorithm.Securities.Keys.Where(x => x.Value != "SPY")
+                .Select(x => GetInsight(x, direction, _algorithm.UtcTime)).ToArray();
+
+            // Create target from an empty insights array
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void WeightsProportionally(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            // create two insights whose weights sums up to 2
+            var insights = new[]
+            {
+                GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime, weight:1),
+                GetInsight(Symbol.Create("IBM", SecurityType.Equity, Market.USA),
+                    InsightDirection.Down, _algorithm.UtcTime, weight:1)
+            };
+
+            // they will each share, proportionally, the total portfolio value
+            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)0.5;
+            var expectedTargets = _algorithm.Securities.Where(pair => insights.Any(insight => pair.Key == insight.Symbol))
+                .Select(x => new PortfolioTarget(x.Key, (int)InsightDirection.Down
+                    * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
+                        / x.Value.Price)));
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            Assert.AreEqual(2, actualTargets.Count);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        private Security GetSecurity(Symbol symbol)
+        {
+            var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);
+            return new Equity(
+                symbol,
+                config,
+                new Cash(Currencies.USD, 0, 1),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance
+            );
+        }
+
+        private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double weight = Weight)
+        {
+            period = period ?? TimeSpan.FromDays(1);
+            var insight = Insight.Price(symbol, period.Value, direction, weight: weight);
+            insight.GeneratedTimeUtc = generatedTimeUtc;
+            insight.CloseTimeUtc = generatedTimeUtc.Add(period.Value);
+            return insight;
+        }
+
+        private void SetPortfolioConstruction(Language language, QCAlgorithmFramework algorithm)
+        {
+            algorithm.SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel());
+            if (language == Language.Python)
+            {
+                using (Py.GIL())
+                {
+                    var name = nameof(InsightWeightingPortfolioConstructionModel);
+                    var instance = Py.Import(name).GetAttr(name).Invoke();
+                    var model = new PortfolioConstructionModelPythonWrapper(instance);
+                    algorithm.SetPortfolioConstruction(model);
+                }
+            }
+
+            foreach (var kvp in _algorithm.Portfolio)
+            {
+                kvp.Value.SetHoldings(kvp.Value.Price, 0);
+            }
+            _algorithm.Portfolio.SetCash(_startingCash);
+            SetUtcTime(new DateTime(2018, 7, 31));
+
+            var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
+            algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+        }
+
+        private void SetUtcTime(DateTime dateTime)
+        {
+            _algorithm.SetDateTime(dateTime.ConvertToUtc(_algorithm.TimeZone));
+        }
+
+        private void AssertTargets(IEnumerable<IPortfolioTarget> expectedTargets, IEnumerable<IPortfolioTarget> actualTargets)
+        {
+            var list = actualTargets.ToList();
+            Assert.AreEqual(expectedTargets.Count(), list.Count);
+
+            foreach (var expected in expectedTargets)
+            {
+                var actual = list.FirstOrDefault(x => x.Symbol == expected.Symbol);
+                Assert.IsNotNull(actual);
+                Assert.AreEqual(expected.Quantity, actual.Quantity);
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Algorithm\Framework\FrameworkModelsPythonInheritanceTests.cs" />
     <Compile Include="Algorithm\Framework\InsightTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\BlackLittermanOptimizationPortfolioConstructionModelTests.cs" />
+    <Compile Include="Algorithm\Framework\Portfolio\InsightWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding optional portfolio Weight property for `Insights`
- Adding new `InsightWeightingPortfolioConstructionModel` (C# / Py) that will
generate percent `Targets` based on the latest active `Insight` `Weight` per
`Symbol`.
   - Will ignore `Insights` that have no `Weight`.(unit tested)
   - If the sum of all the last active `Insight` per `Symbol` is bigger than 1, it
will factor down each target percent holdings proportionally so the sum is 1. (unit tested)
   - Adding unit tests
   - Adding a new regression test framework algorithm (C#/Py)
   - ~**Note most of the code, including tests, are reused from the
`EqualWeightingPortfolioConstructionModel`**~ `InsightWeightingPortfolioConstructionModel` inherits from the `EqualWeightingPortfolioConstructionModel`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3015
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Insights did not have a way to set a portfolio weight.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
- Yes https://www.quantconnect.com/docs/alpha-streams/creating-an-alpha and https://www.quantconnect.com/docs/algorithm-framework/alpha-creation too
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->