### PR TITLE
Improve IB brokerage error reporting for failed logins and security dialog

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2833,14 +2833,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
 
             // an existing session was detected and IBAutomater clicked the "Exit Application" button
-            if (e.Data.Contains("Existing session detected"))
+            else if (e.Data.Contains("Existing session detected"))
             {
                 _existingSessionDetected = true;
                 _ibAutomaterInitializeEvent.Set();
             }
 
             // a security dialog (2FA/code card) was detected by IBAutomater
-            if (e.Data.Contains("Second Factor Authentication") ||
+            else if (e.Data.Contains("Second Factor Authentication") ||
                 e.Data.Contains("Security Code Card Authentication") ||
                 e.Data.Contains("Enter security code"))
             {
@@ -2849,7 +2849,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
 
             // initialization completed
-            if (e.Data.Contains("Configuration settings updated"))
+            else if (e.Data.Contains("Configuration settings updated"))
             {
                 _ibAutomaterInitializeEvent.Set();
             }

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -50,6 +50,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
     {
         private readonly IBAutomater.IBAutomater _ibAutomater;
         private readonly AutoResetEvent _ibAutomaterInitializeEvent = new AutoResetEvent(false);
+        private bool _loginFailed;
         private bool _existingSessionDetected;
         private bool _securityDialogDetected;
 
@@ -2824,6 +2825,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterOutputDataReceived(): {e.Data}");
 
+            // login failed
+            if (e.Data.Contains("Login failed"))
+            {
+                _loginFailed = true;
+                _ibAutomaterInitializeEvent.Set();
+            }
+
             // an existing session was detected and IBAutomater clicked the "Exit Application" button
             if (e.Data.Contains("Existing session detected"))
             {
@@ -2832,7 +2840,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
 
             // a security dialog (2FA/code card) was detected by IBAutomater
-            if (e.Data.Contains("Second Factor Authentication") || e.Data.Contains("Security Code Card Authentication"))
+            if (e.Data.Contains("Second Factor Authentication") ||
+                e.Data.Contains("Security Code Card Authentication") ||
+                e.Data.Contains("Enter security code"))
             {
                 _securityDialogDetected = true;
                 _ibAutomaterInitializeEvent.Set();
@@ -2859,6 +2869,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
         private void CheckIbAutomaterErrors()
         {
+            if (_loginFailed)
+            {
+                throw new Exception(
+                    "InteractiveBrokersBrokerage.CheckIbAutomaterErrors(): " +
+                    "Login failed. " +
+                    "Please check the validity of your login credentials.");
+            }
+
             if (_existingSessionDetected)
             {
                 throw new Exception(
@@ -2866,6 +2884,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     "An existing session was detected and will not be automatically disconnected. " +
                     "Please close the existing session manually.");
             }
+
             if (_securityDialogDetected)
             {
                 throw new Exception(


### PR DESCRIPTION

#### Description
The IB brokerage implementation has been updated to include a meaningful error message for the following cases:

1. Failed login (e.g. invalid login credentials)
2. Invalid IB security configuration

#### Related Issue
Closes #3209 

#### Motivation and Context
Better error message -- instead of the usual 15-second timeout error

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Tested the failed login case, locally and in the cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`