### PR TITLE
Extends NormalizedAverageTrueRange and TrueRange Indicators With IIndicatorWarmUpPeriodProvider

### DIFF
--- a/Indicators/NormalizedAverageTrueRange.cs
+++ b/Indicators/NormalizedAverageTrueRange.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ namespace QuantConnect.Indicators
     /// The Normalized Average True Range is calculated with the following formula:
     /// NATR = (ATR(period) / Close) * 100
     /// </summary>
-    public class NormalizedAverageTrueRange : BarIndicator
+    public class NormalizedAverageTrueRange : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly int _period;
         private readonly TrueRange _tr;
@@ -47,17 +47,19 @@ namespace QuantConnect.Indicators
         /// </summary> 
         /// <param name="period">The period of the NATR</param>
         public NormalizedAverageTrueRange(int period)
-            : this("NATR" + period, period)
+            : this($"NATR({period})", period)
         {
         }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples > _period; }
-        }
+        public override bool IsReady => Samples > _period;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => _period + 1;
 
         /// <summary>
         /// Computes the next value of this indicator from the given state

--- a/Indicators/TrueRange.cs
+++ b/Indicators/TrueRange.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,19 +19,27 @@ using QuantConnect.Data.Market;
 namespace QuantConnect.Indicators
 {
     /// <summary>
-    /// This indicator computes the True Range (TR). 
-    /// The True Range is the greatest of the following values: 
+    /// This indicator computes the True Range (TR).
+    /// The True Range is the greatest of the following values:
     /// value1 = distance from today's high to today's low.
     /// value2 = distance from yesterday's close to today's high.
-    /// value3 = distance from yesterday's close to today's low.    
+    /// value3 = distance from yesterday's close to today's low.
     /// </summary>
-    public class TrueRange : BarIndicator
+    public class TrueRange : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private IBaseDataBar _previousInput;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TrueRange"/> class using the specified name.
-        /// </summary> 
+        /// </summary>
+        public TrueRange()
+            : base("TR")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrueRange"/> class using the specified name.
+        /// </summary>
         /// <param name="name">The name of this indicator</param>
         public TrueRange(string name)
             : base(name)
@@ -41,10 +49,12 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples > 1; }
-        }
+        public override bool IsReady => Samples > 1;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => 2;
 
         /// <summary>
         /// Computes the next value of this indicator from the given state

--- a/Tests/Indicators/NormalizedAverageTrueRangeTests.cs
+++ b/Tests/Indicators/NormalizedAverageTrueRangeTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,42 +14,21 @@
 */
 
 using NUnit.Framework;
+using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class NormalizedAverageTrueRangeTests
+    public class NormalizedAverageTrueRangeTests : CommonIndicatorTests<IBaseDataBar>
     {
-        [Test]
-        public void ComparesAgainstExternalData()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
-            var indicator = new NormalizedAverageTrueRange(5);
-
-            RunTestIndicator(indicator);
+            return new NormalizedAverageTrueRange(5);
         }
 
-        [Test]
-        public void ComparesAgainstExternalDataAfterReset()
-        {
-            var indicator = new NormalizedAverageTrueRange(5);
+        protected override string TestFileName => "spy_natr.txt";
 
-            RunTestIndicator(indicator);
-            indicator.Reset();
-            RunTestIndicator(indicator);
-        }
-
-        [Test]
-        public void ResetsProperly()
-        {
-            var indicator = new NormalizedAverageTrueRange(5);
-
-            TestHelper.TestIndicatorReset(indicator, "spy_natr.txt");
-        }
-
-        private static void RunTestIndicator(BarIndicator indicator)
-        {
-            TestHelper.TestIndicator(indicator, "spy_natr.txt", "NATR_5", (ind, expected) => Assert.AreEqual(expected, (double)ind.Current.Value, 1e-3));
-        }
+        protected override string TestColumnName => "NATR_5";
     }
 }

--- a/Tests/Indicators/TrueRangeTests.cs
+++ b/Tests/Indicators/TrueRangeTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,17 +24,11 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
-            return new TrueRange("TR");
+            return new TrueRange();
         }
 
-        protected override string TestFileName
-        {
-            get { return "spy_tr.txt"; }
-        }
+        protected override string TestFileName => "spy_tr.txt";
 
-        protected override string TestColumnName
-        {
-            get { return "TR"; }
-        }
+        protected override string TestColumnName => "TR";
     }
 }


### PR DESCRIPTION
#### Description
Extends `NormalizedAverageTrueRange` and `TrueRange` indicators with `IIndicatorWarmUpPeriodProvider`.

#### Related Issue
#3074 

#### Motivation and Context
See #3074 

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`