### PR TITLE
Extends PercentagePriceOscillator and UltimateOscillator Indicators With IIndicatorWarmUpPeriodProvider

### DIFF
--- a/Indicators/PercentagePriceOscillator.cs
+++ b/Indicators/PercentagePriceOscillator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,7 @@ namespace QuantConnect.Indicators
         /// <param name="slowPeriod">The slow moving average period</param>
         /// <param name="movingAverageType">The type of moving average to use</param>
         public PercentagePriceOscillator(int fastPeriod, int slowPeriod, MovingAverageType movingAverageType = MovingAverageType.Simple)
-            : this(string.Format("PPO({0},{1})", fastPeriod, slowPeriod), fastPeriod, slowPeriod, movingAverageType)
+            : this($"PPO({fastPeriod},{slowPeriod})", fastPeriod, slowPeriod, movingAverageType)
         {
         }
 

--- a/Indicators/UltimateOscillator.cs
+++ b/Indicators/UltimateOscillator.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     /// The Ultimate Oscillator is calculated as explained here:
     /// http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:ultimate_oscillator
     /// </summary>
-    public class UltimateOscillator : BarIndicator
+    public class UltimateOscillator : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly int _period;
         private IBaseDataBar _previousInput;
@@ -42,7 +42,7 @@ namespace QuantConnect.Indicators
         /// <param name="period2">The second period</param>
         /// <param name="period3">The third period</param>
         public UltimateOscillator(int period1, int period2, int period3)
-            : this(string.Format("ULTOSC({0},{1},{2})", period1, period2, period3), period1, period2, period3)
+            : this($"ULTOSC({period1},{period2},{period3})", period1, period2, period3)
         {
         }
 
@@ -69,10 +69,12 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples > _period; }
-        }
+        public override bool IsReady => Samples > _period;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => _period + 1;
 
         /// <summary>
         /// Computes the next value of this indicator from the given state

--- a/Tests/Indicators/PercentagePriceOscillatorTests.cs
+++ b/Tests/Indicators/PercentagePriceOscillatorTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,14 +26,8 @@ namespace QuantConnect.Tests.Indicators
             return new PercentagePriceOscillator(5, 10);
         }
 
-        protected override string TestFileName
-        {
-            get { return "spy_ppo.txt"; }
-        }
+        protected override string TestFileName => "spy_ppo.txt";
 
-        protected override string TestColumnName
-        {
-            get { return "PPO_5_10"; }
-        }
+        protected override string TestColumnName => "PPO_5_10";
     }
 }

--- a/Tests/Indicators/UltimateOscillatorTests.cs
+++ b/Tests/Indicators/UltimateOscillatorTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,14 +27,8 @@ namespace QuantConnect.Tests.Indicators
             return new UltimateOscillator(7, 14, 28);
         }
 
-        protected override string TestFileName
-        {
-            get { return "spy_ultosc.txt"; }
-        }
+        protected override string TestFileName => "spy_ultosc.txt";
 
-        protected override string TestColumnName
-        {
-            get { return "ULTOSC_7_14_28"; }
-        }
+        protected override string TestColumnName => "ULTOSC_7_14_28";
     }
 }


### PR DESCRIPTION
#### Description
Extends `PercentagePriceOscillator` and `UltimateOscillator` indicators with `IIndicatorWarmUpPeriodProvider`.

#### Related Issue
#3074 

#### Motivation and Context
See #3074 

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`