### PR TITLE
Add Mapfile Support For Custom Data Sources

### DIFF
--- a/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
@@ -1,0 +1,146 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Custom.SEC;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders.Fees;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm demonstrating use of map files with custom data
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="custom data" />
+    /// <meta name="tag" content="regression test" />
+    /// <meta name="tag" content="SEC" />
+    /// <meta name="tag" content="rename event" />
+    /// <meta name="tag" content="map" />
+    /// <meta name="tag" content="mapping" />
+    /// <meta name="tag" content="map files" />
+    public class CustomDataUsingMapFileRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+        private bool _changedSymbol;
+        private bool _properSymbolBeforeRename;
+        private bool _properSymbolAfterRename;
+
+        /// <summary>
+        /// Ticker we use for testing
+        /// </summary>
+        public const string Ticker = "TWX";
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2001, 1, 1);
+            SetEndDate(2003, 12, 31);
+            SetCash(100000);
+
+            // AOL renames to TWX in 2003
+            _symbol = AddData<SECReport8K>(Ticker, Resolution.Daily).Symbol;
+            AddEquity(Ticker, Resolution.Daily);
+        }
+
+        /// <summary>
+        /// Checks to see if the stock has been renamed, and places an order once the symbol has changed
+        /// </summary>
+        /// <param name="slice"></param>
+        public override void OnData(Slice slice)
+        {
+            if (slice.SymbolChangedEvents.ContainsKey(_symbol))
+            {
+                // Check to see if it was renamed on the 16th
+                _changedSymbol = Time.Date == new DateTime(2003, 10, 16);
+                Log($"{Time} - Ticker changed from: {slice.SymbolChangedEvents[_symbol].OldSymbol} to {slice.SymbolChangedEvents[_symbol].NewSymbol}");
+            }
+
+            foreach (var report in slice.Get<SECReport8K>())
+            {
+                if (!_properSymbolBeforeRename)
+                {
+                    _properSymbolBeforeRename = report.Key.Value == "AOL" && Time < new DateTime(2003, 10, 16);
+                }
+                if (!_properSymbolAfterRename)
+                {
+                    _properSymbolAfterRename = report.Key.Value == "TWX" && Time >= new DateTime(2003, 10, 16);
+                }
+
+                Log($"{Time} - Received 8-K report for {report.Key.Value}");
+            }
+        }
+        
+        /// <summary>
+        /// Final step of the algorithm
+        /// </summary>
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_changedSymbol)
+            {
+                throw new Exception("The ticker did not rename throughout the course of its life even though it should have");
+            }
+            if (!_properSymbolBeforeRename)
+            {
+                throw new Exception("The SEC report data never renamed to its old ticker");
+            }
+            if (!_properSymbolAfterRename)
+            {
+                throw new Exception("The SEC report data never renamed back to its present-day ticker");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = false;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -144,6 +144,7 @@
     <Compile Include="CapmAlphaRankingFrameworkAlgorithm.cs" />
     <Compile Include="OnEndOfDayRegressionAlgorithm.cs" />
     <Compile Include="SECReportDataAlgorithm.cs" />
+    <Compile Include="CustomDataUsingMapFileRegressionAlgorithm.cs" />
     <Compile Include="G10CurrencySelectionModelFrameworkAlgorithm.cs" />
     <Compile Include="ExpiryHelperAlphaModelFrameworkAlgorithm.cs" />
     <Compile Include="CfdTimeZonesRegressionAlgorithm.cs" />

--- a/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
@@ -1,0 +1,78 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Data.Custom.SEC import *
+
+from datetime import datetime
+
+### <summary>
+### Demonstration algorithm showing how to use and access SEC data
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="custom data" />
+### <meta name="tag" content="regression test" />
+### <meta name="tag" content="SEC" />
+### <meta name="tag" content="rename event" />
+### <meta name="tag" content="map" />
+### <meta name="tag" content="mapping" />
+### <meta name="tag" content="map files" />
+class CustomDataUsingMapFileRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        # Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        self.SetStartDate(2001, 1, 1)
+        self.SetEndDate(2003, 12, 31)
+        self.SetCash(100000)
+
+        self.proper_symbol_before_rename = False
+        self.proper_symbol_after_rename = False
+
+        self.ticker = "TWX"
+        self.symbol = self.AddData(SECReport8K, self.ticker).Symbol
+        self.AddEquity(self.ticker, Resolution.Daily)
+
+    def OnData(self, slice):
+        if slice.SymbolChangedEvents.ContainsKey(self.symbol):
+            self.changed_symbol = True
+            self.Log("{0} - Ticker changed from: {1} to {2}".format(str(self.Time), slice.SymbolChangedEvents[self.symbol].OldSymbol, slice.SymbolChangedEvents[self.symbol].NewSymbol))
+        
+        if not slice.ContainsKey(self.symbol):
+            return
+            
+        data = slice[self.symbol]
+
+        if not isinstance(data, SECReport8K):
+            return
+
+        report = data.Report
+
+        if not self.proper_symbol_before_rename:
+            self.proper_symbol_before_rename = data.Symbol.Value == "AOL" and self.Time < datetime(2003, 10, 16)
+        if not self.proper_symbol_after_rename:
+            self.proper_symbol_after_rename = data.Symbol.Value == "TWX" and self.Time >= datetime(2003, 10, 16)
+
+        self.Log(f"{str(self.Time)} - Received 8-K report for {data.Symbol.Value}")
+
+    def OnEndOfAlgorithm(self):
+        if not self.changed_symbol:
+            raise Exception("The ticker did not rename throughout the course of its life even though it should have")
+
+

--- a/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
@@ -74,5 +74,9 @@ class CustomDataUsingMapFileRegressionAlgorithm(QCAlgorithm):
     def OnEndOfAlgorithm(self):
         if not self.changed_symbol:
             raise Exception("The ticker did not rename throughout the course of its life even though it should have")
+        if not self.proper_symbol_before_rename:
+            raise Exception("The SEC report data never renamed to its old ticker")
+        if not self.proper_symbol_after_rename:
+            raise Exception("The SEC report data never renamed to its present-day ticker")
 
 

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -55,6 +55,7 @@
     <Content Include="BasicCSharpIntegrationTemplateAlgorithm.py" />
     <Content Include="BasicSetAccountCurrencyAlgorithm.py" />
     <Content Include="KerasNeuralNetworkAlgorithm.py" />
+    <Content Include="CustomDataUsingMapFileRegressionAlgorithm.py" />
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />
     <Content Include="SECReportDataAlgorithm.py" />

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -89,7 +89,7 @@ namespace QuantConnect.Algorithm
             MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, symbol, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
-            var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA), symbol);
+            var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA, SubscriptionDataConfig.MapFileTypes.Contains(dataType)), symbol);
 
             //Add this new generic data as a tradeable security:
             var config = SubscriptionManager.SubscriptionDataConfigService.Add(dataType,

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1814,7 +1814,7 @@ namespace QuantConnect.Algorithm
             MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, ticker, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
-            var symbol = new Symbol(SecurityIdentifier.GenerateBase(ticker, Market.USA), ticker);
+            var symbol = new Symbol(SecurityIdentifier.GenerateBase(ticker, Market.USA, SubscriptionDataConfig.MapFileTypes.Contains(typeof(T))), ticker);
 
             //Add this new generic data as a tradeable security:
             var config = SubscriptionManager.SubscriptionDataConfigService.Add(typeof(T),

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -35,7 +35,7 @@ namespace QuantConnect
 
         /// <summary>
         /// Provides a convience method for creating a Symbol for most security types.
-        /// This method currently does not support Option, Commodity, and Future
+        /// This method currently does not support Commodities
         /// </summary>
         /// <param name="ticker">The string ticker symbol</param>
         /// <param name="securityType">The security type of the ticker. If securityType == Option, then a canonical symbol is created</param>

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
@@ -90,8 +90,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private string GetMappedSymbol(SubscriptionRequest request, DateTime date)
         {
             var config = request.Configuration;
-            if (config.Symbol.ID.SecurityType == SecurityType.Option ||
-                config.Symbol.ID.SecurityType == SecurityType.Equity )
+            if (config.UsesMapFiles)
             {
                 var mapFile = config.Symbol.HasUnderlying ?
                         _mapFileResolver.ResolveMapFile(config.Symbol.Underlying.ID.Symbol, config.Symbol.Underlying.ID.Date) :

--- a/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
@@ -80,34 +80,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             MapFileResolver mapFileResolver)
         {
             var mapFileToUse = new MapFile(config.Symbol.Value, new List<MapFileRow>());
+            var hasUnderlying = config.Symbol.HasUnderlying;
 
-            // load up the map and factor files for equities
-            if (!config.IsCustomData && config.SecurityType == SecurityType.Equity)
+            // load up the map and factor files for equities, options, and custom data
+            if (config.UsesMapFiles)
             {
                 try
                 {
-                    var mapFile = mapFileResolver.ResolveMapFile(
-                        config.Symbol.ID.Symbol,
-                        config.Symbol.ID.Date);
+                    var symbol = hasUnderlying ? config.Symbol.Underlying.ID.Symbol : config.Symbol.ID.Symbol;
+                    var date = hasUnderlying ? config.Symbol.Underlying.ID.Date : config.Symbol.ID.Date;
 
-                    // only take the resolved map file if it has data, otherwise we'll use the empty one we defined above
-                    if (mapFile.Any()) mapFileToUse = mapFile;
-                }
-                catch (Exception err)
-                {
-                    Log.Error(err, "CorporateEventEnumeratorFactory.GetMapFileToUse():" +
-                        " Map File: " + config.Symbol.ID + ": ");
-                }
-            }
-
-            // load up the map and factor files for underlying of equity option
-            if (!config.IsCustomData && config.SecurityType == SecurityType.Option)
-            {
-                try
-                {
-                    var mapFile = mapFileResolver.ResolveMapFile(
-                        config.Symbol.Underlying.ID.Symbol,
-                        config.Symbol.Underlying.ID.Date);
+                    var mapFile = mapFileResolver.ResolveMapFile(symbol, date);
 
                     // only take the resolved map file if it has data, otherwise we'll use the empty one we defined above
                     if (mapFile.Any()) mapFileToUse = mapFile;

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -74,8 +74,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <returns>An enumerator reading the subscription request</returns>
         public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
         {
-            var mapFileResolver = request.Configuration.SecurityType == SecurityType.Equity ||
-                                  request.Configuration.SecurityType == SecurityType.Option
+            var mapFileResolver = request.Configuration.UsesMapFiles 
                                     ? _mapFileProvider.Get(request.Security.Symbol.ID.Market)
                                     : MapFileResolver.Empty;
 

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -104,11 +104,11 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 SymbolProperties.GetDefault(Currencies.NullCurrency),
                 ErrorCurrencyConverter.Instance
             );
-            var mapFileResolver = config.SecurityType == SecurityType.Equity
+            var mapFileResolver = config.UsesMapFiles
                 ? _mapFileProvider.Get(config.Market)
                 : MapFileResolver.Empty;
 
-            if (config.SecurityType == SecurityType.Equity)
+            if (config.UsesMapFiles)
             {
                 var mapFile = mapFileResolver.ResolveMapFile(config.Symbol.ID.Symbol, config.Symbol.ID.Date);
                 config.MappedSymbol = mapFile.GetMappedSymbol(start, config.MappedSymbol);

--- a/Tests/Common/Securities/SecurityIdentifierTests.cs
+++ b/Tests/Common/Securities/SecurityIdentifierTests.cs
@@ -253,7 +253,7 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void DeserializesFromSimpleStringWithinContainerClass()
         {
-            var sid = new Container{sid =SPY};
+            var sid = new Container { sid = SPY };
             var str =
 @"
 {
@@ -302,6 +302,32 @@ namespace QuantConnect.Tests.Common.Securities
         public void ThrowsOnInvalidSymbolCharacters(string input)
         {
             new SecurityIdentifier(input, 0);
+        }
+
+        [Test]
+        public void GenerateEquityWithTickerUsingMapFile()
+        {
+            var expectedFirstDate = new DateTime(1998, 1, 2);
+            var sid = SecurityIdentifier.GenerateWithFirstDate("TWX", Market.USA, SecurityType.Equity, true);
+
+            Assert.AreEqual(sid.Date, expectedFirstDate);
+            Assert.AreEqual(sid.Symbol, "AOL");
+        }
+        
+        [Test]
+        public void GenerateBaseDataWithTickerUsingMapFile()
+        {
+            var expectedFirstDate = new DateTime(1998, 1, 2);
+            var sid = SecurityIdentifier.GenerateWithFirstDate("TWX", Market.USA, SecurityType.Base);
+
+            Assert.AreEqual(sid.Date, expectedFirstDate);
+            Assert.AreEqual(sid.Symbol, "AOL");
+        }
+        
+        [Test]
+        public void AttemptToGenerateFromMapFileWithNotSupportedSecurityType()
+        {
+            Assert.Throws<ArgumentException>(() => { SecurityIdentifier.GenerateWithFirstDate("CL", Market.USA, SecurityType.Future); });
         }
 
         class Container

--- a/Tests/Common/Securities/SecurityIdentifierTests.cs
+++ b/Tests/Common/Securities/SecurityIdentifierTests.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using QuantConnect.Data.Auxiliary;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -308,7 +309,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void GenerateEquityWithTickerUsingMapFile()
         {
             var expectedFirstDate = new DateTime(1998, 1, 2);
-            var sid = SecurityIdentifier.GenerateWithFirstDate("TWX", Market.USA, SecurityType.Equity, true);
+            var sid = SecurityIdentifier.GenerateEquity("TWX", Market.USA, mapSymbol: true, mapFileProvider: new LocalDiskMapFileProvider());
 
             Assert.AreEqual(sid.Date, expectedFirstDate);
             Assert.AreEqual(sid.Symbol, "AOL");
@@ -318,18 +319,12 @@ namespace QuantConnect.Tests.Common.Securities
         public void GenerateBaseDataWithTickerUsingMapFile()
         {
             var expectedFirstDate = new DateTime(1998, 1, 2);
-            var sid = SecurityIdentifier.GenerateWithFirstDate("TWX", Market.USA, SecurityType.Base);
+            var sid = SecurityIdentifier.GenerateBase("TWX", Market.USA, mapSymbol: true);
 
             Assert.AreEqual(sid.Date, expectedFirstDate);
             Assert.AreEqual(sid.Symbol, "AOL");
         }
         
-        [Test]
-        public void AttemptToGenerateFromMapFileWithNotSupportedSecurityType()
-        {
-            Assert.Throws<ArgumentException>(() => { SecurityIdentifier.GenerateWithFirstDate("CL", Market.USA, SecurityType.Future); });
-        }
-
         class Container
         {
             public SecurityIdentifier sid;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Implements the ability to use map files for custom data. 

This means that you can now apply rename events to custom data and be alerted when the symbol changes, and have the new updated symbol track the symbol at a given time T.

An example:
```
      AOL     ----------------------->     TWX      

   2003-10-15                           2003-10-16
```

Previously, if you added your symbol as "TWX" (the current stock ticker), you would only receive data points for "TWX" before 2003-10-16. But now, when you add "TWX", through the map file system, we load data for "AOL" before 2003-10-16, and rename the symbol on 2003-10-16 to "TWX" in your backtest containing custom data. 

This feature is opt-in via the `SubscriptionDataConfig.MapFileTypes` list. You can add your class to this list in order to enable mapping for your source of custom data

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3296 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fulfills a requirement for sources of custom data based on equities
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes. The tutorial teaching how to add custom data should consider adding a section detailing how to add a custom data class to the supported mapping (rename event) types.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New regression tests and unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->