### PR TITLE
Fix failing LiveTradingDataFeed unit tests

### DIFF
--- a/Tests/Engine/DataFeeds/CustomMockedFileBaseData.cs
+++ b/Tests/Engine/DataFeeds/CustomMockedFileBaseData.cs
@@ -24,12 +24,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
     /// </summary>
     public class CustomMockedFileBaseData : BaseData
     {
-        private int _minutesToAdd;
+        private int _incrementsToAdd;
         public static DateTime StartDate;
 
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
-            var start = StartDate.Add(TimeSpan.FromMinutes(_minutesToAdd++)).ConvertFromUtc(config.DataTimeZone);
+            var start = StartDate.AddTicks(config.Increment.Ticks * _incrementsToAdd++).ConvertFromUtc(config.DataTimeZone);
             return new CustomMockedFileBaseData
             {
                 Symbol = config.Symbol,

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -458,7 +458,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var previousTime = DateTime.Now;
             Console.WriteLine("start: " + previousTime.ToString("o"));
-            ConsumeBridge(feed, TimeSpan.FromSeconds(5), false, ts =>
+            ConsumeBridge(feed, TimeSpan.FromSeconds(3), false, ts =>
             {
                 // because this is a remote file we may skip data points while the newest
                 // version of the file is downloading [internet speed] and also we decide
@@ -466,19 +466,19 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 stopwatch.Stop();
                 if (ts.Slice.Count == 0) return;
 
-                Assert.AreEqual(100, ts.Slice.Count);
-
                 count++;
                 emittedData = true;
 
                 // make sure within 3 seconds
                 var delta = DateTime.Now.Subtract(previousTime);
                 previousTime = DateTime.Now;
-                Assert.IsTrue(delta <= TimeSpan.FromSeconds(3), delta.ToString());
+                Assert.IsTrue(delta <= TimeSpan.FromSeconds(2), delta.ToString());
                 ConsoleWriteLine("TimeProvider now: " + _manualTimeProvider.GetUtcNow() + " Count: "
                                   + ts.Slice.Count + ". Delta (ms): "
                                   + ((decimal)delta.TotalMilliseconds).SmartRounding() + Environment.NewLine);
             });
+
+            Assert.That(count, Is.GreaterThan(5));
 
             Console.WriteLine("Count: " + count);
             Console.WriteLine("Spool up time: " + stopwatch.Elapsed);

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -324,10 +324,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         [Test]
         public void Unsubscribes()
         {
-            var customMockedFileBaseData = SymbolCache.GetSymbol("CustomMockedFileBaseData");
             FuncDataQueueHandler dataQueueHandler;
             var feed = RunDataFeed(out dataQueueHandler, equities: new List<string> { "SPY" }, forex: new List<string> { "EURUSD" });
             _algorithm.AddData<CustomMockedFileBaseData>("CustomMockedFileBaseData");
+            var customMockedFileBaseData = SymbolCache.GetSymbol("CustomMockedFileBaseData");
 
             var emittedData = false;
             var currentSubscriptionCount = 0;
@@ -359,10 +359,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         {
             _algorithm.SetFinishedWarmingUp();
             _algorithm.Transactions.SetOrderProcessor(new FakeOrderProcessor());
-            var customMockedFileBaseData = SymbolCache.GetSymbol("CustomMockedFileBaseData");
             FuncDataQueueHandler dataQueueHandler;
             var feed = RunDataFeed(out dataQueueHandler, equities: new List<string> { "SPY" }, forex: new List<string> { "EURUSD" });
             _algorithm.AddData<CustomMockedFileBaseData>("CustomMockedFileBaseData");
+            var customMockedFileBaseData = SymbolCache.GetSymbol("CustomMockedFileBaseData");
 
             var emittedData = false;
             var currentSubscriptionCount = 0;
@@ -466,12 +466,15 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 stopwatch.Stop();
                 if (ts.Slice.Count == 0) return;
 
-                emittedData = true;
+                Assert.AreEqual(100, ts.Slice.Count);
+
                 count++;
-                // make sure within 2 seconds
+                emittedData = true;
+
+                // make sure within 3 seconds
                 var delta = DateTime.Now.Subtract(previousTime);
                 previousTime = DateTime.Now;
-                Assert.IsTrue(delta <= TimeSpan.FromSeconds(2), delta.ToString());
+                Assert.IsTrue(delta <= TimeSpan.FromSeconds(3), delta.ToString());
                 ConsoleWriteLine("TimeProvider now: " + _manualTimeProvider.GetUtcNow() + " Count: "
                                   + ts.Slice.Count + ". Delta (ms): "
                                   + ((decimal)delta.TotalMilliseconds).SmartRounding() + Environment.NewLine);
@@ -480,7 +483,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Console.WriteLine("Count: " + count);
             Console.WriteLine("Spool up time: " + stopwatch.Elapsed);
 
-            Assert.That(count, Is.GreaterThan(5));
             Assert.IsTrue(emittedData);
         }
 
@@ -488,10 +490,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void HandlesRestApi()
         {
             var resolution = Resolution.Second;
-            var symbol = SymbolCache.GetSymbol("RestApi");
             FuncDataQueueHandler dqgh;
             var feed = RunDataFeed(out dqgh);
             _algorithm.AddData<RestApiBaseData>("RestApi", resolution);
+            var symbol = SymbolCache.GetSymbol("RestApi");
 
             var count = 0;
             var receivedData = false;

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -466,10 +466,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 stopwatch.Stop();
                 if (ts.Slice.Count == 0) return;
 
-                count++;
                 emittedData = true;
+                count++;
 
-                // make sure within 3 seconds
+                // make sure within 2 seconds
                 var delta = DateTime.Now.Subtract(previousTime);
                 previousTime = DateTime.Now;
                 Assert.IsTrue(delta <= TimeSpan.FromSeconds(2), delta.ToString());
@@ -478,11 +478,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                                   + ((decimal)delta.TotalMilliseconds).SmartRounding() + Environment.NewLine);
             });
 
-            Assert.That(count, Is.GreaterThan(5));
-
             Console.WriteLine("Count: " + count);
             Console.WriteLine("Spool up time: " + stopwatch.Elapsed);
 
+            Assert.That(count, Is.GreaterThan(5));
             Assert.IsTrue(emittedData);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- In some tests `SymbolCache.GetSymbol` was being called before `AddData`, throwing an exception when launched as single tests.
- `HandlesManyCustomDataSubscriptions` was failing both locally and in Travis (only occasionally). This behavior started since #3040 was merged. The PR made the LTDF loop slightly slower, and it doesn't reach the time for the data to be released, since its incrementing the frontier in seconds and each data point had a minute gap.
   - Updating `CustomMockedFileBaseData` to respect configuration increment. Note: increasing the frontier step also solved the issue
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3181
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Failing unit tests
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->