### PR TITLE
Provide unit tests for NotificationManager, NotitificationEmail and default message/subject

### DIFF
--- a/Common/Notifications/Notification.cs
+++ b/Common/Notifications/Notification.cs
@@ -1,17 +1,20 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
+using System;
+using QuantConnect.Util;
 
 namespace QuantConnect.Notifications
 {
@@ -90,6 +93,8 @@ namespace QuantConnect.Notifications
     /// </summary>
     public class NotificationEmail : Notification
     {
+        private const string DefaultMessageAndSubject = "QuantConnect LEAN Email Notification";
+
         /// <summary>
         /// Send to address:
         /// </summary>
@@ -119,10 +124,15 @@ namespace QuantConnect.Notifications
         /// <param name="data">Data to attach to the email</param>
         public NotificationEmail(string address, string subject, string message, string data)
         {
-            Message = message;
-            Data = data;
-            Subject = subject;
+            if (!Validate.EmailAddress(address))
+            {
+                throw new ArgumentException($"Invalid email address: {address}");
+            }
+
             Address = address;
+            Data = data ?? string.Empty;
+            Message = message ?? DefaultMessageAndSubject;
+            Subject = subject ?? DefaultMessageAndSubject;
         }
     }
 }

--- a/Common/Notifications/Notification.cs
+++ b/Common/Notifications/Notification.cs
@@ -93,8 +93,6 @@ namespace QuantConnect.Notifications
     /// </summary>
     public class NotificationEmail : Notification
     {
-        private const string DefaultMessageAndSubject = "QuantConnect LEAN Email Notification";
-
         /// <summary>
         /// Send to address:
         /// </summary>
@@ -118,11 +116,12 @@ namespace QuantConnect.Notifications
         /// <summary>
         /// Default constructor for sending an email notification
         /// </summary>
-        /// <param name="address">Address to send to</param>
-        /// <param name="subject">Subject of the email</param>
-        /// <param name="message">Message body of the email</param>
-        /// <param name="data">Data to attach to the email</param>
-        public NotificationEmail(string address, string subject, string message, string data)
+        /// <param name="address">Address to send to. Will throw <see cref="ArgumentException"/> if invalid
+        /// <see cref="Validate.EmailAddress"/></param>
+        /// <param name="subject">Subject of the email. Will set to <see cref="string.Empty"/> if null</param>
+        /// <param name="message">Message body of the email. Will set to <see cref="string.Empty"/> if null</param>
+        /// <param name="data">Data to attach to the email. Will set to <see cref="string.Empty"/> if null</param>
+        public NotificationEmail(string address, string subject = "", string message = "", string data = "")
         {
             if (!Validate.EmailAddress(address))
             {
@@ -131,8 +130,8 @@ namespace QuantConnect.Notifications
 
             Address = address;
             Data = data ?? string.Empty;
-            Message = message ?? DefaultMessageAndSubject;
-            Subject = subject ?? DefaultMessageAndSubject;
+            Message = message ?? string.Empty;
+            Subject = subject ?? string.Empty;
         }
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -723,6 +723,7 @@
     <Compile Include="Util\ReaderWriterLockSlimExtensions.cs" />
     <Compile Include="Util\Ref.cs" />
     <Compile Include="Util\SingleValueListConverter.cs" />
+    <Compile Include="Util\Validate.cs" />
     <Compile Include="Util\VersionHelper.cs" />
     <Compile Include="Util\WorkerThread.cs" />
     <Compile Include="Util\XElementExtensions.cs" />

--- a/Common/Util/Validate.cs
+++ b/Common/Util/Validate.cs
@@ -1,0 +1,106 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace QuantConnect.Util
+{
+    /// <summary>
+    /// Provides methods for validating strings following a certain format, such as an email address
+    /// </summary>
+    public static class Validate
+    {
+        /// <summary>
+        /// Validates the provided email address
+        /// </summary>
+        /// <remarks>
+        /// Implementation taken from msdn (with slight refactoring for readability and C#6 compliance):
+        /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format
+        /// </remarks>
+        /// <param name="emailAddress">The email address to be validated</param>
+        /// <returns>True if the provided email address is valid</returns>
+        public static bool EmailAddress(string emailAddress)
+        {
+            if (string.IsNullOrWhiteSpace(emailAddress))
+            {
+                return false;
+            }
+
+            emailAddress = NormalizeEmailAddressDomainName(emailAddress);
+            if (emailAddress == null)
+            {
+                // an error occurred during domain name normalization
+                return false;
+            }
+
+            try
+            {
+                return RegularExpression.Email.IsMatch(emailAddress);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string NormalizeEmailAddressDomainName(string emailAddress)
+        {
+            try
+            {
+                // Normalize the domain
+                emailAddress = RegularExpression.EmailDomainName.Replace(emailAddress, match =>
+                {
+                    // Use IdnMapping class to convert Unicode domain names.
+                    var idn = new IdnMapping();
+
+                    // Pull out and process domain name (throws ArgumentException on invalid)
+                    var domainName = idn.GetAscii(match.Groups[2].Value);
+
+                    return match.Groups[1].Value + domainName;
+                });
+            }
+            catch
+            {
+                return null;
+            }
+
+            return emailAddress;
+        }
+
+        /// <summary>
+        /// Provides static storage of compiled regular expressions to preclude parsing on each invocation
+        /// </summary>
+        public static class RegularExpression
+        {
+            private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
+
+            /// <summary>
+            /// Matches the domain name in an email address ignored@[domain.com]
+            /// Pattern sourced via msdn:
+            /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format
+            /// </summary>
+            public static readonly Regex EmailDomainName = new Regex(@"(@)(.+)$", RegexOptions.Compiled, MatchTimeout);
+
+            /// <summary>
+            /// Matches a valid email address address@sub.domain.com
+            /// Pattern sourced via msdn:
+            /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format
+            /// </summary>
+            public static readonly Regex Email = new Regex(@"^(?("")("".+?(?<!\\)""@)|(([0-9a-z]((\.(?!\.))|[-!#\$%&'\*\+/=\?\^`\{\}\|~\w])*)(?<=[0-9a-z])@))(?(\[)(\[(\d{1,3}\.){3}\d{1,3}\])|(([0-9a-z][-0-9a-z]*[0-9a-z]*\.)+[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))$", RegexOptions.IgnoreCase | RegexOptions.Compiled, MatchTimeout);
+        }
+    }
+}

--- a/QuantConnect.Lean.sln.DotSettings
+++ b/QuantConnect.Lean.sln.DotSettings
@@ -9,4 +9,5 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Quant/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=QUANTCONNECT/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/Tests/Common/Notifications/NotificationEmailTests.cs
+++ b/Tests/Common/Notifications/NotificationEmailTests.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
 using NUnit.Framework;
 using QuantConnect.Notifications;
 
@@ -16,19 +31,19 @@ namespace QuantConnect.Tests.Common.Notifications
         }
 
         [Test]
-        public void Constructor_SetsNullSubject_ToDefaultQuantConnectLeanEmailNotification()
+        public void Constructor_SetsNullSubject_ToEmptyString()
         {
-            // default subject chosen to provide context for the email
+            // empty string used if subject is null
             var email = new NotificationEmail("e@d.com", null, "message", "data");
-            Assert.AreEqual("QuantConnect LEAN Email Notification", email.Subject);
+            Assert.AreEqual(string.Empty, email.Subject);
         }
 
         [Test]
-        public void Constructor_SetsNullMessage_ToDefaultQuantConnectLeanEmailNotification()
+        public void Constructor_SetsNullMessage_ToEmptyString()
         {
-            // default message chosen to provide context for the email
+            // empty string used if message is null
             var email = new NotificationEmail("e@d.com", "subject", null, "data");
-            Assert.AreEqual("QuantConnect LEAN Email Notification", email.Message);
+            Assert.AreEqual(string.Empty, email.Message);
         }
 
         [Test]

--- a/Tests/Common/Notifications/NotificationEmailTests.cs
+++ b/Tests/Common/Notifications/NotificationEmailTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using NUnit.Framework;
+using QuantConnect.Notifications;
+
+namespace QuantConnect.Tests.Common.Notifications
+{
+    [TestFixture]
+    public class NotificationEmailTests
+    {
+        [Test]
+        public void Constructor_SetsNullData_ToEmptyString()
+        {
+            // empty string used as default following NotificationManager.Email's default value for data
+            var email = new NotificationEmail("e@d.com", "subject", "message", null);
+            Assert.AreEqual(string.Empty, email.Data);
+        }
+
+        [Test]
+        public void Constructor_SetsNullSubject_ToDefaultQuantConnectLeanEmailNotification()
+        {
+            // default subject chosen to provide context for the email
+            var email = new NotificationEmail("e@d.com", null, "message", "data");
+            Assert.AreEqual("QuantConnect LEAN Email Notification", email.Subject);
+        }
+
+        [Test]
+        public void Constructor_SetsNullMessage_ToDefaultQuantConnectLeanEmailNotification()
+        {
+            // default message chosen to provide context for the email
+            var email = new NotificationEmail("e@d.com", "subject", null, "data");
+            Assert.AreEqual("QuantConnect LEAN Email Notification", email.Message);
+        }
+
+        [Test]
+        [TestCase("js@contoso.中国", true)]
+        [TestCase("j@proseware.com9", true)]
+        [TestCase("js@proseware.com9", true)]
+        [TestCase("j_9@[129.126.118.1]", true)]
+        [TestCase("jones@ms1.proseware.com", true)]
+        [TestCase("david.jones@proseware.com", true)]
+        [TestCase("d.j@server1.proseware.com", true)]
+        [TestCase("js#internal@proseware.com", true)]
+        [TestCase("j.s@server1.proseware.com", true)]
+        [TestCase("\"j\\\"s\\\"\"@proseware.com", true)]
+
+        [TestCase("js*@proseware.com", false)]
+        [TestCase("js@proseware..com", false)]
+        [TestCase("j..s@proseware.com", false)]
+        [TestCase("j.@server1.proseware.com", false)]
+        public void Constructor_ThrowsArgumentException_WhenEmailAddressIsInvalid(string address, bool isValid)
+        {
+            // Test cases sourced via msdn:
+            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format
+
+            TestDelegate ctor = () => new NotificationEmail(
+                address,
+                string.Empty,
+                string.Empty,
+                string.Empty
+            );
+
+            if (isValid)
+            {
+                Assert.DoesNotThrow(ctor);
+            }
+            else
+            {
+                Assert.Throws<ArgumentException>(ctor);
+            }
+        }
+    }
+}

--- a/Tests/Common/Notifications/NotificationManagerTests.cs
+++ b/Tests/Common/Notifications/NotificationManagerTests.cs
@@ -1,0 +1,117 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Notifications;
+
+namespace QuantConnect.Tests.Common.Notifications
+{
+    [TestFixture(true)]
+    [TestFixture(false)]
+    public class NotificationManagerTests
+    {
+        private readonly bool _liveMode;
+        private NotificationManager _notify;
+
+        public NotificationManagerTests(bool liveMode)
+        {
+            _liveMode = liveMode;
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _notify = new NotificationManager(_liveMode);
+        }
+
+        [Test]
+        public void Email_AddsNotificationEmail_ToMessages_WhenLiveModeIsTrue()
+        {
+            Assert.AreEqual(_liveMode, _notify.Email("address@domain.com", "subject", "message", "data"));
+            Assert.AreEqual(_liveMode ? 1 : 0, _notify.Messages.Count);
+            if (_liveMode)
+            {
+                Assert.IsInstanceOf<NotificationEmail>(_notify.Messages.Single());
+            }
+        }
+
+        [Test]
+        public void Sms_AddsNotificationSms_ToMessages_WhenLiveModeIsTrue()
+        {
+            Assert.AreEqual(_liveMode, _notify.Sms("phone-number", "message"));
+            Assert.AreEqual(_liveMode ? 1 : 0, _notify.Messages.Count);
+            if (_liveMode)
+            {
+                Assert.IsInstanceOf<NotificationSms>(_notify.Messages.Single());
+            }
+        }
+
+        [Test]
+        public void Web_AddsNotificationWeb_ToMessages_WhenLiveModeIsTrue()
+        {
+            Assert.AreEqual(_liveMode, _notify.Web("address", "data"));
+            Assert.AreEqual(_liveMode ? 1 : 0, _notify.Messages.Count);
+            if (_liveMode)
+            {
+                Assert.IsInstanceOf<NotificationWeb>(_notify.Messages.Single());
+            }
+        }
+
+        [Test]
+        [TestCase("email")]
+        [TestCase("sms")]
+        [TestCase("web")]
+        public void RateLimits_Notifications_AfterThirtyCalls(string method)
+        {
+            for (var invocationNumber = 1; invocationNumber <= 31; invocationNumber++)
+            {
+                bool result;
+                switch (method)
+                {
+                    case "email":
+                        result = _notify.Email("address@domain.com", "subject", "message", "data");
+                        break;
+
+                    case "sms":
+                        result = _notify.Sms("phone-number", "message");
+                        break;
+
+                    case "web":
+                        result = _notify.Web("address", "data");
+                        break;
+
+                    default:
+                        throw new ArgumentException($"Invalid method: {method}");
+                }
+
+                if (_liveMode && invocationNumber <= 30)
+                {
+                    Assert.IsTrue(result);
+                }
+                else
+                {
+                    Assert.IsFalse(result);
+                    if (!_liveMode)
+                    {
+                        // no need to test further
+                        Assert.Pass();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/Common/Util/ValidateTests.cs
+++ b/Tests/Common/Util/ValidateTests.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Common.Util
+{
+    [TestFixture]
+    public class ValidateTests
+    {
+        [Test]
+        [TestCase("js@contoso.中国", true)]
+        [TestCase("j@proseware.com9", true)]
+        [TestCase("js@proseware.com9", true)]
+        [TestCase("j_9@[129.126.118.1]", true)]
+        [TestCase("jones@ms1.proseware.com", true)]
+        [TestCase("david.jones@proseware.com", true)]
+        [TestCase("d.j@server1.proseware.com", true)]
+        [TestCase("js#internal@proseware.com", true)]
+        [TestCase("j.s@server1.proseware.com", true)]
+        [TestCase(@"""j\""s\""""@proseware.com", true)]
+
+        [TestCase("js*@proseware.com", false)]
+        [TestCase("js@proseware..com", false)]
+        [TestCase("j..s@proseware.com", false)]
+        [TestCase("j.@server1.proseware.com", false)]
+        public void EmailAddress(string emailAddress, bool isValid)
+        {
+            Assert.AreEqual(isValid, Validate.EmailAddress(emailAddress));
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -289,6 +289,7 @@
     <Compile Include="Common\Data\MockSubscriptionDataConfigProvider.cs" />
     <Compile Include="Common\Data\UniverseSelection\UniverseTests.cs" />
     <Compile Include="Common\IsolatorTests.cs" />
+    <Compile Include="Common\Notifications\NotificationManagerTests.cs" />
     <Compile Include="Common\Orders\Fees\BackwardsCompatibilityFeeModelTests.cs" />
     <Compile Include="Common\Orders\Fees\BitfinexFeeModelTests.cs" />
     <Compile Include="Common\Orders\Fees\GDAXFeeModelTests.cs" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -289,6 +289,7 @@
     <Compile Include="Common\Data\MockSubscriptionDataConfigProvider.cs" />
     <Compile Include="Common\Data\UniverseSelection\UniverseTests.cs" />
     <Compile Include="Common\IsolatorTests.cs" />
+    <Compile Include="Common\Notifications\NotificationEmailTests.cs" />
     <Compile Include="Common\Notifications\NotificationManagerTests.cs" />
     <Compile Include="Common\Orders\Fees\BackwardsCompatibilityFeeModelTests.cs" />
     <Compile Include="Common\Orders\Fees\BitfinexFeeModelTests.cs" />
@@ -311,6 +312,7 @@
     <Compile Include="Common\Util\ListComparerTests.cs" />
     <Compile Include="Common\Util\SeriesJsonConverterTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />
+    <Compile Include="Common\Util\ValidateTests.cs" />
     <Compile Include="Engine\Alphas\InsightAnalysisContextTests.cs" />
     <Compile Include="Engine\BrokerageTransactionHandlerTests\BacktestingTransactionHandlerTests.cs" />
     <Compile Include="Engine\DataFeeds\DataManagerStub.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Without access to the `IMessagingHandler` implementation used in the production environment, the next best solution is to provide a default value for `message` and `subject` to ensure it's never null. The likely culprit is a null reference exception that is being swallowed on a different thread where the notification messages are being processed.

This change adds unit tests for `NotificationManager` as well as provides some basic refactoring to match style guidelines, stream-line `Allow` checks, as well as removing a race condition in the rate limiting checks (perhaps should be updated to `RateGate`, but felt it was outside the scope of this PR). Additionally, the `_resetTime` was changed to use `DateTime.UtcNow` to avoid potential issues with local time zone settings and the inevitable time discontinuity that arises from things like daylight savings adjustments.

In addition to providing default values for `NotificationEmail.Subject` and `NotificationEmail.Message`, validation has been added to ensure a valid email address has been provided via a new `Validate` class with a `Validate.EmailAddress` method. The reasoning behind a new class here is to provide a location for further string based validations (such as phone number, web address, etc) and to provide a singular location for potentially complicated regular expressions.

Another change was made to the `QuantConnect.sln.DotSettings` file to include `QUANTCONNECT` in the custom dictionary to avoid R# typo warnings in the license headers.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #3021 - Notify.Email fails silently if message is null

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `Notify.Email` method should not fail when given a null message or subject as these are mandatory fields when sending an email.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No. This change updates the behavior to the expected behavior of not failing.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes extensively tested via unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->