### PR TITLE
Fix IB connection refused error at startup or after gateway restart

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -586,8 +586,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     // if message processing thread is still running, wait until it terminates
                     Disconnect();
 
-                    // There is socket exception happening when reconnecting right away. Testing showed 10 ms is enough, using 50ms to be on the safe side.
-                    Thread.Sleep(50);
+                    // At initial startup or after a gateway restart, we need to wait for the gateway to be ready for a connect request.
+                    // Attempting to connect to the socket too early will get a SocketException: Connection refused.
+                    if (attempt == 1)
+                    {
+                        Thread.Sleep(2500);
+                    }
 
                     // we're going to try and connect several times, if successful break
                     _client.ClientSocket.eConnect(_host, _port, _clientId);


### PR DESCRIPTION
#### Description
At startup or after a gateway restart, we need to wait for the gateway to be ready for a connect request. Attempting to connect to the socket too early will get a `SocketException: Connection refused`.

This issue was introduced in #3175 (when a constant 30-second delay was removed)

#### Motivation and Context
`SocketException` error message displayed in user logs at startup or after gateway restart.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Algorithm live deployment in the cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.