### PR TITLE
Add support for IB Non-Disclosed Broker accounts

### DIFF
--- a/Brokerages/InteractiveBrokers/FinancialAdvisor/FinancialAdvisorConfiguration.cs
+++ b/Brokerages/InteractiveBrokers/FinancialAdvisor/FinancialAdvisorConfiguration.cs
@@ -147,7 +147,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.FinancialAdvisor
             }
 
             // save the master account code
-            var entry = _accountAliases.FirstOrDefault(x => x.Account.Contains("F"));
+            var entry = _accountAliases.FirstOrDefault(x => InteractiveBrokersBrokerage.IsMasterAccount(x.Account));
             if (entry == null)
             {
                 throw new Exception("The Financial Advisor master account was not found.");

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -133,9 +133,19 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         public override bool IsConnected => _client != null && _client.Connected && !_disconnected1100Fired;
 
         /// <summary>
-        /// Returns true if the connected user is a financial advisor
+        /// Returns true if the connected user is a financial advisor or non-disclosed broker
         /// </summary>
-        public bool IsFinancialAdvisor => _account.Contains("F");
+        public bool IsFinancialAdvisor => IsMasterAccount(_account);
+
+        /// <summary>
+        /// Returns true if the account is a financial advisor or non-disclosed broker master account
+        /// </summary>
+        /// <param name="account">The account code</param>
+        /// <returns>True if the account is a master account</returns>
+        public static bool IsMasterAccount(string account)
+        {
+            return account.Contains("F") || account.Contains("I");
+        }
 
         /// <summary>
         /// Creates a new InteractiveBrokersBrokerage using values from configuration:


### PR DESCRIPTION

#### Description
- Non-Disclosed Broker master accounts are now identified and handled as Financial Advisor master accounts.

#### Related Issue
Closes #3398

#### Motivation and Context
Non-Disclosed Broker master accounts not supported.

#### Requires Documentation Change
No.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`