### PR TITLE
Fix plugin-directory config override

### DIFF
--- a/Common/Util/Composer.cs
+++ b/Common/Util/Composer.cs
@@ -35,12 +35,21 @@ namespace QuantConnect.Util
     /// </summary>
     public class Composer
     {
-        private static readonly string PluginDirectory = Config.Get("plugin-directory");
+        private static string PluginDirectory;
+        private static readonly Lazy<Composer> LazyComposer = new Lazy<Composer>(
+            () =>
+            {
+                PluginDirectory = Config.Get("plugin-directory");
+                return new Composer();
+            });
 
         /// <summary>
         /// Gets the singleton instance
         /// </summary>
-        public static readonly Composer Instance = new Composer();
+        /// <remarks>Intentionally using a property so that when its gotten it will
+        /// trigger the lazy construction which will be after the right configuration
+        /// is loaded. See GH issue 3258</remarks>
+        public static Composer Instance => LazyComposer.Value;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Composer"/> class. This type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Replace static field for property + lazy construction
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3258
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- `plugin-directory` configuration couldn't be overruled when using a configuration specified by parameter
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Composer unit tests, regression tests and debugging the reported steps to reproduce the issue.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->