### PR TITLE
Update IB cash sync to not be performed during server reset times

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2895,6 +2895,17 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             return history;
         }
 
+        /// <summary>
+        /// Returns whether the brokerage should perform the cash synchronization
+        /// </summary>
+        /// <param name="currentTimeUtc">The current time (UTC)</param>
+        /// <returns>True if the cash sync should be performed</returns>
+        public override bool ShouldPerformCashSync(DateTime currentTimeUtc)
+        {
+            return !IsWithinScheduledServerResetTimes() &&
+                   base.ShouldPerformCashSync(currentTimeUtc);
+        }
+
         private void CheckRateLimiting()
         {
             if (!_messagingRateLimiter.WaitToProceed(TimeSpan.Zero))

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2902,8 +2902,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <returns>True if the cash sync should be performed</returns>
         public override bool ShouldPerformCashSync(DateTime currentTimeUtc)
         {
-            return !IsWithinScheduledServerResetTimes() &&
-                   base.ShouldPerformCashSync(currentTimeUtc);
+            return base.ShouldPerformCashSync(currentTimeUtc) &&
+                   !IsWithinScheduledServerResetTimes();
         }
 
         private void CheckRateLimiting()

--- a/Common/Interfaces/IBrokerage.cs
+++ b/Common/Interfaces/IBrokerage.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Brokerages;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 
@@ -27,7 +26,7 @@ namespace QuantConnect.Interfaces
     /// Brokerage interface that defines the operations all brokerages must implement. The IBrokerage implementation
     /// must have a matching IBrokerageFactory implementation.
     /// </summary>
-    public interface IBrokerage : IDisposable
+    public interface IBrokerage : IBrokerageCashSynchronizer, IDisposable
     {
         /// <summary>
         /// Event that fires each time an order is filled

--- a/Common/Interfaces/IBrokerageCashSynchronizer.cs
+++ b/Common/Interfaces/IBrokerageCashSynchronizer.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Interfaces
+{
+    /// <summary>
+    /// Defines live brokerage cash synchronization operations.
+    /// </summary>
+    public interface IBrokerageCashSynchronizer
+    {
+        /// <summary>
+        /// Gets the datetime of the last sync (UTC)
+        /// </summary>
+        DateTime LastSyncDateTimeUtc { get; }
+
+        /// <summary>
+        /// Returns whether the brokerage should perform the cash synchronization
+        /// </summary>
+        /// <param name="currentTimeUtc">The current time (UTC)</param>
+        /// <returns>True if the cash sync should be performed</returns>
+        bool ShouldPerformCashSync(DateTime currentTimeUtc);
+
+        /// <summary>
+        /// Synchronizes the cashbook with the brokerage account
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="currentTimeUtc">The current time (UTC)</param>
+        /// <param name="getTimeSinceLastFill">A function which returns the time elapsed since the last fill</param>
+        /// <returns>True if the cash sync was performed successfully</returns>
+        bool PerformCashSync(IAlgorithm algorithm, DateTime currentTimeUtc, Func<TimeSpan> getTimeSinceLastFill);
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -256,6 +256,7 @@
     <Compile Include="Indicators\IIndicatorWarmUpPeriodProvider.cs" />
     <Compile Include="Interfaces\IAccountCurrencyProvider.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />
+    <Compile Include="Interfaces\IBrokerageCashSynchronizer.cs" />
     <Compile Include="Interfaces\IBusyCollection.cs" />
     <Compile Include="Interfaces\IDownloadProvider.cs" />
     <Compile Include="Interfaces\IHistoryProvider.cs" />

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -18,7 +18,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using QuantConnect.Brokerages;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
@@ -37,7 +36,6 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
     {
         private IAlgorithm _algorithm;
         private IBrokerage _brokerage;
-        private bool _syncedLiveBrokerageCashToday;
 
         // Counter to keep track of total amount of processed orders
         private int _totalOrderCount;
@@ -47,11 +45,6 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
         // this value is used for determining how confident we are in our cash balance update
         private long _lastFillTimeTicks;
-        private long _lastSyncTimeTicks;
-        private readonly object _performCashSyncReentranceGuard = new object();
-
-        // 7:45 AM (New York time zone)
-        private static readonly TimeSpan LiveBrokerageCashSyncTime = new TimeSpan(7, 45, 0);
 
         private const int MaxCashSyncAttempts = 5;
         private int _failedCashSyncAttempts;
@@ -149,8 +142,6 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             _orderRequestQueue = new BusyBlockingCollection<OrderRequest>();
             // we don't need to do this today because we just initialized/synced
             _resultHandler = resultHandler;
-            _syncedLiveBrokerageCashToday = true;
-            _lastSyncTimeTicks = CurrentTimeUtc.Ticks;
 
             _brokerage = brokerage;
             _brokerage.OrderStatusChanged += (sender, fill) =>
@@ -559,21 +550,13 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
             Log.Debug("BrokerageTransactionHandler.ProcessSynchronousEvents(): Enter");
 
-            // every morning flip this switch back
-            var currentTimeNewYork = CurrentTimeUtc.ConvertFromUtc(TimeZones.NewYork);
-            if (_syncedLiveBrokerageCashToday && currentTimeNewYork.Date != LastSyncDate)
-            {
-                _syncedLiveBrokerageCashToday = false;
-                _failedCashSyncAttempts = 0;
-            }
-
-            // we want to sync up our cash balance before market open
-            if (_algorithm.LiveMode && !_syncedLiveBrokerageCashToday && currentTimeNewYork.TimeOfDay >= LiveBrokerageCashSyncTime)
+            // check if the brokerage should perform cash sync now
+            if (_brokerage.ShouldPerformCashSync(CurrentTimeUtc))
             {
                 // only perform cash syncs if we haven't had a fill for at least 10 seconds
                 if (TimeSinceLastFill > TimeSpan.FromSeconds(10))
                 {
-                    if (!PerformCashSync())
+                    if (!_brokerage.PerformCashSync(_algorithm, CurrentTimeUtc, () => TimeSinceLastFill))
                     {
                         if (++_failedCashSyncAttempts >= MaxCashSyncAttempts)
                         {
@@ -615,107 +598,6 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             _completeOrderTickets.AddOrUpdate(order.Id, orderTicket);
         }
 
-        /// <summary>
-        /// Syncs cash from brokerage with portfolio object
-        /// </summary>
-        private bool PerformCashSync()
-        {
-            try
-            {
-                // prevent reentrance in this method
-                if (!Monitor.TryEnter(_performCashSyncReentranceGuard))
-                {
-                    Log.Trace("BrokerageTransactionHandler.PerformCashSync(): Reentrant call, cash sync not performed");
-                    return false;
-                }
-
-                Log.Trace("BrokerageTransactionHandler.PerformCashSync(): Sync cash balance");
-
-                var balances = new List<CashAmount>();
-                try
-                {
-                    balances = _brokerage.GetCashBalance();
-                }
-                catch (Exception err)
-                {
-                    Log.Error(err, "Error in GetCashBalance:");
-                }
-
-                if (balances.Count == 0)
-                {
-                    Log.Trace("BrokerageTransactionHandler.PerformCashSync(): No cash balances available, cash sync not performed");
-                    return false;
-                }
-
-                //Adds currency to the cashbook that the user might have deposited
-                foreach (var balance in balances)
-                {
-                    Cash cash;
-                    if (!_algorithm.Portfolio.CashBook.TryGetValue(balance.Currency, out cash))
-                    {
-                        Log.LogHandler.Trace("BrokerageTransactionHandler.PerformCashSync(): Unexpected cash found {0} {1}", balance.Currency, balance.Amount);
-                        _algorithm.Portfolio.SetCash(balance.Currency, balance.Amount, 0);
-                    }
-                }
-
-                // if we were returned our balances, update everything and flip our flag as having performed sync today
-                foreach (var kvp in _algorithm.Portfolio.CashBook)
-                {
-                    var cash = kvp.Value;
-
-                    //update the cash if the entry if found in the balances
-                    var balanceCash = balances.Find(balance => balance.Currency == cash.Symbol);
-                    if (balanceCash != default(CashAmount))
-                    {
-                        // compare in account currency
-                        var delta = cash.Amount - balanceCash.Amount;
-                        if (Math.Abs(_algorithm.Portfolio.CashBook.ConvertToAccountCurrency(delta, cash.Symbol)) > 5)
-                        {
-                            // log the delta between
-                            Log.LogHandler.Trace("BrokerageTransactionHandler.PerformCashSync(): {0} Delta: {1}", balanceCash.Currency,
-                                delta.ToString("0.00"));
-                        }
-                        _algorithm.Portfolio.CashBook[cash.Symbol].SetAmount(balanceCash.Amount);
-                    }
-                    else
-                    {
-                        //Set the cash amount to zero if cash entry not found in the balances
-                        Log.LogHandler.Trace($"BrokerageTransactionHandler.PerformCashSync(): {cash.Symbol} was not found " +
-                            "in brokerage cash balance, setting the amount to 0");
-                        _algorithm.Portfolio.CashBook[cash.Symbol].SetAmount(0);
-                    }
-                }
-                _syncedLiveBrokerageCashToday = true;
-                _lastSyncTimeTicks = CurrentTimeUtc.Ticks;
-            }
-            finally
-            {
-                Monitor.Exit(_performCashSyncReentranceGuard);
-            }
-
-            // fire off this task to check if we've had recent fills, if we have then we'll invalidate the cash sync
-            // and do it again until we're confident in it
-            Task.Delay(TimeSpan.FromSeconds(10)).ContinueWith(_ =>
-            {
-                // we want to make sure this is a good value, so check for any recent fills
-                if (TimeSinceLastFill <= TimeSpan.FromSeconds(20))
-                {
-                    // this will cause us to come back in and reset cash again until we
-                    // haven't processed a fill for +- 10 seconds of the set cash time
-                    _syncedLiveBrokerageCashToday = false;
-                    _failedCashSyncAttempts = 0;
-                    Log.Trace("BrokerageTransactionHandler.PerformCashSync(): Unverified cash sync - resync required.");
-                }
-                else
-                {
-                    Log.Trace("BrokerageTransactionHandler.PerformCashSync(): Verified cash sync.");
-
-                    _algorithm.Portfolio.LogMarginInformation();
-                }
-            });
-
-            return true;
-        }
 
         /// <summary>
         /// Signal a end of thread request to stop monitoring the transactions.
@@ -1193,18 +1075,8 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// <summary>
         /// Gets the amount of time since the last call to algorithm.Portfolio.ProcessFill(fill)
         /// </summary>
-        protected virtual TimeSpan TimeSinceLastFill
-        {
-            get { return CurrentTimeUtc - new DateTime(Interlocked.Read(ref _lastFillTimeTicks)); }
-        }
-
-        /// <summary>
-        /// Gets the date of the last sync (New York time zone)
-        /// </summary>
-        protected DateTime LastSyncDate
-        {
-            get { return new DateTime(Interlocked.Read(ref _lastSyncTimeTicks)).ConvertFromUtc(TimeZones.NewYork).Date; }
-        }
+        protected virtual TimeSpan TimeSinceLastFill =>
+            CurrentTimeUtc - new DateTime(Interlocked.Read(ref _lastFillTimeTicks));
 
         /// <summary>
         /// Gets current time UTC. This is here to facilitate testing

--- a/Tests/Algorithm/AlgorithmLiveTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmLiveTradingTests.cs
@@ -89,6 +89,9 @@ namespace QuantConnect.Tests.Algorithm
             public void Disconnect() {}
             public bool AccountInstantlyUpdated { get; } = true;
             public IEnumerable<BaseData> GetHistory(HistoryRequest request) { return Enumerable.Empty<BaseData>(); }
+            public DateTime LastSyncDateTimeUtc { get; } = DateTime.UtcNow;
+            public bool ShouldPerformCashSync(DateTime currentTimeUtc) { return false; }
+            public bool PerformCashSync(IAlgorithm algorithm, DateTime currentTimeUtc, Func<TimeSpan> getTimeSinceLastFill) { return true; }
         }
     }
 }

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Moq;
 using NodaTime;
 using NUnit.Framework;
@@ -32,13 +31,14 @@ using QuantConnect.Securities;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Tests.Engine.DataFeeds;
+using QuantConnect.Tests.Engine.Setup;
 using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 {
     [TestFixture]
-    class BrokerageTransactionHandlerTests
+    public class BrokerageTransactionHandlerTests
     {
         private const string Ticker = "EURUSD";
         private TestAlgorithm _algorithm;
@@ -760,10 +760,9 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         {
             // Initializes the transaction handler
             var transactionHandler = new TestBrokerageTransactionHandler();
-            var broker = new Mock<IBrokerage>();
+            var brokerage = new TestBrokerage();
 
-            broker.Setup(m => m.GetCashBalance()).Returns(new List<CashAmount> { new CashAmount(10, Currencies.USD) });
-            transactionHandler.Initialize(_algorithm, broker.Object, new BacktestingResultHandler());
+            transactionHandler.Initialize(_algorithm, brokerage, new BacktestingResultHandler());
             _algorithm.SetLiveMode(true);
 
             var lastSyncDateBefore = transactionHandler.GetLastSyncDate();
@@ -780,7 +779,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var lastSyncDateAfterAgain = transactionHandler.GetLastSyncDate();
             Assert.AreEqual(lastSyncDateAfter, lastSyncDateAfterAgain);
 
-            broker.Verify(m => m.GetCashBalance(), Times.Once);
+            Assert.AreEqual(1, brokerage.GetCashBalanceCallCount);
         }
 
         [Test]
@@ -788,10 +787,9 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         {
             // Initializes the transaction handler
             var transactionHandler = new TestBrokerageTransactionHandler();
-            var broker = new Mock<IBrokerage>();
+            var brokerage = new TestBrokerage();
 
-            broker.Setup(m => m.GetCashBalance()).Returns(new List<CashAmount> { new CashAmount(10, Currencies.USD) });
-            transactionHandler.Initialize(_algorithm, broker.Object, new BacktestingResultHandler());
+            transactionHandler.Initialize(_algorithm, brokerage, new BacktestingResultHandler());
             _algorithm.SetLiveMode(true);
 
             var lastSyncDateBefore = transactionHandler.GetLastSyncDate();
@@ -812,7 +810,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             transactionHandler.ProcessSynchronousEvents();
 
-            broker.Verify(m => m.GetCashBalance(), Times.Exactly(2));
+            Assert.AreEqual(2, brokerage.GetCashBalanceCallCount);
         }
 
         [Test]
@@ -820,14 +818,12 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         {
             // Initializes the transaction handler
             var transactionHandler = new TestBrokerageTransactionHandler();
-            var broker = new Mock<IBrokerage>();
-
-            broker.Setup(m => m.GetCashBalance()).Returns(new List<CashAmount> { new CashAmount(10, Currencies.USD) });
+            var brokerage = new TestBrokerage();
 
             // This is 2 am New York
             transactionHandler.TestCurrentTimeUtc = new DateTime(1, 1, 1, 7, 0, 0);
 
-            transactionHandler.Initialize(_algorithm, broker.Object, new BacktestingResultHandler());
+            transactionHandler.Initialize(_algorithm, brokerage, new BacktestingResultHandler());
             _algorithm.SetLiveMode(true);
 
             var lastSyncDateBefore = transactionHandler.GetLastSyncDate();
@@ -840,7 +836,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             Assert.AreEqual(lastSyncDateAfter, lastSyncDateBefore);
 
-            broker.Verify(m => m.GetCashBalance(), Times.Exactly(0));
+            Assert.AreEqual(0, brokerage.GetCashBalanceCallCount);
         }
 
         [Test]
@@ -850,6 +846,21 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var ib = new Mock<IBrokerage>();
             ib.Setup(m => m.GetCashBalance()).Callback(() => { throw new Exception("Connection error in CashBalance"); });
             ib.Setup(m => m.IsConnected).Returns(false);
+            ib.Setup(m => m.ShouldPerformCashSync(It.IsAny<DateTime>())).Returns(true);
+            ib.Setup(m => m.PerformCashSync(It.IsAny<IAlgorithm>(), It.IsAny<DateTime>(), It.IsAny<Func<TimeSpan>>()))
+                .Returns(
+                    () =>
+                    {
+                        try
+                        {
+                            ib.Object.GetCashBalance();
+                        }
+                        catch (Exception)
+                        {
+                            return false;
+                        }
+                        return true;
+                    });
 
             var brokerage = ib.Object;
             Assert.IsFalse(brokerage.IsConnected);
@@ -992,6 +1003,8 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
         internal class TestBrokerageTransactionHandler : BrokerageTransactionHandler
         {
+            private IBrokerageCashSynchronizer _brokerage;
+
             public int CancelPendingOrdersSize => _cancelPendingOrders.GetCancelPendingOrdersSize;
 
             public TimeSpan TestTimeSinceLastFill = TimeSpan.FromDays(1);
@@ -1002,9 +1015,16 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             protected override TimeSpan TimeSinceLastFill => TestTimeSinceLastFill;
 
+            public override void Initialize(IAlgorithm algorithm, IBrokerage brokerage, IResultHandler resultHandler)
+            {
+                _brokerage = brokerage;
+
+                base.Initialize(algorithm, brokerage, resultHandler);
+            }
+
             public DateTime GetLastSyncDate()
             {
-                return LastSyncDate;
+                return _brokerage.LastSyncDateTimeUtc.ConvertFromUtc(TimeZones.NewYork);
             }
 
             protected override void InitializeTransactionThread()


### PR DESCRIPTION

#### Description
- A new `IBrokerageCashSynchronizer` interface has been added to allow brokerage implementations to handle the cash sync process. Most of the cash sync logic has been moved from the `BrokerageTransactionHandler` to the base `Brokerage` class.
- The IB brokerage will not attempt to perform cash sync during server reset times, respecting the different regional schedules (see also #3413).

#### Related Issue
Closes #3395 
Replaces #3375 

#### Motivation and Context
- Handle IB regional server reset times
- Fix cash sync errors during weekends

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Live IB deployment across the weekend.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`