### PR TITLE
Fix Orders Placed in OnOrderEvent

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -163,6 +163,7 @@
     <Compile Include="SetCashOnDataRegressionAlgorithm.cs" />
     <Compile Include="SmaCrossUniverseSelectionAlgorithm.cs" />
     <Compile Include="StartingCapitalRegressionAlgorithm.cs" />
+    <Compile Include="StopLossOnOrderEventRegressionAlgorithm.cs" />
     <Compile Include="TrailingStopRiskFrameworkAlgorithm.cs" />
     <Compile Include="BasicTemplateFuturesFrameworkAlgorithm.cs" />
     <Compile Include="BasicTemplateOptionsFrameworkAlgorithm.cs" />

--- a/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
@@ -1,0 +1,94 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This regression test algorithm reproduces GH issue 3239, where the stopLoss order
+    /// place on <see cref="OnOrderEvent"/> was not being filled.
+    /// </summary>
+    public class StopLossOnOrderEventRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _spy;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+            _spy = AddEquity("SPY").Symbol;
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Debug($"{orderEvent}");
+            var order = Transactions.GetOrderById(orderEvent.OrderId);
+            if (order.Tag == "Entry" && orderEvent.Status == OrderStatus.Filled)
+            {
+                Debug("Enter short at " + orderEvent.FillPrice + " set STOPLOSS at 151.0m");
+                StopMarketOrder(order.Symbol, order.Quantity, 151.0m, "StopLoss");
+            }
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                MarketOrder(_spy, -100, false, "Entry");
+                Debug("Purchased Stock");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "-43.065%"},
+            {"Drawdown", "1.000%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "-0.718%"},
+            {"Sharpe Ratio", "-7.226"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-0.005"},
+            {"Beta", "-32.327"},
+            {"Annual Standard Deviation", "0.05"},
+            {"Annual Variance", "0.003"},
+            {"Information Ratio", "-7.431"},
+            {"Tracking Error", "0.05"},
+            {"Treynor Ratio", "0.011"},
+            {"Total Fees", "$2.00"}
+        };
+    }
+}

--- a/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
@@ -27,6 +27,7 @@ namespace QuantConnect.Algorithm.CSharp
     public class StopLossOnOrderEventRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol _spy;
+        private bool _alreadyTraded;
 
         public override void Initialize()
         {
@@ -42,14 +43,15 @@ namespace QuantConnect.Algorithm.CSharp
             if (order.Tag == "Entry" && orderEvent.Status == OrderStatus.Filled)
             {
                 Debug("Enter short at " + orderEvent.FillPrice + " set STOPLOSS at 151.0m");
-                StopMarketOrder(order.Symbol, order.Quantity, 151.0m, "StopLoss");
+                StopMarketOrder(order.Symbol, -order.Quantity, 151.0m, "StopLoss");
             }
         }
 
         public override void OnData(Slice data)
         {
-            if (!Portfolio.Invested)
+            if (!Portfolio.Invested && !_alreadyTraded)
             {
+                _alreadyTraded = true;
                 MarketOrder(_spy, -100, false, "Entry");
                 Debug("Purchased Stock");
             }
@@ -71,23 +73,23 @@ namespace QuantConnect.Algorithm.CSharp
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "2"},
-            {"Average Win", "0%"},
+            {"Average Win", "0.00%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "-43.065%"},
-            {"Drawdown", "1.000%"},
+            {"Compounding Annual Return", "0.273%"},
+            {"Drawdown", "0.000%"},
             {"Expectancy", "0"},
-            {"Net Profit", "-0.718%"},
-            {"Sharpe Ratio", "-7.226"},
+            {"Net Profit", "0.003%"},
+            {"Sharpe Ratio", "7.099"},
             {"Loss Rate", "0%"},
-            {"Win Rate", "0%"},
+            {"Win Rate", "100%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "-0.005"},
-            {"Beta", "-32.327"},
-            {"Annual Standard Deviation", "0.05"},
-            {"Annual Variance", "0.003"},
-            {"Information Ratio", "-7.431"},
-            {"Tracking Error", "0.05"},
-            {"Treynor Ratio", "0.011"},
+            {"Alpha", "0.009"},
+            {"Beta", "-0.636"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-14.596"},
+            {"Tracking Error", "0.001"},
+            {"Treynor Ratio", "-0.003"},
             {"Total Fees", "$2.00"}
         };
     }

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -432,8 +432,9 @@ namespace QuantConnect.Brokerages.Backtesting
                     }
                 }
 
-                // if we didn't fill then we need to continue to scan
-                _needsScan = stillNeedsScan;
+                // if we didn't fill then we need to continue to scan or
+                // if there are still pending orders
+                _needsScan = stillNeedsScan || !_pending.IsEmpty;
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- The `BacktestingBrokerage` will also verify there are no more pending
orders when deciding if it needs to continue scanning.
   - The issue was being caused due to the re entrant nature of the `BacktestingBrokerage.Scan()` method. `stillNeedsScan` could be `false` for the last entry of `Scan()` but deeper stack calls had added a new order.

Performance tests C# RegressionAlgorithm 5.4K trades
`PR`
9.61 seconds at 192k data points per second. Processing total of 1,842,728 data points.
9.60 seconds at 192k data points per second. Processing total of 1,842,728 data points.
9.62 seconds at 192k data points per second. Processing total of 1,842,728 data points.
`master`
9.67 seconds at 190k data points per second. Processing total of 1,842,728 data points.
9.43 seconds at 195k data points per second. Processing total of 1,842,728 data points.
9.62 seconds at 192k data points per second. Processing total of 1,842,728 data points.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3239
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- StopLoss order being placed in OnOrderEvent wasn't being filled
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->