### PR TITLE
Adds Custom Data from US Energy Information Administration (eia.gov)

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -258,6 +258,7 @@
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.cs" />
     <Compile Include="UniverseSharingSecurityDifferentSubscriptionRequestRegressionAlgorithm.cs" />
     <Compile Include="UniverseSharingSubscriptionRequestRegressionAlgorithm.cs" />
+    <Compile Include="USEnergyInformationAdministrationAlgorithm.cs" />
     <Compile Include="UserDefinedUniverseAlgorithm.cs" />
     <Compile Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs" />
     <Compile Include="WarmupAlgorithm.cs" />

--- a/Algorithm.CSharp/USEnergyInformationAdministrationAlgorithm.cs
+++ b/Algorithm.CSharp/USEnergyInformationAdministrationAlgorithm.cs
@@ -49,10 +49,10 @@ namespace QuantConnect.Algorithm.CSharp
             // Set your Tiingo API Token here
             Tiingo.SetAuthCode("my-tiingo-api-token");
             // Set your US Energy Information Administration (EIA) Token here
-            EiaData.SetAuthCode("my-us-energy-information-api-token");
+            USEnergyInformation.SetAuthCode("my-us-energy-information-api-token");
 
             _tiingoSymbol = AddData<TiingoDailyData>(tiingoTicker, Resolution.Daily).Symbol;
-            _energySymbol = AddData<EiaData>(energyTicker).Symbol;
+            _energySymbol = AddData<USEnergyInformation>(energyTicker).Symbol;
 
             _emaFast = EMA(_tiingoSymbol, 5);
             _emaSlow = EMA(_tiingoSymbol, 10);
@@ -72,7 +72,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
 
             // Extract US EIA data from the slice
-            var energyData = slice.Get<EiaData>();
+            var energyData = slice.Get<USEnergyInformation>();
             foreach (var row in energyData.Values)
             {
                 Log($"{Time} - {row.Symbol.Value} - {row.Value} ");

--- a/Algorithm.CSharp/USEnergyInformationAdministrationAlgorithm.cs
+++ b/Algorithm.CSharp/USEnergyInformationAdministrationAlgorithm.cs
@@ -1,0 +1,92 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Data.Custom;
+using QuantConnect.Data.Custom.Tiingo;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This example algorithm shows how to import and use Tiingo daily prices data.
+    /// </summary>
+    /// <meta name="tag" content="strategy example" />
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="custom data" />
+    /// <meta name="tag" content="tiingo" />
+    public class USEnergyInformationAdministrationAlgorithm : QCAlgorithm
+    {
+        private const string tiingoTicker = "AAPL";
+        private const string energyTicker = "NUC_STATUS.OUT.US.D";  // US nuclear capacity outage (Daily)
+        private Symbol _tiingoSymbol;
+        private Symbol _energySymbol;
+
+        private ExponentialMovingAverage _emaFast;
+        private ExponentialMovingAverage _emaSlow;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2017, 1, 1);
+            SetEndDate(2017, 12, 31);
+            SetCash(100000);
+
+            // Set your Tiingo API Token here
+            Tiingo.SetAuthCode("my-tiingo-api-token");
+            // Set your US Energy Information Administration (EIA) Token here
+            EiaData.SetAuthCode("my-us-energy-information-api-token");
+
+            _tiingoSymbol = AddData<TiingoDailyData>(tiingoTicker, Resolution.Daily).Symbol;
+            _energySymbol = AddData<EiaData>(energyTicker).Symbol;
+
+            _emaFast = EMA(_tiingoSymbol, 5);
+            _emaSlow = EMA(_tiingoSymbol, 10);
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            // Extract Tiingo data from the slice
+            var tiingoData = slice.Get<TiingoDailyData>();
+            foreach (var row in tiingoData.Values)
+            {
+                Log($"{Time} - {row.Symbol.Value} - {row.Close} {row.Value} {row.Price} - EmaFast:{_emaFast} - EmaSlow:{_emaSlow}");
+            }
+
+            // Extract US EIA data from the slice
+            var energyData = slice.Get<EiaData>();
+            foreach (var row in energyData.Values)
+            {
+                Log($"{Time} - {row.Symbol.Value} - {row.Value} ");
+            }
+
+            // Simple EMA cross
+            if (!Portfolio.Invested && _emaFast > _emaSlow)
+            {
+                SetHoldings(_tiingoSymbol, 1);
+            }
+            else if (Portfolio.Invested && _emaFast < _emaSlow)
+            {
+                Liquidate(_tiingoSymbol);
+            }
+        }
+    }
+}

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -54,6 +54,7 @@
     <Content Include="Alphas\TripleLeverageETFPairVolatilityDecayAlpha.py" />
     <Content Include="Alphas\VIXDualThrustAlpha.py" />
     <Content Include="BasicSetAccountCurrencyAlgorithm.py" />
+    <Content Include="USEnergyInformationAdministrationAlgorithm.py" />
     <None Include="RawPricesUniverseRegressionAlgorithm.py" />
     <None Include="CapmAlphaRankingFrameworkAlgorithm.py" />
     <None Include="SmaCrossUniverseSelectionAlgorithm.py" />

--- a/Algorithm.Python/USEnergyInformationAdministrationAlgorithm.py
+++ b/Algorithm.Python/USEnergyInformationAdministrationAlgorithm.py
@@ -1,0 +1,73 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Data.Custom import EiaData
+from QuantConnect.Data.Custom.Tiingo import *
+
+### <summary>
+### This example algorithm shows how to import and use Tiingo daily prices data.
+### </summary>
+### <meta name="tag" content="strategy example" />
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="custom data" />
+### <meta name="tag" content="tiingo" />
+class USEnergyInformationAdministrationAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        # Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        self.SetStartDate(2017, 1, 1)
+        self.SetEndDate(2017, 12, 31)
+        self.SetCash(100000)
+
+        # Set your Tiingo API Token here
+        Tiingo.SetAuthCode("my-tiingo-api-token")
+        # Set your US Energy Information Administration (EIA) API Token here
+        EiaData.SetAuthCode("my-us-energy-information-api-token")
+
+
+        self.tiingoTicker = "AAPL"
+        self.energyTicker = "NUC_STATUS.OUT.US.D"
+        self.tiingoSymbol = self.AddData(TiingoDailyData, self.tiingoTicker, Resolution.Daily).Symbol
+        self.energySymbol = self.AddData(EiaData, self.energyTicker).Symbol
+
+
+        self.emaFast = self.EMA(self.tiingoSymbol, 5)
+        self.emaSlow = self.EMA(self.tiingoSymbol, 10)
+
+
+    def OnData(self, slice):
+        # OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+
+        if (not slice.ContainsKey(self.tiingoTicker)) or (not slice.ContainsKey(self.energyTicker)): return
+
+        # Extract Tiingo data from the slice
+        tiingoRow = slice[self.tiingoTicker]
+        energyRow = slice[self.energyTicker]
+
+        self.Log(f"{self.Time} - {tiingoRow.Symbol.Value} - {tiingoRow.Close} {tiingoRow.Value} {tiingoRow.Price} - EmaFast:{self.emaFast} - EmaSlow:{self.emaSlow}")
+        self.Log(f"{self.Time} - {energyRow.Symbol.Value} - {energyRow.Value}")
+
+        # Simple EMA cross
+        if not self.Portfolio.Invested and self.emaFast > self.emaSlow:
+            self.SetHoldings(self.tiingoSymbol, 1)
+
+        elif self.Portfolio.Invested and self.emaFast < self.emaSlow:
+            self.Liquidate(self.tiingoSymbol)

--- a/Algorithm.Python/USEnergyInformationAdministrationAlgorithm.py
+++ b/Algorithm.Python/USEnergyInformationAdministrationAlgorithm.py
@@ -19,7 +19,7 @@ AddReference("QuantConnect.Common")
 from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import *
-from QuantConnect.Data.Custom import EiaData
+from QuantConnect.Data.Custom import USEnergyInformation
 from QuantConnect.Data.Custom.Tiingo import *
 
 ### <summary>
@@ -40,13 +40,13 @@ class USEnergyInformationAdministrationAlgorithm(QCAlgorithm):
         # Set your Tiingo API Token here
         Tiingo.SetAuthCode("my-tiingo-api-token")
         # Set your US Energy Information Administration (EIA) API Token here
-        EiaData.SetAuthCode("my-us-energy-information-api-token")
+        USEnergyInformation.SetAuthCode("my-us-energy-information-api-token")
 
 
         self.tiingoTicker = "AAPL"
         self.energyTicker = "NUC_STATUS.OUT.US.D"
         self.tiingoSymbol = self.AddData(TiingoDailyData, self.tiingoTicker, Resolution.Daily).Symbol
-        self.energySymbol = self.AddData(EiaData, self.energyTicker).Symbol
+        self.energySymbol = self.AddData(USEnergyInformation, self.energyTicker).Symbol
 
 
         self.emaFast = self.EMA(self.tiingoSymbol, 5)

--- a/Common/Data/Custom/EiaData.cs
+++ b/Common/Data/Custom/EiaData.cs
@@ -1,0 +1,205 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Data;
+using System.Globalization;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Data.Custom
+{
+    /// <summary>
+    /// US Energy Information Association provides extensive data on energy usage, import, export,
+    /// and forecasting across all US energy sectors.
+    /// https://www.eia.gov/opendata/
+    /// </summary>
+
+    public class EiaData : BaseData
+    {
+        /// <summary>
+        /// Declare string representations of different periods and the variable
+        /// to hold our chosen date format
+        /// </summary>
+        private const string _hourly = "yyyyMMdd'T'HH'Z'";
+        private const string _daily = "yyyyMMdd";
+        private const string _monthly = "yyyyMM";
+        private const string _quarterly = "yyyyqq";
+        private const string _annual = "yyyy";
+        private string _dateFormatChosen;
+
+        /// <summary>
+        /// The end time of this data. Some data covers spans (trade bars) and as such we want
+        /// to know the entire time span covered
+        /// </summary>
+        public override DateTime EndTime
+        {
+            get { return Time + Period; }
+            set { Time = value - Period; }
+        }
+
+        /// <summary>
+        /// The period of this data (hour, month, quarter, or annual)
+        /// </summary>
+        public TimeSpan Period
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Gets the Eia API token.
+        /// </summary>
+        public static string AuthCode { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Returns true if the Tiingo API token has been set.
+        /// </summary>
+        public static bool IsAuthCodeSet { get; private set; }
+
+        /// <summary>
+        /// Sets the Tiingo API token.
+        /// </summary>
+        /// <param name="authCode">The Tiingo API token</param>
+        public static void SetAuthCode(string authCode)
+        {
+            if (string.IsNullOrWhiteSpace(authCode)) return;
+
+            AuthCode = authCode;
+            IsAuthCodeSet = true;
+        }
+
+        /// <summary>
+        /// Return the Subscription Data Source gained from the URL
+        /// </summary>
+        /// <param name="config">Configuration object</param>
+        /// <param name="date">Date of this source file</param>
+        /// <param name="isLiveMode">true if we're in live mode, false for backtesting mode</param>
+        /// <returns>Subscription Data Source.</returns>
+        public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+        {
+            var source = $"https://api.eia.gov/series/?api_key={EiaData.AuthCode}&series_id={config.Symbol}";
+            return new SubscriptionDataSource(source, SubscriptionTransportMedium.Rest, FileFormat.Collection);
+        }
+
+        /// <summary>
+        /// Takes the Series ID of the data and assigns the appropriate Period and string format of the date
+        /// </summary>
+        /// <param name="seriesId">The string appended at the end of URL to retrieve dataset</param>
+        /// <returns></returns>
+        private string GetFormat(string seriesId)
+        {
+            switch (seriesId.Last())
+            {
+                // Periods are closest approximation possible in days, except hourly
+                // Annual data has Period ~ 365 days
+                case 'A':
+                    Period = TimeSpan.FromDays(365);
+                    _dateFormatChosen = _annual;
+                    break;
+                // Quarterly data has Period ~ 90 days
+                case 'Q':
+                    Period = TimeSpan.FromDays(90);
+                    _dateFormatChosen = _quarterly;
+                    break;
+                // Monthly data has Period ~ 30 days
+                case 'M':
+                    Period = TimeSpan.FromDays(30);
+                    _dateFormatChosen = _monthly;
+                    break;
+                // Daily has Period = 1 day
+                case 'D':
+                    Period = TimeSpan.FromDays(1);
+                    _dateFormatChosen = _daily;
+                    break;
+                // Hourly has period = 1 Hour
+                case 'H':
+                    Period = TimeSpan.FromHours(1);
+                    _dateFormatChosen = _hourly;
+                    break;
+                default:
+                    throw new Exception("Unsupported Period");
+            }
+
+            return _dateFormatChosen;
+        }
+
+        /// <summary>
+        /// Special case handler for quarterly data (Series ID ends with Q1, Q2, etc)
+        /// </summary>
+        /// <param name="dateData">String containing raw date format</param>
+        /// <returns>
+        ///     Properly formatted datestring
+        /// </returns>
+        private string QuarterDateHandler(string dateData)
+        {
+            string dateString;
+            if (dateData.Contains("Q"))
+            {
+                switch (dateData.Last())
+                {
+                    case '1':
+                        dateString = dateData.Substring(0, 4) + "0331";
+                        break;
+                    case '2':
+                        dateString = dateData.Substring(0, 4) + "0630";
+                        break;
+                    case '3':
+                        dateString = dateData.Substring(0, 4) + "0930";
+                        break;
+                    case '4':
+                        dateString = dateData.Substring(0, 4) + "1231";
+                        break;
+                    default:
+                        throw (new Exception("invalid quarter input"));
+                }
+            }
+            else
+            {
+                dateString = dateData;
+            }
+            return dateString;
+        }
+
+        /// <summary>
+        ///     Reader converts each line of the data source into BaseData objects.
+        /// </summary>
+        /// <param name="config">Subscription data config setup object</param>
+        /// <param name="content">Content of the source document</param>
+        /// <param name="date">Date of the requested data</param>
+        /// <param name="isLiveMode">true if we're in live mode, false for backtesting mode</param>
+        /// <returns>
+        ///     Collection of BaseData objects
+        /// </returns>
+        public override BaseData Reader(SubscriptionDataConfig config, string content, DateTime date, bool isLiveMode)
+        {
+            var rawData = JObject.Parse(content)["series"][0]["data"];
+            var objectList = new List<EiaData>();
+            var format = GetFormat(config.Symbol.Value);
+
+            objectList = ((JArray)rawData).Select(element => new EiaData
+            {
+                Time = DateTime.ParseExact(QuarterDateHandler(element[0].ToString()), format, CultureInfo.InvariantCulture),
+                Value = Convert.ToDecimal(element[1]),
+                Period = Period,
+                Symbol = config.Symbol
+            }).OrderBy(element => element.Time).ToList();
+
+            return new BaseDataCollection(date, config.Symbol, objectList);
+        }
+    }
+}

--- a/Common/Data/Custom/EiaData.cs
+++ b/Common/Data/Custom/EiaData.cs
@@ -105,33 +105,26 @@ namespace QuantConnect.Data.Custom
                 // Annual data has Period ~ 365 days
                 case 'A':
                     Period = TimeSpan.FromDays(365);
-                    _dateFormatChosen = _annual;
-                    break;
+                    return _annual;
                 // Quarterly data has Period ~ 90 days
                 case 'Q':
                     Period = TimeSpan.FromDays(90);
-                    _dateFormatChosen = _quarterly;
-                    break;
+                    return _quarterly;
                 // Monthly data has Period ~ 30 days
                 case 'M':
                     Period = TimeSpan.FromDays(30);
-                    _dateFormatChosen = _monthly;
-                    break;
+                    return _monthly;
                 // Daily has Period = 1 day
                 case 'D':
                     Period = TimeSpan.FromDays(1);
-                    _dateFormatChosen = _daily;
-                    break;
+                    return _daily;
                 // Hourly has period = 1 Hour
                 case 'H':
                     Period = TimeSpan.FromHours(1);
-                    _dateFormatChosen = _hourly;
-                    break;
+                    return _hourly;
                 default:
                     throw new Exception("Unsupported Period");
             }
-
-            return _dateFormatChosen;
         }
 
         /// <summary>

--- a/Common/Data/Custom/EiaData.cs
+++ b/Common/Data/Custom/EiaData.cs
@@ -46,11 +46,7 @@ namespace QuantConnect.Data.Custom
         /// The end time of this data. Some data covers spans (trade bars) and as such we want
         /// to know the entire time span covered
         /// </summary>
-        public override DateTime EndTime
-        {
-            get { return Time + Period; }
-            set { Time = value - Period; }
-        }
+        public override DateTime EndTime => Time + Period;
 
         /// <summary>
         /// The period of this data (hour, month, quarter, or annual)
@@ -147,32 +143,23 @@ namespace QuantConnect.Data.Custom
         /// </returns>
         private string QuarterDateHandler(string dateData)
         {
-            string dateString;
             if (dateData.Contains("Q"))
             {
                 switch (dateData.Last())
                 {
                     case '1':
-                        dateString = dateData.Substring(0, 4) + "0331";
-                        break;
+                        return dateData.Substring(0, 4) + "0331";
                     case '2':
-                        dateString = dateData.Substring(0, 4) + "0630";
-                        break;
+                        return dateData.Substring(0, 4) + "0630";
                     case '3':
-                        dateString = dateData.Substring(0, 4) + "0930";
-                        break;
+                        return dateData.Substring(0, 4) + "0930";
                     case '4':
-                        dateString = dateData.Substring(0, 4) + "1231";
-                        break;
+                        return dateData.Substring(0, 4) + "1231";
                     default:
                         throw (new Exception("invalid quarter input"));
                 }
             }
-            else
-            {
-                dateString = dateData;
-            }
-            return dateString;
+            return dateData;
         }
 
         /// <summary>

--- a/Common/Data/Custom/EiaData.cs
+++ b/Common/Data/Custom/EiaData.cs
@@ -40,7 +40,6 @@ namespace QuantConnect.Data.Custom
         private const string _monthly = "yyyyMM";
         private const string _quarterly = "yyyyqq";
         private const string _annual = "yyyy";
-        private string _dateFormatChosen;
 
         /// <summary>
         /// The end time of this data. Some data covers spans (trade bars) and as such we want

--- a/Common/Data/Custom/USEnergyInformation.cs
+++ b/Common/Data/Custom/USEnergyInformation.cs
@@ -194,7 +194,7 @@ namespace QuantConnect.Data.Custom
             catch(Exception err)
             {
                 Logging.Log.Error($"Exception: {err}");
-                return new USEnergyInformation();
+                return null;
             }
         }
     }

--- a/Common/Data/Custom/USEnergyInformation.cs
+++ b/Common/Data/Custom/USEnergyInformation.cs
@@ -171,7 +171,7 @@ namespace QuantConnect.Data.Custom
                 var rawData = JObject.Parse(content)["series"][0]["data"];
                 var format = GetFormat(config.Symbol.Value);
 
-                var objectList = ((JArray)rawData).Select(element => new EiaData
+                var objectList = ((JArray)rawData).Select(element => new USEnergyInformation
                 {
                     Time = DateTime.ParseExact(QuarterDateHandler(element[0].ToString()), format, CultureInfo.InvariantCulture),
                     Value = Convert.ToDecimal(element[1]),
@@ -183,7 +183,7 @@ namespace QuantConnect.Data.Custom
             }
             catch
             {
-                return new EiaData();
+                return new USEnergyInformation();
             }
         }
     }

--- a/Common/Data/Custom/USEnergyInformation.cs
+++ b/Common/Data/Custom/USEnergyInformation.cs
@@ -142,11 +142,11 @@ namespace QuantConnect.Data.Custom
                     case '1':
                         return dateData.Substring(0, 4) + "0101";
                     case '2':
-                        return dateData.Substring(0, 4) + "0331";
+                        return dateData.Substring(0, 4) + "0401";
                     case '3':
                         return dateData.Substring(0, 4) + "0701";
                     case '4':
-                        return dateData.Substring(0, 4) + "0930";
+                        return dateData.Substring(0, 4) + "1001";
                     default:
                         throw (new Exception("invalid quarter input"));
                 }

--- a/Common/Data/Custom/USEnergyInformation.cs
+++ b/Common/Data/Custom/USEnergyInformation.cs
@@ -33,12 +33,12 @@ namespace QuantConnect.Data.Custom
         private DateTime _previousDate = DateTime.MinValue;
 
         /// <summary>
-        /// The time at the end of the period
+        /// Represents the date/time when the analysis period stops
         /// </summary>
-        public DateTime CloseTime { get; set; }
+        public DateTime EnergyDataPointCloseTime { get; set; }
 
         /// <summary>
-        /// The end time of this data.
+        /// Analysis period (see <see cref="EnergyDataPointCloseTime"/>) plus a delay to make the data lag emit times realistic
         /// </summary>
         public override DateTime EndTime { get; set; }
 
@@ -126,7 +126,7 @@ namespace QuantConnect.Data.Custom
                     {
                         Symbol = config.Symbol,
                         Time = closeTime - _period,
-                        CloseTime = closeTime,
+                        EnergyDataPointCloseTime = closeTime,
                         EndTime = closeTime + offset,
                         Value = (decimal)jToken[1]
                     }

--- a/Common/Data/Custom/USEnergyInformation.cs
+++ b/Common/Data/Custom/USEnergyInformation.cs
@@ -96,7 +96,7 @@ namespace QuantConnect.Data.Custom
             // Do not emit if the content did not change
             if (string.IsNullOrWhiteSpace(format) || _previousContent == content)
             {
-                return null;
+                return GetEmptyCollection(config.Symbol);
             }
             _previousContent = content;
 
@@ -109,7 +109,10 @@ namespace QuantConnect.Data.Custom
 
                 // Do not emit if the end of the series did not change
                 date = (DateTime)series["updated"];
-                if (_previousDate == date) return null;
+                if (_previousDate == date)
+                {
+                    return GetEmptyCollection(config.Symbol);
+                }
                 _previousDate = date;
 
                 var last = series.Value<string>("lastHistoricalPeriod") ?? series["end"];
@@ -133,8 +136,13 @@ namespace QuantConnect.Data.Custom
             }
             catch
             {
-                return null;
+                return GetEmptyCollection(config.Symbol);
             }
+        }
+
+        private BaseDataCollection GetEmptyCollection(Symbol symbol)
+        {
+            return new BaseDataCollection(_previousDate, symbol);
         }
 
         /// <summary>

--- a/Common/Data/Custom/USEnergyInformation.cs
+++ b/Common/Data/Custom/USEnergyInformation.cs
@@ -13,13 +13,11 @@
  * limitations under the License.
 */
 
-using System;
-using System.Linq;
-using System.Data;
-using System.Globalization;
 using Newtonsoft.Json.Linq;
-using System.Collections.Generic;
 using QuantConnect.Data.UniverseSelection;
+using System;
+using System.Globalization;
+using System.Linq;
 
 namespace QuantConnect.Data.Custom
 {
@@ -28,48 +26,34 @@ namespace QuantConnect.Data.Custom
     /// and forecasting across all US energy sectors.
     /// https://www.eia.gov/opendata/
     /// </summary>
-
     public class USEnergyInformation : BaseData
     {
-        /// <summary>
-        /// Declare string representations of different periods and the variable
-        /// to hold our chosen date format
-        /// </summary>
-        private const string _hourly = "yyyyMMdd'T'HH'Z'";
-        private const string _daily = "yyyyMMdd";
-        private const string _monthly = "yyyyMM";
-        private const string _quarterly = "yyyyMMdd";
-        private const string _annual = "yyyy";
+        private string _previousContent = string.Empty;
 
         /// <summary>
-        /// The end time of this data. Some data covers spans (trade bars) and as such we want
-        /// to know the entire time span covered
+        /// The end time of this data.
         /// </summary>
         public override DateTime EndTime => Time + Period;
 
         /// <summary>
         /// The period of this data (hour, month, quarter, or annual)
         /// </summary>
-        public TimeSpan Period
-        {
-            get;
-            private set;
-        }
+        public TimeSpan Period { get; private set; }
 
         /// <summary>
-        /// Gets the Eia API token.
+        /// Gets the EIA API token.
         /// </summary>
         public static string AuthCode { get; private set; } = string.Empty;
 
         /// <summary>
-        /// Returns true if the Tiingo API token has been set.
+        /// Returns true if the EIA API token has been set.
         /// </summary>
         public static bool IsAuthCodeSet { get; private set; }
 
         /// <summary>
-        /// Sets the Tiingo API token.
+        /// Sets the EIA API token.
         /// </summary>
-        /// <param name="authCode">The Tiingo API token</param>
+        /// <param name="authCode">The EIA API token</param>
         public static void SetAuthCode(string authCode)
         {
             if (string.IsNullOrWhiteSpace(authCode)) return;
@@ -87,8 +71,55 @@ namespace QuantConnect.Data.Custom
         /// <returns>Subscription Data Source.</returns>
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
-            var source = $"https://api.eia.gov/series/?api_key={USEnergyInformation.AuthCode}&series_id={config.Symbol}";
-            return new SubscriptionDataSource(source, SubscriptionTransportMedium.Rest, FileFormat.Collection);
+            return new SubscriptionDataSource(
+                $"https://api.eia.gov/series/?api_key={AuthCode}&series_id={config.Symbol}",
+                SubscriptionTransportMedium.Rest,
+                FileFormat.Collection);
+        }
+
+        /// <summary>
+        /// Reader converts each line of the data source into BaseData objects.
+        /// </summary>
+        /// <param name="config">Subscription data config setup object</param>
+        /// <param name="content">Content of the source document</param>
+        /// <param name="date">Date of the requested data</param>
+        /// <param name="isLiveMode">true if we're in live mode, false for backtesting mode</param>
+        /// <returns>
+        /// Collection of USEnergyInformation objects
+        /// </returns>
+        public override BaseData Reader(SubscriptionDataConfig config, string content, DateTime date, bool isLiveMode)
+        {
+            if (_previousContent == content)
+            {
+                return null;
+            }
+            _previousContent = content;
+
+            try
+            {
+                var format = GetFormat(config.Symbol.Value);
+                var series = JObject.Parse(content)["series"][0];
+                date = DateTimeConverter(series["end"], format);
+
+                var objectList = (
+                    from jToken in series["data"]
+                    where jToken[1].Type != JTokenType.Null
+                    select new USEnergyInformation
+                    {
+                        Symbol = config.Symbol,
+                        Period = Period,
+                        Value = (decimal)jToken[1],
+                        Time = DateTimeConverter(jToken[0], format)
+                            .ConvertFromUtc(config.DataTimeZone) - Period
+                    })
+                    .OrderBy(x => x.EndTime);
+
+                return new BaseDataCollection(date, config.Symbol, objectList);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         /// <summary>
@@ -104,98 +135,62 @@ namespace QuantConnect.Data.Custom
                 // Annual data has Period ~ 365 days
                 case 'A':
                     Period = TimeSpan.FromDays(365);
-                    return _annual;
+                    return "yyyy";
                 // Quarterly data has Period ~ 90 days
                 case 'Q':
                     Period = TimeSpan.FromDays(90);
-                    return _quarterly;
+                    return DateFormat.EightCharacter;
                 // Monthly data has Period ~ 30 days
                 case 'M':
                     Period = TimeSpan.FromDays(30);
-                    return _monthly;
+                    return DateFormat.YearMonth;
                 // Daily has Period = 1 day
                 case 'D':
                     Period = TimeSpan.FromDays(1);
-                    return _daily;
+                    return DateFormat.EightCharacter;
                 // Hourly has period = 1 Hour
                 case 'H':
                     Period = TimeSpan.FromHours(1);
-                    return _hourly;
+                    return "yyyyMMdd'T'HHZ";
                 default:
                     throw new Exception("Unsupported Period");
             }
         }
 
         /// <summary>
-        /// Special case handler for quarterly data (Series ID ends with Q1, Q2, etc)
+        /// Converts a <see cref="JToken"/> object containing raw date into a <see cref="DateTime"/> object.
+        /// Handles special case for quarterly data (Series ID ends with Q1, Q2, etc)
         /// </summary>
-        /// <param name="dateData">String containing raw date format</param>
+        /// <param name="jToken">The raw date</param>
+        /// <param name="format">The date format</param>
         /// <returns>
-        ///     Properly formatted datestring
+        /// <see cref="DateTime"/> corresponding to the <see cref="JToken"/>.
         /// </returns>
-        private string QuarterDateHandler(string dateData)
+        private DateTime DateTimeConverter(JToken jToken, string format)
         {
+            var dateData = jToken.ToString();
+
             if (dateData.Contains("Q"))
             {
                 switch (dateData.Last())
                 {
                     case '1':
-                        return dateData.Substring(0, 4) + "0101";
+                        dateData = dateData.Substring(0, 4) + "0101";
+                        break;
                     case '2':
-                        return dateData.Substring(0, 4) + "0401";
+                        dateData = dateData.Substring(0, 4) + "0401";
+                        break;
                     case '3':
-                        return dateData.Substring(0, 4) + "0701";
+                        dateData = dateData.Substring(0, 4) + "0701";
+                        break;
                     case '4':
-                        return dateData.Substring(0, 4) + "1001";
+                        dateData = dateData.Substring(0, 4) + "1001";
+                        break;
                     default:
                         throw (new Exception("invalid quarter input"));
                 }
             }
-            return dateData;
-        }
-
-        /// <summary>
-        ///     Reader converts each line of the data source into BaseData objects.
-        /// </summary>
-        /// <param name="config">Subscription data config setup object</param>
-        /// <param name="content">Content of the source document</param>
-        /// <param name="date">Date of the requested data</param>
-        /// <param name="isLiveMode">true if we're in live mode, false for backtesting mode</param>
-        /// <returns>
-        ///     Collection of BaseData objects
-        /// </returns>
-        public override BaseData Reader(SubscriptionDataConfig config, string content, DateTime date, bool isLiveMode)
-        {
-            try
-            {
-                var rawData = JObject.Parse(content)["series"][0]["data"];                
-                var format = GetFormat(config.Symbol.Value);
-                var objectList = new List<USEnergyInformation>();
-
-                foreach (var element in (JArray)rawData)
-                {
-                    decimal value;
-                    if (!Decimal.TryParse(element[1].ToString(), out value))
-                    {
-                        continue;
-                    }
-                    objectList.Add(new USEnergyInformation
-                    {
-                        Time = DateTime.ParseExact(QuarterDateHandler(element[0].ToString()), format, CultureInfo.InvariantCulture),
-                        Value = value,
-                        Period = Period,
-                        Symbol = config.Symbol
-                    });
-                }
-                objectList = objectList.OrderBy(element => element.Time).ToList();
-
-                return new BaseDataCollection(date, config.Symbol, objectList);
-            }
-            catch(Exception err)
-            {
-                Logging.Log.Error($"Exception: {err}");
-                return null;
-            }
+            return DateTime.ParseExact(dateData, format, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
         }
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -220,7 +220,6 @@
     <Compile Include="Data\Consolidators\CalendarType.cs" />
     <Compile Include="Data\Consolidators\FilteredIdentityDataConsolidator.cs" />
     <Compile Include="Data\Custom\USEnergyInformation.cs" />
-    <Compile Include="Data\Custom\EiaData.cs" />
     <Compile Include="Data\Fundamental\AssetClassificationHelper.cs" />
     <Compile Include="Data\HistoryProviderBase.cs" />
     <Compile Include="Data\HistoryProviderInitializeParameters.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -219,6 +219,7 @@
     <Compile Include="ChartPoint.cs" />
     <Compile Include="Data\Consolidators\CalendarType.cs" />
     <Compile Include="Data\Consolidators\FilteredIdentityDataConsolidator.cs" />
+    <Compile Include="Data\Custom\USEnergyInformation.cs" />
     <Compile Include="Data\Custom\EiaData.cs" />
     <Compile Include="Data\Fundamental\AssetClassificationHelper.cs" />
     <Compile Include="Data\HistoryProviderBase.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -219,6 +219,7 @@
     <Compile Include="ChartPoint.cs" />
     <Compile Include="Data\Consolidators\CalendarType.cs" />
     <Compile Include="Data\Consolidators\FilteredIdentityDataConsolidator.cs" />
+    <Compile Include="Data\Custom\EiaData.cs" />
     <Compile Include="Data\Fundamental\AssetClassificationHelper.cs" />
     <Compile Include="Data\HistoryProviderBase.cs" />
     <Compile Include="Data\HistoryProviderInitializeParameters.cs" />

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -210,10 +210,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         Tiingo.SetAuthCode(Config.Get("tiingo-auth-token"));
                     }
 
-                    if (!EiaData.IsAuthCodeSet)
+                    if (!USEnergyInformation.IsAuthCodeSet)
                     {
                         // we're not using the SubscriptionDataReader, so be sure to set the auth token here
-                        EiaData.SetAuthCode(Config.Get("us-energy-information-auth-token"));
+                        USEnergyInformation.SetAuthCode(Config.Get("us-energy-information-auth-token"));
                     }
 
                     var factory = new LiveCustomDataSubscriptionEnumeratorFactory(_timeProvider);

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -210,6 +210,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         Tiingo.SetAuthCode(Config.Get("tiingo-auth-token"));
                     }
 
+                    if (!EiaData.IsAuthCodeSet)
+                    {
+                        // we're not using the SubscriptionDataReader, so be sure to set the auth token here
+                        EiaData.SetAuthCode(Config.Get("us-energy-information-auth-token"));
+                    }
+
                     var factory = new LiveCustomDataSubscriptionEnumeratorFactory(_timeProvider);
                     var enumeratorStack = factory.CreateEnumerator(request, _dataProvider);
 

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -208,6 +208,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
             }
 
+            // If USEnergyInformation data, set the access token in data factory
+            var energyInformation = _dataFactory as USEnergyInformation;
+            if (energyInformation != null)
+            {
+                if (!USEnergyInformation.IsAuthCodeSet)
+                {
+                    USEnergyInformation.SetAuthCode(Config.Get("us-energy-information-auth-token"));
+                }
+            }
+
             _factorFile = new FactorFile(_config.Symbol.Value, new List<FactorFileRow>());
             _mapFile = new MapFile(_config.Symbol.Value, new List<MapFileRow>());
 

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -116,6 +116,10 @@
   // To get your access token go to https://www.tiingo.com
   "tiingo-auth-token": "",
 
+  // Required to access data from US Energy Information Administration
+  // To get your access token go to https://www.eia.gov/opendata
+  "us-energy-information-auth-token": "",
+
   // alpaca configuration
   // available trading mode: 'paper', 'live'
   "alpaca-key-id": "",


### PR DESCRIPTION
#### Description
Built new custom data class for US Energy Information Administration data. Accommodates hourly, daily, monthly, quarterly, and yearly resolutions.

#### Related Issue
Closes #3106 

#### Motivation and Context
Adds new custom data class to expand current custom data capabilities and add functionality for users.

#### Requires Documentation Change
Not likely, although updates to custom data documentation will be needed if deemed necessary. Additionally, documentation updates may be needed for Python indicators since it has been found that 
`self.EMA` returns the same as `self.EMA.Current.Value`, at least when formatted in logging. This will need further testing.

#### How Has This Been Tested?
Tested locally across numerous tickers and resolutions.
Tested in QuantConnect Cloud in backtesting and live mode.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`