### PR TITLE
IB Brokerage - Detect and handle competing session

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2853,6 +2853,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 _ibAutomaterInitializeEvent.Set();
             }
+
+            // the IB session was disconnected by the user logging in from another location
+            else if (e.Data.Contains("Re-login is required"))
+            {
+                const string message = "A new competing session was started from another location and the current session has been terminated.";
+
+                _algorithm.Error("Brokerage Error: " + message);
+                _algorithm.RunTimeError = new Exception(message);
+            }
         }
 
         private void OnIbAutomaterErrorDataReceived(object sender, ErrorDataReceivedEventArgs e)


### PR DESCRIPTION

#### Description
This PR aims to further improve the IB Brokerage error handling.
Specifically, the case of a competing session (login with same user name) started remotely by a user with an algorithm already running.

#### Motivation and Context
Currently, when a user logs into the account from another location, the algorithm will disconnect and try to reconnect for **15 minutes** (in vain) and then exit with the following error message:
```
Connection with Interactive Brokers lost. 
This could be because of internet connectivity issues or a log in from another location.
```
With this update, the algorithm will now exit **immediately** with the following new error message:
```
A new competing session was started from another location 
and the current session has been terminated.
```

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Deployed an IB algorithm in the cloud, opened IB Gateway from another location and verified that the correct message was displayed.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`