### PR TITLE
Fix null data catch in IEXDataQueueHandler

### DIFF
--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -423,7 +423,7 @@ namespace QuantConnect.ToolBox.IEX
 
                     Interlocked.Increment(ref _dataPointCount);
 
-                    if (item["open"] == null)
+                    if (item["open"].Type == JTokenType.Null)
                     {
                         continue;
                     }


### PR DESCRIPTION
Fixes the previous check for null data, which failed to catch null open prices.
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The previous check
```
if (item["open"] == null)
```
failed to catch null data. The data type was JToken.Null and it wasn't being caught, so there were errors being thrown for data downloads with missing data. Current check
```
if (item["open"].Type == JTokenType.Null)
```
catches these data points and skips over them.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Using the IEX Data Downloader for some downloads threw errors and failed to download.
```
System.InvalidCastException: Null object cannot be converted to a value type.
   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at Newtonsoft.Json.Linq.Extensions.Convert[T,U](T token)
   at Newtonsoft.Json.Linq.Extensions.Value[T,U](IEnumerable`1 value)
   at Newtonsoft.Json.Linq.Extensions.Value[U](IEnumerable`1 value)
   at QuantConnect.ToolBox.IEX.IEXDataQueueHandler.<ProcessHistoryRequests>d__30.MoveNext() in C:\Users\Jack Simonson\QuantConnect\Lean\ToolBox\IEX\IEXDataQueueHandler.cs:line 430
   at QuantConnect.ToolBox.IEX.IEXDataQueueHandler.<GetHistory>d__29.MoveNext() in C:\Users\Jack Simonson\QuantConnect\Lean\ToolBox\IEX\IEXDataQueueHandler.cs:line 329
   at QuantConnect.ToolBox.IEX.IEXDataDownloader.<Get>d__3.MoveNext() in C:\Users\Jack Simonson\QuantConnect\Lean\ToolBox\IEX\IEXDataDownloader.cs:line 72
   at QuantConnect.ToolBox.LeanDataWriter.WriteMinuteOrSecondOrTick(IEnumerable`1 source) in C:\Users\Jack Simonson\QuantConnect\Lean\ToolBox\LeanDataWriter.cs:line 102
   at QuantConnect.ToolBox.LeanDataWriter.Write(IEnumerable`1 source) in C:\Users\Jack Simonson\QuantConnect\Lean\ToolBox\LeanDataWriter.cs:line 85
   at QuantConnect.ToolBox.IEX.IEXDownloaderProgram.IEXDownloader(IList`1 tickers, String resolution, DateTime fromDate, DateTime toDate) in C:\Users\Jack Simonson\QuantConnect\Lean\ToolBox\IEX\IEXDownloaderProgram.cs:line 65
```

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the code line below with current code and with changes. No errors were thrown with the changes.
```
QuantConnect.ToolBox.exe --app=IEXDownloader --tickers=NFLX --resolution=Minute --from-date=20190422-09:30:00 --to-date=20190424-13:45:00
```
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->