### PR TITLE
Prevents Multiple Warning from Market to MarketOnOpenOrder

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -27,6 +27,7 @@ namespace QuantConnect.Algorithm
     public partial class QCAlgorithm
     {
         private int _maxOrders = 10000;
+        private bool _isMarketOnOpenOrderWarningSent = false;
 
         /// <summary>
         /// Transaction Manager - Process transaction fills and order management.
@@ -205,10 +206,14 @@ namespace QuantConnect.Algorithm
             if (!security.Exchange.ExchangeOpen)
             {
                 var mooTicket = MarketOnOpenOrder(security.Symbol, quantity, tag);
-                var anyNonDailySubscriptions = security.Subscriptions.Any(x => x.Resolution != Resolution.Daily);
-                if (mooTicket.SubmitRequest.Response.IsSuccess && !anyNonDailySubscriptions)
+                if (!_isMarketOnOpenOrderWarningSent)
                 {
-                    Debug("Converted OrderID: " + mooTicket.OrderId + " into a MarketOnOpen order.");
+                    var anyNonDailySubscriptions = security.Subscriptions.Any(x => x.Resolution != Resolution.Daily);
+                    if (mooTicket.SubmitRequest.Response.IsSuccess && !anyNonDailySubscriptions)
+                    {
+                        Debug("Warning: all market orders sent using daily data, or market orders sent after hours are automatically converted into MarketOnOpen orders.");
+                        _isMarketOnOpenOrderWarningSent = true;
+                    }
                 }
                 return mooTicket;
             }


### PR DESCRIPTION
#### Description
Adds a flag that prevents multiple warning from market to `MarketOnOpenOrder`.

#### Related Issue
Closes #3053 

#### Motivation and Context
Multiple warnings on the conversion from market orders to `MarketOnOpenOrder` don't add relevant information. However, it increases the log size significantly especially for Universe Selection algorithms that may trade hundreds of securities.

#### How Has This Been Tested?
```csharp
public class BasicTemplateAlgorithm : QCAlgorithm {
    public override void Initialize() {
        SetStartDate(2013, 10, 07);
        SetEndDate(2013, 10, 11);
        AddEquity("SPY", Resolution.Daily);
    }

    public override void OnData(Slice data) {
        MarketOrder(_spy, 100);
    }
}
```
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`