### PR TITLE
Fix failing LiveTradingDataFeed unit tests

### DIFF
--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -324,10 +324,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         [Test]
         public void Unsubscribes()
         {
-            var customMockedFileBaseData = SymbolCache.GetSymbol("CustomMockedFileBaseData");
             FuncDataQueueHandler dataQueueHandler;
             var feed = RunDataFeed(out dataQueueHandler, equities: new List<string> { "SPY" }, forex: new List<string> { "EURUSD" });
             _algorithm.AddData<CustomMockedFileBaseData>("CustomMockedFileBaseData");
+            var customMockedFileBaseData = SymbolCache.GetSymbol("CustomMockedFileBaseData");
 
             var emittedData = false;
             var currentSubscriptionCount = 0;
@@ -359,10 +359,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         {
             _algorithm.SetFinishedWarmingUp();
             _algorithm.Transactions.SetOrderProcessor(new FakeOrderProcessor());
-            var customMockedFileBaseData = SymbolCache.GetSymbol("CustomMockedFileBaseData");
             FuncDataQueueHandler dataQueueHandler;
             var feed = RunDataFeed(out dataQueueHandler, equities: new List<string> { "SPY" }, forex: new List<string> { "EURUSD" });
             _algorithm.AddData<CustomMockedFileBaseData>("CustomMockedFileBaseData");
+            var customMockedFileBaseData = SymbolCache.GetSymbol("CustomMockedFileBaseData");
 
             var emittedData = false;
             var currentSubscriptionCount = 0;
@@ -466,12 +466,15 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 stopwatch.Stop();
                 if (ts.Slice.Count == 0) return;
 
-                emittedData = true;
+                Assert.AreEqual(100, ts.Slice.Count);
+
                 count++;
-                // make sure within 2 seconds
+                emittedData = true;
+
+                // make sure within 3 seconds
                 var delta = DateTime.Now.Subtract(previousTime);
                 previousTime = DateTime.Now;
-                Assert.IsTrue(delta <= TimeSpan.FromSeconds(2), delta.ToString());
+                Assert.IsTrue(delta <= TimeSpan.FromSeconds(3), delta.ToString());
                 ConsoleWriteLine("TimeProvider now: " + _manualTimeProvider.GetUtcNow() + " Count: "
                                   + ts.Slice.Count + ". Delta (ms): "
                                   + ((decimal)delta.TotalMilliseconds).SmartRounding() + Environment.NewLine);
@@ -480,7 +483,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Console.WriteLine("Count: " + count);
             Console.WriteLine("Spool up time: " + stopwatch.Elapsed);
 
-            Assert.That(count, Is.GreaterThan(5));
             Assert.IsTrue(emittedData);
         }
 
@@ -488,10 +490,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void HandlesRestApi()
         {
             var resolution = Resolution.Second;
-            var symbol = SymbolCache.GetSymbol("RestApi");
             FuncDataQueueHandler dqgh;
             var feed = RunDataFeed(out dqgh);
             _algorithm.AddData<RestApiBaseData>("RestApi", resolution);
+            var symbol = SymbolCache.GetSymbol("RestApi");
 
             var count = 0;
             var receivedData = false;


### PR DESCRIPTION

#### Description
- In some tests `SymbolCache.GetSymbol` was being called before `AddData`, throwing an exception when launched as single tests.
- `HandlesManyCustomDataSubscriptions` was failing both locally and in Travis (only occasionally). This behavior started since #3040 was merged (`LiveSynchronizer` is now using a 500ms timeout for the reset event) and the asserts have been updated to reflect this.

#### Related Issue
Closes #3181 

#### Motivation and Context
Failing unit tests

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`