### PR TITLE
Overall performance improvements

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -783,13 +783,20 @@ namespace QuantConnect.Algorithm
                 return orderIdList;
             }
 
-
-            foreach (var symbol in Securities.Keys.OrderBy(x => x.Value))
+            IEnumerable<Symbol> toLiquidate;
+            if (symbolToLiquidate != null)
             {
-                // symbol not matching, do nothing
-                if (symbol != symbolToLiquidate && symbolToLiquidate != null)
-                    continue;
+                toLiquidate = Securities.ContainsKey(symbolToLiquidate)
+                    ? new[] { symbolToLiquidate } : Enumerable.Empty<Symbol>();
+            }
+            else
+            {
+                toLiquidate = Securities.Keys.OrderBy(x => x.Value);
+            }
 
+
+            foreach (var symbol in toLiquidate)
+            {
                 // get open orders
                 var orders = Transactions.GetOpenOrders(symbol);
 

--- a/Common/Algorithm/Framework/Alphas/Analysis/ISecurityValuesProvider.cs
+++ b/Common/Algorithm/Framework/Alphas/Analysis/ISecurityValuesProvider.cs
@@ -29,6 +29,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Analysis
         /// <param name="symbol">The symbol to get price/volatility for</param>
         /// <returns>The insight target values for the specified symbol</returns>
         SecurityValues GetValues(Symbol symbol);
+
+        /// <summary>
+        /// Gets the current values for all the algorithm securities (price/volatility)
+        /// </summary>
+        /// <returns>The insight target values for all the algorithm securities</returns>
+        ReadOnlySecurityValuesCollection GetAllValues();
     }
 
     /// <summary>

--- a/Common/Algorithm/Framework/Alphas/Analysis/Providers/AlgorithmSecurityValuesProvider.cs
+++ b/Common/Algorithm/Framework/Alphas/Analysis/Providers/AlgorithmSecurityValuesProvider.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
@@ -46,6 +47,23 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Analysis.Providers
             var security = _algorithm.Securities[symbol];
             var volume = security.Cache.GetData<TradeBar>()?.Volume ?? 0;
             return new SecurityValues(symbol, _algorithm.UtcTime, security.Exchange.Hours, security.Price, security.VolatilityModel.Volatility, volume, security.QuoteCurrency.ConversionRate);
+        }
+
+        /// <summary>
+        /// Gets the current values for all the algorithm securities (price/volatility)
+        /// </summary>
+        /// <returns>The insight target values for all the algorithm securities</returns>
+        public ReadOnlySecurityValuesCollection GetAllValues()
+        {
+            var values = new Dictionary<Symbol, SecurityValues>();
+            foreach (var kvp in _algorithm.Securities)
+            {
+                var security = kvp.Value;
+                var volume = security.Cache.GetData<TradeBar>()?.Volume ?? 0;
+                var value = new SecurityValues(security.Symbol, _algorithm.UtcTime, security.Exchange.Hours, security.Price, security.VolatilityModel.Volatility, volume, security.QuoteCurrency.ConversionRate);
+                values[security.Symbol] = value;
+            }
+            return new ReadOnlySecurityValuesCollection(values);
         }
     }
 }

--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -198,17 +198,17 @@ namespace QuantConnect.Data.Market
                 {
                     //Equity File Data Format:
                     case SecurityType.Equity:
-                        return ParseEquity<TradeBar>(config, line, date);
+                        return ParseEquity(config, line, date);
 
                     //FOREX has a different data file format:
                     case SecurityType.Forex:
-                        return ParseForex<TradeBar>(config, line, date);
+                        return ParseForex(config, line, date);
 
                     case SecurityType.Crypto:
-                        return ParseCrypto<TradeBar>(config, line, date);
+                        return ParseCrypto(config, line, date);
 
                     case SecurityType.Cfd:
-                        return ParseCfd<TradeBar>(config, line, date);
+                        return ParseCfd(config, line, date);
 
                     case SecurityType.Option:
                         return ParseOption(config, line, date);
@@ -266,6 +266,13 @@ namespace QuantConnect.Data.Market
                 Period = config.Increment
             };
 
+            ParseEquity(tradeBar, config, line, date);
+
+            return tradeBar;
+        }
+
+        private static void ParseEquity(TradeBar tradeBar, SubscriptionDataConfig config, string line, DateTime date)
+        {
             var csv = line.ToCsv(6);
             if (config.Resolution == Resolution.Daily || config.Resolution == Resolution.Hour)
             {
@@ -283,8 +290,6 @@ namespace QuantConnect.Data.Market
             tradeBar.Low = csv[3].ToDecimal()*_scaleFactor;
             tradeBar.Close = csv[4].ToDecimal()*_scaleFactor;
             tradeBar.Volume = csv[5].ToDecimal();
-
-            return tradeBar;
         }
 
         /// <summary>
@@ -296,7 +301,13 @@ namespace QuantConnect.Data.Market
         /// <returns></returns>
         public static TradeBar ParseEquity(SubscriptionDataConfig config, string line, DateTime date)
         {
-            return ParseEquity<TradeBar>(config, line, date);
+            var tradeBar = new TradeBar
+            {
+                Symbol = config.Symbol,
+                Period = config.Increment
+            };
+            ParseEquity(tradeBar, config, line, date);
+            return tradeBar;
         }
 
         /// <summary>
@@ -315,7 +326,13 @@ namespace QuantConnect.Data.Market
                 Symbol = config.Symbol,
                 Period = config.Increment
             };
+            ParseForex(tradeBar, config, line, date);
 
+            return tradeBar;
+        }
+
+        private static void ParseForex(TradeBar tradeBar, SubscriptionDataConfig config, string line, DateTime date)
+        {
             var csv = line.ToCsv(5);
             if (config.Resolution == Resolution.Daily || config.Resolution == Resolution.Hour)
             {
@@ -332,8 +349,6 @@ namespace QuantConnect.Data.Market
             tradeBar.High = csv[2].ToDecimal();
             tradeBar.Low = csv[3].ToDecimal();
             tradeBar.Close = csv[4].ToDecimal();
-
-            return tradeBar;
         }
 
         /// <summary>
@@ -351,7 +366,31 @@ namespace QuantConnect.Data.Market
                 Symbol = config.Symbol,
                 Period = config.Increment
             };
+            ParseCrypto(tradeBar, config, line, date);
 
+            return tradeBar;
+        }
+
+        /// <summary>
+        /// Parses crypto trade bar data into the specified tradebar type, useful for custom types with OHLCV data deriving from TradeBar
+        /// </summary>
+        /// <param name="config">Symbols, Resolution, DataType, </param>
+        /// <param name="line">Line from the data file requested</param>
+        /// <param name="date">The base data used to compute the time of the bar since the line specifies a milliseconds since midnight</param>
+        public static TradeBar ParseCrypto(SubscriptionDataConfig config, string line, DateTime date)
+        {
+            var tradeBar = new TradeBar
+            {
+                Symbol = config.Symbol,
+                Period = config.Increment
+            };
+            ParseCrypto(tradeBar, config, line, date);
+
+            return tradeBar;
+        }
+
+        private static void ParseCrypto(TradeBar tradeBar, SubscriptionDataConfig config, string line, DateTime date)
+        {
             var csv = line.ToCsv(6);
             if (config.Resolution == Resolution.Daily || config.Resolution == Resolution.Hour)
             {
@@ -369,8 +408,6 @@ namespace QuantConnect.Data.Market
             tradeBar.Low = csv[3].ToDecimal();
             tradeBar.Close = csv[4].ToDecimal();
             tradeBar.Volume = csv[5].ToDecimal();
-
-            return tradeBar;
         }
 
         /// <summary>
@@ -382,7 +419,13 @@ namespace QuantConnect.Data.Market
         /// <returns></returns>
         public static TradeBar ParseForex(SubscriptionDataConfig config, string line, DateTime date)
         {
-            return ParseForex<TradeBar>(config, line, date);
+            var tradeBar = new TradeBar
+            {
+                Symbol = config.Symbol,
+                Period = config.Increment
+            };
+            ParseForex(tradeBar, config, line, date);
+            return tradeBar;
         }
 
         /// <summary>
@@ -409,7 +452,8 @@ namespace QuantConnect.Data.Market
         /// <returns></returns>
         public static TradeBar ParseCfd(SubscriptionDataConfig config, string line, DateTime date)
         {
-            return ParseCfd<TradeBar>(config, line, date);
+            // CFD has the same data format as Forex
+            return ParseForex(config, line, date);
         }
 
         /// <summary>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -988,6 +988,86 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Converts the specified <paramref name="securityType"/> value to its corresponding lower-case string representation
+        /// </summary>
+        /// <remarks>This method provides faster performance than <see cref="ToLower"/></remarks>
+        /// <param name="securityType">The SecurityType value</param>
+        /// <returns>A lower-case string representation of the specified SecurityType value</returns>
+        public static string SecurityTypeToLower(this SecurityType securityType)
+        {
+            switch (securityType)
+            {
+                case SecurityType.Base:
+                    return "base";
+                case SecurityType.Equity:
+                    return "equity";
+                case SecurityType.Option:
+                    return "option";
+                case SecurityType.Commodity:
+                    return "commodity";
+                case SecurityType.Forex:
+                    return "forex";
+                case SecurityType.Future:
+                    return "future";
+                case SecurityType.Cfd:
+                    return "cfd";
+                case SecurityType.Crypto:
+                    return "crypto";
+                default:
+                    // just in case
+                    return securityType.ToLower();
+            }
+        }
+
+        /// <summary>
+        /// Converts the specified <paramref name="tickType"/> value to its corresponding lower-case string representation
+        /// </summary>
+        /// <remarks>This method provides faster performance than <see cref="ToLower"/></remarks>
+        /// <param name="tickType">The tickType value</param>
+        /// <returns>A lower-case string representation of the specified tickType value</returns>
+        public static string TickTypeToLower(this TickType tickType)
+        {
+            switch (tickType)
+            {
+                case TickType.Trade:
+                    return "trade";
+                case TickType.Quote:
+                    return "quote";
+                case TickType.OpenInterest:
+                    return "openinterest";
+                default:
+                    // just in case
+                    return tickType.ToLower();
+            }
+        }
+
+        /// <summary>
+        /// Converts the specified <paramref name="resolution"/> value to its corresponding lower-case string representation
+        /// </summary>
+        /// <remarks>This method provides faster performance than <see cref="ToLower"/></remarks>
+        /// <param name="resolution">The resolution value</param>
+        /// <returns>A lower-case string representation of the specified resolution value</returns>
+        public static string ResolutionToLower(this Resolution resolution)
+        {
+            switch (resolution)
+            {
+                case Resolution.Tick:
+                    return "tick";
+                case Resolution.Second:
+                    return "second";
+                case Resolution.Minute:
+                    return "minute";
+                case Resolution.Hour:
+                    return "hour";
+                case Resolution.Daily:
+                    return "daily";
+                default:
+                    // just in case
+                    return resolution.ToLower();
+            }
+        }
+
+        /// <summary>
         /// Turn order into an order ticket
         /// </summary>
         /// <param name="order">The <see cref="Order"/> being converted</param>

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -160,7 +160,11 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return AveragePrice * Convert.ToDecimal(Quantity) * _security.QuoteCurrency.ConversionRate * _security.SymbolProperties.ContractMultiplier;
+                if (Quantity == 0)
+                {
+                    return 0;
+                }
+                return AveragePrice * Quantity * _security.QuoteCurrency.ConversionRate * _security.SymbolProperties.ContractMultiplier;
             }
         }
 
@@ -215,7 +219,14 @@ namespace QuantConnect.Securities
         /// </summary>
         public virtual decimal HoldingsValue
         {
-            get { return _price * Quantity * _security.QuoteCurrency.ConversionRate * _security.SymbolProperties.ContractMultiplier; }
+            get
+            {
+                if (Quantity == 0)
+                {
+                    return 0;
+                }
+                return _price * Quantity * _security.QuoteCurrency.ConversionRate * _security.SymbolProperties.ContractMultiplier;
+            }
         }
 
         /// <summary>
@@ -425,7 +436,7 @@ namespace QuantConnect.Securities
         /// <remarks>Does not use the transaction model for market fills but should.</remarks>
         public virtual decimal TotalCloseProfit()
         {
-            if (AbsoluteQuantity == 0)
+            if (Quantity == 0)
             {
                 return 0;
             }

--- a/Common/SecurityIdentifier.cs
+++ b/Common/SecurityIdentifier.cs
@@ -98,8 +98,7 @@ namespace QuantConnect
         private readonly string _symbol;
         private readonly ulong _properties;
         private readonly SidBox _underlying;
-        private readonly Lazy<SecurityType> _lazySecurityType;
-        private readonly Lazy<int> _lazyHashCode;
+        private readonly int _hashCode;
 
         #endregion
 
@@ -186,7 +185,7 @@ namespace QuantConnect
         /// <summary>
         /// Gets the security type component of this security identifier.
         /// </summary>
-        public SecurityType SecurityType => _lazySecurityType.Value;
+        public SecurityType SecurityType { get; }
 
         /// <summary>
         /// Gets the option strike price. This only applies to SecurityType.Option
@@ -264,8 +263,8 @@ namespace QuantConnect
             _symbol = symbol;
             _properties = properties;
             _underlying = null;
-            _lazySecurityType = new Lazy<SecurityType>(() => (SecurityType)ExtractFromProperties(SecurityTypeOffset, SecurityTypeWidth, properties));
-            _lazyHashCode = new Lazy<int>(() => unchecked (symbol.GetHashCode() * 397) ^ properties.GetHashCode());
+            SecurityType = (SecurityType)ExtractFromProperties(SecurityTypeOffset, SecurityTypeWidth, properties);
+            _hashCode = unchecked (symbol.GetHashCode() * 397) ^ properties.GetHashCode();
         }
 
         /// <summary>
@@ -724,7 +723,7 @@ namespace QuantConnect
         /// A hash code for the current <see cref="T:System.Object"/>.
         /// </returns>
         /// <filterpriority>2</filterpriority>
-        public override int GetHashCode() => _lazyHashCode.Value;
+        public override int GetHashCode() => _hashCode;
 
         /// <summary>
         /// Override equals operator

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -361,9 +361,9 @@ namespace QuantConnect.Util
         public static string GenerateRelativeZipFileDirectory(Symbol symbol, Resolution resolution)
         {
             var isHourOrDaily = resolution == Resolution.Hour || resolution == Resolution.Daily;
-            var securityType = symbol.ID.SecurityType.ToLower();
+            var securityType = symbol.ID.SecurityType.SecurityTypeToLower();
             var market = symbol.ID.Market.ToLower();
-            var res = resolution.ToLower();
+            var res = resolution.ResolutionToLower();
             var directory = Path.Combine(securityType, market, res);
             switch (symbol.ID.SecurityType)
             {
@@ -412,7 +412,7 @@ namespace QuantConnect.Util
         /// </summary>
         public static string GenerateRelativeZipFilePath(string symbol, SecurityType securityType, string market, DateTime date, Resolution resolution)
         {
-            var directory = Path.Combine(securityType.ToLower(), market.ToLower(), resolution.ToLower());
+            var directory = Path.Combine(securityType.SecurityTypeToLower(), market.ToLower(), resolution.ResolutionToLower());
             if (resolution != Resolution.Daily && resolution != Resolution.Hour)
             {
                 directory = Path.Combine(directory, symbol.ToLower());
@@ -456,8 +456,8 @@ namespace QuantConnect.Util
                     return string.Format("{0}_{1}_{2}_{3}.csv",
                         formattedDate,
                         symbol.Value.ToLower(),
-                        resolution.ToLower(),
-                        tickType.ToLower()
+                        resolution.ResolutionToLower(),
+                        tickType.TickTypeToLower()
                         );
 
                 case SecurityType.Option:
@@ -465,7 +465,7 @@ namespace QuantConnect.Util
                     {
                         return string.Join("_",
                             symbol.Underlying.Value.ToLower(), // underlying
-                            tickType.ToLower(),
+                            tickType.TickTypeToLower(),
                             symbol.ID.OptionStyle.ToLower(),
                             symbol.ID.OptionRight.ToLower(),
                             Scale(symbol.ID.StrikePrice),
@@ -476,8 +476,8 @@ namespace QuantConnect.Util
                     return string.Join("_",
                         formattedDate,
                         symbol.Underlying.Value.ToLower(), // underlying
-                        resolution.ToLower(),
-                        tickType.ToLower(),
+                        resolution.ResolutionToLower(),
+                        tickType.TickTypeToLower(),
                         symbol.ID.OptionStyle.ToLower(),
                         symbol.ID.OptionRight.ToLower(),
                         Scale(symbol.ID.StrikePrice),
@@ -489,7 +489,7 @@ namespace QuantConnect.Util
                     {
                         return string.Join("_",
                             symbol.ID.Symbol.ToLower(),
-                            tickType.ToLower(),
+                            tickType.TickTypeToLower(),
                             symbol.ID.Date.ToString(DateFormat.YearMonth)
                             ) + ".csv";
                     }
@@ -497,8 +497,8 @@ namespace QuantConnect.Util
                     return string.Join("_",
                         formattedDate,
                         symbol.ID.Symbol.ToLower(),
-                        resolution.ToLower(),
-                        tickType.ToLower(),
+                        resolution.ResolutionToLower(),
+                        tickType.TickTypeToLower(),
                         symbol.ID.Date.ToString(DateFormat.YearMonth)
                         ) + ".csv";
 
@@ -513,7 +513,7 @@ namespace QuantConnect.Util
         /// </summary>
         public static string GenerateZipFileName(Symbol symbol, DateTime date, Resolution resolution, TickType tickType)
         {
-            var tickTypeString = tickType.ToLower();
+            var tickTypeString = tickType.TickTypeToLower();
             var formattedDate = date.ToString(DateFormat.EightCharacter);
             var isHourOrDaily = resolution == Resolution.Hour || resolution == Resolution.Daily;
 
@@ -593,7 +593,7 @@ namespace QuantConnect.Util
 
             var zipFileName = date.ToString(DateFormat.EightCharacter);
             tickType = tickType ?? (securityType == SecurityType.Forex || securityType == SecurityType.Cfd ? TickType.Quote : TickType.Trade);
-            var suffix = string.Format("_{0}.zip", tickType.Value.ToLower());
+            var suffix = string.Format("_{0}.zip", tickType.Value.TickTypeToLower());
             return zipFileName + suffix;
         }
 

--- a/Engine/Alphas/DefaultAlphaHandler.cs
+++ b/Engine/Alphas/DefaultAlphaHandler.cs
@@ -245,7 +245,7 @@ namespace QuantConnect.Lean.Engine.Alphas
         private ReadOnlySecurityValuesCollection CreateSecurityValuesSnapshot()
         {
             _lastSecurityValuesSnapshotTime = Algorithm.UtcTime;
-            return _securityValuesProvider.GetValues(Algorithm.Securities.Keys);
+            return _securityValuesProvider.GetAllValues();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -241,18 +241,22 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
             else
             {
-                // count data subscriptions by symbol, ignoring multiple data types.
-                // this limit was added due to the limits IB places on number of subscriptions
-                var uniqueCount = SubscriptionManagerSubscriptions
-                    .Where(x => !x.Symbol.IsCanonical())
-                    .DistinctBy(x => x.Symbol.Value)
-                    .Count();
-
-                if (uniqueCount > _algorithmSettings.DataSubscriptionLimit)
+                // for performance, only count if we are above the limit
+                if (SubscriptionManagerCount() > _algorithmSettings.DataSubscriptionLimit)
                 {
-                    throw new Exception(
-                        $"The maximum number of concurrent market data subscriptions was exceeded ({_algorithmSettings.DataSubscriptionLimit})." +
-                        "Please reduce the number of symbols requested or increase the limit using Settings.DataSubscriptionLimit.");
+                    // count data subscriptions by symbol, ignoring multiple data types.
+                    // this limit was added due to the limits IB places on number of subscriptions
+                    var uniqueCount = SubscriptionManagerSubscriptions
+                        .Where(x => !x.Symbol.IsCanonical())
+                        .DistinctBy(x => x.Symbol.Value)
+                        .Count();
+
+                    if (uniqueCount > _algorithmSettings.DataSubscriptionLimit)
+                    {
+                        throw new Exception(
+                            $"The maximum number of concurrent market data subscriptions was exceeded ({_algorithmSettings.DataSubscriptionLimit})." +
+                            "Please reduce the number of symbols requested or increase the limit using Settings.DataSubscriptionLimit.");
+                    }
                 }
 
                 // add the time zone to our time keeper

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -245,6 +245,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // find new selections and add them to the algorithm
             foreach (var symbol in selections)
             {
+                if (universe.Securities.ContainsKey(symbol))
+                {
+                    // if its already part of the universe no need to re add it
+                    continue;
+                }
+
                 // create the new security, the algorithm thread will add this at the appropriate time
                 Security security;
                 if (!pendingAdditions.TryGetValue(symbol, out security) && !_algorithm.Securities.TryGetValue(symbol, out security))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `FactorFile` will keep an ordered reversed list with the dates.
Calling `Reverse()` on the `SortedList` is expensive.
- `MapFiles` will keep first and last date, so we don't need to call
`First()` and `Last()` multiple times.
- `Liquidate` will go through all the algorithms securities only if
necessary
- `TradeBar` parsing will not call `new T` for pure `TradeBar` which is
expensive
- Removing `Lazy` hash code and security type for the
`SecurityIdentifier`, replacing for direct initialization. Accessing the
`Lazy` value adds an overhead.
- Replacing `Enum` to string for hardcoded switch statement. `Enum.ToString` is expensive.
- `DataManager` will be lazy for counting the subscriptions for
determining if its above the limit
- Adding `AlgorithmSecurityValuesProvider.GetAllValues()`, removes the
need to fetch all the security keys twice.
- During universe selection, will not try to re add already added symbol.
   **- NOTE: this causes a small reduction in the data points. This is because when a security is delisted, it's removed from the data feed system, and if the universe reselected it, it was re added causing Lean to re process (not re emit) the warning and delisted data points twice. This is not perceived by the algorithm since the delisting events are correctly emitted**

**Local performance tests: StatelessCoarseUniverseSelectionBenchmark 01-06-2017 to 01-01-2018**
`Master`
52.69 seconds at 22k data points per second. Processing total of 1,133,262 data points.
54.78 seconds at 21k data points per second. Processing total of 1,133,262 data points.
50.88 seconds at 22k data points per second. Processing total of 1,133,262 data points.

`PR ~40-50% improvement`
36.37 seconds at 31k data points per second. Processing total of 1,133,250 data points.
35.68 seconds at 32k data points per second. Processing total of 1,133,250 data points.
37.17 seconds at 30k data points per second. Processing total of 1,133,250 data points.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to #3076
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Lean runs as fast as possible
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression and performance tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->