### PR TITLE
Implements UniverseSettings.DataNormalizationMode

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -155,6 +155,7 @@
     <Compile Include="CompositeRiskManagementModelFrameworkAlgorithm.cs" />
     <Compile Include="OrderBasedInsightGeneratedAlgorithm.cs" />
     <Compile Include="ProcessSplitSymbolsRegressionAlgorithm.cs" />
+    <Compile Include="RawPricesUniverseRegressionAlgorithm.cs" />
     <Compile Include="SetAccountCurrencyCashBuyingPowerModelRegressionAlgorithm.cs" />
     <Compile Include="SetAccountCurrencySecurityMarginModelRegressionAlgorithm.cs" />
     <Compile Include="SetCashOnDataRegressionAlgorithm.cs" />

--- a/Algorithm.CSharp/RawPricesUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RawPricesUniverseRegressionAlgorithm.cs
@@ -1,0 +1,116 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// In this algorithm we demonstrate how to use the UniverseSettings
+    /// to define the data normalization mode (raw)
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="universes" />
+    /// <meta name="tag" content="coarse universes" />
+    /// <meta name="tag" content="regression test" />
+    public class RawPricesUniverseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            // what resolution should the data *added* to the universe be?
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            // Use raw prices
+            UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw;
+
+            SetStartDate(2014,3,24);
+            SetEndDate(2014,4,7);
+            SetCash(50000);
+
+            // Set the security initializer with zero fees
+            SetSecurityInitializer(x => x.SetFeeModel(new ConstantFeeModel(0)));
+
+            AddUniverse("MyUniverse", Resolution.Daily, SelectionFunction);
+        }
+
+        public IEnumerable<string> SelectionFunction(DateTime dateTime)
+        {
+            return dateTime.Day % 2 == 0
+                ? new[] { "SPY", "IWM", "QQQ" }
+                : new[] { "AIG", "BAC", "IBM" };
+        }
+
+        // this event fires whenever we have changes to our universe
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            foreach (var security in changes.RemovedSecurities)
+            {
+                if (security.Invested)
+                {
+                    Liquidate(security.Symbol);
+                }
+            }
+
+            // we want 20% allocation in each security in our universe
+            foreach (var security in changes.AddedSecurities)
+            {
+                SetHoldings(security.Symbol, 0.2m);
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "27"},
+            {"Average Win", "0.21%"},
+            {"Average Loss", "-0.21%"},
+            {"Compounding Annual Return", "-7.431%"},
+            {"Drawdown", "0.800%"},
+            {"Expectancy", "0.003"},
+            {"Net Profit", "-0.317%"},
+            {"Sharpe Ratio", "-1.31"},
+            {"Loss Rate", "50%"},
+            {"Win Rate", "50%"},
+            {"Profit-Loss Ratio", "1.01"},
+            {"Alpha", "-0.077"},
+            {"Beta", "1.393"},
+            {"Annual Standard Deviation", "0.043"},
+            {"Annual Variance", "0.002"},
+            {"Information Ratio", "-1.655"},
+            {"Tracking Error", "0.043"},
+            {"Treynor Ratio", "-0.04"},
+            {"Total Fees", "$0.00"}
+        };
+    }
+}

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -54,6 +54,7 @@
     <Content Include="Alphas\TripleLeverageETFPairVolatilityDecayAlpha.py" />
     <Content Include="Alphas\VIXDualThrustAlpha.py" />
     <Content Include="BasicSetAccountCurrencyAlgorithm.py" />
+    <None Include="RawPricesUniverseRegressionAlgorithm.py" />
     <None Include="CapmAlphaRankingFrameworkAlgorithm.py" />
     <Content Include="G10CurrencySelectionModelFrameworkAlgorithm.py" />
     <Content Include="ExpiryHelperAlphaModelFrameworkAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -106,6 +106,7 @@
     <Compile Include="QuandlFuturesDataAlgorithm.py" />
     <Compile Include="QuandlImporterAlgorithm.py" />
     <Compile Include="RawPricesCoarseUniverseAlgorithm.py" />
+    <Compile Include="RawPricesUniverseRegressionAlgorithm.py" />
     <Compile Include="RegressionAlgorithm.py" />
     <Compile Include="RegressionChannelAlgorithm.py" />
     <Compile Include="RenkoConsolidatorAlgorithm.py" />

--- a/Algorithm.Python/RawPricesUniverseRegressionAlgorithm.py
+++ b/Algorithm.Python/RawPricesUniverseRegressionAlgorithm.py
@@ -1,0 +1,71 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System.Core")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import QCAlgorithm
+from QuantConnect.Data.UniverseSelection import *
+from QuantConnect.Orders import OrderStatus
+from QuantConnect.Orders.Fees import ConstantFeeModel
+
+### <summary>
+### In this algorithm we demonstrate how to use the UniverseSettings
+### to define the data normalization mode (raw)
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="universes" />
+### <meta name="tag" content="coarse universes" />
+### <meta name="tag" content="fine universes" />
+class RawPricesUniverseRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        # what resolution should the data *added* to the universe be?
+        self.UniverseSettings.Resolution = Resolution.Daily
+
+        # Use raw prices
+        self.UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw;
+
+        self.SetStartDate(2014,3,24)    #Set Start Date
+        self.SetEndDate(2014,4,7)      #Set End Date
+        self.SetCash(50000)            #Set Strategy Cash
+
+        # Set the security initializer with zero fees
+        self.SetSecurityInitializer(lambda x: x.SetFeeModel(ConstantFeeModel(0)))
+
+        self.AddUniverse("MyUniverse", Resolution.Daily, self.SelectionFunction);
+
+
+    def SelectionFunction(self, dateTime):
+        if dateTime.day % 2 == 0:
+            return ["SPY", "IWM", "QQQ"]
+        else:
+            return ["AIG", "BAC", "IBM"]
+
+
+    # this event fires whenever we have changes to our universe
+    def OnSecuritiesChanged(self, changes):
+        # liquidate removed securities
+        for security in changes.RemovedSecurities:
+            if security.Invested:
+                self.Liquidate(security.Symbol)
+
+        # we want 20% allocation in each security in our universe
+        for security in changes.AddedSecurities:
+            self.SetHoldings(security.Symbol, 0.2)

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -121,6 +121,7 @@ namespace QuantConnect.Data
         ///     True if this subscription should have filters applied to it (market hours/user
         ///     filters from security), false otherwise
         /// </param>
+        /// <param name="dataNormalizationMode">Define how data is normalized</param>
         /// <returns>
         ///     The newly created <see cref="SubscriptionDataConfig" /> or existing instance if it already existed
         /// </returns>
@@ -135,12 +136,14 @@ namespace QuantConnect.Data
             bool fillDataForward = true,
             bool extendedMarketHours = false,
             bool isInternalFeed = false,
-            bool isFilteredSubscription = true
+            bool isFilteredSubscription = true,
+            DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted
             )
         {
             return SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward,
                 extendedMarketHours, isFilteredSubscription, isInternalFeed, isCustomData,
-                new List<Tuple<Type, TickType>> {new Tuple<Type, TickType>(dataType, tickType)}).First();
+                new List<Tuple<Type, TickType>> {new Tuple<Type, TickType>(dataType, tickType)},
+                dataNormalizationMode).First();
         }
 
 

--- a/Common/Data/UniverseSelection/OptionChainUniverse.cs
+++ b/Common/Data/UniverseSelection/OptionChainUniverse.cs
@@ -246,16 +246,10 @@ namespace QuantConnect.Data.UniverseSelection
         {
             var result = subscriptionService.Add(security.Symbol, UniverseSettings.Resolution,
                                                  UniverseSettings.FillForward,
-                                                 UniverseSettings.ExtendedMarketHours);
+                                                 UniverseSettings.ExtendedMarketHours,
+                                                 // force raw data normalization mode for underlying
+                                                 dataNormalizationMode: DataNormalizationMode.Raw);
 
-            // force raw data normalization mode for underlying
-            if (security.Symbol == _underlyingSymbol.First())
-            {
-                foreach (var config in result)
-                {
-                    config.DataNormalizationMode = DataNormalizationMode.Raw;
-                }
-            }
             return result.Select(config => new SubscriptionRequest(isUniverseSubscription: false,
                                                                    universe: this,
                                                                    security: security,

--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -247,11 +247,11 @@ namespace QuantConnect.Data.UniverseSelection
             DateTime maximumEndTimeUtc,
             ISubscriptionDataConfigService subscriptionService)
         {
-
             var result = subscriptionService.Add(security.Symbol,
                 UniverseSettings.Resolution,
                 UniverseSettings.FillForward,
-                UniverseSettings.ExtendedMarketHours);
+                UniverseSettings.ExtendedMarketHours,
+                dataNormalizationMode: UniverseSettings.DataNormalizationMode);
             return result.Select(config => new SubscriptionRequest(isUniverseSubscription: false,
                 universe: this,
                 security: security,

--- a/Common/Data/UniverseSelection/UniverseSettings.cs
+++ b/Common/Data/UniverseSelection/UniverseSettings.cs
@@ -49,6 +49,11 @@ namespace QuantConnect.Data.UniverseSelection
         public TimeSpan MinimumTimeInUniverse;
 
         /// <summary>
+        /// Defines how universe data is normalized before being send into the algorithm
+        /// </summary>
+        public DataNormalizationMode DataNormalizationMode;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="UniverseSettings"/> class
         /// </summary>
         /// <param name="resolution">The resolution</param>
@@ -56,13 +61,15 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="fillForward">True to fill data forward, false otherwise</param>
         /// <param name="extendedMarketHours">True to allow exended market hours data, false otherwise</param>
         /// <param name="minimumTimeInUniverse">Defines the minimum amount of time a security must remain in the universe before being removed</param>
-        public UniverseSettings(Resolution resolution, decimal leverage, bool fillForward, bool extendedMarketHours, TimeSpan minimumTimeInUniverse)
+        /// <param name="dataNormalizationMode">Defines how universe data is normalized before being send into the algorithm</param>
+        public UniverseSettings(Resolution resolution, decimal leverage, bool fillForward, bool extendedMarketHours, TimeSpan minimumTimeInUniverse, DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted)
         {
             Resolution = resolution;
             Leverage = leverage;
             FillForward = fillForward;
             ExtendedMarketHours = extendedMarketHours;
             MinimumTimeInUniverse = minimumTimeInUniverse;
+            DataNormalizationMode = dataNormalizationMode;
         }
     }
 }

--- a/Common/Interfaces/ISubscriptionDataConfigService.cs
+++ b/Common/Interfaces/ISubscriptionDataConfigService.cs
@@ -39,7 +39,8 @@ namespace QuantConnect.Interfaces
             bool extendedMarketHours = false,
             bool isFilteredSubscription = true,
             bool isInternalFeed = false,
-            bool isCustomData = false
+            bool isCustomData = false,
+            DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted
             );
 
         /// <summary>
@@ -55,7 +56,8 @@ namespace QuantConnect.Interfaces
             bool isFilteredSubscription = true,
             bool isInternalFeed = false,
             bool isCustomData = false,
-            List<Tuple<Type, TickType>> subscriptionDataTypes = null
+            List<Tuple<Type, TickType>> subscriptionDataTypes = null,
+            DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted
             );
 
         /// <summary>

--- a/Common/Securities/SecurityService.cs
+++ b/Common/Securities/SecurityService.cs
@@ -154,8 +154,10 @@ namespace QuantConnect.Securities
                 security.SetLeverage(leverage);
             }
 
-            // In live mode, equity assumes specific price variation model
-            if (_isLiveMode && security.Type == SecurityType.Equity)
+            var isNotNormalized = configList.DataNormalizationMode() == DataNormalizationMode.Raw;
+
+            // In live mode and non normalized data, equity assumes specific price variation model
+            if ((_isLiveMode || isNotNormalized) && security.Type == SecurityType.Equity)
             {
                 security.PriceVariationModel = new EquityPriceVariationModel();
             }

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -311,11 +311,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             bool extendedMarketHours = false,
             bool isFilteredSubscription = true,
             bool isInternalFeed = false,
-            bool isCustomData = false
+            bool isCustomData = false,
+            DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted
             )
         {
             return Add(symbol, resolution, fillForward, extendedMarketHours, isFilteredSubscription, isInternalFeed, isCustomData,
-                new List<Tuple<Type, TickType>> { new Tuple<Type, TickType>(dataType, LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType))})
+                new List<Tuple<Type, TickType>> { new Tuple<Type, TickType>(dataType, LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType))}, dataNormalizationMode)
                 .First();
         }
 
@@ -332,7 +333,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             bool isFilteredSubscription = true,
             bool isInternalFeed = false,
             bool isCustomData = false,
-            List<Tuple<Type, TickType>> subscriptionDataTypes = null
+            List<Tuple<Type, TickType>> subscriptionDataTypes = null,
+            DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted
             )
         {
             var dataTypes = subscriptionDataTypes ??
@@ -340,9 +342,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             var marketHoursDbEntry = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType);
             var exchangeHours = marketHoursDbEntry.ExchangeHours;
-            var dataNormalizationMode = symbol.ID.SecurityType == SecurityType.Option || symbol.ID.SecurityType == SecurityType.Future
-                ? DataNormalizationMode.Raw
-                : DataNormalizationMode.Adjusted;
+            if (symbol.ID.SecurityType == SecurityType.Option || symbol.ID.SecurityType == SecurityType.Future)
+            {
+                dataNormalizationMode = DataNormalizationMode.Raw;
+            }
 
             if (marketHoursDbEntry.DataTimeZone == null)
             {

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -253,7 +253,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     var configs = _algorithm.SubscriptionManager.SubscriptionDataConfigService.Add(symbol,
                         universe.UniverseSettings.Resolution,
                         universe.UniverseSettings.FillForward,
-                        universe.UniverseSettings.ExtendedMarketHours);
+                        universe.UniverseSettings.ExtendedMarketHours,
+                        dataNormalizationMode: universe.UniverseSettings.DataNormalizationMode);
 
                     security =_securityService.CreateSecurity(symbol, configs, universe.UniverseSettings.Leverage, symbol.ID.SecurityType == SecurityType.Option);
 

--- a/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
+++ b/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Securities;
+using System.Linq;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmUniverseSettingsTests
+    {
+        [TestCase(DataNormalizationMode.Raw)]
+        [TestCase(DataNormalizationMode.Adjusted)]
+        [TestCase(DataNormalizationMode.SplitAdjusted)]
+        [TestCase(DataNormalizationMode.TotalReturn)]
+        public void CheckUniverseSelectionSecurityDataNormalizationMode(DataNormalizationMode dataNormalizationMode)
+        {
+            var algorithm = new QCAlgorithm();
+
+            var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+
+            var dataManager = new DataManager(
+                new MockDataFeed(),
+                new UniverseSelection(
+                    algorithm,
+                    new SecurityService(
+                        algorithm.Portfolio.CashBook,
+                        marketHoursDatabase,
+                        SymbolPropertiesDatabase.FromDataFolder(),
+                        algorithm)),
+                algorithm,
+                algorithm.TimeKeeper,
+                marketHoursDatabase);
+
+            algorithm.SubscriptionManager.SetDataManager(dataManager);
+
+            var symbol = Symbols.SPY;
+            algorithm.UniverseSettings.DataNormalizationMode = dataNormalizationMode;
+            algorithm.AddUniverse(coarse => new[] { symbol });
+
+            var changes = dataManager.UniverseSelection
+                .ApplyUniverseSelection(
+                    algorithm.UniverseManager.First().Value, 
+                    algorithm.UtcTime,
+                    new BaseDataCollection(algorithm.UtcTime, null, Enumerable.Empty<CoarseFundamental>()));
+
+            Assert.AreEqual(1, changes.AddedSecurities.Count());
+
+            var security = changes.AddedSecurities.First();
+            Assert.AreEqual(symbol, security.Symbol);
+            Assert.AreEqual(dataNormalizationMode, security.DataNormalizationMode);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Algorithm\AlgorithmSetHoldingsTests.cs" />
     <Compile Include="Algorithm\AlgorithmSettingsTest.cs" />
     <Compile Include="Algorithm\AlgorithmSubscriptionManagerRemoveConsolidatorTests.cs" />
+    <Compile Include="Algorithm\AlgorithmUniverseSettingsTests.cs" />
     <Compile Include="Algorithm\CashModelAlgorithmTradingTests.cs" />
     <Compile Include="Algorithm\AlgorithmTradingTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\CommonAlphaModelTests.cs" />


### PR DESCRIPTION
#### Description
Implements `DataNormalizationMode` field in `UniverseSettings` to enable the settings of a desired `DataNormalizationMode` to the securities that are chosen in Universe Selection.

#### Related Issue
Closes #3082 

#### How Has This Been Tested?
Unit test.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`