### PR TITLE
Adds Parameterless Overload to SecurityTransactionManager.CancelOpenOrders()

### DIFF
--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -191,7 +191,7 @@ namespace QuantConnect.Securities
             var cancelledOrders = new List<OrderTicket>();
             foreach (var ticket in GetOpenOrderTickets())
             {
-                ticket.Cancel($"Canceled by CancelOpenOrders() on {_algorithm.UtcTime:o}");
+                ticket.Cancel($"Canceled by CancelOpenOrders() at {_algorithm.UtcTime:o}");
                 cancelledOrders.Add(ticket);
             }
             return cancelledOrders;

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -178,6 +178,26 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Cancels all open orders for all symbols
+        /// </summary>
+        /// <returns>List containing the cancelled order tickets</returns>
+        public List<OrderTicket> CancelOpenOrders()
+        {
+            if (_algorithm != null && _algorithm.IsWarmingUp)
+            {
+                throw new Exception("This operation is not allowed in Initialize or during warm up: CancelOpenOrders. Please move this code to the OnWarmupFinished() method.");
+            }
+
+            var cancelledOrders = new List<OrderTicket>();
+            foreach (var ticket in GetOpenOrderTickets())
+            {
+                ticket.Cancel($"Canceled by CancelOpenOrders() on {_algorithm.UtcTime:o}");
+                cancelledOrders.Add(ticket);
+            }
+            return cancelledOrders;
+        }
+
+        /// <summary>
         /// Cancels all open orders for the specified symbol
         /// </summary>
         /// <param name="symbol">The symbol whose orders are to be cancelled</param>


### PR DESCRIPTION
#### Description
Adds parameterless overload to SecurityTransactionManager.CancelOpenOrders().
Unlike the other overload, it is not possible to set up a tag to the order because of the implicit conversion between String and Symbol. 

#### Related Issue
Closes #3020 

#### Motivation and Context
Be able to cancel all open order with just one statement. Currently, in order to cancel all open order, we need to get the open orders and loop through the result to cancel open orders of each symbol.

#### Requires Documentation Change
Yes. In [Trading And Orders](https://www.quantconnect.com/docs/algorithm-reference/trading-and-orders), add the code snippet.

#### How Has This Been Tested?
Running an algorithm with open order and verify that they were closed after the method was called.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`