### PR TITLE
Fix Launcher project rebuilding with no changes

### DIFF
--- a/Launcher/QuantConnect.Lean.Launcher.csproj
+++ b/Launcher/QuantConnect.Lean.Launcher.csproj
@@ -142,7 +142,7 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="Python.Runtime.dll.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION

#### Description
The `CopyToOutputDirectory` build setting for `Python.Runtime.dll.config` has been changes from 
`Always` to `PreserveNewest`.

#### Motivation and Context
The unnecessary build of Lean Launcher project with no changes.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local build.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`