### PR TITLE
Remove usage of DateTime.UtcNow in DataManager

### DIFF
--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -75,7 +75,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _marketHoursDatabase = marketHoursDatabase;
             _liveMode = liveMode;
 
-            var liveStart = DateTime.UtcNow;
             // wire ourselves up to receive notifications when universes are added/removed
             algorithm.UniverseManager.CollectionChanged += (sender, args) =>
             {
@@ -85,7 +84,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         foreach (var universe in args.NewItems.OfType<Universe>())
                         {
                             var config = universe.Configuration;
-                            var start = algorithm.LiveMode ? liveStart : algorithm.UtcTime;
+                            var start = algorithm.UtcTime;
 
                             var end = algorithm.LiveMode ? Time.EndOfTime
                                 : algorithm.EndDate.ConvertToUtc(algorithm.TimeZone);


### PR DESCRIPTION

#### Description
The `DataManager` was calling `DateTime.UtcNow` to set the start time for universe subscription requests.
This has now been replaced with `algorithm.UtcTime` (same as in backtesting).

#### Related Issue
None.

#### Motivation and Context
The usage of `DateTime.UtcNow` in the `DataManager` was preventing us from creating live trading unit tests with starting date in the past.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.