### PR TITLE
Fix Turnover Ratio for Futures/CFDs

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -125,7 +125,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.414"},
             {"Treynor Ratio", "10.413"},
             {"Total Fees", "$15207.00"},
-            {"Fitness Score", "0.034"}
+            {"Fitness Score", "0.033"}
         };
     }
 }

--- a/Common/AlphaRuntimeStatistics.cs
+++ b/Common/AlphaRuntimeStatistics.cs
@@ -32,6 +32,10 @@ namespace QuantConnect
         // this is only used when deserializing to this type since it represents a computed property dependent on internal state
         private decimal _overrideEstimatedMonthlyAlphaValue;
         private readonly IAccountCurrencyProvider _accountCurrencyProvider;
+        private decimal _fitnessScore;
+        private decimal _portfolioTurnover;
+        private decimal _returnOverMaxDrawdown;
+        private decimal _sortinoRatio;
 
         /// <summary>
         /// Creates a new instance
@@ -82,26 +86,70 @@ namespace QuantConnect
         /// <summary>
         /// Score of the strategy's performance, and suitability for the Alpha Stream Market
         /// </summary>
-        /// <remarks>See https://www.quantconnect.com/research/3bc40ecee68d36a9424fbd1b338eb227 </remarks>
-        public decimal FitnessScore { get; set; }
+        /// <remarks>See https://www.quantconnect.com/research/3bc40ecee68d36a9424fbd1b338eb227.
+        /// For performance we only truncate when the value is gotten</remarks>
+        public decimal FitnessScore
+        {
+            get
+            {
+                return _fitnessScore.TruncateTo3DecimalPlaces();
+            }
+            set
+            {
+                _fitnessScore = value;
+            }
+        }
 
         /// <summary>
         /// Measurement of the strategies trading activity with respect to the portfolio value.
         /// Calculated as the sales volume with respect to the average total portfolio value.
         /// </summary>
-        public decimal PortfolioTurnover { get; set; }
+        /// <remarks>For performance we only truncate when the value is gotten</remarks>
+        public decimal PortfolioTurnover
+        {
+            get
+            {
+                return _portfolioTurnover.TruncateTo3DecimalPlaces();
+            }
+            set
+            {
+                _portfolioTurnover = value;
+            }
+        }
 
         /// <summary>
         /// Provides a risk adjusted way to factor in the returns and drawdown of the strategy.
         /// It is calculated by dividing the Portfolio Annualized Return by the Maximum Drawdown seen during the backtest.
         /// </summary>
-        public decimal ReturnOverMaxDrawdown { get; set; }
+        /// <remarks>For performance we only truncate when the value is gotten</remarks>
+        public decimal ReturnOverMaxDrawdown
+        {
+            get
+            {
+                return _returnOverMaxDrawdown.TruncateTo3DecimalPlaces();
+            }
+            set
+            {
+                _returnOverMaxDrawdown = value;
+            }
+        }
 
         /// <summary>
         /// Gives a relative picture of the strategy volatility.
         /// It is calculated by taking a portfolio's annualized rate of return and subtracting the risk free rate of return.
         /// </summary>
-        public decimal SortinoRatio { get; set; }
+        /// <remarks>For performance we only truncate when the value is gotten</remarks>
+        public decimal SortinoRatio
+        {
+            get
+            {
+                return _sortinoRatio.TruncateTo3DecimalPlaces();
+            }
+            set
+            {
+                _sortinoRatio = value;
+            }
+        }
 
         /// <summary>
         /// Suggested Value of the Alpha On A Monthly Basis For Licensing

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -224,6 +224,22 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Will truncate the provided decimal, without rounding, to 3 decimal places
+        /// </summary>
+        /// <param name="value">The value to truncate</param>
+        /// <returns>New instance with just 3 decimal places</returns>
+        public static decimal TruncateTo3DecimalPlaces(this decimal value)
+        {
+            if (value == decimal.MaxValue
+                || value == decimal.MinValue
+                || value == 0)
+            {
+                return value;
+            }
+            return Math.Truncate(1000 * value) / 1000;
+        }
+
+        /// <summary>
         /// Provides global smart rounding, numbers larger than 1000 will round to 4 decimal places,
         /// while numbers smaller will round to 7 significant digits
         /// </summary>

--- a/Common/Securities/SecurityPortfolioModel.cs
+++ b/Common/Securities/SecurityPortfolioModel.cs
@@ -49,19 +49,9 @@ namespace QuantConnect.Securities
             try
             {
                 // apply sales value to holdings in the account currency
-                if (security.Type == SecurityType.Future || security.Type == SecurityType.Cfd)
-                {
-                    // for futures/CFDs, we measure volume of sales, not notionals
-                    var saleValueInQuoteCurrency = fill.FillPrice * Convert.ToDecimal(fill.AbsoluteFillQuantity);
-                    var saleValue = saleValueInQuoteCurrency * quoteCash.ConversionRate;
-                    security.Holdings.AddNewSale(saleValue);
-                }
-                else
-                {
-                    var saleValueInQuoteCurrency = fill.FillPrice * Convert.ToDecimal(fill.AbsoluteFillQuantity) * security.SymbolProperties.ContractMultiplier;
-                    var saleValue = saleValueInQuoteCurrency * quoteCash.ConversionRate;
-                    security.Holdings.AddNewSale(saleValue);
-                }
+                var saleValueInQuoteCurrency = fill.FillPrice * Convert.ToDecimal(fill.AbsoluteFillQuantity) * security.SymbolProperties.ContractMultiplier;
+                var saleValue = saleValueInQuoteCurrency * quoteCash.ConversionRate;
+                security.Holdings.AddNewSale(saleValue);
 
                 // subtract transaction fees from the portfolio
                 var feeInAccountCurrency = 0m;

--- a/Common/Statistics/FitnessScoreManager.cs
+++ b/Common/Statistics/FitnessScoreManager.cs
@@ -108,8 +108,7 @@ namespace QuantConnect.Statistics
                     var currentPortfolioValue = _algorithm.Portfolio.TotalPortfolioValue;
 
                     // calculate portfolio annualized return
-                    var currentPortfolioReturn = (currentPortfolioValue - _startingPortfolioValue) / _startingPortfolioValue;
-                    var annualFactor = (_algorithm.UtcTime - _startUtcTime).TotalDays / 365;
+                    var annualFactor = (decimal)(_algorithm.UtcTime - _startUtcTime).TotalDays / 365m;
 
                     // just in case...
                     if (annualFactor <= 0)
@@ -117,7 +116,7 @@ namespace QuantConnect.Statistics
                         return;
                     }
 
-                    var portfolioAnnualizedReturn = (Math.Pow((double)currentPortfolioReturn + 1, 1 / annualFactor) - 1).SafeDecimalCast();
+                    var portfolioAnnualizedReturn = Statistics.CompoundingAnnualPerformance(_startingPortfolioValue, currentPortfolioValue, annualFactor); ;
 
                     var scaledSortinoRatio = GetScaledSortinoRatio(currentPortfolioValue, portfolioAnnualizedReturn);
 
@@ -127,7 +126,7 @@ namespace QuantConnect.Statistics
 
                     var rawFitnessScore = scaledPortfolioTurnover * (scaledReturnOverMaxDrawdown + scaledSortinoRatio);
 
-                    FitnessScore = Math.Round(ScaleToRange(rawFitnessScore, maximumValue: 20, minimumValue: 0), 3);
+                    FitnessScore = ScaleToRange(rawFitnessScore, maximumValue: 20, minimumValue: 0);
                 }
             }
             catch (Exception exception)

--- a/Common/Statistics/FitnessScoreManager.cs
+++ b/Common/Statistics/FitnessScoreManager.cs
@@ -116,7 +116,7 @@ namespace QuantConnect.Statistics
                         return;
                     }
 
-                    var portfolioAnnualizedReturn = Statistics.CompoundingAnnualPerformance(_startingPortfolioValue, currentPortfolioValue, annualFactor); ;
+                    var portfolioAnnualizedReturn = Statistics.CompoundingAnnualPerformance(_startingPortfolioValue, currentPortfolioValue, annualFactor);
 
                     var scaledSortinoRatio = GetScaledSortinoRatio(currentPortfolioValue, portfolioAnnualizedReturn);
 

--- a/Common/Statistics/PortfolioStatistics.cs
+++ b/Common/Statistics/PortfolioStatistics.cs
@@ -195,7 +195,7 @@ namespace QuantConnect.Statistics
             }
 
             var fractionOfYears = (decimal) (equity.Keys.LastOrDefault() - equity.Keys.FirstOrDefault()).TotalDays / 365;
-            CompoundingAnnualReturn = CompoundingAnnualPerformance(startingCapital, equity.Values.LastOrDefault(), fractionOfYears);
+            CompoundingAnnualReturn = Statistics.CompoundingAnnualPerformance(startingCapital, equity.Values.LastOrDefault(), fractionOfYears);
 
             Drawdown = DrawdownPercent(equity, 3);
 
@@ -233,18 +233,6 @@ namespace QuantConnect.Statistics
         public static decimal GetRiskFreeRate()
         {
             return RiskFreeRate;
-        }
-
-        /// <summary>
-        /// Annual compounded returns statistic based on the final-starting capital and years.
-        /// </summary>
-        /// <param name="startingCapital">Algorithm starting capital</param>
-        /// <param name="finalCapital">Algorithm final capital</param>
-        /// <param name="years">Years trading</param>
-        /// <returns>Decimal fraction for annual compounding performance</returns>
-        private static decimal CompoundingAnnualPerformance(decimal startingCapital, decimal finalCapital, decimal years)
-        {
-            return (years == 0 ? 0d : Math.Pow((double)finalCapital / (double)startingCapital, 1 / (double)years) - 1).SafeDecimalCast();
         }
 
         /// <summary>

--- a/Common/Statistics/Statistics.cs
+++ b/Common/Statistics/Statistics.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -108,13 +108,13 @@ namespace QuantConnect.Statistics
         /// <param name="totalTrades">Total number of orders executed.</param>
         /// <param name="tradingDaysPerYear">Number of trading days per year</param>
         /// <returns>Statistics Array, Broken into Annual Periods</returns>
-        public static Dictionary<string, string> Generate(IEnumerable<ChartPoint> pointsEquity, 
-            SortedDictionary<DateTime, decimal> profitLoss, 
-            IEnumerable<ChartPoint> pointsPerformance, 
-            Dictionary<DateTime, decimal> unsortedBenchmark, 
-            decimal startingCash, 
-            decimal totalFees, 
-            decimal totalTrades, 
+        public static Dictionary<string, string> Generate(IEnumerable<ChartPoint> pointsEquity,
+            SortedDictionary<DateTime, decimal> profitLoss,
+            IEnumerable<ChartPoint> pointsPerformance,
+            Dictionary<DateTime, decimal> unsortedBenchmark,
+            decimal startingCash,
+            decimal totalFees,
+            decimal totalTrades,
             double tradingDaysPerYear = 252
             )
         {
@@ -321,7 +321,7 @@ namespace QuantConnect.Statistics
                 if (profitLossRatio == -1) profitLossRatioHuman = "0";
 
                 //Add the over all results first, break down by year later:
-                statistics = new Dictionary<string, string> { 
+                statistics = new Dictionary<string, string> {
                     { "Total Trades", Math.Round(totalTrades, 0).ToString(CultureInfo.InvariantCulture) },
                     { "Average Win", Math.Round(averageWin * 100, 2) + "%"  },
                     { "Average Loss", Math.Round(averageLoss * 100, 2) + "%" },
@@ -331,7 +331,7 @@ namespace QuantConnect.Statistics
                     { "Net Profit", Math.Round(totalNetProfit * 100, 3) + "%"},
                     { "Sharpe Ratio", Math.Round(SharpeRatio(listPerformance, riskFreeRate), 3).ToString(CultureInfo.InvariantCulture) },
                     { "Loss Rate", Math.Round(lossRate * 100) + "%" },
-                    { "Win Rate", Math.Round(winRate * 100) + "%" }, 
+                    { "Win Rate", Math.Round(winRate * 100) + "%" },
                     { "Profit-Loss Ratio", profitLossRatioHuman },
                     { "Alpha", Math.Round(Alpha(listPerformance, listBenchmark, riskFreeRate), 3).ToString(CultureInfo.InvariantCulture) },
                     { "Beta", Math.Round(Beta(listPerformance, listBenchmark), 3).ToString(CultureInfo.InvariantCulture) },
@@ -441,7 +441,7 @@ namespace QuantConnect.Statistics
         /// <returns>Decimal fraction for annual compounding performance</returns>
         public static decimal CompoundingAnnualPerformance(decimal startingCapital, decimal finalCapital, decimal years)
         {
-            return (Math.Pow((double)finalCapital / (double)startingCapital, (1 / (double)years)) - 1).SafeDecimalCast();
+            return (years == 0 ? 0d : Math.Pow((double)finalCapital / (double)startingCapital, 1 / (double)years) - 1).SafeDecimalCast();
         }
 
         /// <summary>
@@ -482,7 +482,7 @@ namespace QuantConnect.Statistics
         {
             return Math.Sqrt(performance.Variance() * tradingDaysPerYear);
         }
-        
+
         /// <summary>
         /// Algorithm "beta" statistic - the covariance between the algorithm and benchmark performance, divided by benchmark's variance
         /// </summary>
@@ -519,7 +519,7 @@ namespace QuantConnect.Statistics
             return Math.Sqrt(AnnualVariance(algoPerformance) - 2 * Correlation.Pearson(algoPerformance, benchmarkPerformance) * AnnualStandardDeviation(algoPerformance) * AnnualStandardDeviation(benchmarkPerformance) + AnnualVariance(benchmarkPerformance));
         }
 
-        
+
         /// <summary>
         /// Information ratio - risk adjusted return
         /// </summary>

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -529,12 +529,13 @@ namespace QuantConnect.Tests.Common.Securities
             var fillBuy = new OrderEvent(1, Symbols.Fut_SPY_Feb19_2016, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Buy, 100, 100, OrderFee.Zero);
             portfolio.ProcessFill(fillBuy);
 
-            Assert.AreEqual(100 * 100, securities[Symbols.Fut_SPY_Feb19_2016].Holdings.TotalSaleVolume);
+            var security = securities[Symbols.Fut_SPY_Feb19_2016];
+            Assert.AreEqual(100 * 100 * security.SymbolProperties.ContractMultiplier, security.Holdings.TotalSaleVolume);
 
             var fillSell = new OrderEvent(2, Symbols.Fut_SPY_Feb19_2016, DateTime.MinValue, OrderStatus.Filled, OrderDirection.Sell, 100, -100, OrderFee.Zero);
             portfolio.ProcessFill(fillSell);
 
-            Assert.AreEqual(2 * 100 * 100, securities[Symbols.Fut_SPY_Feb19_2016].Holdings.TotalSaleVolume);
+            Assert.AreEqual(2 * 100 * 100 * security.SymbolProperties.ContractMultiplier, security.Holdings.TotalSaleVolume);
         }
 
         [Test]

--- a/Tests/Common/Statistics/FitnessScoreManagerTests.cs
+++ b/Tests/Common/Statistics/FitnessScoreManagerTests.cs
@@ -106,7 +106,7 @@ namespace QuantConnect.Tests.Common.Statistics
             // FitnessScore: 0.333 * (-3.299 + -5)
             fitnessScore.UpdateScores();
             score = fitnessScore.FitnessScore;
-            Assert.AreEqual(0.028m, score);
+            Assert.AreEqual(0.028m, score.TruncateTo3DecimalPlaces());
         }
 
         [TestCase(2)]
@@ -130,7 +130,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 IncreaseCashAmount(algorithm, returnFactor);
                 IncreaseSalesVolumeAmount(algorithm);
             }
-            Assert.AreEqual(returnFactor < 1 ? 0.174m : 1m, score);
+            Assert.AreEqual(returnFactor < 1 ? 0.174m : 1m, score.TruncateTo3DecimalPlaces());
         }
 
         private void IncreaseCashAmount(IAlgorithm algorithm, double factor)

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -764,6 +764,13 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(order.SecurityType, orderTicket.SecurityType);
         }
 
+        [Test]
+        public void DecimalTruncateTo3DecimalPlaces()
+        {
+            var value = 10.999999m;
+            Assert.AreEqual(10.999m, value.TruncateTo3DecimalPlaces());
+        }
+
         private PyObject ConvertToPyObject(object value)
         {
             using (Py.GIL())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `Futures` and `CFDs` sales value will use `ContractMultiplier` as the
rest of the securities.
- `FitnessScore` values will be truncated, not rounded, to 3 decimal places.
- Reducing code duplication for calculating the
`CompoundingAnnualPerformance`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3278
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Fixes for fitness score
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->