### PR TITLE
Fix GDAX authentication for get requests with querystring parameters

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Utility.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Utility.cs
@@ -56,7 +56,22 @@ namespace QuantConnect.Brokerages.GDAX
         public AuthenticationToken GetAuthenticationToken(IRestRequest request)
         {
             var body = request.Parameters.SingleOrDefault(b => b.Type == ParameterType.RequestBody);
-            var token = GetAuthenticationToken(body == null ? "" : body.Value.ToString(), request.Method.ToString().ToUpper(), request.Resource);
+
+            string url;
+            if (request.Parameters.Count > 0)
+            {
+                var parameters = request.Parameters.Count > 0
+                    ? string.Join("&", request.Parameters.Select(x => $"{x.Name}={x.Value}"))
+                    : string.Empty;
+                url = $"{request.Resource}?{parameters}";
+            }
+            else
+            {
+                url = request.Resource;
+            }
+
+
+            var token = GetAuthenticationToken(body?.Value.ToString() ?? string.Empty, request.Method.ToString().ToUpper(), url);
 
             request.AddHeader(SignHeader, token.Signature);
             request.AddHeader(KeyHeader, ApiKey);


### PR DESCRIPTION

#### Description
- The GDAX brokerage authentication has been fixed to handle the breaking change in the RestSharp library upgrade (in #3407).
- The only method affected by this bug was `GetOpenOrders`.

#### Related Issue
Closes #3428 

#### Motivation and Context
Invalid signature error in `GetOpenOrders`

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Live GDAX testing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`