### PR TITLE
Add retry logic to LiveOptionChainProvider.GetOptionContractList

### DIFF
--- a/Engine/DataFeeds/LiveOptionChainProvider.cs
+++ b/Engine/DataFeeds/LiveOptionChainProvider.cs
@@ -55,9 +55,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             var attempt = 1;
-            var contracts = Enumerable.Empty<Symbol>();
+            IEnumerable<Symbol> contracts;
 
-            do
+            while (true)
             {
                 try
                 {
@@ -66,13 +66,18 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     contracts = FindOptionContracts(symbol.Value);
                     break;
                 }
-                catch (Exception exception)
+                catch (WebException exception)
                 {
                     Log.Error(exception);
+
+                    if (++attempt > MaxDownloadAttempts)
+                    {
+                        throw;
+                    }
+
                     Thread.Sleep(1000);
-                    attempt++;
                 }
-            } while (attempt <= MaxDownloadAttempts);
+            }
 
             return contracts;
         }

--- a/Tests/Common/Securities/Options/OptionChainProviderTests.cs
+++ b/Tests/Common/Securities/Options/OptionChainProviderTests.cs
@@ -24,8 +24,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Common.Securities.Options
 {
-    // For now these tests are excluded from the Travis build because of occasional web server errors.
-    [TestFixture, Category("TravisExclude")]
+    [TestFixture]
     public class OptionChainProviderTests
     {
         [Test]
@@ -59,9 +58,24 @@ namespace QuantConnect.Tests.Common.Securities.Options
         public void LiveOptionChainProviderReturnsData()
         {
             var provider = new LiveOptionChainProvider();
-            var result = provider.GetOptionContractList(Symbols.AAPL, DateTime.Today);
 
-            Assert.IsTrue(result.Any());
+            foreach (var symbol in new[] { Symbols.SPY, Symbols.AAPL, Symbols.MSFT })
+            {
+                var result = provider.GetOptionContractList(symbol, DateTime.Today);
+
+                Assert.IsTrue(result.Any());
+            }
+        }
+
+        [Test]
+        public void LiveOptionChainProviderReturnsNoDataForInvalidSymbol()
+        {
+            var symbol = Symbol.Create("ABCDEF123", SecurityType.Equity, Market.USA);
+
+            var provider = new LiveOptionChainProvider();
+            var result = provider.GetOptionContractList(symbol, DateTime.Today);
+
+            Assert.IsFalse(result.Any());
         }
     }
 


### PR DESCRIPTION

#### Description
- The `LiveOptionChainProvider.GetOptionContractList` method has been updated to retry failed API calls up to a maximum of 5 attempts.
- `OptionChainProvider` unit tests have been re-enabled for Travis build (previously disabled in #2588) 

#### Related Issue
Closes #3364 

#### Motivation and Context
Prevent algorithm termination after a single Web request failure.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Existing unit tests with forced failure on the first attempt
- Existing unit tests with forced failure on all attempts
- Existing unit tests with a real failure (timeout + server unreachable) -- got lucky there :)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`