### PR TITLE
Fix infinite live rest custom data polling

### DIFF
--- a/Common/Interfaces/IStreamReader.cs
+++ b/Common/Interfaces/IStreamReader.cs
@@ -41,6 +41,6 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Gets whether or not this stream reader should be rate limited
         /// </summary>
-        bool RateLimit { get; }
+        bool ShouldBeRateLimited { get; }
     }
 }

--- a/Common/Interfaces/IStreamReader.cs
+++ b/Common/Interfaces/IStreamReader.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,8 +34,13 @@ namespace QuantConnect.Interfaces
         bool EndOfStream { get; }
 
         /// <summary>
-        /// Gets the next line/batch of content from the stream 
+        /// Gets the next line/batch of content from the stream
         /// </summary>
         string ReadLine();
+
+        /// <summary>
+        /// Gets whether or not this stream reader should be rate limited
+        /// </summary>
+        bool RateLimit { get; }
     }
 }

--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -100,13 +100,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 var raw = "";
                 while (!reader.EndOfStream)
                 {
-                    BaseDataCollection instances;
+                    BaseDataCollection instances = null;
                     try
                     {
                         raw = reader.ReadLine();
                         var result = _factory.Reader(_config, raw, _date, _isLiveMode);
                         instances = result as BaseDataCollection;
-                        if (instances == null)
+                        if (instances == null && !reader.RateLimit)
                         {
                             OnInvalidSource(source, new Exception("Reader must generate a BaseDataCollection with the FileFormat.Collection"));
                             continue;
@@ -115,7 +115,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     catch (Exception err)
                     {
                         OnReaderError(raw, err);
-                        continue;
+                        if (!reader.RateLimit)
+                        {
+                            continue;
+                        }
                     }
 
                     if (_isLiveMode)

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -119,12 +119,22 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                     // always skip past all times emitted on the previous invocation of this enumerator
                     // this allows data at the same time from the same refresh of the source while excluding
                     // data from different refreshes of the source
-                    if (datum.EndTime > localFrontier.Value)
+                    if (datum != null && datum.EndTime > localFrontier.Value)
                     {
                         yield return datum;
                     }
+                    else if (!SourceRequiresFastForward(source))
+                    {
+                        // if the 'source' is Rest and there is no new value,
+                        // we return null, else we will be caught in a tight loop
+                        // because Rest source never ends!
+                        yield return null;
+                    }
 
-                    newLocalFrontier = Time.Max(datum.EndTime, newLocalFrontier);
+                    if (datum != null)
+                    {
+                        newLocalFrontier = Time.Max(datum.EndTime, newLocalFrontier);
+                    }
                 }
 
                 localFrontier.Value = newLocalFrontier;

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -138,6 +138,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                 yield return instance;
                             }
                         }
+                        else if (reader.RateLimit)
+                        {
+                            yield return instance;
+                        }
                     }
                 }
 

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -138,7 +138,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                 yield return instance;
                             }
                         }
-                        else if (reader.RateLimit)
+                        else if (reader.ShouldBeRateLimited)
                         {
                             yield return instance;
                         }

--- a/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
@@ -16,7 +16,6 @@
 
 using System.IO;
 using Ionic.Zip;
-using System.IO.Compression;
 using QuantConnect.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,7 +34,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// <summary>
         /// Gets whether or not this stream reader should be rate limited
         /// </summary>
-        public bool RateLimit => false;
+        public bool ShouldBeRateLimited => false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LocalFileSubscriptionStreamReader"/> class.

--- a/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/LocalFileSubscriptionStreamReader.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +31,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
     {
         private StreamReader _streamReader;
         private readonly ZipFile _zipFile;
+
+        /// <summary>
+        /// Gets whether or not this stream reader should be rate limited
+        /// </summary>
+        public bool RateLimit => false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LocalFileSubscriptionStreamReader"/> class.
@@ -117,7 +122,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         }
 
         /// <summary>
-        /// Gets the next line/batch of content from the stream 
+        /// Gets the next line/batch of content from the stream
         /// </summary>
         public string ReadLine()
         {

--- a/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// <summary>
         /// Gets whether or not this stream reader should be rate limited
         /// </summary>
-        public bool RateLimit => false;
+        public bool ShouldBeRateLimited => false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteFileSubscriptionStreamReader"/> class.

--- a/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
@@ -31,6 +31,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         private readonly IStreamReader _streamReader;
 
         /// <summary>
+        /// Gets whether or not this stream reader should be rate limited
+        /// </summary>
+        public bool RateLimit => false;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RemoteFileSubscriptionStreamReader"/> class.
         /// </summary>
         /// <param name="dataCacheProvider">The <see cref="IDataCacheProvider"/> used to retrieve a stream of data</param>

--- a/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         /// <summary>
         /// Gets whether or not this stream reader should be rate limited
         /// </summary>
-        public bool RateLimit => _isLiveMode;
+        public bool ShouldBeRateLimited => _isLiveMode;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RestSubscriptionStreamReader"/> class.

--- a/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RestSubscriptionStreamReader.cs
@@ -29,8 +29,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
     {
         private readonly RestClient _client;
         private readonly RestRequest _request;
-        private bool _isLiveMode;
+        private readonly bool _isLiveMode;
         private bool _delivered;
+
+        /// <summary>
+        /// Gets whether or not this stream reader should be rate limited
+        /// </summary>
+        public bool RateLimit => _isLiveMode;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RestSubscriptionStreamReader"/> class.

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -490,7 +490,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
         [TestCase(FileFormat.Csv)]
         [TestCase(FileFormat.Collection)]
-        public void RestCustomDataReturningNullDoNotInfinitelyPoll(FileFormat fileFormat)
+        public void RestCustomDataReturningNullDoesNotInfinitelyPoll(FileFormat fileFormat)
         {
             TestCustomData.FileFormat = fileFormat;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding `IStreamReader.RateLimit { get; }` specifying if calls to
`ReadLine()` should be rate limited by the source readers.
- Adding three failling unit tests in `master`
    - Live rest custom data: returning null, throwing an exception, returning old data will not infinitely poll

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3156
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix infinite live custom data rest polling
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->