### PR TITLE
Implements Insight Expiry Helper

### DIFF
--- a/Algorithm.CSharp/ExpiryHelperAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/ExpiryHelperAlphaModelFrameworkAlgorithm.cs
@@ -1,0 +1,109 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Expiry Helper framework algorithm uses <see cref="Expiry"/> helper class in an Alpha Model
+    /// </summary>
+    public class ExpiryHelperAlphaModelFrameworkAlgorithm : QCAlgorithmFramework
+    {
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            // Set requested data resolution
+            UniverseSettings.Resolution = Resolution.Hour;
+
+            SetStartDate(2013, 10, 07);  //Set Start Date
+            SetEndDate(2014, 1, 1);      //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+
+            // set algorithm framework models
+            SetUniverseSelection(new ManualUniverseSelectionModel(QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)));
+            SetAlpha(new ExpiryHelperAlphaModel());
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetRiskManagement(new MaximumDrawdownPercentPerSecurity(0.01m));
+
+            InsightsGenerated += (s, e) =>
+            {
+                foreach (var insight in e.Insights)
+                {
+                    Log($"{e.DateTimeUtc.DayOfWeek}: Close Time {insight.CloseTimeUtc} {insight.CloseTimeUtc.DayOfWeek}");
+                }
+            };
+        }
+
+        /// <summary>
+        /// <see cref="ExpiryHelperAlphaModel"/> shows how we can use the <see cref="Expiry"/> helper class
+        /// to set an insight with a calendar expiry.
+        /// </summary>
+        private class ExpiryHelperAlphaModel : AlphaModel
+        {
+            private const InsightDirection _direction = InsightDirection.Up;
+            private DateTime _nextUpdate = DateTime.MinValue;
+
+            public override IEnumerable<Insight> Update(QCAlgorithmFramework algorithm, Slice data)
+            {
+                if (_nextUpdate > algorithm.Time)
+                {
+                    yield break;
+                }
+
+                var expiry = Expiry.EndOfDay;
+
+                // Use the Expiry helper to calculate a date/time in the future
+                _nextUpdate = expiry(algorithm.Time);
+
+                foreach (var symbol in data.Bars.Keys)
+                {
+                    switch (algorithm.Time.DayOfWeek)
+                    {
+                        // Expected CloseTime: next month on the same day and time
+                        case DayOfWeek.Monday:
+                            yield return Insight.Price(symbol, Expiry.OneMonth, _direction);
+                            break;
+                        // Expected CloseTime: next month on the 1st at market open time
+                        case DayOfWeek.Tuesday:
+                            yield return Insight.Price(symbol, Expiry.EndOfMonth, _direction);
+                            break;
+                        // Expected CloseTime: next Monday at market open time
+                        case DayOfWeek.Wednesday:
+                            yield return Insight.Price(symbol, Expiry.EndOfWeek, _direction);
+                            break;
+                        // Expected CloseTime: next day (Friday) at market open time
+                        case DayOfWeek.Thursday:
+                            yield return Insight.Price(symbol, Expiry.EndOfDay, _direction);
+                            break;
+                        default:
+                            yield break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Alphas\TripleLeveragedETFPairVolatilityDecayAlpha.cs" />
     <Compile Include="Alphas\VixDualThrustAlpha.cs" />
     <Compile Include="BasicSetAccountCurrencyAlgorithm.cs" />
+    <Compile Include="ExpiryHelperAlphaModelFrameworkAlgorithm.cs" />
     <Compile Include="CfdTimeZonesRegressionAlgorithm.cs" />
     <Compile Include="CoarseNoLookAheadBiasAlgorithm.cs" />
     <Compile Include="HistoryWithSymbolChangesRegressionAlgorithm.cs" />

--- a/Algorithm.Python/ExpiryHelperAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/ExpiryHelperAlphaModelFrameworkAlgorithm.py
@@ -1,0 +1,91 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
+
+### <summary>
+### Expiry Helper framework algorithm uses Expiry helper class in an Alpha Model
+### </summary>
+class ExpiryHelperAlphaModelFrameworkAlgorithm(QCAlgorithmFramework):
+    '''Expiry Helper framework algorithm uses Expiry helper class in an Alpha Model'''
+
+    def Initialize(self):
+        ''' Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        # Set requested data resolution
+        self.UniverseSettings.Resolution = Resolution.Hour
+
+        self.SetStartDate(2013,10,7)   #Set Start Date
+        self.SetEndDate(2014,1,1)      #Set End Date
+        self.SetCash(100000)           #Set Strategy Cash
+
+        symbols = [ Symbol.Create("SPY", SecurityType.Equity, Market.USA) ]
+
+        # set algorithm framework models
+        self.SetUniverseSelection(ManualUniverseSelectionModel(symbols))
+        self.SetAlpha(self.ExpiryHelperAlphaModel())
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+        self.SetRiskManagement(MaximumDrawdownPercentPerSecurity(0.01))
+
+        self.InsightsGenerated += self.OnInsightsGenerated
+
+    def OnInsightsGenerated(self, s, e):
+        for insight in e.Insights:
+            self.Log(f"{e.DateTimeUtc.isoweekday()}: Close Time {insight.CloseTimeUtc} {insight.CloseTimeUtc.isoweekday()}")
+
+    class ExpiryHelperAlphaModel(AlphaModel):
+        nextUpdate = None
+        direction = InsightDirection.Up
+
+        def Update(self, algorithm, data):
+
+            if self.nextUpdate is not None and self.nextUpdate > algorithm.Time:
+                return []
+
+            expiry = Expiry.EndOfDay
+
+            # Use the Expiry helper to calculate a date/time in the future
+            self.nextUpdate = expiry(algorithm.Time)
+
+            weekday = algorithm.Time.isoweekday()
+
+            insights = []
+            for symbol in data.Bars.Keys:
+                # Expected CloseTime: next month on the same day and time
+                if weekday == 1:
+                    insights.append(Insight.Price(symbol, Expiry.OneMonth, self.direction))
+                # Expected CloseTime: next month on the 1st at market open time
+                elif weekday == 2:
+                    insights.append(Insight.Price(symbol, Expiry.EndOfMonth, self.direction))
+                # Expected CloseTime: next Monday at market open time
+                elif weekday == 3:
+                    insights.append(Insight.Price(symbol, Expiry.EndOfWeek, self.direction))
+                # Expected CloseTime: next day (Friday) at market open time
+                elif weekday == 4:
+                    insights.append(Insight.Price(symbol, Expiry.EndOfDay, self.direction))
+
+            return insights

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -51,6 +51,7 @@
     <Content Include="Alphas\TripleLeverageETFPairVolatilityDecayAlpha.py" />
     <Content Include="Alphas\VIXDualThrustAlpha.py" />
     <Content Include="BasicSetAccountCurrencyAlgorithm.py" />
+    <Content Include="ExpiryHelperAlphaModelFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateFuturesFrameworkAlgorithm.py" />
     <Content Include="BasicTemplateOptionsFrameworkAlgorithm.py" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Common/Expiry.cs
+++ b/Common/Expiry.cs
@@ -1,0 +1,67 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+
+namespace QuantConnect
+{
+    /// <summary>
+    /// Provides static functions that can be used to compute a future <see cref="DateTime"/> (expiry) given a <see cref="DateTime"/>.
+    /// </summary>
+    public static class Expiry
+    {
+        /// <summary>
+        /// Computes a date/time one month after a given date/time (nth day to nth day)
+        /// </summary>
+        public static Func<DateTime, DateTime> OneMonth => dt => dt.AddMonths(1);
+
+        /// <summary>
+        /// Computes the end of day (mid-night of the next day) of given date/time
+        /// </summary>
+        public static Func<DateTime, DateTime> EndOfDay => dt => dt.AddDays(1).Date;
+
+        /// <summary>
+        /// Computes the end of week (next Monday) of given date/time
+        /// </summary>
+        public static Func<DateTime, DateTime> EndOfWeek
+        {
+            get
+            {
+                return dt =>
+                {
+                    var value = 8 - (int)dt.DayOfWeek;
+                    if (value == 8) value = 1;   // Sunday
+                    return dt.AddDays(value).Date;
+                };
+            }
+        }
+
+        /// <summary>
+        /// Computes the end of month (1st of the next month) of given date/time
+        /// </summary>
+        public static Func<DateTime, DateTime> EndOfMonth
+        {
+            get
+            {
+                return dt =>
+                {
+                    var value = 1 - dt.Day;
+                    return OneMonth(dt).AddDays(value).Date;
+                };
+            }
+        }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Data\HistoryProviderInitializeParameters.cs" />
     <Compile Include="Data\HistoryRequestFactory.cs" />
     <Compile Include="Data\SubscriptionDataConfigExtensions.cs" />
+    <Compile Include="Expiry.cs" />
     <Compile Include="HistoryProviderEvents.cs" />
     <Compile Include="Interfaces\IAccountCurrencyProvider.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -213,6 +213,65 @@ namespace QuantConnect.Tests.Algorithm.Framework
         }
 
         [Test]
+        [TestCase("SPY", SecurityType.Equity, Market.USA, 2018, 12, 4, 9, 30)]
+        [TestCase("EURUSD", SecurityType.Forex, Market.FXCM, 2018, 12, 4, 0, 0)]
+        public void SetPeriodAndCloseTimeUsingExpiryEndOfDay(string ticker, SecurityType securityType, string market, int year, int month, int day, int hour, int minute)
+        {
+            var symbol = Symbol.Create(ticker, securityType, market);
+
+            SetPeriodAndCloseTimeUsingExpiryFunc(
+                Insight.Price(symbol, Expiry.EndOfDay, InsightDirection.Up),
+                new DateTime(year, month, day, hour, minute, 0).ConvertToUtc(TimeZones.NewYork));
+        }
+
+        [Test]
+        [TestCase("SPY", SecurityType.Equity, Market.USA, 2018, 12, 10, 9, 30)]
+        [TestCase("EURUSD", SecurityType.Forex, Market.FXCM, 2018, 12, 10, 0, 0)]
+        public void SetPeriodAndCloseTimeUsingExpiryEndOfWeek(string ticker, SecurityType securityType, string market, int year, int month, int day, int hour, int minute)
+        {
+            var symbol = Symbol.Create(ticker, securityType, market);
+
+            SetPeriodAndCloseTimeUsingExpiryFunc(
+                Insight.Price(symbol, Expiry.EndOfWeek, InsightDirection.Up),
+                new DateTime(year, month, day, hour, minute, 0).ConvertToUtc(TimeZones.NewYork));
+        }
+
+        [Test]
+        [TestCase("SPY", SecurityType.Equity, Market.USA, 2019, 1, 2, 9, 30)]
+        [TestCase("EURUSD", SecurityType.Forex, Market.FXCM, 2019, 1, 2, 0, 0)]
+        public void SetPeriodAndCloseTimeUsingExpiryEndOfMonth(string ticker, SecurityType securityType, string market, int year, int month, int day, int hour, int minute)
+        {
+            var symbol = Symbol.Create(ticker, securityType, market);
+
+            SetPeriodAndCloseTimeUsingExpiryFunc(
+                Insight.Price(symbol, Expiry.EndOfMonth, InsightDirection.Up),
+                new DateTime(year, month, day, hour, minute, 0).ConvertToUtc(TimeZones.NewYork));
+        }
+
+        [Test]
+        [TestCase("SPY", SecurityType.Equity, Market.USA, 2019, 1, 3, 9, 31)]
+        [TestCase("EURUSD", SecurityType.Forex, Market.FXCM, 2019, 1, 3, 9, 31)]
+        public void SetPeriodAndCloseTimeUsingExpiryOneMonth(string ticker, SecurityType securityType, string market, int year, int month, int day, int hour, int minute)
+        {
+            var symbol = Symbol.Create(ticker, securityType, market);
+
+            SetPeriodAndCloseTimeUsingExpiryFunc(
+                Insight.Price(symbol, Expiry.OneMonth, InsightDirection.Up),
+                new DateTime(year, month, day, hour, minute, 0).ConvertToUtc(TimeZones.NewYork));
+        }
+
+        private void SetPeriodAndCloseTimeUsingExpiryFunc(Insight insight, DateTime expected)
+        {
+            var symbol = insight.Symbol;
+            insight.GeneratedTimeUtc = new DateTime(2018, 12, 3, 9, 31, 0).ConvertToUtc(TimeZones.NewYork);
+
+            var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+            insight.SetPeriodAndCloseTime(exchangeHours);
+
+            Assert.AreEqual(expected, insight.CloseTimeUtc);
+        }
+
+        [Test]
         [TestCase(Resolution.Tick, 1)]
         [TestCase(Resolution.Tick, 10)]
         [TestCase(Resolution.Tick, 100)]


### PR DESCRIPTION
#### Description
Implement a new overload to `Insight` constructor that accepts a  `Func<DateTime, DateTime>` that is used to compute the `CloseTimeUtc` and `Period` after the `Insight` object is emitted (`SetPeriodAndCloseTime` method).

Adds the static Expiry class with functions that can be used to compute a future date/time (expiry) given a date/time.

#### Related Issue
Closes #3038

#### Motivation and Context
Add helpers to prevent repetitive calculations.

#### Requires Documentation Change
Yes. Explicitly add this new option in the docs.

#### How Has This Been Tested?
Unit tests. Manually testing in an algorithm.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`