### PR TITLE
Prevent IB cash sync error during weekends

### DIFF
--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -212,10 +212,12 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Specifies whether the brokerage will instantly update account balances
         /// </summary>
-        public virtual bool AccountInstantlyUpdated
-        {
-            get { return false; }
-        }
+        public virtual bool AccountInstantlyUpdated => false;
+
+        /// <summary>
+        /// Returns whether the brokerage can perform synchronization of account balances at the current time
+        /// </summary>
+        public virtual bool CanPerformCashSynchronization => true;
 
         /// <summary>
         /// Gets the history for the requested security

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -540,6 +540,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         }
 
         /// <summary>
+        /// Returns whether the brokerage can perform synchronization of account balances at the current time
+        /// </summary>
+        public override bool CanPerformCashSynchronization => !IsWithinScheduledServerResetTimes();
+
+        /// <summary>
         /// Gets the execution details matching the filter
         /// </summary>
         /// <returns>A list of executions matching the filter</returns>

--- a/Common/Interfaces/IBrokerage.cs
+++ b/Common/Interfaces/IBrokerage.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Brokerages;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 
@@ -112,6 +111,11 @@ namespace QuantConnect.Interfaces
         /// Specifies whether the brokerage will instantly update account balances
         /// </summary>
         bool AccountInstantlyUpdated { get; }
+
+        /// <summary>
+        /// Returns whether the brokerage can perform synchronization of account balances at the current time
+        /// </summary>
+        bool CanPerformCashSynchronization { get; }
 
         /// <summary>
         /// Gets the history for the requested security

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -634,7 +634,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 {
                     if (!_brokerage.CanPerformCashSynchronization)
                     {
-                        Log.Trace("BrokerageTransactionHandler.PerformCashSync(): Reentrant call, cash sync not performed");
+                        Log.Trace("BrokerageTransactionHandler.PerformCashSync(): Brokerage cannot perform cash sync at this time");
                         _syncedLiveBrokerageCashToday = true;
                         _lastSyncTimeTicks = CurrentTimeUtc.Ticks;
                         return true;

--- a/Tests/Algorithm/AlgorithmLiveTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmLiveTradingTests.cs
@@ -87,7 +87,8 @@ namespace QuantConnect.Tests.Algorithm
             public bool CancelOrder(Order order) { return true; }
             public void Connect() {}
             public void Disconnect() {}
-            public bool AccountInstantlyUpdated { get; } = true;
+            public bool AccountInstantlyUpdated { get; } = false;
+            public bool CanPerformCashSynchronization { get; } = false;
             public IEnumerable<BaseData> GetHistory(HistoryRequest request) { return Enumerable.Empty<BaseData>(); }
         }
     }

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Moq;
 using NodaTime;
 using NUnit.Framework;
@@ -762,6 +761,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var transactionHandler = new TestBrokerageTransactionHandler();
             var broker = new Mock<IBrokerage>();
 
+            broker.Setup(m => m.CanPerformCashSynchronization).Returns(true);
             broker.Setup(m => m.GetCashBalance()).Returns(new List<CashAmount> { new CashAmount(10, Currencies.USD) });
             transactionHandler.Initialize(_algorithm, broker.Object, new BacktestingResultHandler());
             _algorithm.SetLiveMode(true);
@@ -790,6 +790,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var transactionHandler = new TestBrokerageTransactionHandler();
             var broker = new Mock<IBrokerage>();
 
+            broker.Setup(m => m.CanPerformCashSynchronization).Returns(true);
             broker.Setup(m => m.GetCashBalance()).Returns(new List<CashAmount> { new CashAmount(10, Currencies.USD) });
             transactionHandler.Initialize(_algorithm, broker.Object, new BacktestingResultHandler());
             _algorithm.SetLiveMode(true);
@@ -822,6 +823,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var transactionHandler = new TestBrokerageTransactionHandler();
             var broker = new Mock<IBrokerage>();
 
+            broker.Setup(m => m.CanPerformCashSynchronization).Returns(true);
             broker.Setup(m => m.GetCashBalance()).Returns(new List<CashAmount> { new CashAmount(10, Currencies.USD) });
 
             // This is 2 am New York
@@ -848,6 +850,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         {
             // simulate connect failure
             var ib = new Mock<IBrokerage>();
+            ib.Setup(m => m.CanPerformCashSynchronization).Returns(true);
             ib.Setup(m => m.GetCashBalance()).Callback(() => { throw new Exception("Connection error in CashBalance"); });
             ib.Setup(m => m.IsConnected).Returns(false);
 

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -485,7 +485,10 @@ namespace QuantConnect.Tests.Engine.Setup
             throw new NotImplementedException();
         }
 
-        public bool AccountInstantlyUpdated { get; }
+        public bool AccountInstantlyUpdated { get; } = false;
+
+        public bool CanPerformCashSynchronization { get; } = false;
+
         public IEnumerable<BaseData> GetHistory(HistoryRequest request)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
#### Description
During weekends we cannot perform cash sync with IB because algorithms are disconnected. To solve this problem the new `IBrokerage.CanPerformCashSynchronization` property has been added, allowing any brokerage implementation to decide if cash sync can be performed successfully by the `BrokerageTransactionHandler` at the current time.

#### Related Issue
Closes #3395 

#### Motivation and Context
Occasional IB live algorithm runtime error during weekends.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Live algorithm deployed to IB and verified that cash sync is not performed during the weekend.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.