### PR TITLE
Dispose PyObjects from C#->Py calls

### DIFF
--- a/Algorithm/Portfolio/PortfolioConstructionModelPythonWrapper.cs
+++ b/Algorithm/Portfolio/PortfolioConstructionModelPythonWrapper.cs
@@ -58,11 +58,13 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             using (Py.GIL())
             {
                 var targets = _model.CreateTargets(algorithm, insights) as PyObject;
-                foreach (PyObject target in targets)
+                var iterator = targets.GetIterator();
+                foreach (PyObject target in iterator)
                 {
-                    yield return target.AsManagedObject(typeof(IPortfolioTarget)) as IPortfolioTarget;
+                    yield return target.GetAndDispose<IPortfolioTarget>();
                 }
-                targets.Destroy();
+                iterator.Dispose();
+                targets.Dispose();
             }
         }
 

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -383,7 +383,9 @@ namespace QuantConnect.Algorithm
             {
                 using (Py.GIL())
                 {
-                    indicator.InvokeMethod("Update", new[] { consolidated.ToPython() });
+                    var data = consolidated.ToPython();
+                    indicator.InvokeMethod("Update", new[] { data });
+                    data.Dispose();
                 }
             };
         }
@@ -400,7 +402,7 @@ namespace QuantConnect.Algorithm
             {
                 try
                 {
-                    decimal value = ((dynamic)pyObject).Current.Value;
+                    var value = (((dynamic)pyObject).Current.Value as PyObject).GetAndDispose<decimal>();
                     Plot(series, value);
                 }
                 catch

--- a/Algorithm/Risk/RiskManagementModelPythonWrapper.cs
+++ b/Algorithm/Risk/RiskManagementModelPythonWrapper.cs
@@ -48,11 +48,13 @@ namespace QuantConnect.Algorithm.Framework.Risk
             using (Py.GIL())
             {
                 var riskTargetOverrides = _model.ManageRisk(algorithm, targets) as PyObject;
-                foreach (PyObject target in riskTargetOverrides)
+                var iterator = riskTargetOverrides.GetIterator();
+                foreach (PyObject target in iterator)
                 {
-                    yield return target.AsManagedObject(typeof(IPortfolioTarget)) as IPortfolioTarget;
+                    yield return target.GetAndDispose<IPortfolioTarget>();
                 }
-                riskTargetOverrides.Destroy();
+                iterator.Dispose();
+                riskTargetOverrides.Dispose();
             }
         }
 

--- a/Algorithm/Selection/UniverseSelectionModelPythonWrapper.cs
+++ b/Algorithm/Selection/UniverseSelectionModelPythonWrapper.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
 
             using (Py.GIL())
             {
-                return _model.GetNextRefreshTimeUtc();
+                return (_model.GetNextRefreshTimeUtc() as PyObject).GetAndDispose<DateTime>();
             }
         }
 
@@ -76,11 +76,13 @@ namespace QuantConnect.Algorithm.Framework.Selection
             using (Py.GIL())
             {
                 var universes = _model.CreateUniverses(algorithm) as PyObject;
-                foreach (PyObject universe in universes)
+                var iterator = universes.GetIterator();
+                foreach (PyObject universe in iterator)
                 {
-                    yield return universe.AsManagedObject(typeof(Universe)) as Universe;
+                    yield return universe.GetAndDispose<Universe>();
                 }
-                universes.Destroy();
+                iterator.Dispose();
+                universes.Dispose();
             }
         }
     }

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -61,8 +61,8 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
                     Logging.Log.Trace($"AlgorithmPythonWrapper(): Python version {PythonEngine.Version}: Importing python module {moduleName}");
 
                     var module = Py.Import(moduleName);
-
-                    foreach (var name in module.Dir())
+                    var pyList = module.Dir();
+                    foreach (var name in pyList)
                     {
                         Type type;
                         var attr = module.GetAttr(name.ToString());
@@ -90,8 +90,10 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
 
                             _onOrderEvent = (_algorithm as PyObject).GetAttr("OnOrderEvent");
                         }
+                        attr.Dispose();
                     }
-
+                    module.Dispose();
+                    pyList.Dispose();
                     // If _algorithm could not be set, throw exception
                     if (_algorithm == null)
                     {

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -51,7 +51,7 @@ namespace QuantConnect.Python
             {
                 using (Py.GIL())
                 {
-                    return _model.AccountType;
+                    return (_model.AccountType as PyObject).GetAndDispose<AccountType>();
                 }
             }
         }
@@ -66,7 +66,7 @@ namespace QuantConnect.Python
             {
                 using (Py.GIL())
                 {
-                    return _model.RequiredFreeBuyingPowerPercent;
+                    return (_model.RequiredFreeBuyingPowerPercent as PyObject).GetAndDispose<decimal>();
                 }
             }
         }
@@ -80,7 +80,8 @@ namespace QuantConnect.Python
             {
                 using (Py.GIL())
                 {
-                    return _model.DefaultMarkets;
+                    return (_model.DefaultMarkets as PyObject)
+                        .GetAndDispose<IReadOnlyDictionary<SecurityType, string>>();
                 }
             }
         }
@@ -112,7 +113,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.CanExecuteOrder(security, order);
+                return (_model.CanExecuteOrder(security, order) as PyObject).GetAndDispose<bool>();
             }
         }
 
@@ -131,7 +132,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.CanSubmitOrder(security, order, out message);
+                return (_model.CanSubmitOrder(security, order, out message) as PyObject).GetAndDispose<bool>();
             }
         }
 
@@ -147,7 +148,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.CanUpdateOrder(security, order, out message);
+                return (_model.CanUpdateOrder(security, order, out message) as PyObject).GetAndDispose<bool>();
             }
         }
 
@@ -160,7 +161,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetFeeModel(security);
+                return (_model.GetFeeModel(security) as PyObject).GetAndDispose<IFeeModel>();
             }
         }
 
@@ -173,7 +174,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetFillModel(security);
+                return (_model.GetFillModel(security) as PyObject).GetAndDispose<IFillModel>();
             }
         }
 
@@ -186,7 +187,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetLeverage(security);
+                return (_model.GetLeverage(security) as PyObject).GetAndDispose<decimal>();
             }
         }
 
@@ -199,7 +200,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetSettlementModel(security);
+                return (_model.GetSettlementModel(security) as PyObject).GetAndDispose<ISettlementModel>();
             }
         }
 
@@ -214,7 +215,8 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetSettlementModel(security, accountType);
+                return (_model.GetSettlementModel(security, accountType)
+                    as PyObject).GetAndDispose<ISettlementModel>();
             }
         }
 
@@ -227,7 +229,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetSlippageModel(security);
+                return (_model.GetSlippageModel(security) as PyObject).GetAndDispose<ISlippageModel>();
             }
         }
 
@@ -241,7 +243,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetBuyingPowerModel(security);
+                return (_model.GetBuyingPowerModel(security) as PyObject).GetAndDispose<IBuyingPowerModel>();
             }
         }
 
@@ -256,7 +258,8 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetBuyingPowerModel(security, accountType);
+                return (_model.GetBuyingPowerModel(security, accountType)
+                    as PyObject).GetAndDispose<IBuyingPowerModel>();
             }
         }
     }

--- a/Common/Python/BuyingPowerModelPythonWrapper.cs
+++ b/Common/Python/BuyingPowerModelPythonWrapper.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetBuyingPower(parameters);
+                return (_model.GetBuyingPower(parameters) as PyObject).GetAndDispose<BuyingPower>();
             }
         }
 
@@ -67,7 +67,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetLeverage(security);
+                return (_model.GetLeverage(security) as PyObject).GetAndDispose<decimal>();
             }
         }
 
@@ -80,7 +80,8 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetMaximumOrderQuantityForTargetValue(parameters);
+                return (_model.GetMaximumOrderQuantityForTargetValue(parameters)
+                    as PyObject).GetAndDispose<GetMaximumOrderQuantityForTargetValueResult>();
             }
         }
 
@@ -93,7 +94,8 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetReservedBuyingPowerForPosition(parameters);
+                return (_model.GetReservedBuyingPowerForPosition(parameters)
+                    as PyObject).GetAndDispose<ReservedBuyingPowerForPosition>();
             }
         }
 
@@ -106,7 +108,8 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.HasSufficientBuyingPowerForOrder(parameters);
+                return (_model.HasSufficientBuyingPowerForOrder(parameters)
+                    as PyObject).GetAndDispose<HasSufficientBuyingPowerForOrderResult>();
             }
         }
 

--- a/Common/Python/FeeModelPythonWrapper.cs
+++ b/Common/Python/FeeModelPythonWrapper.cs
@@ -50,14 +50,15 @@ namespace QuantConnect.Python
                 {
                     try
                     {
-                        return _model.GetOrderFee(parameters);
+                        return (_model.GetOrderFee(parameters) as PyObject).GetAndDispose<OrderFee>();
                     }
                     catch (PythonException)
                     {
                         _extendedVersion = false;
                     }
                 }
-                decimal fee = _model.GetOrderFee(parameters.Security, parameters.Order);
+                var fee = (_model.GetOrderFee(parameters.Security, parameters.Order)
+                    as PyObject).GetAndDispose<decimal>();
                 return new OrderFee(new CashAmount(fee, "USD"));
             }
         }

--- a/Common/Python/FillModelPythonWrapper.cs
+++ b/Common/Python/FillModelPythonWrapper.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Python
             Parameters = parameters;
             using (Py.GIL())
             {
-                return _model.Fill(parameters);
+                return (_model.Fill(parameters) as PyObject).GetAndDispose<Fill>();
             }
         }
 
@@ -64,7 +64,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.LimitFill(asset, order);
+                return (_model.LimitFill(asset, order) as PyObject).GetAndDispose<OrderEvent>();
             }
         }
 
@@ -78,7 +78,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.MarketFill(asset, order);
+                return (_model.MarketFill(asset, order) as PyObject).GetAndDispose<OrderEvent>();
             }
         }
 
@@ -92,7 +92,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.MarketOnCloseFill(asset, order);
+                return (_model.MarketOnCloseFill(asset, order) as PyObject).GetAndDispose<OrderEvent>();
             }
         }
 
@@ -106,7 +106,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.MarketOnOpenFill(asset, order);
+                return (_model.MarketOnOpenFill(asset, order) as PyObject).GetAndDispose<OrderEvent>();
             }
         }
 
@@ -120,7 +120,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.StopLimitFill(asset, order);
+                return (_model.StopLimitFill(asset, order) as PyObject).GetAndDispose<OrderEvent>();
             }
         }
 
@@ -134,7 +134,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.StopMarketFill(asset, order);
+                return (_model.StopMarketFill(asset, order) as PyObject).GetAndDispose<OrderEvent>();
             }
         }
 
@@ -147,7 +147,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetPrices(asset, direction);
+                return (_model.GetPrices(asset, direction) as PyObject).GetAndDispose<Prices>();
             }
         }
     }

--- a/Common/Python/PythonActivator.cs
+++ b/Common/Python/PythonActivator.cs
@@ -47,7 +47,8 @@ namespace QuantConnect.Python
             using (Py.GIL())
             {
                 var pythonType = value.Invoke().GetPythonType();
-                isPythonQuandl = pythonType.As<Type>() == typeof(PythonQuandl) ;
+                isPythonQuandl = pythonType.As<Type>() == typeof(PythonQuandl);
+                pythonType.Dispose();
             }
 
             if (isPythonQuandl)
@@ -57,7 +58,10 @@ namespace QuantConnect.Python
                     using (Py.GIL())
                     {
                         var instance = value.Invoke();
-                        var valueColumnName = instance.GetAttr("ValueColumnName").ToString();
+                        var pyValueColumnName = instance.GetAttr("ValueColumnName");
+                        var valueColumnName = pyValueColumnName.ToString();
+                        instance.Dispose();
+                        pyValueColumnName.Dispose();
                         return new PythonQuandl(valueColumnName);
                     }
                 };

--- a/Common/Python/PythonData.cs
+++ b/Common/Python/PythonData.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Python
             using (Py.GIL())
             {
                 var source = _pythonData.GetSource(config, date, isLiveMode);
-                return GetTypeAndDispose<SubscriptionDataSource>(source);
+                return (source as PyObject).GetAndDispose<SubscriptionDataSource>();
             }
         }
 
@@ -73,7 +73,7 @@ namespace QuantConnect.Python
             using (Py.GIL())
             {
                 var data = _pythonData.Reader(config, line, date, isLiveMode);
-                return GetTypeAndDispose<BaseData>(data);
+                return (data as PyObject).GetAndDispose<BaseData>();
             }
         }
 
@@ -93,23 +93,6 @@ namespace QuantConnect.Python
             {
                 SetProperty(index, value is double ? Convert.ToDecimal(value) : value);
             }
-        }
-
-        private T GetTypeAndDispose<T>(dynamic instance)
-        {
-            if (instance == null)
-            {
-                return default(T);
-            }
-            var pyInstance = instance as PyObject;
-            if (pyInstance != null)
-            {
-                var returnInstance = pyInstance.As<T>();
-                pyInstance.Dispose();
-                return returnInstance;
-            }
-            throw new ArgumentException($"Unexpected type: {instance.GetType()}." +
-                $" Was expecting {nameof(PyObject)}");
         }
     }
 }

--- a/Common/Python/PythonData.cs
+++ b/Common/Python/PythonData.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Python
     public class PythonData : DynamicData
     {
         private readonly dynamic _pythonData;
-        
+
         /// <summary>
         /// Constructor for initialising the PythonData class
         /// </summary>
@@ -43,7 +43,7 @@ namespace QuantConnect.Python
         {
             _pythonData = pythonData;
         }
-      
+
         /// <summary>
         /// Source Locator for algorithm written in Python.
         /// </summary>
@@ -54,8 +54,9 @@ namespace QuantConnect.Python
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
             using (Py.GIL())
-            {             
-                return _pythonData.GetSource(config, date, isLiveMode);               
+            {
+                var source = _pythonData.GetSource(config, date, isLiveMode);
+                return GetTypeAndDispose<SubscriptionDataSource>(source);
             }
         }
 
@@ -68,13 +69,14 @@ namespace QuantConnect.Python
         /// <param name="isLiveMode">true if we're in live mode, false for backtesting mode</param>
         /// <returns></returns>
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
-        {   
+        {
             using (Py.GIL())
             {
-                return _pythonData.Reader(config, line, date, isLiveMode);
+                var data = _pythonData.Reader(config, line, date, isLiveMode);
+                return GetTypeAndDispose<BaseData>(data);
             }
         }
-        
+
         /// <summary>
         /// Indexes into this PythonData, where index is key to the dynamic property
         /// </summary>
@@ -82,7 +84,7 @@ namespace QuantConnect.Python
         /// <returns>Dynamic property of a given index</returns>
         public object this[string index]
         {
-            get 
+            get
             {
                 return GetProperty(index);
             }
@@ -91,6 +93,23 @@ namespace QuantConnect.Python
             {
                 SetProperty(index, value is double ? Convert.ToDecimal(value) : value);
             }
-        }   
+        }
+
+        private T GetTypeAndDispose<T>(dynamic instance)
+        {
+            if (instance == null)
+            {
+                return default(T);
+            }
+            var pyInstance = instance as PyObject;
+            if (pyInstance != null)
+            {
+                var returnInstance = pyInstance.As<T>();
+                pyInstance.Dispose();
+                return returnInstance;
+            }
+            throw new ArgumentException($"Unexpected type: {instance.GetType()}." +
+                $" Was expecting {nameof(PyObject)}");
+        }
     }
 }

--- a/Common/Python/SlippageModelPythonWrapper.cs
+++ b/Common/Python/SlippageModelPythonWrapper.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetSlippageApproximation(asset, order);
+                return (_model.GetSlippageApproximation(asset, order) as PyObject).GetAndDispose<decimal>();
             }
         }
     }

--- a/Common/Python/VolatilityModelPythonWrapper.cs
+++ b/Common/Python/VolatilityModelPythonWrapper.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.Python
             {
                 using (Py.GIL())
                 {
-                    return (decimal)_model.Volatility;
+                    return (_model.Volatility as PyObject).GetAndDispose<decimal>();
                 }
             }
         }
@@ -87,7 +87,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                return _model.GetHistoryRequirements(security, utcTime);
+                return (_model.GetHistoryRequirements(security, utcTime) as PyObject).GetAndDispose<IEnumerable<HistoryRequest>>();
             }
         }
 

--- a/Common/Util/PythonUtil.cs
+++ b/Common/Util/PythonUtil.cs
@@ -28,6 +28,8 @@ namespace QuantConnect.Util
     /// </summary>
     public class PythonUtil
     {
+        private static readonly Lazy<dynamic> lazyInspect = new Lazy<dynamic>(() => Py.Import("inspect"));
+
         /// <summary>
         /// Encapsulates a python method with a <see cref="System.Action{T1}"/>
         /// </summary>
@@ -184,19 +186,24 @@ namespace QuantConnect.Util
         {
             using (Py.GIL())
             {
-                dynamic inspect = Py.Import("inspect");
-
+                var inspect = lazyInspect.Value;
                 if (inspect.isfunction(pyObject))
                 {
-                    var args = inspect.getargspec(pyObject).args;
-                    length = new PyList(args).Length();
+                    var args = inspect.getargspec(pyObject).args as PyObject;
+                    var pyList = new PyList(args);
+                    length = pyList.Length();
+                    pyList.Dispose();
+                    args.Dispose();
                     return true;
                 }
 
                 if (inspect.ismethod(pyObject))
                 {
-                    var args = inspect.getargspec(pyObject).args;
-                    length = new PyList(args).Length() - 1;
+                    var args = inspect.getargspec(pyObject).args as PyObject;
+                    var pyList = new PyList(args);
+                    length = pyList.Length() - 1;
+                    pyList.Dispose();
+                    args.Dispose();
                     return true;
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding _some_ of the missing `PyObject.Dispose` calls. Specifically in the cases
where C# is calling the Python side. Testing has shown that relying on the GC finalizer
is unreliable.
   - Note: testing has shown that Python calls to C# code is correctly handling the
   disposure of resources.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3067
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix memory leaks with custom python data
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression and cloud testing
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->