### PR TITLE
Fixes StandardDeviationExecutionModel

### DIFF
--- a/Tests/Algorithm/Framework/Execution/StandardDeviationExecutionModelTests.cs
+++ b/Tests/Algorithm/Framework/Execution/StandardDeviationExecutionModelTests.cs
@@ -63,13 +63,14 @@ namespace QuantConnect.Tests.Algorithm.Framework.Execution
             Assert.AreEqual(0, actualOrdersSubmitted.Count);
         }
 
-        [TestCase(Language.CSharp, new[] { 270d, 260d, 250d }, 1, 10)]
-        [TestCase(Language.CSharp, new[] { 250d, 250d, 250d }, 0, 0)]
-        [TestCase(Language.Python, new[] { 270d, 260d, 250d }, 1, 10)]
-        [TestCase(Language.Python, new[] { 250d, 250d, 250d }, 0, 0)]
+        [TestCase(Language.CSharp, new[] { 270d, 260d, 250d }, 240, 1, 10)]
+        [TestCase(Language.CSharp, new[] { 250d, 250d, 250d }, 250, 0, 0)]
+        [TestCase(Language.Python, new[] { 270d, 260d, 250d }, 240, 1, 10)]
+        [TestCase(Language.Python, new[] { 250d, 250d, 250d }, 250, 0, 0)]
         public void OrdersAreSubmittedWhenRequiredForTargetsToExecute(
             Language language,
             double[] historicalPrices,
+            decimal currentPrice,
             int expectedOrdersSubmitted,
             decimal expectedTotalQuantity)
         {
@@ -101,7 +102,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Execution
             algorithm.SetDateTime(time.AddMinutes(5));
 
             var security = algorithm.AddEquity(Symbols.AAPL.Value);
-            security.SetMarketPrice(new TradeBar { Value = 250 });
+            security.SetMarketPrice(new TradeBar { Value = currentPrice });
 
             algorithm.SetFinishedWarmingUp();
 


### PR DESCRIPTION
#### Description
This model was assuming that the history request used to warm up the indicators contains the 'close' column which is only valid for Equity.

The models were also refactored to update the indicators without a consolidator since the last data point from the history request was not pushed through the indicators.

#### Related Issue
Closes #3075 

#### Motivation and Context
Framework models should work with all security types unless they were explicitly designed to not to (in this case, a security type check and warning should be in place).  

#### How Has This Been Tested?
`StandardDeviationExecutionModelRegressionAlgorithm` and unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`