### PR TITLE
MapFile and FactorFile data feed stack resolution

### DIFF
--- a/Algorithm.CSharp/AddUniverseSelectionModelCoarseAlgorithm.cs
+++ b/Algorithm.CSharp/AddUniverseSelectionModelCoarseAlgorithm.cs
@@ -120,8 +120,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Estimated Insight Value", "$-131244.2"},
             {"Mean Population Direction", "46.6667%"},
             {"Mean Population Magnitude", "46.6667%"},
-            {"Rolling Averaged Population Direction", "61.5364%"},
-            {"Rolling Averaged Population Magnitude", "61.5364%"}
+            {"Rolling Averaged Population Direction", "61.4247%"},
+            {"Rolling Averaged Population Magnitude", "61.4247%"}
         };
     }
 }

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -221,7 +221,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Estimated Insight Value", "$12360.0462"},
             {"Mean Population Direction", "61.5385%"},
             {"Mean Population Magnitude", "0%"},
-            {"Rolling Averaged Population Direction", "65.1281%"},
+            {"Rolling Averaged Population Direction", "65.1708%"},
             {"Rolling Averaged Population Magnitude", "0%"}
         };
     }

--- a/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
@@ -112,7 +112,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Estimated Insight Value", "$-178726.7"},
             {"Mean Population Direction", "36.6667%"},
             {"Mean Population Magnitude", "0%"},
-            {"Rolling Averaged Population Direction", "56.6585%"},
+            {"Rolling Averaged Population Direction", "56.482%"},
             {"Rolling Averaged Population Magnitude", "0%"}
         };
     }

--- a/Common/Data/Auxiliary/FactorFileRow.cs
+++ b/Common/Data/Auxiliary/FactorFileRow.cs
@@ -29,6 +29,9 @@ namespace QuantConnect.Data.Auxiliary
     /// </summary>
     public class FactorFileRow
     {
+        private decimal _splitFactor;
+        private decimal _priceFactor;
+
         /// <summary>
         /// Gets the date associated with this data
         /// </summary>
@@ -37,17 +40,40 @@ namespace QuantConnect.Data.Auxiliary
         /// <summary>
         /// Gets the price factor associated with this data
         /// </summary>
-        public decimal PriceFactor { get; set; }
+        public decimal PriceFactor
+        {
+            get
+            {
+                return _priceFactor;
+
+            }
+            set
+            {
+                _priceFactor = value;
+                UpdatePriceScaleFactor();
+            }
+        }
 
         /// <summary>
         /// Gets the split factor associated with the date
         /// </summary>
-        public decimal SplitFactor { get; set; }
+        public decimal SplitFactor
+        {
+            get
+            {
+                return _splitFactor;
+            }
+            set
+            {
+                _splitFactor = value;
+                UpdatePriceScaleFactor();
+            }
+        }
 
         /// <summary>
         /// Gets the combined factor used to create adjusted prices from raw prices
         /// </summary>
-        public decimal PriceScaleFactor => PriceFactor*SplitFactor;
+        public decimal PriceScaleFactor { get; private set; }
 
         /// <summary>
         /// Gets the raw closing value from the trading date before the updated factor takes effect
@@ -283,6 +309,15 @@ namespace QuantConnect.Data.Auxiliary
         public override string ToString()
         {
             return $"{Date:yyyy-MM-dd}: {PriceScaleFactor:0.0000} {SplitFactor:0.0000}";
+        }
+
+        /// <summary>
+        /// For performance we update <see cref="PriceScaleFactor"/> when underlying
+        /// values are updated to avoid decimal multiplication on each get operation.
+        /// </summary>
+        private void UpdatePriceScaleFactor()
+        {
+            PriceScaleFactor = _priceFactor * _splitFactor;
         }
     }
 }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -369,9 +369,6 @@ namespace QuantConnect.Lean.Engine
                 // security prices got updated
                 algorithm.Portfolio.InvalidateTotalPortfolioValue();
 
-                // sample alpha charts now that we've updated time/price information but BEFORE we receive new insights
-                alphas.ProcessSynchronousEvents();
-
                 // fire real time events after we've updated based on the new data
                 realtime.SetTime(timeSlice.Time);
 
@@ -689,6 +686,10 @@ namespace QuantConnect.Lean.Engine
                 //If its the historical/paper trading models, wait until market orders have been "filled"
                 // Manually trigger the event handler to prevent thread switch.
                 transactions.ProcessSynchronousEvents();
+
+                // sample alpha charts now that we've updated time/price information and after transactions
+                // are processed so that insights closed because of new order based insights get updated
+                alphas.ProcessSynchronousEvents();
 
                 //Save the previous time for the sample calculations
                 _previousTime = time;

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -184,10 +184,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             if (_liveMode)
             {
                 OnSubscriptionAdded(subscription);
+                Log.Trace($"DataManager.AddSubscription(): Added {request.Configuration}." +
+                    $" Start: {request.StartTimeUtc}. End: {request.EndTimeUtc}");
+            }
+            else if(Log.DebuggingEnabled)
+            {
+                // for performance lets not create the message string if debugging is not enabled
+                // this can be executed many times and its in the algorithm thread
+                Log.Debug($"DataManager.AddSubscription(): Added {request.Configuration}." +
+                    $" Start: {request.StartTimeUtc}. End: {request.EndTimeUtc}");
             }
 
-            LiveDifferentiatedLog($"DataManager.AddSubscription(): Added {request.Configuration}." +
-                $" Start: {request.StartTimeUtc}. End: {request.EndTimeUtc}");
             return DataFeedSubscriptions.TryAdd(subscription);
         }
 
@@ -225,7 +232,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     RemoveSubscriptionDataConfig(subscription);
 
-                    LiveDifferentiatedLog($"DataManager.RemoveSubscription(): Removed {configuration}");
+                    if (_liveMode)
+                    {
+                        Log.Trace($"DataManager.RemoveSubscription(): Removed {configuration}");
+                    }
+                    else if(Log.DebuggingEnabled)
+                    {
+                        // for performance lets not create the message string if debugging is not enabled
+                        // this can be executed many times and its in the algorithm thread
+                        Log.Debug($"DataManager.RemoveSubscription(): Removed {configuration}");
+                    }
                     return true;
                 }
             }
@@ -274,8 +290,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var config = _subscriptionManagerSubscriptions.GetOrAdd(newConfig, newConfig);
 
             // if the reference is not the same, means it was already there and we did not add anything new
-            if (!ReferenceEquals(config, newConfig))
+            if (!ReferenceEquals(config, newConfig) && Log.DebuggingEnabled)
             {
+                // for performance lets not create the message string if debugging is not enabled
+                // this can be executed many times and its in the algorithm thread
                 Log.Debug("DataManager.SubscriptionManagerGetOrAdd(): subscription already added: " + config);
             }
             else
@@ -473,17 +491,5 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public UniverseSelection UniverseSelection { get; }
 
         #endregion
-
-        private void LiveDifferentiatedLog(string message)
-        {
-            if (_liveMode)
-            {
-                Log.Trace(message);
-            }
-            else
-            {
-                Log.Debug(message);
-            }
-        }
     }
 }

--- a/Engine/DataFeeds/Enumerators/AuxiliaryDataEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/AuxiliaryDataEnumerator.cs
@@ -85,7 +85,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             Lazy<MapFile> mapFile,
             ITradableDateEventProvider[] tradableDateEventProviders)
         {
-            _initialized = true;
             foreach (var tradableDateEventProvider in tradableDateEventProviders)
             {
                 tradableDateEventProvider.Initialize(
@@ -93,6 +92,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     factorFile?.Value,
                     mapFile?.Value);
             }
+            _initialized = true;
         }
 
 

--- a/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
@@ -50,13 +50,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             MapFileResolver mapFileResolver,
             bool includeAuxiliaryData)
         {
-            var mapFileToUse = GetMapFileToUse(config, mapFileResolver);
-            var factorFile = GetFactorFileToUse(config, factorFileProvider);
+            var lazyFactorFile =
+                new Lazy<FactorFile>(() => GetFactorFileToUse(config, factorFileProvider));
 
             var enumerator = new AuxiliaryDataEnumerator(
                 config,
-                factorFile,
-                mapFileToUse,
+                lazyFactorFile,
+                new Lazy<MapFile>(() => GetMapFileToUse(config, mapFileResolver)),
                 new ITradableDateEventProvider[]
                 {
                     new MappingEventProvider(),
@@ -70,7 +70,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             var priceScaleFactorEnumerator = new PriceScaleFactorEnumerator(
                 rawDataEnumerator,
                 config,
-                factorFile);
+                lazyFactorFile);
 
             return new SynchronizingEnumerator(priceScaleFactorEnumerator, enumerator);
         }

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -102,9 +102,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 mapFileResolver,
                 _includeAuxiliaryData);
 
-            // has to be initialized after adding all the enumerators since it will execute a MoveNext
-            dataReader.Initialize();
-
             return result;
         }
 

--- a/Engine/DataFeeds/Enumerators/PriceScaleFactorEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/PriceScaleFactorEnumerator.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
     {
         private readonly IEnumerator<BaseData> _rawDataEnumerator;
         private readonly SubscriptionDataConfig _config;
-        private readonly FactorFile _factorFile;
+        private readonly Lazy<FactorFile> _factorFile;
         private DateTime _lastTradableDate;
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         public PriceScaleFactorEnumerator(
             IEnumerator<BaseData> rawDataEnumerator,
             SubscriptionDataConfig config,
-            FactorFile factorFile)
+            Lazy<FactorFile> factorFile)
         {
             _lastTradableDate = DateTime.MinValue;
             _config = config;
@@ -201,11 +201,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 
                 case DataNormalizationMode.TotalReturn:
                 case DataNormalizationMode.SplitAdjusted:
-                    _config.PriceScaleFactor = _factorFile.GetSplitFactor(date);
+                    _config.PriceScaleFactor = _factorFile.Value.GetSplitFactor(date);
                     break;
 
                 case DataNormalizationMode.Adjusted:
-                    _config.PriceScaleFactor = _factorFile.GetPriceScaleFactor(date);
+                    _config.PriceScaleFactor = _factorFile.Value.GetPriceScaleFactor(date);
                     break;
 
                 default:

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -306,6 +306,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             if (!_initialized)
             {
+                // Late initialization so it is performed in the data feed stack
+                // and not in the algorithm thread
                 Initialize();
             }
 

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -321,8 +321,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 EnsureCurrencyDataFeeds(securityChanges);
             }
 
-            if (securityChanges != SecurityChanges.None)
+            if (securityChanges != SecurityChanges.None && Log.DebuggingEnabled)
             {
+                // for performance lets not create the message string if debugging is not enabled
+                // this can be executed many times and its in the algorithm thread
                 Log.Debug("UniverseSelection.ApplyUniverseSelection(): " + dateTimeUtc + ": " + securityChanges);
             }
 

--- a/Tests/Engine/DataFeeds/Enumerators/PriceScaleFactorEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/PriceScaleFactorEnumeratorTests.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var enumerator = new PriceScaleFactorEnumerator(
                 _rawDataEnumerator,
                 _config,
-                _factorFile);
+                new Lazy<FactorFile>(() => _factorFile));
             _rawDataEnumerator.CurrentValue = new TradeBar(
                 new DateTime(2018, 1, 1),
                 _config.Symbol,
@@ -83,7 +83,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var enumerator = new PriceScaleFactorEnumerator(
                 _rawDataEnumerator,
                 _config,
-                _factorFile);
+                new Lazy<FactorFile>(() => _factorFile));
             _rawDataEnumerator.CurrentValue = new QuoteBar(
                 new DateTime(2018, 1, 1),
                 _config.Symbol,
@@ -121,7 +121,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var enumerator = new PriceScaleFactorEnumerator(
                 _rawDataEnumerator,
                 _config,
-                _factorFile);
+                new Lazy<FactorFile>(() => _factorFile));
             _rawDataEnumerator.CurrentValue = new Tick(
                 new DateTime(2018, 1, 1),
                 _config.Symbol,
@@ -162,7 +162,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var enumerator = new PriceScaleFactorEnumerator(
                 _rawDataEnumerator,
                 _config,
-                _factorFile);
+                new Lazy<FactorFile>(() => _factorFile));
             _rawDataEnumerator.CurrentValue = new Tick(
                 new DateTime(2018, 1, 1),
                 _config.Symbol,
@@ -180,7 +180,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var enumerator = new PriceScaleFactorEnumerator(
                 _rawDataEnumerator,
                 _config,
-                _factorFile);
+                new Lazy<FactorFile>(() => _factorFile));
             _rawDataEnumerator.CurrentValue = null;
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNull(enumerator.Current);
@@ -196,7 +196,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             var enumerator = new PriceScaleFactorEnumerator(
                 _rawDataEnumerator,
                 _config,
-                _factorFile);
+                new Lazy<FactorFile>(() => _factorFile));
 
             // Before factor file update date (2018, 3, 15)
             _rawDataEnumerator.CurrentValue = new Tick(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- **This PR is on top of https://github.com/QuantConnect/Lean/pull/3299**
- Moving `MapFile` and `FactorFile` resolution to the data feed stack so
that they do not add a performance overhead to the algorithm thread.
- Create debug level logging string messages only if required.
- Calculate `FactorFileRow.PriceScaleFactor` the least amount of times

`Performance tests StatefulCoarseUniverseSelectionBenchmark 2017 - 2018 | 250 securities`
**PR https://github.com/QuantConnect/Lean/pull/3299: algorithm thread waiting on data for ~11 seconds**
![imagen](https://user-images.githubusercontent.com/18473240/59385943-d48b5a00-8d3b-11e9-86e5-bdcd24283ca4.png)

**This PR: slightly faster and waiting on data for ~14 seconds. See reduction of `ApplyUniverseSelection`**
![imagen](https://user-images.githubusercontent.com/18473240/59385932-cf2e0f80-8d3b-11e9-8fbc-030d94c9ee75.png)

**Note: the idea is to improve the data feed stack in following PRs**

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3302
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Performance
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regresion tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->