### PR TITLE
Fix LiveEquityDataSynchronizingEnumerator for input data after the current time

### DIFF
--- a/Tests/Engine/DataFeeds/Enumerators/LiveEquityDataSynchronizingEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveEquityDataSynchronizingEnumeratorTests.cs
@@ -21,32 +21,58 @@ using NUnit.Framework;
 using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+using QuantConnect.Logging;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
 {
     [TestFixture]
     public class LiveEquityDataSynchronizingEnumeratorTests
     {
-        [Test]
-        public void SynchronizesData()
+        // this test case generates data points in the past, will complete very quickly
+        [TestCase(-15, 1)]
+        // this test case generates data points in the future, will require at least 10 seconds to complete
+        [TestCase(0, 11)]
+        public void SynchronizesData(int timeOffsetSeconds, int testTimeSeconds)
         {
             var start = DateTime.UtcNow;
-            var end = start.AddSeconds(15);
+            var end = start.AddSeconds(testTimeSeconds);
 
             var time = start;
-            var stream1 = Enumerable.Range(0, 10).Select(x => new Tick { Time = time.AddSeconds(x * 1) }).GetEnumerator();
-            var stream2 = Enumerable.Range(0, 5).Select(x => new Tick { Time = time.AddSeconds(x * 2) }).GetEnumerator();
+            var tickList1 = Enumerable.Range(0, 10).Select(x => new Tick { Time = time.AddSeconds(x * 1 + timeOffsetSeconds), Value = x }).ToList();
+            var tickList2 = Enumerable.Range(0, 5).Select(x => new Tick { Time = time.AddSeconds(x * 2 + timeOffsetSeconds), Value = x + 100 }).ToList();
+            var stream1 = tickList1.GetEnumerator();
+            var stream2 = tickList2.GetEnumerator();
 
+            var count1 = 0;
+            var count2 = 0;
             var previous = DateTime.MinValue;
             var synchronizer = new LiveEquityDataSynchronizingEnumerator(new RealTimeProvider(), DateTimeZone.Utc, stream1, stream2);
             while (synchronizer.MoveNext() && DateTime.UtcNow < end)
             {
                 if (synchronizer.Current != null)
                 {
+                    if (synchronizer.Current.Value < 100)
+                    {
+                        Assert.AreEqual(count1, synchronizer.Current.Value);
+                        count1++;
+                    }
+                    else
+                    {
+                        Assert.AreEqual(count2 + 100, synchronizer.Current.Value);
+                        count2++;
+                    }
+
                     Assert.That(synchronizer.Current.EndTime, Is.GreaterThanOrEqualTo(previous));
                     previous = synchronizer.Current.EndTime;
+
+                    Log.Trace($"Data point emitted: {synchronizer.Current.EndTime:O} - {synchronizer.Current}");
                 }
             }
+
+            Log.Trace($"Total point count: {count1 + count2}");
+
+            Assert.AreEqual(tickList1.Count, count1);
+            Assert.AreEqual(tickList2.Count, count2);
         }
     }
 }


### PR DESCRIPTION
#### Description
Previously the enumerator would get stuck and stop emitting data if one of the underlying enumerators returned a data point with the time greater than the current time. The existing unit test would only emit the first data point for the two underlying streams.

The enumerator has been updated to support data points in the future and the unit test has been extended to assert both data point counts and values.

#### Related Issue
Closes #3335 

#### Motivation and Context
`LiveEquityDataSynchronizingEnumerator` not emitting data in some cases.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- The existing unit test has been expanded to cover the failing case.
- An equity live algorithm has also been tested in the cloud

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`