### PR TITLE
Replaces Exception for Error Logging when OnData for Custom Data is not Defined

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -187,12 +187,7 @@ namespace QuantConnect.Lean.Engine
                     //If we already have this Type-handler then don't add it to invokers again.
                     if (methodInvokers.ContainsKey(config.Type)) continue;
 
-                    //If we couldnt find the event handler, let the user know we can't fire that event.
-                    if (genericMethod == null && !hasOnDataSlice)
-                    {
-                        algorithm.Debug("Data event handler not found, please create a function matching this template: public void OnData(" + config.Type.Name + " data) {  }");
-                    }
-                    else if (genericMethod != null)
+                    if (genericMethod != null)
                     {
                         methodInvokers.Add(config.Type, genericMethod.DelegateForCallMethod());
                     }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -190,11 +190,9 @@ namespace QuantConnect.Lean.Engine
                     //If we couldnt find the event handler, let the user know we can't fire that event.
                     if (genericMethod == null && !hasOnDataSlice)
                     {
-                        algorithm.RunTimeError = new Exception("Data event handler not found, please create a function matching this template: public void OnData(" + config.Type.Name + " data) {  }");
-                        _algorithm.Status = AlgorithmStatus.RuntimeError;
-                        return;
+                        algorithm.Error("Data event handler not found, please create a function matching this template: public void OnData(" + config.Type.Name + " data) {  }");
                     }
-                    if (genericMethod != null)
+                    else if (genericMethod != null)
                     {
                         methodInvokers.Add(config.Type, genericMethod.DelegateForCallMethod());
                     }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -190,7 +190,7 @@ namespace QuantConnect.Lean.Engine
                     //If we couldnt find the event handler, let the user know we can't fire that event.
                     if (genericMethod == null && !hasOnDataSlice)
                     {
-                        algorithm.Error("Data event handler not found, please create a function matching this template: public void OnData(" + config.Type.Name + " data) {  }");
+                        algorithm.Debug("Data event handler not found, please create a function matching this template: public void OnData(" + config.Type.Name + " data) {  }");
                     }
                     else if (genericMethod != null)
                     {


### PR DESCRIPTION
#### Description
Replaces exception for error logging when `OnData` for custom data is not defined.

#### Related Issue
Closes #3051 

#### Motivation and Context
Custom data can be added to an algorithm with a framework model or as a benchmark. In these cases, `OnData` doesn't need to be defined. Therefore it suffices to warn the user and not stop the algorithm execution.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Remove `OnData` from [CustomDataNiftyAlgorithm](https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`