### PR TITLE
Add missing null check in LiveTradingResultHandler.Exit

### DIFF
--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -910,7 +910,12 @@ namespace QuantConnect.Lean.Engine.Results
             {
                 _exitTriggered = true;
                 _cancellationTokenSource.Cancel();
-                ProcessSynchronousEvents(true);
+
+                if (_algorithm != null)
+                {
+                    ProcessSynchronousEvents(true);
+                }
+
                 lock (_logStoreLock)
                 {
                     StoreLog(_logStore);


### PR DESCRIPTION

#### Description
- Added a missing null check in `LiveTradingResultHandler.Exit`

#### Motivation and Context
`NullReferenceException` in `LiveTradingResultHandler.ProcessSynchronousEvents` after a brokerage initialization error (e.g. invalid username/password).

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Deployed to IB in the cloud with incorrect credentials.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`