### PR TITLE
Fix aggregation with aligned ticks in Trade/QuoteBarBuilderEnumerator

### DIFF
--- a/Engine/DataFeeds/Enumerators/QuoteBarBuilderEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/QuoteBarBuilderEnumerator.cs
@@ -84,6 +84,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 var utcNow = _timeProvider.GetUtcNow();
                 var currentLocalTime = utcNow.ConvertFromUtc(_timeZone);
                 var barStartTime = currentLocalTime.RoundDown(_barSize);
+
+                if (barStartTime == currentLocalTime)
+                {
+                    // adjust start time if tick aligned to bar period
+                    barStartTime = currentLocalTime.Subtract(_barSize);
+                }
+
                 working = new QuoteBar();
                 working.Update(data.Value, bidPrice, askPrice, qty, bidSize, askSize);
                 working.Period = _barSize;

--- a/Engine/DataFeeds/Enumerators/TradeBarBuilderEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/TradeBarBuilderEnumerator.cs
@@ -79,6 +79,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 var utcNow = _timeProvider.GetUtcNow();
                 var currentLocalTime = utcNow.ConvertFromUtc(_timeZone);
                 var barStartTime = currentLocalTime.RoundDown(_barSize);
+
+                if (barStartTime == currentLocalTime)
+                {
+                    // adjust start time if tick aligned to bar period
+                    barStartTime = currentLocalTime.Subtract(_barSize);
+                }
+
                 working = new TradeBar(barStartTime, data.Symbol, marketPrice, marketPrice, marketPrice, marketPrice, qty, _barSize);
                 _queue.Enqueue(working);
 

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
@@ -92,17 +92,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             var enumerator = (DataQueueOptionChainUniverseDataCollectionEnumerator) factory.CreateEnumerator(request, new DefaultDataProvider());
 
             // 2018-10-19 10:00 AM UTC
-            underlyingEnumerator.ProcessData(new Tick { Symbol = Symbols.SPY, Value = 280m });
+            underlyingEnumerator.ProcessData(new Tick { EndTime = timeProvider.GetUtcNow(), Symbol = Symbols.SPY, Value = 280m });
 
             Assert.IsTrue(enumerator.MoveNext());
-            // no underlying data available yet
-            Assert.IsNull(enumerator.Current);
-            Assert.AreEqual(0, symbolUniverse.TotalLookupCalls);
+            Assert.IsNotNull(enumerator.Current);
+            Assert.AreEqual(1, symbolUniverse.TotalLookupCalls);
 
             // 2018-10-19 10:01 AM UTC
             timeProvider.Advance(Time.OneMinute);
 
-            underlyingEnumerator.ProcessData(new Tick { Symbol = Symbols.SPY, Value = 280m });
+            underlyingEnumerator.ProcessData(new Tick { EndTime = timeProvider.GetUtcNow(), Symbol = Symbols.SPY, Value = 280m });
 
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNotNull(enumerator.Current);
@@ -115,7 +114,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             // 2018-10-19 10:02 AM UTC
             timeProvider.Advance(Time.OneMinute);
 
-            underlyingEnumerator.ProcessData(new Tick { Symbol = Symbols.SPY, Value = 280m });
+            underlyingEnumerator.ProcessData(new Tick { EndTime = timeProvider.GetUtcNow(), Symbol = Symbols.SPY, Value = 280m });
 
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNotNull(enumerator.Current);
@@ -128,7 +127,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             // 2018-10-19 10:03 AM UTC
             timeProvider.Advance(Time.OneMinute);
 
-            underlyingEnumerator.ProcessData(new Tick { Symbol = Symbols.SPY, Value = 280m });
+            underlyingEnumerator.ProcessData(new Tick { EndTime = timeProvider.GetUtcNow(), Symbol = Symbols.SPY, Value = 280m });
 
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNotNull(enumerator.Current);
@@ -141,7 +140,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             // 2018-10-20 10:03 AM UTC
             timeProvider.Advance(Time.OneDay);
 
-            underlyingEnumerator.ProcessData(new Tick { Symbol = Symbols.SPY, Value = 280m });
+            underlyingEnumerator.ProcessData(new Tick { EndTime = timeProvider.GetUtcNow(), Symbol = Symbols.SPY, Value = 280m });
 
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNotNull(enumerator.Current);
@@ -154,7 +153,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             // 2018-10-20 10:04 AM UTC
             timeProvider.Advance(Time.OneMinute);
 
-            underlyingEnumerator.ProcessData(new Tick { Symbol = Symbols.SPY, Value = 280m });
+            underlyingEnumerator.ProcessData(new Tick { EndTime = timeProvider.GetUtcNow(), Symbol = Symbols.SPY, Value = 280m });
 
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNotNull(enumerator.Current);

--- a/Tests/Engine/DataFeeds/Enumerators/LiveEquityDataSynchronizingEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveEquityDataSynchronizingEnumeratorTests.cs
@@ -21,32 +21,58 @@ using NUnit.Framework;
 using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+using QuantConnect.Logging;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
 {
     [TestFixture]
     public class LiveEquityDataSynchronizingEnumeratorTests
     {
-        [Test]
-        public void SynchronizesData()
+        // this test case generates data points in the past, will complete very quickly
+        [TestCase(-15, 1)]
+        // this test case generates data points in the future, will require at least 10 seconds to complete
+        [TestCase(0, 11)]
+        public void SynchronizesData(int timeOffsetSeconds, int testTimeSeconds)
         {
             var start = DateTime.UtcNow;
-            var end = start.AddSeconds(15);
+            var end = start.AddSeconds(testTimeSeconds);
 
             var time = start;
-            var stream1 = Enumerable.Range(0, 10).Select(x => new Tick { Time = time.AddSeconds(x * 1) }).GetEnumerator();
-            var stream2 = Enumerable.Range(0, 5).Select(x => new Tick { Time = time.AddSeconds(x * 2) }).GetEnumerator();
+            var tickList1 = Enumerable.Range(0, 10).Select(x => new Tick { Time = time.AddSeconds(x * 1 + timeOffsetSeconds), Value = x }).ToList();
+            var tickList2 = Enumerable.Range(0, 5).Select(x => new Tick { Time = time.AddSeconds(x * 2 + timeOffsetSeconds), Value = x + 100 }).ToList();
+            var stream1 = tickList1.GetEnumerator();
+            var stream2 = tickList2.GetEnumerator();
 
+            var count1 = 0;
+            var count2 = 0;
             var previous = DateTime.MinValue;
             var synchronizer = new LiveEquityDataSynchronizingEnumerator(new RealTimeProvider(), DateTimeZone.Utc, stream1, stream2);
             while (synchronizer.MoveNext() && DateTime.UtcNow < end)
             {
                 if (synchronizer.Current != null)
                 {
+                    if (synchronizer.Current.Value < 100)
+                    {
+                        Assert.AreEqual(count1, synchronizer.Current.Value);
+                        count1++;
+                    }
+                    else
+                    {
+                        Assert.AreEqual(count2 + 100, synchronizer.Current.Value);
+                        count2++;
+                    }
+
                     Assert.That(synchronizer.Current.EndTime, Is.GreaterThanOrEqualTo(previous));
                     previous = synchronizer.Current.EndTime;
+
+                    Log.Trace($"Data point emitted: {synchronizer.Current.EndTime:O} - {synchronizer.Current}");
                 }
             }
+
+            Log.Trace($"Total point count: {count1 + count2}");
+
+            Assert.AreEqual(tickList1.Count, count1);
+            Assert.AreEqual(tickList2.Count, count2);
         }
     }
 }


### PR DESCRIPTION

#### Description
This PR fixes an issue when processing ticks with a timestamp aligned with the bar period and only one tick per bar period. In this case incorrect bars would be emitted, by grouping every two consecutive ticks in the same bar.
This edge-case scenario is very unlikely to happen in live trading, but quite common in unit tests.

> Note to reviewers: This PR includes the changes in #3336 (since an upcoming PR with new LiveTradingDataFeed tests requires both fixes)

#### Related Issue
n/a

#### Motivation and Context
Incorrect bar aggregation in unit tests.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.