### PR TITLE
Adds Missing Fundamentals Initialization in UniverseSelection

### DIFF
--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="universe">The universe to perform selection on</param>
         /// <param name="dateTimeUtc">The current date time in utc</param>
         /// <param name="universeData">The data provided to perform selection with</param>
-        public SecurityChanges  ApplyUniverseSelection(Universe universe, DateTime dateTimeUtc, BaseDataCollection universeData)
+        public SecurityChanges ApplyUniverseSelection(Universe universe, DateTime dateTimeUtc, BaseDataCollection universeData)
         {
             var algorithmEndDateUtc = _algorithm.EndDate.ConvertToUtc(_algorithm.TimeZone);
             if (dateTimeUtc > algorithmEndDateUtc)
@@ -104,7 +104,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     var dataProvider = new DefaultDataProvider();
 
                     // use all available threads, the entire system is waiting for this to complete
-                    var options = new ParallelOptions{MaxDegreeOfParallelism = Environment.ProcessorCount};
+                    var options = new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount };
                     Parallel.ForEach(selectSymbolsResult, options, symbol =>
                     {
                         var config = FineFundamentalUniverse.CreateConfiguration(symbol);
@@ -149,6 +149,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             Time = fine.Time,
                             EndTime = fine.EndTime,
                             DataType = fine.DataType,
+                            AssetClassification = fine.AssetClassification,
+                            CompanyProfile = fine.CompanyProfile,
                             CompanyReference = fine.CompanyReference,
                             EarningReports = fine.EarningReports,
                             EarningRatios = fine.EarningRatios,
@@ -262,7 +264,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         universe.UniverseSettings.ExtendedMarketHours,
                         dataNormalizationMode: universe.UniverseSettings.DataNormalizationMode);
 
-                    security =_securityService.CreateSecurity(symbol, configs, universe.UniverseSettings.Leverage, symbol.ID.SecurityType == SecurityType.Option);
+                    security = _securityService.CreateSecurity(symbol, configs, universe.UniverseSettings.Leverage, symbol.ID.SecurityType == SecurityType.Option);
 
                     pendingAdditions.Add(symbol, security);
 


### PR DESCRIPTION
#### Description
`AssetClassification` and `CompanyProfile` properties of `Fundamentals` objects were not being set. This information is used to pass fundamental data to the `Security` object.

#### Related Issue
Closes #3129 

#### Motivation and Context
`Security` objects should have the latest data and they didn't have the right values for `AssetClassification` and `CompanyProfile`.

#### How Has This Been Tested?
Logging the values of `Security.Fundamentals.AssetClassification` in a Universe Selection algorithm in QuantConnect cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`