### PR TITLE
Created new method. To set configuration value at specified json path.

### DIFF
--- a/Configuration/Config.cs
+++ b/Configuration/Config.cs
@@ -182,6 +182,44 @@ namespace QuantConnect.Configuration
         }
 
         /// <summary>
+        /// Sets new configuration value at the specified path. If some of the properties
+        /// that constitute a path do not exist method will create them.
+        /// </summary>
+        /// <param name="path">Json value path. A path could be multi-levelled (separated by commas).</param>
+        /// <param name="value">Value to set.</param>
+        public static void SetValue(string path, string value)
+        {
+            // value token at given path
+            var token = Settings.Value.SelectToken(path);
+
+            // if do not exist - we need to create the missing properties
+            if (token == null)
+            {
+                // Going down a multi-level path we will create the missing properties
+                // Current json object will hold the inner JObject that resides by the current path
+                var currentJObject = Settings.Value;
+                foreach (var word in path.Split('.'))
+                {
+                    if (currentJObject[word] == null)
+                    {
+                        currentJObject.Add(word, new JObject());
+                    }
+
+                    // Move an object one step down
+                    currentJObject = (JObject)currentJObject[word];
+                }
+
+                // Now as we made sure the token for given path does exist - populate the token with given value
+                currentJObject.Replace(value);
+            }
+            else
+            {
+                // If path token does exist - just populate with given value
+                token.Replace(value);
+            }
+        }
+
+        /// <summary>
         /// Get a boolean value configuration setting by a configuration key.
         /// </summary>
         /// <param name="key">String value of the configuration key.</param>

--- a/Configuration/Config.cs
+++ b/Configuration/Config.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Configuration
                     {
                         environment["environments"] = environments = new JObject();
                     }
-                    environment = environments[envName];
+                    environment = environments[envName] = new JObject();
                 }
                 environment[key] = value;
             }

--- a/Tests/Configuration/ConfigTests.cs
+++ b/Tests/Configuration/ConfigTests.cs
@@ -53,11 +53,15 @@ namespace QuantConnect.Tests.Configuration
         [Test]
         public void SetNestedToSpecificEnvironment()
         {
-            Assert.Throws<NullReferenceException>(() =>
+            Assert.DoesNotThrow(() =>
                 {
                     Config.Set("mega-backtesting.setup-handler", "3285-testing");
                 }
             );
+
+            // Set new environment ->
+            Config.Set("environment", "mega-backtesting");
+            Assert.AreEqual("3285-testing", Config.Get("setup-handler"));
         }
 
         [Test]

--- a/Tests/Configuration/ConfigTests.cs
+++ b/Tests/Configuration/ConfigTests.cs
@@ -51,6 +51,16 @@ namespace QuantConnect.Tests.Configuration
         }
 
         [Test]
+        public void SetNestedToSpecificEnvironment()
+        {
+            Assert.Throws<NullReferenceException>(() =>
+                {
+                    Config.Set("mega-backtesting.setup-handler", "3285-testing");
+                }
+            );
+        }
+
+        [Test]
         public void FlattenTest()
         {
             // read in and rewrite the environment based on the settings

--- a/Tests/Configuration/ConfigTests.cs
+++ b/Tests/Configuration/ConfigTests.cs
@@ -14,8 +14,7 @@
 */
 
 using System;
-using System.IO;
-using System.Linq;
+using System.Globalization;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using QuantConnect.Configuration;
@@ -35,6 +34,20 @@ namespace QuantConnect.Tests.Configuration
 
             bool betaMode2 = Config.GetBool("beta-mode");
             Assert.AreNotEqual(betaMode, betaMode2);
+        }
+
+        [Test]
+        public void SetNestedObject()
+        {
+            string key = "A.B.C.D";
+            decimal value = 0.325m;
+
+            // Set and get
+            Config.Set(key, value.ToString(CultureInfo.InvariantCulture), isEnvironmentContext:false);
+            decimal value2 = Config.GetValue<decimal>(key);
+
+            // Assert
+            Assert.AreEqual(value, value2);
         }
 
         [Test]


### PR DESCRIPTION
#### Description
The method allows to set the value in the configuration at the specified path. This can be useful for passing algorithm parameters to a program. For example, Config.SetValue("parameters.intrinio-username", "igaripov")

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
I wrote a program where I passed various parameters to the agorithm programmatically. While there is a function to read a value from composite path. Example - Config.GetValue<decimal>("parameters.sma26") there is no natural method to set values to a voluntary config path. I implemented the functionality with this commit.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
I ran few exmplaes .

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->