### PR TITLE
RollingWindow errors made more verbose

### DIFF
--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -137,10 +137,18 @@ namespace QuantConnect.Indicators
                 {
                     _listLock.EnterReadLock();
 
-                    if (i < 0 || i > Count - 1)
-                    {
-                        throw new ArgumentOutOfRangeException("i", i, string.Format("Must be between 0 and {0}", Count - 1));
-                    }
+					if (Count == 0)
+					{
+						throw new ArgumentException("Rolling window is empty");
+					}
+					else if (i > Size - 1 || i < 0)
+					{
+						throw new ArgumentOutOfRangeException("i", i, string.Format("Index must be between 0 and {0} (rolling window is of size {1})", Size - 1, Size));
+					}
+					else if (i > Count - 1)
+					{
+						throw new ArgumentOutOfRangeException("i", i, string.Format("Index must be between 0 and {0} (entry {1} does not exist yet)", Count - 1, i));
+					}
                     return _list[(Count + _tail - i - 1) % Count];
                 }
                 finally

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -139,7 +139,7 @@ namespace QuantConnect.Indicators
 
                     if (Count == 0)
                     {
-                        throw new ArgumentException("Rolling window is empty");
+                        throw new ArgumentOutOfRangeException("i", "Rolling window is empty");
                     }
                     else if (i > Size - 1 || i < 0)
                     {

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -137,18 +137,18 @@ namespace QuantConnect.Indicators
                 {
                     _listLock.EnterReadLock();
 
-					if (Count == 0)
-					{
-						throw new ArgumentException("Rolling window is empty");
-					}
-					else if (i > Size - 1 || i < 0)
-					{
-						throw new ArgumentOutOfRangeException("i", i, string.Format("Index must be between 0 and {0} (rolling window is of size {1})", Size - 1, Size));
-					}
-					else if (i > Count - 1)
-					{
-						throw new ArgumentOutOfRangeException("i", i, string.Format("Index must be between 0 and {0} (entry {1} does not exist yet)", Count - 1, i));
-					}
+                    if (Count == 0)
+                    {
+                        throw new ArgumentException("Rolling window is empty");
+                    }
+                    else if (i > Size - 1 || i < 0)
+                    {
+                        throw new ArgumentOutOfRangeException("i", i, string.Format("Index must be between 0 and {0} (rolling window is of size {1})", Size - 1, Size));
+                    }
+                    else if (i > Count - 1)
+                    {
+                        throw new ArgumentOutOfRangeException("i", i, string.Format("Index must be between 0 and {0} (entry {1} does not exist yet)", Count - 1, i));
+                    }
                     return _list[(Count + _tail - i - 1) % Count];
                 }
                 finally


### PR DESCRIPTION
Let's once and for all eliminate all `RollingWindow` posts on the forums 😉 !

## Description
`RollingWindow` error messages are now more verbose and explicit depending on the type of error:

- Window is empty (`Count == 0`)
- `i` is outside allowable range (`i < 0 || i > Size-1`)
- `i` is not populated yet (`i > Count-1`)

(see issue for more details)

#### Related Issue
#3306 

#### Motivation and Context
I'd like to see a world where no users are ever confused about why their rolling windows don't work.

#### Requires Documentation Change
None that I know of.

#### How Has This Been Tested?
Ran the following algorithm:
```c#
namespace QuantConnect.Algorithm.CSharp
{
	public class BasicTemplateFrameworkAlgorithm : QCAlgorithm
	{
		public Indicators.RollingWindow<double> winEmpty;
		public Indicators.RollingWindow<double> winPop;
		public Indicators.RollingWindow<double> winAlmostPop;

		public override void Initialize()
		{
			winEmpty = new RollingWindow<double>(3);
			winPop = new RollingWindow<double>(5) { 0.3, 0.4, 0.5, 0.6, 0.7 };
			winAlmostPop = new RollingWindow<double>(5) { 0.1, 0.2, 0.3, 0.4 };

			// case 1: no entries in the window yet
			//Log(winEmpty[1]);

			// case 2: i outside allowable range of i's
			//Log(winPop[56]);

			// case 2b: i less than 0
			//Log(winPop[-3]);

			// case 3: i not yet populated
			//Log(winAlmostPop[4]);

			// case 4: correct
			//Log(winPop[2]);
		}
	}
}
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] ~I have added tests to cover my changes.~ **Should not be needed as it doesn't change how rolling windows work.**
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`