### PR TITLE
Implements Alpha Streams Fee Model

### DIFF
--- a/Common/Orders/Fees/AlphaStreamsFeeModel.cs
+++ b/Common/Orders/Fees/AlphaStreamsFeeModel.cs
@@ -24,8 +24,6 @@ namespace QuantConnect.Orders.Fees
     /// </summary>
     public class AlphaStreamsFeeModel : FeeModel
     {
-        private readonly Security _libor;
-
         private readonly IDictionary<SecurityType, decimal> _feeRates = new Dictionary<SecurityType, decimal>
         {
             {SecurityType.Equity, 0.004m},
@@ -34,15 +32,6 @@ namespace QuantConnect.Orders.Fees
             {SecurityType.Future, 0.4m + 0.1m},
             {SecurityType.Option, 0.4m + 0.1m}
         };
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AlphaStreamsFeeModel"/>
-        /// </summary>
-        /// <param name="libor">Average interest rate at which major global banks borrow from one another</param>
-        public AlphaStreamsFeeModel(Security libor = null)
-        {
-            _libor = libor;
-        }
 
         /// <summary>
         /// Gets the order fee associated with the specified order. This returns the cost
@@ -72,26 +61,6 @@ namespace QuantConnect.Orders.Fees
             var value = security.Type == SecurityType.Equity || security.Type == SecurityType.Forex
                 ? Math.Abs(order.GetValue(security))
                 : order.AbsoluteQuantity;
-
-            // The LIBOR is taken into account for Equity trading
-            // Long positions on margin pays LIBOR
-            // Short positions on margin receives LIBOR
-            if (security.Type == SecurityType.Equity)
-            {
-                if (_libor == null)
-                {
-                    throw new ArgumentNullException($"AlphaStreamsFeeModel.GetOrderFee(): LIBOR security cannot be null for fee calculation of equity orders");
-                }
-
-                if (order.Direction == OrderDirection.Buy)
-                {
-                    feeRate += _libor.Price;
-                }
-                else
-                {
-                    feeRate -= _libor.Price;
-                }
-            }
 
             return new OrderFee(new CashAmount(feeRate * value, Currencies.USD));
         }

--- a/Common/Orders/Fees/AlphaStreamsFeeModel.cs
+++ b/Common/Orders/Fees/AlphaStreamsFeeModel.cs
@@ -1,0 +1,163 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QLNet;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Orders.Fills;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Orders.Fees
+{
+    public class AlphaStreamsFeeModel : FeeModel
+    {
+
+        private readonly decimal _forexCommissionRate = 0.000002m;
+        private decimal _liborRate;
+
+        private readonly Dictionary<string, EquityFee> _equityFee =
+            new Dictionary<string, EquityFee>();
+
+        private readonly Dictionary<string, CashAmount> _futureFee =
+            //                                                               Commission plus clearing fee
+            new Dictionary<string, CashAmount> { { Market.USA, new CashAmount(0.4m + 0.1m, "USD") } };
+
+        private readonly Dictionary<string, CashAmount> _optionFee =
+            //                                                               Commission plus clearing fee
+            new Dictionary<string, CashAmount> { { Market.USA, new CashAmount(0.4m + 0.1m, "USD") } };
+
+        public AlphaStreamsFeeModel(decimal liborRate = 0.024m)
+        {
+            _liborRate = Math.Abs(liborRate);
+            _equityFee.Add(Market.USA, new EquityFee("USD", 0.004m + _liborRate, 0));
+        }
+        /// <summary>
+        /// Gets the order fee associated with the specified order. This returns the cost
+        /// of the transaction in the account currency
+        /// </summary>
+        /// <param name="parameters">A <see cref="OrderFeeParameters"/> object
+        /// containing the security and order</param>
+        /// <returns>The cost of the order in units of the account currency</returns>
+        public override OrderFee GetOrderFee(OrderFeeParameters parameters)
+        {
+            var order = parameters.Order;
+            var security = parameters.Security;
+
+            // Option exercise for equity options is free of charge
+            if (order.Type == OrderType.OptionExercise)
+            {
+                var optionOrder = (OptionExerciseOrder)order;
+
+                if (optionOrder.Symbol.ID.SecurityType == SecurityType.Option &&
+                    optionOrder.Symbol.ID.Underlying.SecurityType == SecurityType.Equity)
+                {
+                    return OrderFee.Zero;
+                }
+            }
+
+            decimal feeResult;
+            string feeCurrency;
+            var market = security.Symbol.ID.Market;
+            switch (security.Type)
+            {
+                case SecurityType.Forex:
+                    // get the total order value in the account currency
+                    var totalOrderValue = order.GetValue(security);
+                    var fee = Math.Abs(_forexCommissionRate * totalOrderValue);
+                    feeResult = Math.Max(0, fee);
+                    // Forex fees are all in USD
+                    feeCurrency = Currencies.USD;
+                    break;
+
+                case SecurityType.Option:
+                    CashAmount optionsFeeRatePerContract;
+                    if (!_optionFee.TryGetValue(market, out optionsFeeRatePerContract))
+                    {
+                        throw new Exception($"AlphaStreamsFeeModel(): unexpected future Market {market}");
+                    }
+                    feeResult = order.AbsoluteQuantity * optionsFeeRatePerContract.Amount;
+                    feeCurrency = optionsFeeRatePerContract.Currency;
+                    break;
+
+                case SecurityType.Future:
+                    if (market == Market.Globex || market == Market.NYMEX
+                        || market == Market.CBOT || market == Market.ICE
+                        || market == Market.CBOE || market == Market.NSE)
+                    {
+                        // just in case...
+                        market = Market.USA;
+                    }
+
+                    CashAmount futuresFeeRatePerContract;
+                    if (!_futureFee.TryGetValue(market, out futuresFeeRatePerContract))
+                    {
+                        throw new Exception($"AlphaStreamsFeeModel(): unexpected future Market {market}");
+                    }
+                    feeResult = order.AbsoluteQuantity * futuresFeeRatePerContract.Amount;
+                    feeCurrency = futuresFeeRatePerContract.Currency;
+                    break;
+
+                case SecurityType.Equity:
+                    EquityFee equityFee;
+                    if (!_equityFee.TryGetValue(market, out equityFee))
+                    {
+                        throw new Exception($"AlphaStreamsFeeModel(): unexpected equity Market {market}");
+                    }
+                    
+                    //Per trade notional value fees
+                    var tradeFee = equityFee.FeePerTrade * order.GetValue(security);
+
+                    if (tradeFee < equityFee.MinimumFee)
+                    {
+                        tradeFee = equityFee.MinimumFee;
+                    }
+                    
+                    feeCurrency = equityFee.Currency;
+                    //Always return a positive fee.
+                    feeResult = Math.Abs(tradeFee);
+                    break;
+
+                default:
+                    // unsupported security type
+                    throw new ArgumentException($"Unsupported security type: {security.Type}");
+            }
+
+            return new OrderFee(new CashAmount(
+                feeResult,
+                feeCurrency));
+        }
+
+        /// <summary>
+        /// Helper class to handle IB Equity fees
+        /// </summary>
+        private class EquityFee
+        {
+            public string Currency { get; }
+            public decimal FeePerTrade { get; }
+            public decimal MinimumFee { get; }
+            public decimal LiborRate { get; }
+
+            public EquityFee(string currency,
+                decimal feePerTrade,
+                decimal minimumFee)
+            {
+                Currency = currency;
+                FeePerTrade = feePerTrade;
+                MinimumFee = minimumFee;
+            }
+        }
+    }
+}

--- a/Common/Orders/Fees/AlphaStreamsFeeModel.cs
+++ b/Common/Orders/Fees/AlphaStreamsFeeModel.cs
@@ -55,7 +55,9 @@ namespace QuantConnect.Orders.Fees
 
             if (!_feeRates.TryGetValue(security.Type, out feeRate))
             {
-                throw new ArgumentException($"Unsupported security type: {security.Type}");
+                throw new ArgumentException(
+                    $"Unsupported security type: {security.Type}. For direct-to-exchange assets such as Crypto, use the fee model specified by the exchange."
+                );
             }
 
             var value = security.Type == SecurityType.Equity || security.Type == SecurityType.Forex

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -266,6 +266,7 @@
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />
     <Compile Include="IsolatorLimitResult.cs" />
+    <Compile Include="Orders\Fees\AlphaStreamsFeeModel.cs" />
     <Compile Include="Orders\Fills\Fill.cs" />
     <Compile Include="Orders\Fills\FillModelParameters.cs" />
     <Compile Include="Orders\Fees\FeeModel.cs" />

--- a/Tests/Common/Orders/Fees/AlphaStreamsFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/AlphaStreamsFeeModelTests.cs
@@ -1,0 +1,198 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Cfd;
+using QuantConnect.Securities.Forex;
+using QuantConnect.Securities.Future;
+using QuantConnect.Securities.Option;
+using QuantConnect.Tests.Common.Securities;
+
+namespace QuantConnect.Tests.Common.Orders.Fees
+{
+    [TestFixture]
+    class AlphaStreamsFeeModelTests
+    {
+        private decimal _liborRate = 0.024m;
+        private readonly IFeeModel _feeModel = new AlphaStreamsFeeModel(0.024m);
+
+        [Test]
+        public void USAEquityFeeInUSD()
+        {
+            var security = SecurityTests.GetSecurity();
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1000, DateTime.UtcNow)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            Assert.AreEqual((0.004m + _liborRate) * security.Price * 1000, fee.Value.Amount);
+        }
+
+        [Test]
+        public void USAFutureFee()
+        {
+            var tz = TimeZones.NewYork;
+            var security = new Future(Symbols.Fut_SPY_Feb19_2016,
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("USD", 0, 0),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance
+            );
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1000, DateTime.UtcNow)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            Assert.AreEqual(1000 * 0.50m, fee.Value.Amount);
+        }
+
+        [Test]
+        public void USAOptionFee()
+        {
+            var tz = TimeZones.NewYork;
+            var security = new Option(Symbols.SPY_C_192_Feb19_2016,
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("USD", 0, 0),
+                new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
+                ErrorCurrencyConverter.Instance
+            );
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1000, DateTime.UtcNow)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            Assert.AreEqual(0.50m * 1000, fee.Value.Amount);
+        }
+
+        [Test]
+        public void USAOptionMinimumFee()
+        {
+            var tz = TimeZones.NewYork;
+            var security = new Option(Symbols.SPY_C_192_Feb19_2016,
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("USD", 0, 0),
+                new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
+                ErrorCurrencyConverter.Instance
+            );
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1, DateTime.UtcNow)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            Assert.AreEqual(0.50m, fee.Value.Amount);
+        }
+
+        [Test]
+        public void ForexFeeUSD()
+        {
+            var tz = TimeZones.NewYork;
+            var security = new Forex(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("USD", 0, 1),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURUSD, Resolution.Minute, tz, tz, true, false, false),
+                new SymbolProperties("EURUSD", "USD", 1, 0.01m, 0.00000001m),
+                ErrorCurrencyConverter.Instance
+            );
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1000, DateTime.UtcNow)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            Assert.AreEqual(0.000002m * security.Price * 1000, fee.Value.Amount);
+        }
+
+        [Test]
+        public void ForexFee_NonUSD()
+        {
+            var tz = TimeZones.NewYork;
+            var security = new Forex(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("GBP", 0, 1.2m),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURGBP, Resolution.Minute, tz, tz, true, false, false),
+                new SymbolProperties("EURGBP", "GBP", 1, 0.01m, 0.00000001m),
+                ErrorCurrencyConverter.Instance
+            );
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1000000, DateTime.UtcNow)
+                )
+            );
+
+            Assert.AreEqual(Currencies.USD, fee.Value.Currency);
+            Assert.AreEqual(0.000002m * security.Price * 1000000 * 1.2m, fee.Value.Amount);
+        }
+
+        // Add USD Forex Test
+
+        [Test]
+        public void GetOrderFeeThrowsForUnsupportedSecurityType()
+        {
+            Assert.Throws<ArgumentException>(
+                () =>
+                {
+                    var tz = TimeZones.NewYork;
+                    var security = new Cfd(
+                        SecurityExchangeHours.AlwaysOpen(tz),
+                        new Cash("EUR", 0, 0),
+                        new SubscriptionDataConfig(typeof(QuoteBar), Symbols.DE30EUR, Resolution.Minute, tz, tz, true, false, false),
+                        new SymbolProperties("DE30EUR", "EUR", 1, 0.01m, 1m),
+                        ErrorCurrencyConverter.Instance
+                    );
+                    security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 12000, 12000));
+
+                    _feeModel.GetOrderFee(
+                        new OrderFeeParameters(
+                            security,
+                            new MarketOrder(security.Symbol, 1, DateTime.UtcNow)
+                        )
+                    );
+                });
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -289,6 +289,7 @@
     <Compile Include="Common\Data\MockSubscriptionDataConfigProvider.cs" />
     <Compile Include="Common\Data\UniverseSelection\UniverseTests.cs" />
     <Compile Include="Common\IsolatorTests.cs" />
+    <Compile Include="Common\Orders\Fees\AlphaStreamsFeeModelTests.cs" />
     <Compile Include="Common\Orders\Fees\BackwardsCompatibilityFeeModelTests.cs" />
     <Compile Include="Common\Orders\Fees\BitfinexFeeModelTests.cs" />
     <Compile Include="Common\Orders\Fees\GDAXFeeModelTests.cs" />


### PR DESCRIPTION
#### Description
Created a Fee Model to be used for Alpha Streams submissions. The fee model reflects the general fees that funds will pay based on security type.
Equities -- 40 basis points + 1-month Libor (~2.4%) applied to the total notional value of the trade in USD
Forex -- 0.02 basis points applied to the total notional value of the trade in USD
Options/Futures -- $0.40 commission + $0.10 clearing fee per contract

#### Related Issue
This resolves part of issue #3346 . Replace and close #3351 (thanks @simonsonjack ) 

#### Motivation and Context
This will allow us to apply a universal, relevant fee model to all Alpha submissions.

#### How Has This Been Tested?
Unit tests created and added to the QuantConnect.Tests project. Run in Windows 10.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`