### PR TITLE
Add a virtual property get in LiveSynchronizer

### DIFF
--- a/Engine/DataFeeds/LiveSynchronizer.cs
+++ b/Engine/DataFeeds/LiveSynchronizer.cs
@@ -31,6 +31,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private readonly AutoResetEvent _newLiveDataEmitted = new AutoResetEvent(false);
 
         /// <summary>
+        /// Maximum time to wait for new live data before synchronizing the data feed subscriptions
+        /// </summary>
+        protected virtual TimeSpan NewLiveDataTimeout { get; } = TimeSpan.FromMilliseconds(500);
+
+        /// <summary>
         /// Initializes the instance of the Synchronizer class
         /// </summary>
         public override void Initialize(
@@ -66,7 +71,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                _newLiveDataEmitted.WaitOne(TimeSpan.FromMilliseconds(500));
+                _newLiveDataEmitted.WaitOne(NewLiveDataTimeout);
 
                 TimeSlice timeSlice;
                 try


### PR DESCRIPTION

#### Description
- This new property in `LiveSynchronizer` enables overriding of the hardcoded `500ms` value in unit tests.

#### Related Issue
n/a

#### Motivation and Context
Enables custom configurations for additional live trading unit tests.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Live trading data feed unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.