### PR TITLE
Fix invalid signature error in GDAX brokerage

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Utility.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Utility.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.Brokerages.GDAX
             var body = request.Parameters.SingleOrDefault(b => b.Type == ParameterType.RequestBody);
 
             string url;
-            if (request.Parameters.Count > 0)
+            if (request.Method == Method.GET && request.Parameters.Count > 0)
             {
                 var parameters = request.Parameters.Count > 0
                     ? string.Join("&", request.Parameters.Select(x => $"{x.Name}={x.Value}"))

--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Brokerages.GDAX
                 payload.stop_price = (order as StopLimitOrder).StopPrice;
             }
 
-            req.AddJsonBody(payload);
+            req.AddJsonBody(JsonConvert.SerializeObject(payload));
 
             GetAuthenticationToken(req);
             var response = ExecuteRestRequest(req, GdaxEndpointType.Private);


### PR DESCRIPTION

#### Description
The invalid signature error was only partially fixed in #3429, this PR completes the updates to the GDAX brokerage implementation required after #3407

#### Related Issue
Closes #3428

#### Motivation and Context
Invalid signature errors in GDAX brokerage.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Live testing on GDAX real account of all REST API calls:
  `GetOpenOrders`, `GetCashBalance`, `PlaceOrder` and `CancelOrder`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`