### PR TITLE
Improve FineFundamental backtesting source resolution performance

### DIFF
--- a/Common/Data/Fundamental/FineFundamental.cs
+++ b/Common/Data/Fundamental/FineFundamental.cs
@@ -58,8 +58,8 @@ namespace QuantConnect.Data.Fundamental
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
             var source =
-                Path.Combine(Globals.DataFolder, "equity", config.Market, "fundamental", "fine",
-                config.Symbol.Value.ToLower(), date.ToString("yyyyMMdd") + ".zip");
+                Path.Combine(Globals.DataFolder,
+                    $"equity/{config.Market}/fundamental/fine/{config.Symbol.Value.ToLower()}/{date:yyyyMMdd}.zip");
 
             return new SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
         }

--- a/Engine/DataFeeds/DefaultDataProvider.cs
+++ b/Engine/DataFeeds/DefaultDataProvider.cs
@@ -32,13 +32,20 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>A <see cref="Stream"/> of the data requested</returns>
         public Stream Fetch(string key)
         {
-            if (!File.Exists(key))
+            try
             {
-                Log.Error("DefaultDataProvider.Fetch(): The specified file was not found: {0}", key);
-                return null;
+                return new FileStream(key, FileMode.Open, FileAccess.Read, FileShare.Read);
             }
-
-            return new FileStream(key, FileMode.Open, FileAccess.Read, FileShare.Read);
+            catch (Exception exception)
+            {
+                if (exception is DirectoryNotFoundException
+                    || exception is FileNotFoundException)
+                {
+                    Log.Error("DefaultDataProvider.Fetch(): The specified file was not found: {0}", key);
+                    return null;
+                }
+                throw;
+            }
         }
 
         /// <summary>

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
@@ -80,6 +80,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             Assert.AreEqual(parameters.EquityPerShareGrowth1Y, row.EarningRatios.EquityPerShareGrowth.OneYear);
             Assert.AreEqual(parameters.EquityPerShareGrowth1Y, row.EarningRatios.EquityPerShareGrowth);
             Assert.AreEqual(parameters.PeRatio, row.ValuationRatios.PERatio);
+            Assert.AreEqual(parameters.NetIncomeExtraordinary3M, row.FinancialStatements.IncomeStatement.NetIncomeExtraordinary.ThreeMonths);
         }
 
         [Test]
@@ -190,7 +191,21 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     EquityPerShareGrowth1Y = 0.091652m,
                     PeRatio = 13.012858m
                 },
-                new FineFundamentalTestParameters("AAPL-BeforeLastDate")
+                new FineFundamentalTestParameters("AAPL-AfterFirstDate")
+                {
+                    Symbol = Symbols.AAPL,
+                    StartDate = new DateTime(2014, 3, 2),
+                    EndDate = new DateTime(2014, 3, 2),
+                    RowCount = 1,
+                    CompanyShortName = "Apple",
+                    Ebitda3M = 19937000000m,
+                    Ebitda12M = 57048000000m,
+                    CostOfRevenue3M = 35748000000m,
+                    CostOfRevenue12M = 106606000000m,
+                    EquityPerShareGrowth1Y = 0.091652m,
+                    PeRatio = 13.012858m
+                },
+                new FineFundamentalTestParameters("AAPL-PreviousBeforeLastDate")
                 {
                     Symbol = Symbols.AAPL,
                     StartDate = new DateTime(2014, 4, 15),
@@ -204,11 +219,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     EquityPerShareGrowth1Y = 0.091652m,
                     PeRatio = 13.272502m
                 },
-                new FineFundamentalTestParameters("AAPL-LastDate")
+                new FineFundamentalTestParameters("AAPL-BeforeLastDate")
                 {
                     Symbol = Symbols.AAPL,
-                    StartDate = new DateTime(2014, 4, 25),
-                    EndDate = new DateTime(2014, 4, 25),
+                    StartDate = new DateTime(2014, 4, 26),
+                    EndDate = new DateTime(2014, 4, 26),
                     RowCount = 1,
                     CompanyShortName = "Apple",
                     Ebitda3M = 15790000000m,
@@ -218,7 +233,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     EquityPerShareGrowth1Y = 0.091652m,
                     PeRatio = 13.272502m
                 },
-                new FineFundamentalTestParameters("AAPL-AfterLastDate")
+                new FineFundamentalTestParameters("AAPL-LastDate")
                 {
                     Symbol = Symbols.AAPL,
                     StartDate = new DateTime(2014, 4, 30),
@@ -230,9 +245,33 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     CostOfRevenue3M = 27699000000m,
                     CostOfRevenue12M = 106606000000m,
                     EquityPerShareGrowth1Y = 0.091652m,
-                    PeRatio = 13.272502m
+                    PeRatio = 13.272502m,
+                    // different than AAPL-BeforeLastDate
+                    NetIncomeExtraordinary3M = 3000000
                 },
-
+                new FineFundamentalTestParameters("AAPL-AfterLastDate")
+                {
+                    Symbol = Symbols.AAPL,
+                    StartDate = new DateTime(2014, 5, 10),
+                    EndDate = new DateTime(2014, 5, 10),
+                    RowCount = 1,
+                    CompanyShortName = "Apple",
+                    Ebitda3M = 15790000000m,
+                    Ebitda12M = 57048000000m,
+                    CostOfRevenue3M = 27699000000m,
+                    CostOfRevenue12M = 106606000000m,
+                    EquityPerShareGrowth1Y = 0.091652m,
+                    PeRatio = 13.272502m,
+                    // different than AAPL-BeforeLastDate
+                    NetIncomeExtraordinary3M = 3000000
+                },
+                new FineFundamentalTestParameters("No-Fine")
+                {
+                    Symbol = Symbols.EURUSD,
+                    StartDate = new DateTime(2014, 5, 10),
+                    EndDate = new DateTime(2014, 5, 10),
+                    RowCount = 1
+                }
             }.Select(x => new TestCaseData(x).SetName(x.Name)).ToArray();
         }
 
@@ -250,6 +289,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             public decimal CostOfRevenue12M { get; set; }
             public decimal EquityPerShareGrowth1Y { get; set; }
             public decimal PeRatio { get; set; }
+            public decimal NetIncomeExtraordinary3M { get; set; }
 
             public FineFundamentalTestParameters(string name)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Reduce the amount of `Path.Combine()` usages -> it has a performance
overhead
- Improving `FineFundamentalSubscriptionFactory` GetSource algorithm,
now it will not check if each file exists while finding the appropriate,
since we already iterated the directory before
- `DefaultDataProvider` will not check if file exists since `new
FileStream` performs the same operation internally
- Adding some more unit test cases

`Local performance tests  - CoarseFineFundamentalComboAlgorithm 2017 to 2018 - 100 Coarse selected symbols`
`pr`
42.95 seconds at 1k data points per second. Processing total of 25,479 data points.
38.92 seconds at 1k data points per second. Processing total of 25,479 data points.
40.52 seconds at 1k data points per second. Processing total of 25,479 data points.

`master`
81.14 seconds at 0k data points per second. Processing total of 25,479 data points.
79.88 seconds at 0k data points per second. Processing total of 25,479 data points.
78.83 seconds at 0k data points per second. Processing total of 25,479 data points.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3403
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Improve FineFundamental backtesting performance
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->