### PR TITLE
Fixes Volatility Discontinuities in Security.VolatilityModel

### DIFF
--- a/Common/Securities/Volatility/BaseVolatilityModel.cs
+++ b/Common/Securities/Volatility/BaseVolatilityModel.cs
@@ -27,6 +27,8 @@ namespace QuantConnect.Securities.Volatility
     /// </summary>
     public class BaseVolatilityModel : IVolatilityModel
     {
+        private decimal? _lastFactor;
+
         /// <summary>
         /// Provides access to registered <see cref="SubscriptionDataConfig"/>
         /// </summary>
@@ -40,7 +42,23 @@ namespace QuantConnect.Securities.Volatility
         /// <summary>
         /// Latest price factor to be applied
         /// </summary>
-        public decimal? LastFactor { get; private set; }
+        protected decimal? LastFactor
+        {
+            get
+            {
+                return _lastFactor;
+            }
+            set
+            {
+                if (!_lastFactor.HasValue || !value.HasValue)
+                {
+                    _lastFactor = value;
+                    return;
+                }
+
+                _lastFactor *= value;
+            }
+        }
 
         /// <summary>
         /// Sets the <see cref="ISubscriptionDataConfigProvider"/> instance to use.
@@ -77,7 +95,7 @@ namespace QuantConnect.Securities.Volatility
             }
 
             var factor = 1 - dividend.Distribution / dividend.ReferencePrice;
-            SetLastFactor(factor);
+            LastFactor = factor;
         }
 
         /// <summary>
@@ -94,22 +112,7 @@ namespace QuantConnect.Securities.Volatility
                 return;
             }
 
-            SetLastFactor(split.SplitFactor);
-        }
-
-        /// <summary>
-        /// Sets the value of the latest price factor
-        /// </summary>
-        /// <param name="factor">Latest price factor to be applied</param>
-        public void SetLastFactor(decimal? factor)
-        {
-            if (!LastFactor.HasValue || !factor.HasValue)
-            {
-                LastFactor = factor;
-                return;
-            }
-
-            LastFactor *= factor;
+            LastFactor = split.SplitFactor;
         }
 
         /// <summary>

--- a/Common/Securities/Volatility/IVolatilityModel.cs
+++ b/Common/Securities/Volatility/IVolatilityModel.cs
@@ -17,6 +17,7 @@ using QuantConnect.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data.Market;
 using QuantConnect.Securities.Volatility;
 
 namespace QuantConnect.Securities
@@ -40,6 +41,22 @@ namespace QuantConnect.Securities
         /// <param name="security">The security to calculate volatility for</param>
         /// <param name="data">The new data used to update the model</param>
         void Update(Security security, BaseData data);
+
+        /// <summary>
+        /// Applies a dividend to the portfolio
+        /// </summary>
+        /// <param name="dividend">The dividend to be applied</param>
+        /// <param name="liveMode">True if live mode, false for backtest</param>
+        /// <param name="mode">The <see cref="DataNormalizationMode"/> for this security</param>
+        void ApplyDividend(Dividend dividend, bool liveMode, DataNormalizationMode mode);
+
+        /// <summary>
+        /// Applies a split to the model
+        /// </summary>
+        /// <param name="split">The split to be applied</param>
+        /// <param name="liveMode">True if live mode, false for backtest</param>
+        /// <param name="mode">The <see cref="DataNormalizationMode"/> for this security</param>
+        void ApplySplit(Split split, bool liveMode, DataNormalizationMode mode);
 
         /// <summary>
         /// Returns history requirements for the volatility model expressed in the form of history request
@@ -66,6 +83,9 @@ namespace QuantConnect.Securities
             public decimal Volatility { get; private set; }
 
             public void Update(Security security, BaseData data) { }
+            public void ApplyDividend(Dividend split, bool liveMode, DataNormalizationMode mode) { }
+
+            public void ApplySplit(Split split, bool liveMode, DataNormalizationMode mode) { }
 
             public IEnumerable<HistoryRequest> GetHistoryRequirements(Security security, DateTime utcTime) { return Enumerable.Empty<HistoryRequest>(); }
         }

--- a/Common/Securities/Volatility/IndicatorVolatilityModel.cs
+++ b/Common/Securities/Volatility/IndicatorVolatilityModel.cs
@@ -18,6 +18,7 @@ using QuantConnect.Data;
 using QuantConnect.Indicators;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data.Market;
 
 namespace QuantConnect.Securities
 {
@@ -35,10 +36,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Gets the volatility of the security as a percentage
         /// </summary>
-        public decimal Volatility
-        {
-            get { return _indicator.Current; }
-        }
+        public decimal Volatility => _indicator.Current;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IVolatilityModel"/> using
@@ -78,6 +76,26 @@ namespace QuantConnect.Securities
             {
                 _indicatorUpdate(security, data, _indicator);
             }
+        }
+
+        /// <summary>
+        /// Applies a dividend to the portfolio
+        /// </summary>
+        /// <param name="dividend">The dividend to be applied</param>
+        /// <param name="liveMode">True if live mode, false for backtest</param>
+        /// <param name="mode">The <see cref="DataNormalizationMode"/> for this security</param>
+        public void ApplyDividend(Dividend dividend, bool liveMode, DataNormalizationMode mode)
+        {
+        }
+
+        /// <summary>
+        /// Applies a split to the model
+        /// </summary>
+        /// <param name="split">The split to be applied</param>
+        /// <param name="liveMode">True if live mode, false for backtest</param>
+        /// <param name="mode">The <see cref="DataNormalizationMode"/> for this security</param>
+        public void ApplySplit(Split split, bool liveMode, DataNormalizationMode mode)
+        {
         }
 
         /// <summary>

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -104,7 +104,7 @@ namespace QuantConnect.Securities
                             _window[i] *= (double) LastFactor.Value;
                         }
 
-                        SetLastFactor(null);
+                        LastFactor = null;
                     }
 
                     _needsUpdate = true;

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -1,5 +1,4 @@
-﻿
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -97,12 +96,24 @@ namespace QuantConnect.Securities
             {
                 lock (_sync)
                 {
+                    // Updates all the window values applying the last price factor
+                    if (LastFactor.HasValue)
+                    {
+                        for (var i = 0; i < _window.Count; i++)
+                        {
+                            _window[i] *= (double) LastFactor.Value;
+                        }
+
+                        SetLastFactor(null);
+                    }
+
                     _needsUpdate = true;
                     // we purposefully use security.Price for consistency in our reporting
                     // some streams of data will have trade/quote data, so if we just use
                     // data.Value we could be mixing and matching data streams
-                    _window.Add((double)security.Price);
+                    _window.Add((double) security.Price);
                 }
+
                 _lastUpdate = data.EndTime;
             }
         }
@@ -151,7 +162,7 @@ namespace QuantConnect.Securities
                                    configurations.GetHighestResolution(),
                                    extendedMarketHours,
                                    configurations.IsCustomData(),
-                                   configurations.DataNormalizationMode(),
+                                   DataNormalizationMode.Adjusted,
                                    LeanData.GetCommonTickTypeForCommonDataTypes(typeof(TradeBar), security.Type))
             };
         }

--- a/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
+++ b/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
@@ -89,10 +89,18 @@ namespace QuantConnect.Securities
                 {
                     if (_lastPrice > 0.0m)
                     {
+                        // Updates the last price applying the last price factor
+                        if (LastFactor.HasValue)
+                        {
+                            _lastPrice *= LastFactor.Value;
+                            SetLastFactor(null);
+                        }
+
                         _needsUpdate = true;
-                        _window.Add((double)(data.Price / _lastPrice) - 1.0);
+                        _window.Add((double) (data.Price / _lastPrice) - 1.0);
                     }
                 }
+
                 _lastUpdate = data.EndTime;
                 _lastPrice = data.Price;
             }
@@ -141,7 +149,7 @@ namespace QuantConnect.Securities
                                    Resolution.Daily,
                                    extendedMarketHours,
                                    configurations.IsCustomData(),
-                                   configurations.DataNormalizationMode(),
+                                   DataNormalizationMode.Adjusted,
                                    LeanData.GetCommonTickTypeForCommonDataTypes(typeof(TradeBar), security.Type))
             };
         }

--- a/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
+++ b/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Securities
                         if (LastFactor.HasValue)
                         {
                             _lastPrice *= LastFactor.Value;
-                            SetLastFactor(null);
+                            LastFactor = null;
                         }
 
                         _needsUpdate = true;

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -478,7 +478,7 @@ namespace QuantConnect.Lean.Engine
                     Log.Debug($"AlgorithmManager.Run(): {algorithm.Time}: Applying Dividend: {dividend}");
 
                     Security security = null;
-                    if (_liveMode && algorithm.Securities.TryGetValue(dividend.Symbol, out security))
+                    if (_liveMode & algorithm.Securities.TryGetValue(dividend.Symbol, out security))
                     {
                         Log.Trace($"AlgorithmManager.Run(): {algorithm.Time}: Pre-Dividend: {dividend}. " +
                             $"Security Holdings: {security.Holdings.Quantity} Account Currency Holdings: " +
@@ -491,6 +491,9 @@ namespace QuantConnect.Lean.Engine
 
                     // apply the dividend event to the portfolio
                     algorithm.Portfolio.ApplyDividend(dividend, _liveMode, mode);
+
+                    // apply the dividend event to the volatility model
+                    security.VolatilityModel.ApplyDividend(dividend, _liveMode, mode);
 
                     if (_liveMode && security != null)
                     {
@@ -514,7 +517,7 @@ namespace QuantConnect.Lean.Engine
                         Log.Debug($"AlgorithmManager.Run(): {algorithm.Time}: Applying Split for {split.Symbol}");
 
                         Security security = null;
-                        if (_liveMode && algorithm.Securities.TryGetValue(split.Symbol, out security))
+                        if (_liveMode & algorithm.Securities.TryGetValue(split.Symbol, out security))
                         {
                             Log.Trace($"AlgorithmManager.Run(): {algorithm.Time}: Pre-Split for {split}. Security Price: {security.Price} Holdings: {security.Holdings.Quantity}");
                         }
@@ -525,6 +528,9 @@ namespace QuantConnect.Lean.Engine
 
                         // apply the split event to the portfolio
                         algorithm.Portfolio.ApplySplit(split, _liveMode, mode);
+
+                        // apply the split event to the volatility model
+                        security.VolatilityModel.ApplySplit(split, _liveMode, mode);
 
                         if (_liveMode && security != null)
                         {

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -477,8 +477,8 @@ namespace QuantConnect.Lean.Engine
                 {
                     Log.Debug($"AlgorithmManager.Run(): {algorithm.Time}: Applying Dividend: {dividend}");
 
-                    Security security = null;
-                    if (_liveMode & algorithm.Securities.TryGetValue(dividend.Symbol, out security))
+                    Security security;
+                    if (algorithm.Securities.TryGetValue(dividend.Symbol, out security) && _liveMode)
                     {
                         Log.Trace($"AlgorithmManager.Run(): {algorithm.Time}: Pre-Dividend: {dividend}. " +
                             $"Security Holdings: {security.Holdings.Quantity} Account Currency Holdings: " +
@@ -516,8 +516,8 @@ namespace QuantConnect.Lean.Engine
 
                         Log.Debug($"AlgorithmManager.Run(): {algorithm.Time}: Applying Split for {split.Symbol}");
 
-                        Security security = null;
-                        if (_liveMode & algorithm.Securities.TryGetValue(split.Symbol, out security))
+                        Security security;
+                        if (algorithm.Securities.TryGetValue(split.Symbol, out security) && _liveMode)
                         {
                             Log.Trace($"AlgorithmManager.Run(): {algorithm.Time}: Pre-Split for {split}. Security Price: {security.Price} Holdings: {security.Holdings.Quantity}");
                         }

--- a/Tests/Common/Securities/IndicatorVolatilityModelTests.cs
+++ b/Tests/Common/Securities/IndicatorVolatilityModelTests.cs
@@ -1,0 +1,112 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+using QuantConnect.Securities;
+using System;
+using System.Linq;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class IndicatorVolatilityModelTests
+    {
+        [Test]
+        public void UpdatesAfterCorrectPeriodElapses()
+        {
+            const int periods = 3;
+            var model = new IndicatorVolatilityModel<IndicatorDataPoint>(
+                new StandardDeviation(periods),
+                (s, d, i) => i.Update(d)
+            );
+            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
+
+            var security = GetSecurity(reference, model);
+            for (var i = 0; i < periods; i++)
+            {
+                security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(i + 1), i + 1));
+            }
+
+            var expected = Math.Sqrt(2.0 / 3);
+            Assert.AreEqual(expected, model.Volatility);
+        }
+
+        [Test]
+        public void DoesntUpdateOnZeroPrice()
+        {
+            const int periods = 3;
+            var model = new IndicatorVolatilityModel<IndicatorDataPoint>(
+                new StandardDeviation(periods),
+                (s, d, i) =>
+                {
+                    if (s.Price > 0)
+                        i.Update(d);
+                }
+            );
+            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
+
+            var security = GetSecurity(reference, model);
+            for (var i = 0; i < periods; i++)
+            {
+                security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(i + 1), i + 1));
+            }
+
+            var expected = Math.Sqrt(2.0 / 3);
+            Assert.AreEqual(expected, model.Volatility);
+
+            // update should not be applied as price is 0 since this condition is defined by indicatorUpdate
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(3), 0m));
+            Assert.AreEqual(expected, model.Volatility);
+        }
+
+        [Test]
+        public void GetHistoryRequirementsWorks()
+        {
+            const int periods = 3;
+            var model = new IndicatorVolatilityModel<IndicatorDataPoint>(
+                new StandardDeviation(periods),
+                (s, d, i) => i.Update(d)
+            );
+            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
+
+            var security = GetSecurity(reference, model);
+
+            var result = model.GetHistoryRequirements(security, DateTime.UtcNow);
+            Assert.AreEqual(Enumerable.Empty<HistoryRequest>(), result);
+        }
+
+        private static Security GetSecurity(DateTime reference, IVolatilityModel model)
+        {
+            var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
+            var timeKeeper = new TimeKeeper(referenceUtc);
+            var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, false, false);
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(Currencies.USD, 0, 0),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance
+            );
+            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            security.VolatilityModel = model;
+
+            return security;
+        }
+    }
+}

--- a/Tests/Common/Securities/OptionPriceModelTests.cs
+++ b/Tests/Common/Securities/OptionPriceModelTests.cs
@@ -22,6 +22,7 @@ using QuantConnect.Securities;
 using QuantConnect.Securities.Equity;
 using QuantConnect.Securities.Option;
 using System.Collections.Generic;
+using QuantConnect.Securities.Volatility;
 
 namespace QuantConnect.Tests.Common
 {
@@ -308,37 +309,13 @@ namespace QuantConnect.Tests.Common
         /// <summary>
         /// Dummy implementation of volatility model (for tests only)
         /// </summary>
-        class DummyVolatilityModel : IVolatilityModel
+        class DummyVolatilityModel : BaseVolatilityModel
         {
-            private decimal _volatility;
+            public override decimal Volatility { get; }
 
             public DummyVolatilityModel(decimal volatility)
             {
-                _volatility = volatility;
-            }
-            public decimal Volatility
-            {
-                get
-                {
-                    return _volatility;
-                }
-            }
-
-            public IEnumerable<HistoryRequest> GetHistoryRequirements(Security security, DateTime date)
-            {
-                return Enumerable.Empty<HistoryRequest>();
-            }
-
-            public void Update(Security security, BaseData data)
-            {
-            }
-
-            public void ApplyDividend(Dividend dividend, bool liveMode, DataNormalizationMode mode)
-            {
-            }
-
-            public void ApplySplit(Split split, bool liveMode, DataNormalizationMode mode)
-            {
+                Volatility = volatility;
             }
         }
     }

--- a/Tests/Common/Securities/OptionPriceModelTests.cs
+++ b/Tests/Common/Securities/OptionPriceModelTests.cs
@@ -332,6 +332,14 @@ namespace QuantConnect.Tests.Common
             public void Update(Security security, BaseData data)
             {
             }
+
+            public void ApplyDividend(Dividend dividend, bool liveMode, DataNormalizationMode mode)
+            {
+            }
+
+            public void ApplySplit(Split split, bool liveMode, DataNormalizationMode mode)
+            {
+            }
         }
     }
 }

--- a/Tests/Common/Securities/RelativeStandardDeviationVolatilityModelTests.cs
+++ b/Tests/Common/Securities/RelativeStandardDeviationVolatilityModelTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Linq;
+using Accord.Statistics;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -32,21 +33,10 @@ namespace QuantConnect.Tests.Common.Securities
         {
             const int periods = 3;
             var periodSpan = Time.OneMinute;
-            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
-            var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
-            var timeKeeper = new TimeKeeper(referenceUtc);
-            var config = new SubscriptionDataConfig(typeof (TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, false, false);
-            var security = new Security(
-                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                config,
-                new Cash(Currencies.USD, 0, 0),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
-            );
-            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
-
             var model = new RelativeStandardDeviationVolatilityModel(periodSpan, periods);
-            security.VolatilityModel = model;
+            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
+
+            var security = GetSecurity(reference, model);
 
             var first = new IndicatorDataPoint(reference, 1);
             security.SetMarketPrice(first);
@@ -177,6 +167,100 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(true, result.IsCustomData);
             Assert.AreEqual(true, result.FillForwardResolution != null);
             Assert.AreEqual(true, result.IncludeExtendedMarketHours);
+        }
+
+        [Test]
+        public void HandlesPriceDiscontinuityDueToSplit()
+        {
+            const int periods = 3;
+            var periodSpan = Time.OneMinute;
+            var model = new RelativeStandardDeviationVolatilityModel(periodSpan, periods);
+            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
+
+            var security = GetSecurity(reference, model);
+
+            security.SetMarketPrice(new IndicatorDataPoint(reference, 1));
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(1), 2));
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(1.01), 1000));
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(2), 3m));
+
+            var split = new Split(security.Symbol, reference.AddMinutes(2.5), 3m, 10m, SplitType.SplitOccurred);
+            model.ApplySplit(split, false, DataNormalizationMode.Raw);
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(3), 30m));
+
+            var prices = new[] {20.0, 30.0, 30.0};
+            var expected = prices.StandardDeviation().SafeDecimalCast() / Math.Abs(prices.Mean().SafeDecimalCast());
+            Assert.AreEqual(expected, model.Volatility);
+        }
+
+        [Test]
+        public void HandlesPriceDiscontinuityDueToDividend()
+        {
+            const int periods = 3;
+            var periodSpan = Time.OneMinute;
+            var model = new RelativeStandardDeviationVolatilityModel(periodSpan, periods);
+            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
+
+            var security = GetSecurity(reference, model);
+
+            security.SetMarketPrice(new IndicatorDataPoint(reference, 1));
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(1), 2));
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(1.01), 1000));
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(2), 3m));
+
+            var dividend = new Dividend(security.Symbol, reference.AddMinutes(2.5), .031m, 3.1m);
+            model.ApplyDividend(dividend, false, DataNormalizationMode.Raw);
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(3), 3m));
+
+            var prices = new[] { 2*.99, 3*.99, 3.0 };
+            var expected = prices.StandardDeviation().SafeDecimalCast() / Math.Abs(prices.Mean().SafeDecimalCast());
+            Assert.AreEqual(expected, model.Volatility);
+        }
+
+        [Test]
+        public void HandlesPriceDiscontinuityDueToSplitAndDividend()
+        {
+            const int periods = 3;
+            var periodSpan = Time.OneMinute;
+            var model = new RelativeStandardDeviationVolatilityModel(periodSpan, periods);
+            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
+
+            var security = GetSecurity(reference, model);
+
+            security.SetMarketPrice(new IndicatorDataPoint(reference, 1));
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(1), 2));
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(1.01), 1000));
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(2), 3m));
+
+            var split = new Split(security.Symbol, reference.AddMinutes(2.5), 3m, 10m, SplitType.SplitOccurred);
+            model.ApplySplit(split, false, DataNormalizationMode.Raw);
+            var dividend = new Dividend(security.Symbol, reference.AddMinutes(2.5), .031m, 3.1m);
+            model.ApplyDividend(dividend, false, DataNormalizationMode.Raw);
+            security.SetMarketPrice(new IndicatorDataPoint(reference.AddMinutes(3), 30m));
+
+            const double factor = 9.9; // Split 10 and Dividend 0.99
+            var prices = new[] {2 * factor, 3 * factor, 30.0};
+            var expected = prices.StandardDeviation().SafeDecimalCast() / Math.Abs(prices.Mean().SafeDecimalCast());
+            Assert.AreEqual(expected, model.Volatility);
+        }
+
+        private static Security GetSecurity(DateTime reference, IVolatilityModel model)
+        {
+            var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
+            var timeKeeper = new TimeKeeper(referenceUtc);
+            var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, false, false);
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(Currencies.USD, 0, 0),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance
+            );
+            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            security.VolatilityModel = model;
+
+            return security;
         }
     }
 }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -307,6 +307,7 @@
     <Compile Include="Common\Securities\AccountCurrencyImmediateSettlementModelTests.cs" />
     <Compile Include="Common\Securities\Options\OptionPortfolioModelTests.cs" />
     <Compile Include="Common\Securities\ProcessVolatilityHistoryRequirementsTests.cs" />
+    <Compile Include="Common\Securities\IndicatorVolatilityModelTests.cs" />
     <Compile Include="Common\Securities\SecurityHoldingTests.cs" />
     <Compile Include="Common\Securities\SecurityServiceTests.cs" />
     <Compile Include="Common\Securities\TestAccountCurrencyProvider.cs" />


### PR DESCRIPTION
#### Description
Uses `Split` and `Dividend` information to update past input to the `IVolatilityModel` objects.

When there is a split and/or dividend event, the last price factor is saved in the volatility model and used to update the past price(s) to put them in line with post-event prices.

#### Related Issue
Closes #2127

#### Motivation and Context
Security volatility is an important value for trading and option pricing. Discontinuities in their values due to split and dividend events signs an artificial change in volatility.

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`