### PR TITLE
Add Suspicious Tick Filtering in LiveTradingDataFeed

### DIFF
--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -254,7 +254,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             {
                                 var tick = data as Tick;
 
-                                if (tick.TickType == TickType.Quote)
+                                if (tick?.TickType == TickType.Quote && !tick.Suspicious)
                                 {
                                     quoteBarAggregator.ProcessData(tick);
 
@@ -290,7 +290,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                 else
                                 {
                                     var tick = data as Tick;
-                                    if (tick.TickType == TickType.Trade)
+                                    if (tick?.TickType == TickType.Trade && !tick.Suspicious)
                                     {
                                         tradeBarAggregator.ProcessData(tick);
 
@@ -320,7 +320,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             {
                                 var tick = data as Tick;
 
-                                if (tick.TickType == TickType.OpenInterest)
+                                if (tick?.TickType == TickType.OpenInterest && !tick.Suspicious)
                                 {
                                     oiAggregator.ProcessData(tick);
                                 }

--- a/Engine/DataFeeds/TimeSliceFactory.cs
+++ b/Engine/DataFeeds/TimeSliceFactory.cs
@@ -140,6 +140,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // don't add internal feed data to ticks/bars objects
                     if (baseData.DataType != MarketDataType.Auxiliary)
                     {
+                        var tick = baseData as Tick;
+
                         if (!packet.Configuration.IsInternalFeed)
                         {
                             PopulateDataDictionaries(baseData, ticks, tradeBars, quoteBars, optionChains, futuresChains);
@@ -171,12 +173,15 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             }
 
                             // this is data used to update consolidators
-                            consolidatorUpdate.Add(baseData);
+                            // do not add it if it is a Suspicious tick
+                            if (tick == null || !tick.Suspicious)
+                            {
+                                consolidatorUpdate.Add(baseData);
+                            }
                         }
 
                         // this is the data used set market prices
                         // do not add it if it is a Suspicious tick
-                        var tick = baseData as Tick;
                         if (tick != null && tick.Suspicious) continue;
 
                         securityUpdate.Add(baseData);


### PR DESCRIPTION
#### Description
- In the `LiveTradingDataFeed` data handlers, suspicious ticks are now filtered and not included in bar aggregation

**Note**: when using `Tick` resolution, ticks will never be filtered for the algorithm, but they will be excluded from consolidator update data (when creating `TimeSlice` objects)

#### Related Issue
Closes #3190 

#### Motivation and Context
Invalid ticks were causing equity jumps in Live trading.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests included

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`