### PR TITLE
Fix invalid currency pairs in G10CurrencySelectionModel

### DIFF
--- a/Algorithm.CSharp/G10CurrencySelectionModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/G10CurrencySelectionModelFrameworkAlgorithm.cs
@@ -75,8 +75,8 @@ namespace QuantConnect.Algorithm.CSharp
                 "NZDUSD",
                 "USDCAD",
                 "USDCHF",
-                "NOKUSD",
-                "SEKUSD"
+                "USDNOK",
+                "USDSEK"
                 }.Select(x => QuantConnect.Symbol.Create(x, SecurityType.Forex, Market.Oanda)))
             {
             }

--- a/Algorithm.Python/G10CurrencySelectionModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/G10CurrencySelectionModelFrameworkAlgorithm.py
@@ -71,5 +71,5 @@ class G10CurrencySelectionModelFrameworkAlgorithm(QCAlgorithm):
                                         "NZDUSD",
                                         "USDCAD",
                                         "USDCHF",
-                                        "NOKUSD",
-                                        "SEKUSD" ]])
+                                        "USDNOK",
+                                        "USDSEK" ]])


### PR DESCRIPTION

#### Description
In the `G10CurrencySelectionModel` the invalid `NOKUSD` and `SEKUSD` currency pairs have been replaced with the correct pairs: `USDNOK` and `USDSEK`.

#### Related Issue
Closes #3133 

#### Motivation and Context
Invalid symbols.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
The algorithm in #3087 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`