### PR TITLE
Overall performance improvements

### DIFF
--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.cs
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.cs
@@ -74,37 +74,40 @@ namespace QuantConnect.Algorithm.Framework.Execution
         {
             _targetsCollection.AddRange(targets);
 
-            foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))
+            if (_targetsCollection.Count > 0)
             {
-                var symbol = target.Symbol;
-
-                // calculate remaining quantity to be ordered
-                var unorderedQuantity = OrderSizing.GetUnorderedQuantity(algorithm, target);
-
-                // fetch our symbol data containing our STD/SMA indicators
-                SymbolData data;
-                if (!_symbolData.TryGetValue(symbol, out data))
+                foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))
                 {
-                    continue;
-                }
+                    var symbol = target.Symbol;
 
-                // check order entry conditions
-                if (data.STD.IsReady && PriceIsFavorable(data, unorderedQuantity))
-                {
-                    // get the maximum order size based on total order value
-                    var maxOrderSize = OrderSizing.Value(data.Security, MaximumOrderValue);
-                    var orderSize = Math.Min(maxOrderSize, Math.Abs(unorderedQuantity));
+                    // calculate remaining quantity to be ordered
+                    var unorderedQuantity = OrderSizing.GetUnorderedQuantity(algorithm, target);
 
-                    // round down to even lot size
-                    orderSize -= orderSize % data.Security.SymbolProperties.LotSize;
-                    if (orderSize != 0)
+                    // fetch our symbol data containing our STD/SMA indicators
+                    SymbolData data;
+                    if (!_symbolData.TryGetValue(symbol, out data))
                     {
-                        algorithm.MarketOrder(symbol, Math.Sign(unorderedQuantity) * orderSize);
+                        continue;
+                    }
+
+                    // check order entry conditions
+                    if (data.STD.IsReady && PriceIsFavorable(data, unorderedQuantity))
+                    {
+                        // get the maximum order size based on total order value
+                        var maxOrderSize = OrderSizing.Value(data.Security, MaximumOrderValue);
+                        var orderSize = Math.Min(maxOrderSize, Math.Abs(unorderedQuantity));
+
+                        // round down to even lot size
+                        orderSize -= orderSize % data.Security.SymbolProperties.LotSize;
+                        if (orderSize != 0)
+                        {
+                            algorithm.MarketOrder(symbol, Math.Sign(unorderedQuantity) * orderSize);
+                        }
                     }
                 }
-            }
 
-            _targetsCollection.ClearFulfilled(algorithm);
+                _targetsCollection.ClearFulfilled(algorithm);
+            }
         }
 
         /// <summary>

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.cs
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Algorithm.Framework.Portfolio;
-using QuantConnect.Data;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Indicators;
@@ -74,6 +73,7 @@ namespace QuantConnect.Algorithm.Framework.Execution
         {
             _targetsCollection.AddRange(targets);
 
+            // for performance we check count value, OrderByMarginImpact and ClearFulfilled are expensive to call
             if (_targetsCollection.Count > 0)
             {
                 foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
@@ -63,6 +63,8 @@ class StandardDeviationExecutionModel(ExecutionModel):
            algorithm: The algorithm instance
            targets: The portfolio targets'''
         self.targetsCollection.AddRange(targets)
+
+        # for performance we check count value, OrderByMarginImpact and ClearFulfilled are expensive to call
         if self.targetsCollection.Count > 0:
             for target in self.targetsCollection.OrderByMarginImpact(algorithm):
                 symbol = target.Symbol

--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
@@ -51,6 +51,8 @@ namespace QuantConnect.Algorithm.Framework.Execution
         {
             // update the complete set of portfolio targets with the new targets
             _targetsCollection.AddRange(targets);
+
+            // for performance we check count value, OrderByMarginImpact and ClearFulfilled are expensive to call
             if (_targetsCollection.Count > 0)
             {
                 foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))

--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
@@ -51,38 +51,40 @@ namespace QuantConnect.Algorithm.Framework.Execution
         {
             // update the complete set of portfolio targets with the new targets
             _targetsCollection.AddRange(targets);
-
-            foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))
+            if (_targetsCollection.Count > 0)
             {
-                var symbol = target.Symbol;
-
-                // calculate remaining quantity to be ordered
-                var unorderedQuantity = OrderSizing.GetUnorderedQuantity(algorithm, target);
-
-                // fetch our symbol data containing our VWAP indicator
-                SymbolData data;
-                if (!_symbolData.TryGetValue(symbol, out data))
+                foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))
                 {
-                    continue;
-                }
+                    var symbol = target.Symbol;
 
-                // check order entry conditions
-                if (PriceIsFavorable(data, unorderedQuantity))
-                {
-                    // get the maximum order size based on a percentage of current volume
-                    var maxOrderSize = OrderSizing.PercentVolume(data.Security, MaximumOrderQuantityPercentVolume);
-                    var orderSize = Math.Min(maxOrderSize, Math.Abs(unorderedQuantity));
+                    // calculate remaining quantity to be ordered
+                    var unorderedQuantity = OrderSizing.GetUnorderedQuantity(algorithm, target);
 
-                    // round down to even lot size
-                    orderSize -= orderSize % data.Security.SymbolProperties.LotSize;
-                    if (orderSize != 0)
+                    // fetch our symbol data containing our VWAP indicator
+                    SymbolData data;
+                    if (!_symbolData.TryGetValue(symbol, out data))
                     {
-                        algorithm.MarketOrder(data.Security.Symbol, Math.Sign(unorderedQuantity) * orderSize);
+                        continue;
+                    }
+
+                    // check order entry conditions
+                    if (PriceIsFavorable(data, unorderedQuantity))
+                    {
+                        // get the maximum order size based on a percentage of current volume
+                        var maxOrderSize = OrderSizing.PercentVolume(data.Security, MaximumOrderQuantityPercentVolume);
+                        var orderSize = Math.Min(maxOrderSize, Math.Abs(unorderedQuantity));
+
+                        // round down to even lot size
+                        orderSize -= orderSize % data.Security.SymbolProperties.LotSize;
+                        if (orderSize != 0)
+                        {
+                            algorithm.MarketOrder(data.Security.Symbol, Math.Sign(unorderedQuantity) * orderSize);
+                        }
                     }
                 }
-            }
 
-            _targetsCollection.ClearFulfilled(algorithm);
+                _targetsCollection.ClearFulfilled(algorithm);
+            }
         }
 
         /// <summary>

--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.py
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.py
@@ -55,6 +55,8 @@ class VolumeWeightedAveragePriceExecutionModel(ExecutionModel):
 
         # update the complete set of portfolio targets with the new targets
         self.targetsCollection.AddRange(targets)
+
+        # for performance we check count value, OrderByMarginImpact and ClearFulfilled are expensive to call
         if self.targetsCollection.Count > 0:
             for target in self.targetsCollection.OrderByMarginImpact(algorithm):
                 symbol = target.Symbol

--- a/Algorithm/Execution/ImmediateExecutionModel.cs
+++ b/Algorithm/Execution/ImmediateExecutionModel.cs
@@ -35,6 +35,7 @@ namespace QuantConnect.Algorithm.Framework.Execution
         public override void Execute(QCAlgorithm algorithm, IPortfolioTarget[] targets)
         {
             _targetsCollection.AddRange(targets);
+            // for performance we check count value, OrderByMarginImpact and ClearFulfilled are expensive to call
             if (_targetsCollection.Count > 0)
             {
                 foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))

--- a/Algorithm/Execution/ImmediateExecutionModel.cs
+++ b/Algorithm/Execution/ImmediateExecutionModel.cs
@@ -35,20 +35,22 @@ namespace QuantConnect.Algorithm.Framework.Execution
         public override void Execute(QCAlgorithm algorithm, IPortfolioTarget[] targets)
         {
             _targetsCollection.AddRange(targets);
-
-            foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))
+            if (_targetsCollection.Count > 0)
             {
-                var existing = algorithm.Securities[target.Symbol].Holdings.Quantity
-                    + algorithm.Transactions.GetOpenOrderTickets(target.Symbol)
-                        .Aggregate(0m, (d, ticket) => d + ticket.Quantity - ticket.QuantityFilled);
-                var quantity = target.Quantity - existing;
-                if (quantity != 0)
+                foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))
                 {
-                    algorithm.MarketOrder(target.Symbol, quantity);
+                    var existing = algorithm.Securities[target.Symbol].Holdings.Quantity
+                        + algorithm.Transactions.GetOpenOrderTickets(target.Symbol)
+                            .Aggregate(0m, (d, ticket) => d + ticket.Quantity - ticket.QuantityFilled);
+                    var quantity = target.Quantity - existing;
+                    if (quantity != 0)
+                    {
+                        algorithm.MarketOrder(target.Symbol, quantity);
+                    }
                 }
-            }
 
-            _targetsCollection.ClearFulfilled(algorithm);
+                _targetsCollection.ClearFulfilled(algorithm);
+            }
         }
 
         /// <summary>

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -38,6 +38,7 @@ class ImmediateExecutionModel(ExecutionModel):
             algorithm: The algorithm instance
             targets: The portfolio targets to be ordered'''
 
+        # for performance we check count value, OrderByMarginImpact and ClearFulfilled are expensive to call
         self.targetsCollection.AddRange(targets)
         if self.targetsCollection.Count > 0:
             for target in self.targetsCollection.OrderByMarginImpact(algorithm):

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -39,12 +39,12 @@ class ImmediateExecutionModel(ExecutionModel):
             targets: The portfolio targets to be ordered'''
 
         self.targetsCollection.AddRange(targets)
+        if self.targetsCollection.Count > 0:
+            for target in self.targetsCollection.OrderByMarginImpact(algorithm):
+                open_quantity = sum([x.Quantity - x.QuantityFilled for x in algorithm.Transactions.GetOpenOrderTickets(target.Symbol)])
+                existing = algorithm.Securities[target.Symbol].Holdings.Quantity + open_quantity
+                quantity = target.Quantity - existing
+                if quantity != 0:
+                    algorithm.MarketOrder(target.Symbol, quantity)
 
-        for target in self.targetsCollection.OrderByMarginImpact(algorithm):
-            open_quantity = sum([x.Quantity - x.QuantityFilled for x in algorithm.Transactions.GetOpenOrderTickets(target.Symbol)])
-            existing = algorithm.Securities[target.Symbol].Holdings.Quantity + open_quantity
-            quantity = target.Quantity - existing
-            if quantity != 0:
-                algorithm.MarketOrder(target.Symbol, quantity)
-
-        self.targetsCollection.ClearFulfilled(algorithm)
+            self.targetsCollection.ClearFulfilled(algorithm)

--- a/Common/Algorithm/Framework/Alphas/Analysis/Providers/AlgorithmSecurityValuesProvider.cs
+++ b/Common/Algorithm/Framework/Alphas/Analysis/Providers/AlgorithmSecurityValuesProvider.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
@@ -55,15 +54,14 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Analysis.Providers
         /// <returns>The insight target values for all the algorithm securities</returns>
         public ReadOnlySecurityValuesCollection GetAllValues()
         {
-            var values = new Dictionary<Symbol, SecurityValues>();
-            foreach (var kvp in _algorithm.Securities)
-            {
-                var security = kvp.Value;
-                var volume = security.Cache.GetData<TradeBar>()?.Volume ?? 0;
-                var value = new SecurityValues(security.Symbol, _algorithm.UtcTime, security.Exchange.Hours, security.Price, security.VolatilityModel.Volatility, volume, security.QuoteCurrency.ConversionRate);
-                values[security.Symbol] = value;
-            }
-            return new ReadOnlySecurityValuesCollection(values);
+            // lets be lazy creating the SecurityValues
+            return new ReadOnlySecurityValuesCollection(
+                symbol =>
+                {
+                    var security = _algorithm.Securities[symbol];
+                    var volume = security.Cache.GetData<TradeBar>()?.Volume ?? 0;
+                    return new SecurityValues(security.Symbol, _algorithm.UtcTime, security.Exchange.Hours, security.Price, security.VolatilityModel.Volatility, volume, security.QuoteCurrency.ConversionRate);
+                });
         }
     }
 }

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTargetCollection.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTargetCollection.cs
@@ -318,11 +318,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <param name="algorithm">The algorithm instance</param>
         public IEnumerable<IPortfolioTarget> OrderByMarginImpact(IAlgorithm algorithm)
         {
-            if (Count == 0)
-            {
-                // shortcut for performance
-                return Enumerable.Empty<IPortfolioTarget>();
-            }
             return _targets
                 .Select(x => x.Value)
                 .Where(x => {

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -529,7 +529,13 @@ namespace QuantConnect
                 // divide by zero exception
                 return dateTime;
             }
-            return dateTime.AddTicks(-(dateTime.Ticks % interval.Ticks));
+
+            var amount = dateTime.Ticks % interval.Ticks;
+            if (amount > 0)
+            {
+                return dateTime.AddTicks(-amount);
+            }
+            return dateTime;
         }
 
         /// <summary>

--- a/Common/Securities/DefaultMarginCallModel.cs
+++ b/Common/Securities/DefaultMarginCallModel.cs
@@ -76,11 +76,11 @@ namespace QuantConnect.Securities
             {
                 return new List<SubmitOrderRequest>();
             }
+            var totalPortfolioValue = Portfolio.TotalPortfolioValue;
 
-            var marginRemaining = Portfolio.MarginRemaining;
+            var marginRemaining = Portfolio.GetMarginRemaining(totalPortfolioValue);
 
             // issue a margin warning when we're down to 5% margin remaining
-            var totalPortfolioValue = Portfolio.TotalPortfolioValue;
             if (marginRemaining <= totalPortfolioValue * 0.05m)
             {
                 issueMarginCallWarning = true;

--- a/Common/TimeKeeper.cs
+++ b/Common/TimeKeeper.cs
@@ -28,7 +28,7 @@ namespace QuantConnect
     {
         private DateTime _utcDateTime;
 
-        private readonly Dictionary<DateTimeZone, LocalTimeKeeper> _localTimeKeepers;
+        private readonly Dictionary<string, LocalTimeKeeper> _localTimeKeepers;
 
         /// <summary>
         /// Gets the current time in UTC
@@ -60,7 +60,7 @@ namespace QuantConnect
         public TimeKeeper(DateTime utcDateTime, IEnumerable<DateTimeZone> timeZones)
         {
             _utcDateTime = utcDateTime;
-            _localTimeKeepers = timeZones.Distinct().Select(x => new LocalTimeKeeper(utcDateTime, x)).ToDictionary(x => x.TimeZone);
+            _localTimeKeepers = timeZones.Distinct().Select(x => new LocalTimeKeeper(utcDateTime, x)).ToDictionary(x => x.TimeZone.Id);
         }
 
         /// <summary>
@@ -95,10 +95,10 @@ namespace QuantConnect
         public LocalTimeKeeper GetLocalTimeKeeper(DateTimeZone timeZone)
         {
             LocalTimeKeeper localTimeKeeper;
-            if (!_localTimeKeepers.TryGetValue(timeZone, out localTimeKeeper))
+            if (!_localTimeKeepers.TryGetValue(timeZone.Id, out localTimeKeeper))
             {
                 localTimeKeeper = new LocalTimeKeeper(UtcTime, timeZone);
-                _localTimeKeepers[timeZone] = localTimeKeeper;
+                _localTimeKeepers[timeZone.Id] = localTimeKeeper;
             }
             return localTimeKeeper;
         }
@@ -109,9 +109,9 @@ namespace QuantConnect
         /// <param name="timeZone"></param>
         public void AddTimeZone(DateTimeZone timeZone)
         {
-            if (!_localTimeKeepers.ContainsKey(timeZone))
+            if (!_localTimeKeepers.ContainsKey(timeZone.Id))
             {
-                _localTimeKeepers[timeZone] = new LocalTimeKeeper(_utcDateTime, timeZone);
+                _localTimeKeepers[timeZone.Id] = new LocalTimeKeeper(_utcDateTime, timeZone);
             }
         }
     }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -75,7 +75,8 @@ namespace QuantConnect.Lean.Engine
         /// </summary>
         public TimeSpan CurrentTimeStepElapsed
         {
-            get {
+            get
+            {
                 if (_currentTimeStepTime == DateTime.MinValue)
                 {
                     _currentTimeStepTime = DateTime.UtcNow;

--- a/Engine/Alphas/DefaultAlphaHandler.cs
+++ b/Engine/Alphas/DefaultAlphaHandler.cs
@@ -135,7 +135,7 @@ namespace QuantConnect.Lean.Engine.Alphas
             // check the last snap shot time, we may have already produced a snapshot via OnInsightssGenerated
             if (_lastSecurityValuesSnapshotTime != Algorithm.UtcTime)
             {
-                InsightManager.Step(Algorithm.UtcTime, CreateSecurityValuesSnapshot(), new GeneratedInsightsCollection(Algorithm.UtcTime, Enumerable.Empty<Insight>()));
+                InsightManager.Step(Algorithm.UtcTime, CreateSecurityValuesSnapshot(), null);
             }
         }
 

--- a/Engine/DataFeeds/DataFeedPacket.cs
+++ b/Engine/DataFeeds/DataFeedPacket.cs
@@ -66,7 +66,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="configuration">The subscription configuration that produced this data</param>
         /// <param name="isSubscriptionRemoved">Reference to whether or not the subscription has since been removed, defaults to false</param>
         public DataFeedPacket(ISecurityPrice security, SubscriptionDataConfig configuration, IReadOnlyRef<bool> isSubscriptionRemoved = null)
-            : this(security, configuration, new List<BaseData>(), isSubscriptionRemoved)
+            : this(security,
+                configuration,
+                new List<BaseData>(1), // performance: by default the list has 0 capacity, so lets initialize it with at least 1
+                isSubscriptionRemoved)
         {
         }
 

--- a/Engine/DataFeeds/DataFeedPacket.cs
+++ b/Engine/DataFeeds/DataFeedPacket.cs
@@ -68,7 +68,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public DataFeedPacket(ISecurityPrice security, SubscriptionDataConfig configuration, IReadOnlyRef<bool> isSubscriptionRemoved = null)
             : this(security,
                 configuration,
-                new List<BaseData>(1), // performance: by default the list has 0 capacity, so lets initialize it with at least 1
+                new List<BaseData>(4), // performance: by default the list has 0 capacity, so lets initialize it with at least 4 (which is the default)
                 isSubscriptionRemoved)
         {
         }

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -135,7 +135,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         }
                     }
 
-                    if (packet != null && packet.Count > 0)
+                    if (packet?.Count > 0)
                     {
                         // we have new universe data to select based on, store the subscription data until the end
                         if (!subscription.IsUniverseSelectionSubscription)

--- a/Engine/DataFeeds/TimeSliceFactory.cs
+++ b/Engine/DataFeeds/TimeSliceFactory.cs
@@ -32,6 +32,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     {
         private readonly DateTimeZone _timeZone;
 
+        // performance: these collections are not always used so keep a reference to an empty
+        // instance to use and avoid unnecessary constructors and allocations
+        private readonly List<UpdateData<ISecurityPrice>> _emptyCustom = new List<UpdateData<ISecurityPrice>>();
+        private readonly TradeBars _emptyTradeBars = new TradeBars();
+        private readonly QuoteBars _emptyQuoteBars = new QuoteBars();
+        private readonly Ticks _emptyTicks = new Ticks();
+        private readonly Splits _emptySplits = new Splits();
+        private readonly Dividends _emptyDividends = new Dividends();
+        private readonly Delistings _emptyDelistings = new Delistings();
+        private readonly OptionChains _emptyOptionChains = new OptionChains();
+        private readonly FuturesChains _emptyFuturesChains = new FuturesChains();
+        private readonly SymbolChangedEvents _emptySymbolChangedEvents = new SymbolChangedEvents();
+
         /// <summary>
         /// Creates a new instance
         /// </summary>
@@ -55,9 +68,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             Dictionary<Universe, BaseDataCollection> universeData)
         {
             int count = 0;
-            var security = new List<UpdateData<ISecurityPrice>>();
-            var custom = new List<UpdateData<ISecurityPrice>>();
-            var consolidator = new List<UpdateData<SubscriptionDataConfig>>();
+            var security = new List<UpdateData<ISecurityPrice>>(data.Count);
+            List<UpdateData<ISecurityPrice>> custom = null;
+            var consolidator = new List<UpdateData<SubscriptionDataConfig>>(data.Count);
             var allDataForAlgorithm = new List<BaseData>(data.Count);
             var optionUnderlyingUpdates = new Dictionary<Symbol, BaseData>();
 
@@ -73,15 +86,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var sliceFuture = new Lazy<Slice>(() => slice);
 
             var algorithmTime = utcDateTime.ConvertFromUtc(_timeZone);
-            var tradeBars = new TradeBars(algorithmTime);
-            var quoteBars = new QuoteBars(algorithmTime);
-            var ticks = new Ticks(algorithmTime);
-            var splits = new Splits(algorithmTime);
-            var dividends = new Dividends(algorithmTime);
-            var delistings = new Delistings(algorithmTime);
-            var optionChains = new OptionChains(algorithmTime);
-            var futuresChains = new FuturesChains(algorithmTime);
-            var symbolChanges = new SymbolChangedEvents(algorithmTime);
+            TradeBars tradeBars = null;
+            QuoteBars quoteBars = null;
+            Ticks ticks = null;
+            Splits splits = null;
+            Dividends dividends = null;
+            Delistings delistings = null;
+            OptionChains optionChains = null;
+            FuturesChains futuresChains = null;
+            SymbolChangedEvents symbolChanges = null;
+
+            UpdateEmptyCollections(algorithmTime);
 
             if (universeData.Count > 0)
             {
@@ -123,6 +138,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                 if (!packet.Configuration.IsInternalFeed && packet.Configuration.IsCustomData)
                 {
+                    if (custom == null)
+                    {
+                        custom = new List<UpdateData<ISecurityPrice>>(1);
+                    }
                     // This is all the custom data
                     custom.Add(new UpdateData<ISecurityPrice>(packet.Security, packet.Configuration.Type, list));
                 }
@@ -144,11 +163,58 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                         if (!packet.Configuration.IsInternalFeed)
                         {
-                            PopulateDataDictionaries(baseData, ticks, tradeBars, quoteBars, optionChains, futuresChains);
+                            // populate data dictionaries
+                            switch (baseData.DataType)
+                            {
+                                case MarketDataType.Tick:
+                                    if (ticks == null)
+                                    {
+                                        ticks = new Ticks(algorithmTime);
+                                    }
+                                    ticks.Add(baseData.Symbol, (Tick)baseData);
+                                    break;
+
+                                case MarketDataType.TradeBar:
+                                    if (tradeBars == null)
+                                    {
+                                        tradeBars = new TradeBars(algorithmTime);
+                                    }
+                                    tradeBars[baseData.Symbol] = (TradeBar)baseData;
+                                    break;
+
+                                case MarketDataType.QuoteBar:
+                                    if (quoteBars == null)
+                                    {
+                                        quoteBars = new QuoteBars(algorithmTime);
+                                    }
+                                    quoteBars[baseData.Symbol] = (QuoteBar)baseData;
+                                    break;
+
+                                case MarketDataType.OptionChain:
+                                    if (optionChains == null)
+                                    {
+                                        optionChains = new OptionChains(algorithmTime);
+                                    }
+                                    optionChains[baseData.Symbol] = (OptionChain)baseData;
+                                    break;
+
+                                case MarketDataType.FuturesChain:
+                                    if (futuresChains == null)
+                                    {
+                                        futuresChains = new FuturesChains(algorithmTime);
+                                    }
+                                    futuresChains[baseData.Symbol] = (FuturesChain)baseData;
+                                    break;
+                            }
 
                             // special handling of options data to build the option chain
                             if (symbol.SecurityType == SecurityType.Option)
                             {
+                                if (optionChains == null)
+                                {
+                                    optionChains = new OptionChains(algorithmTime);
+                                }
+
                                 if (baseData.DataType == MarketDataType.OptionChain)
                                 {
                                     optionChains[baseData.Symbol] = (OptionChain)baseData;
@@ -162,6 +228,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             // special handling of futures data to build the futures chain
                             if (symbol.SecurityType == SecurityType.Future)
                             {
+                                if (futuresChains == null)
+                                {
+                                    futuresChains = new FuturesChains(algorithmTime);
+                                }
                                 if (baseData.DataType == MarketDataType.FuturesChain)
                                 {
                                     futuresChains[baseData.Symbol] = (FuturesChain)baseData;
@@ -195,18 +265,34 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // include checks for various aux types so we don't have to construct the dictionaries in Slice
                     else if ((delisting = baseData as Delisting) != null)
                     {
+                        if (delistings == null)
+                        {
+                            delistings = new Delistings(algorithmTime);
+                        }
                         delistings[symbol] = delisting;
                     }
                     else if ((dividend = baseData as Dividend) != null)
                     {
+                        if (dividends == null)
+                        {
+                            dividends = new Dividends(algorithmTime);
+                        }
                         dividends[symbol] = dividend;
                     }
                     else if ((split = baseData as Split) != null)
                     {
+                        if (splits == null)
+                        {
+                            splits = new Splits(algorithmTime);
+                        }
                         splits[symbol] = split;
                     }
                     else if ((symbolChange = baseData as SymbolChangedEvent) != null)
                     {
+                        if (symbolChanges == null)
+                        {
+                            symbolChanges = new SymbolChangedEvents(algorithmTime);
+                        }
                         // symbol changes is keyed by the requested symbol
                         symbolChanges[packet.Configuration.Symbol] = symbolChange;
                     }
@@ -222,41 +308,33 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
             }
 
-            slice = new Slice(algorithmTime, allDataForAlgorithm, tradeBars, quoteBars, ticks, optionChains, futuresChains, splits, dividends, delistings, symbolChanges, allDataForAlgorithm.Count > 0);
+            slice = new Slice(algorithmTime, allDataForAlgorithm, tradeBars ?? _emptyTradeBars, quoteBars ?? _emptyQuoteBars, ticks ?? _emptyTicks, optionChains ?? _emptyOptionChains, futuresChains ?? _emptyFuturesChains, splits ?? _emptySplits, dividends ?? _emptyDividends, delistings ?? _emptyDelistings, symbolChanges ?? _emptySymbolChangedEvents, allDataForAlgorithm.Count > 0);
 
-            return new TimeSlice(utcDateTime, count, slice, data, security, consolidator, custom, changes, universeData);
+            return new TimeSlice(utcDateTime, count, slice, data, security, consolidator, custom ?? _emptyCustom, changes, universeData);
         }
 
-        /// <summary>
-        /// Adds the specified <see cref="BaseData"/> instance to the appropriate <see cref="DataDictionary{T}"/>
-        /// </summary>
-        private void PopulateDataDictionaries(BaseData baseData, Ticks ticks, TradeBars tradeBars, QuoteBars quoteBars, OptionChains optionChains, FuturesChains futuresChains)
+        private void UpdateEmptyCollections(DateTime algorithmTime)
         {
-            var symbol = baseData.Symbol;
+            // just in case
+            _emptyTradeBars.Clear();
+            _emptyQuoteBars.Clear();
+            _emptyTicks.Clear();
+            _emptySplits.Clear();
+            _emptyDividends.Clear();
+            _emptyDelistings.Clear();
+            _emptyOptionChains.Clear();
+            _emptyFuturesChains.Clear();
+            _emptySymbolChangedEvents.Clear();
 
-            // populate data dictionaries
-            switch (baseData.DataType)
-            {
-                case MarketDataType.Tick:
-                    ticks.Add(symbol, (Tick)baseData);
-                    break;
-
-                case MarketDataType.TradeBar:
-                    tradeBars[symbol] = (TradeBar)baseData;
-                    break;
-
-                case MarketDataType.QuoteBar:
-                    quoteBars[symbol] = (QuoteBar)baseData;
-                    break;
-
-                case MarketDataType.OptionChain:
-                    optionChains[symbol] = (OptionChain)baseData;
-                    break;
-
-                case MarketDataType.FuturesChain:
-                    futuresChains[symbol] = (FuturesChain)baseData;
-                    break;
-            }
+            _emptyTradeBars.Time
+                = _emptyQuoteBars.Time
+                = _emptyTicks.Time
+                = _emptySplits.Time
+                = _emptyDividends.Time
+                = _emptyDelistings.Time
+                = _emptyOptionChains.Time
+                = _emptyFuturesChains.Time
+                = _emptySymbolChangedEvents.Time = algorithmTime;
         }
 
         private bool HandleOptionData(DateTime algorithmTime, BaseData baseData, OptionChains optionChains, ISecurityPrice security, Lazy<Slice> sliceFuture, IReadOnlyDictionary<Symbol, BaseData> optionUnderlyingUpdates)

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -814,36 +814,49 @@ namespace QuantConnect.Lean.Engine.Results
                 }
             }
 
-            //Send out the debug messages:
-            var endTime = DateTime.UtcNow.AddMilliseconds(250).Ticks;
-            while (Algorithm.DebugMessages.Count > 0 && DateTime.UtcNow.Ticks < endTime)
+            long endTime;
+            // avoid calling utcNow if not required
+            if (Algorithm.DebugMessages.Count > 0)
             {
-                string message;
-                if (Algorithm.DebugMessages.TryDequeue(out message))
+                //Send out the debug messages:
+                endTime = DateTime.UtcNow.AddMilliseconds(250).Ticks;
+                while (Algorithm.DebugMessages.Count > 0 && DateTime.UtcNow.Ticks < endTime)
                 {
-                    DebugMessage(message);
+                    string message;
+                    if (Algorithm.DebugMessages.TryDequeue(out message))
+                    {
+                        DebugMessage(message);
+                    }
                 }
             }
 
-            //Send out the error messages:
-            endTime = DateTime.UtcNow.AddMilliseconds(250).Ticks;
-            while (Algorithm.ErrorMessages.Count > 0 && DateTime.UtcNow.Ticks < endTime)
+            // avoid calling utcNow if not required
+            if (Algorithm.ErrorMessages.Count > 0)
             {
-                string message;
-                if (Algorithm.ErrorMessages.TryDequeue(out message))
+                //Send out the error messages:
+                endTime = DateTime.UtcNow.AddMilliseconds(250).Ticks;
+                while (Algorithm.ErrorMessages.Count > 0 && DateTime.UtcNow.Ticks < endTime)
                 {
-                    ErrorMessage(message);
+                    string message;
+                    if (Algorithm.ErrorMessages.TryDequeue(out message))
+                    {
+                        ErrorMessage(message);
+                    }
                 }
             }
 
-            //Send out the log messages:
-            endTime = DateTime.UtcNow.AddMilliseconds(250).Ticks;
-            while (Algorithm.LogMessages.Count > 0 && DateTime.UtcNow.Ticks < endTime)
+            // avoid calling utcNow if not required
+            if (Algorithm.LogMessages.Count > 0)
             {
-                string message;
-                if (Algorithm.LogMessages.TryDequeue(out message))
+                //Send out the log messages:
+                endTime = DateTime.UtcNow.AddMilliseconds(250).Ticks;
+                while (Algorithm.LogMessages.Count > 0 && DateTime.UtcNow.Ticks < endTime)
                 {
-                    LogMessage(message);
+                    string message;
+                    if (Algorithm.LogMessages.TryDequeue(out message))
+                    {
+                        LogMessage(message);
+                    }
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `TimeSliceFactory` will avoid creating empty collections
- `ExecutionModels` will check target collection count before trying to
enumerate
- Reduce calls to .`TotalPortfolioValue`
- `SecurityValues` will only be created when required
- `TimeKeeper` will use TimeZone unique Id as dictionary key. The
TimeZone hash is expensive.
- `AlgorithmManager` will avoid calling `DateTime.UtcNow`,
`ConvertFromUtc()` and `RoundDownInTimeZone()`

` Performance tests C# IndicatorRibbonBenchmark: ~40% improvement`
`PR`
37.00 seconds at 21k data points per second. Processing total of 782,223 data points.
38.42 seconds at 20k data points per second. Processing total of 782,223 data points.
36.43 seconds at 21k data points per second. Processing total of 782,223 data points.
37.41 seconds at 21k data points per second. Processing total of 782,223 data points.

`master`
59.28 seconds at 13k data points per second. Processing total of 782,223 data points.
62.70 seconds at 12k data points per second. Processing total of 782,223 data points.
64.09 seconds at 12k data points per second. Processing total of 782,223 data points.
64.53 seconds at 12k data points per second. Processing total of 782,223 data points.


` Performance tests C# BasicTemplateBenchmark: ~10% improvement`
`PR`:
28.65 seconds at 58k data points per second. Processing total of 1,664,679 data points.
28.88 seconds at 58k data points per second. Processing total of 1,664,679 data points.
28.67 seconds at 58k data points per second. Processing total of 1,664,679 data points.
`master`
34.09 seconds at 49k data points per second. Processing total of 1,664,679 data points.
33.86 seconds at 49k data points per second. Processing total of 1,664,679 data points.
34.04 seconds at 49k data points per second. Processing total of 1,664,679 data points.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None, continuous efforts for a faster Lean
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Need for speed
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->