### PR TITLE
Stream downloaded data in more cases

### DIFF
--- a/PythonToolbox/quantconnect/api.py
+++ b/PythonToolbox/quantconnect/api.py
@@ -17,6 +17,8 @@ from requests import get as requests_get, Request
 from time import mktime
 from quantconnect import ApiConnection
 
+DOWNLOAD_CHUNK_SIZE = 256 * 1024
+
 class Api:
     """QuantConnect.com Interaction Via API.
     Attributes:
@@ -470,7 +472,7 @@ class Api:
             # download and save the data
             request = requests_get(link['link'], stream=True)
             with open(fileName + '.zip', "wb") as code:
-                for chunk in request.iter_content(None):
+                for chunk in request.iter_content(DOWNLOAD_CHUNK_SIZE):
                     code.write(chunk)
 
         return link['success']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Passing `chunk_size=None` to `iter_content()` works fine for chunk-encoded responses, but still leaves us buffering the entire response when the server just specifies a `Content-Length`.

Now, stream the response 256k at a time.

Why 256k? It's large enough that you won't be in a tight loop doing tiny reads, but small enough that it shouldn't be any great memory concern. If anyone finds that it's problematic, they can always monkey-patch `quantconnect.api.DOWNLOAD_CHUNK_SIZE`.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Follow-up to PR #3353 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested _in situ_, but testing with `requests` and a little server app run using `eventlet`:
```
(py37) $ cat test.py 
import eventlet
import eventlet.wsgi

CONTENT = [b'x' * i * 3 for i in range(10)]
def app(environ, start_response):
    environ['eventlet.minimum_write_chunk_size'] = 1
    if environ['PATH_INFO'] == '/chunked':
        start_response('200 OK', [])
    else:
        start_response('200 OK', [
            ('Content-Length', str(sum(len(x) for x in CONTENT))),
        ])

    def gen():
        for chunk in CONTENT:
            eventlet.sleep(.5)
            yield chunk

    return gen()

if __name__ == '__main__':
    eventlet.wsgi.server(sock=eventlet.listen(('', 8000)), site=app)

(py37) $ python test.py 2>/dev/null &
[1] 15170
```
Use curl (with `-N` to disable buffering) to verify that the server behaves as expected, which is to say that
- the `/chunked` response includes `Transfer-Encoding: chunked` in the headers while the `/` response specifies a `Content-Length`, and
- the `x`s arrive in larger and larger chunks with a noticeable delay between chunks:
```
(py37) $ curl -Nv http://localhost:8000/chunked
*   Trying ::1...
* TCP_NODELAY set
* connect to ::1 port 8000 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /chunked HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.64.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Wed, 03 Jul 2019 04:20:19 GMT
< Transfer-Encoding: chunked
< 
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx* Connection #0 to host localhost left intact

(py37) $ curl -Nv http://localhost:8000/
*   Trying ::1...
* TCP_NODELAY set
* connect to ::1 port 8000 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET / HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.64.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 135
< Date: Wed, 03 Jul 2019 04:20:32 GMT
< 
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx* Connection #0 to host localhost left intact
```
See how requests behaves:
```
(py37) $ python -c 'import requests; resp = requests.get("http://localhost:8000/chunked", stream=True); print([len(chunk) for chunk in resp.iter_content(None)])'
[3, 6, 9, 12, 15, 18, 21, 24, 27]

(py37) $ python -c 'import requests; resp = requests.get("http://localhost:8000/", stream=True); print([len(chunk) for chunk in resp.iter_content(None)])'
[135]

(py37) $ python -c 'import requests; resp = requests.get("http://localhost:8000/", stream=True); print([len(chunk) for chunk in resp.iter_content(1<<6)])'
[64, 64, 7]

(py37) $ python -c 'import requests; resp = requests.get("http://localhost:8000/chunked", stream=True); print([len(chunk) for chunk in resp.iter_content(1<<6)])'
[3, 6, 9, 12, 15, 18, 21, 24, 27]

(py37) $ kill %1
[1]+  Terminated              python test.py 2> /dev/null
```
You can also edit the server script to crank up the base chunk size to something like 3MB and check that the non-chunked `iter_content(None)` result holds with bigger payloads:
```
(py37) $ python -c 'import requests; resp = requests.get("http://localhost:8000/", stream=True); print([len(chunk) for chunk in resp.iter_content(None)])'
[135000000]
```
...and _that's_ the crux of the issue: we don't want to be buffering 135MB before writing to disk!

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->