### PR TITLE
Extends OnBalanceVolume, ParabolicStopAndReverse and RegressionChannel Indicators With IIndicatorWarmUpPeriodProvider

### DIFF
--- a/Indicators/OnBalanceVolume.cs
+++ b/Indicators/OnBalanceVolume.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,9 +24,17 @@ namespace QuantConnect.Indicators
     /// If the current close price is higher the volume of that day is added to the OBV, while a lower close price will
     /// result in negative value.
     /// </summary>
-    public class OnBalanceVolume : TradeBarIndicator
+    public class OnBalanceVolume : TradeBarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private TradeBar _previousInput;
+
+        /// <summary>
+        /// Initializes a new instance of the Indicator class using the specified name.
+        /// </summary> 
+        public OnBalanceVolume()
+            : base("OBV")
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the Indicator class using the specified name.
@@ -40,10 +48,12 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return _previousInput != null; }
-        }
+        public override bool IsReady => _previousInput != null;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => 1;
 
         /// <summary>
         /// Computes the next value of this indicator from the given state

--- a/Indicators/ParabolicStopAndReverse.cs
+++ b/Indicators/ParabolicStopAndReverse.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ namespace QuantConnect.Indicators
     /// Parabolic SAR Indicator 
     /// Based on TA-Lib implementation
     /// </summary>
-    public class ParabolicStopAndReverse : BarIndicator
+    public class ParabolicStopAndReverse : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private bool _isLong;
         private IBaseDataBar _previousBar;
@@ -57,17 +57,19 @@ namespace QuantConnect.Indicators
         /// <param name="afIncrement">Acceleration factor increment value</param>
         /// <param name="afMax">Acceleration factor max value</param>
         public ParabolicStopAndReverse(decimal afStart = 0.02m, decimal afIncrement = 0.02m, decimal afMax = 0.2m)
-            : this(string.Format("PSAR({0},{1},{2})", afStart, afIncrement, afMax), afStart, afIncrement, afMax)
+            : this($"PSAR({afStart},{afIncrement},{afMax})", afStart, afIncrement, afMax)
         {
         }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples >= 2; }
-        }
+        public override bool IsReady => Samples >= 2;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => 2;
 
         /// <summary>
         /// Resets this indicator to its initial state

--- a/Indicators/RegressionChannel.cs
+++ b/Indicators/RegressionChannel.cs
@@ -21,45 +21,47 @@ namespace QuantConnect.Indicators
     /// the linear regression line by a user defined number of standard deviations.
     /// Reference: http://www.onlinetradingconcepts.com/TechnicalAnalysis/LinRegChannel.html
     /// </summary>
-    public class RegressionChannel : Indicator
+    public class RegressionChannel : Indicator, IIndicatorWarmUpPeriodProvider
     {
         /// <summary>
         /// Gets the standard deviation
         /// </summary>
-        private IndicatorBase<IndicatorDataPoint> _standardDeviation;
+        private readonly IndicatorBase<IndicatorDataPoint> _standardDeviation;
 
         /// <summary>
         /// Gets the linear regression
         /// </summary>
-        public LeastSquaresMovingAverage LinearRegression { get; private set; }
+        public LeastSquaresMovingAverage LinearRegression { get; }
 
         /// <summary>
         /// Gets the upper channel (linear regression + k * stdDev)
         /// </summary>
-        public IndicatorBase<IndicatorDataPoint> UpperChannel { get; private set; }
+        public IndicatorBase<IndicatorDataPoint> UpperChannel { get; }
 
         /// <summary>
         /// Gets the lower channel (linear regression - k * stdDev)
         /// </summary>
-        public IndicatorBase<IndicatorDataPoint> LowerChannel { get; private set; }
+        public IndicatorBase<IndicatorDataPoint> LowerChannel { get; }
 
         /// <summary>
         /// The point where the regression line crosses the y-axis (price-axis)
         /// </summary>
-        public IndicatorBase<IndicatorDataPoint> Intercept { get { return LinearRegression.Intercept; } }
+        public IndicatorBase<IndicatorDataPoint> Intercept => LinearRegression.Intercept;
 
         /// <summary>
         /// The regression line slope
         /// </summary>
-        public IndicatorBase<IndicatorDataPoint> Slope { get { return LinearRegression.Slope; } }
+        public IndicatorBase<IndicatorDataPoint> Slope => LinearRegression.Slope;
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return _standardDeviation.IsReady && LinearRegression.IsReady && UpperChannel.IsReady && LowerChannel.IsReady; }
-        }
+        public override bool IsReady => _standardDeviation.IsReady && LinearRegression.IsReady && UpperChannel.IsReady && LowerChannel.IsReady;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RegressionChannel"/> class.
@@ -74,6 +76,7 @@ namespace QuantConnect.Indicators
             LinearRegression = new LeastSquaresMovingAverage(name + "_LinearRegression", period);
             LowerChannel = LinearRegression.Minus(_standardDeviation.Times(k), name + "_LowerChannel");
             UpperChannel = LinearRegression.Plus(_standardDeviation.Times(k), name + "_UpperChannel");
+            WarmUpPeriod = period;
         }
 
         /// <summary>
@@ -82,7 +85,7 @@ namespace QuantConnect.Indicators
         /// <param name="period">The number of data points to hold in the window.</param>
         /// <param name="k">The number of standard deviations specifying the distance between the linear regression and upper or lower channel lines</param>
         public RegressionChannel(int period, decimal k)
-            : this(string.Format("RC({0},{1})", period, k), period, k)
+            : this($"RC({period},{k})", period, k)
         {
         }
 

--- a/Tests/Indicators/OnBalanceVolumeTest.cs
+++ b/Tests/Indicators/OnBalanceVolumeTest.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,40 +14,26 @@
 */
 
 using NUnit.Framework;
+using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
+using System;
 
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class OnBalanceVolumeTests
+    public class OnBalanceVolumeTests : CommonIndicatorTests<TradeBar>
     {
-        [Test]
-        public void ComparesAgainstExternalData()
+        protected override IndicatorBase<TradeBar> CreateIndicator()
         {
-            var onBalanceVolumeIndicator = new OnBalanceVolume("OBV");
-
-            TestHelper.TestIndicator(onBalanceVolumeIndicator, "spy_with_obv.txt", "OBV",
-                (ind, expected) => Assert.AreEqual(
-                    expected.ToString("0.##E-00"),
-                    (onBalanceVolumeIndicator.Current.Value).ToString("0.##E-00")
-                    )
-                );
+            return new OnBalanceVolume();
         }
 
-        [Test]
-        public void ResetsProperly()
-        {
-            var onBalanceVolumeIndicator = new OnBalanceVolume("OBV");
-            foreach (var data in TestHelper.GetTradeBarStream("spy_with_obv.txt", false))
-            {
-                onBalanceVolumeIndicator.Update(data);
-            }
+        protected override string TestFileName => "spy_with_obv.txt";
 
-            Assert.IsTrue(onBalanceVolumeIndicator.IsReady);
+        protected override string TestColumnName => "OBV";
 
-            onBalanceVolumeIndicator.Reset();
-
-            TestHelper.AssertIndicatorIsInDefaultState(onBalanceVolumeIndicator);
-        }
+        protected override Action<IndicatorBase<TradeBar>, double> Assertion =>
+            (indicator, expected) =>
+                Assert.AreEqual(expected.ToString("0.##E-00"), indicator.Current.Value.ToString("0.##E-00"));
     }
 }

--- a/Tests/Indicators/ParabolicStopAndReverseTests.cs
+++ b/Tests/Indicators/ParabolicStopAndReverseTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,26 +14,21 @@
 */
 
 using NUnit.Framework;
+using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class ParabolicStopAndReverseTests
+    public class ParabolicStopAndReverseTests : CommonIndicatorTests<IBaseDataBar>
     {
-        [Test]
-        public void ComparesWithExternalData()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
-            var psar = new ParabolicStopAndReverse();
-            TestHelper.TestIndicator(psar, "spy_parabolic_SAR.txt", "Parabolic SAR 0.02 0.20");
+            return new ParabolicStopAndReverse();
         }
 
-        [Test]
-        public void ResetsProperly()
-        {
-            var psar = new ParabolicStopAndReverse();
+        protected override string TestFileName => "spy_parabolic_SAR.txt";
 
-            TestHelper.TestIndicatorReset(psar, "spy_parabolic_SAR.txt");
-        }
+        protected override string TestColumnName => "Parabolic SAR 0.02 0.20";
     }
 }

--- a/Tests/Indicators/RegressionChannelTest.cs
+++ b/Tests/Indicators/RegressionChannelTest.cs
@@ -69,6 +69,21 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
+        public void WarmsUpProperly()
+        {
+            var indicator = new RegressionChannel(20, 2);
+            var period = ((IIndicatorWarmUpPeriodProvider)indicator).WarmUpPeriod;
+            var prices = LeastSquaresMovingAverageTest.Prices;
+            var time = DateTime.Now;
+
+            for (var i = 0; i < period; i++)
+            {
+                indicator.Update(time.AddMinutes(i), prices[i]);
+                Assert.AreEqual(i == period - 1, indicator.IsReady);
+            }
+        }
+
+        [Test]
         public void LowerUpperChannelUpdateOnce()
         {
             var regressionChannel = new RegressionChannel(2, 2m);


### PR DESCRIPTION
#### Description
Extends `OnBalanceVolume`, `ParabolicStopAndReverse` and `RegressionChannel` indicators with `IIndicatorWarmUpPeriodProvider`.

#### Related Issue
#3074 

#### Motivation and Context
See #3074 

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`