### PR TITLE
Extends SwissArmyKnife, Trix and WilderMovingAverage Indicators With IIndicatorWarmUpPeriodProvider

### DIFF
--- a/Indicators/SwissArmyKnife.cs
+++ b/Indicators/SwissArmyKnife.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,19 +13,17 @@
  * limitations under the License.
 */
 
-using QuantConnect.Data.Market;
 using System;
 
 namespace QuantConnect.Indicators
 {
-
     /// <summary>
     /// The tools of the Swiss Army Knife. Some of the tools lend well to chaining with the "Of" Method, others may be treated as moving averages
     /// </summary>
     public enum SwissArmyKnifeTool
     {
         /// <summary>
-        /// Two Pole Guassian Filter
+        /// Two Pole Gaussian Filter
         /// </summary>
         Gauss,
         /// <summary>
@@ -49,22 +47,18 @@ namespace QuantConnect.Indicators
     /// <summary>
     /// Swiss Army Knife indicator by John Ehlers
     /// </summary>
-    public class SwissArmyKnife : Indicator
+    public class SwissArmyKnife : Indicator, IIndicatorWarmUpPeriodProvider
     {
-
-        RollingWindow<double> _price;
-        RollingWindow<double> _filt;
-        SwissArmyKnifeTool _tool;
-        double _period = 20;
-        double _delta = 0.1;
-        double _c0 = 1;
-        double _c1 = 0;
-        double _b0 = 1;
-        double _b1 = 0;
-        double _b2 = 0;
-        double _a0 = 1;
-        double _a1 = 0;
-        double _a2 = 0;
+        private readonly RollingWindow<double> _price;
+        private readonly RollingWindow<double> _filt;
+        private readonly int _period;
+        private readonly double _a0 = 1;
+        private readonly double _a1 = 0;
+        private readonly double _a2 = 0;
+        private readonly double _b0 = 1;
+        private readonly double _b1 = 0;
+        private readonly double _b2 = 0;
+        private readonly double _c0 = 1;
 
         /// <summary>
         /// Swiss Army Knife indicator by John Ehlers
@@ -73,7 +67,7 @@ namespace QuantConnect.Indicators
         /// <param name="delta"></param>
         /// <param name="tool"></param>
         public SwissArmyKnife(int period, double delta, SwissArmyKnifeTool tool)
-            : this("Swiss" + period, period, delta, tool)
+            : this($"Swiss({period},{delta},{tool})", period, delta, tool)
         {
         }
 
@@ -87,76 +81,63 @@ namespace QuantConnect.Indicators
         public SwissArmyKnife(string name, int period, double delta, SwissArmyKnifeTool tool)
             : base(name)
         {
-            _period = period;
-            _tool = tool;
-            _delta = delta;
-            _filt = new RollingWindow<double>(2) { 0.0, 0.0 };
+            _filt = new RollingWindow<double>(2) {0, 0};
             _price = new RollingWindow<double>(3);
-            double alpha;
-            double beta;
-            double gamma;
+            _period = period;
+            var beta = 2.415 * (1 - Math.Cos(2 * Math.PI / period));
+            var alpha = -beta + Math.Sqrt(Math.Pow(beta, 2) + 2d * beta);
 
-            if (_tool == SwissArmyKnifeTool.Gauss)
+            switch (tool)
             {
-                beta = 2.415 * (1 - Math.Cos(2 * Math.PI / _period));
-                alpha = -beta + Math.Sqrt(Math.Pow(beta, 2) + 2d * beta);
-                _c0 = alpha * alpha;
-                _a1 = 2d * (1 - alpha);
-                _a2 = -(1 - alpha) * (1 - alpha);
+                case SwissArmyKnifeTool.Gauss:
+                    _c0 = alpha * alpha;
+                    _a1 = 2d * (1 - alpha);
+                    _a2 = -(1 - alpha) * (1 - alpha);
+                    break;
+                case SwissArmyKnifeTool.Butter:
+                    _c0 = alpha * alpha / 4d;
+                    _b1 = 2;
+                    _b2 = 1;
+                    _a1 = 2d * (1 - alpha);
+                    _a2 = -(1 - alpha) * (1 - alpha);
+                    break;
+                case SwissArmyKnifeTool.HighPass:
+                    alpha = (Math.Cos(2 * Math.PI / period) + Math.Sin(2 * Math.PI / period) - 1) / Math.Cos(2 * Math.PI / period);
+                    _c0 = (1 + alpha) / 2;
+                    _b1 = -1;
+                    _a1 = 1 - alpha;
+                    break;
+                case SwissArmyKnifeTool.TwoPoleHighPass:
+                    _c0 = (1 + alpha) * (1 + alpha) / 4;
+                    _b1 = -2;
+                    _b2 = 1;
+                    _a1 = 2d * (1 - alpha);
+                    _a2 = -(1 - alpha) * (1 - alpha);
+                    break;
+                case SwissArmyKnifeTool.BandPass:
+                    beta = Math.Cos(2 * Math.PI / period);
+                    var gamma = (1 / Math.Cos(4 * Math.PI * delta / period));
+                    alpha = gamma - Math.Sqrt(Math.Pow(gamma, 2) - 1);
+                    _c0 = (1 - alpha) / 2d;
+                    _b0 = 1;
+                    _b2 = -1;
+                    _a1 = -beta * (1 - alpha);
+                    _a2 = alpha;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(tool), tool, "Invalid SwissArmyKnifeTool");
             }
-
-            if (_tool == SwissArmyKnifeTool.Butter)
-            {
-                beta = 2.415 * (1 - Math.Cos(2 * Math.PI / _period));
-                alpha = -beta + Math.Sqrt(Math.Pow(beta, 2) + 2d * beta);
-                _c0 = alpha * alpha / 4d;
-                _b1 = 2;
-                _b2 = 1;
-                _a1 = 2d * (1 - alpha);
-                _a2 = -(1 - alpha) * (1 - alpha);
-            }
-
-            if (_tool == SwissArmyKnifeTool.HighPass)
-            {
-                alpha = (Math.Cos(2 * Math.PI / _period) + Math.Sin(2 * Math.PI / _period) - 1) / Math.Cos(2 * Math.PI / _period);
-                _c0 = (1 + alpha) / 2;
-                _b1 = -1;
-                _a1 = 1 - alpha;
-            }
-
-            if (_tool == SwissArmyKnifeTool.TwoPoleHighPass)
-            {
-                beta = 2.415 * (1 - Math.Cos(2 * Math.PI / _period));
-                alpha = -beta + Math.Sqrt(Math.Pow(beta, 2) + 2d * beta);
-                _c0 = (1 + alpha) * (1 + alpha) / 4;
-                _b1 = -2;
-                _b2 = 1;
-                _a1 = 2d * (1 - alpha);
-                _a2 = -(1 - alpha) * (1 - alpha);
-            }
-
-            if (_tool == SwissArmyKnifeTool.BandPass)
-            {
-                beta = Math.Cos(2 * Math.PI / _period);
-                gamma = (1 / Math.Cos(4 * Math.PI * _delta / _period));
-                alpha = gamma - Math.Sqrt(Math.Pow(gamma, 2) - 1);
-                _c0 = (1 - alpha) / 2d;
-                _b0 = 1;
-                _b2 = -1;
-                _a1 = -beta * (1 - alpha);
-                _a2 = alpha;
-            }
-
         }
-
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady
-        {
-            get { return Samples >= _period; }
-        }
+        public override bool IsReady => Samples >= _period;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => _period;
 
         /// <summary>
         /// Computes the next value of this indicator from the given state
@@ -165,16 +146,15 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IndicatorDataPoint input)
         {
-
             _price.Add((double)input.Price);
 
             if (_price.Samples == 1)
             {
                 _price.Add(_price[0]);
-                _price.Add(_price[0]);           
+                _price.Add(_price[0]);
             }
 
-            double signal = _a0 * _c0 * (_b0 * _price[0] + _b1 * _price[1] + _b2 * _price[2]) + _a0 * (_a1 * _filt[0] + _a2 * _filt[1]);
+            var signal = _a0 * _c0 * (_b0 * _price[0] + _b1 * _price[1] + _b2 * _price[2]) + _a0 * (_a1 * _filt[0] + _a2 * _filt[1]);
 
             _filt.Add(signal);
 
@@ -186,13 +166,11 @@ namespace QuantConnect.Indicators
         /// </summary>
         public override void Reset()
         {
-            _period = 20;
-            _delta = 0.1;
-            _filt = new RollingWindow<double>(2) { 0.0, 0.0 };
-            _price = new RollingWindow<double>(3);
+            _price.Reset();
+            _filt.Reset();
+            _filt.Add(0);
+            _filt.Add(0);
             base.Reset();
         }
-
-
     }
 }

--- a/Indicators/WilderMovingAverage.cs
+++ b/Indicators/WilderMovingAverage.cs
@@ -15,18 +15,18 @@
 
 namespace QuantConnect.Indicators
 {
-
     /// <summary>
-    ///     Represents the moving average indicator defined by Welles Wilder in his book: 
-    ///     New Concepts in Technical Trading Systems.
+    /// Represents the moving average indicator defined by Welles Wilder in his book:
+    /// New Concepts in Technical Trading Systems.
     /// </summary>
-    public class WilderMovingAverage : Indicator
+    public class WilderMovingAverage : Indicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly decimal _k;
         private readonly int _period;
         private readonly IndicatorBase<IndicatorDataPoint> _sma;
 
-        /// <summary>Initializes a new instance of the WilderMovingAverage class with the specified name and period
+        /// <summary>
+        /// Initializes a new instance of the WilderMovingAverage class with the specified name and period
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The period of the Wilder Moving Average</param>
@@ -39,7 +39,7 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        ///     Initializes a new instance of the WilderMovingAverage class with the default name and period
+        /// Initializes a new instance of the WilderMovingAverage class with the default name and period
         /// </summary>
         /// <param name="period">The period of the Wilder Moving Average</param>
         public WilderMovingAverage(int period)
@@ -48,12 +48,17 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        ///     Gets a flag indicating when this indicator is ready and fully initialized
+        /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
         public override bool IsReady => Samples >= _period;
 
         /// <summary>
-        ///     Resets this indicator to its initial state
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod => _period;
+
+        /// <summary>
+        /// Resets this indicator to its initial state
         /// </summary>
         public override void Reset()
         {
@@ -62,7 +67,7 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        ///     Computes the next value of this indicator from the given state
+        /// Computes the next value of this indicator from the given state
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
@@ -73,7 +78,7 @@ namespace QuantConnect.Indicators
                 _sma.Update(input);
                 return _sma;
             }
-            return input*_k + Current*(1 - _k);
+            return input * _k + Current * (1 - _k);
         }
     }
 }

--- a/Tests/Indicators/SwissArmyKnifeTests.cs
+++ b/Tests/Indicators/SwissArmyKnifeTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,20 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class SwissArmyKnifeTests
+    public class SwissArmyKnifeTests : CommonIndicatorTests<IndicatorDataPoint>
     {
+        protected override IndicatorBase<IndicatorDataPoint> CreateIndicator()
+        {
+            return new SwissArmyKnife(20, 0.1, SwissArmyKnifeTool.Gauss);
+        }
+
+        protected override string TestFileName => "spy_swiss.txt";
+
+        protected override string TestColumnName => "Gauss";
+
+        protected override Action<IndicatorBase<IndicatorDataPoint>, double> Assertion =>
+            (indicator, expected) => 
+                Assert.AreEqual(expected, (double) indicator.Current.Value, 0.01);
 
         [Test]
         public void ResetsProperly()
@@ -44,41 +56,34 @@ namespace QuantConnect.Tests.Indicators
         [Test]
         public void ComparesBandPassAgainstExternalData()
         {
-            var indicator = new SwissArmyKnife("", 20, 0.1, SwissArmyKnifeTool.BandPass);
+            var indicator = new SwissArmyKnife(20, 0.1, SwissArmyKnifeTool.BandPass);
             RunTestIndicator(indicator, "BP", 0.043m);
         }
 
         [Test]
         public void Compares2PHPAgainstExternalData()
         {
-            var indicator = new SwissArmyKnife("", 20, 0.1, SwissArmyKnifeTool.TwoPoleHighPass);
+            var indicator = new SwissArmyKnife(20, 0.1, SwissArmyKnifeTool.TwoPoleHighPass);
             RunTestIndicator(indicator, "2PHP", 0.01m);
         }
 
         [Test]
         public void ComparesHPAgainstExternalData()
         {
-            var indicator = new SwissArmyKnife("", 20, 0.1, SwissArmyKnifeTool.HighPass);
+            var indicator = new SwissArmyKnife(20, 0.1, SwissArmyKnifeTool.HighPass);
             RunTestIndicator(indicator, "HP", 0.01m);
         }
 
         [Test]
         public void ComparesButterAgainstExternalData()
         {
-            var indicator = new SwissArmyKnife("", 20, 0.1, SwissArmyKnifeTool.Butter);
+            var indicator = new SwissArmyKnife(20, 0.1, SwissArmyKnifeTool.Butter);
             RunTestIndicator(indicator, "Butter", 0.01m);
         }
 
-        [Test]
-        public void ComparesGaussAgainstExternalData()
+        private void RunTestIndicator(IndicatorBase<IndicatorDataPoint> indicator, string field, decimal variance)
         {
-            var indicator = new SwissArmyKnife("", 20, 0.1, SwissArmyKnifeTool.Gauss);
-            RunTestIndicator(indicator, "Gauss", 0.01m);
-        }
-
-        private static void RunTestIndicator(IndicatorBase<IndicatorDataPoint> indicator, string field, decimal variance)
-        {
-            TestHelper.TestIndicator(indicator, "spy_swiss.txt", field, (actual, expected) => { AssertResult(expected, actual.Current.Value, variance); });
+            TestHelper.TestIndicator(indicator, TestFileName, field, (actual, expected) => { AssertResult(expected, actual.Current.Value, variance); });
         }
 
         private static void AssertResult(double expected, decimal actual, decimal variance)
@@ -86,6 +91,5 @@ namespace QuantConnect.Tests.Indicators
             System.Diagnostics.Debug.WriteLine(expected + "," + actual + "," + Math.Abs((decimal)expected - actual));
             Assert.IsTrue(Math.Abs((decimal)expected - actual) < variance);
         }
-
     }
 }

--- a/Tests/Indicators/TrixTests.cs
+++ b/Tests/Indicators/TrixTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,14 +26,8 @@ namespace QuantConnect.Tests.Indicators
             return new Trix(5);
         }
 
-        protected override string TestFileName
-        {
-            get { return "spy_trix.txt"; }
-        }
+        protected override string TestFileName => "spy_trix.txt";
 
-        protected override string TestColumnName
-        {
-            get { return "TRIX_5"; }
-        }
+        protected override string TestColumnName => "TRIX_5";
     }
 }


### PR DESCRIPTION
#### Description
Extends `SwissArmyKnife`, `Trix` and `WilderMovingAverage` Indicators With `IIndicatorWarmUpPeriodProvider`

#### Related Issue
#3074 

#### Motivation and Context
See #3074 

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`