### PR TITLE
 Implements QCAlgorithm.WarmUpIndicator

### DIFF
--- a/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
@@ -47,8 +47,13 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
 
             //Define the symbol and "type" of our generic data:
-            AddData<DollarRupee>("USDINR");
-            AddData<Nifty>("NIFTY");
+            var rupee = AddData<DollarRupee>("USDINR", Resolution.Daily).Symbol;
+            var nifty = AddData<Nifty>("NIFTY", Resolution.Daily).Symbol;
+
+            EnableAutomaticIndicatorWarmUp = true;
+            var rupeeSma = SMA(rupee, 20);
+            var niftySma = SMA(rupee, 20);
+            Log($"SMA - Is ready? USDINR: {rupeeSma.IsReady} NIFTY: {niftySma.IsReady}");
         }
 
         /// <summary>

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -161,6 +161,7 @@
     <Compile Include="SetAccountCurrencyCashBuyingPowerModelRegressionAlgorithm.cs" />
     <Compile Include="SetAccountCurrencySecurityMarginModelRegressionAlgorithm.cs" />
     <Compile Include="SetCashOnDataRegressionAlgorithm.cs" />
+    <Compile Include="SmaCrossUniverseSelectionAlgorithm.cs" />
     <Compile Include="StartingCapitalRegressionAlgorithm.cs" />
     <Compile Include="TrailingStopRiskFrameworkAlgorithm.cs" />
     <Compile Include="BasicTemplateFuturesFrameworkAlgorithm.cs" />

--- a/Algorithm.CSharp/SmaCrossUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/SmaCrossUniverseSelectionAlgorithm.cs
@@ -39,12 +39,22 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2019, 01, 01);
             SetCash(1000000);
 
-            IsWarmUpIndicatorEnabled = true;
+            EnableAutomaticIndicatorWarmUp = true;
 
-            var symbol = AddEquity("SPY", Resolution.Hour).Symbol;
-            var ema = EMA(symbol, 10);
-            WarmUpIndicator(symbol, ema);
-            Log($"{ema.Name}: {ema.Current.Time} - {ema}. IsReady? {ema.IsReady}");
+            var ibm = AddEquity("IBM", Resolution.Tick).Symbol;
+            var ibmSma = SMA(ibm, 40);
+            Log($"{ibmSma.Name}: {ibmSma.Current.Time} - {ibmSma}. IsReady? {ibmSma.IsReady}");
+
+            var spy = AddEquity("SPY", Resolution.Hour).Symbol;
+            var spySma = SMA(spy, 10);     // Data point indicator
+            var spyAtr = ATR(spy, 10);     // Bar indicator
+            var spyVwap = VWAP(spy, 10);   // TradeBar indicator
+            Log($"SPY    - Is ready? SMA: {spySma.IsReady}, ATR: {spyAtr.IsReady}, VWAP: {spyVwap.IsReady}");
+
+            var eur = AddForex("EURUSD", Resolution.Hour).Symbol;
+            var eurSma = SMA(eur, 20, Resolution.Daily);
+            var eurAtr = ATR(eur, 20, resolution: Resolution.Daily);
+            Log($"EURUSD - Is ready? SMA: {eurSma.IsReady}, ATR: {eurAtr.IsReady}");
 
             AddUniverse(coarse =>
             {
@@ -64,7 +74,7 @@ namespace QuantConnect.Algorithm.CSharp
                         select cf.Symbol).Take(_count);
             });
 
-            // Since the SPY EMA is ready, we will receive error messages
+            // Since the indicators are ready, we will receive error messages
             // reporting that the algorithm manager is trying to add old information
             SetWarmUp(10);
         }

--- a/Algorithm.CSharp/SmaCrossUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/SmaCrossUniverseSelectionAlgorithm.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Indicators;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Provides an example where WarmUpIndicator method is used to warm up indicators
+    /// after their security is added and before (Universe Selection scenario)
+    /// </summary>
+    public class SmaCrossUniverseSelectionAlgorithm : QCAlgorithm
+    {
+        private const int _count = 10;
+        private const decimal _tolerance = 0.01m;
+        private const decimal _targetPercent = 1m / _count;
+
+        public override void Initialize()
+        {
+            UniverseSettings.Leverage = 2.0m;
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            SetStartDate(2018, 01, 01);
+            SetEndDate(2019, 01, 01);
+            SetCash(1000000);
+
+            IsWarmUpIndicatorEnabled = true;
+
+            var symbol = AddEquity("SPY", Resolution.Hour).Symbol;
+            var ema = EMA(symbol, 10);
+            WarmUpIndicator(symbol, ema);
+            Log($"{ema.Name}: {ema.Current.Time} - {ema}. IsReady? {ema.IsReady}");
+
+            AddUniverse(coarse =>
+            {
+                var averages = new ConcurrentDictionary<Symbol, IndicatorBase<IndicatorDataPoint>>();
+
+                return (from cf in coarse
+                        where cf.HasFundamentalData
+                        // grab the SMA instance for this symbol
+                        let avg = averages.GetOrAdd(cf.Symbol, sym => WarmUpIndicator(cf.Symbol, new SimpleMovingAverage(100), Resolution.Daily))
+                        // Update returns true when the indicators are ready, so don't accept until they are
+                        where avg.Update(cf.EndTime, cf.AdjustedPrice)
+                        // only pick symbols who have their price over their 100 day sma
+                        where avg > cf.AdjustedPrice * _tolerance
+                        // prefer symbols with a larger delta by percentage between the two averages
+                        orderby (avg - cf.AdjustedPrice) / ((avg + cf.AdjustedPrice) / 2m) descending
+                        // we only need to return the symbol and return 'Count' symbols
+                        select cf.Symbol).Take(_count);
+            });
+
+            // Since the SPY EMA is ready, we will receive error messages
+            // reporting that the algorithm manager is trying to add old information
+            SetWarmUp(10);
+        }
+
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            foreach (var security in changes.RemovedSecurities.Where(x => x.Invested))
+            {
+                Liquidate(security.Symbol);
+            }
+
+            foreach (var security in changes.AddedSecurities)
+            {
+                SetHoldings(security.Symbol, _targetPercent);
+            }
+        }
+    }
+}

--- a/Algorithm.Python/CustomDataNIFTYAlgorithm.py
+++ b/Algorithm.Python/CustomDataNIFTYAlgorithm.py
@@ -41,8 +41,13 @@ class CustomDataNIFTYAlgorithm(QCAlgorithm):
         self.SetCash(100000)
 
         # Define the symbol and "type" of our generic data:
-        self.AddData(DollarRupee, "USDINR")
-        self.AddData(Nifty, "NIFTY")
+        rupee = self.AddData(DollarRupee, "USDINR", Resolution.Daily).Symbol
+        nifty = self.AddData(Nifty, "NIFTY", Resolution.Daily).Symbol
+
+        self.EnableAutomaticIndicatorWarmUp = True
+        rupeeSma = self.SMA(rupee, 20)
+        niftySma = self.SMA(rupee, 20)
+        self.Log(f"SMA - Is ready? USDINR: {rupeeSma.IsReady} NIFTY: {niftySma.IsReady}")
 
         self.minimumCorrelationHistory = 50
         self.today = CorrelationPair()

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -56,6 +56,7 @@
     <Content Include="BasicSetAccountCurrencyAlgorithm.py" />
     <None Include="RawPricesUniverseRegressionAlgorithm.py" />
     <None Include="CapmAlphaRankingFrameworkAlgorithm.py" />
+    <None Include="SmaCrossUniverseSelectionAlgorithm.py" />
     <Content Include="Benchmarks\StatefulCoarseUniverseSelectionBenchmark.py" />
     <Content Include="Benchmarks\StatelessCoarseUniverseSelectionBenchmark.py" />
     <Content Include="G10CurrencySelectionModelFrameworkAlgorithm.py" />

--- a/Algorithm.Python/SmaCrossUniverseSelectionAlgorithm.py
+++ b/Algorithm.Python/SmaCrossUniverseSelectionAlgorithm.py
@@ -1,0 +1,85 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Indicators")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Indicators import *
+from QuantConnect.Data.UniverseSelection import *
+
+class SmaCrossUniverseSelectionAlgorithm(QCAlgorithm):
+    '''Provides an example where WarmUpIndicator method is used to warm up indicators
+    after their security is added and before (Universe Selection scenario)'''
+
+    count = 10;
+    tolerance = 0.01
+    targetPercent = 1 / count
+    averages = dict()
+
+    def Initialize(self):
+
+        self.UniverseSettings.Leverage = 2
+        self.UniverseSettings.Resolution = Resolution.Daily
+
+        self.SetStartDate(2018, 1, 1)
+        self.SetEndDate(2019, 1, 1)
+        self.SetCash(1000000)
+
+        self.IsWarmUpIndicatorEnabled = True
+
+        symbol = self.AddEquity("SPY", Resolution.Hour).Symbol
+        ema = self.EMA(symbol, 10)
+        ema = self.WarmUpIndicator(symbol, ema)
+        self.Log(f"{ema.Name}: {ema.Current.Time} - {ema}. IsReady? {ema.IsReady}");
+
+        self.AddUniverse(self.CoarseSmaSelector)
+
+    # Since the SPY EMA is ready, we will receive error messages
+    # reporting that the algorithm manager is trying to add old information
+    self.SetWarmUp(10)
+
+    def CoarseSmaSelector(self, coarse):
+
+        score = dict()
+        for cf in coarse:
+            if not cf.HasFundamentalData:
+               continue
+            symbol = cf.Symbol
+            price = cf.AdjustedPrice
+            # grab the SMA instance for this symbol
+            avg = self.averages.setdefault(symbol, 
+                self.WarmUpIndicator(symbol, SimpleMovingAverage(100), Resolution.Daily))
+            # Update returns true when the indicators are ready, so don't accept until they are
+            if avg.Update(cf.EndTime, price):
+               value = avg.Current.Value
+               # only pick symbols who have their price over their 100 day sma
+               if value > price * self.tolerance:
+                    score[symbol] = (value - price) / ((value + price) / 2)
+
+        # prefer symbols with a larger delta by percentage between the two averages
+        sortedScore = sorted(score.items(), key=lambda kvp: kvp[1], reverse=True)
+        return [x[0] for x in sortedScore[:self.count]]
+
+    def OnSecuritiesChanged(self, changes):
+        for security in changes.RemovedSecurities:
+            if security.Invested:
+                self.Liquidate(security.Symbol)
+
+        for security in changes.AddedSecurities:
+            self.SetHoldings(security.Symbol, self.targetPercent)

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -574,7 +574,7 @@ namespace QuantConnect.Algorithm
             {
                 var requests = new List<HistoryRequest>();
 
-                foreach (var config in GetMatchingSubscriptions(x, typeof(BaseData)))
+                foreach (var config in GetMatchingSubscriptions(x, typeof(BaseData), resolution))
                 {
                     var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), resolution);
 
@@ -602,7 +602,21 @@ namespace QuantConnect.Algorithm
                 var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res.Value, exchange);
                 var end = Time.RoundDown(res.Value.ToTimeSpan());
 
-                return GetMatchingSubscriptions(x, typeof(BaseData))
+                return GetMatchingSubscriptions(x, typeof(BaseData), resolution)
+                    .Select(config => _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res));
+            });
+        }
+
+        private IEnumerable<HistoryRequest> CreateBarCountHistoryRequestsWithNewSubscription(IEnumerable<Symbol> symbols, int periods, Resolution? resolution)
+        {
+            return symbols.Where(x => !x.IsCanonical()).SelectMany(x =>
+            {
+                var res = resolution ?? UniverseSettings.Resolution;
+                var exchange = GetExchangeHours(x);
+                var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res, exchange);
+                var end = Time.RoundDown(res.ToTimeSpan());
+
+                return CreateSubscriptions(x, typeof(BaseData), resolution)
                     .Select(config => _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res));
             });
         }
@@ -613,7 +627,7 @@ namespace QuantConnect.Algorithm
             return GetMatchingSubscriptions(symbol, type).FirstOrDefault();
         }
 
-        private IEnumerable<SubscriptionDataConfig> GetMatchingSubscriptions(Symbol symbol, Type type)
+        private IEnumerable<SubscriptionDataConfig> GetMatchingSubscriptions(Symbol symbol, Type type, Resolution? resolution = null)
         {
             Security security;
             if (Securities.TryGetValue(symbol, out security))
@@ -625,11 +639,29 @@ namespace QuantConnect.Algorithm
             }
             else
             {
-                var resolution = UniverseSettings.Resolution;
-                var timeZone = GetExchangeHours(symbol).TimeZone;
-                var subscriptionDataTypes = SubscriptionManager.LookupSubscriptionConfigDataTypes(symbol.SecurityType, resolution, symbol.IsCanonical());
-                return subscriptionDataTypes.Select(x => new SubscriptionDataConfig(x.Item1, symbol, resolution, timeZone, timeZone, UniverseSettings.FillForward, UniverseSettings.ExtendedMarketHours, false, false, x.Item2));
+                return CreateSubscriptions(symbol, type, resolution);
             }
+        }
+
+        private IEnumerable<SubscriptionDataConfig> CreateSubscriptions(Symbol symbol, Type type, Resolution? resolution = null)
+        {
+            var timeZone = GetExchangeHours(symbol).TimeZone;
+            resolution = GetResolution(symbol, resolution) ?? UniverseSettings.Resolution;
+
+            return SubscriptionManager
+                .LookupSubscriptionConfigDataTypes(symbol.SecurityType, resolution.Value, symbol.IsCanonical())
+                .Select(x => new SubscriptionDataConfig(
+                    x.Item1,
+                    symbol,
+                    resolution.Value,
+                    timeZone, timeZone,
+                    UniverseSettings.FillForward,
+                    UniverseSettings.ExtendedMarketHours,
+                    true,
+                    false,
+                    x.Item2,
+                    true,
+                    UniverseSettings.DataNormalizationMode));
         }
 
         private SecurityExchangeHours GetExchangeHours(Symbol symbol)

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -640,8 +640,8 @@ namespace QuantConnect.Algorithm
                         true,
                         false,
                         x.Item2,
-                        true));
-                // TODO: replace default DataNormalizationMode for a UniverseSettings variable
+                        true,
+                        UniverseSettings.DataNormalizationMode));
             }
         }
 

--- a/Common/Indicators/IIndicatorWarmUpPeriodProvider.cs
+++ b/Common/Indicators/IIndicatorWarmUpPeriodProvider.cs
@@ -1,0 +1,28 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Indicators
+{
+    /// <summary>
+    /// Represents an indicator with a warm up period provider.
+    /// </summary>
+    public interface IIndicatorWarmUpPeriodProvider
+    {
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        int WarmUpPeriod { get; }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Data\SubscriptionDataConfigExtensions.cs" />
     <Compile Include="Expiry.cs" />
     <Compile Include="HistoryProviderEvents.cs" />
+    <Compile Include="Indicators\IIndicatorWarmUpPeriodProvider.cs" />
     <Compile Include="Interfaces\IAccountCurrencyProvider.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />
     <Compile Include="Interfaces\IHistoryProvider.cs" />

--- a/Indicators/AverageTrueRange.cs
+++ b/Indicators/AverageTrueRange.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Indicators
     ///   ABS(High - PreviousClose)
     ///   ABS(Low  - PreviousClose)
     /// </summary>
-    public class AverageTrueRange : BarIndicator
+    public class AverageTrueRange : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         /// <summary>This indicator is used to smooth the TrueRange computation</summary>
         /// <remarks>This is not exposed publicly since it is the same value as this indicator, meaning
@@ -49,6 +49,11 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod { get; }
+
+        /// <summary>
         /// Creates a new AverageTrueRange indicator using the specified period and moving average type
         /// </summary>
         /// <param name="name">The name of this indicator</param>
@@ -57,6 +62,8 @@ namespace QuantConnect.Indicators
         public AverageTrueRange(string name, int period, MovingAverageType movingAverageType = MovingAverageType.Wilders)
             : base(name)
         {
+            WarmUpPeriod = period;
+
             _smoother = movingAverageType.AsIndicator(string.Format("{0}_{1}", name, movingAverageType), period);
 
             IBaseDataBar previous = null;

--- a/Indicators/ExponentialMovingAverage.cs
+++ b/Indicators/ExponentialMovingAverage.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,27 +15,32 @@
 
 namespace QuantConnect.Indicators
 {
-
     /// <summary>
-    ///     Represents the traditional exponential moving average indicator (EMA)
+    /// Represents the traditional exponential moving average indicator (EMA)
     /// </summary>
-    public class ExponentialMovingAverage : Indicator
+    public class ExponentialMovingAverage : Indicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly decimal _k;
-        private readonly int _period;
 
-        /// <summary>Initializes a new instance of the ExponentialMovingAverage class with the specified name and period
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the ExponentialMovingAverage class with the specified name and period
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The period of the EMA</param>
         public ExponentialMovingAverage(string name, int period)
             : base(name)
         {
-            _period = period;
-            _k = ExponentialMovingAverage.SmoothingFactorDefault(period);
+            WarmUpPeriod = period;
+            _k = SmoothingFactorDefault(period);
         }
 
-        /// <summary>Initializes a new instance of the ExponentialMovingAverage class with the specified name and period
+        /// <summary>
+        /// Initializes a new instance of the ExponentialMovingAverage class with the specified name and period
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The period of the EMA</param>
@@ -43,12 +48,12 @@ namespace QuantConnect.Indicators
         public ExponentialMovingAverage(string name, int period, decimal smoothingFactor)
             : base(name)
         {
-            _period = period;
+            WarmUpPeriod = period;
             _k = smoothingFactor;
         }
 
         /// <summary>
-        ///     Initializes a new instance of the ExponentialMovingAverage class with the default name and period
+        /// Initializes a new instance of the ExponentialMovingAverage class with the default name and period
         /// </summary>
         /// <param name="period">The period of the EMA</param>
         public ExponentialMovingAverage(int period)
@@ -56,7 +61,8 @@ namespace QuantConnect.Indicators
         {
         }
 
-        /// <summary>Initializes a new instance of the ExponentialMovingAverage class with the default name and period
+        /// <summary>
+        /// Initializes a new instance of the ExponentialMovingAverage class with the default name and period
         /// </summary>
         /// <param name="period">The period of the EMA</param>
         /// <param name="smoothingFactor">The percentage of data from the previous value to be carried into the next value</param>
@@ -65,36 +71,27 @@ namespace QuantConnect.Indicators
         {
         }
 
-        /// <summary>Calculates the default smoothing factor for an ExponentialMovingAverage indicator
+        /// <summary>
+        /// Calculates the default smoothing factor for an ExponentialMovingAverage indicator
         /// </summary>
         /// <param name="period">The period of the EMA</param>
         /// <returns>The default smoothing factor</returns>
-        public static decimal SmoothingFactorDefault(int period)
-        {
-            return 2.0m / ((decimal) period + 1.0m);
-        }
+        public static decimal SmoothingFactorDefault(int period) => 2.0m / (1 + period);
 
         /// <summary>
-        ///     Gets a flag indicating when this indicator is ready and fully initialized
+        /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples >= _period; }
-        }
+        public override bool IsReady => Samples >= WarmUpPeriod;
 
         /// <summary>
-        ///     Computes the next value of this indicator from the given state
+        /// Computes the next value of this indicator from the given state
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IndicatorDataPoint input)
         {
             // our first data point just return identity
-            if (Samples == 1)
-            {
-                return input;
-            }
-            return input*_k + Current*(1 - _k);
+            return Samples == 1 ? input : input * _k + Current * (1 - _k);
         }
     }
 }

--- a/Indicators/ExponentialMovingAverage.cs
+++ b/Indicators/ExponentialMovingAverage.cs
@@ -21,11 +21,12 @@ namespace QuantConnect.Indicators
     public class ExponentialMovingAverage : Indicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly decimal _k;
+        private readonly int _period;
 
         /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.
         /// </summary>
-        public int WarmUpPeriod { get; }
+        public int WarmUpPeriod => _period;
 
         /// <summary>
         /// Initializes a new instance of the ExponentialMovingAverage class with the specified name and period
@@ -35,7 +36,7 @@ namespace QuantConnect.Indicators
         public ExponentialMovingAverage(string name, int period)
             : base(name)
         {
-            WarmUpPeriod = period;
+            _period = period;
             _k = SmoothingFactorDefault(period);
         }
 
@@ -48,7 +49,7 @@ namespace QuantConnect.Indicators
         public ExponentialMovingAverage(string name, int period, decimal smoothingFactor)
             : base(name)
         {
-            WarmUpPeriod = period;
+            _period = period;
             _k = smoothingFactor;
         }
 
@@ -81,7 +82,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady => Samples >= WarmUpPeriod;
+        public override bool IsReady => Samples >= _period;
 
         /// <summary>
         /// Computes the next value of this indicator from the given state
@@ -91,7 +92,11 @@ namespace QuantConnect.Indicators
         protected override decimal ComputeNextValue(IndicatorDataPoint input)
         {
             // our first data point just return identity
-            return Samples == 1 ? input : input * _k + Current * (1 - _k);
+            if (Samples == 1)
+            {
+                return input;
+            }
+            return input * _k + Current * (1 - _k);
         }
     }
 }

--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Diagnostics;
 using QuantConnect.Data;
+using QuantConnect.Logging;
 
 namespace QuantConnect.Indicators
 {
@@ -76,8 +77,9 @@ namespace QuantConnect.Indicators
         {
             if (_previousInput != null && input.Time < _previousInput.Time)
             {
-                // if we receive a time in the past, throw
-                throw new ArgumentException($"This is a forward only indicator: {Name} Input: {input.Time:u} Previous: {_previousInput.Time:u}");
+                // if we receive a time in the past, log and return
+                Log.Error($"This is a forward only indicator: {Name} Input: {input.Time:u} Previous: {_previousInput.Time:u}. It will not be updated with this input.");
+                return IsReady;
             }
             if (!ReferenceEquals(input, _previousInput))
             {

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -242,6 +242,10 @@
       <Project>{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}</Project>
       <Name>QuantConnect</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Logging\QuantConnect.Logging.csproj">
+      <Project>{01911409-86be-4e7d-9947-df714138610d}</Project>
+      <Name>QuantConnect.Logging</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IndicatorBase.Operators.cs" />

--- a/Indicators/SimpleMovingAverage.cs
+++ b/Indicators/SimpleMovingAverage.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,30 +17,29 @@
 namespace QuantConnect.Indicators
 {
     /// <summary>
-    ///     Represents the traditional simple moving average indicator (SMA)
+    /// Represents the traditional simple moving average indicator (SMA)
     /// </summary>
-    public class SimpleMovingAverage : WindowIndicator<IndicatorDataPoint>
+    public class SimpleMovingAverage : WindowIndicator<IndicatorDataPoint>, IIndicatorWarmUpPeriodProvider
     {
         /// <summary>A rolling sum for computing the average for the given period</summary>
         public IndicatorBase<IndicatorDataPoint> RollingSum { get; private set; }
 
         /// <summary>
-        ///     Gets a flag indicating when this indicator is ready and fully initialized
+        /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady{
-            get { return RollingSum.IsReady; }
-        }
+        public override bool IsReady => RollingSum.IsReady;
 
         /// <summary>
         /// Resets this indicator to its initial state
         /// </summary>
-        public override void Reset() {
+        public override void Reset()
+        {
             RollingSum.Reset();
             base.Reset();
         }
 
         /// <summary>
-        ///     Initializes a new instance of the SimpleMovingAverage class with the specified name and period
+        /// Initializes a new instance of the SimpleMovingAverage class with the specified name and period
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The period of the SMA</param>
@@ -51,7 +50,7 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        ///     Initializes a new instance of the SimpleMovingAverage class with the default name and period
+        /// Initializes a new instance of the SimpleMovingAverage class with the default name and period
         /// </summary>
         /// <param name="period">The period of the SMA</param>
         public SimpleMovingAverage(int period)
@@ -60,7 +59,7 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        ///     Computes the next value for this indicator from the given state.
+        /// Computes the next value for this indicator from the given state.
         /// </summary>
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input value to this indicator on this time step</param>
@@ -70,5 +69,10 @@ namespace QuantConnect.Indicators
             RollingSum.Update(input.Time, input.Value);
             return RollingSum.Current.Value / window.Count;
         }
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => 1 + Period;
     }
 }

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     /// It is calculated by adding up the dollars traded for every transaction (price multiplied
     /// by number of shares traded) and then dividing by the total shares traded for the day.
     /// </summary>
-    public class VolumeWeightedAveragePriceIndicator : TradeBarIndicator
+    public class VolumeWeightedAveragePriceIndicator : TradeBarIndicator, IIndicatorWarmUpPeriodProvider
     {
         /// <summary>
         /// In this VWAP calculation, typical price is defined by (O + H + L + C) / 4
@@ -49,6 +49,8 @@ namespace QuantConnect.Indicators
         public VolumeWeightedAveragePriceIndicator(string name, int period)
             : base(name)
         {
+            WarmUpPeriod = period;
+
             _price = new Identity("Price");
             _volume = new Identity("Volume");
 
@@ -63,6 +65,11 @@ namespace QuantConnect.Indicators
         {
             get { return _vwap.IsReady; }
         }
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod { get; }
 
         /// <summary>
         /// Resets this indicator to its initial state

--- a/Indicators/WindowIndicator.cs
+++ b/Indicators/WindowIndicator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@ using QuantConnect.Data;
 namespace QuantConnect.Indicators
 {
     /// <summary>
-    ///     Represents an indicator that acts on a rolling window of data
+    /// Represents an indicator that acts on a rolling window of data
     /// </summary>
     public abstract class WindowIndicator<T> : IndicatorBase<T>
         where T : IBaseData
@@ -29,13 +29,10 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets the period of this window indicator
         /// </summary>
-        public int Period
-        {
-            get { return _window.Size; }
-        }
+        public int Period => _window.Size;
 
         /// <summary>
-        ///     Initializes a new instance of the WindowIndicator class
+        /// Initializes a new instance of the WindowIndicator class
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The number of data points to hold in the window</param>
@@ -46,15 +43,12 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        ///     Gets a flag indicating when this indicator is ready and fully initialized
+        /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return _window.IsReady; }
-        }
+        public override bool IsReady => _window.IsReady;
 
         /// <summary>
-        ///     Computes the next value of this indicator from the given state
+        /// Computes the next value of this indicator from the given state
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
@@ -74,7 +68,7 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        ///     Computes the next value for this indicator from the given state.
+        /// Computes the next value for this indicator from the given state.
         /// </summary>
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input value to this indicator on this time step</param>

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -60,18 +60,6 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentException), MatchType = MessageMatch.Contains, ExpectedMessage = "forward only")]
-        public void ThrowsOnPastTimes()
-        {
-            var target = new TestIndicator();
-
-            var time = DateTime.UtcNow;
-
-            target.Update(new IndicatorDataPoint(time, 1m));
-            target.Update(new IndicatorDataPoint(time.AddMilliseconds(-1), 2m));
-        }
-
-        [Test]
         [ExpectedException(typeof(ArgumentException), MatchType = MessageMatch.Contains, ExpectedMessage = "expected to be of type")]
         public void ThrowsOnDifferentDataType()
         {


### PR DESCRIPTION
#### Description
- Implements IIndicatorWarmUpPeriodProvider Interface
  - `IIndicatorWarmUpPeriodProvider` represents an indicator with a warm-up period provider.
  - `SimpleMovingAverage` and `ExponentialMovingAverage` implement `IIndicatorWarmUpPeriodProvider`.
- Adds DataNormalizationMode Field to UniverseSettings
- Adds QCAlgorithm.WarmUpIndicator Method
  - This helper method can be used to warm up indicators individually whether it is created after the security has been added to the universe or before (universe selection scenario).
  - Fix the subscription addition to `SubcriptionManager` when a History request is made before the security is created since it should be not added.
  - `IndicatorBase.Update` does not throw when an input is older than the last update. We only log (adds QuantConnect.Logging dependency to QuantConnect.Indicators) the error and discard the addition. Removes unit test for that exception.
- Adds SmaCrossUniverseSelectionAlgorithm
  - This algorithm is an example of WarmUpIndicator method usage.

#### Related Issue
Related to #3074 

#### Motivation and Context
Lean/QuantConnect users rely a lot on history requests to warm up indicators, therefore a helper method would simplify a lot of algorithms, especially in Python.

#### Requires Documentation Change
Yes. Add the information about this helper method in the Indicators section of the docs.

#### How Has This Been Tested?
An algorithm that is included in this PR.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests pass.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`