### PR TITLE
Extends Sum, StandardDeviation and Variance Indicators With IIndicatorWarmUpPeriodProvider

### DIFF
--- a/Indicators/StandardDeviation.cs
+++ b/Indicators/StandardDeviation.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,35 +24,27 @@ namespace QuantConnect.Indicators
     {
         /// <summary>
         /// Initializes a new instance of the StandardDeviation class with the specified period.
-        /// 
-        /// Evaluates the standard deviation of samples in the lookback period. 
-        /// On a dataset of size N will use an N normalizer and would thus be biased if applied to a subset.
+        ///
+        /// Evaluates the standard deviation of samples in the look-back period. 
+        /// On a data set of size N will use an N normalizer and would thus be biased if applied to a subset.
         /// </summary>
         /// <param name="period">The sample size of the standard deviation</param>
         public StandardDeviation(int period)
-            : this("STD" + period, period)
+            : this($"STD({period})", period)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the StandardDeviation class with the specified name and period.
         /// 
-        /// Evaluates the standard deviation of samples in the lookback period. 
-        /// On a dataset of size N will use an N normalizer and would thus be biased if applied to a subset.
+        /// Evaluates the standard deviation of samples in the look-back period.
+        /// On a data set of size N will use an N normalizer and would thus be biased if applied to a subset.
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The sample size of the standard deviation</param>
         public StandardDeviation(string name, int period)
             : base(name, period)
         {
-        }
-
-        /// <summary>
-        /// Gets a flag indicating when this indicator is ready and fully initialized
-        /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples >= Period; }
         }
 
         /// <summary>
@@ -63,7 +55,7 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
-            return (decimal)Math.Sqrt((double)base.ComputeNextValue(window, input));
+            return (decimal) Math.Sqrt((double) base.ComputeNextValue(window, input));
         }
     }
 }

--- a/Indicators/Sum.cs
+++ b/Indicators/Sum.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,32 +13,34 @@
  * limitations under the License.
 */
 
-
-namespace QuantConnect.Indicators {
+namespace QuantConnect.Indicators
+{
     /// <summary>
-    /// Represents an indictor capable of tracking the sum for the given period
+    /// Represents an indicator capable of tracking the sum for the given period
     /// </summary>
-    public class Sum : WindowIndicator<IndicatorDataPoint> {
-        /// <summary>The sum for the given period</summary>
+    public class Sum : WindowIndicator<IndicatorDataPoint>, IIndicatorWarmUpPeriodProvider
+    {
+        /// <summary>
+        /// The sum for the given period
+        /// </summary>
         private decimal _sum;
 
         /// <summary>
-        ///     Gets a flag indicating when this indicator is ready and fully initialized
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
         /// </summary>
-        public override bool IsReady {
-            get { return Samples >= Period; }
-        }
+        public int WarmUpPeriod => Period;
 
         /// <summary>
         /// Resets this indicator to its initial state
         /// </summary>
-        public override void Reset() {
+        public override void Reset()
+        {
             _sum = 0.0m;
             base.Reset();
         }
 
         /// <summary>
-        ///     Initializes a new instance of the Sum class with the specified name and period
+        /// Initializes a new instance of the Sum class with the specified name and period
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The period of the SMA</param>
@@ -48,23 +50,25 @@ namespace QuantConnect.Indicators {
         }
 
         /// <summary>
-        ///     Initializes a new instance of the Sum class with the default name and period
+        /// Initializes a new instance of the Sum class with the default name and period
         /// </summary>
         /// <param name="period">The period of the SMA</param>
         public Sum(int period)
-            : this("SUM" + period, period)
+            : this($"SUM({period})", period)
         {
         }
 
         /// <summary>
-        ///     Computes the next value for this indicator from the given state.
+        /// Computes the next value for this indicator from the given state.
         /// </summary>
         /// <param name="window">The window of data held in this indicator</param>
         /// <param name="input">The input value to this indicator on this time step</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input) {
+        protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
+        {
             _sum += input.Value;
-            if (window.Samples > window.Size) {
+            if (window.Samples > window.Size)
+            {
                 _sum -= window.MostRecentlyRemoved.Value;
             }
             return _sum;

--- a/Indicators/Variance.cs
+++ b/Indicators/Variance.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,12 +13,14 @@
  * limitations under the License.
 */
 
+using System;
+
 namespace QuantConnect.Indicators
 {
     /// <summary>
     /// This indicator computes the n-period population variance.
     /// </summary>
-    public class Variance : WindowIndicator<IndicatorDataPoint>
+    public class Variance : WindowIndicator<IndicatorDataPoint>, IIndicatorWarmUpPeriodProvider
     {
         private decimal _rollingSum;
         private decimal _rollingSumOfSquares;
@@ -28,7 +30,7 @@ namespace QuantConnect.Indicators
         /// </summary> 
         /// <param name="period">The period of the indicator</param>
         public Variance(int period)
-            : this("VAR" + period, period)
+            : this($"VAR({period})", period)
         {
         }
 
@@ -43,12 +45,9 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        /// Gets a flag indicating when this indicator is ready and fully initialized
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
         /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples >= Period; }
-        }
+        public int WarmUpPeriod => Period;
 
         /// <summary>
         /// Computes the next value of this indicator from the given state
@@ -64,10 +63,7 @@ namespace QuantConnect.Indicators
             if (Samples < 2)
                 return 0m;
 
-            var n = Period;
-            if (Samples < n)
-                n = (int)Samples;
-
+            var n = Math.Min(Period, Samples);
             var meanValue1 = _rollingSum / n;
             var meanValue2 = _rollingSumOfSquares / n;
 
@@ -79,7 +75,7 @@ namespace QuantConnect.Indicators
             }
 
             // Ensure non-negative variance
-            return System.Math.Max(0m, meanValue2 - meanValue1 * meanValue1);
+            return Math.Max(0m, meanValue2 - meanValue1 * meanValue1);
         }
 
         /// <summary>

--- a/Tests/Indicators/StandardDeviationTests.cs
+++ b/Tests/Indicators/StandardDeviationTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -64,19 +64,12 @@ namespace QuantConnect.Tests.Indicators
             return new StandardDeviation(10);
         }
 
-        protected override string TestFileName
-        {
-            get { return "spy_var.txt"; }
-        }
+        protected override string TestFileName => "spy_var.txt";
 
-        protected override string TestColumnName
-        {
-            get { return "Var"; }
-        }
+        protected override string TestColumnName => "Var";
 
-        protected override Action<IndicatorBase<IndicatorDataPoint>, double> Assertion
-        {
-            get { return (indicator, expected) => Assert.AreEqual(Math.Sqrt(expected), (double)indicator.Current.Value, 1e-6); }
-        }
+        protected override Action<IndicatorBase<IndicatorDataPoint>, double> Assertion =>
+            (indicator, expected) =>
+                Assert.AreEqual(Math.Sqrt(expected), (double) indicator.Current.Value, 1e-6);
     }
 }

--- a/Tests/Indicators/SumTests.cs
+++ b/Tests/Indicators/SumTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +17,14 @@ using System;
 using NUnit.Framework;
 using QuantConnect.Indicators;
 
-namespace QuantConnect.Tests.Indicators {
-
+namespace QuantConnect.Tests.Indicators
+{
     [TestFixture]
-    public class SumTests {
-
+    public class SumTests
+    {
         [Test]
-        public void ComputesCorrectly() {
+        public void ComputesCorrectly()
+        {
             var sum = new Sum(2);
             var time = DateTime.UtcNow;
 
@@ -35,7 +36,8 @@ namespace QuantConnect.Tests.Indicators {
         }
 
         [Test]
-        public void ResetsCorrectly() {
+        public void ResetsCorrectly()
+        {
             var sum = new Sum(2);
             var time = DateTime.UtcNow;
 
@@ -51,6 +53,20 @@ namespace QuantConnect.Tests.Indicators {
             Assert.AreEqual(sum.Current.Value, 0m);
             sum.Update(time.AddDays(1), 1);
             Assert.AreEqual(sum.Current.Value, 1m);
+        }
+
+        [Test]
+        public void WarmsUpProperly()
+        {
+            var indicator = new Sum(2);
+            var time = DateTime.UtcNow;
+            var period = ((IIndicatorWarmUpPeriodProvider)indicator).WarmUpPeriod;
+
+            for (var i = 0; i < period; i++)
+            {
+                indicator.Update(time.AddMinutes(i), i);
+                Assert.AreEqual(i == period - 1, indicator.IsReady);
+            }
         }
     }
 }

--- a/Tests/Indicators/SumTests.cs
+++ b/Tests/Indicators/SumTests.cs
@@ -20,30 +20,34 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class SumTests
+    public class SumTests : CommonIndicatorTests<IndicatorDataPoint>
     {
-        [Test]
-        public void ComputesCorrectly()
+        protected override IndicatorBase<IndicatorDataPoint> CreateIndicator()
         {
-            var sum = new Sum(2);
+            return new Sum(2);
+        }
+
+        protected override string TestFileName => "";
+
+        protected override string TestColumnName => "";
+
+        protected override void RunTestIndicator(IndicatorBase<IndicatorDataPoint> indicator)
+        {
             var time = DateTime.UtcNow;
 
-            sum.Update(time.AddDays(1), 1m);
-            sum.Update(time.AddDays(1), 2m);
-            sum.Update(time.AddDays(1), 3m);
+            foreach (var i in new[] {1, 2, 3})
+            {
+                indicator.Update(time.AddDays(i), i);
+            }
 
-            Assert.AreEqual(sum.Current.Value, 2m + 3m);
+            Assert.AreEqual(indicator.Current.Value, 2m + 3m);
         }
 
         [Test]
-        public void ResetsCorrectly()
+        public override void ResetsProperly()
         {
-            var sum = new Sum(2);
-            var time = DateTime.UtcNow;
-
-            sum.Update(time.AddDays(1), 1m);
-            sum.Update(time.AddDays(1), 2m);
-            sum.Update(time.AddDays(1), 3m);
+            var sum = (Sum) CreateIndicator();
+            RunTestIndicator(sum);
 
             Assert.IsTrue(sum.IsReady);
 
@@ -51,22 +55,8 @@ namespace QuantConnect.Tests.Indicators
 
             TestHelper.AssertIndicatorIsInDefaultState(sum);
             Assert.AreEqual(sum.Current.Value, 0m);
-            sum.Update(time.AddDays(1), 1);
+            sum.Update(DateTime.UtcNow, 1);
             Assert.AreEqual(sum.Current.Value, 1m);
-        }
-
-        [Test]
-        public void WarmsUpProperly()
-        {
-            var indicator = new Sum(2);
-            var time = DateTime.UtcNow;
-            var period = ((IIndicatorWarmUpPeriodProvider)indicator).WarmUpPeriod;
-
-            for (var i = 0; i < period; i++)
-            {
-                indicator.Update(time.AddMinutes(i), i);
-                Assert.AreEqual(i == period - 1, indicator.IsReady);
-            }
         }
     }
 }

--- a/Tests/Indicators/VarianceTests.cs
+++ b/Tests/Indicators/VarianceTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,14 +26,8 @@ namespace QuantConnect.Tests.Indicators
             return new Variance(10);
         }
 
-        protected override string TestFileName
-        {
-            get { return "spy_var.txt"; }
-        }
+        protected override string TestFileName => "spy_var.txt";
 
-        protected override string TestColumnName
-        {
-            get { return "Var"; }
-        }
+        protected override string TestColumnName => "Var";
     }
 }


### PR DESCRIPTION
#### Description
Extends `Sum`, `StandardDeviation` and `Variance` indicators with `IIndicatorWarmUpPeriodProvider`.

#### Related Issue
#3074 

#### Motivation and Context
See #3074 

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`