### PR TITLE
Implements QCAlgorith.IsTraining and QCAlgorithm.Train

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Alphas\VixDualThrustAlpha.cs" />
     <Compile Include="BasicPythonIntegrationTemplateAlgorithm.cs" />
     <Compile Include="BasicSetAccountCurrencyAlgorithm.cs" />
+    <Compile Include="TrainExampleAlgorithm.cs" />
     <Compile Include="Benchmarks\StatefulCoarseUniverseSelectionBenchmark.cs" />
     <Compile Include="Benchmarks\StatelessCoarseUniverseSelectionBenchmark.cs" />
     <Compile Include="CapmAlphaRankingFrameworkAlgorithm.cs" />

--- a/Algorithm.CSharp/TrainExampleAlgorithm.cs
+++ b/Algorithm.CSharp/TrainExampleAlgorithm.cs
@@ -1,0 +1,69 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using System;
+using System.Threading;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This example shows how we can execute a method that takes longer than Lean timeout limit
+    /// This feature is useful for algorithms that train models
+    /// </summary>
+    /// <meta name="tag" content="using quantconnect" />
+    public class TrainExampleAlgorithm : QCAlgorithm
+    {
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);  //Set Start Date
+            SetEndDate(2013, 10, 11);    //Set End Date
+
+            AddEquity("SPY");
+
+            Schedule.On(
+                DateRules.EveryDay("SPY"),
+                TimeRules.AfterMarketOpen("SPY", 10),
+                () => {
+                    Train(
+                        SleepTraining,
+                        TimeSpan.FromSeconds(20),
+                        () => { Debug($"Callback called at {Time:O}"); }
+                    );
+                }
+            );
+        }
+
+        private void SleepTraining()
+        {
+            Thread.Sleep(10000);
+            Debug($"Portfolio Invested: {Portfolio.Invested}.");
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (Portfolio.Invested) return;
+
+            SetHoldings("SPY", 1);
+        }
+    }
+}

--- a/Algorithm.CSharp/TrainExampleAlgorithm.cs
+++ b/Algorithm.CSharp/TrainExampleAlgorithm.cs
@@ -15,7 +15,6 @@
 
 using QuantConnect.Data;
 using System;
-using System.Threading;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -26,6 +25,8 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="using quantconnect" />
     public class TrainExampleAlgorithm : QCAlgorithm
     {
+        private string _piString;
+
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
         /// </summary>
@@ -41,18 +42,68 @@ namespace QuantConnect.Algorithm.CSharp
                 TimeRules.AfterMarketOpen("SPY", 10),
                 () => {
                     Train(
-                        SleepTraining,
+                        () => _piString = CalculatePi(10000),
                         TimeSpan.FromSeconds(20),
-                        () => { Debug($"Callback called at {Time:O}"); }
+                        () => { Debug($"{Time:O} :: Pi: {_piString}"); }
                     );
                 }
             );
         }
 
-        private void SleepTraining()
+        public static string CalculatePi(int digits)
         {
-            Thread.Sleep(10000);
-            Debug($"Portfolio Invested: {Portfolio.Invested}.");
+            // Credit to https://stackoverflow.com/a/11679007
+            digits++;
+
+            var pi = new uint[digits];
+            var x = new uint[digits * 10 / 3 + 2];
+            var r = new uint[digits * 10 / 3 + 2];
+
+            for (var j = 0; j < x.Length; j++)
+            {
+                x[j] = 20;
+            }
+
+            for (var i = 0; i < digits; i++)
+            {
+                uint carry = 0;
+                for (var j = 0; j < x.Length; j++)
+                {
+                    var num = (uint)(x.Length - j - 1);
+                    var dem = num * 2 + 1;
+
+                    x[j] += carry;
+
+                    var q = x[j] / dem;
+                    r[j] = x[j] % dem;
+
+                    carry = q * num;
+                }
+
+
+                pi[i] = x[x.Length - 1] / 10;
+
+                r[x.Length - 1] = x[x.Length - 1] % 10;
+
+                for (var j = 0; j < x.Length; j++)
+                {
+                    x[j] = r[j] * 10;
+                }
+            }
+
+            var result = "";
+
+            uint c = 0;
+
+            for (var i = pi.Length - 1; i >= 0; i--)
+            {
+                pi[i] += c;
+                c = pi[i] / 10;
+
+                result = (pi[i] % 10) + result;
+            }
+
+            return result;
         }
 
         /// <summary>

--- a/Algorithm.CSharp/TrainExampleAlgorithm.cs
+++ b/Algorithm.CSharp/TrainExampleAlgorithm.cs
@@ -15,6 +15,8 @@
 
 using QuantConnect.Data;
 using System;
+using System.Collections.Generic;
+using QuantConnect.Interfaces;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -23,7 +25,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// This feature is useful for algorithms that train models
     /// </summary>
     /// <meta name="tag" content="using quantconnect" />
-    public class TrainExampleAlgorithm : QCAlgorithm
+    public class TrainExampleAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private string _piString;
 
@@ -116,5 +118,42 @@ namespace QuantConnect.Algorithm.CSharp
 
             SetHoldings("SPY", 1);
         }
+
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "263.153%"},
+            {"Drawdown", "2.200%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "1.663%"},
+            {"Sharpe Ratio", "4.41"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0.007"},
+            {"Beta", "76.118"},
+            {"Annual Standard Deviation", "0.192"},
+            {"Annual Variance", "0.037"},
+            {"Information Ratio", "4.354"},
+            {"Tracking Error", "0.192"},
+            {"Treynor Ratio", "0.011"},
+            {"Total Fees", "$3.26"}
+        };
     }
 }

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -54,6 +54,7 @@
     <Content Include="Alphas\VIXDualThrustAlpha.py" />
     <Content Include="BasicCSharpIntegrationTemplateAlgorithm.py" />
     <Content Include="BasicSetAccountCurrencyAlgorithm.py" />
+    <None Include="TrainExampleAlgorithm.py" />
     <Content Include="KerasNeuralNetworkAlgorithm.py" />
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -116,6 +116,7 @@
     <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
     <Compile Include="TimeInForceAlgorithm.py" />
     <Compile Include="TrailingStopRiskFrameworkAlgorithm.py" />
+    <Compile Include="TrainExampleAlgorithm.py" />
     <Compile Include="UniverseSelectionDefinitionsAlgorithm.py" />
     <Compile Include="UniverseSelectionRegressionAlgorithm.py" />
     <Compile Include="UpdateOrderRegressionAlgorithm.py" />

--- a/Algorithm.Python/TrainExampleAlgorithm.py
+++ b/Algorithm.Python/TrainExampleAlgorithm.py
@@ -20,7 +20,6 @@ from System import *
 from QuantConnect import *
 from QuantConnect.Algorithm import *
 from datetime import timedelta
-from time import sleep
 
 ### <summary>
 ### This example shows how we can execute a method that takes longer than Lean timeout limit
@@ -35,7 +34,7 @@ class TrainExampleAlgorithm(QCAlgorithm):
 
     def Initialize(self):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
-        self.sleep = True
+        self.piString = ""
 
         self.SetStartDate(2013,10, 7)  #Set Start Date
         self.SetEndDate(2013,10,11)    #Set End Date
@@ -45,15 +44,49 @@ class TrainExampleAlgorithm(QCAlgorithm):
         self.Schedule.On(
                 self.DateRules.EveryDay("SPY"),
                 self.TimeRules.AfterMarketOpen("SPY", 10),
-                lambda : self.Train(self.SleepTraining,
+                lambda : self.Train(lambda: self.CalculatePi(10000),
                                     timedelta(seconds=20),
-                                    lambda: self.Debug(f"Callback called at {self.Time}")
+                                    lambda: self.Debug(f"{self.Time} :: Pi: {self.piString}")
                                     )
                         )
 
-    def SleepTraining(self):
-        sleep(10)
-        self.Debug(f"Portfolio Invested: {self.Portfolio.Invested}.")
+    def CalculatePi(self, digits):
+        # Credits to https://www.w3resource.com/projects/python/python-projects-1.php
+        q, r, t, k, n, l = 1, 0, 1, 1, 3, 3
+
+        decimal = digits
+        counter = 0
+
+        result = ""
+
+        while counter != decimal + 1:
+            if 4 * q + r - t < n * t:
+                # yield digit
+                result = result + str(n)
+                # insert period after first digit
+                if counter == 0:
+                    result = result + '.'
+                # end
+                if decimal == counter:
+                    break
+                counter += 1
+                nr = 10 * (r - n * t)
+                n = ((10 * (3 * q + r)) // t) - 10 * n
+                q *= 10
+                r = nr
+            else:
+                nr = (2 * q + r) * l
+                nn = (q * (7 * k) + 2 + (r * l)) // (t * l)
+                q *= k
+                t *= l
+                l += 2
+                k += 1
+                n = nn
+                r = nr
+
+        self.piString = result
+        return result
+
 
     def OnData(self, data):
         '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.'''        

--- a/Algorithm.Python/TrainExampleAlgorithm.py
+++ b/Algorithm.Python/TrainExampleAlgorithm.py
@@ -1,0 +1,61 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from datetime import timedelta
+from time import sleep
+
+### <summary>
+### This example shows how we can execute a method that takes longer than Lean timeout limit
+### This feature is useful for algorithms that train models
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="using quantconnect" />
+### <meta name="tag" content="trading and orders" />
+class TrainExampleAlgorithm(QCAlgorithm):
+    '''This example shows how we can execute a method that takes longer than Lean timeout limit
+    This feature is useful for algorithms that train models'''
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+        self.sleep = True
+
+        self.SetStartDate(2013,10, 7)  #Set Start Date
+        self.SetEndDate(2013,10,11)    #Set End Date
+
+        self.AddEquity("SPY")
+
+        self.Schedule.On(
+                self.DateRules.EveryDay("SPY"),
+                self.TimeRules.AfterMarketOpen("SPY", 10),
+                lambda : self.Train(self.SleepTraining,
+                                    timedelta(seconds=20),
+                                    lambda: self.Debug(f"Callback called at {self.Time}")
+                                    )
+                        )
+
+    def SleepTraining(self):
+        sleep(10)
+        self.Debug(f"Portfolio Invested: {self.Portfolio.Invested}.")
+
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.'''        
+        if self.Portfolio.Invested: return
+        self.SetHoldings("SPY", 1)

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -792,6 +792,39 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// In synchronous mode, execute the work and the callback in sequence while <see cref="IsTraining"/> flag is true
+        /// to signal the algorithm is in training mode.
+        /// In asynchronous mode, queues the specified work to run on the thread pool
+        /// that must complete within a specified time interval.
+        /// If the work completes within the interval, a new action is invoked if defined.
+        /// </summary>
+        /// <param name="action">The work to execute asynchronously</param>
+        /// <param name="timeout">The time span to wait before completing the returned task, or TimeSpan.FromMilliseconds(-1) to wait indefinitely.</param>
+        /// <param name="callback">The work to execute synchronously after the first work is completed</param>
+        /// <param name="synchronous">Queue the work synchronously (true). Otherwise we'll block until it is completed</param>
+        public void Train(PyObject action, TimeSpan? timeout = null, PyObject callback = null, bool synchronous = true)
+        {
+            Train(
+                () =>
+                {
+                    using (Py.GIL())
+                    {
+                        action.Invoke();
+                    }
+                },
+                timeout,
+                () =>
+                {
+                    using (Py.GIL())
+                    {
+                        callback?.Invoke();
+                    }
+                },
+                synchronous
+            );
+        }
+
+        /// <summary>
         /// Gets Enumerable of <see cref="Symbol"/> from a PyObject
         /// </summary>
         /// <param name="pyObject">PyObject containing Symbol or Array of Symbol</param>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2162,6 +2162,14 @@ namespace QuantConnect.Algorithm
         /// <param name="synchronous">Queue the work synchronously (true). Otherwise we'll block until it is completed</param>
         public void Train(Action action, TimeSpan? timeout = null, Action callback = null, bool synchronous = true)
         {
+            if (!synchronous && !LiveMode)
+            {
+                throw new ArgumentException(
+                    "In backtesting mode, please use QCAlgorithm.Train() synchronously",
+                    nameof(synchronous)
+                );
+            }
+
             IsTraining = true;
 
             if (synchronous)

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -176,6 +176,11 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         }
 
         /// <summary>
+        /// Gets whether or not this algorithm is training a model
+        /// </summary>
+        public bool IsTraining => _baseAlgorithm.IsTraining;
+
+        /// <summary>
         /// Gets whether or not this algorithm is still warming up
         /// </summary>
         public bool IsWarmingUp => _baseAlgorithm.IsWarmingUp;

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -157,6 +157,14 @@ namespace QuantConnect.Interfaces
         }
 
         /// <summary>
+        /// Gets whether or not this algorithm is training a model
+        /// </summary>
+        bool IsTraining
+        {
+            get;
+        }
+
+        /// <summary>
         /// Gets whether or not this algorithm is still warming up
         /// </summary>
         bool IsWarmingUp

--- a/Common/Packets/Controls.cs
+++ b/Common/Packets/Controls.cs
@@ -78,6 +78,12 @@ namespace QuantConnect.Packets
         public int MaximumDataPointsPerChartSeries;
 
         /// <summary>
+        /// Maximum number of minutes, accurate to the nearest millisecond, to wait before completing a work in the thread pool
+        /// </summary>
+        [JsonProperty(PropertyName = "iTimeLoopMaximumTraining")]
+        public int TimeLoopMaximumTraining;
+
+        /// <summary>
         /// Initializes a new default instance of the <see cref="Controls"/> class
         /// </summary>
         public Controls()
@@ -91,6 +97,7 @@ namespace QuantConnect.Packets
             RemainingLogAllowance = 10000;
             BacktestingMaxInsights = 10000;
             MaximumDataPointsPerChartSeries = 4000;
+            TimeLoopMaximumTraining = 30;
         }
 
         /// <summary>

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -88,7 +88,8 @@ namespace QuantConnect.Queues
                 SecondLimit = Config.GetInt("symbol-second-limit", 10000),
                 TickLimit = Config.GetInt("symbol-tick-limit", 10000),
                 RamAllocation = int.MaxValue,
-                MaximumDataPointsPerChartSeries =  Config.GetInt("maximum-data-points-per-chart-series", 4000)
+                MaximumDataPointsPerChartSeries = Config.GetInt("maximum-data-points-per-chart-series", 4000),
+                TimeLoopMaximumTraining = Config.GetInt("training-model-custom-loop-timeout", 30)
             };
 
             //If this isn't a backtesting mode/request, attempt a live job.

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Python.Runtime;
@@ -769,6 +770,47 @@ namespace QuantConnect.Tests.Common.Util
         {
             var value = 10.999999m;
             Assert.AreEqual(10.999m, value.TruncateTo3DecimalPlaces());
+        }
+
+        [Test]
+        public void TimeoutAfterAndContinueTests()
+        {
+            Action action = () => Thread.Sleep(1000);
+            Action divideByZeroAction = () => { var x = 0; var y = 1 / x; };
+
+            action.TimeoutAfterAndContinue(TimeSpan.FromMilliseconds(2000))
+                .ContinueWith(x => Assert.IsTrue(x.IsCompleted))
+                .Wait();
+
+            // Timeout exception: wait 900 ms for a 2s work
+            var task1 = action.TimeoutAfterAndContinue(TimeSpan.FromMilliseconds(900));
+            task1.ContinueWith(x =>
+                {
+                    Assert.IsTrue(x.IsFaulted);
+                    Assert.AreEqual(x.Exception?.InnerException?.GetType(), typeof(TimeoutException));
+                }
+            );
+            Assert.Throws<AggregateException>(() => task1.Wait());
+
+            // Action throws exception
+            var task2 = divideByZeroAction.TimeoutAfterAndContinue(TimeSpan.FromMilliseconds(900));
+            task2.ContinueWith(x =>
+                {
+                    Assert.IsTrue(x.IsFaulted);
+                    Assert.AreEqual(x.Exception?.InnerException?.GetType(), typeof(DivideByZeroException));
+                }
+            );
+            Assert.Throws<AggregateException>(() => task2.Wait());
+
+            // Callback throws exception
+            var task3 = action.TimeoutAfterAndContinue(TimeSpan.FromMilliseconds(2000), divideByZeroAction);
+            task3.ContinueWith(x =>
+                {
+                    Assert.IsTrue(x.IsFaulted);
+                    Assert.AreEqual(x.Exception?.InnerException?.GetType(), typeof(DivideByZeroException));
+                }
+            );
+            Assert.Throws<AggregateException>(() => task3.Wait());
         }
 
         private PyObject ConvertToPyObject(object value)


### PR DESCRIPTION
#### Description
`QCAlgorithm.IsTraining` is a flag that signals that work is being performed by the `QCAlgorithm.Train`. The `AlgorithmManager` is aware of this special algorithm state and use a larger loop timeout set by `Controls`.

#### Related Issue
Closes #3319 

#### Motivation and Context
With the rise of AI it is becoming more common to do expensive computations in a strategy which might take a while. LEAN currently has a limit of 10 minutes per loop of the algorithm designed to prevent an algorithm locking up and crashing without user awareness.

#### Requires Documentation Change
Yes. We need to add a section that explains its usage.

#### How Has This Been Tested?
Unit tests and example algorithm.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`