### PR TITLE
Emit an error if desktop-exe does not exist

### DIFF
--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -110,6 +110,12 @@ namespace QuantConnect.Lean.Launcher
 
             if (environment.EndsWith("-desktop"))
             {
+                if (!File.Exists(Config.Get("desktop-exe")))
+                {
+                    var message = $"desktop-exe path ({Config.Get("desktop-exe")}) does not exist. You may need to update this path with the build configuration (currently ${mode})";
+                    Log.Error(message);
+                    throw new FileNotFoundException(message);
+                }
                 var info = new ProcessStartInfo
                 {
                     UseShellExecute = false,


### PR DESCRIPTION
Currently, desktop-exe, which is used in -desktop configurations, looks for Quantconnect.Views.Exe in the config. The default config file ships with a path to the debug version of the executable, which isn't built in release mode, leading to a mysterious win32 file not found error (as seen in issue #1284). Notably, it is easy to get yourself in this configuration (release mode) by following the tutorials.

#### Description
This PR adds a minimal error message suggesting to the user that they need to update this path. In the future, it might be a good idea to auto-detect this path or just link the executable directly to the launcher.

#### Related Issue
See previous issue #1204 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
No, but consider updating the documentation for https://www.quantconnect.com/tutorials/open-source/desktop-charting-with-lean

#### How Has This Been Tested?
I'm not sure if this change requires a test. It seems that launcher has no existing coverage, if I'm not mistaken.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. -Not needed for launcher?
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

Not really sure why its necessary to rename my branch?