### PR TITLE
Fix duplicate OnOrderEvent invoke

### DIFF
--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -406,6 +406,11 @@ namespace QuantConnect.Brokerages.Backtesting
                         // change in status or a new fill
                         if (order.Status != fill.Status || fill.FillQuantity != 0)
                         {
+                            // we update the order status so we do not re process it if we re enter
+                            // because of the call to OnOrderEvent.
+                            // Note: this is done by the transaction handler but we have a clone of the order
+                            order.Status = fill.Status;
+
                             //If the fill models come back suggesting filled, process the affects on portfolio
                             OnOrderEvent(fill);
                         }

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BacktestingTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BacktestingTransactionHandlerTests.cs
@@ -14,13 +14,17 @@
 */
 
 using System;
+using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
 using QuantConnect.Brokerages;
 using QuantConnect.Brokerages.Backtesting;
+using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Orders.Fills;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
 
@@ -44,6 +48,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             _algorithm.SetCash(100000);
             _algorithm.AddSecurity(SecurityType.Forex, Ticker);
             _algorithm.SetFinishedWarmingUp();
+            TestPartialFilledModel.FilledOrders = new Dictionary<int, Order>();
         }
 
         [Test]
@@ -71,6 +76,178 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.IsTrue(orderRequest.Response.IsError);
             Assert.IsTrue(orderRequest.Response.ErrorMessage
                 .Contains("Cannot process submit request because order with id {0} already exists"));
+        }
+
+        [Test]
+        public void SendingNewOrderFromOnOrderEvent()
+        {
+            //Initializes the transaction handler
+            var transactionHandler = new BacktestingTransactionHandler();
+            var brokerage = new BacktestingBrokerage(_algorithm);
+            transactionHandler.Initialize(_algorithm, brokerage, new BacktestingResultHandler());
+
+            // Creates a market order
+            var security = _algorithm.Securities[Ticker];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.UtcNow.AddDays(-1), security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 0, DateTime.UtcNow, "");
+            var orderRequest2 = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, -1000, 0, 0, DateTime.UtcNow, "");
+            orderRequest.SetOrderId(1);
+            orderRequest2.SetOrderId(2);
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.Is<int>(i => i == 1))).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.Is<int>(i => i == 2))).Returns(new OrderTicket(_algorithm.Transactions, orderRequest2));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            var orderEventCalls = 0;
+            brokerage.OrderStatusChanged += (sender, orderEvent) =>
+            {
+                orderEventCalls++;
+                switch (orderEventCalls)
+                {
+                    case 1:
+                        Assert.AreEqual(1, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.Submitted, orderEvent.Status);
+
+                        // we send a new order request
+                        var ticket2 = transactionHandler.Process(orderRequest2);
+                        break;
+                    case 2:
+                        Assert.AreEqual(2, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.Submitted, orderEvent.Status);
+                        break;
+                    case 3:
+                        Assert.AreEqual(1, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.Filled, orderEvent.Status);
+                        break;
+                    case 4:
+                        Assert.AreEqual(2, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.Filled, orderEvent.Status);
+                        break;
+                }
+                Console.WriteLine($"{orderEvent}");
+            };
+
+            var ticket = transactionHandler.Process(orderRequest);
+
+            Assert.IsTrue(orderRequest.Response.IsProcessed);
+            Assert.IsTrue(orderRequest.Response.IsSuccess);
+            Assert.AreEqual(OrderRequestStatus.Processed, orderRequest.Status);
+            Assert.IsTrue(orderRequest2.Response.IsProcessed);
+            Assert.IsTrue(orderRequest2.Response.IsSuccess);
+            Assert.AreEqual(OrderRequestStatus.Processed, orderRequest2.Status);
+
+            var order1 = transactionHandler.GetOrderById(1);
+            Assert.AreEqual(OrderStatus.Filled, order1.Status);
+            var order2 = transactionHandler.GetOrderById(2);
+            Assert.AreEqual(OrderStatus.Filled, order2.Status);
+
+            // 2 submitted and 2 filled
+            Assert.AreEqual(4, orderEventCalls);
+        }
+
+        [Test]
+        public void SendingNewOrderFromPartiallyFilledOnOrderEvent()
+        {
+            //Initializes the transaction handler
+            var transactionHandler = new BacktestingTransactionHandler();
+            var brokerage = new BacktestingBrokerage(_algorithm);
+            transactionHandler.Initialize(_algorithm, brokerage, new BacktestingResultHandler());
+
+            // Creates a market order
+            var security = _algorithm.Securities[Ticker];
+            security.FillModel = new TestPartialFilledModel();
+
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.UtcNow.AddDays(-1), security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 0, DateTime.UtcNow, "");
+            var orderRequest2 = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, -1000, 0, 0, DateTime.UtcNow, "");
+            orderRequest.SetOrderId(1);
+            orderRequest2.SetOrderId(2);
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.Is<int>(i => i == 1))).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.Is<int>(i => i == 2))).Returns(new OrderTicket(_algorithm.Transactions, orderRequest2));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            var orderEventCalls = 0;
+            brokerage.OrderStatusChanged += (sender, orderEvent) =>
+            {
+                orderEventCalls++;
+                switch (orderEventCalls)
+                {
+                    case 1:
+                        Assert.AreEqual(1, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.Submitted, orderEvent.Status);
+
+                        // we send a new order request
+                        var ticket2 = transactionHandler.Process(orderRequest2);
+                        break;
+                    case 2:
+                        Assert.AreEqual(2, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.Submitted, orderEvent.Status);
+                        break;
+                    case 3:
+                        Assert.AreEqual(1, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.PartiallyFilled, orderEvent.Status);
+                        break;
+                    case 4:
+                        Assert.AreEqual(2, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.PartiallyFilled, orderEvent.Status);
+                        break;
+                    case 5:
+                        Assert.AreEqual(1, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.Filled, orderEvent.Status);
+                        break;
+                    case 6:
+                        Assert.AreEqual(2, orderEvent.OrderId);
+                        Assert.AreEqual(OrderStatus.Filled, orderEvent.Status);
+                        break;
+                }
+                Console.WriteLine($"{orderEvent}");
+            };
+
+            var ticket = transactionHandler.Process(orderRequest);
+
+            Assert.IsTrue(orderRequest.Response.IsProcessed);
+            Assert.IsTrue(orderRequest.Response.IsSuccess);
+            Assert.AreEqual(OrderRequestStatus.Processed, orderRequest.Status);
+            Assert.IsTrue(orderRequest2.Response.IsProcessed);
+            Assert.IsTrue(orderRequest2.Response.IsSuccess);
+            Assert.AreEqual(OrderRequestStatus.Processed, orderRequest2.Status);
+
+            var order1 = transactionHandler.GetOrderById(1);
+            Assert.AreEqual(OrderStatus.Filled, order1.Status);
+            var order2 = transactionHandler.GetOrderById(2);
+            Assert.AreEqual(OrderStatus.Filled, order2.Status);
+
+            // 2 submitted and 2 PartiallyFilled and 2 Filled
+            Assert.AreEqual(6, orderEventCalls);
+        }
+
+        internal class TestPartialFilledModel : IFillModel
+        {
+            public static Dictionary<int, Order> FilledOrders;
+
+            public Fill Fill(FillModelParameters parameters)
+            {
+                var order = parameters.Order;
+                var status = OrderStatus.PartiallyFilled;
+                if (FilledOrders.ContainsKey(order.Id))
+                {
+                    status = OrderStatus.Filled;
+                }
+                FilledOrders[order.Id] = order;
+                return new Fill(new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero)
+                {
+                    FillPrice = parameters.Security.Price,
+                    FillQuantity = order.Quantity / 2,
+                    Status = status
+                });
+            }
         }
     }
 }

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -266,7 +266,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var security = algo.AddSecurity(SecurityType.Crypto, "BTCUSD", Resolution.Hour, Market.GDAX, false, 3.3m, true);
 
             //Initializes the transaction handler
-            var transactionHandler = new BrokerageTransactionHandler();
+            var transactionHandler = new TestBrokerageTransactionHandler();
             transactionHandler.Initialize(algo, new BacktestingBrokerage(algo), new BacktestingResultHandler());
 
             // Creates the order
@@ -290,7 +290,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var security = algo.AddSecurity(SecurityType.Crypto, "BTCUSD", Resolution.Hour, Market.GDAX, false, 3.3m, true);
 
             //Initializes the transaction handler
-            var transactionHandler = new BrokerageTransactionHandler();
+            var transactionHandler = new TestBrokerageTransactionHandler();
             transactionHandler.Initialize(algo, new BacktestingBrokerage(algo), new BacktestingResultHandler());
 
             // Creates the order
@@ -314,7 +314,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var security = algo.AddSecurity(SecurityType.Crypto, "BTCUSD", Resolution.Hour, Market.GDAX, false, 3.3m, true);
 
             //Initializes the transaction handler
-            var transactionHandler = new BrokerageTransactionHandler();
+            var transactionHandler = new TestBrokerageTransactionHandler();
             transactionHandler.Initialize(algo, new BacktestingBrokerage(algo), new BacktestingResultHandler());
 
             // Creates the order
@@ -450,7 +450,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         public void CancelOrderRequestShouldFailForFilledOrder()
         {
             // Initializes the transaction handler
-            var transactionHandler = new BrokerageTransactionHandler();
+            var transactionHandler = new TestBrokerageTransactionHandler();
             var broker = new BacktestingBrokerage(_algorithm);
             transactionHandler.Initialize(_algorithm, broker, new BacktestingResultHandler());
 
@@ -916,7 +916,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         public void FillMessageIsAddedToOrderTag()
         {
             // Initializes the transaction handler
-            var transactionHandler = new BrokerageTransactionHandler();
+            var transactionHandler = new TestBrokerageTransactionHandler();
             var brokerage = new BacktestingBrokerage(_algorithm);
             transactionHandler.Initialize(_algorithm, brokerage, new BacktestingResultHandler());
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- After https://github.com/QuantConnect/Lean/pull/3184, `BacktestingBrokerage.Scan()` is now reentrant and was causing duplicate processing and events. To solve this, I'm updating the order status kept by the backtesting brokerage. Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3219
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Algorithms sending a new order from the `OnOrderEvent` callback
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests, reported algorithm reproducing the issue
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->