### PR TITLE
Optimize backtest result json

### DIFF
--- a/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
+++ b/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
@@ -15,6 +15,7 @@
 
 using System;
 using Newtonsoft.Json;
+using QuantConnect.Util;
 
 namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
 {
@@ -97,12 +98,14 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
         /// See <see cref="Insight.Magnitude"/>
         /// </summary>
         [JsonProperty("magnitude", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public double? Magnitude { get; set; }
 
         /// <summary>
         /// See <see cref="Insight.Confidence"/>
         /// </summary>
         [JsonProperty("confidence", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public double? Confidence { get; set; }
 
         /// <summary>
@@ -115,18 +118,21 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
         /// See <see cref="InsightScore.Magnitude"/>
         /// </summary>
         [JsonProperty("score-magnitude", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public double ScoreMagnitude { get; set; }
 
         /// <summary>
         /// See <see cref="InsightScore.Direction"/>
         /// </summary>
         [JsonProperty("score-direction", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public double ScoreDirection { get; set; }
 
         /// <summary>
         /// See <see cref="Insight.EstimatedValue"/>
         /// </summary>
         [JsonProperty("estimated-value", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal EstimatedValue { get; set; }
 
         /// <summary>

--- a/Common/Chart.cs
+++ b/Common/Chart.cs
@@ -91,11 +91,12 @@ namespace QuantConnect
         /// <param name="unit">Unit for the series axis</param>
         /// <param name="color">Color of the series</param>
         /// <param name="symbol">Symbol for the marker in a scatter plot series</param>
+        /// <param name="forceAddNew">True will always add a new Series instance, stepping on existing if any</param>
         public Series TryAddAndGetSeries(string name, SeriesType type, int index, string unit,
-                                      Color color, ScatterMarkerSymbol symbol)
+                                      Color color, ScatterMarkerSymbol symbol, bool forceAddNew = false)
         {
             Series series;
-            if (!Series.TryGetValue(name, out series))
+            if (forceAddNew || !Series.TryGetValue(name, out series))
             {
                 series = new Series(name, type, index, unit)
                 {

--- a/Common/ChartPoint.cs
+++ b/Common/ChartPoint.cs
@@ -15,6 +15,7 @@
 
 using System;
 using Newtonsoft.Json;
+using QuantConnect.Util;
 
 namespace QuantConnect
 {
@@ -28,6 +29,7 @@ namespace QuantConnect
         public long x;
 
         /// Value of this chart point:  lower case for javascript encoding simplicty
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal y;
 
         /// <summary>

--- a/Common/ChartPoint.cs
+++ b/Common/ChartPoint.cs
@@ -15,7 +15,6 @@
 
 using System;
 using Newtonsoft.Json;
-using QuantConnect.Util;
 
 namespace QuantConnect
 {
@@ -29,7 +28,6 @@ namespace QuantConnect
         public long x;
 
         /// Value of this chart point:  lower case for javascript encoding simplicty
-        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal y;
 
         /// <summary>

--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 
@@ -76,16 +77,19 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Gets the utc time the last fill was received, or null if no fills have been received
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public DateTime? LastFillTime { get; internal set; }
 
         /// <summary>
         /// Gets the utc time this order was last updated, or null if the order has not been updated.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public DateTime? LastUpdateTime { get; internal set; }
 
         /// <summary>
         /// Gets the utc time this order was canceled, or null if the order was not canceled.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public DateTime? CanceledTime { get; internal set; }
 
         /// <summary>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -675,6 +675,7 @@
     <Compile Include="Util\FixedSizeQueue.cs" />
     <Compile Include="Util\FixedSizeHashQueue.cs" />
     <Compile Include="Util\FuncTextWriter.cs" />
+    <Compile Include="Util\JsonRoundingConverter.cs" />
     <Compile Include="Util\LeanData.cs" />
     <Compile Include="Util\LeanDataPathComponents.cs" />
     <Compile Include="Util\ListComparer.cs" />

--- a/Common/Statistics/PortfolioStatistics.cs
+++ b/Common/Statistics/PortfolioStatistics.cs
@@ -17,6 +17,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MathNet.Numerics.Statistics;
+using Newtonsoft.Json;
+using QuantConnect.Util;
 
 namespace QuantConnect.Statistics
 {
@@ -30,93 +32,110 @@ namespace QuantConnect.Statistics
         /// <summary>
         /// The average rate of return for winning trades
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageWinRate { get; set; }
 
         /// <summary>
         /// The average rate of return for losing trades
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageLossRate { get; set; }
 
         /// <summary>
         /// The ratio of the average win rate to the average loss rate
         /// </summary>
         /// <remarks>If the average loss rate is zero, ProfitLossRatio is set to 0</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal ProfitLossRatio { get; set; }
 
         /// <summary>
         /// The ratio of the number of winning trades to the total number of trades
         /// </summary>
         /// <remarks>If the total number of trades is zero, WinRate is set to zero</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal WinRate { get; set; }
 
         /// <summary>
         /// The ratio of the number of losing trades to the total number of trades
         /// </summary>
         /// <remarks>If the total number of trades is zero, LossRate is set to zero</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal LossRate { get; set; }
 
         /// <summary>
         /// The expected value of the rate of return
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal Expectancy { get; set; }
 
         /// <summary>
         /// Annual compounded returns statistic based on the final-starting capital and years.
         /// </summary>
         /// <remarks>Also known as Compound Annual Growth Rate (CAGR)</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal CompoundingAnnualReturn { get; set; }
 
         /// <summary>
         /// Drawdown maximum percentage.
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal Drawdown { get; set; }
 
         /// <summary>
         /// The total net profit percentage.
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal TotalNetProfit { get; set; }
 
         /// <summary>
         /// Sharpe ratio with respect to risk free rate: measures excess of return per unit of risk.
         /// </summary>
         /// <remarks>With risk defined as the algorithm's volatility</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal SharpeRatio { get; set; }
 
         /// <summary>
         /// Algorithm "Alpha" statistic - abnormal returns over the risk free rate and the relationshio (beta) with the benchmark returns.
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal Alpha { get; set; }
 
         /// <summary>
         /// Algorithm "beta" statistic - the covariance between the algorithm and benchmark performance, divided by benchmark's variance
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal Beta { get; set; }
 
         /// <summary>
         /// Annualized standard deviation
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AnnualStandardDeviation { get; set; }
 
         /// <summary>
         /// Annualized variance statistic calculation using the daily performance variance and trading days per year.
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AnnualVariance { get; set; }
 
         /// <summary>
         /// Information ratio - risk adjusted return
         /// </summary>
         /// <remarks>(risk = tracking error volatility, a volatility measures that considers the volatility of both algo and benchmark)</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal InformationRatio { get; set; }
 
         /// <summary>
         /// Tracking error volatility (TEV) statistic - a measure of how closely a portfolio follows the index to which it is benchmarked
         /// </summary>
         /// <remarks>If algo = benchmark, TEV = 0</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal TrackingError { get; set; }
 
         /// <summary>
         /// Treynor ratio statistic is a measurement of the returns earned in excess of that which could have been earned on an investment that has no diversifiable risk
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal TreynorRatio { get; set; }
 
 

--- a/Common/Statistics/TradeStatistics.cs
+++ b/Common/Statistics/TradeStatistics.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,8 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using QuantConnect.Util;
 
 namespace QuantConnect.Statistics
 {
@@ -51,41 +53,49 @@ namespace QuantConnect.Statistics
         /// <summary>
         /// The total profit/loss for all trades (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal TotalProfitLoss { get; set; }
 
         /// <summary>
         /// The total profit for all winning trades (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal TotalProfit { get; set; }
 
         /// <summary>
         /// The total loss for all losing trades (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal TotalLoss { get; set; }
 
         /// <summary>
         /// The largest profit in a single trade (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal LargestProfit { get; set; }
 
         /// <summary>
         /// The largest loss in a single trade (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal LargestLoss { get; set; }
 
         /// <summary>
         /// The average profit/loss (a.k.a. Expectancy or Average Trade) for all trades (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageProfitLoss { get; set; }
 
         /// <summary>
         /// The average profit for all winning trades (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageProfit { get; set; }
 
         /// <summary>
         /// The average loss for all winning trades (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageLoss { get; set; }
 
         /// <summary>
@@ -117,6 +127,7 @@ namespace QuantConnect.Statistics
         /// The ratio of the average profit per trade to the average loss per trade
         /// </summary>
         /// <remarks>If the average loss is zero, ProfitLossRatio is set to 0</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal ProfitLossRatio { get; set; }
 
         /// <summary>
@@ -124,61 +135,72 @@ namespace QuantConnect.Statistics
         /// </summary>
         /// <remarks>If the total number of trades is zero, WinLossRatio is set to zero</remarks>
         /// <remarks>If the number of losing trades is zero and the number of winning trades is nonzero, WinLossRatio is set to 10</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal WinLossRatio { get; set; }
 
         /// <summary>
         /// The ratio of the number of winning trades to the total number of trades
         /// </summary>
         /// <remarks>If the total number of trades is zero, WinRate is set to zero</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal WinRate { get; set; }
 
         /// <summary>
         /// The ratio of the number of losing trades to the total number of trades
         /// </summary>
         /// <remarks>If the total number of trades is zero, LossRate is set to zero</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal LossRate { get; set; }
 
         /// <summary>
         /// The average Maximum Adverse Excursion for all trades
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageMAE { get; set; }
 
         /// <summary>
         /// The average Maximum Favorable Excursion for all trades
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageMFE { get; set; }
 
         /// <summary>
         /// The largest Maximum Adverse Excursion in a single trade (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal LargestMAE { get; set; }
 
         /// <summary>
         /// The largest Maximum Favorable Excursion in a single trade (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal LargestMFE { get; set; }
 
         /// <summary>
         /// The maximum closed-trade drawdown for all trades (as symbol currency)
         /// </summary>
         /// <remarks>The calculation only takes into account the profit/loss of each trade</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal MaximumClosedTradeDrawdown { get; set; }
 
         /// <summary>
         /// The maximum intra-trade drawdown for all trades (as symbol currency)
         /// </summary>
         /// <remarks>The calculation takes into account MAE and MFE of each trade</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal MaximumIntraTradeDrawdown { get; set; }
 
         /// <summary>
         /// The standard deviation of the profits/losses for all trades (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal ProfitLossStandardDeviation { get; set; }
 
         /// <summary>
         /// The downside deviation of the profits/losses for all trades (as symbol currency)
         /// </summary>
         /// <remarks>This metric only considers deviations of losing trades</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal ProfitLossDownsideDeviation { get; set; }
 
         /// <summary>
@@ -186,16 +208,19 @@ namespace QuantConnect.Statistics
         /// </summary>
         /// <remarks>If the total profit is zero, ProfitFactor is set to zero</remarks>
         /// <remarks>if the total loss is zero and the total profit is nonzero, ProfitFactor is set to 10</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal ProfitFactor { get; set; }
 
         /// <summary>
         /// The ratio of the average profit/loss to the standard deviation
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal SharpeRatio { get; set; }
 
         /// <summary>
         /// The ratio of the average profit/loss to the downside deviation
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal SortinoRatio { get; set; }
 
         /// <summary>
@@ -203,16 +228,19 @@ namespace QuantConnect.Statistics
         /// </summary>
         /// <remarks>If the total profit/loss is zero, ProfitToMaxDrawdownRatio is set to zero</remarks>
         /// <remarks>if the drawdown is zero and the total profit is nonzero, ProfitToMaxDrawdownRatio is set to 10</remarks>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal ProfitToMaxDrawdownRatio { get; set; }
 
         /// <summary>
         /// The maximum amount of profit given back by a single trade before exit (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal MaximumEndTradeDrawdown { get; set; }
 
         /// <summary>
         /// The average amount of profit given back by all trades before exit (as symbol currency)
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageEndTradeDrawdown { get; set; }
 
         /// <summary>
@@ -223,6 +251,7 @@ namespace QuantConnect.Statistics
         /// <summary>
         /// The sum of fees for all trades
         /// </summary>
+        [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal TotalFees { get; set; }
 
         /// <summary>
@@ -266,10 +295,10 @@ namespace QuantConnect.Statistics
                     TotalProfitLoss += trade.ProfitLoss;
                     TotalProfit += trade.ProfitLoss;
                     AverageProfit += (trade.ProfitLoss - AverageProfit) / NumberOfWinningTrades;
-                    
+
                     AverageWinningTradeDuration += TimeSpan.FromSeconds((trade.Duration.TotalSeconds - AverageWinningTradeDuration.TotalSeconds) / NumberOfWinningTrades);
 
-                    if (trade.ProfitLoss > LargestProfit) 
+                    if (trade.ProfitLoss > LargestProfit)
                         LargestProfit = trade.ProfitLoss;
 
                     maxConsecutiveWinners++;
@@ -321,7 +350,7 @@ namespace QuantConnect.Statistics
 
                 var prevAverageProfitLoss = AverageProfitLoss;
                 AverageProfitLoss += (trade.ProfitLoss - AverageProfitLoss) / TotalNumberOfTrades;
-                
+
                 sumForVariance += (trade.ProfitLoss - prevAverageProfitLoss) * (trade.ProfitLoss - AverageProfitLoss);
                 var variance = TotalNumberOfTrades > 1 ? sumForVariance / (TotalNumberOfTrades - 1) : 0;
                 ProfitLossStandardDeviation = (decimal)Math.Sqrt((double)variance);
@@ -330,10 +359,10 @@ namespace QuantConnect.Statistics
                 AverageMAE += (trade.MAE - AverageMAE) / TotalNumberOfTrades;
                 AverageMFE += (trade.MFE - AverageMFE) / TotalNumberOfTrades;
 
-                if (trade.MAE < LargestMAE) 
+                if (trade.MAE < LargestMAE)
                     LargestMAE = trade.MAE;
 
-                if (trade.MFE > LargestMFE) 
+                if (trade.MFE > LargestMFE)
                     LargestMFE = trade.MFE;
 
                 if (trade.EndTradeDrawdown < MaximumEndTradeDrawdown)

--- a/Common/SymbolJsonConverter.cs
+++ b/Common/SymbolJsonConverter.cs
@@ -36,8 +36,6 @@ namespace QuantConnect
             if (ReferenceEquals(symbol, null)) return;
 
             writer.WriteStartObject();
-            writer.WritePropertyName("$type");
-            writer.WriteValue("QuantConnect.Symbol, QuantConnect.Common");
             writer.WritePropertyName("Value");
             writer.WriteValue(symbol.Value);
             writer.WritePropertyName("ID");

--- a/Common/Util/JsonRoundingConverter.cs
+++ b/Common/Util/JsonRoundingConverter.cs
@@ -1,0 +1,81 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using Newtonsoft.Json;
+
+namespace QuantConnect.Util
+{
+    /// <summary>
+    /// Helper <see cref="JsonConverter"/> that will round decimal and double types,
+    /// to <see cref="FractionalDigits"/> fractional digits
+    /// </summary>
+    public class JsonRoundingConverter : JsonConverter
+    {
+        /// <summary>
+        /// The number of fractional digits to round to
+        /// </summary>
+        public const int FractionalDigits = 4;
+
+        /// <summary>
+        /// Will always return false.
+        /// Gets a value indicating whether this <see cref="T:Newtonsoft.Json.JsonConverter" /> can read JSON.
+        /// </summary>
+        public override bool CanRead => false;
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>True if this instance can convert the specified object type</returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(decimal)
+                || objectType == typeof(double);
+        }
+
+        /// <summary>
+        /// Not implemented, will throw <see cref="NotImplementedException"/>
+        /// </summary>
+        /// <param name="reader">The <see cref="T:Newtonsoft.Json.JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value is double)
+            {
+                var rounded = Math.Round((double)value, FractionalDigits);
+                writer.WriteValue(rounded);
+            }
+            else
+            {
+                var rounded = Math.Round((decimal)value, FractionalDigits);
+                writer.WriteValue(rounded);
+            }
+        }
+    }
+}

--- a/Engine/Alphas/ChartingInsightManagerExtension.cs
+++ b/Engine/Alphas/ChartingInsightManagerExtension.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Algorithm.Framework.Alphas.Analysis;
 using QuantConnect.Interfaces;
@@ -29,6 +28,11 @@ namespace QuantConnect.Lean.Engine.Alphas
     /// </summary>
     public class ChartingInsightManagerExtension : IInsightManagerExtension
     {
+        /// <summary>
+        /// The string name used for the Alpha Assets chart
+        /// </summary>
+        public const string AlphaAssets = "Alpha Assets";
+
         private readonly bool _liveMode;
         private readonly StatisticsInsightManagerExtension _statisticsManager;
 
@@ -36,7 +40,7 @@ namespace QuantConnect.Lean.Engine.Alphas
         private DateTime _lastInsightCountSampleDateUtc;
         private DateTime _nextChartSampleAlgorithmTimeUtc;
 
-        private readonly Chart _totalInsightCountPerSymbolChart = new Chart("Alpha Assets");          // Heatmap chart
+        private readonly Chart _totalInsightCountPerSymbolChart = new Chart(AlphaAssets);          // Heatmap chart
         private readonly Series _totalInsightCountSeries = new Series("Count", SeriesType.Bar, "#");
 
         private int _dailyCount;

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -29,6 +29,7 @@ using QuantConnect.Packets;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
 using System.IO;
+using QuantConnect.Lean.Engine.Alphas;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Lean.Engine.Results
@@ -652,21 +653,24 @@ namespace QuantConnect.Lean.Engine.Results
                 foreach (var update in updates)
                 {
                     //Create the chart if it doesn't exist already:
-                    if (!Charts.ContainsKey(update.Name))
+                    Chart chart;
+                    if (!Charts.TryGetValue(update.Name, out chart))
                     {
-                        Charts.AddOrUpdate(update.Name, new Chart(update.Name));
+                        chart = new Chart(update.Name);
+                        Charts.AddOrUpdate(update.Name, chart);
                     }
+
+                    // for alpha assets chart, we always create a new series instance (step on previous value)
+                    var forceNewSeries = update.Name == ChartingInsightManagerExtension.AlphaAssets;
 
                     //Add these samples to this chart.
                     foreach (var series in update.Series.Values)
                     {
-                        //If we don't already have this record, its the first packet
-                        var chart = Charts[update.Name];
-
-                        var thisSeries = chart.TryAddAndGetSeries(series.Name, series.SeriesType, series.Index,
-                                                               series.Unit, series.Color, series.ScatterMarkerSymbol);
                         if (series.Values.Count > 0)
                         {
+                            var thisSeries = chart.TryAddAndGetSeries(series.Name, series.SeriesType, series.Index,
+                                series.Unit, series.Color, series.ScatterMarkerSymbol,
+                                forceNewSeries);
                             if (series.SeriesType == SeriesType.Pie)
                             {
                                 var dataPoint = series.ConsolidateChartPoints();
@@ -677,7 +681,7 @@ namespace QuantConnect.Lean.Engine.Results
                             }
                             else
                             {
-                                var values = chart.Series[series.Name].Values;
+                                var values = thisSeries.Values;
                                 if ((values.Count + series.Values.Count) <= _job.Controls.MaximumDataPointsPerChartSeries) // check chart data point limit first
                                 {
                                     //We already have this record, so just the new samples to the end:

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -64,6 +64,22 @@ namespace QuantConnect.Tests.Algorithm.Framework
         }
 
         [Test]
+        public void SerializationUsingJsonConvertTrimsEstimatedValue()
+        {
+            var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);
+            var insight = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2, "source-model");
+            insight.EstimatedValue = 0.00001m;
+            insight.Score.SetScore(InsightScoreType.Direction, 0.00001, DateTime.UtcNow);
+            insight.Score.SetScore(InsightScoreType.Magnitude, 0.00001, DateTime.UtcNow);
+            var serialized = JsonConvert.SerializeObject(insight);
+            var deserialized = JsonConvert.DeserializeObject<Insight>(serialized);
+
+            Assert.AreEqual(0, deserialized.EstimatedValue);
+            Assert.AreEqual(0, deserialized.Score.Direction);
+            Assert.AreEqual(0, deserialized.Score.Magnitude);
+        }
+
+        [Test]
         public void SurvivesRoundTripCopy()
         {
             var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- For the `Alpha Assets` chart, result handlers, will only store last data point
- Adding new `JsonRoundingConverter` that will round to 4 (number of
digits currently used for comparing alpha statistics) fractional
digits.
   - Will be used for `Insights` and result statistics (`TradeStatistics`, `PortfolioStatistics`)
- Json converter will ignore `Order` nullable properties
- Remove `type` field in `Symbol` json. Not used by the Json reader.
- Adding `try catch` for disposed Timer -> seen it happen during cloud backtesting
- Add default type value for the `TimeInForceJsonConverter`. Covered by existing unit tests.

`Backtest result json size for BasicTemplateFuturesAlgorithm`
`PR` 9439 KB
`Master` 12129 KB

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3149
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Allow the cloud and UI to process the result json faster
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression and cloud testing
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->