### PR TITLE
Enable Acceleration Bands support for QuoteBars

### DIFF
--- a/Indicators/AccelerationBands.cs
+++ b/Indicators/AccelerationBands.cs
@@ -5,8 +5,8 @@ namespace QuantConnect.Indicators
     /// <summary>
     ///     The Acceleration Bands created by Price Headley plots upper and lower envelope bands around a moving average.
     /// </summary>
-    /// <seealso cref="Indicators.IndicatorBase{TradeBar}" />
-    public class AccelerationBands : IndicatorBase<TradeBar>
+    /// <seealso cref="Indicators.IndicatorBase{IBaseDataBar}" />
+    public class AccelerationBands : IndicatorBase<IBaseDataBar>
     {
         private readonly decimal _width;
 
@@ -90,7 +90,7 @@ namespace QuantConnect.Indicators
         /// <returns>
         ///     A new value for this indicator
         /// </returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             MiddleBand.Update(new IndicatorDataPoint
             {

--- a/Tests/Indicators/AccelerationBandsTests.cs
+++ b/Tests/Indicators/AccelerationBandsTests.cs
@@ -5,9 +5,9 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class AccelerationBandsTests : CommonIndicatorTests<TradeBar>
+    public class AccelerationBandsTests : CommonIndicatorTests<IBaseDataBar>
     {
-        protected override IndicatorBase<TradeBar> CreateIndicator()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
             return new AccelerationBands(period: 20, width: 4m);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Enable Acceleration bands indicator support for QuoteBars

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3069 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Acceleration bands indicator was only working with TradeBars.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run a basic forex algorithm using Acceleration bands.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->