### PR TITLE
Extends T3, Triangular and TripleExponential Moving Averages Indicators With IIndicatorWarmUpPeriodProvider

### DIFF
--- a/Indicators/T3MovingAverage.cs
+++ b/Indicators/T3MovingAverage.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,14 +16,14 @@
 namespace QuantConnect.Indicators
 {
     /// <summary>
-    /// This indicator computes the T3 Moving Average (T3). 
+    /// This indicator computes the T3 Moving Average (T3).
     /// The T3 Moving Average is calculated with the following formula:
     /// EMA1(x, Period) = EMA(x, Period)
     /// EMA2(x, Period) = EMA(EMA1(x, Period),Period)
     /// GD(x, Period, volumeFactor) = (EMA1(x, Period)*(1+volumeFactor)) - (EMA2(x, Period)* volumeFactor)
     /// T3 = GD(GD(GD(t, Period, volumeFactor), Period, volumeFactor), Period, volumeFactor);
     /// </summary>
-    public class T3MovingAverage : IndicatorBase<IndicatorDataPoint>
+    public class T3MovingAverage : IndicatorBase<IndicatorDataPoint>, IIndicatorWarmUpPeriodProvider
     {
         private readonly int _period;
         private readonly DoubleExponentialMovingAverage _gd1;
@@ -51,17 +51,19 @@ namespace QuantConnect.Indicators
         /// <param name="period">The period of the T3MovingAverage</param>
         /// <param name="volumeFactor">The volume factor of the T3MovingAverage (value must be in the [0,1] range, defaults to 0.7)</param>
         public T3MovingAverage(int period, decimal volumeFactor = 0.7m)
-            : this(string.Format("T3({0},{1})", period, volumeFactor), period, volumeFactor)
+            : this($"T3({period},{volumeFactor})", period, volumeFactor)
         {
         }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples > 6 * (_period - 1); }
-        }
+        public override bool IsReady => Samples > 6 * (_period - 1);
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => 1 + 6 * (_period - 1);
 
         /// <summary>
         /// Computes the next value of this indicator from the given state

--- a/Indicators/TriangularMovingAverage.cs
+++ b/Indicators/TriangularMovingAverage.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,7 @@ namespace QuantConnect.Indicators
     /// (1) When the period is even, TRIMA(x,period)=SMA(SMA(x,period/2),(period/2)+1)
     /// (2) When the period is odd,  TRIMA(x,period)=SMA(SMA(x,(period+1)/2),(period+1)/2)
     /// </summary>
-    public class TriangularMovingAverage : IndicatorBase<IndicatorDataPoint>
+    public class TriangularMovingAverage : Indicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly int _period;
         private readonly SimpleMovingAverage _sma1;
@@ -49,17 +49,19 @@ namespace QuantConnect.Indicators
         /// </summary> 
         /// <param name="period">The period of the indicator</param>
         public TriangularMovingAverage(int period)
-            : this("TRIMA" + period, period)
+            : this($"TRIMA({period})", period)
         {
         }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples >= _period; }
-        }
+        public override bool IsReady => Samples >= _period;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => _period;
 
         /// <summary>
         /// Computes the next value of this indicator from the given state

--- a/Tests/Indicators/T3MovingAverageTests.cs
+++ b/Tests/Indicators/T3MovingAverageTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,41 +15,24 @@
 
 using NUnit.Framework;
 using QuantConnect.Indicators;
+using System;
 
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class T3MovingAverageTests
+    public class T3MovingAverageTests : CommonIndicatorTests<IndicatorDataPoint>
     {
-        [Test]
-        public void ComparesAgainstExternalData()
+        protected override IndicatorBase<IndicatorDataPoint> CreateIndicator()
         {
-            var indicator = new T3MovingAverage(5);
-
-            RunTestIndicator(indicator);
+            return new T3MovingAverage(5);
         }
 
-        [Test]
-        public void ComparesAgainstExternalDataAfterReset()
-        {
-            var indicator = new T3MovingAverage(5);
+        protected override string TestFileName => "spy_t3.txt";
 
-            RunTestIndicator(indicator);
-            indicator.Reset();
-            RunTestIndicator(indicator);
-        }
+        protected override string TestColumnName => "T3_5";
 
-        [Test]
-        public void ResetsProperly()
-        {
-            var indicator = new T3MovingAverage(5, 1);
-
-            TestHelper.TestIndicatorReset(indicator, "spy_t3.txt");
-        }
-
-        private static void RunTestIndicator(IndicatorBase<IndicatorDataPoint> indicator)
-        {
-            TestHelper.TestIndicator(indicator, "spy_t3.txt", "T3_5", (ind, expected) => Assert.AreEqual(expected, (double)ind.Current.Value, 2e-2));
-        }
+        protected override Action<IndicatorBase<IndicatorDataPoint>, double> Assertion =>
+            (indicator, expected)
+                => Assert.AreEqual(expected, (double) indicator.Current.Value, 2e-2);
     }
 }

--- a/Tests/Indicators/TriangularMovingAverageTests.cs
+++ b/Tests/Indicators/TriangularMovingAverageTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,15 @@ namespace QuantConnect.Tests.Indicators
     [TestFixture]
     public class TriangularMovingAverageTests : CommonIndicatorTests<IndicatorDataPoint>
     {
+        protected override IndicatorBase<IndicatorDataPoint> CreateIndicator()
+        {
+            return new TriangularMovingAverage(5);
+        }
+
+        protected override string TestFileName => "spy_trima.txt";
+
+        protected override string TestColumnName => "TRIMA";
+
         [Test]
         public override void ComparesAgainstExternalData()
         {
@@ -40,21 +49,6 @@ namespace QuantConnect.Tests.Indicators
                 indicator.Reset();
                 RunTestIndicator(indicator, period);
             }
-        }
-
-        protected override IndicatorBase<IndicatorDataPoint> CreateIndicator()
-        {
-            return new TriangularMovingAverage(5);
-        }
-
-        protected override string TestFileName
-        {
-            get { return "spy_trima.txt"; }
-        }
-
-        protected override string TestColumnName
-        {
-            get { return "TRIMA"; }
         }
 
         private void RunTestIndicator(TriangularMovingAverage trima, int period)

--- a/Tests/Indicators/TripleExponentialMovingAverageTests.cs
+++ b/Tests/Indicators/TripleExponentialMovingAverageTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,14 +26,8 @@ namespace QuantConnect.Tests.Indicators
             return new TripleExponentialMovingAverage(5);
         }
 
-        protected override string TestFileName
-        {
-            get { return "spy_tema.txt"; }
-        }
+        protected override string TestFileName => "spy_tema.txt";
 
-        protected override string TestColumnName
-        {
-            get { return "TEMA_5"; }
-        }
+        protected override string TestColumnName => "TEMA_5";
     }
 }


### PR DESCRIPTION
#### Description
Extends `T3MovingAverage`, `TriangularMovingAverage` and `TripleExponentialMovingAverage` indicators with `IIndicatorWarmUpPeriodProvider`.

#### Related Issue
#3074 

#### Motivation and Context
See #3074 

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`