### PR TITLE
Fix Live coarse universe carrying over securities from previous day

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -153,7 +153,7 @@ namespace QuantConnect.Algorithm
             // universe selection
             UniverseManager = new UniverseManager();
             Universe = new UniverseDefinitions(this);
-            UniverseSettings = new UniverseSettings(Resolution.Minute, 2m, true, false, TimeSpan.FromDays(1));
+            UniverseSettings = new UniverseSettings(Resolution.Minute, 2m, true, false, TimeSpan.Zero);
 
             // initialize our scheduler, this acts as a liason to the real time handler
             Schedule = new ScheduleManager(Securities, TimeZone);

--- a/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
+++ b/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
@@ -16,11 +16,11 @@
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Data.UniverseSelection;
-using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 using System;
 using System.Linq;
+using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Algorithm
 {
@@ -81,6 +81,24 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(symbol, security.Symbol);
             Assert.AreEqual(spy, security);
             Assert.AreEqual(expected, security.DataNormalizationMode);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void LiveCoarseUniverseMinimumTimeIsSetToZeroIfMoreThanOneDay(bool liveMode)
+        {
+            var algorithm = new QCAlgorithm
+            {
+                UniverseSettings = { MinimumTimeInUniverse = TimeSpan.FromDays(1) }
+            };
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm, new MockDataFeed()));
+            algorithm.SetLiveMode(liveMode);
+
+            algorithm.AddUniverse(coarse => Enumerable.Empty<Symbol>());
+
+            Assert.AreEqual(
+                liveMode ? TimeSpan.Zero : TimeSpan.FromDays(1),
+                algorithm.UniverseSettings.MinimumTimeInUniverse);
         }
 
         private Tuple<QCAlgorithm, DataManager> GetAlgorithmAndDataManager()

--- a/Tests/Engine/DataFeeds/LiveCoarseUniverseTests.cs
+++ b/Tests/Engine/DataFeeds/LiveCoarseUniverseTests.cs
@@ -1,0 +1,177 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Moq;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.Results;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Logging;
+using QuantConnect.Orders;
+using QuantConnect.Packets;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture]
+    public class LiveCoarseUniverseTests
+    {
+        [Test]
+        public void CoarseUniverseRotatesActiveSecurity()
+        {
+            var startDate = new DateTime(2014, 3, 24);
+            var endDate = new DateTime(2014, 3, 28);
+
+            var timeProvider = new ManualTimeProvider(TimeZones.NewYork);
+            timeProvider.SetCurrentTime(startDate);
+
+            var coarseTimes = new List<DateTime>
+            {
+                new DateTime(2014, 3, 25),
+                new DateTime(2014, 3, 25, 23, 0, 0),
+                new DateTime(2014, 3, 27, 1, 0, 0)
+            }.ToHashSet();
+
+            var coarseSymbols = new List<Symbol> { Symbols.SPY, Symbols.AAPL, Symbols.MSFT };
+
+            var coarseUsaSymbol = CoarseFundamental.CreateUniverseSymbol(Market.USA, false);
+
+            var coarseDataEmittedCount = 0;
+            var lastTime = DateTime.MinValue;
+            var dataQueueHandler = new FuncDataQueueHandler(fdqh =>
+            {
+                var time = timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork);
+                if (time != lastTime)
+                {
+                    lastTime = time;
+
+                    if (coarseTimes.Contains(time))
+                    {
+                        // emit coarse data at selected times
+                        var coarseData = new BaseDataCollection { Symbol = coarseUsaSymbol };
+                        foreach (var symbol in coarseSymbols)
+                        {
+                            coarseData.Data.Add(
+                                new CoarseFundamental
+                                {
+                                    Symbol = symbol,
+                                    Time = time,
+                                    Market = Market.USA,
+                                    Value = 100
+                                });
+                        }
+                        coarseDataEmittedCount++;
+                        return new List<BaseData> { coarseData };
+                    }
+                }
+                return Enumerable.Empty<BaseData>();
+            });
+
+            var feed = new TestableLiveTradingDataFeed(dataQueueHandler);
+
+            var algorithm = new AlgorithmStub(feed);
+            algorithm.SetLiveMode(true);
+
+            var mock = new Mock<ITransactionHandler>();
+            mock.Setup(m => m.GetOpenOrders(It.IsAny<Func<Order, bool>>())).Returns(new List<Order>());
+            algorithm.Transactions.SetOrderProcessor(mock.Object);
+
+            var synchronizer = new TestableLiveSynchronizer(timeProvider);
+            synchronizer.Initialize(algorithm, algorithm.DataManager);
+
+            var mapFileProvider = new LocalDiskMapFileProvider();
+            feed.Initialize(algorithm, new LiveNodePacket(), new BacktestingResultHandler(),
+                mapFileProvider, new LocalDiskFactorFileProvider(mapFileProvider), new DefaultDataProvider(), algorithm.DataManager, synchronizer);
+
+            var symbolIndex = 0;
+            var coarseUniverseSelectionCount = 0;
+            algorithm.AddUniverse(
+                coarse =>
+                {
+                    coarseUniverseSelectionCount++;
+
+                    // rotate single symbol in universe
+                    if (symbolIndex == coarseSymbols.Count) symbolIndex = 0;
+
+                    return new [] { coarseSymbols[symbolIndex++] };
+                });
+
+            algorithm.PostInitialize();
+
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            Exception exceptionThrown = null;
+
+            // create a timer to advance time much faster than realtime
+            var timerInterval = TimeSpan.FromMilliseconds(50);
+            var timer = Ref.Create<Timer>(null);
+            timer.Value = new Timer(state =>
+            {
+                try
+                {
+                    // stop the timer to prevent reentrancy
+                    timer.Value.Change(Timeout.Infinite, Timeout.Infinite);
+
+                    var currentTime = timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork);
+
+                    if (currentTime.Date > endDate.Date)
+                    {
+                        feed.Exit();
+                        cancellationTokenSource.Cancel();
+                        return;
+                    }
+
+                    timeProvider.Advance(TimeSpan.FromHours(1));
+
+                    var activeSecuritiesCount = algorithm.ActiveSecurities.Count;
+
+                    Assert.That(activeSecuritiesCount <= 1);
+
+                    // restart the timer
+                    timer.Value.Change(timerInterval, timerInterval);
+                }
+                catch (Exception exception)
+                {
+                    Log.Error(exception);
+                    exceptionThrown = exception;
+
+                    feed.Exit();
+                    cancellationTokenSource.Cancel();
+                }
+
+            }, null, TimeSpan.FromSeconds(1), timerInterval);
+
+            foreach (var _ in synchronizer.StreamData(cancellationTokenSource.Token)) { }
+
+            timer.Value.Dispose();
+
+            if (exceptionThrown != null)
+            {
+                throw new Exception("Exception in timer: ", exceptionThrown);
+            }
+
+            Assert.AreEqual(coarseTimes.Count, coarseDataEmittedCount);
+            Assert.AreEqual(coarseTimes.Count, coarseUniverseSelectionCount);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />
     <Compile Include="Engine\Alphas\InsightAnalysisContextTests.cs" />
     <Compile Include="Engine\BrokerageTransactionHandlerTests\BacktestingTransactionHandlerTests.cs" />
+    <Compile Include="Engine\DataFeeds\LiveCoarseUniverseTests.cs" />
     <Compile Include="Engine\DataFeeds\DataManagerStub.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\Factories\OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\DelistingEnumeratorTests.cs" />


### PR DESCRIPTION
#### Description
- The default value of `QCAlgorithm.UniverseSettings.MinimumTimeInUniverse` has been changed from `TimeSpan.FromDays(1)` to `TimeSpan.Zero`.

#### Related Issue
Closes #3287 

#### Motivation and Context
Live algorithms using Coarse universe selection were including symbols selected on the previous day.
This is caused by the fact that in Live mode Coarse universe selection is not triggered **exactly** at the same time every day, but it can happen several minutes before (or after) the 24-hour offset from the time of the previous day.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`