### PR TITLE
Fix LiveTradingDataFeed.CreateDataSubscription with multiple tick types

### DIFF
--- a/Tests/Engine/DataFeeds/AlgorithmStub.cs
+++ b/Tests/Engine/DataFeeds/AlgorithmStub.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             SubscriptionManager.SetDataManager(DataManager);
         }
 
-        public void AddSecurities(Resolution resolution = Resolution.Second, List<string> equities = null, List<string> forex = null)
+        public void AddSecurities(Resolution resolution = Resolution.Second, List<string> equities = null, List<string> forex = null, List<string> crypto = null)
         {
             foreach (var ticker in equities ?? new List<string>())
             {
@@ -58,6 +58,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 AddSecurity(SecurityType.Forex, ticker, resolution);
                 var symbol = SymbolCache.GetSymbol(ticker);
                 Securities[symbol].Exchange = new SecurityExchange(SecurityExchangeHours.AlwaysOpen(TimeZones.EasternStandard));
+            }
+            foreach (var ticker in crypto ?? new List<string>())
+            {
+                AddSecurity(SecurityType.Crypto, ticker, resolution);
+                var symbol = SymbolCache.GetSymbol(ticker);
+                Securities[symbol].Exchange = new SecurityExchange(SecurityExchangeHours.AlwaysOpen(TimeZones.Utc));
             }
         }
 

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -765,17 +765,55 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.IsFalse(unhandledExceptionWasThrown);
         }
 
+        [Test]
+        public void HandlesAllTickTypesAtTickResolution()
+        {
+            var symbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX);
+
+            var feed = RunDataFeed(
+                Resolution.Tick,
+                crypto: new List<string> { symbol.Value },
+                getNextTicksFunction: dqh => Enumerable.Range(0, 2)
+                    .Select(x => new Tick
+                    {
+                        Symbol = symbol,
+                        TickType = x % 2 == 0 ? TickType.Trade : TickType.Quote
+                    })
+                    .ToList());
+
+            var emittedData = false;
+            ConsumeBridge(feed, TimeSpan.FromSeconds(1), true, ts =>
+            {
+                if (ts.Slice.HasData)
+                {
+                    emittedData = true;
+                    foreach (var security in _algorithm.Securities.Values)
+                    {
+                        foreach (var config in security.Subscriptions)
+                        {
+                            Assert.IsTrue(ts.ConsolidatorUpdateData.Count == 2); // Trades + Quotes
+                            Assert.IsTrue(ts.ConsolidatorUpdateData.Select(x => x.Target).Contains(config));
+                            Assert.IsTrue(ts.ConsolidatorUpdateData.All(x => x.Data.Count > 0));
+                        }
+                    }
+                }
+            });
+
+            Assert.IsTrue(emittedData);
+        }
+
         private IDataFeed RunDataFeed(Resolution resolution = Resolution.Second,
                                     List<string> equities = null,
                                     List<string> forex = null,
+                                    List<string> crypto = null,
                                     Func<FuncDataQueueHandler, IEnumerable<BaseData>> getNextTicksFunction = null)
         {
             FuncDataQueueHandler dataQueueHandler;
-            return RunDataFeed(out dataQueueHandler, getNextTicksFunction, resolution, equities, forex);
+            return RunDataFeed(out dataQueueHandler, getNextTicksFunction, resolution, equities, forex, crypto);
         }
 
         private IDataFeed RunDataFeed(out FuncDataQueueHandler dataQueueHandler, Func<FuncDataQueueHandler, IEnumerable<BaseData>> getNextTicksFunction = null,
-            Resolution resolution = Resolution.Second, List<string> equities = null, List<string> forex = null)
+            Resolution resolution = Resolution.Second, List<string> equities = null, List<string> forex = null, List<string> crypto = null)
         {
             _algorithm.SetStartDate(_startDate);
 
@@ -816,9 +854,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 marketHoursDatabase,
                 true);
             _algorithm.SubscriptionManager.SetDataManager(_dataManager);
-            _algorithm.AddSecurities(resolution, equities, forex);
-            _synchronizer = new TestableLiveSynchronizer(_manualTimeProvider);
-            _synchronizer.Initialize(_algorithm, _dataManager);
+            _algorithm.AddSecurities(resolution, equities, forex, crypto);
+            _synchronizer = new TestableSynchronizer(_algorithm, _dataManager, true, _manualTimeProvider);
 
             feed.Initialize(_algorithm, job, resultHandler, mapFileProvider,
                 new LocalDiskFactorFileProvider(mapFileProvider), fileProvider, _dataManager, _synchronizer);

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -855,7 +855,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 true);
             _algorithm.SubscriptionManager.SetDataManager(_dataManager);
             _algorithm.AddSecurities(resolution, equities, forex, crypto);
-            _synchronizer = new TestableSynchronizer(_algorithm, _dataManager, true, _manualTimeProvider);
+            _synchronizer = new TestableLiveSynchronizer(_manualTimeProvider);
+            _synchronizer.Initialize(_algorithm, _dataManager);
 
             feed.Initialize(_algorithm, job, resultHandler, mapFileProvider,
                 new LocalDiskFactorFileProvider(mapFileProvider), fileProvider, _dataManager, _synchronizer);


### PR DESCRIPTION

#### Description
The `LiveTradingDataFeed.CreateDataSubscription` method has been updated to handle multiple tick types properly, with subscriptions at `Resolution.Tick`.
Only `Crypto`, `Future` and `Option` security types were affected by this bug.

#### Related Issue
Closes #3163 

#### Motivation and Context
`TickConsolidator` was not receiving ticks with `TickType.Trade` in live mode.
The reason was that the exchange data handlers were being overwritten (the subscription for the last tick type was the only one receiving ticks, previously added enumerators were created but not used).

#### Requires Documentation Change
No.

#### How Has This Been Tested?
The test algorithm included in #3163 was tested both locally and in the cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->