### PR TITLE
Fix LiveTradingDataFeed handling of Auxiliary data at Tick resolution

### DIFF
--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -336,18 +336,26 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     _exchange.AddDataHandler(request.Configuration.Symbol, data =>
                     {
-                        var tick = data as Tick;
-                        if (tick.TickType == request.Configuration.TickType)
+                        if (data.DataType == MarketDataType.Auxiliary)
                         {
                             tickEnumerator.Enqueue(data);
                             subscription.OnNewDataAvailable();
-                            if (data.DataType != MarketDataType.Auxiliary && tick.TickType != TickType.OpenInterest)
+                        }
+                        else
+                        {
+                            var tick = data as Tick;
+                            if (tick?.TickType == request.Configuration.TickType)
                             {
-                                UpdateSubscriptionRealTimePrice(
-                                    subscription,
-                                    timeZoneOffsetProvider,
-                                    request.Security.Exchange.Hours,
-                                    data);
+                                tickEnumerator.Enqueue(data);
+                                subscription.OnNewDataAvailable();
+                                if (tick.TickType != TickType.OpenInterest)
+                                {
+                                    UpdateSubscriptionRealTimePrice(
+                                        subscription,
+                                        timeZoneOffsetProvider,
+                                        request.Security.Exchange.Hours,
+                                        data);
+                                }
                             }
                         }
                     });


### PR DESCRIPTION

#### Description
The `LiveTradingDataFeed` data handler for `Tick` resolution has been updated to handle incoming `BaseData` instances with `MarketDataType.Auxiliary`.

#### Related Issue
None

#### Motivation and Context
Incoming live Auxiliary data for Equity subscriptions at Tick resolution would not be processed and a `NullReferenceException` would be logged.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.