### PR TITLE
Performance improvements for Options

### DIFF
--- a/Common/Data/Market/QuoteBar.cs
+++ b/Common/Data/Market/QuoteBar.cs
@@ -272,7 +272,14 @@ namespace QuantConnect.Data.Market
         /// <returns>Enumerable iterator for returning each line of the required data.</returns>
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
-            var csvLength = line.Split(',').Length;
+            var csvLength = 0;
+            for (var i = 0; i < line.Length && csvLength <= 5; i++)
+            {
+                if (line[i] == ',')
+                {
+                    csvLength++;
+                }
+            }
 
             try
             {

--- a/Common/Data/Market/QuoteBar.cs
+++ b/Common/Data/Market/QuoteBar.cs
@@ -272,44 +272,27 @@ namespace QuantConnect.Data.Market
         /// <returns>Enumerable iterator for returning each line of the required data.</returns>
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
-            var csvLength = 0;
-            for (var i = 0; i < line.Length && csvLength <= 5; i++)
-            {
-                if (line[i] == ',')
-                {
-                    csvLength++;
-                }
-            }
-
             try
             {
-                // "Scaffold" code - simple check to see how the data is formatted and decide how to parse appropriately
-                // TODO: Once all FX is reprocessed to QuoteBars, remove this check
-                if (csvLength > 5)
+                switch (config.SecurityType)
                 {
-                    switch (config.SecurityType)
-                    {
-                        case SecurityType.Equity:
-                            return ParseEquity(config, line, date);
+                    case SecurityType.Equity:
+                        return ParseEquity(config, line, date);
 
-                        case SecurityType.Forex:
-                        case SecurityType.Crypto:
-                            return ParseForex(config, line, date);
+                    case SecurityType.Forex:
+                    case SecurityType.Crypto:
+                        return ParseForex(config, line, date);
 
-                        case SecurityType.Cfd:
-                            return ParseCfd(config, line, date);
+                    case SecurityType.Cfd:
+                        return ParseCfd(config, line, date);
 
-                        case SecurityType.Option:
-                            return ParseOption(config, line, date);
+                    case SecurityType.Option:
+                        return ParseOption(config, line, date);
 
-                        case SecurityType.Future:
-                            return ParseFuture(config, line, date);
+                    case SecurityType.Future:
+                        return ParseFuture(config, line, date);
 
-                    }
                 }
-
-                // Parse as trade
-                return ParseTradeAsQuoteBar(config, date, line);
             }
             catch (Exception err)
             {

--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -208,8 +208,7 @@ namespace QuantConnect.Securities
                 _uniqueStrikes = _allSymbols
                     .DistinctBy(x => x.ID.StrikePrice)
                     .OrderBy(x => x.ID.StrikePrice)
-                    .Select(symbol => symbol.ID.StrikePrice)
-                    .ToList();
+                    .ToList(symbol => symbol.ID.StrikePrice);
 
                 _uniqueStrikesResolveDate = _underlying.Time.Date;
             }
@@ -281,14 +280,9 @@ namespace QuantConnect.Securities
             var minPrice = _uniqueStrikes[indexMinPrice];
             var maxPrice = _uniqueStrikes[indexMaxPrice];
 
-            var filtered =
-                    from symbol in _allSymbols
-                    let contract = symbol.ID
-                    where contract.StrikePrice >= minPrice
-                        && contract.StrikePrice <= maxPrice
-                    select symbol;
-
-            _allSymbols = filtered.ToList();
+            _allSymbols = _allSymbols
+                .Where(symbol => symbol.ID.StrikePrice >= minPrice && symbol.ID.StrikePrice <= maxPrice)
+                .ToList();
 
             return this;
         }
@@ -313,14 +307,9 @@ namespace QuantConnect.Securities
             var minExpiryToDate = _underlying.Time.Date + minExpiry;
             var maxExpiryToDate = _underlying.Time.Date + maxExpiry;
 
-            var filtered =
-                   from symbol in _allSymbols
-                   let contract = symbol.ID
-                   where contract.Date >= minExpiryToDate
-                      && contract.Date <= maxExpiryToDate
-                   select symbol;
-
-            _allSymbols = filtered.ToList();
+            _allSymbols = _allSymbols
+                .Where(symbol => symbol.ID.Date >= minExpiryToDate && symbol.ID.Date <= maxExpiryToDate)
+                .ToList();
 
             return this;
         }

--- a/Common/SecurityIdentifier.cs
+++ b/Common/SecurityIdentifier.cs
@@ -204,6 +204,7 @@ namespace QuantConnect
                     throw new InvalidOperationException("OptionType is only defined for SecurityType.Option");
                 }
 
+                // performance: lets calculate strike price once
                 if (_strikePrice == -1)
                 {
                     var scale = ExtractFromProperties(StrikeScaleOffset, StrikeScaleWidth);
@@ -293,6 +294,7 @@ namespace QuantConnect
             }
             _symbol = symbol;
             _properties = properties;
+            // performance: directly call Equals(SecurityIdentifier other), shortcuts Equals(object other)
             if (!underlying.Equals(Empty))
             {
                 _underlying = new SidBox(underlying);

--- a/Common/SecurityIdentifier.cs
+++ b/Common/SecurityIdentifier.cs
@@ -102,6 +102,7 @@ namespace QuantConnect
         private readonly ulong _properties;
         private readonly SidBox _underlying;
         private readonly int _hashCode;
+        private decimal _strikePrice;
 
         #endregion
 
@@ -202,10 +203,15 @@ namespace QuantConnect
                 {
                     throw new InvalidOperationException("OptionType is only defined for SecurityType.Option");
                 }
-                var scale = ExtractFromProperties(StrikeScaleOffset, StrikeScaleWidth);
-                var unscaled = ExtractFromProperties(StrikeOffset, StrikeWidth);
-                var pow = Math.Pow(10, (int)scale - StrikeDefaultScale);
-                return unscaled * (decimal)pow;
+
+                if (_strikePrice == -1)
+                {
+                    var scale = ExtractFromProperties(StrikeScaleOffset, StrikeScaleWidth);
+                    var unscaled = ExtractFromProperties(StrikeOffset, StrikeWidth);
+                    var pow = Math.Pow(10, (int)scale - StrikeDefaultScale);
+                    _strikePrice = unscaled * (decimal)pow;
+                }
+                return _strikePrice;
             }
         }
 
@@ -266,6 +272,7 @@ namespace QuantConnect
             _symbol = symbol;
             _properties = properties;
             _underlying = null;
+            _strikePrice = -1;
             SecurityType = (SecurityType)ExtractFromProperties(SecurityTypeOffset, SecurityTypeWidth, properties);
             _hashCode = unchecked (symbol.GetHashCode() * 397) ^ properties.GetHashCode();
         }
@@ -286,7 +293,7 @@ namespace QuantConnect
             }
             _symbol = symbol;
             _properties = properties;
-            if (underlying != Empty)
+            if (!underlying.Equals(Empty))
             {
                 _underlying = new SidBox(underlying);
             }

--- a/Engine/DataFeeds/ZipDataCacheProvider.cs
+++ b/Engine/DataFeeds/ZipDataCacheProvider.cs
@@ -67,12 +67,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             // handles zip files
-            if (filename.GetExtension() == ".zip")
+            if (filename.EndsWith(".zip"))
             {
                 Stream stream = null;
 
                 // scan the cache once every 3 seconds
-                if (_lastCacheScan == DateTime.MinValue || _lastCacheScan < DateTime.Now.AddSeconds(-3))
+                if (_lastCacheScan == DateTime.MinValue || _lastCacheScan < DateTime.UtcNow.AddSeconds(-3))
                 {
                     CleanCache();
                 }
@@ -172,7 +172,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         private void CleanCache()
         {
-            var clearCacheIfOlderThan = DateTime.Now.AddSeconds(-CacheSeconds);
+            var clearCacheIfOlderThan = DateTime.UtcNow.AddSeconds(-CacheSeconds);
 
             // clean all items that that are older than CacheSeconds than the current date
             foreach (var zip in _zipFileCache)
@@ -189,7 +189,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
             }
 
-            _lastCacheScan = DateTime.Now;
+            _lastCacheScan = DateTime.UtcNow;
         }
 
         /// <summary>
@@ -256,7 +256,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     }
                 }
 
-                entry.OpenReader().CopyTo(stream);
+                entry.Extract(stream);
                 stream.Position = 0;
                 return stream;
             }
@@ -303,7 +303,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 EntryCache[entry.FileName] = entry;
             }
             Key = key;
-            _dateCached = DateTime.Now;
+            _dateCached = DateTime.UtcNow;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/ZipDataCacheProvider.cs
+++ b/Engine/DataFeeds/ZipDataCacheProvider.cs
@@ -256,6 +256,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     }
                 }
 
+                // extract directly into the stream
                 entry.Extract(stream);
                 stream.Position = 0;
                 return stream;

--- a/Tests/Common/Data/Market/QuoteBarTests.cs
+++ b/Tests/Common/Data/Market/QuoteBarTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,30 +47,6 @@ namespace QuantConnect.Tests.Common.Data.Market
             Assert.AreEqual(11, bar.High);
             Assert.AreEqual(11, bar.Low);
             Assert.AreEqual(11, bar.Close);
-        }
-
-        [Test]
-        public void QuoteBarReader_CanParseTradeBarFormattedData_Successfully()
-        {
-            var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
-            var line = "14280000,1.10905,1.10909,1.10904,1.10908";
-            var date = DateTime.MaxValue;
-            var isLiveMode = false;
-
-            var quoteBar = new QuoteBar();
-            var parsedQuoteBar = (QuoteBar) quoteBar.Reader(config, line, date, isLiveMode);
-
-            Assert.AreEqual(parsedQuoteBar.Symbol, Symbols.SPY);
-
-            Assert.AreEqual(parsedQuoteBar.Ask.Open, 1.10905);
-            Assert.AreEqual(parsedQuoteBar.Ask.High, 1.10909);
-            Assert.AreEqual(parsedQuoteBar.Ask.Low, 1.10904);
-            Assert.AreEqual(parsedQuoteBar.Ask.Close, 1.10908);
-
-            Assert.AreEqual(parsedQuoteBar.Bid.Open, 1.10905);
-            Assert.AreEqual(parsedQuoteBar.Bid.High, 1.10909);
-            Assert.AreEqual(parsedQuoteBar.Bid.Low, 1.10904);
-            Assert.AreEqual(parsedQuoteBar.Bid.Close, 1.10908);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `QuoteBar.cs`: Replace `Split` for simple for loop, avoids creating unnecessary substrings.
- `SecurityIdentifier` will calculate `StrikePrice` just once. Replacing
`!=` for a direct call to `Equals()` preventing unnecessary checks.
- Slightly improving Linq queries at `OptionFilterUniverse`
- Replace `OpenReader().CopyTo` for `Extract(stream)`, avoids copying the
data twice.
- Replace `DateTime.Now` for `DateTime.UtcNow`

**Performance tests**
```
        public override void Initialize()
        {
            SetStartDate(2018, 1, 1);
            SetEndDate(2018, 6, 1);
            SetCash(10000);

            var option = AddOption("GOOG");

            option.SetFilter(-8, +8, TimeSpan.FromDays(20), TimeSpan.FromDays(50));
        }
```
`master`
243.22 seconds at 553k data points per second. Processing total of 134,502,627 data points.
233.58 seconds at 576k data points per second. Processing total of 134,502,627 data points.
225.68 seconds at 596k data points per second. Processing total of 134,502,627 data points.

`PR ~30% improvement`
154.34 seconds at 871k data points per second. Processing total of 134,502,627 data points.
149.04 seconds at 902k data points per second. Processing total of 134,502,627 data points.
147.59 seconds at 911k data points per second. Processing total of 134,502,627 data points.

```
        public override void Initialize()
        {
            SetStartDate(2018, 1, 1);
            SetEndDate(2018, 2, 1);
            SetCash(10000);

            var option = AddOption("GOOG");

            option.SetFilter(
                universe => universe.IncludeWeeklys().Strikes(-8, +8).Expiration(TimeSpan.FromDays(20), TimeSpan.FromDays(50))
            );
        }
```
`master`
105.30 seconds at 293k data points per second. Processing total of 30,883,838 data points.
92.11 seconds at 335k data points per second. Processing total of 30,883,838 data points.
100.15 seconds at 308k data points per second. Processing total of 30,883,838 data points.
`PR ~25% improvements`
75.10 seconds at 411k data points per second. Processing total of 30,883,838 data points.
75.32 seconds at 410k data points per second. Processing total of 30,883,838 data points.
75.73 seconds at 408k data points per second. Processing total of 30,883,838 data points.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/Lean/issues/3283
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Faster algorithms trading Options
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->