### PR TITLE
Refactors PythonIndicator

### DIFF
--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.py
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.py
@@ -153,7 +153,7 @@ class IntradayVwap:
         '''Computes the new VWAP'''
         success, volume, averagePrice = self.GetVolumeAndAveragePrice(input)
         if not success:
-            return
+            return self.IsReady
 
         # reset vwap on daily boundaries
         if self.lastDate != input.EndTime.date():
@@ -168,10 +168,10 @@ class IntradayVwap:
         if self.sumOfVolume == 0.0:
            # if we have no trade volume then use the current price as VWAP
            self.Value = input.Value
-           return
+           return self.IsReady
 
         self.Value = self.sumOfPriceTimesVolume / self.sumOfVolume
-
+        return self.IsReady
 
     def GetVolumeAndAveragePrice(self, input):
         '''Determines the volume and price to be used for the current input in the VWAP computation'''

--- a/Algorithm.Python/CustomIndicatorAlgorithm.py
+++ b/Algorithm.Python/CustomIndicatorAlgorithm.py
@@ -40,40 +40,45 @@ class CustomIndicatorAlgorithm(QCAlgorithm):
         # Create a QuantConnect indicator and a python custom indicator for comparison
         self.sma = self.SMA("SPY", 60, Resolution.Minute)
         self.custom = CustomSimpleMovingAverage('custom', 60)
+
+        # The python custom class must inherit from PythonIndicator to enable Updated event handler
+        self.custom.Updated += self.CustomUpdated
+
+        self.customWindow = RollingWindow[IndicatorDataPoint](5)
         self.RegisterIndicator("SPY", self.custom, Resolution.Minute)
         self.PlotIndicator('cSMA', self.custom)
+
+    def CustomUpdated(self, sender, updated):
+        self.customWindow.Add(updated)
 
     def OnData(self, data):
         if not self.Portfolio.Invested:
             self.SetHoldings("SPY", 1)
 
         if self.Time.second == 0:
-            self.Log(f"   sma -> IsReady: {self.sma.IsReady}. Time: {self.sma.Current.Time}. Value: {self.sma.Current.Value}")
-            self.Log(str(self.custom))
+            self.Log(f"   sma -> IsReady: {self.sma.IsReady}. Value: {self.sma.Current.Value}")
+            self.Log(f"custom -> IsReady: {self.custom.IsReady}. Value: {self.custom.Value}")
 
         # Regression test: test fails with an early quit
         diff = abs(self.custom.Value - self.sma.Current.Value)
         if diff > 1e-10:
             self.Quit(f"Quit: indicators difference is {diff}")
 
+    def OnEndOfAlgorithm(self):
+        for item in self.customWindow:
+            self.Log(f'{item}')
 
 # Python implementation of SimpleMovingAverage.
 # Represents the traditional simple moving average indicator (SMA).
-class CustomSimpleMovingAverage:
+class CustomSimpleMovingAverage(PythonIndicator):
     def __init__(self, name, period):
         self.Name = name
-        self.Time = datetime.min
         self.Value = 0
-        self.IsReady = False
         self.queue = deque(maxlen=period)
-
-    def __repr__(self):
-        return f"{self.Name} -> IsReady: {self.IsReady}. Time: {self.Time}. Value: {self.Value}"
 
     # Update method is mandatory
     def Update(self, input):
-        self.queue.appendleft(input.Close)
+        self.queue.appendleft(input.Value)
         count = len(self.queue)
-        self.Time = input.EndTime
         self.Value = sum(self.queue) / count
-        self.IsReady = count == self.queue.maxlen
+        return count == self.queue.maxlen

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1001,9 +1001,16 @@ namespace QuantConnect.Algorithm
         private PythonIndicator WrapPythonIndicator(PyObject pyObject)
         {
             PythonIndicator pythonIndicator;
+
             if (!_pythonIndicators.TryGetValue(pyObject.Handle, out pythonIndicator))
             {
-                pythonIndicator = new PythonIndicator(pyObject);
+                pyObject.TryConvert(out pythonIndicator);
+                pythonIndicator?.SetIndicator(pyObject);
+
+                if (pythonIndicator == null)
+                {
+                    pythonIndicator = new PythonIndicator(pyObject);
+                }
 
                 // Save to prevent future additions
                 _pythonIndicators.Add(pyObject.Handle, pythonIndicator);

--- a/Tests/Indicators/PythonIndicatorNoinheritanceTests.cs
+++ b/Tests/Indicators/PythonIndicatorNoinheritanceTests.cs
@@ -1,0 +1,112 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Tests.Indicators
+{
+    [TestFixture]
+    public class PythonIndicatorNoinheritanceTests : PythonIndicatorTests
+    {
+        protected override IndicatorBase<IBaseData> CreateIndicator()
+        {
+            using (Py.GIL())
+            {
+                var module = PythonEngine.ModuleFromString(
+                    Guid.NewGuid().ToString(),
+                    @"
+from collections import deque
+from datetime import datetime, timedelta
+from numpy import sum
+
+class CustomSimpleMovingAverage():
+    def __init__(self, name, period):
+        self.Name = name
+        self.Value = 0
+        self.IsReady = False
+        self.queue = deque(maxlen=period)
+
+    # Update method is mandatory
+    def Update(self, input):
+        self.queue.appendleft(input.Value)
+        count = len(self.queue)
+        self.Value = sum(self.queue) / count
+        self.IsReady = count == self.queue.maxlen
+        return self.IsReady
+"
+                );
+                var indicator = module.GetAttr("CustomSimpleMovingAverage")
+                    .Invoke("custom".ToPython(), 14.ToPython());
+
+                return new PythonIndicator(indicator);
+            }
+        }
+
+        protected override void RunTestIndicator(IndicatorBase<IBaseData> indicator)
+        {
+            var first = true;
+            var closeIndex = -1;
+            var targetIndex = -1;
+            foreach (var line in File.ReadLines(Path.Combine("TestData", TestFileName)))
+            {
+                var parts = line.Split(new[] { ',' }, StringSplitOptions.None);
+
+                if (first)
+                {
+                    first = false;
+                    for (var i = 0; i < parts.Length; i++)
+                    {
+                        if (parts[i].Trim() == "Close")
+                        {
+                            closeIndex = i;
+                        }
+                        if (parts[i].Trim() == TestColumnName)
+                        {
+                            targetIndex = i;
+                        }
+                    }
+                    if (closeIndex * targetIndex < 0)
+                    {
+                        Assert.Fail($"Didn't find one of 'Close' or '{line}' in the header: ", TestColumnName);
+                    }
+
+                    continue;
+                }
+
+                var close = decimal.Parse(parts[closeIndex], CultureInfo.InvariantCulture);
+                var date = Time.ParseDate(parts[0]);
+
+                var data = new IndicatorDataPoint(date, close);
+                indicator.Update(data);
+
+                if (!indicator.IsReady || parts[targetIndex].Trim() == string.Empty)
+                {
+                    continue;
+                }
+
+                var expected = double.Parse(parts[targetIndex], CultureInfo.InvariantCulture);
+                Assertion.Invoke(indicator, expected);
+            }
+        }
+    }
+}

--- a/Tests/Indicators/PythonIndicatorTests.cs
+++ b/Tests/Indicators/PythonIndicatorTests.cs
@@ -1,0 +1,168 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Tests.Indicators
+{
+    [TestFixture]
+    public class PythonIndicatorTests : CommonIndicatorTests<IBaseData>
+    {
+        protected override IndicatorBase<IBaseData> CreateIndicator()
+        {
+            using (Py.GIL())
+            {
+                var module = PythonEngine.ModuleFromString(
+                    Guid.NewGuid().ToString(),
+                    @"
+from clr import AddReference
+AddReference('QuantConnect.Indicators')
+
+from QuantConnect.Indicators import PythonIndicator
+from collections import deque
+from datetime import datetime, timedelta
+from numpy import sum
+
+class CustomSimpleMovingAverage(PythonIndicator):
+    def __init__(self, name, period):
+        self.Name = name
+        self.Value = 0
+        self.queue = deque(maxlen=period)
+
+    # Update method is mandatory
+    def Update(self, input):
+        self.queue.appendleft(input.Value)
+        count = len(self.queue)
+        self.Value = sum(self.queue) / count
+        return count == self.queue.maxlen
+"
+                );
+                var indicator = module.GetAttr("CustomSimpleMovingAverage")
+                    .Invoke("custom".ToPython(), 14.ToPython());
+
+                return new PythonIndicator(indicator);
+            }
+        }
+
+        protected override string TestFileName => "spy_with_indicators.txt";
+
+        protected override string TestColumnName => "SMA14";
+
+        protected override void RunTestIndicator(IndicatorBase<IBaseData> indicator)
+        {
+            var first = true;
+            var closeIndex = -1;
+            var targetIndex = -1;
+            foreach (var line in File.ReadLines(Path.Combine("TestData", TestFileName)))
+            {
+                var parts = line.Split(new[] { ',' }, StringSplitOptions.None);
+
+                if (first)
+                {
+                    first = false;
+                    for (var i = 0; i < parts.Length; i++)
+                    {
+                        if (parts[i].Trim() == "Close")
+                        {
+                            closeIndex = i;
+                        }
+                        if (parts[i].Trim() == TestColumnName)
+                        {
+                            targetIndex = i;
+                        }
+                    }
+                    if (closeIndex * targetIndex < 0)
+                    {
+                        Assert.Fail($"Didn't find one of 'Close' or '{line}' in the header: ", TestColumnName);
+                    }
+
+                    continue;
+                }
+
+                var close = decimal.Parse(parts[closeIndex], CultureInfo.InvariantCulture);
+                var date = Time.ParseDate(parts[0]);
+
+                var data = new IndicatorDataPoint(date, close);
+                indicator.Update(data);
+
+                if (!indicator.IsReady || parts[targetIndex].Trim() == string.Empty)
+                {
+                    continue;
+                }
+
+                var expected = double.Parse(parts[targetIndex], CultureInfo.InvariantCulture);
+                Assertion.Invoke(indicator, expected);
+            }
+        }
+
+        protected override Action<IndicatorBase<IBaseData>, double> Assertion => (indicator, expected) =>
+            Assert.AreEqual(expected, (double) indicator.Current.Value, 1e-2);
+
+        [Test]
+        public void SmaComputesCorrectly()
+        {
+            var sma = new SimpleMovingAverage(4);
+            var data = new[] {1m, 10m, 100m, 1000m, 10000m, 1234m, 56789m};
+
+            var seen = new List<decimal>();
+            for (int i = 0; i < data.Length; i++)
+            {
+                var datum = data[i];
+                seen.Add(datum);
+                sma.Update(new IndicatorDataPoint(DateTime.Now.AddSeconds(i), datum));
+                Assert.AreEqual(Enumerable.Reverse(seen).Take(sma.Period).Average(), sma.Current.Value);
+            }
+        }
+
+        [Test]
+        public void IsReadyAfterPeriodUpdates()
+        {
+            var sma = new SimpleMovingAverage(3);
+
+            sma.Update(DateTime.UtcNow, 1m);
+            sma.Update(DateTime.UtcNow, 1m);
+            Assert.IsFalse(sma.IsReady);
+            sma.Update(DateTime.UtcNow, 1m);
+            Assert.IsTrue(sma.IsReady);
+        }
+
+        [Test]
+        public override void ResetsProperly()
+        {
+            var sma = new SimpleMovingAverage(3);
+
+            foreach (var data in TestHelper.GetDataStream(4))
+            {
+                sma.Update(data);
+            }
+            Assert.IsTrue(sma.IsReady);
+            
+            sma.Reset();
+
+            TestHelper.AssertIndicatorIsInDefaultState(sma);
+            TestHelper.AssertIndicatorIsInDefaultState(sma.RollingSum);
+            sma.Update(DateTime.UtcNow, 2.0m);
+            Assert.AreEqual(sma.Current.Value, 2.0m);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -331,6 +331,8 @@
     <Compile Include="Engine\DataFeeds\UniverseSelectionTests.cs" />
     <Compile Include="Engine\DataFeeds\SubscriptionTests.cs" />
     <Compile Include="Engine\RealTime\BacktestingRealTimeHandlerTests.cs" />
+    <Compile Include="Indicators\PythonIndicatorNoinheritanceTests.cs" />
+    <Compile Include="Indicators\PythonIndicatorTests.cs" />
     <Compile Include="PythonSetup.cs" />
     <Compile Include="Algorithm\Framework\QCAlgorithmFrameworkTests.cs" />
     <Compile Include="Algorithm\Framework\Risk\MaximumDrawdownPercentPerSecurityTests.cs" />


### PR DESCRIPTION
#### Description
In order to provide full Lean Indicator functionality to python custom indicators, they need to inherit from a C# class. `PythonIndicator` will serve for this purpose.
Algorithms can use the former version (no inheritance).

#### Related Issue
Closes #3423 

#### Motivation and Context
Python custom indicators should have full Lean Indicator functionality.

#### How Has This Been Tested?
New and old unit tests. Changes in `CustomIndicatorAlgorithm.py`. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`