### PR TITLE
Remove IBController from Lean Foundation Dockerfile

### DIFF
--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -36,12 +36,6 @@ RUN wget http://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-lin
     wget -O ~/Jts/jts.ini http://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64-v974.4g.jts.ini && \
     rm ibgateway-latest-standalone-linux-x64-v974.4g.sh
 
-# Install IB Controller: Installs to ~/IBController
-RUN wget http://cdn.quantconnect.com/interactive/IBController-QuantConnect-3.2.0.5.zip && \
-    unzip IBController-QuantConnect-3.2.0.5.zip -d ~/IBController && \
-    chmod -R 777 ~/IBController && \
-    rm IBController-QuantConnect-3.2.0.5.zip
-
 # Mono C# for LEAN:
 # From https://github.com/mono/docker/blob/master/
 RUN apt-get update && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION

#### Description
The installation steps for IBController have been removed from the Lean Foundation Dockerfile.

Note: requires #3175 to be merged first

#### Related Issue
Closes #3187 

#### Motivation and Context
Remove unnecessary files from Lean Foundation docker image.

#### Requires Documentation Change
No.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->