### PR TITLE
Add SecurityType check in BitfinexBrokerage.GetHistory

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.cs
@@ -267,6 +267,13 @@ namespace QuantConnect.Brokerages.Bitfinex
         /// <returns>An enumerable of bars covering the span specified in the request</returns>
         public override IEnumerable<BaseData> GetHistory(Data.HistoryRequest request)
         {
+            if (request.Symbol.SecurityType != SecurityType.Crypto)
+            {
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidSecurityType",
+                    $"{request.Symbol.SecurityType} security type not supported, no history returned"));
+                yield break;
+            }
+
             if (request.Resolution == Resolution.Tick || request.Resolution == Resolution.Second)
             {
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidResolution",

--- a/Tests/Brokerages/Bitfinex/BitfinexBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexBrokerageHistoryProviderTests.cs
@@ -22,51 +22,35 @@ using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Logging;
 using QuantConnect.Securities;
 using QuantConnect.Brokerages.Bitfinex;
-using QuantConnect.Tests.Common.Securities;
 
 namespace QuantConnect.Tests.Brokerages.Bitfinex
 {
     [TestFixture]
     public partial class BitfinexBrokerageTests
     {
-        public TestCaseData[] ValidHistory
+        public TestCaseData[] History => new[]
         {
-            get
-            {
-                return new[]
-                {
-                    // valid
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Minute, Time.OneHour, false),
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Hour, Time.OneDay, false),
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Daily, TimeSpan.FromDays(15), false),
-                };
-            }
-        }
-        public TestCaseData[] InvalidHistory
-        {
-            get
-            {
-                return new[]
-                {
-                    // invalid resolution
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Tick, TimeSpan.FromSeconds(15), true),
-                    new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Second, Time.OneMinute, true),
+            // valid
+            new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Minute, Time.OneHour, false),
+            new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Hour, Time.OneDay, false),
+            new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Daily, TimeSpan.FromDays(15), false),
 
-                    // invalid period, no error, empty result
-                    new TestCaseData(Symbols.EURUSD, Resolution.Daily, TimeSpan.FromDays(-15), true),
+            // invalid resolution, no error, empty result
+            new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Tick, TimeSpan.FromSeconds(15), false),
+            new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Second, Time.OneMinute, false),
 
-                    // invalid symbol, throws "System.ArgumentException : Unknown symbol: XYZ"
-                    new TestCaseData(Symbol.Create("XYZ", SecurityType.Crypto, Market.Bitfinex), Resolution.Daily, TimeSpan.FromDays(15), true),
+            // invalid period, no error, empty result
+            new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Daily, TimeSpan.FromDays(-15), false),
 
-                    // invalid security type, throws "System.ArgumentException : Invalid security type: Equity"
-                    new TestCaseData(Symbols.AAPL, Resolution.Daily, TimeSpan.FromDays(15), true),
-                };
-            }
-        }
+            // invalid symbol, throws "System.ArgumentException : Unknown symbol: XYZ"
+            new TestCaseData(Symbol.Create("XYZ", SecurityType.Crypto, Market.Bitfinex), Resolution.Daily, TimeSpan.FromDays(15), true),
+
+            // invalid security type, no error, empty result
+            new TestCaseData(Symbols.EURUSD, Resolution.Daily, TimeSpan.FromDays(15), false)
+        };
 
         [Test]
-        [TestCaseSource("ValidHistory")]
-        [TestCaseSource("InvalidHistory")]
+        [TestCaseSource(nameof(History))]
         public void GetsHistory(Symbol symbol, Resolution resolution, TimeSpan period, bool throwsException)
         {
             TestDelegate test = () =>


### PR DESCRIPTION

#### Description
- Added missing security type check in `BitfinexBrokerage.GetHistory`
- Updated Bitfinex history provider unit tests

#### Related Issue
Closes #3253 

#### Motivation and Context
Exception is thrown with non-USD pairs in local deployments.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Test algorithm in #3253 
- Updated unit tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`