### PR TITLE
Adds Custom Python Indicator Support for QCAlgorithm.PlotIndicator

### DIFF
--- a/Algorithm.Python/CustomIndicatorAlgorithm.py
+++ b/Algorithm.Python/CustomIndicatorAlgorithm.py
@@ -41,19 +41,20 @@ class CustomIndicatorAlgorithm(QCAlgorithm):
         self.sma = self.SMA("SPY", 60, Resolution.Minute)
         self.custom = CustomSimpleMovingAverage('custom', 60)
         self.RegisterIndicator("SPY", self.custom, Resolution.Minute)
+        self.PlotIndicator('cSMA', self.custom)
 
     def OnData(self, data):
         if not self.Portfolio.Invested:
             self.SetHoldings("SPY", 1)
 
         if self.Time.second == 0:
-            self.Log("   sma -> IsReady: {0}. Time: {1}. Value: {2}".format(self.sma.IsReady, self.sma.Current.Time, self.sma.Current.Value))
+            self.Log(f"   sma -> IsReady: {self.sma.IsReady}. Time: {self.sma.Current.Time}. Value: {self.sma.Current.Value}")
             self.Log(str(self.custom))
 
         # Regression test: test fails with an early quit
         diff = abs(self.custom.Value - self.sma.Current.Value)
-        if diff > 1e-25:
-            self.Quit("Quit: indicators difference is {0}".format(diff))
+        if diff > 1e-10:
+            self.Quit(f"Quit: indicators difference is {diff}")
 
 
 # Python implementation of SimpleMovingAverage.
@@ -67,7 +68,7 @@ class CustomSimpleMovingAverage:
         self.queue = deque(maxlen=period)
 
     def __repr__(self):
-        return "{0} -> IsReady: {1}. Time: {2}. Value: {3}".format(self.Name, self.IsReady, self.Time, self.Value)
+        return f"{self.Name} -> IsReady: {self.IsReady}. Time: {self.Time}. Value: {self.Value}"
 
     # Update method is mandatory
     def Update(self, input):

--- a/Indicators/PythonIndicator.cs
+++ b/Indicators/PythonIndicator.cs
@@ -1,0 +1,116 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Python.Runtime;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using System;
+
+namespace QuantConnect.Indicators
+{
+    /// <summary>
+    /// Provides a wrapper for <see cref="IndicatorBase{IBaseDataBar}"/> implementations written in python
+    /// </summary>
+    public class PythonIndicator : IndicatorBase<IBaseDataBar>
+    {
+        private readonly dynamic _indicator;
+
+        /// <summary>
+        /// Get the indicator Name. If not defined, use the class name
+        /// </summary>
+        /// <param name="indicator">The python implementation of <see cref="IndicatorBase{IBaseDataBar}"/></param>
+        /// <returns>The indicator Name.</returns>
+        private static string GetIndicatorName(PyObject indicator)
+        {
+            using (Py.GIL())
+            {
+                var name = indicator.HasAttr("Name")
+                    ? indicator.GetAttr("Name")
+                    : indicator.GetAttr("__class__").GetAttr("__name__");
+
+                return name.GetAndDispose<string>();
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the PythonIndicator class using the specified name.
+        /// </summary>
+        /// <param name="indicator">The python implementation of <see cref="IndicatorBase{IBaseDataBar}"/></param>
+        public PythonIndicator(PyObject indicator)
+            : base(GetIndicatorName(indicator))
+        {
+            using (Py.GIL())
+            {
+                foreach (var attributeName in new[] {"Update", "IsReady", "Value"})
+                {
+                    if (!indicator.HasAttr(attributeName))
+                    {
+                        throw new NotImplementedException(
+                            $"Indicator.{attributeName} must be implemented. Please implement this missing method on {indicator.GetPythonType()}"
+                        );
+                    }
+                }
+            }
+
+            _indicator = indicator;
+        }
+
+        /// <summary>
+        /// Updates the state of this indicator with the given value and returns true
+        /// if this indicator is ready, false otherwise
+        /// </summary>
+        /// <param name="input">The value to use to update this indicator</param>
+        /// <returns>True if this indicator is ready, false otherwise</returns>
+        public new bool Update(IBaseData input)
+        {
+            using (Py.GIL())
+            {
+                _indicator.Update(input);
+            }
+
+            return IsReady;
+        }
+
+        /// <summary>
+        /// Gets a flag indicating when this indicator is ready and fully initialized
+        /// </summary>
+        /// <remarks>If IsReady is not defined in the Python indicator, always returns false</remarks>
+        public override bool IsReady
+        {
+            get
+            {
+                using (Py.GIL())
+                {
+                    return _indicator.IsReady;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the next value of this indicator from the given state
+        /// </summary>
+        /// <param name="input">The input given to the indicator</param>
+        /// <returns>A new value for this indicator</returns>
+        protected override decimal ComputeNextValue(IBaseDataBar input)
+        {
+            Update(input);
+
+            using (Py.GIL())
+            {
+                return _indicator.Value;
+            }
+        }
+    }
+}

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -165,6 +165,7 @@
     <Compile Include="DetrendedPriceOscillator.cs" />
     <Compile Include="DonchianChannel.cs" />
     <Compile Include="DoubleExponentialMovingAverage.cs" />
+    <Compile Include="PythonIndicator.cs" />
     <Compile Include="IntradayVwap.cs" />
     <Compile Include="WilderMovingAverage.cs" />
     <Compile Include="FractalAdaptiveMovingAverage.cs" />

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -127,12 +127,15 @@ namespace QuantConnect.Tests.Algorithm
                 var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
                     "class GoodCustomIndicator:\n" +
                     "    def __init__(self):\n" +
+                    "        self.IsReady = True\n" +
+                    "        self.Value = 0\n" +
                     "        pass\n" +
                     "    def Update(self, input):\n" +
                     "        return input\n" +
                     "class BadCustomIndicator:\n" +
                     "    def __init__(self):\n" +
-                    "        pass\n" +
+                    "        self.IsReady = True\n" +
+                    "        self.Value = 0\n" +
                     "    def Updat(self, input):\n" +
                     "        return input");
 
@@ -143,7 +146,7 @@ namespace QuantConnect.Tests.Algorithm
                 Assert.AreEqual(1, actual);
 
                 var badIndicator = module.GetAttr("BadCustomIndicator").Invoke();
-                Assert.Throws<ArgumentException>(() => _algorithm.RegisterIndicator(_spy, badIndicator, Resolution.Minute));
+                Assert.Throws<NotImplementedException>(() => _algorithm.RegisterIndicator(_spy, badIndicator, Resolution.Minute));
             }
         }
 


### PR DESCRIPTION
#### Description
In order to add support custom python indicators for `QCAlgorithm.PlotIndicator`, we created a `PythonIndicator` class that wraps the custom python indicator. In `QCAlgorithm`, the reference of the wrapper is saved into a dictionary keyed by the python indicator handle.

#### Related Issue
Closes #2850 

#### Motivation and Context
All QCAlgorithm features must be available for C# and Python.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Adds a statement in `CustomIndicatorAlgorithm` to test `QCAlgorithm.PlotIndicator`. This implementation also affected in `QCAlgorithm.RegisterIndicator` and unit tests are passing after a change that was made due to the fact that custom indicators in python need to implement more attributes.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`