### PR TITLE
Improve FineFundamental backtesting source resolution performance

### DIFF
--- a/Common/Data/Fundamental/FineFundamental.cs
+++ b/Common/Data/Fundamental/FineFundamental.cs
@@ -58,8 +58,8 @@ namespace QuantConnect.Data.Fundamental
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
             var source =
-                Path.Combine(Globals.DataFolder, "equity", config.Market, "fundamental", "fine",
-                config.Symbol.Value.ToLower(), date.ToString("yyyyMMdd") + ".zip");
+                Path.Combine(Globals.DataFolder,
+                    $"equity/{config.Market}/fundamental/fine/{config.Symbol.Value.ToLower()}/{date:yyyyMMdd}.zip");
 
             return new SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
         }

--- a/Engine/DataFeeds/DefaultDataProvider.cs
+++ b/Engine/DataFeeds/DefaultDataProvider.cs
@@ -32,13 +32,20 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>A <see cref="Stream"/> of the data requested</returns>
         public Stream Fetch(string key)
         {
-            if (!File.Exists(key))
+            try
             {
-                Log.Error("DefaultDataProvider.Fetch(): The specified file was not found: {0}", key);
-                return null;
+                return new FileStream(key, FileMode.Open, FileAccess.Read, FileShare.Read);
             }
-
-            return new FileStream(key, FileMode.Open, FileAccess.Read, FileShare.Read);
+            catch (Exception exception)
+            {
+                if (exception is DirectoryNotFoundException
+                    || exception is FileNotFoundException)
+                {
+                    Log.Error("DefaultDataProvider.Fetch(): The specified file was not found: {0}", key);
+                    return null;
+                }
+                throw;
+            }
         }
 
         /// <summary>

--- a/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactory.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -33,6 +34,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
     /// </summary>
     public class FineFundamentalSubscriptionEnumeratorFactory : ISubscriptionEnumeratorFactory
     {
+        private static readonly ConcurrentDictionary<int, List<DateTime>> FineFilesCache
+            = new ConcurrentDictionary<int, List<DateTime>>();
+
         private readonly bool _isLiveMode;
         private readonly Func<SubscriptionRequest, IEnumerable<DateTime>> _tradableDaysProvider;
         private string _lastUsedFileName;
@@ -101,47 +105,107 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
 
             if (!File.Exists(source.Source))
             {
-                if (_lastUsedFileName == null)
+                // only use cache in backtest, since in live mode new fine files are added
+                if (!_isLiveMode)
                 {
-                    // find first file date
-                    var path = Path.GetDirectoryName(source.Source) ?? string.Empty;
-                    if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
-                        return source;
-
-                    var firstFileName = Path.GetFileNameWithoutExtension(Directory.GetFiles(path, "*.zip").OrderBy(x => x).First());
-                    var firstDate = DateTime.ParseExact(firstFileName, "yyyyMMdd", CultureInfo.InvariantCulture);
-
-                    // requested date before first date, return current invalid source anyway
-                    if (date < firstDate)
-                        return source;
-
-                    // requested date after first date, save date of first existing file
-                    _lastUsedFileName = firstFileName;
-
-                    // loop back in time until we find an existing file
-                    while (string.CompareOrdinal(fileName, _lastUsedFileName) > 0)
+                    var cacheKey = config.Symbol.Value.ToLower().GetHashCode();
+                    List<DateTime> availableDates;
+                    // we still didn't load available fine dates for this symbol
+                    if (!FineFilesCache.TryGetValue(cacheKey, out availableDates))
                     {
-                        // get previous date
-                        date = date.AddDays(-1);
+                        try
+                        {
+                            var path = Path.GetDirectoryName(source.Source) ?? string.Empty;
+                            availableDates = Directory.GetFiles(path, "*.zip")
+                                .Select(
+                                    filePath =>
+                                    {
+                                        try
+                                        {
+                                            return DateTime.ParseExact(
+                                                Path.GetFileNameWithoutExtension(filePath),
+                                                "yyyyMMdd",
+                                                CultureInfo.InvariantCulture
+                                            );
+                                        }
+                                        catch
+                                        {
+                                            // just in case...
+                                            return DateTime.MaxValue;
+                                        }
+                                    }
+                                )
+                                .Where(time => time != DateTime.MaxValue)
+                                .OrderBy(x => x)
+                                .ToList();
+                        }
+                        catch
+                        {
+                            // directory doesn't exist or path is null
+                            FineFilesCache[cacheKey] = new List<DateTime>();
+                            return source;
+                        }
+                        FineFilesCache[cacheKey] = availableDates;
+                    }
 
-                        // get file name for this date
-                        source = fine.GetSource(config, date, _isLiveMode);
-                        fileName = Path.GetFileNameWithoutExtension(source.Source);
-
-                        if (!File.Exists(source.Source))
-                            continue;
-
-                        // we found the file, save its name and return the source
-                        _lastUsedFileName = fileName;
-
-                        break;
+                    // requested date before first date, return null source
+                    if (availableDates.Count == 0 || date < availableDates[0])
+                    {
+                        return source;
+                    }
+                    for (var i = availableDates.Count - 1; i >= 0; i--)
+                    {
+                        // we iterate backwards ^ and find the first data point before 'date'
+                        if (availableDates[i] <= date)
+                        {
+                            return fine.GetSource(config, availableDates[i], _isLiveMode);
+                        }
                     }
                 }
                 else
                 {
-                    // return source for last existing file date
-                    date = DateTime.ParseExact(_lastUsedFileName, "yyyyMMdd", CultureInfo.InvariantCulture);
-                    source = fine.GetSource(config, date, _isLiveMode);
+                    if (_lastUsedFileName == null)
+                    {
+                        // find first file date
+                        var path = Path.GetDirectoryName(source.Source) ?? string.Empty;
+                        if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+                            return source;
+
+                        var firstFileName = Path.GetFileNameWithoutExtension(Directory.GetFiles(path, "*.zip").OrderBy(x => x).First());
+                        var firstDate = DateTime.ParseExact(firstFileName, "yyyyMMdd", CultureInfo.InvariantCulture);
+
+                        // requested date before first date, return current invalid source anyway
+                        if (date < firstDate)
+                            return source;
+
+                        // requested date after first date, save date of first existing file
+                        _lastUsedFileName = firstFileName;
+
+                        // loop back in time until we find an existing file
+                        while (string.CompareOrdinal(fileName, _lastUsedFileName) > 0)
+                        {
+                            // get previous date
+                            date = date.AddDays(-1);
+
+                            // get file name for this date
+                            source = fine.GetSource(config, date, _isLiveMode);
+                            fileName = Path.GetFileNameWithoutExtension(source.Source);
+
+                            if (!File.Exists(source.Source))
+                                continue;
+
+                            // we found the file, save its name and return the source
+                            _lastUsedFileName = fileName;
+
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        // return source for last existing file date
+                        date = DateTime.ParseExact(_lastUsedFileName, "yyyyMMdd", CultureInfo.InvariantCulture);
+                        source = fine.GetSource(config, date, _isLiveMode);
+                    }
                 }
             }
             else

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
@@ -34,7 +34,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
     [TestFixture]
     public class FineFundamentalSubscriptionEnumeratorFactoryTests
     {
-        [Test, TestCaseSource(nameof(GetFineFundamentalTestParameters))]
+        [TestCaseSource(nameof(GetFineFundamentalTestParametersBacktest))]
+        [TestCaseSource(nameof(GetFineFundamentalTestParametersLive))]
         public void ReadsFineFundamental(FineFundamentalTestParameters parameters)
         {
             var stopwatch = Stopwatch.StartNew();
@@ -158,7 +159,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             Assert.IsTrue(ramUsageAfterLoop - ramUsageBeforeLoop < 10);
         }
 
-        private static TestCaseData[] GetFineFundamentalTestParameters()
+        private static TestCaseData[] GetFineFundamentalTestParametersBacktest =>
+            GetFineFundamentalTestParameters(false);
+
+        private static TestCaseData[] GetFineFundamentalTestParametersLive =>
+            GetFineFundamentalTestParameters(true);
+
+        private static TestCaseData[] GetFineFundamentalTestParameters(bool liveMode)
         {
             return new List<FineFundamentalTestParameters>
             {
@@ -167,14 +174,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     Symbol = Symbols.AAPL,
                     StartDate = new DateTime(2014, 1, 1),
                     EndDate = new DateTime(2014, 12, 31),
-                    RowCount = 365
+                    RowCount = 365,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-BeforeFirstDate")
                 {
                     Symbol = Symbols.AAPL,
                     StartDate = new DateTime(2014, 2, 20),
                     EndDate = new DateTime(2014, 2, 20),
-                    RowCount = 1
+                    RowCount = 1,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-FirstDate")
                 {
@@ -188,7 +197,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     CostOfRevenue3M = 35748000000m,
                     CostOfRevenue12M = 106606000000m,
                     EquityPerShareGrowth1Y = 0.091652m,
-                    PeRatio = 13.012858m
+                    PeRatio = 13.012858m,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-BeforeLastDate")
                 {
@@ -202,7 +212,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     CostOfRevenue3M = 35748000000m,
                     CostOfRevenue12M = 106606000000m,
                     EquityPerShareGrowth1Y = 0.091652m,
-                    PeRatio = 13.272502m
+                    PeRatio = 13.272502m,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-LastDate")
                 {
@@ -216,7 +227,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     CostOfRevenue3M = 27699000000m,
                     CostOfRevenue12M = 106606000000m,
                     EquityPerShareGrowth1Y = 0.091652m,
-                    PeRatio = 13.272502m
+                    PeRatio = 13.272502m,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-AfterLastDate")
                 {
@@ -230,7 +242,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     CostOfRevenue3M = 27699000000m,
                     CostOfRevenue12M = 106606000000m,
                     EquityPerShareGrowth1Y = 0.091652m,
-                    PeRatio = 13.272502m
+                    PeRatio = 13.272502m,
+                    LiveMode = liveMode
                 },
 
             }.Select(x => new TestCaseData(x).SetName(x.Name)).ToArray();
@@ -239,6 +252,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
         public class FineFundamentalTestParameters
         {
             public string Name { get; }
+            public bool LiveMode { get; set; }
             public Symbol Symbol { get; set; }
             public DateTime StartDate { get; set; }
             public DateTime EndDate { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Reduce the amount of `Path.Combine()` usages -> it has a performance
overhead
- For backtesting, adding new private static fine cache that will hold the available dates
for which there is a fine file, reducing the number of times we
enumerate the files in the directory. Updating unit tests.
- `DefaultDataProvider` will not check if file exists since `new
FileStream` performs the same operation internally

`Cloud performance tests CoarseFineFundamentalComboAlgorithm 2015-2016 - 100 coarse and 10 fine symbols`
`.OrderByDescending(x => x.DollarVolume)`
`pr`
103.86 seconds at 0k data points per second. Processing total of 28,167 data points.
95.29 seconds at 0k data points per second. Processing total of 28,168 data points.
93.20 seconds at 0k data points per second. Processing total of 28,168 data points.

`master`
109.59 seconds at 0k data points per second. Processing total of 28,168 data points.
119.64 seconds at 0k data points per second. Processing total of 28,167 data points.
123.88 seconds at 0k data points per second. Processing total of 28,167 data points.

`.OrderBy(x => x.DollarVolume)` -> **these symbols are most likely to have less fine files**
`pr`
234.42 seconds at 0k data points per second. Processing total of 28,688 data points.
217.90 seconds at 0k data points per second. Processing total of 28,688 data points.
`master`
405.12 seconds at 0k data points per second. Processing total of 28,688 data points.
436.87 seconds at 0k data points per second. Processing total of 28,688 data points.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3403
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Improve FineFundamental backtesting performance
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests, cloud testing
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->