### PR TITLE
SubscriptionFrontierTimeProvider will advance new subscriptions

### DIFF
--- a/Algorithm.CSharp/ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Algorithm.CSharp
                 var symbol = kvp.Key;
                 _dataPointsPerSymbol[symbol]++;
 
-                Log($"{Time} {symbol.Value} {kvp.Value.Price}");
+                Log($"{Time} {symbol.Value} {kvp.Value.Price} EndTime {kvp.Value.EndTime}");
             }
         }
 
@@ -94,7 +94,7 @@ namespace QuantConnect.Algorithm.CSharp
             var expectedDataPointsPerSymbol = new Dictionary<string, int>
             {
                 { "EURGBP", 3 },
-                { "EURUSD", 25 }
+                { "EURUSD", 47 }
             };
 
             foreach (var kvp in _dataPointsPerSymbol)

--- a/Algorithm.CSharp/ForexInternalFeedOnDataSameResolutionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ForexInternalFeedOnDataSameResolutionRegressionAlgorithm.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Algorithm.CSharp
                 var symbol = kvp.Key;
                 _dataPointsPerSymbol[symbol]++;
 
-                Log($"{Time} {symbol.Value} {kvp.Value.Price}");
+                Log($"{Time} {symbol.Value} {kvp.Value.Price} EndTime {kvp.Value.EndTime}");
             }
         }
 
@@ -96,7 +96,7 @@ namespace QuantConnect.Algorithm.CSharp
                 // normal feed
                 { "EURGBP", 3 },
                 // internal feed on the first day, normal feed on the other two days
-                { "EURUSD", 3 },
+                { "EURUSD", 2 },
                 // internal feed only
                 { "GBPUSD", 0 }
             };

--- a/Engine/DataFeeds/SubscriptionFrontierTimeProvider.cs
+++ b/Engine/DataFeeds/SubscriptionFrontierTimeProvider.cs
@@ -57,6 +57,15 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             long earlyBirdTicks = MaxDateTimeTicks;
             foreach (var subscription in _subscriptionManager.DataFeedSubscriptions)
             {
+                if (subscription.Current == null
+                    && !subscription.IsUniverseSelectionSubscription
+                    && subscription.UtcStartTime == _utcNow)
+                {
+                    // this is a data subscription we just added
+                    // lets move it next to find the initial emit time
+                    subscription.MoveNext();
+                }
+
                 if (subscription.Current != null)
                 {
                     if (earlyBirdTicks == MaxDateTimeTicks)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `SubscriptionFrontierTimeProvider` will advance new subscriptions to find the current emit time of the enumerator. This will make enumeration more deterministic, since we will not skip any time step of the new enumerators (versus relying on the emit time of the other present enumerators)
- Adding a just in case flag to the backtesting `Synchronizer` to retry creating a new time slice when the time has not advanced but there is data in the slice, this could happen with subscriptions added after initialize using `Algorithm.AddSecurity()` API, where the subscription start time is the current time loop (but should just happen once) https://github.com/QuantConnect/Lean/blob/master/Engine/DataFeeds/FileSystemDataFeed.cs#L237

Regression algorithm reproducing the issue `ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm`
PR

> 20190729 19:44:02.704 Trace:: Log: 10/7/2013 1:00:00 AM EURGBP 0.846305
> **AddForex("EURUSD", Resolution.Hour)**
> 20190729 19:44:03.010 Trace:: Log: 10/7/2013 2:00:00 AM EURUSD 1.357005
> 20190729 19:44:03.010 Trace:: Log: 10/7/2013 3:00:00 AM EURUSD 1.357535
> 20190729 19:44:03.010 Trace:: Log: 10/7/2013 4:00:00 AM EURUSD 1.35796
> 20190729 19:44:03.010 Trace:: Log: 10/7/2013 5:00:00 AM EURUSD 1.358845
> 20190729 19:44:03.010 Trace:: Log: 10/7/2013 6:00:00 AM EURUSD 1.357365
> 20190729 19:44:03.010 Trace:: Log: 10/7/2013 7:00:00 AM EURUSD 1.35761
> 20190729 19:44:03.010 Trace:: Log: 10/7/2013 8:00:00 AM EURUSD 1.35671
> 20190729 19:44:03.010 Trace:: Log: 10/7/2013 9:00:00 AM EURUSD 1.35679
> 20190729 19:44:03.010 Trace:: Log: 10/7/2013 10:00:00 AM EURUSD 1.35648
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 11:00:00 AM EURUSD 1.357095
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 12:00:00 PM EURUSD 1.356885
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 1:00:00 PM EURUSD 1.35751
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 2:00:00 PM EURUSD 1.35778
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 3:00:00 PM EURUSD 1.35768
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 4:00:00 PM EURUSD 1.35780
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 5:00:00 PM EURUSD 1.35813
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 6:00:00 PM EURUSD 1.35772
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 7:00:00 PM EURUSD 1.357585
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 8:00:00 PM EURUSD 1.35809
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 9:00:00 PM EURUSD 1.35748
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 10:00:00 PM EURUSD 1.356805
> 20190729 19:44:03.011 Trace:: Log: 10/7/2013 11:00:00 PM EURUSD 1.356835
> 20190729 19:44:03.011 Trace:: Log: 10/8/2013 12:00:00 AM EURUSD 1.356295
> 20190729 19:44:03.011 Trace:: Log: 10/8/2013 1:00:00 AM EURGBP 0.84388
> 20190729 19:44:03.011 Trace:: Log: 10/8/2013 1:00:00 AM EURUSD 1.35629
> 20190729 19:44:03.011 Trace:: Log: 10/8/2013 2:00:00 AM EURUSD 1.35645
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 3:00:00 AM EURUSD 1.356525
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 4:00:00 AM EURUSD 1.357085
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 5:00:00 AM EURUSD 1.357065
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 6:00:00 AM EURUSD 1.357605
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 7:00:00 AM EURUSD 1.357155
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 8:00:00 AM EURUSD 1.35718
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 9:00:00 AM EURUSD 1.358405
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 10:00:00 AM EURUSD 1.359365
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 11:00:00 AM EURUSD 1.35969
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 12:00:00 PM EURUSD 1.358085
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 1:00:00 PM EURUSD 1.357405
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 2:00:00 PM EURUSD 1.35732
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 3:00:00 PM EURUSD 1.356575
> 20190729 19:44:03.012 Trace:: Log: 10/8/2013 4:00:00 PM EURUSD 1.357365
> 20190729 19:44:03.013 Trace:: Log: 10/8/2013 5:00:00 PM EURUSD 1.35735
> 20190729 19:44:03.013 Trace:: Log: 10/8/2013 6:00:00 PM EURUSD 1.35734
> 20190729 19:44:03.013 Trace:: Log: 10/8/2013 7:00:00 PM EURUSD 1.3591
> 20190729 19:44:03.013 Trace:: Log: 10/8/2013 8:00:00 PM EURUSD 1.35989
> 20190729 19:44:03.013 Trace:: Log: 10/8/2013 9:00:00 PM EURUSD 1.357825
> 20190729 19:44:03.013 Trace:: Log: 10/8/2013 10:00:00 PM EURUSD 1.357025
> 20190729 19:44:03.013 Trace:: Log: 10/8/2013 11:00:00 PM EURUSD 1.35653
> 20190729 19:44:03.013 Trace:: Log: 10/9/2013 12:00:00 AM EURUSD 1.35662
> 20190729 19:44:03.013 Trace:: Log: 10/9/2013 1:00:00 AM EURGBP 0.844525
> 20190729 19:44:03.013 Trace:: Log: Data points for symbol EURGBP: 3
> 20190729 19:44:03.013 Trace:: Log: Data points for symbol EURUSD: 47

`master` -> behavior is not deterministic, adding another subscription could make the missing `EURUSD` time steps appear -> this was seen while testing the `SPY default benchmark security` https://github.com/QuantConnect/Lean/pull/3431, which adds an internal daily equity subscription

> 20190729 19:45:28.089 Trace:: Log: 10/7/2013 1:00:00 AM EURGBP 0.846305
> **AddForex("EURUSD", Resolution.Hour)**
> 20190729 19:45:28.394 Trace:: Log: 10/8/2013 1:00:00 AM EURGBP 0.84388
> 20190729 19:45:28.394 Trace:: Log: 10/8/2013 1:00:00 AM EURUSD 1.35629
> 20190729 19:45:28.394 Trace:: Log: 10/8/2013 2:00:00 AM EURUSD 1.35645
> 20190729 19:45:28.394 Trace:: Log: 10/8/2013 3:00:00 AM EURUSD 1.356525
> 20190729 19:45:28.394 Trace:: Log: 10/8/2013 4:00:00 AM EURUSD 1.357085
> 20190729 19:45:28.394 Trace:: Log: 10/8/2013 5:00:00 AM EURUSD 1.357065
> 20190729 19:45:28.395 Trace:: Log: 10/8/2013 6:00:00 AM EURUSD 1.357605
> 20190729 19:45:28.396 Trace:: Log: 10/8/2013 7:00:00 AM EURUSD 1.357155
> 20190729 19:45:28.396 Trace:: Log: 10/8/2013 8:00:00 AM EURUSD 1.35718
> 20190729 19:45:28.396 Trace:: Log: 10/8/2013 9:00:00 AM EURUSD 1.358405
> 20190729 19:45:28.396 Trace:: Log: 10/8/2013 10:00:00 AM EURUSD 1.359365
> 20190729 19:45:28.397 Trace:: Log: 10/8/2013 11:00:00 AM EURUSD 1.35969
> 20190729 19:45:28.397 Trace:: Log: 10/8/2013 12:00:00 PM EURUSD 1.358085
> 20190729 19:45:28.398 Trace:: Log: 10/8/2013 1:00:00 PM EURUSD 1.357405
> 20190729 19:45:28.398 Trace:: Log: 10/8/2013 2:00:00 PM EURUSD 1.35732
> 20190729 19:45:28.399 Trace:: Log: 10/8/2013 3:00:00 PM EURUSD 1.356575
> 20190729 19:45:28.399 Trace:: Log: 10/8/2013 4:00:00 PM EURUSD 1.357365
> 20190729 19:45:28.399 Trace:: Log: 10/8/2013 5:00:00 PM EURUSD 1.35735
> 20190729 19:45:28.400 Trace:: Log: 10/8/2013 6:00:00 PM EURUSD 1.35734
> 20190729 19:45:28.400 Trace:: Log: 10/8/2013 7:00:00 PM EURUSD 1.3591
> 20190729 19:45:28.401 Trace:: Log: 10/8/2013 8:00:00 PM EURUSD 1.35989
> 20190729 19:45:28.401 Trace:: Log: 10/8/2013 9:00:00 PM EURUSD 1.357825
> 20190729 19:45:28.402 Trace:: Log: 10/8/2013 10:00:00 PM EURUSD 1.357025
> 20190729 19:45:28.403 Trace:: Log: 10/8/2013 11:00:00 PM EURUSD 1.35653
> 20190729 19:45:28.410 Trace:: Log: 10/9/2013 12:00:00 AM EURUSD 1.35662
> 20190729 19:45:28.410 Trace:: Log: 10/9/2013 1:00:00 AM EURGBP 0.844525
> 20190729 19:45:28.411 Trace:: Log: Data points for symbol EURGBP: 3
> 20190729 19:45:28.411 Trace:: Log: Data points for symbol EURUSD: 24


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3444
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve backtesting determinism 
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->