### PR TITLE
Fix PriceCurrency in FXCM order events

### DIFF
--- a/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
@@ -381,7 +381,8 @@ namespace QuantConnect.Brokerages.Fxcm
                     // existing order
                     if (!OrderIsBeingProcessed(orderStatus.getCode()))
                     {
-                        order.PriceCurrency = message.getCurrency();
+                        var security = _securityProvider.GetSecurity(order.Symbol);
+                        order.PriceCurrency = security.SymbolProperties.QuoteCurrency;
 
                         var orderEvent = new OrderEvent(order,
                             DateTime.UtcNow,
@@ -395,7 +396,6 @@ namespace QuantConnect.Brokerages.Fxcm
                         // we're catching the first fill so we apply the fees only once
                         if ((int)message.getCumQty() == (int)message.getLastQty() && message.getLastQty() > 0)
                         {
-                            var security = _securityProvider.GetSecurity(order.Symbol);
                             orderEvent.OrderFee = security.FeeModel.GetOrderFee(
                                 new OrderFeeParameters(security, order));
                         }
@@ -407,7 +407,7 @@ namespace QuantConnect.Brokerages.Fxcm
                 {
                     _mapFxcmOrderIdsToOrders[orderId] = order;
                     order.BrokerId.Add(orderId);
-                    order.PriceCurrency = message.getCurrency();
+                    order.PriceCurrency = _securityProvider.GetSecurity(order.Symbol).SymbolProperties.QuoteCurrency;
 
                     // new order
                     var orderEvent = new OrderEvent(order,


### PR DESCRIPTION

#### Description
- The FXCM brokerage has been updated to set the correct value for the `PriceCurrency` property in order fill events.

#### Related Issue
Closes #3322 

#### Motivation and Context
Incorrect currency displayed in logs and QC IDE trade list.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Live algorithm deployed to FXCM and verified that order fills have the correct price currency.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`