### PR TITLE
Add CoinApiDataConverter ToolBox application

### DIFF
--- a/Configuration/ToolboxArgumentParser.cs
+++ b/Configuration/ToolboxArgumentParser.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.CommandLineUtils;
 
@@ -23,7 +39,7 @@ namespace QuantConnect.Configuration
                                                      + "/KrakenDownloader or KDL/OandaDownloader or ODL/QuandlBitfinexDownloader or QBDL"
                                                      + "/YahooDownloader or YDL/AlgoSeekFuturesConverter or ASFC/AlgoSeekOptionsConverter or ASOC"
                                                      + "/IVolatilityEquityConverter or IVEC/KaikoDataConverter or KDC/NseMarketDataConverter or NMDC"
-                                                     + "/QuantQuoteConverter or QQC/CoarseUniverseGenerator or CUG\n"
+                                                     + "/QuantQuoteConverter or QQC/CoarseUniverseGenerator or CUG/CoinApiDataConverter or CADC\n"
                                                      + "RandomDataGenerator or RDG"
                                                      + "Example 1: --app=DDL\n"
                                                      + "Example 2: --app=NseMarketDataConverter\n"
@@ -42,7 +58,7 @@ namespace QuantConnect.Configuration
                 new CommandLineOption("date", CommandOptionType.SingleValue, "[REQUIRED for AlgoSeekFuturesConverter, AlgoSeekOptionsConverter, KaikoDataConverter] "
                                                                              + "Date for the option bz files: --date=yyyyMMdd"),
                 new CommandLineOption("source-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter, KaikoDataConverter,"
-                                                                                   + " NseMarketDataConverter, QuantQuoteConverter]"),
+                                                                                   + " CoinApiDataConverter, NseMarketDataConverter, QuantQuoteConverter]"),
                 new CommandLineOption("destination-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter, "
                                                                                         + "NseMarketDataConverter, QuantQuoteConverter]"),
                 new CommandLineOption("source-meta-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter]"),

--- a/ToolBox/CoinApiDataConverter/CoinApiDataConverterProgram.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiDataConverterProgram.cs
@@ -1,0 +1,124 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using ICSharpCode.SharpZipLib.Tar;
+using QuantConnect.Logging;
+
+namespace QuantConnect.ToolBox.CoinApiDataConverter
+{
+    /// <summary>
+    /// Console application for converting CoinApi raw data into Lean data format for high resolutions (tick, second and minute)
+    /// </summary>
+    public static class CoinApiDataConverterProgram
+    {
+        /// <summary>
+        /// CoinAPI data converter entry point.
+        /// </summary>
+        /// <param name="sourceDirectory">The source directory where all CoinAPI raw files are stored.</param>
+        /// <exception cref="ArgumentException">Source folder does not exists.</exception>
+        /// <remarks>This converter will automatically convert data for every exchange, date and tick type contained in each raw data file in the sourceDirectory</remarks>
+        public static void CoinApiDataConverter(string sourceDirectory)
+        {
+            var folderPath = new DirectoryInfo(sourceDirectory);
+            if (!folderPath.Exists)
+            {
+                throw new ArgumentException($"CoinApiDataConverter(): Source folder not found: {folderPath.FullName}");
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+
+            var coinapiDataReader = new CoinApiDataReader();
+
+            foreach (var fileName in folderPath.EnumerateFiles("*.tar"))
+            {
+                Log.Trace($"CoinApiDataConverter(): Starting data conversion from source file: {fileName.Name}...");
+
+                using (var stream = new FileStream(fileName.FullName, FileMode.Open))
+                {
+                    using (var tar = new TarInputStream(stream))
+                    {
+                        TarEntry entry;
+                        while ((entry = tar.GetNextEntry()) != null)
+                        {
+                            if (entry.IsDirectory) continue;
+
+                            try
+                            {
+                                ProcessEntry(coinapiDataReader, tar, entry);
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Error(e, $"CoinApiDataConverter(): Error processing entry: {entry.Name}");
+                            }
+                        }
+                    }
+                }
+            }
+
+            Log.Trace($"CoinApiDataConverter(): Finished in {stopwatch.Elapsed}");
+        }
+
+        private static void ProcessEntry(CoinApiDataReader coinapiDataReader, TarInputStream tar, TarEntry entry)
+        {
+            var entryData = coinapiDataReader.GetCoinApiEntryData(tar, entry);
+
+            // materialize the enumerable into a list, since we need to enumerate over it twice
+            var ticks = coinapiDataReader.ProcessCoinApiEntry(tar, entryData).ToList();
+
+            var writer = new LeanDataWriter(Resolution.Tick, entryData.Symbol, Globals.DataFolder, entryData.TickType);
+            writer.Write(ticks);
+
+            Log.Trace($"CoinApiDataConverter(): Starting consolidation for {entryData.Symbol.Value} {entryData.TickType}");
+            var consolidators = new List<TickAggregator>();
+
+            if (entryData.TickType == TickType.Trade)
+            {
+                consolidators.AddRange(new[]
+                {
+                    new TradeTickAggregator(Resolution.Second),
+                    new TradeTickAggregator(Resolution.Minute)
+                });
+            }
+            else
+            {
+                consolidators.AddRange(new[]
+                {
+                    new QuoteTickAggregator(Resolution.Second),
+                    new QuoteTickAggregator(Resolution.Minute)
+                });
+            }
+
+            foreach (var tick in ticks)
+            {
+                foreach (var consolidator in consolidators)
+                {
+                    consolidator.Update(tick);
+                }
+            }
+
+            foreach (var consolidator in consolidators)
+            {
+                writer = new LeanDataWriter(consolidator.Resolution, entryData.Symbol, Globals.DataFolder, entryData.TickType);
+                writer.Write(consolidator.Flush());
+            }
+        }
+    }
+}

--- a/ToolBox/CoinApiDataConverter/CoinApiDataConverterProgram.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiDataConverterProgram.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.Linq;
 using ICSharpCode.SharpZipLib.Tar;
 using QuantConnect.Logging;
+using QuantConnect.Util;
 
 namespace QuantConnect.ToolBox.CoinApiDataConverter
 {
@@ -29,6 +30,15 @@ namespace QuantConnect.ToolBox.CoinApiDataConverter
     /// </summary>
     public static class CoinApiDataConverterProgram
     {
+        /// <summary>
+        /// List of supported exchanges
+        /// </summary>
+        private static readonly HashSet<string> SupportedMarkets = new[]
+        {
+            Market.GDAX,
+            Market.Bitfinex
+        }.ToHashSet();
+
         /// <summary>
         /// CoinAPI data converter entry point.
         /// </summary>
@@ -79,6 +89,12 @@ namespace QuantConnect.ToolBox.CoinApiDataConverter
         private static void ProcessEntry(CoinApiDataReader coinapiDataReader, TarInputStream tar, TarEntry entry)
         {
             var entryData = coinapiDataReader.GetCoinApiEntryData(tar, entry);
+
+            if (!SupportedMarkets.Contains(entryData.Symbol.ID.Market))
+            {
+                // only convert data for supported exchanges
+                return;
+            }
 
             // materialize the enumerable into a list, since we need to enumerate over it twice
             var ticks = coinapiDataReader.ProcessCoinApiEntry(tar, entryData).ToList();

--- a/ToolBox/CoinApiDataConverter/CoinApiDataReader.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiDataReader.cs
@@ -1,0 +1,176 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using ICSharpCode.SharpZipLib.Tar;
+using Ionic.Zlib;
+using QuantConnect.Data.Market;
+using QuantConnect.Logging;
+
+namespace QuantConnect.ToolBox.CoinApiDataConverter
+{
+    /// <summary>
+    /// Reader class for CoinAPI crypto raw data.
+    /// </summary>
+    public class CoinApiDataReader
+    {
+        /// <summary>
+        /// Gets the data for the given CoinAPI tar entry
+        /// </summary>
+        /// <param name="tar">The tar input stream</param>
+        /// <param name="entry">The tar entry</param>
+        /// <returns>A new instance of type <see cref="CoinApiEntryData"/></returns>
+        public CoinApiEntryData GetCoinApiEntryData(TarInputStream tar, TarEntry entry)
+        {
+            var gzipFileName = entry.Name;
+            Log.Trace($"CoinApiDataReader.ProcessTarEntry(): Processing entry: {gzipFileName}");
+
+            // datatype-exchange-date-symbol/trades/COINBASE/2019/05/07/27781-COINBASE_SPOT_LTC_BTC.csv.gz
+            var parts = gzipFileName.Split('/');
+            if (parts.Length != 7)
+            {
+                throw new Exception($"CoinApiDataReader.ProcessTarEntry(): Unexpected entry path in tar file: {gzipFileName}");
+            }
+
+            var tickType = parts[1] == "trades" ? TickType.Trade : TickType.Quote;
+            var market = parts[2] == "COINBASE" ? Market.GDAX : parts[2].ToLower();
+            var year = Convert.ToInt32(parts[3]);
+            var month = Convert.ToInt32(parts[4]);
+            var day = Convert.ToInt32(parts[5]);
+            var date = new DateTime(year, month, day);
+
+            var nameParts = Path.GetFileNameWithoutExtension(parts[6].Substring(0, parts[6].IndexOf('.'))).Split('_');
+            if (nameParts.Length != 4)
+            {
+                throw new Exception($"CoinApiDataReader.ProcessTarEntry(): Unexpected entry name in tar file: {gzipFileName}");
+            }
+            var ticker = nameParts[2] + nameParts[3];
+            var symbol = Symbol.Create(ticker, SecurityType.Crypto, market);
+
+            return new CoinApiEntryData
+            {
+                Name = gzipFileName,
+                Symbol = symbol,
+                TickType = tickType,
+                Date = date
+            };
+        }
+
+        /// <summary>
+        /// Gets an enumerable of ticks for the given CoinAPI tar entry
+        /// </summary>
+        /// <param name="tar">The tar input stream</param>
+        /// <param name="entryData">The entry data</param>
+        /// <returns>An <see cref="IEnumerable{Tick}"/> for the ticks read from the entry</returns>
+        public IEnumerable<Tick> ProcessCoinApiEntry(TarInputStream tar, CoinApiEntryData entryData)
+        {
+            Log.Trace("CoinApiDataReader.ProcessTarEntry(): Processing " +
+                      $"{entryData.Symbol.ID.Market}-{entryData.Symbol.Value}-{entryData.TickType} " +
+                      $"for {entryData.Date:yyyy-MM-dd}");
+
+            using (var gzipStream = new MemoryStream())
+            {
+                tar.CopyEntryContents(gzipStream);
+                gzipStream.Seek(0, SeekOrigin.Begin);
+
+                using (var innerStream = new GZipStream(gzipStream, CompressionMode.Decompress))
+                {
+                    using (var reader = new StreamReader(innerStream))
+                    {
+                        var headerLine = reader.ReadLine();
+                        if (headerLine == null)
+                        {
+                            throw new Exception($"CoinApiDataReader.ProcessTarEntry(): CSV header not found for entry name: {entryData.Name}");
+                        }
+
+                        var headerParts = headerLine.Split(';').ToList();
+
+                        var ticks = entryData.TickType == TickType.Trade
+                            ? ParseTradeData(entryData.Symbol, reader, headerParts)
+                            : ParseQuoteData(entryData.Symbol, reader, headerParts);
+
+                        foreach (var tick in ticks)
+                        {
+                            yield return tick;
+                        }
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<Tick> ParseTradeData(Symbol symbol, StreamReader reader, List<string> headerParts)
+        {
+            var columnTime = headerParts.FindIndex(x => x == "time_exchange");
+            var columnPrice = headerParts.FindIndex(x => x == "price");
+            var columnQuantity = headerParts.FindIndex(x => x == "base_amount");
+
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                var lineParts = line.Split(';');
+
+                var time = DateTime.Parse(lineParts[columnTime], CultureInfo.InvariantCulture);
+                var price = lineParts[columnPrice].ToDecimal();
+                var quantity = lineParts[columnQuantity].ToDecimal();
+
+                yield return new Tick
+                {
+                    Symbol = symbol,
+                    Time = time,
+                    Value = price,
+                    Quantity = quantity,
+                    TickType = TickType.Trade
+                };
+            }
+        }
+
+        private IEnumerable<Tick> ParseQuoteData(Symbol symbol, StreamReader reader, List<string> headerParts)
+        {
+            var columnTime = headerParts.FindIndex(x => x == "time_exchange");
+            var columnAskPrice = headerParts.FindIndex(x => x == "ask_px");
+            var columnAskSize = headerParts.FindIndex(x => x == "ask_sx");
+            var columnBidPrice = headerParts.FindIndex(x => x == "bid_px");
+            var columnBidSize = headerParts.FindIndex(x => x == "bid_sx");
+
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                var lineParts = line.Split(';');
+
+                var time = DateTime.Parse(lineParts[columnTime], CultureInfo.InvariantCulture);
+                var askPrice = lineParts[columnAskPrice].ToDecimal();
+                var askSize = lineParts[columnAskSize].ToDecimal();
+                var bidPrice = lineParts[columnBidPrice].ToDecimal();
+                var bidSize = lineParts[columnBidSize].ToDecimal();
+
+                yield return new Tick
+                {
+                    Symbol = symbol,
+                    Time = time,
+                    AskPrice = askPrice,
+                    AskSize = askSize,
+                    BidPrice = bidPrice,
+                    BidSize = bidSize,
+                    TickType = TickType.Quote
+                };
+            }
+        }
+    }
+}

--- a/ToolBox/CoinApiDataConverter/CoinApiEntryData.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiEntryData.cs
@@ -1,0 +1,46 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.ToolBox.CoinApiDataConverter
+{
+    /// <summary>
+    /// Contains information extracted from CoinAPI entry name
+    /// </summary>
+    public class CoinApiEntryData
+    {
+        /// <summary>
+        /// The entry name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The LEAN symbol
+        /// </summary>
+        public Symbol Symbol { get; set; }
+
+        /// <summary>
+        /// The tick type (Trade or Quote)
+        /// </summary>
+        public TickType TickType { get; set; }
+
+        /// <summary>
+        /// The date of the entry
+        /// </summary>
+        public DateTime Date { get; set; }
+    }
+}

--- a/ToolBox/Program.cs
+++ b/ToolBox/Program.cs
@@ -21,6 +21,7 @@ using QuantConnect.ToolBox.AlgoSeekFuturesConverter;
 using QuantConnect.ToolBox.AlgoSeekOptionsConverter;
 using QuantConnect.ToolBox.BitfinexDownloader;
 using QuantConnect.ToolBox.CoarseUniverseGenerator;
+using QuantConnect.ToolBox.CoinApiDataConverter;
 using QuantConnect.ToolBox.CryptoiqDownloader;
 using QuantConnect.ToolBox.DukascopyDownloader;
 using QuantConnect.ToolBox.FxcmDownloader;
@@ -141,6 +142,10 @@ namespace QuantConnect.ToolBox
                         KaikoDataConverterProgram.KaikoDataConverter(GetParameterOrExit(optionsObject, "source-dir"),
                                                                      GetParameterOrExit(optionsObject, "date"),
                                                                      GetParameterOrDefault(optionsObject, "exchange", string.Empty));
+                        break;
+                    case "cadc":
+                    case "coinapidataconverter":
+                        CoinApiDataConverterProgram.CoinApiDataConverter(GetParameterOrExit(optionsObject, "source-dir"));
                         break;
                     case "nmdc":
                     case "nsemarketdataconverter":

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -206,6 +206,9 @@
   <ItemGroup>
     <Compile Include="BitfinexDownloader\BitfinexDataDownloader.cs" />
     <Compile Include="BitfinexDownloader\BitfinexDownloaderProgram.cs" />
+    <Compile Include="CoinApiDataConverter\CoinApiDataConverterProgram.cs" />
+    <Compile Include="CoinApiDataConverter\CoinApiDataReader.cs" />
+    <Compile Include="CoinApiDataConverter\CoinApiEntryData.cs" />
     <Compile Include="GDAXDownloader\GDAXDownloader.cs" />
     <Compile Include="GDAXDownloader\GDAXDownloaderProgram.cs" />
     <Compile Include="GzipStreamProvider.cs" />

--- a/ToolBox/README.md
+++ b/ToolBox/README.md
@@ -47,6 +47,8 @@ Example: --app=GoogleDownloader --tickers=SPY,AAPL --resolution=Minute --from-da
 		- **'--date=yyyyMMdd'** reference date.
 	- AlgoSeekOptionsConverter or ASOC
 		- **'--date=yyyyMMdd'** reference date.
+	- CoinApiDataConverter or CADC
+		- **'--source-dir='** path to the raw CoinAPI data.
 	- IVolatilityEquityConverter or IVEC
 		- **'--source-dir='** source archived IVolatility data.
 		- **'--source-meta-dir='** source archived IVolatility meta data.


### PR DESCRIPTION
#### Description
The new converter converts CoinAPI raw tick data files to LEAN format (`Tick`, `Second` and `Minute` resolutions).
Only data for supported exchanges will be imported (CoinBasePro and Bitfinex).

#### Related Issue
Closes #3198 

#### Motivation and Context
Historical trades and quotes for more Crypto exchanges.

#### Requires Documentation Change
Readme file for ToolBox has been updated.

#### How Has This Been Tested?
This has been tested with the provided sample data file, containing CoinbasePro/GDAX data (all symbols for a single date).

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`