### PR TITLE
Remove stack trace from ApiConnection.TryRequest error logging

### DIFF
--- a/Api/ApiConnection.cs
+++ b/Api/ApiConnection.cs
@@ -104,7 +104,7 @@ namespace QuantConnect.Api
                 //Verify success
                 if (restsharpResponse.ErrorException != null)
                 {
-                    Log.Error(restsharpResponse.ErrorException);
+                    Log.Error($"ApiConnection.TryRequest({request.Resource}): Error: {restsharpResponse.ErrorException.Message}");
                     result = null;
                     return false;
                 }
@@ -119,7 +119,7 @@ namespace QuantConnect.Api
             }
             catch (Exception err)
             {
-                Log.Error($"Api.ApiConnection.TryRequest({request.Resource}): Failed to make REST request. Response content: {responseContent}, Error: {err}");
+                Log.Error($"ApiConnection.TryRequest({request.Resource}): Error: {err.Message}, Response content: {responseContent}");
                 result = null;
                 return false;
             }


### PR DESCRIPTION

#### Description
`ApiConnection.TryRequest` will now log only the error message instead of the whole stack trace, making it easier to read long system logs.

#### Related Issue
None

#### Motivation and Context
The stack trace for API requests does not have additional debugging information.

#### Requires Documentation Change
No.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`