### PR TITLE
Handle unsupported security type in IB FeeModel

### DIFF
--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -80,8 +80,8 @@ namespace QuantConnect.Orders.Fees
                 }
             }
 
-            decimal feeResult = 0;
-            var feeCurrency = "";
+            decimal feeResult;
+            string feeCurrency;
             var market = security.Symbol.ID.Market;
             switch (security.Type)
             {
@@ -93,6 +93,7 @@ namespace QuantConnect.Orders.Fees
                     // IB Forex fees are all in USD
                     feeCurrency = Currencies.USD;
                     break;
+
                 case SecurityType.Option:
                     Func<decimal, decimal, CashAmount> optionsCommissionFunc;
                     if (!_optionFee.TryGetValue(market, out optionsCommissionFunc))
@@ -104,6 +105,7 @@ namespace QuantConnect.Orders.Fees
                     feeResult = optionFee.Amount;
                     feeCurrency = optionFee.Currency;
                     break;
+
                 case SecurityType.Future:
                     if (market == Market.Globex || market == Market.NYMEX
                         || market == Market.CBOT || market == Market.ICE
@@ -121,6 +123,7 @@ namespace QuantConnect.Orders.Fees
                     feeResult = order.AbsoluteQuantity * feeRatePerContract.Amount;
                     feeCurrency = feeRatePerContract.Currency;
                     break;
+
                 case SecurityType.Equity:
                     EquityFee equityFee;
                     if (!_equityFee.TryGetValue(market, out equityFee))
@@ -148,6 +151,10 @@ namespace QuantConnect.Orders.Fees
                     //Always return a positive fee.
                     feeResult = Math.Abs(tradeFee);
                     break;
+
+                default:
+                    // return zero fee for unsupported security types
+                    return OrderFee.Zero;
             }
 
             return new OrderFee(new CashAmount(

--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -153,8 +153,8 @@ namespace QuantConnect.Orders.Fees
                     break;
 
                 default:
-                    // return zero fee for unsupported security types
-                    return OrderFee.Zero;
+                    // unsupported security type
+                    throw new ArgumentException($"Unsupported security type: {security.Type}");
             }
 
             return new OrderFee(new CashAmount(

--- a/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
@@ -161,27 +161,28 @@ namespace QuantConnect.Tests.Common.Orders.Fees
         }
 
         [Test]
-        public void ReturnsZeroForUnsupportedSecurityType()
+        public void GetOrderFeeThrowsForUnsupportedSecurityType()
         {
-            var tz = TimeZones.NewYork;
-            var security = new Cfd(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new Cash("EUR", 0, 0),
-                new SubscriptionDataConfig(typeof(QuoteBar), Symbols.DE30EUR, Resolution.Minute, tz, tz, true, false, false),
-                new SymbolProperties("DE30EUR", "EUR", 1, 0.01m, 1m),
-                ErrorCurrencyConverter.Instance
-            );
-            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 12000, 12000));
+            Assert.Throws<ArgumentException>(
+                () =>
+                {
+                    var tz = TimeZones.NewYork;
+                    var security = new Cfd(
+                        SecurityExchangeHours.AlwaysOpen(tz),
+                        new Cash("EUR", 0, 0),
+                        new SubscriptionDataConfig(typeof(QuoteBar), Symbols.DE30EUR, Resolution.Minute, tz, tz, true, false, false),
+                        new SymbolProperties("DE30EUR", "EUR", 1, 0.01m, 1m),
+                        ErrorCurrencyConverter.Instance
+                    );
+                    security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 12000, 12000));
 
-            var fee = _feeModel.GetOrderFee(
-                new OrderFeeParameters(
-                    security,
-                    new MarketOrder(security.Symbol, 1, DateTime.UtcNow)
-                )
-            );
-
-            Assert.AreEqual(Currencies.NullCurrency, fee.Value.Currency);
-            Assert.AreEqual(0m, fee.Value.Amount);
+                    _feeModel.GetOrderFee(
+                        new OrderFeeParameters(
+                            security,
+                            new MarketOrder(security.Symbol, 1, DateTime.UtcNow)
+                        )
+                    );
+                });
         }
     }
 }


### PR DESCRIPTION
#### Description
- updated `IBFeeModel.GetOrderFee` to throw an exception with specific message for unsupported securities.

#### Related Issue
Closes #3216 

#### Motivation and Context
Unhandled exception in the IB FeeModel.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`