### PR TITLE
Reduce CPU Usage in Live Equity Enumerator Stack

### DIFF
--- a/Engine/DataFeeds/Enumerators/LiveAuxiliaryDataEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/LiveAuxiliaryDataEnumerator.cs
@@ -1,0 +1,117 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using NodaTime;
+using QuantConnect.Data;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
+{
+    /// <summary>
+    /// Emits auxiliary data points ready to be time synced
+    /// </summary>
+    public class LiveAuxiliaryDataEnumerator : IEnumerator<BaseData>
+    {
+        private readonly DateTimeZone _timeZone;
+        private readonly ITimeProvider _timeProvider;
+        private readonly ConcurrentQueue<BaseData> _queue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiveAuxiliaryDataEnumerator"/> class
+        /// </summary>
+        /// <param name="timeZone">The time zone the raw data is time stamped in</param>
+        /// <param name="timeProvider">The time provider instance used to determine when bars are completed and
+        /// can be emitted</param>
+        public LiveAuxiliaryDataEnumerator(DateTimeZone timeZone, ITimeProvider timeProvider)
+        {
+            _timeZone = timeZone;
+            _timeProvider = timeProvider;
+            _queue = new ConcurrentQueue<BaseData>();
+        }
+        /// <summary>
+        /// Pushes the data point. This data point will be emitted after the allotted time has passed
+        /// </summary>
+        /// <param name="data">The new data point</param>
+        public void Enqueue(BaseData data)
+        {
+            _queue.Enqueue(data);
+        }
+
+        /// <summary>
+        /// Advances the enumerator to the next element of the collection.
+        /// </summary>
+        /// <returns>
+        /// true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.
+        /// </returns>
+        public bool MoveNext()
+        {
+            BaseData dataPoint;
+
+            // check if there's a data point there and if its time to pull it off
+            if (_queue.TryPeek(out dataPoint) && dataPoint.EndTime.ConvertToUtc(_timeZone) <= _timeProvider.GetUtcNow())
+            {
+                // data point is good to go, set it to current and remove from the queue
+                Current = dataPoint;
+                _queue.TryDequeue(out dataPoint);
+            }
+            else
+            {
+                Current = null;
+            }
+
+            // IEnumerator contract dictates that we return true unless we're actually
+            // finished with the 'collection' and since this is live, we're never finished
+            return true;
+        }
+
+        /// <summary>
+        /// Sets the enumerator to its initial position, which is before the first element in the collection.
+        /// </summary>
+        public void Reset()
+        {
+            _queue.Clear();
+        }
+
+        /// <summary>
+        /// Gets the element in the collection at the current position of the enumerator.
+        /// </summary>
+        /// <returns>
+        /// The element in the collection at the current position of the enumerator.
+        /// </returns>
+        public BaseData Current
+        {
+            get; private set;
+        }
+
+        /// <summary>
+        /// Gets the current element in the collection.
+        /// </summary>
+        /// <returns>
+        /// The current element in the collection.
+        /// </returns>
+        object IEnumerator.Current => Current;
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+        }
+    }
+}
+
+

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -257,7 +257,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         case TickType.Trade:
                         default:
                             var tradeBarAggregator = new TradeBarBuilderEnumerator(request.Configuration.Increment, request.Security.Exchange.TimeZone, _timeProvider);
-                            var auxDataEnumerator = new EnqueueableEnumerator<BaseData>();
+                            var auxDataEnumerator = new LiveAuxiliaryDataEnumerator(request.Security.Exchange.TimeZone, _timeProvider);
 
                             _exchange.AddDataHandler(request.Configuration.Symbol, data =>
                             {
@@ -282,7 +282,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             });
 
                             enumerator = request.Configuration.SecurityType == SecurityType.Equity
-                                ? (IEnumerator<BaseData>) new LiveBaseDataSynchronizingEnumerator(_frontierTimeProvider, request.Security.Exchange.TimeZone, auxDataEnumerator, tradeBarAggregator)
+                                ? (IEnumerator<BaseData>) new LiveEquityDataSynchronizingEnumerator(_frontierTimeProvider, request.Security.Exchange.TimeZone, auxDataEnumerator, tradeBarAggregator)
                                 : tradeBarAggregator;
                             break;
 

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -157,11 +157,12 @@
     <Compile Include="DataFeeds\Enumerators\Factories\CorporateEventEnumeratorFactory.cs" />
     <Compile Include="DataFeeds\Enumerators\ITradableDateEventProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\ITradableDatesNotifier.cs" />
+    <Compile Include="DataFeeds\Enumerators\LiveEquityDataSynchronizingEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\MappingEventProvider.cs" />
+    <Compile Include="DataFeeds\Enumerators\LiveAuxiliaryDataEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\PriceScaleFactorEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\SplitEventProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\Factories\LiveCustomDataSubscriptionEnumeratorFactory.cs" />
-    <Compile Include="DataFeeds\Enumerators\LiveBaseDataSynchronizingEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\QuoteBarFillForwardEnumerator.cs" />
     <Compile Include="DataFeeds\Enumerators\AuxiliaryDataEnumerator.cs" />
     <Compile Include="DataFeeds\IDataFeedSubscriptionManager.cs" />

--- a/Tests/Engine/DataFeeds/Enumerators/LiveEquityDataSynchronizingEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveEquityDataSynchronizingEnumeratorTests.cs
@@ -25,7 +25,7 @@ using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
 {
     [TestFixture]
-    public class LiveBaseDataSynchronizingEnumeratorTests
+    public class LiveEquityDataSynchronizingEnumeratorTests
     {
         [Test]
         public void SynchronizesData()
@@ -36,10 +36,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var time = start;
             var stream1 = Enumerable.Range(0, 10).Select(x => new Tick { Time = time.AddSeconds(x * 1) }).GetEnumerator();
             var stream2 = Enumerable.Range(0, 5).Select(x => new Tick { Time = time.AddSeconds(x * 2) }).GetEnumerator();
-            var stream3 = Enumerable.Range(0, 20).Select(x => new Tick { Time = time.AddSeconds(x * 0.5) }).GetEnumerator();
 
             var previous = DateTime.MinValue;
-            var synchronizer = new LiveBaseDataSynchronizingEnumerator(new RealTimeProvider(), DateTimeZone.Utc, stream1, stream2, stream3);
+            var synchronizer = new LiveEquityDataSynchronizingEnumerator(new RealTimeProvider(), DateTimeZone.Utc, stream1, stream2);
             while (synchronizer.MoveNext() && DateTime.UtcNow < end)
             {
                 if (synchronizer.Current != null)

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -384,7 +384,7 @@
     <Compile Include="Engine\DataFeeds\Enumerators\Factories\LiveCustomDataSubscriptionEnumeratorFactoryTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\FastForwardEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\FrontierAwareEnumeratorTests.cs" />
-    <Compile Include="Engine\DataFeeds\Enumerators\LiveBaseDataSynchronizingEnumeratorTests.cs" />
+    <Compile Include="Engine\DataFeeds\Enumerators\LiveEquityDataSynchronizingEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\LiveFillForwardEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\OptionChainUniverseDataCollectionAggregatorEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\QuoteBarFillForwardEnumeratorTests.cs" />


### PR DESCRIPTION
#### Description
The live equity enumerator stack has been refactored and optimized, cutting total CPU usage by **50-70%** with the included benchmark algorithm:

- **Replaced the generic `LiveBaseDataSynchronizingEnumerator` with a faster `LiveEquityDataSynchronizingEnumerator`**
The previous `LiveBaseDataSynchronizingEnumerator` was performing LINQ queries with filtering and sorting in every call to MoveNext. This wasn't really necessary since we only need to synchronize two enumerators here (the trade bar aggregator and the auxiliary data enumerator). 
More than half the CPU savings were obtained with this change alone.

- **Added a new `LiveAuxiliaryDataEnumerator`, used instead of `EnqueueableEnumerator`**
Internally the `EnqueueableEnumerator` uses a `BlockingCollection` (which is more CPU intensive to poll), while the new enumerator uses `ConcurrentQueue` instead (further reducing CPU usage).

#### Motivation and Context
High CPU usage in live algorithms.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
This live algorithm has been profiled locally and also tested in the cloud:
``` C#
    public class BasicTemplateFrameworkAlgorithm : QCAlgorithmFramework
    {
        public override void Initialize()
        {
            UniverseSettings.Resolution = Resolution.Minute;

            SetStartDate(2013, 10, 07);
            SetEndDate(2013, 10, 11);
            SetCash(100000);

            var tickers = new[] { "TDG", "WPC", "LMT", "NEM", "SNV", "VLO", "ABBV", "WSM", "LNC", "URI", "DRI", "DFS", "AZO", "JLL", "FRC", "LH", "DAL", "PG", "VZ", "CBRE", "KMX", "OKE", "CMG", "PGR", "BKNG", "MOH", "TSS", "NOC", "VMW", "EBIX", "JNPR", "MHK", "GPN", "ALL", "MDLZ", "ORLY", "SIRI", "CGNX", "GM", "MAS", "MTN", "ICE", "CXO", "UTX", "HUN", "MS", "ICUI", "IAC", "WTW", "BIIB", "HRB", "FL", "SWKS", "HPQ", "ROST", "GOOGL", "CVS", "PEG", "PCAR", "BBT", "CUZ", "BXP", "HCP", "PXD", "PPG", "X", "EQIX", "BLL", "ABT", "ARE", "PHM", "IONS", "M", "WDC", "BEN", "ABC", "CMS", "WAT", "MCO", "PSA", "PEP", "MTB", "MKTX", "DVN", "CERN", "MMM", "NSC", "DECK", "TROW", "DHI", "STMP", "COP", "ACHC", "MO", "ADP", "SJM", "ALGN", "UDR", "JNJ", "SFM", "ANSS", "CHRW", "OLED", "DLTR", "GOOG", "EIX", "ES", "APA", "FTNT", "APH", "INTU", "AOS", "NKE", "T", "CMI", "WES", "WM", "AKAM", "FIS", "IRBT", "ADBE", "CBRL", "NEE", "LB", "NRZ", "QRTEA", "HIG", "KSS", "PTC", "KSU", "YUM", "GWW", "CHK", "RHI", "CME", "COST", "USB", "PNW", "TTD", "OC", "STOR", "PE", "GDDY", "MGM", "TWTR", "EAT", "ABMD", "AVY", "SCHW", "NTAP", "IFF", "OHI", "MMP", "FDX", "BMY", "CMCSA", "XLNX", "EXEL", "IBM", "HCA", "BAX", "REGN", "ULTA", "FDC", "CF", "HLT", "MAR", "PZZA", "GD", "HPE", "DUK", "ETSY", "CBS", "MLM", "PH", "DTE", "FIVE", "FBHS", "PRU", "LOGM", "VIAB", "HSIC", "APD", "MRK", "WY", "WP", "CTSH", "CNP", "COO", "CPRT", "PAYC", "DVA", "GILD", "PSX", "ON", "CLX", "CFG", "GLW", "CSCO", "CE", "TRU", "NTRS", "RTN", "FAST", "V", "CI", "NFLX", "TXN", "EW", "GRUB", "DOV", "WU", "COG", "ORCL", "MET", "CDNS", "KR", "TTWO", "UAL", "ETFC", "MA", "SIVB", "AVB", "INCY", "WEC", "JWN", "CRI", "SEE", "NBIX", "MSCI", "TJX", "MTZ", "PKI", "WLK", "RL", "ENTG", "SSNC", "IPG", "ILMN", "BDX", "ADM", "EOG", "OMC", "CSGP", "EQR", "SAVE", "MRO", "ALV", "WCG", "BURL", "MNST", "PLD", "XOM", "WBC", "HRL", "AEO", "CLR", "FB", "URBN", "CELG", "PYPL", "LUV", "AAPL", "PRAH", "FFIV", "PNC", "CPT", "KMB", "SRE", "AME", "TSCO", "VRTX", "NXST", "GPC", "YELP", "CTXS", "LOW", "HSY", "FITB", "SHW", "IDXX", "LLY", "HD", "KEYS", "HST", "IQV", "COLD", "SNPS", "CMA", "LEN", "ADI", "AGNC", "BIO", "CAH", "UNH", "ATUS", "AAP", "WAB", "DE", "DLR", "SYF", "BHGE", "AMP", "EBAY", "TRIP", "HFC", "GPS", "XPO", "LLL", "VFC", "KO", "MSFT", "HBI", "AXP", "DPZ", "AVGO", "FND", "EMN", "KAR", "KMI", "TIF", "MSI", "RHT", "TPR", "LVS", "RF", "SWK", "AMGN", "PAYX", "PFG", "VMC", "BAC", "ANET", "XEL", "MTD", "TGT", "DRE", "KLAC", "FTV", "O", "CHTR", "FANG", "NVDA", "TRV", "EPD", "PKG", "KDP", "SBUX", "APC", "WYNN", "ROK", "CAG", "C", "DWDP", "HON", "ALRM", "CSX", "COF", "BLK", "SWN", "ALB", "CCI", "BRK.B", "STZ", "UHS", "ULTI", "VAR", "LXP", "EL", "DHR", "MAC", "IRM", "WRK", "AJG", "RMD", "WFC", "MCHP", "ISRG", "GIS", "ZION", "TMO", "WEX", "HUM", "ETR", "ROP", "EA", "TSN", "HAS", "BSX", "HBAN", "CHD", "FLT", "AFL", "ALK", "WMT", "UPS", "CTAS", "DKS", "SNA", "INTC", "HRS", "LULU", "XEC", "VEEV", "FISV", "OLN", "LEA", "AEP", "MU", "VSM", "LRCX", "ADS", "BEAT", "CAT", "MPC", "HII", "ECL", "KEY", "DNKN", "TRN", "MMC", "DGX", "AMD", "GS", "JEC", "VRSN", "EXC", "PM", "K", "BR", "EFX", "SO", "STI", "PFE", "DG", "TAP", "MCD", "CNC", "HAL", "AMT", "CRM", "PLNT", "FMC", "CVX", "FCX", "FE", "VTR", "BBY", "WBA", "WELL", "F", "BA", "ZTS", "EXR", "EXPE", "MXIM", "TOL", "TGNA", "SYY", "NUE", "ITW", "DIS", "JPM", "SPGI", "TMUS", "UNVR", "ARMK", "CL", "ATVI", "ANTM", "AMAT", "ED", "SPG", "EMR", "AES", "SYK", "WEN", "STT", "MKC", "AAL", "AMZN", "IP", "A", "D", "FSLR", "AIV", "PPL", "LW", "LKQ", "BK", "CZR", "XRX", "KKR", "UNP", "OXY", "DXC", "ALXN", "PVH", "KIM" };
            var symbols = tickers.Select(x => QuantConnect.Symbol.Create(x, SecurityType.Equity, Market.USA));

            SetUniverseSelection(new ManualUniverseSelectionModel(symbols));
            SetAlpha(new NullAlphaModel());
            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
            SetExecution(new NullExecutionModel());
            SetRiskManagement(new NullRiskManagementModel());
        }
    }
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`