### PR TITLE
Upgrade RestSharp library from v105.2.3 to v106.6.10

### DIFF
--- a/Api/QuantConnect.Api.csproj
+++ b/Api/QuantConnect.Api.csproj
@@ -89,14 +89,14 @@
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RestSharp, Version=106.6.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.6.10\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Api/packages.config
+++ b/Api/packages.config
@@ -6,6 +6,6 @@
   <package id="MathNet.Numerics" version="3.19.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net45" requireReinstallation="true" />
+  <package id="RestSharp" version="106.6.10" targetFramework="net452" />
   <package id="WebSocketSharpFork" version="1.0.4.0" targetFramework="net45" />
 </packages>

--- a/Brokerages/Oanda/RestV20/Client/ApiClient.cs
+++ b/Brokerages/Oanda/RestV20/Client/ApiClient.cs
@@ -1,4 +1,4 @@
-/* 
+/*
  * OANDA v20 REST API
  *
  * The full OANDA v20 REST API Specification. This specification defines how to interact with v20 Accounts, Trades, Orders, Pricing and more.
@@ -132,7 +132,7 @@ namespace Oanda.RestV20.Client
             // add file parameter, if any
             foreach(var param in fileParams)
             {
-                request.AddFile(param.Value.Name, param.Value.Writer, param.Value.FileName, param.Value.ContentType);
+                request.AddFile(param.Value.Name, param.Value.Writer, param.Value.FileName, param.Value.ContentLength, param.Value.ContentType);
             }
 
             if (postBody != null) // http body (model or byte[]) parameter

--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -151,9 +151,8 @@
     <Reference Include="QuantConnect.IBAutomater, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\QuantConnect.IBAutomater.1.0.4\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RestSharp, Version=106.6.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.6.10\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -161,6 +160,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Brokerages/packages.config
+++ b/Brokerages/packages.config
@@ -5,7 +5,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
   <package id="QuantConnect.IBAutomater" version="1.0.4" targetFramework="net452" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net45" requireReinstallation="true" />
+  <package id="RestSharp" version="106.6.10" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.3" targetFramework="net452" />
   <package id="WebSocketSharpFork" version="1.0.4.0" targetFramework="net452" />
 </packages>

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -128,9 +128,8 @@
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RestSharp, Version=106.6.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.6.10\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -139,6 +138,7 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Engine/packages.config
+++ b/Engine/packages.config
@@ -6,5 +6,5 @@
   <package id="MathNet.Numerics" version="3.19.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net45" requireReinstallation="true" />
+  <package id="RestSharp" version="106.6.10" targetFramework="net452" />
 </packages>

--- a/Messaging/QuantConnect.Messaging.csproj
+++ b/Messaging/QuantConnect.Messaging.csproj
@@ -47,13 +47,13 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RestSharp, Version=106.6.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.6.10\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Messaging/packages.config
+++ b/Messaging/packages.config
@@ -3,5 +3,5 @@
   <package id="AsyncIO" version="0.1.26.0" targetFramework="net452" />
   <package id="NetMQ" version="4.0.0.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net45" requireReinstallation="true" />
+  <package id="RestSharp" version="106.6.10" targetFramework="net452" />
 </packages>

--- a/Tests/API/ApiTests.cs
+++ b/Tests/API/ApiTests.cs
@@ -16,12 +16,12 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Web;
 using NUnit.Framework;
 using QuantConnect.Api;
 using QuantConnect.API;
 using QuantConnect.Brokerages;
 using QuantConnect.Configuration;
-using RestSharp.Extensions.MonoHttp;
 
 namespace QuantConnect.Tests.API
 {

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -165,9 +165,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Brokerages\Fxcm\QuantConnect.Fxcm.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RestSharp, Version=106.6.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.6.10\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -177,6 +176,7 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -14,6 +14,6 @@
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net452" />
   <package id="QuantConnect.pythonnet" version="1.0.5.20" targetFramework="net452" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net45" requireReinstallation="true" />
+  <package id="RestSharp" version="106.6.10" targetFramework="net452" />
   <package id="WebSocketSharpFork" version="1.0.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION

#### Description
- The RestSharp library has been upgraded from `v105.2.3` to `v106.6.10`

#### Related Issue
n/a

#### Motivation and Context
A couple of reasons for the upgrade:
1. The current version of this library is ~4 years old -- several bug fixes included
2. Preparation for future migration to .NET Core 2.0

#### Requires Documentation Change
No.

#### How Has This Been Tested?
QC cloud Backtesting and Live.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.