### PR TITLE
Fix execution models to handle partially filled orders

### DIFF
--- a/Algorithm/Execution/ImmediateExecutionModel.cs
+++ b/Algorithm/Execution/ImmediateExecutionModel.cs
@@ -39,8 +39,8 @@ namespace QuantConnect.Algorithm.Framework.Execution
             foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))
             {
                 var existing = algorithm.Securities[target.Symbol].Holdings.Quantity
-                    + algorithm.Transactions.GetOpenOrders(target.Symbol)
-                        .Aggregate(0m, (d, order) => d + order.Quantity);
+                    + algorithm.Transactions.GetOpenOrderTickets(target.Symbol)
+                        .Aggregate(0m, (d, ticket) => d + ticket.Quantity - ticket.QuantityFilled);
                 var quantity = target.Quantity - existing;
                 if (quantity != 0)
                 {

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -41,7 +41,7 @@ class ImmediateExecutionModel(ExecutionModel):
         self.targetsCollection.AddRange(targets)
 
         for target in self.targetsCollection.OrderByMarginImpact(algorithm):
-            open_quantity = sum([x.Quantity for x in algorithm.Transactions.GetOpenOrders(target.Symbol)])
+            open_quantity = sum([x.Quantity - x.QuantityFilled for x in algorithm.Transactions.GetOpenOrderTickets(target.Symbol)])
             existing = algorithm.Securities[target.Symbol].Holdings.Quantity + open_quantity
             quantity = target.Quantity - existing
             if quantity != 0:

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTargetCollection.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTargetCollection.cs
@@ -334,8 +334,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                     PortfolioTarget = x,
                     TargetQuantity = x.Quantity,
                     ExistingQuantity = algorithm.Portfolio[x.Symbol].Quantity
-                                       + algorithm.Transactions.GetOpenOrders(o => o.Symbol == x.Symbol)
-                                           .Aggregate(0m, (d, o) => d + o.Quantity),
+                                       + algorithm.Transactions.GetOpenOrderTickets(x.Symbol)
+                                           .Aggregate(0m, (d, t) => d + t.Quantity - t.QuantityFilled),
                     Price = algorithm.Securities[x.Symbol].Price
                 })
                 .Select(x => new {

--- a/Common/Orders/OrderSizing.cs
+++ b/Common/Orders/OrderSizing.cs
@@ -65,7 +65,8 @@ namespace QuantConnect.Orders
         {
             var security = algorithm.Securities[target.Symbol];
             var holdings = security.Holdings.Quantity;
-            var openOrderQuantity = algorithm.Transactions.GetOpenOrders(target.Symbol).Aggregate(0m, (d, o) => d + o.Quantity);
+            var openOrderQuantity = algorithm.Transactions.GetOpenOrderTickets(target.Symbol)
+                .Aggregate(0m, (d, t) => d + t.Quantity - t.QuantityFilled);
             var quantity = target.Quantity - holdings - openOrderQuantity;
 
             // check if we're below the lot size threshold

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -230,7 +230,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Gets and enumerable of <see cref="OrderTicket"/> matching the specified <paramref name="filter"/>
+        /// Gets an enumerable of <see cref="OrderTicket"/> matching the specified <paramref name="filter"/>
         /// </summary>
         /// <param name="filter">The filter predicate used to find the required order tickets</param>
         /// <returns>An enumerable of <see cref="OrderTicket"/> matching the specified <paramref name="filter"/></returns>
@@ -240,7 +240,17 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Gets and enumerable of opened <see cref="OrderTicket"/> matching the specified <paramref name="filter"/>
+        /// Get an enumerable of open <see cref="OrderTicket"/> for the specified symbol
+        /// </summary>
+        /// <param name="symbol">The symbol for which to return the order tickets</param>
+        /// <returns>An enumerable of open <see cref="OrderTicket"/>.</returns>
+        public IEnumerable<OrderTicket> GetOpenOrderTickets(Symbol symbol)
+        {
+            return GetOpenOrderTickets(x => x.Symbol == symbol);
+        }
+
+        /// <summary>
+        /// Gets an enumerable of opened <see cref="OrderTicket"/> matching the specified <paramref name="filter"/>
         /// </summary>
         /// <param name="filter">The filter predicate used to find the required order tickets</param>
         /// <returns>An enumerable of opened <see cref="OrderTicket"/> matching the specified <paramref name="filter"/></returns>

--- a/Tests/Algorithm/Framework/Portfolio/PortfolioTargetCollectionTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/PortfolioTargetCollectionTests.cs
@@ -146,7 +146,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         }
 
         [Test]
-        public void OrderByMarginImpactDoesNotReturnTargetsForWhichUnorderdQuantityIsZeroBecauseTargetIsZero()
+        public void OrderByMarginImpactDoesNotReturnTargetsForWhichUnorderedQuantityIsZeroBecauseTargetIsZero()
         {
             var algorithm = new FakeAlgorithm();
             algorithm.Transactions.SetOrderProcessor(new FakeOrderProcessor());
@@ -164,7 +164,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         }
 
         [Test]
-        public void OrderByMarginImpactDoesNotReturnTargetsForWhichUnorderdQuantityIsZeroBecauseTargetReached()
+        public void OrderByMarginImpactDoesNotReturnTargetsForWhichUnorderedQuantityIsZeroBecauseTargetReached()
         {
             var algorithm = new FakeAlgorithm();
             algorithm.Transactions.SetOrderProcessor(new FakeOrderProcessor());
@@ -184,7 +184,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         }
 
         [Test]
-        public void OrderByMarginImpactDoesNotReturnTargetsForWhichUnorderdQuantityIsZeroBecauseOpenOrder()
+        public void OrderByMarginImpactDoesNotReturnTargetsForWhichUnorderedQuantityIsZeroBecauseOpenOrder()
         {
             var algorithm = new FakeAlgorithm();
             var orderProcessor = new FakeOrderProcessor();
@@ -195,7 +195,13 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             var collection = new PortfolioTargetCollection();
             var target = new PortfolioTarget(symbol, 1);
             collection.Add(target);
+
+            var openOrderRequest = new SubmitOrderRequest(OrderType.Market, symbol.SecurityType, symbol, 1, 0, 0, DateTime.UtcNow, "");
+            openOrderRequest.SetOrderId(1);
+            var openOrderTicket = new OrderTicket(algorithm.Transactions, openOrderRequest);
+
             orderProcessor.AddOrder(new MarketOrder(symbol, 1, DateTime.UtcNow));
+            orderProcessor.AddTicket(openOrderTicket);
 
             var targets = collection.OrderByMarginImpact(algorithm);
             Assert.AreEqual(collection.Count, 1);


### PR DESCRIPTION

#### Description
The `ImmediateExecutionModel` and other position sizing methods used by other models (in `PortfolioTargetCollection` and `OrderSizing`) have been updated to use the **remaining quantity** instead of the **total order quantity** in the calculation of open order quantities.

#### Related Issue
Closes #3231 

#### Motivation and Context
Incorrect calculation of quantity in execution models.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`