### PR TITLE
Bitfinex GetAccountHoldings will set MarketPrice

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.Utility.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Utility.cs
@@ -216,9 +216,10 @@ namespace QuantConnect.Brokerages.Bitfinex
                 var tick = GetTick(holding.Symbol);
                 holding.MarketPrice = tick.Value;
             }
-            catch (Exception exception)
+            catch (Exception)
             {
-                Log.Trace($"BitfinexBrokerage.ConvertHolding(): failed to set {holding.Symbol} market price: {exception}");
+                Log.Error($"BitfinexBrokerage.ConvertHolding(): failed to set {holding.Symbol} market price");
+                throw;
             }
 
             return holding;

--- a/Brokerages/Bitfinex/BitfinexBrokerage.Utility.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Utility.cs
@@ -201,7 +201,7 @@ namespace QuantConnect.Brokerages.Bitfinex
 
         private Holding ConvertHolding(Messages.Position position)
         {
-            return new Holding()
+            var holding = new Holding
             {
                 Symbol = _symbolMapper.GetLeanSymbol(position.Symbol),
                 AveragePrice = position.AveragePrice,
@@ -210,6 +210,18 @@ namespace QuantConnect.Brokerages.Bitfinex
                 CurrencySymbol = "$",
                 Type = SecurityType.Crypto
             };
+
+            try
+            {
+                var tick = GetTick(holding.Symbol);
+                holding.MarketPrice = tick.Value;
+            }
+            catch (Exception exception)
+            {
+                Log.Trace($"BitfinexBrokerage.ConvertHolding(): failed to set {holding.Symbol} market price: {exception}");
+            }
+
+            return holding;
         }
 
         private Func<Messages.Order, bool> OrderFilter(AccountType accountType)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `Bitfinex.GetAccountHoldings` will set `MarketPrice`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3101
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- `MarketPrice` used by the `BrokerageSetupHandler` to set security prices for any existing holding
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Live tested by @Adalyat https://github.com/QuantConnect/Lean/issues/3101#issuecomment-497452767 thanks!
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->