### PR TITLE
Fix AlpacaBrokerage.GetAccountHoldings implementation

### DIFF
--- a/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
@@ -31,30 +31,27 @@ namespace QuantConnect.Brokerages.Alpaca
     /// </summary>
     public partial class AlpacaBrokerage
     {
+
         /// <summary>
-        /// Retrieves the current rate for each of a list of instruments
+        /// Retrieves the current quotes for an instrument
         /// </summary>
-        /// <param name="instruments">the list of instruments to check</param>
-        /// <returns>Dictionary containing the current quotes for each instrument</returns>
-        private Dictionary<string, Tick> GetRates(IEnumerable<string> instruments)
+        /// <param name="instrument">the instrument to check</param>
+        /// <returns>Returns a Tick object with the current bid/ask prices for the instrument</returns>
+        public Tick GetRates(string instrument)
         {
             CheckRateLimiting();
 
-            var task = _restClient.ListQuotesAsync(instruments);
+            var task = _restClient.GetLastQuoteAsync(instrument);
             var response = task.SynchronouslyAwaitTaskResult();
 
-            return response
-                .ToDictionary(
-                    x => x.Symbol,
-                    x => new Tick
-                    {
-                        Symbol = Symbol.Create(x.Symbol, SecurityType.Equity, Market.USA),
-                        BidPrice = x.BidPrice,
-                        AskPrice = x.AskPrice,
-                        Time = x.LastTime,
-                        TickType = TickType.Quote
-                    }
-                );
+            return new Tick
+            {
+                Symbol = Symbol.Create(response.Symbol, SecurityType.Equity, Market.USA),
+                BidPrice = response.BidPrice,
+                AskPrice = response.AskPrice,
+                Time = response.Time,
+                TickType = TickType.Quote
+            };
         }
 
         private IOrder GenerateAndPlaceOrder(Order order)

--- a/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
@@ -417,6 +417,8 @@ namespace QuantConnect.Brokerages.Alpaca
                 Symbol = symbol,
                 Type = securityType,
                 AveragePrice = position.AverageEntryPrice,
+                MarketPrice = position.AssetCurrentPrice,
+                MarketValue = position.MarketValue,
                 CurrencySymbol = "$",
                 Quantity = position.Side == PositionSide.Long ? position.Quantity : -position.Quantity
             };

--- a/Brokerages/Alpaca/AlpacaBrokerage.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.cs
@@ -382,15 +382,5 @@ namespace QuantConnect.Brokerages.Alpaca
         }
 
         #endregion
-
-        /// <summary>
-        /// Retrieves the current quotes for an instrument
-        /// </summary>
-        /// <param name="instrument">the instrument to check</param>
-        /// <returns>Returns a Tick object with the current bid/ask prices for the instrument</returns>
-        public Tick GetRates(string instrument)
-        {
-            return GetRates(new List<string> { instrument }).Values.First();
-        }
     }
 }

--- a/Brokerages/Alpaca/AlpacaBrokerage.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.cs
@@ -257,28 +257,7 @@ namespace QuantConnect.Brokerages.Alpaca
             var task = _restClient.ListPositionsAsync();
             var holdings = task.SynchronouslyAwaitTaskResult();
 
-            var qcHoldings = holdings.Select(ConvertHolding).ToList();
-
-            // Set MarketPrice in each Holding
-            var alpacaSymbols = qcHoldings
-                .Select(x => x.Symbol.Value)
-                .ToList();
-
-            if (alpacaSymbols.Count > 0)
-            {
-                var quotes = GetRates(alpacaSymbols);
-                foreach (var holding in qcHoldings)
-                {
-                    var alpacaSymbol = holding.Symbol;
-                    Tick tick;
-                    if (quotes.TryGetValue(alpacaSymbol.Value, out tick))
-                    {
-                        holding.MarketPrice = (tick.BidPrice + tick.AskPrice) / 2;
-                    }
-                }
-            }
-
-            return qcHoldings;
+            return holdings.Select(ConvertHolding).ToList();
         }
 
         /// <summary>

--- a/Brokerages/Alpaca/Markets/Messages/JsonPosition.cs
+++ b/Brokerages/Alpaca/Markets/Messages/JsonPosition.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.Brokerages.Alpaca.Markets
         [JsonProperty(PropertyName = "unrealized_intraday_plpc", Required = Required.Always)]
         public Decimal IntradayUnrealizedProfitLossPercent { get; set; }
 
-        [JsonProperty(PropertyName = "current_price ", Required = Required.Default)]
+        [JsonProperty(PropertyName = "current_price", Required = Required.Default)]
         public Decimal AssetCurrentPrice { get; set; }
 
         [JsonProperty(PropertyName = "lastday_price", Required = Required.Always)]


### PR DESCRIPTION
#### Description
Outdated underlying API call `RestClient.ListQuotesAsync()` removed from holdings requesting logic. All required data already exist in response object and can be used directly without additional requests. Outdated API call replaced with correct one `RestClient.GetLastQuoteAsync()` because method `AlpacaBrokerage.GetRates()` is used by unit tests.

#### Related Issue
Closes #3026

#### Motivation and Context
Unable to use `AlpacaBrokerage` class in any algorithm if account has existing holdings.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Tested on Windows only using stage Alpaca environment.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. **Existing tests covers this case.**
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`