### PR TITLE
Add Insight.ReferenceValueFinal

### DIFF
--- a/Common/Algorithm/Framework/Alphas/Analysis/InsightManager.cs
+++ b/Common/Algorithm/Framework/Alphas/Analysis/InsightManager.cs
@@ -240,6 +240,9 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Analysis
                 {
                     context.Score.Finalize(currentTimeUtc);
 
+                    // set the last value used for scoring
+                    context.Insight.ReferenceValueFinal = context.CurrentValues.Get(context.Insight.Type);
+
                     _extensions.ForEach(e => e.OnInsightAnalysisCompleted(context));
 
                     var id = context.Insight.Id;

--- a/Common/Algorithm/Framework/Alphas/Insight.cs
+++ b/Common/Algorithm/Framework/Alphas/Insight.cs
@@ -77,9 +77,14 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         public InsightType Type { get; private set; }
 
         /// <summary>
-        /// Gets the reference value this insight is predicting against. The value is dependent on the specified <see cref="InsightType"/>
+        /// Gets the initial reference value this insight is predicting against. The value is dependent on the specified <see cref="InsightType"/>
         /// </summary>
         public decimal ReferenceValue { get; set; }
+
+        /// <summary>
+        /// Gets the final reference value, used for scoring, this insight is predicting against. The value is dependent on the specified <see cref="InsightType"/>
+        /// </summary>
+        public decimal ReferenceValueFinal { get; set; }
 
         /// <summary>
         /// Gets the predicted direction, down, flat or up
@@ -291,6 +296,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 Id = Id,
                 EstimatedValue = EstimatedValue,
                 ReferenceValue = ReferenceValue,
+                ReferenceValueFinal = ReferenceValueFinal,
                 SourceModel = SourceModel,
                 GroupId = GroupId
             };
@@ -428,6 +434,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 CloseTimeUtc = Time.UnixTimeStampToDateTime(serializedInsight.CloseTime),
                 EstimatedValue = serializedInsight.EstimatedValue,
                 ReferenceValue = serializedInsight.ReferenceValue,
+                ReferenceValueFinal = serializedInsight.ReferenceValueFinal,
                 GroupId = string.IsNullOrEmpty(serializedInsight.GroupId) ? (Guid?) null : Guid.Parse(serializedInsight.GroupId)
             };
 

--- a/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
+++ b/Common/Algorithm/Framework/Alphas/Serialization/SerializedInsight.cs
@@ -82,6 +82,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
         public decimal ReferenceValue { get; set; }
 
         /// <summary>
+        /// See <see cref="Insight.ReferenceValueFinal"/>
+        /// </summary>
+        [JsonProperty("reference-final", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public decimal ReferenceValueFinal { get; set; }
+
+        /// <summary>
         /// See <see cref="Insight.Direction"/>
         /// </summary>
         [JsonProperty("direction")]
@@ -162,6 +168,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas.Serialization
             Ticker = insight.Symbol.Value;
             Type = insight.Type;
             ReferenceValue = insight.ReferenceValue;
+            ReferenceValueFinal = insight.ReferenceValueFinal;
             Direction = insight.Direction;
             Period = insight.Period.TotalSeconds;
             Magnitude = insight.Magnitude;

--- a/Tests/Algorithm/Framework/Alphas/Serialization/InsightJsonConverterTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/Serialization/InsightJsonConverterTests.cs
@@ -46,6 +46,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
 
             // default values for scores
             Assert.AreEqual(false, result.Score.IsFinalScore);
+            Assert.AreEqual(0, result.ReferenceValueFinal);
             Assert.AreEqual(0, result.Score.Magnitude);
             Assert.AreEqual(0, result.Score.Direction);
         }
@@ -71,6 +72,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
             Assert.AreEqual(true, result.Score.IsFinalScore);
             Assert.AreEqual(jObject["score-magnitude"].Value<double>(), result.Score.Magnitude);
             Assert.AreEqual(jObject["score-direction"].Value<double>(), result.Score.Direction);
+            Assert.AreEqual(jObject["reference-final"].Value<decimal>(), result.ReferenceValueFinal);
         }
 
         [Test]
@@ -117,7 +119,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
                 ScoreIsFinal = jObject["score-final"].Value<bool>(),
                 ScoreMagnitude = jObject["score-magnitude"].Value<double>(),
                 ScoreDirection = jObject["score-direction"].Value<double>(),
-                EstimatedValue = jObject["estimated-value"].Value<decimal>()
+                EstimatedValue = jObject["estimated-value"].Value<decimal>(),
+                ReferenceValueFinal = jObject["reference-final"].Value<decimal>()
             });
             var result = JsonConvert.SerializeObject(insight, Formatting.Indented);
             Assert.AreEqual(jsonWithScore, result);
@@ -149,6 +152,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas.Serialization
   ""ticker"": ""BTCUSD"",
   ""type"": ""price"",
   ""reference"": 9143.53,
+  ""reference-final"": 9243.53,
   ""direction"": ""up"",
   ""period"": 5.0,
   ""magnitude"": 0.025,

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -42,6 +42,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
             var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);
             var insight = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2, "source-model", 1);
             Insight.Group(insight);
+            insight.ReferenceValueFinal = 10;
             var serialized = JsonConvert.SerializeObject(insight);
             var deserialized = JsonConvert.DeserializeObject<Insight>(serialized);
 
@@ -62,6 +63,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
             Assert.AreEqual(insight.Symbol, deserialized.Symbol);
             Assert.AreEqual(insight.Type, deserialized.Type);
             Assert.AreEqual(insight.Weight, deserialized.Weight);
+            Assert.AreEqual(insight.ReferenceValueFinal, deserialized.ReferenceValueFinal);
         }
 
         [Test]
@@ -85,6 +87,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
         {
             var time = new DateTime(2000, 01, 02, 03, 04, 05, 06);
             var original = new Insight(time, Symbols.SPY, Time.OneMinute, InsightType.Volatility, InsightDirection.Up, 1, 2, "source-model", 1);
+            original.ReferenceValueFinal = 10;
             Insight.Group(original);
 
             var copy = original.Clone();
@@ -106,6 +109,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
             Assert.AreEqual(original.Symbol, copy.Symbol);
             Assert.AreEqual(original.Type, copy.Type);
             Assert.AreEqual(original.Weight, copy.Weight);
+            Assert.AreEqual(original.ReferenceValueFinal, copy.ReferenceValueFinal);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add `Insight.ReferenceValueFinal { get; }`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3377
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Insight stores initial and final reference value used for scoring
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->