### PR TITLE
Scoring and statistics will ignore flat insights

### DIFF
--- a/Algorithm.CSharp/OrderBasedInsightGeneratedAlgorithm.cs
+++ b/Algorithm.CSharp/OrderBasedInsightGeneratedAlgorithm.cs
@@ -185,9 +185,9 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Monthly Alpha Value", "$8015512.7828"},
             {"Total Accumulated Estimated Alpha Value", "$3250735.7397"},
             {"Mean Population Estimated Insight Value", "$541789.2899"},
-            {"Mean Population Direction", "66.6667%"},
+            {"Mean Population Direction", "83.3333%"},
             {"Mean Population Magnitude", "0%"},
-            {"Rolling Averaged Population Direction", "96.0788%"},
+            {"Rolling Averaged Population Direction", "98.0198%"},
             {"Rolling Averaged Population Magnitude", "0%"}
         };
     }

--- a/Common/Algorithm/Framework/Alphas/Analysis/InsightAnalysisContext.cs
+++ b/Common/Algorithm/Framework/Alphas/Analysis/InsightAnalysisContext.cs
@@ -170,13 +170,13 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Analysis
         /// <returns>True to proceed with analyzing this insight for the specified score type, false to skip analysis of the score type</returns>
         public bool ShouldAnalyze(InsightScoreType scoreType)
         {
-            if (scoreType == InsightScoreType.Magnitude)
+            if (Insight.Direction == InsightDirection.Flat)
+            {
+                return false;
+            }
+            else if (scoreType == InsightScoreType.Magnitude)
             {
                 return Insight.Magnitude.HasValue;
-            }
-            else if (scoreType == InsightScoreType.Direction)
-            {
-                return Insight.Direction != InsightDirection.Flat;
             }
 
             return true;

--- a/Engine/Alphas/StatisticsInsightManagerExtension.cs
+++ b/Engine/Alphas/StatisticsInsightManagerExtension.cs
@@ -122,6 +122,10 @@ namespace QuantConnect.Lean.Engine.Alphas
 
             foreach (var scoreType in InsightManager.ScoreTypes)
             {
+                if (!context.ShouldAnalyze(scoreType))
+                {
+                    continue;
+                }
                 var score = context.Score.GetScore(scoreType);
                 var currentTime = context.CurrentValues.TimeUtc;
 

--- a/Tests/Engine/Alphas/InsightAnalysisContextTests.cs
+++ b/Tests/Engine/Alphas/InsightAnalysisContextTests.cs
@@ -25,16 +25,15 @@ namespace QuantConnect.Tests.Engine.Alphas
     [TestFixture]
     public class InsightAnalysisContextTests
     {
-        [TestCase(InsightScoreType.Direction, false, InsightType.Price, null)]
-        [TestCase(InsightScoreType.Magnitude, false, InsightType.Price, null)]
-        [TestCase(InsightScoreType.Direction, false, InsightType.Volatility, null)]
-        [TestCase(InsightScoreType.Magnitude, false, InsightType.Volatility, null)]
-        [TestCase(InsightScoreType.Direction, false, InsightType.Price, 1.0)]
-        [TestCase(InsightScoreType.Magnitude, true, InsightType.Price, 1.0)]
-        [TestCase(InsightScoreType.Direction, false, InsightType.Volatility, 1.0)]
-        [TestCase(InsightScoreType.Magnitude, true, InsightType.Volatility, 1.0)]
+        [TestCase(InsightScoreType.Direction, InsightType.Price, null)]
+        [TestCase(InsightScoreType.Magnitude, InsightType.Price, null)]
+        [TestCase(InsightScoreType.Direction, InsightType.Volatility, null)]
+        [TestCase(InsightScoreType.Magnitude, InsightType.Volatility, null)]
+        [TestCase(InsightScoreType.Direction, InsightType.Price, 1.0)]
+        [TestCase(InsightScoreType.Magnitude, InsightType.Price, 1.0)]
+        [TestCase(InsightScoreType.Direction, InsightType.Volatility, 1.0)]
+        [TestCase(InsightScoreType.Magnitude, InsightType.Volatility, 1.0)]
         public void ShouldAnalyzeInsight(InsightScoreType scoreType,
-            bool result,
             InsightType insightType,
             double? magnitude)
         {
@@ -50,7 +49,7 @@ namespace QuantConnect.Tests.Engine.Alphas
                     SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
                     1, 1, 1, 1),
                 TimeSpan.FromDays(1));
-            Assert.AreEqual(result, context.ShouldAnalyze(scoreType));
+            Assert.AreEqual(false, context.ShouldAnalyze(scoreType));
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `Flat` insights will be ignored both for scoring (`InsightManager`)
and for statistics (`StatisticsInsightManagerExtension`). Adding unit
tests
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Close https://github.com/QuantConnect/Lean/issues/3091
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`Flat` `InsightScoreType.Direction` are being used when calculating the average alpha score, dragging the score down.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression and cloud testing
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->