### PR TITLE
Fix live coarse data subscription

### DIFF
--- a/Common/Data/Fundamental/FineFundamental.cs
+++ b/Common/Data/Fundamental/FineFundamental.cs
@@ -38,11 +38,16 @@ namespace QuantConnect.Data.Fundamental
         /// Creates the universe symbol used for fine fundamental data
         /// </summary>
         /// <param name="market">The market</param>
+        /// <param name="addGuid">True, will add a random GUID to allow uniqueness</param>
         /// <returns>A fine universe symbol for the specified market</returns>
-        public static Symbol CreateUniverseSymbol(string market)
+        public static Symbol CreateUniverseSymbol(string market, bool addGuid = true)
         {
             market = market.ToLower();
-            var ticker = $"qc-universe-fine-{market}-{Guid.NewGuid()}";
+            var ticker = $"qc-universe-fine-{market}";
+            if (addGuid)
+            {
+                ticker += $"-{Guid.NewGuid()}";
+            }
             var sid = SecurityIdentifier.GenerateEquity(SecurityIdentifier.DefaultDate, ticker, market);
             return new Symbol(sid, ticker);
         }

--- a/Common/Data/UniverseSelection/CoarseFundamental.cs
+++ b/Common/Data/UniverseSelection/CoarseFundamental.cs
@@ -161,11 +161,16 @@ namespace QuantConnect.Data.UniverseSelection
         /// Creates the symbol used for coarse fundamental data
         /// </summary>
         /// <param name="market">The market</param>
+        /// <param name="addGuid">True, will add a random GUID to allow uniqueness</param>
         /// <returns>A coarse universe symbol for the specified market</returns>
-        public static Symbol CreateUniverseSymbol(string market)
+        public static Symbol CreateUniverseSymbol(string market, bool addGuid = true)
         {
             market = market.ToLower();
-            var ticker = $"qc-universe-coarse-{market}-{Guid.NewGuid()}";
+            var ticker = $"qc-universe-coarse-{market}";
+            if (addGuid)
+            {
+                ticker += $"-{Guid.NewGuid()}";
+            }
             var sid = SecurityIdentifier.GenerateEquity(SecurityIdentifier.DefaultDate, ticker, market);
             return new Symbol(sid, ticker);
         }

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -404,12 +404,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             {
                 Log.Trace("LiveTradingDataFeed.CreateUniverseSubscription(): Creating coarse universe: " + config.Symbol.ToString());
 
+                // we subscribe using a normalized symbol, without a random GUID,
+                // since the ticker plant will send the coarse data using this symbol
+                var normalizedSymbol = CoarseFundamental.CreateUniverseSymbol(config.Symbol.ID.Market, false);
+
                 // since we're binding to the data queue exchange we'll need to let him
                 // know that we expect this data
-                _dataQueueHandler.Subscribe(_job, new[] {request.Security.Symbol});
+                _dataQueueHandler.Subscribe(_job, new[] { normalizedSymbol });
 
                 var enqueable = new EnqueueableEnumerator<BaseData>();
-                _exchange.SetDataHandler(config.Symbol, data =>
+                // We `AddDataHandler` not `Set` so we can have multiple handlers for the coarse data
+                _exchange.AddDataHandler(normalizedSymbol, data =>
                 {
                     enqueable.Enqueue(data);
                 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- When subscribing to `Coarse` data the `LiveTradingDataFeed` will use
the normalized `CoarseFundamental Universe Symbol` for that market ->
not using the random GUID
- Adding unit tests which reproduce the issue.

> master affected versions from v5440 to present

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3097
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Live coarse universe selection not triggered
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x]  My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->