### PR TITLE
Extends RelativeStrengthIndex, Stochastic and WilliamsPercentR Indicators With IIndicatorWarmUpPeriodProvider

### DIFF
--- a/Indicators/RelativeStrengthIndex.cs
+++ b/Indicators/RelativeStrengthIndex.cs
@@ -1,41 +1,42 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
 namespace QuantConnect.Indicators
 {
     /// <summary>
     /// Represents the  Relative Strength Index (RSI) developed by K. Welles Wilder.
     /// You can optionally specified a different moving average type to be used in the computation
     /// </summary>
-    public class RelativeStrengthIndex : Indicator
+    public class RelativeStrengthIndex : Indicator, IIndicatorWarmUpPeriodProvider
     {
-        private IndicatorDataPoint previousInput;
+        private IndicatorDataPoint _previousInput;
 
         /// <summary>
         /// Gets the type of indicator used to compute AverageGain and AverageLoss
         /// </summary>
-        public MovingAverageType MovingAverageType { get; private set; }
+        public MovingAverageType MovingAverageType { get; }
 
         /// <summary>
         /// Gets the EMA for the down days
         /// </summary>
-        public IndicatorBase<IndicatorDataPoint> AverageLoss { get; private set; }
+        public IndicatorBase<IndicatorDataPoint> AverageLoss { get; }
 
         /// <summary>
         /// Gets the indicator for average gain
         /// </summary>
-        public IndicatorBase<IndicatorDataPoint> AverageGain { get; private set; }
+        public IndicatorBase<IndicatorDataPoint> AverageGain { get; }
 
         /// <summary>
         /// Initializes a new instance of the RelativeStrengthIndex class with the specified name and period
@@ -43,7 +44,7 @@ namespace QuantConnect.Indicators
         /// <param name="period">The period used for up and down days</param>
         /// <param name="movingAverageType">The type of moving average to be used for computing the average gain/loss values</param>
         public RelativeStrengthIndex(int period, MovingAverageType movingAverageType = MovingAverageType.Wilders)
-            : this("RSI" + period, period, movingAverageType)
+            : this($"RSI({period})", period, movingAverageType)
         {
         }
 
@@ -59,15 +60,18 @@ namespace QuantConnect.Indicators
             MovingAverageType = movingAverageType;
             AverageGain = movingAverageType.AsIndicator(name + "Up", period);
             AverageLoss = movingAverageType.AsIndicator(name + "Down", period);
+            WarmUpPeriod = period + 1;
         }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return AverageGain.IsReady && AverageLoss.IsReady; }
-        }
+        public override bool IsReady => AverageGain.IsReady && AverageLoss.IsReady;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod { get; }
 
         /// <summary>
         /// Computes the next value of this indicator from the given state
@@ -76,18 +80,18 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IndicatorDataPoint input)
         {
-            if (previousInput != null && input.Value >= previousInput.Value)
+            if (_previousInput != null && input.Value >= _previousInput.Value)
             {
-                AverageGain.Update(input.Time, input.Value - previousInput.Value);
+                AverageGain.Update(input.Time, input.Value - _previousInput.Value);
                 AverageLoss.Update(input.Time, 0m);
             }
-            else if (previousInput != null && input.Value < previousInput.Value)
+            else if (_previousInput != null && input.Value < _previousInput.Value)
             {
                 AverageGain.Update(input.Time, 0m);
-                AverageLoss.Update(input.Time, previousInput.Value - input.Value);
+                AverageLoss.Update(input.Time, _previousInput.Value - input.Value);
             }
 
-            previousInput = input;
+            _previousInput = input;
             if (AverageLoss == 0m)
             {
                 // all up days is 100
@@ -103,6 +107,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         public override void Reset()
         {
+            _previousInput = null;
             AverageGain.Reset();
             AverageLoss.Reset();
             base.Reset();

--- a/Indicators/Stochastics.cs
+++ b/Indicators/Stochastics.cs
@@ -64,20 +64,20 @@ namespace QuantConnect.Indicators
             FastStoch = new FunctionalIndicator<IBaseDataBar>(name + "_FastStoch",
                 input => ComputeFastStoch(period, input),
                 fastStoch => _maximum.IsReady,
-                ResetPrivateIndicators
+                () => { }
                 );
 
             StochK = new FunctionalIndicator<IBaseDataBar>(name + "_StochK",
                 input => ComputeStochK(period, kPeriod, input),
                 stochK => _maximum.IsReady,
-                ResetPrivateIndicators
-                );
+                () => { }
+            );
 
             StochD = new FunctionalIndicator<IBaseDataBar>(
                 name + "_StochD",
                 input => ComputeStochD(period, kPeriod, dPeriod),
                 stochD => _maximum.IsReady,
-                ResetPrivateIndicators
+                () => { }
             );
 
             WarmUpPeriod = period;
@@ -176,16 +176,11 @@ namespace QuantConnect.Indicators
             FastStoch.Reset();
             StochK.Reset();
             StochD.Reset();
-            ResetPrivateIndicators();
-            base.Reset();
-        }
-
-        private void ResetPrivateIndicators()
-        {
             _maximum.Reset();
             _minimum.Reset();
             _sumFastK.Reset();
             _sumSlowK.Reset();
+            base.Reset();
         }
     }
 }

--- a/Indicators/Stochastics.cs
+++ b/Indicators/Stochastics.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 
 namespace QuantConnect.Indicators
@@ -23,27 +24,27 @@ namespace QuantConnect.Indicators
     /// multiplied by 100. Once the Fast Stochastics %K is calculated the Slow Stochastic %K is calculated by the average/smoothed price of
     /// of the Fast %K with the given period. The Slow Stochastics %D is then derived from the Slow Stochastics %K with the given period.
     /// </summary>
-    public class Stochastic : BarIndicator
+    public class Stochastic : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly IndicatorBase<IndicatorDataPoint> _maximum;
-        private readonly IndicatorBase<IndicatorDataPoint> _mininum;
+        private readonly IndicatorBase<IndicatorDataPoint> _minimum;
         private readonly IndicatorBase<IndicatorDataPoint> _sumFastK;
         private readonly IndicatorBase<IndicatorDataPoint> _sumSlowK;
 
         /// <summary>
         /// Gets the value of the Fast Stochastics %K given Period.
         /// </summary>
-        public IndicatorBase<IBaseDataBar> FastStoch { get; private set; }
+        public IndicatorBase<IBaseDataBar> FastStoch { get; }
 
         /// <summary>
         /// Gets the value of the Slow Stochastics given Period K.
         /// </summary>
-        public IndicatorBase<IBaseDataBar> StochK { get; private set; }
+        public IndicatorBase<IBaseDataBar> StochK { get; }
 
         /// <summary>
         /// Gets the value of the Slow Stochastics given Period D.
         /// </summary>
-        public IndicatorBase<IBaseDataBar> StochD { get; private set; }
+        public IndicatorBase<IBaseDataBar> StochD { get; }
 
         /// <summary>
         /// Creates a new Stochastics Indicator from the specified periods.
@@ -56,27 +57,30 @@ namespace QuantConnect.Indicators
             : base(name)
         {
             _maximum = new Maximum(name + "_Max", period);
-            _mininum = new Minimum(name + "_Min", period);
+            _minimum = new Minimum(name + "_Min", period);
             _sumFastK = new Sum(name + "_SumFastK", kPeriod);
             _sumSlowK = new Sum(name + "_SumD", dPeriod);
 
             FastStoch = new FunctionalIndicator<IBaseDataBar>(name + "_FastStoch",
                 input => ComputeFastStoch(period, input),
                 fastStoch => _maximum.IsReady,
-                () => _maximum.Reset()
+                ResetPrivateIndicators
                 );
 
             StochK = new FunctionalIndicator<IBaseDataBar>(name + "_StochK",
                 input => ComputeStochK(period, kPeriod, input),
                 stochK => _maximum.IsReady,
-                () => _maximum.Reset()
+                ResetPrivateIndicators
                 );
 
-            StochD = new FunctionalIndicator<IBaseDataBar>(name + "_StochD",
+            StochD = new FunctionalIndicator<IBaseDataBar>(
+                name + "_StochD",
                 input => ComputeStochD(period, kPeriod, dPeriod),
                 stochD => _maximum.IsReady,
-                () => _maximum.Reset()
-                );
+                ResetPrivateIndicators
+            );
+
+            WarmUpPeriod = period;
         }
 
         /// <summary>
@@ -86,17 +90,20 @@ namespace QuantConnect.Indicators
         /// <param name="kPeriod">The K period given to calculated the Slow %K</param>
         /// <param name="dPeriod">The D period given to calculated the Slow %D</param>
         public Stochastic(int period, int kPeriod, int dPeriod)
-            : this("STO" + period, period, kPeriod, dPeriod)
+            : this($"STO({period},{kPeriod},{dPeriod})", period, kPeriod, dPeriod)
         {
         }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return FastStoch.IsReady && StochK.IsReady && StochD.IsReady; }
-        }
+        public override bool IsReady => FastStoch.IsReady && StochK.IsReady && StochD.IsReady;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod { get; }
+
         /// <summary>
         /// Computes the next value of this indicator from the given state
         /// </summary>
@@ -104,10 +111,11 @@ namespace QuantConnect.Indicators
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             _maximum.Update(input.Time, input.High);
-            _mininum.Update(input.Time, input.Low);
+            _minimum.Update(input.Time, input.Low);
             FastStoch.Update(input);
             StochK.Update(input);
             StochD.Update(input);
+
             return FastStoch;
         }
 
@@ -119,18 +127,17 @@ namespace QuantConnect.Indicators
         /// <returns>The Fast Stochastics %K value.</returns>
         private decimal ComputeFastStoch(int period, IBaseDataBar input)
         {
-            var denominator = (_maximum - _mininum);
-            var numerator = (input.Close - _mininum);
-            decimal fastStoch;
+            var denominator = _maximum - _minimum;
+            
+            // if there's no range, just return constant zero
             if (denominator == 0m)
             {
-                // if there's no range, just return constant zero
-                fastStoch = 0m;
+                return 0m;
             }
-            else
-            {
-                fastStoch = _maximum.Samples >= period ? numerator/denominator : new decimal(0.0);
-            }
+
+            var numerator = input.Close - _minimum;
+            var fastStoch = _maximum.Samples >= period ? numerator / denominator : decimal.Zero;
+
             _sumFastK.Update(input.Time, fastStoch);
             return fastStoch * 100;
         }
@@ -142,9 +149,9 @@ namespace QuantConnect.Indicators
         /// <param name="constantK">The constant k.</param>
         /// <param name="input">The input.</param>
         /// <returns>The Slow Stochastics %K value.</returns>
-        private decimal ComputeStochK(int period, int constantK, IBaseDataBar input)
+        private decimal ComputeStochK(int period, int constantK, IBaseData input)
         {
-            var stochK = _maximum.Samples >= (period + constantK - 1) ? _sumFastK / constantK : new decimal(0.0);
+            var stochK = _maximum.Samples >= (period + constantK - 1) ? _sumFastK / constantK : decimal.Zero;
             _sumSlowK.Update(input.Time, stochK);
             return stochK * 100;
         }
@@ -158,7 +165,7 @@ namespace QuantConnect.Indicators
         /// <returns>The Slow Stochastics %D value.</returns>
         private decimal ComputeStochD(int period, int constantK, int constantD)
         {
-            var stochD = _maximum.Samples >= (period + constantK + constantD - 2) ? _sumSlowK / constantD : new decimal(0.0);
+            var stochD = _maximum.Samples >= (period + constantK + constantD - 2) ? _sumSlowK / constantD : decimal.Zero;
             return stochD * 100;
         }
         /// <summary>
@@ -169,9 +176,16 @@ namespace QuantConnect.Indicators
             FastStoch.Reset();
             StochK.Reset();
             StochD.Reset();
+            ResetPrivateIndicators();
+            base.Reset();
+        }
+
+        private void ResetPrivateIndicators()
+        {
+            _maximum.Reset();
+            _minimum.Reset();
             _sumFastK.Reset();
             _sumSlowK.Reset();
-            base.Reset();
         }
     }
 }

--- a/Tests/Indicators/RelativeStrengthIndexTests.cs
+++ b/Tests/Indicators/RelativeStrengthIndexTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,20 +20,26 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class RelativeStrengthIndexTests
+    public class RelativeStrengthIndexTests : CommonIndicatorTests<IndicatorDataPoint>
     {
+        protected override IndicatorBase<IndicatorDataPoint> CreateIndicator()
+        {
+            return new RelativeStrengthIndex(14);
+        }
+
+        protected override string TestFileName => "spy_with_indicators.txt";
+
+        protected override string TestColumnName => "RSI 14 Wilder";
+
         [Test]
-        public void ComparesAgainstExternalData()
+        public void ComparesAgainstExternalDataSma()
         {
             var rsiSimple = new RelativeStrengthIndex("rsi", 14, MovingAverageType.Simple);
             TestHelper.TestIndicator(rsiSimple, "RSI 14");
-
-            var rsiWilder = new RelativeStrengthIndex("rsi", 14, MovingAverageType.Wilders);
-            TestHelper.TestIndicator(rsiWilder, "RSI 14 Wilder");
         }
 
         [Test]
-        public void ResetsProperly()
+        public override void ResetsProperly()
         {
             var rsi = new RelativeStrengthIndex(2);
             rsi.Update(DateTime.Today, 1m);

--- a/Tests/Indicators/StochasticTests.cs
+++ b/Tests/Indicators/StochasticTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,47 +21,56 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class StochasticTests
+    public class StochasticTests : CommonIndicatorTests<IBaseDataBar>
     {
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
+        {
+            return new Stochastic(12, 3, 5);
+        }
+
+        protected override string TestFileName => "spy_with_stoch12k3.txt";
+
+        protected override string TestColumnName => "%D 5";
+
+        protected override Action<IndicatorBase<IBaseDataBar>, double> Assertion =>
+            (indicator, expected) =>
+                Assert.AreEqual(expected, (double)((Stochastic)indicator).StochD.Current.Value, 1e-3);
+
         [Test]
         public void ComparesAgainstExternalDataOnStochasticsK()
         {
-            var stochastics = new Stochastic("sto", 12, 3, 5);
-
-            const double epsilon = 1e-3;
-
-            TestHelper.TestIndicator(stochastics, "spy_with_stoch12k3.txt", "Stochastics 12 %K 3",
-                (ind, expected) => Assert.AreEqual(expected, (double) ((Stochastic) ind).StochK.Current.Value, epsilon)
-                );
+            TestHelper.TestIndicator(
+                CreateIndicator(),
+                TestFileName,
+                "Stochastics 12 %K 3",
+                (ind, expected) => Assert.AreEqual(
+                    expected,
+                    (double) ((Stochastic) ind).StochK.Current.Value,
+                    1e-3
+                )
+            );
         }
 
         [Test]
         public void PrimaryOutputIsFastStochProperty()
         {
-            var stochastics = new Stochastic("sto", 12, 3, 5);
-
-            TestHelper.TestIndicator(stochastics, "spy_with_stoch12k3.txt", "Stochastics 12 %K 3",
-                (ind, expected) => Assert.AreEqual((double) ((Stochastic) ind).FastStoch.Current.Value, ind.Current.Value)
-                );
-        }
-
-        [Test]
-        public void ComparesAgainstExternalDataOnStochasticsD()
-        {
-            var stochastics = new Stochastic("sto", 12, 3, 5);
-
-            const double epsilon = 1e-3;
-            TestHelper.TestIndicator(stochastics, "spy_with_stoch12k3.txt", "%D 5",
-                (ind, expected) => Assert.AreEqual(expected, (double) ((Stochastic) ind).StochD.Current.Value, epsilon)
-                );
+            TestHelper.TestIndicator(
+                CreateIndicator(),
+                TestFileName,
+                "Stochastics 12 %K 3",
+                (ind, expected) => Assert.AreEqual(
+                    (double) ((Stochastic) ind).FastStoch.Current.Value,
+                    ind.Current.Value
+                )
+            );
         }
 
         [Test]
         public void ResetsProperly()
         {
-            var stochastics = new Stochastic("sto", 12, 3, 5);
+            var stochastics = CreateIndicator() as Stochastic;
 
-            foreach (var bar in TestHelper.GetTradeBarStream("spy_with_stoch12k3.txt", false))
+            foreach (var bar in TestHelper.GetTradeBarStream(TestFileName, false))
             {
                 stochastics.Update(bar);
             }
@@ -81,12 +90,11 @@ namespace QuantConnect.Tests.Indicators
         [Test]
         public void HandlesEqualMinAndMax()
         {
-            var reference = new DateTime(2015, 09, 01);
+            var reference = DateTime.Now;
             var stochastics = new Stochastic("sto", 2, 2, 2);
-            for (int i = 0; i < 4; i++)
+            for (var i = 0; i < 4; i++)
             {
-                var bar = new TradeBar{Time = reference.AddSeconds(i)};
-                bar.Open = bar.Close = bar.High = bar.Low = bar.Volume = 1;
+                var bar = new TradeBar(reference.AddSeconds(i), Symbols.SPY, 1, 1, 1, 1, 1);
                 stochastics.Update(bar);
                 Assert.AreEqual(0m, stochastics.Current.Value);
             }

--- a/Tests/Indicators/StochasticTests.cs
+++ b/Tests/Indicators/StochasticTests.cs
@@ -66,7 +66,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public void ResetsProperly()
+        public new void ResetsProperly()
         {
             var stochastics = CreateIndicator() as Stochastic;
 

--- a/Tests/Indicators/WilliamsPercentRTests.cs
+++ b/Tests/Indicators/WilliamsPercentRTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,33 +14,21 @@
 */
 
 using NUnit.Framework;
+using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class WilliamsPercentRTests
+    public class WilliamsPercentRTests : CommonIndicatorTests<IBaseDataBar>
     {
-        [Test]
-        public void ComputesCorrectly()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
-            var wilr = new WilliamsPercentR(14);
-            TestHelper.TestIndicator(wilr, "spy_with_williamsR14.txt", "Williams %R 14", (ind, expected) => Assert.AreEqual(expected, (double) ind.Current.Value, 1e-3));
+            return new WilliamsPercentR(14);
         }
 
-        [Test]
-        public void ResetsProperly()
-        {
-            var wilr = new WilliamsPercentR(14);
-            foreach (var data in TestHelper.GetTradeBarStream("spy_with_williamsR14.txt", false))
-            {
-                wilr.Update(data);
-            }
-            Assert.IsTrue(wilr.IsReady);
+        protected override string TestFileName => "spy_with_williamsR14.txt";
 
-            wilr.Reset();
-
-            TestHelper.AssertIndicatorIsInDefaultState(wilr);
-        }
+        protected override string TestColumnName => "Williams %R 14";
     }
 }


### PR DESCRIPTION
#### Description
Extends `RelativeStrengthIndex`, `Stochastic` and `WilliamsPercentR` indicators with `IIndicatorWarmUpPeriodProvider`.

#### Related Issue
#3074 

#### Motivation and Context
See #3074 

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`