### PR TITLE
Implements Insight Expiry Helper

### DIFF
--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -445,6 +445,21 @@ namespace QuantConnect
     }
 
     /// <summary>
+    /// Expiry calendar. Defines end of a period following calendar rules.
+    /// </summary>
+    public enum ExpiryCalendar
+    {
+        /// End of day (next open)
+        EndOfDay,
+        /// End of week expiry (next Monday)
+        EndOfWeek,
+        /// End of month expiry (1st of the next Month)
+        EndOfMonth,
+        /// Monthly expiry (nth day to nth day of the following month)
+        OneMonth
+    }
+
+    /// <summary>
     /// Specifies the different types of options
     /// </summary>
     public enum OptionRight

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -213,6 +213,42 @@ namespace QuantConnect.Tests.Algorithm.Framework
         }
 
         [Test]
+        [TestCase(ExpiryCalendar.EndOfDay, 2018, 12, 4, 9, 30)]
+        [TestCase(ExpiryCalendar.EndOfWeek, 2018, 12, 10, 9, 30)]
+        [TestCase(ExpiryCalendar.EndOfMonth, 2019, 1, 2, 9, 30)]
+        [TestCase(ExpiryCalendar.OneMonth, 2019, 1, 3, 9, 31)]
+        public void SetPeriodAndCloseTimeUsingExpiryCalendarEquity(ExpiryCalendar expiryCalendar, int year, int month, int day, int hour, int minute)
+        {
+            var symbol = Symbols.SPY;
+            var insight = Insight.Price(symbol, expiryCalendar, InsightDirection.Up);
+            insight.GeneratedTimeUtc = new DateTime(2018, 12, 3, 9, 31, 0).ConvertToUtc(TimeZones.NewYork);
+
+            var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+            insight.SetPeriodAndCloseTime(exchangeHours);
+            
+            var expected = new DateTime(year, month, day, hour, minute, 0).ConvertToUtc(TimeZones.NewYork);
+            Assert.AreEqual(expected, insight.CloseTimeUtc);
+        }
+
+        [Test]
+        [TestCase(ExpiryCalendar.EndOfDay, 2018, 12, 4, 0, 0)]
+        [TestCase(ExpiryCalendar.EndOfWeek, 2018, 12, 10, 0, 0)]
+        [TestCase(ExpiryCalendar.EndOfMonth, 2019, 1, 2, 0, 0)]
+        [TestCase(ExpiryCalendar.OneMonth, 2019, 1, 3, 9, 31)]
+        public void SetPeriodAndCloseTimeUsingExpiryCalendarForex(ExpiryCalendar expiryCalendar, int year, int month, int day, int hour, int minute)
+        {
+            var symbol = Symbols.EURUSD;
+            var insight = Insight.Price(symbol, expiryCalendar, InsightDirection.Up);
+            insight.GeneratedTimeUtc = new DateTime(2018, 12, 3, 9, 31, 0).ConvertToUtc(TimeZones.EasternStandard);
+
+            var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+            insight.SetPeriodAndCloseTime(exchangeHours);
+
+            var expected = new DateTime(year, month, day, hour, minute, 0).ConvertToUtc(TimeZones.EasternStandard);
+            Assert.AreEqual(expected, insight.CloseTimeUtc);
+        }
+
+        [Test]
         [TestCase(Resolution.Tick, 1)]
         [TestCase(Resolution.Tick, 10)]
         [TestCase(Resolution.Tick, 100)]


### PR DESCRIPTION
#### Description
Implement a new overload to `Insight` constructor that accepts an Enum (`ExpiryCalendar`) with the possible calendar rules and compute the `CloseTimeUtc` and `Period` after the `Insight` object is emitted (`SetPeriodAndCloseTime` method).

#### Related Issue
Closes #3038 

#### Motivation and Context
Add helpers to prevent repetitive calculations.

#### Requires Documentation Change
Yes. Explicitly add this new option in the docs. 

#### How Has This Been Tested?
Unit tests. Manually testing in an algorithm.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`