### PR TITLE
Fix Equity Fee Logic for AlphaStreamsFeeModel

### DIFF
--- a/Common/Orders/Fees/AlphaStreamsFeeModel.cs
+++ b/Common/Orders/Fees/AlphaStreamsFeeModel.cs
@@ -60,9 +60,17 @@ namespace QuantConnect.Orders.Fees
                 );
             }
 
-            var value = security.Type == SecurityType.Equity || security.Type == SecurityType.Forex
-                ? Math.Abs(order.GetValue(security))
-                : order.AbsoluteQuantity;
+            var value = order.AbsoluteQuantity;
+
+            switch (security.Type)
+            {
+                case SecurityType.Equity:
+                    value = order.GetValue(security);
+                    break;
+                case SecurityType.Forex:
+                    value = Math.Abs(order.GetValue(security));
+                    break;
+            }
 
             return new OrderFee(new CashAmount(feeRate * value, Currencies.USD));
         }

--- a/Tests/Common/Orders/Fees/AlphaStreamsFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/AlphaStreamsFeeModelTests.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             var fee = feeModel.GetOrderFee(parameters);
 
             Assert.AreEqual(Currencies.USD, fee.Value.Currency);
-            var expected = 0.004m * Math.Abs(security.Price * quantity);
+            var expected = 0.004m * security.Price * quantity;
             Assert.AreEqual(expected, fee.Value.Amount);
         }
 


### PR DESCRIPTION
#### Description
Equities: 40 basis points. Receive fee for short equity positions.

#### Related Issue
Fixes bug in #3385 

#### Motivation and Context
This will allow us to apply a universal, relevant fee model to all Alpha submissions.

#### How Has This Been Tested?
Unit tests created and added to the QuantConnect.Tests project. Run in Windows 10.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`