### PR TITLE
FXCM exchange timezone MHDB change

### DIFF
--- a/Data/market-hours/market-hours-database.json
+++ b/Data/market-hours/market-hours-database.json
@@ -23184,7 +23184,7 @@
     },
     "Forex-fxcm-[*]": {
       "dataTimeZone": "UTC-05",
-      "exchangeTimeZone": "UTC-05",
+      "exchangeTimeZone": "America/New_York",
       "sunday": [
         {
           "start": "17:00:00",

--- a/Tests/Jupyter/QuantBookHistoryTests.cs
+++ b/Tests/Jupyter/QuantBookHistoryTests.cs
@@ -102,13 +102,32 @@ namespace QuantConnect.Tests.Jupyter
 
                 // Get the last 5 candles
                 var periodHistory = securityTestHistory.test_period_overload(5);
+
+                // Note there is no data for BTCUSD at 2014
+
+                //symbol                 EURUSD         SPY
+                //time
+                //2014-05-03 00:00:00       NaN  173.580655
+                //2014-05-05 01:00:00  1.387565         NaN
+                //2014-05-06 00:00:00       NaN  173.903690
+                //2014-05-06 01:00:00  1.388335         NaN
+                //2014-05-07 00:00:00       NaN  172.426958
+                //2014-05-07 01:00:00  1.392495         NaN
+                //2014-05-08 00:00:00       NaN  173.423752
+                //2014-05-08 01:00:00  1.391480         NaN
+                //2014-05-09 00:00:00       NaN  173.229931
+                Console.WriteLine(periodHistory);
+
                 var count = (periodHistory.shape[0] as PyObject).AsManagedObject(typeof(int));
-                Assert.AreEqual(6, count);
+                Assert.AreEqual(9, count);
 
                 // Get the one day of data
                 var timedeltaHistory = securityTestHistory.test_period_overload(TimeSpan.FromDays(8));
                 var firstIndex = (DateTime) (timedeltaHistory.index.values[0] as PyObject).AsManagedObject(typeof(DateTime));
-                Assert.AreEqual(startDate.AddDays(-8), firstIndex);
+
+                // adding an hour because EURUSD exchange time zone, has 1 hour difference with than data time zone
+                // due to day light savings change (data is in exchange time zone)
+                Assert.AreEqual(startDate.AddDays(-8).AddHours(1), firstIndex);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Change FXCM exchange timezone to `America/New_York`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- On daylight savings forex data ends an hour earlier so, in `master`, the last open hour of the FXCM exchange there is actually no data, causing Lean to fail when fetching data for it.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Some insights not being scored
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->