### PR TITLE
Adds Constructor Overload with PyObject to ScheduledUniverse

### DIFF
--- a/Algorithm.CSharp/CapmAlphaRankingFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/CapmAlphaRankingFrameworkAlgorithm.cs
@@ -1,0 +1,126 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using MathNet.Numerics;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Indicators;
+using QuantConnect.Securities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// CapmAlphaRankingFrameworkAlgorithm: example of custom scheduled universe selection model
+    /// Universe Selection inspired by https://www.quantconnect.com/tutorials/strategy-library/capm-alpha-ranking-strategy-on-dow-30-companies
+    /// </summary>
+    public class CapmAlphaRankingFrameworkAlgorithm : QCAlgorithm
+    {
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            // Set requested data resolution
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            SetStartDate(2016, 1, 1);   //Set Start Date
+            SetEndDate(2017, 1, 1);     //Set End Date
+            SetCash(100000);            //Set Strategy Cash
+
+            // set algorithm framework models
+            SetUniverseSelection(new CapmAlphaRankingUniverseSelectionModel());
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromDays(1), 0.025, null));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetRiskManagement(new MaximumDrawdownPercentPerSecurity(0.01m));
+        }
+
+        /// <summary>
+        /// This universe selection model picks stocks with the highest alpha: interception of the linear regression against a benchmark.
+        /// </summary>
+        private class CapmAlphaRankingUniverseSelectionModel : UniverseSelectionModel
+        {
+            private const int period = 21;
+            private const string _benchmark = "SPY";
+
+            // Symbols of Dow 30 companies.
+            private readonly IEnumerable<Symbol> _symbols = new[]
+            {
+                "AAPL", "AXP", "BA", "CAT", "CSCO", "CVX", "DD", "DIS", "GE", "GS",
+                "HD", "IBM", "INTC", "JPM", "KO", "MCD", "MMM", "MRK", "MSFT",
+                "NKE","PFE", "PG", "TRV", "UNH", "UTX", "V", "VZ", "WMT", "XOM"
+            }.Select(x => QuantConnect.Symbol.Create(x, SecurityType.Equity, Market.USA));
+
+            public override IEnumerable<Universe> CreateUniverses(QCAlgorithm algorithm)
+            {
+                // Adds the benchmark to the user defined universe
+                var benchmark = algorithm.AddEquity(_benchmark, Resolution.Daily);
+
+                // Defines a schedule universe that fires after market open when the month starts
+                yield return new ScheduledUniverse(
+                    benchmark.Exchange.TimeZone,
+                    algorithm.DateRules.MonthStart(benchmark.Symbol),
+                    algorithm.TimeRules.AfterMarketOpen(benchmark.Symbol),
+                    datetime => SelectPair(algorithm, datetime),
+                    algorithm.UniverseSettings,
+                    algorithm.SecurityInitializer);
+            }
+
+            /// <summary>
+            /// Selects the pair (two stocks) with the highest alpha
+            /// </summary>
+            private IEnumerable<Symbol> SelectPair(QCAlgorithm algorithm, DateTime dateTime)
+            {
+                var dictionary = new Dictionary<Symbol, double>();
+
+                var benchmark = GetReturns(algorithm, _benchmark);
+
+                foreach (var symbol in _symbols)
+                {
+                    var prices = GetReturns(algorithm, symbol);
+
+                    // Calculate the Least-Square fitting to the returns of a given symbol and the benchmark
+                    var ols = Fit.Line(prices, benchmark);
+
+                    dictionary.Add(symbol, ols.Item1);
+                }
+
+                // Returns the top 2 highest alphas
+                var orderedDictionary = dictionary.OrderByDescending(key => key.Value);
+                return orderedDictionary.Take(2).Select(x => x.Key);
+            }
+
+            private double[] GetReturns(QCAlgorithm algorithm, Symbol symbol)
+            {
+                var window = new RollingWindow<double>(period);
+                var rateOfChange = new RateOfChange(1);
+                rateOfChange.Updated += (s, item) => window.Add((double)item.Value);
+
+                foreach (var bar in algorithm.History(symbol, period, Resolution.Daily))
+                {
+                    rateOfChange.Update(bar.EndTime, bar.Close);
+                }
+                return window.ToArray();
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Alphas\TripleLeveragedETFPairVolatilityDecayAlpha.cs" />
     <Compile Include="Alphas\VixDualThrustAlpha.cs" />
     <Compile Include="BasicSetAccountCurrencyAlgorithm.cs" />
+    <Compile Include="CapmAlphaRankingFrameworkAlgorithm.cs" />
     <Compile Include="G10CurrencySelectionModelFrameworkAlgorithm.cs" />
     <Compile Include="ExpiryHelperAlphaModelFrameworkAlgorithm.cs" />
     <Compile Include="CfdTimeZonesRegressionAlgorithm.cs" />

--- a/Algorithm.Python/CapmAlphaRankingFrameworkAlgorithm.py
+++ b/Algorithm.Python/CapmAlphaRankingFrameworkAlgorithm.py
@@ -1,0 +1,127 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Indicators")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Indicators import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from datetime import timedelta
+import numpy as np
+import pandas as pd
+import ptvsd; ptvsd.enable_attach(); ptvsd.wait_for_attach(); 
+
+### <summary>
+### CapmAlphaRankingFrameworkAlgorithm: example of custom scheduled universe selection model
+### Universe Selection inspired by https://www.quantconnect.com/tutorials/strategy-library/capm-alpha-ranking-strategy-on-dow-30-companies
+### </summary>
+class CapmAlphaRankingFrameworkAlgorithm(QCAlgorithm):
+    '''CapmAlphaRankingFrameworkAlgorithm: example of custom scheduled universe selection model'''
+
+    def Initialize(self):
+        ''' Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        # Set requested data resolution
+        self.UniverseSettings.Resolution = Resolution.Minute
+
+        self.SetStartDate(2016, 1, 1)   #Set Start Date
+        self.SetEndDate(2017, 1, 1)     #Set End Date
+        self.SetCash(100000)            #Set Strategy Cash
+
+        # set algorithm framework models
+        self.SetUniverseSelection(CapmAlphaRankingUniverseSelectionModel())
+        self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(1), 0.025, None))
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+        self.SetRiskManagement(MaximumDrawdownPercentPerSecurity(0.01))
+
+from QuantConnect.Data.UniverseSelection import ScheduledUniverse
+from Selection.UniverseSelectionModel import UniverseSelectionModel
+
+class CapmAlphaRankingUniverseSelectionModel(UniverseSelectionModel):
+    '''This universe selection model picks stocks with the highest alpha: interception of the linear regression against a benchmark.'''
+
+    period = 21;
+    benchmark = "SPY"
+
+    # Symbols of Dow 30 companies.
+    symbols = [Symbol.Create(x, SecurityType.Equity, Market.USA)
+               for x in ["AAPL", "AXP", "BA", "CAT", "CSCO", "CVX", "DD", "DIS", "GE", "GS",
+                         "HD", "IBM", "INTC", "JPM", "KO", "MCD", "MMM", "MRK", "MSFT",
+                         "NKE","PFE", "PG", "TRV", "UNH", "UTX", "V", "VZ", "WMT", "XOM"]]
+
+    def CreateUniverses(self, algorithm):
+
+        # Adds the benchmark to the user defined universe
+        benchmark = algorithm.AddEquity(self.benchmark, Resolution.Daily)
+
+        # Defines a schedule universe that fires after market open when the month starts
+        return [ ScheduledUniverse(
+            benchmark.Exchange.TimeZone,
+            algorithm.DateRules.MonthStart(self.benchmark),
+            algorithm.TimeRules.AfterMarketOpen(self.benchmark),
+            lambda datetime: self.SelectPair(algorithm, datetime),
+            algorithm.UniverseSettings,
+            algorithm.SecurityInitializer)]
+
+    def SelectPair(self, algorithm, date):
+        '''Selects the pair (two stocks) with the highest alpha'''
+        dictionary = dict()
+        ptvsd.break_into_debugger()
+        benchmark = self._getReturns(algorithm, self.benchmark)
+        ones = np.ones(len(benchmark))
+
+        for symbol in self.symbols:
+            prices = self._getReturns(algorithm, symbol)
+            if prices is None: continue
+            A = np.vstack([prices, ones]).T
+
+            # Calculate the Least-Square fitting to the returns of a given symbol and the benchmark
+            ols = np.linalg.lstsq(A, benchmark)[0]
+            dictionary[symbol] = ols[1]
+
+        # Returns the top 2 highest alphas
+        orderedDictionary = sorted(dictionary.items(), key= lambda x: x[1], reverse=True)
+        return [x[0] for x in orderedDictionary[:2]]
+
+    def _getReturns(self, algorithm, symbol):
+
+        history = algorithm.History([symbol], self.period, Resolution.Daily)
+        if history.empty: return None
+
+        window = RollingWindow[float](self.period)
+        rateOfChange = RateOfChange(1)
+
+        def roc_updated(s, item):
+            window.Add(item.Value)
+
+        rateOfChange.Updated += roc_updated
+
+        history = history.close.reset_index(level=0, drop=True).iteritems()
+
+        for time, value in history:
+            rateOfChange.Update(time, value);
+
+        return [ x for x in window]

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -54,6 +54,7 @@
     <Content Include="Alphas\TripleLeverageETFPairVolatilityDecayAlpha.py" />
     <Content Include="Alphas\VIXDualThrustAlpha.py" />
     <Content Include="BasicSetAccountCurrencyAlgorithm.py" />
+    <None Include="CapmAlphaRankingFrameworkAlgorithm.py" />
     <Content Include="G10CurrencySelectionModelFrameworkAlgorithm.py" />
     <Content Include="ExpiryHelperAlphaModelFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateFuturesFrameworkAlgorithm.py" />


### PR DESCRIPTION
#### Description
Adds constructor overload that accepts a PyObject representing a `Func<DateTime, Symbol[]>` object to `ScheduledUniverse`. With this overload, we are able to create a `ScheduledUniverse` with a selector defined in a python script.

#### Related Issue
Closes #3042 

#### Motivation and Context
This feature enables the creation of custom scheduled universe selection models. It can be used to create the universe selection model of the [CAPM Alpha Ranking Strategy on Dow 30 Companies](https://www.quantconnect.com/tutorials/strategy-library/capm-alpha-ranking-strategy-on-dow-30-companies).

#### How Has This Been Tested?
A simplified version of [CAPM Alpha Ranking Strategy on Dow 30 Companies](https://www.quantconnect.com/tutorials/strategy-library/capm-alpha-ranking-strategy-on-dow-30-companies).

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`