### PR TITLE
Fix uncorrelated universe

### DIFF
--- a/Algorithm.Framework/Selection/UncorrelatedUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/UncorrelatedUniverseSelectionModel.py
@@ -76,11 +76,11 @@ class UncorrelatedUniverseSelectionModel(FundamentalUniverseSelectionModel):
             if not data.IsReady:
                 newSymbols.append(symbol)
 
-        # Warm up the dictionary objects of selected symbols and benchmark that do not have enought data
+        # Warm up the dictionary objects of selected symbols and benchmark that do not have enough data
         if len(newSymbols) > 1:
             history = algorithm.History(newSymbols, self.historyLength, Resolution.Daily)
-            if not (history.empty or len(history.index) < self.historyLength):
-                history = history.close.unstack(level=0).dropna()
+            if not history.empty:
+                history = history.close.unstack(level=0).fillna(method='bfill')
                 for symbol in newSymbols:
                     self.cache[symbol].Warmup(history)
 

--- a/Algorithm.Framework/Selection/UncorrelatedUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/UncorrelatedUniverseSelectionModel.py
@@ -79,6 +79,8 @@ class UncorrelatedUniverseSelectionModel(FundamentalUniverseSelectionModel):
         # Warm up the dictionary objects of selected symbols and benchmark that do not have enought data
         if len(newSymbols) > 1:
             history = algorithm.History(newSymbols, self.historyLength, Resolution.Daily)
+            if history.empty or len(history.index) < self.historyLength:
+                return
             history = history.close.unstack(level=0)
             for symbol in newSymbols:
                 self.cache[symbol].Warmup(history)

--- a/Algorithm.Framework/Selection/UncorrelatedUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/UncorrelatedUniverseSelectionModel.py
@@ -80,7 +80,7 @@ class UncorrelatedUniverseSelectionModel(FundamentalUniverseSelectionModel):
         if len(newSymbols) > 1:
             history = algorithm.History(newSymbols, self.historyLength, Resolution.Daily)
             if not history.empty:
-                history = history.close.unstack(level=0).fillna(method='bfill')
+                history = history.close.unstack(level=0)
                 for symbol in newSymbols:
                     self.cache[symbol].Warmup(history)
 

--- a/Algorithm.Framework/Selection/UncorrelatedUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/UncorrelatedUniverseSelectionModel.py
@@ -79,11 +79,10 @@ class UncorrelatedUniverseSelectionModel(FundamentalUniverseSelectionModel):
         # Warm up the dictionary objects of selected symbols and benchmark that do not have enought data
         if len(newSymbols) > 1:
             history = algorithm.History(newSymbols, self.historyLength, Resolution.Daily)
-            if history.empty or len(history.index) < self.historyLength:
-                return
-            history = history.close.unstack(level=0)
-            for symbol in newSymbols:
-                self.cache[symbol].Warmup(history)
+            if not (history.empty or len(history.index) < self.historyLength):
+                history = history.close.unstack(level=0).dropna()
+                for symbol in newSymbols:
+                    self.cache[symbol].Warmup(history)
 
         # Create a new dictionary with the zScore
         zScore = dict()


### PR DESCRIPTION
#### Description
A bug fix for the Uncorrelated Universe Selection Model.

#### Related Issue

The Uncorrelated Universe Selection Model retrieves history for newly added symbols to the universe. Some symbols might have short data history which might result in an error.

#### Motivation and Context

History for all new symbols is retrieved at once and combined in one DataFrame.

This fix fills the DataFrame NA values for symbols that have short data history with the latest price when security has too few data points (a rare occurrence). Further, this fix allows for ranking all securities on dollar volume and without changing the remaining code structure.

#### How Has This Been Tested?
Tested in the cloud using ConstantAlphaModel and EmergingMarketsHFIAlphaModel.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`