### PR TITLE
Fix order price rounding in BrokerageTransactionHandler and EquityPriceVariationModel

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -292,6 +292,7 @@
     <Compile Include="Securities\AccountCurrencyImmediateSettlementModel.cs" />
     <Compile Include="Securities\InitialMarginRequiredForOrderParameters.cs" />
     <Compile Include="Securities\IOrderEventProvider.cs" />
+    <Compile Include="Securities\GetMinimumPriceVariationParameters.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPosition.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPositionParameters.cs" />
     <Compile Include="Securities\SecurityService.cs" />

--- a/Common/Securities/AdjustedPriceVariationModel.cs
+++ b/Common/Securities/AdjustedPriceVariationModel.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,8 +26,9 @@ namespace QuantConnect.Securities
         /// Get the minimum price variation from a security
         /// </summary>
         /// <param name="security">Security which we want the minimum price variation from</param>
+        /// <param name="referencePrice">The reference price to be used for the calculation (usually the limit/stop order price)</param>
         /// <returns>Zero</returns>
-        public virtual decimal GetMinimumPriceVariation(Security security)
+        public virtual decimal GetMinimumPriceVariation(Security security, decimal referencePrice)
         {
             return 0;
         }

--- a/Common/Securities/AdjustedPriceVariationModel.cs
+++ b/Common/Securities/AdjustedPriceVariationModel.cs
@@ -25,10 +25,9 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Get the minimum price variation from a security
         /// </summary>
-        /// <param name="security">Security which we want the minimum price variation from</param>
-        /// <param name="referencePrice">The reference price to be used for the calculation (usually the limit/stop order price)</param>
+        /// <param name="parameters">An object containing the method parameters</param>
         /// <returns>Zero</returns>
-        public virtual decimal GetMinimumPriceVariation(Security security, decimal referencePrice)
+        public virtual decimal GetMinimumPriceVariation(GetMinimumPriceVariationParameters parameters)
         {
             return 0;
         }

--- a/Common/Securities/EquityPriceVariationModel.cs
+++ b/Common/Securities/EquityPriceVariationModel.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,22 +29,23 @@ namespace QuantConnect.Securities
         /// Get the minimum price variation from a security
         /// </summary>
         /// <param name="security">Security which we want the minimum price variation from</param>
+        /// <param name="referencePrice">The reference price to be used for the calculation (usually the limit/stop order price)</param>
         /// <returns>Decimal minimum price variation of a given security</returns>
-        public override decimal GetMinimumPriceVariation(Security security)
+        public override decimal GetMinimumPriceVariation(Security security, decimal referencePrice)
         {
             if (security.Type != SecurityType.Equity)
             {
                 throw new ArgumentException("EquityPriceVariationModel.GetMinimumPriceVariation(): Invalid SecurityType " + security.Type);
             }
-            
+
             // If the quotation is priced less than $1.00 per share, the minimum pricing increment is $0.0001.
             // Source: https://www.law.cornell.edu/cfr/text/17/242.612
-            if (security.Price < 1m)
+            if (referencePrice < 1m)
             {
                 return 0.0001m;
             }
-            
-            return base.GetMinimumPriceVariation(security);
+
+            return base.GetMinimumPriceVariation(security, referencePrice);
         }
     }
 }

--- a/Common/Securities/EquityPriceVariationModel.cs
+++ b/Common/Securities/EquityPriceVariationModel.cs
@@ -28,24 +28,23 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Get the minimum price variation from a security
         /// </summary>
-        /// <param name="security">Security which we want the minimum price variation from</param>
-        /// <param name="referencePrice">The reference price to be used for the calculation (usually the limit/stop order price)</param>
+        /// <param name="parameters">An object containing the method parameters</param>
         /// <returns>Decimal minimum price variation of a given security</returns>
-        public override decimal GetMinimumPriceVariation(Security security, decimal referencePrice)
+        public override decimal GetMinimumPriceVariation(GetMinimumPriceVariationParameters parameters)
         {
-            if (security.Type != SecurityType.Equity)
+            if (parameters.Security.Type != SecurityType.Equity)
             {
-                throw new ArgumentException("EquityPriceVariationModel.GetMinimumPriceVariation(): Invalid SecurityType " + security.Type);
+                throw new ArgumentException($"EquityPriceVariationModel.GetMinimumPriceVariation(): Invalid SecurityType: {parameters.Security.Type}");
             }
 
             // If the quotation is priced less than $1.00 per share, the minimum pricing increment is $0.0001.
             // Source: https://www.law.cornell.edu/cfr/text/17/242.612
-            if (referencePrice < 1m)
+            if (parameters.ReferencePrice < 1m)
             {
                 return 0.0001m;
             }
 
-            return base.GetMinimumPriceVariation(security, referencePrice);
+            return base.GetMinimumPriceVariation(parameters);
         }
     }
 }

--- a/Common/Securities/GetMinimumPriceVariationParameters.cs
+++ b/Common/Securities/GetMinimumPriceVariationParameters.cs
@@ -17,19 +17,29 @@
 namespace QuantConnect.Securities
 {
     /// <summary>
-    /// Provides default implementation of <see cref="IPriceVariationModel"/>
-    /// for use in defining the minimum price variation.
+    /// Defines the parameters for <see cref="IPriceVariationModel.GetMinimumPriceVariation"/>
     /// </summary>
-    public class SecurityPriceVariationModel : IPriceVariationModel
+    public class GetMinimumPriceVariationParameters
     {
         /// <summary>
-        /// Get the minimum price variation from a security
+        /// Gets the security
         /// </summary>
-        /// <param name="parameters">An object containing the method parameters</param>
-        /// <returns>Decimal minimum price variation of a given security</returns>
-        public virtual decimal GetMinimumPriceVariation(GetMinimumPriceVariationParameters parameters)
+        public Security Security { get; }
+
+        /// <summary>
+        /// Gets the reference price to be used for the calculation
+        /// </summary>
+        public decimal ReferencePrice { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetMinimumPriceVariationParameters"/> class
+        /// </summary>
+        /// <param name="security">The security</param>
+        /// <param name="referencePrice">The reference price to be used for the calculation</param>
+        public GetMinimumPriceVariationParameters(Security security, decimal referencePrice)
         {
-            return parameters.Security.SymbolProperties.MinimumPriceVariation;
+            Security = security;
+            ReferencePrice = referencePrice;
         }
     }
 }

--- a/Common/Securities/IPriceVariationModel.cs
+++ b/Common/Securities/IPriceVariationModel.cs
@@ -24,9 +24,8 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Get the minimum price variation from a security
         /// </summary>
-        /// <param name="security">Security which we want the minimum price variation from</param>
-        /// <param name="referencePrice">The reference price to be used for the calculation (usually the limit/stop order price)</param>
+        /// <param name="parameters">An object containing the method parameters</param>
         /// <returns>Decimal minimum price variation of a given security</returns>
-        decimal GetMinimumPriceVariation(Security security, decimal referencePrice);
+        decimal GetMinimumPriceVariation(GetMinimumPriceVariationParameters parameters);
     }
 }

--- a/Common/Securities/IPriceVariationModel.cs
+++ b/Common/Securities/IPriceVariationModel.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@
 namespace QuantConnect.Securities
 {
     /// <summary>
-    /// Gets the minimum price variation of a given security  
+    /// Gets the minimum price variation of a given security
     /// </summary>
     public interface IPriceVariationModel
     {
@@ -25,7 +25,8 @@ namespace QuantConnect.Securities
         /// Get the minimum price variation from a security
         /// </summary>
         /// <param name="security">Security which we want the minimum price variation from</param>
+        /// <param name="referencePrice">The reference price to be used for the calculation (usually the limit/stop order price)</param>
         /// <returns>Decimal minimum price variation of a given security</returns>
-        decimal GetMinimumPriceVariation(Security security);
+        decimal GetMinimumPriceVariation(Security security, decimal referencePrice);
     }
 }

--- a/Common/Securities/SecurityPriceVariationModel.cs
+++ b/Common/Securities/SecurityPriceVariationModel.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,8 +26,9 @@ namespace QuantConnect.Securities
         /// Get the minimum price variation from a security
         /// </summary>
         /// <param name="security">Security which we want the minimum price variation from</param>
+        /// <param name="referencePrice">The reference price to be used for the calculation (usually the limit/stop order price)</param>
         /// <returns>Decimal minimum price variation of a given security</returns>
-        public virtual decimal GetMinimumPriceVariation(Security security)
+        public virtual decimal GetMinimumPriceVariation(Security security, decimal referencePrice)
         {
             return security.SymbolProperties.MinimumPriceVariation;
         }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1116,7 +1116,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// This procedure is needed to meet brokerage precision requirements.
         /// </remarks>
         /// </summary>
-        private void RoundOrderPrices(Order order, Security security)
+        public void RoundOrderPrices(Order order, Security security)
         {
             // Do not need to round market orders
             if (order.Type == OrderType.Market ||
@@ -1126,33 +1126,53 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 return;
             }
 
-            var increment = security.PriceVariationModel.GetMinimumPriceVariation(security);
-            if (increment == 0) return;
-
             var limitPrice = 0m;
-            var limitRound = 0m;
             var stopPrice = 0m;
+            var limitRound = 0m;
             var stopRound = 0m;
 
             switch (order.Type)
             {
                 case OrderType.Limit:
-                    limitPrice = ((LimitOrder)order).LimitPrice;
-                    limitRound = Math.Round(limitPrice / increment) * increment;
-                    ((LimitOrder)order).LimitPrice = limitRound;
+                    {
+                        limitPrice = ((LimitOrder) order).LimitPrice;
+                        var increment = security.PriceVariationModel.GetMinimumPriceVariation(security, limitPrice);
+                        if (increment > 0)
+                        {
+                            limitRound = Math.Round(limitPrice / increment) * increment;
+                            ((LimitOrder)order).LimitPrice = limitRound;
+                        }
+                    }
                     break;
                 case OrderType.StopMarket:
-                    stopPrice = ((StopMarketOrder)order).StopPrice;
-                    stopRound = Math.Round(stopPrice / increment) * increment;
-                    ((StopMarketOrder)order).StopPrice = stopRound;
+                    {
+                        stopPrice = ((StopMarketOrder)order).StopPrice;
+                        var increment = security.PriceVariationModel.GetMinimumPriceVariation(security, stopPrice);
+                        if (increment > 0)
+                        {
+                            stopRound = Math.Round(stopPrice / increment) * increment;
+                            ((StopMarketOrder) order).StopPrice = stopRound;
+                        }
+                    }
                     break;
                 case OrderType.StopLimit:
-                    limitPrice = ((StopLimitOrder)order).LimitPrice;
-                    limitRound = Math.Round(limitPrice / increment) * increment;
-                    ((StopLimitOrder)order).LimitPrice = limitRound;
-                    stopPrice = ((StopLimitOrder)order).StopPrice;
-                    stopRound = Math.Round(stopPrice / increment) * increment;
-                    ((StopLimitOrder)order).StopPrice = stopRound;
+                    {
+                        limitPrice = ((StopLimitOrder) order).LimitPrice;
+                        var increment = security.PriceVariationModel.GetMinimumPriceVariation(security, limitPrice);
+                        if (increment > 0)
+                        {
+                            limitRound = Math.Round(limitPrice / increment) * increment;
+                            ((StopLimitOrder) order).LimitPrice = limitRound;
+                        }
+
+                        increment = security.PriceVariationModel.GetMinimumPriceVariation(security, stopPrice);
+                        if (increment > 0)
+                        {
+                            stopPrice = ((StopLimitOrder) order).StopPrice;
+                            stopRound = Math.Round(stopPrice / increment) * increment;
+                            ((StopLimitOrder) order).StopPrice = stopRound;
+                        }
+                    }
                     break;
                 default:
                     break;

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1116,7 +1116,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// This procedure is needed to meet brokerage precision requirements.
         /// </remarks>
         /// </summary>
-        public void RoundOrderPrices(Order order, Security security)
+        protected void RoundOrderPrices(Order order, Security security)
         {
             // Do not need to round market orders
             if (order.Type == OrderType.Market ||

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1136,18 +1136,21 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 case OrderType.Limit:
                     {
                         limitPrice = ((LimitOrder) order).LimitPrice;
-                        var increment = security.PriceVariationModel.GetMinimumPriceVariation(security, limitPrice);
+                        var increment = security.PriceVariationModel.GetMinimumPriceVariation(
+                            new GetMinimumPriceVariationParameters(security, limitPrice));
                         if (increment > 0)
                         {
                             limitRound = Math.Round(limitPrice / increment) * increment;
-                            ((LimitOrder)order).LimitPrice = limitRound;
+                            ((LimitOrder) order).LimitPrice = limitRound;
                         }
                     }
                     break;
+
                 case OrderType.StopMarket:
                     {
-                        stopPrice = ((StopMarketOrder)order).StopPrice;
-                        var increment = security.PriceVariationModel.GetMinimumPriceVariation(security, stopPrice);
+                        stopPrice = ((StopMarketOrder) order).StopPrice;
+                        var increment = security.PriceVariationModel.GetMinimumPriceVariation(
+                            new GetMinimumPriceVariationParameters(security, stopPrice));
                         if (increment > 0)
                         {
                             stopRound = Math.Round(stopPrice / increment) * increment;
@@ -1155,26 +1158,27 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                         }
                     }
                     break;
+
                 case OrderType.StopLimit:
                     {
                         limitPrice = ((StopLimitOrder) order).LimitPrice;
-                        var increment = security.PriceVariationModel.GetMinimumPriceVariation(security, limitPrice);
+                        var increment = security.PriceVariationModel.GetMinimumPriceVariation(
+                            new GetMinimumPriceVariationParameters(security, limitPrice));
                         if (increment > 0)
                         {
                             limitRound = Math.Round(limitPrice / increment) * increment;
                             ((StopLimitOrder) order).LimitPrice = limitRound;
                         }
 
-                        increment = security.PriceVariationModel.GetMinimumPriceVariation(security, stopPrice);
+                        stopPrice = ((StopLimitOrder) order).StopPrice;
+                        increment = security.PriceVariationModel.GetMinimumPriceVariation(
+                            new GetMinimumPriceVariationParameters(security, stopPrice));
                         if (increment > 0)
                         {
-                            stopPrice = ((StopLimitOrder) order).StopPrice;
                             stopRound = Math.Round(stopPrice / increment) * increment;
                             ((StopLimitOrder) order).StopPrice = stopRound;
                         }
                     }
-                    break;
-                default:
                     break;
             }
 

--- a/Tests/Common/Securities/PriceVariationModelsTests.cs
+++ b/Tests/Common/Securities/PriceVariationModelsTests.cs
@@ -37,19 +37,40 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var adjutedEquity = mode == DataNormalizationMode.Adjusted && securityType == SecurityType.Equity;
 
             security.SetMarketPrice(new IndicatorDataPoint(symbol, DateTime.Now, 10m));
-            var actual = security.PriceVariationModel.GetMinimumPriceVariation(security);
+            var actual = security.PriceVariationModel.GetMinimumPriceVariation(security, security.Price);
             Assert.AreEqual(adjutedEquity ? 0 : expected, actual);
 
             security.SetMarketPrice(new IndicatorDataPoint(symbol, DateTime.Now, 1m));
-            actual = security.PriceVariationModel.GetMinimumPriceVariation(security);
+            actual = security.PriceVariationModel.GetMinimumPriceVariation(security, security.Price);
             Assert.AreEqual(adjutedEquity ? 0 : expected, actual);
 
             // Special case, if stock price less than $1, minimum price variation is $0.0001
             if (securityType == SecurityType.Equity) expected = 0.0001m;
 
             security.SetMarketPrice(new IndicatorDataPoint(symbol, DateTime.Now, .99m));
-            actual = security.PriceVariationModel.GetMinimumPriceVariation(security);
+            actual = security.PriceVariationModel.GetMinimumPriceVariation(security, security.Price);
             Assert.AreEqual(adjutedEquity ? 0 : expected, actual);
+        }
+
+        [TestCase(0.9, 1.123456789, 0.01)]
+        [TestCase(0.9, 0.987654321, 0.0001)]
+        [TestCase(0.9, 0.999999999, 0.0001)]
+        [TestCase(0.9, 1, 0.01)]
+        [TestCase(0.9, 1.000000001, 0.01)]
+        [TestCase(1.1, 1.123456789, 0.01)]
+        [TestCase(1.1, 0.987654321, 0.0001)]
+        [TestCase(1.1, 0.999999999, 0.0001)]
+        [TestCase(1.1, 1, 0.01)]
+        [TestCase(1.1, 1.000000001, 0.01)]
+        public void MinimumPriceVariationChangesWithOrderPrice(decimal securityPrice, decimal orderPrice, decimal expected)
+        {
+            var symbol = Symbol.Create("YGTY", SecurityType.Equity, Market.USA);
+            var security = GetSecurity(symbol, DataNormalizationMode.Raw);
+
+            security.SetMarketPrice(new Tick { Value = securityPrice });
+
+            var actual = security.PriceVariationModel.GetMinimumPriceVariation(security, orderPrice);
+            Assert.AreEqual(expected, actual);
         }
 
         private Security GetSecurity(Symbol symbol, DataNormalizationMode mode)

--- a/Tests/Common/Securities/PriceVariationModelsTests.cs
+++ b/Tests/Common/Securities/PriceVariationModelsTests.cs
@@ -37,18 +37,21 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             var adjutedEquity = mode == DataNormalizationMode.Adjusted && securityType == SecurityType.Equity;
 
             security.SetMarketPrice(new IndicatorDataPoint(symbol, DateTime.Now, 10m));
-            var actual = security.PriceVariationModel.GetMinimumPriceVariation(security, security.Price);
+            var actual = security.PriceVariationModel.GetMinimumPriceVariation(
+                new GetMinimumPriceVariationParameters(security, security.Price));
             Assert.AreEqual(adjutedEquity ? 0 : expected, actual);
 
             security.SetMarketPrice(new IndicatorDataPoint(symbol, DateTime.Now, 1m));
-            actual = security.PriceVariationModel.GetMinimumPriceVariation(security, security.Price);
+            actual = security.PriceVariationModel.GetMinimumPriceVariation(
+                new GetMinimumPriceVariationParameters(security, security.Price));
             Assert.AreEqual(adjutedEquity ? 0 : expected, actual);
 
             // Special case, if stock price less than $1, minimum price variation is $0.0001
             if (securityType == SecurityType.Equity) expected = 0.0001m;
 
             security.SetMarketPrice(new IndicatorDataPoint(symbol, DateTime.Now, .99m));
-            actual = security.PriceVariationModel.GetMinimumPriceVariation(security, security.Price);
+            actual = security.PriceVariationModel.GetMinimumPriceVariation(
+                new GetMinimumPriceVariationParameters(security, security.Price));
             Assert.AreEqual(adjutedEquity ? 0 : expected, actual);
         }
 
@@ -69,7 +72,8 @@ namespace QuantConnect.Tests.Common.Securities.Equity
 
             security.SetMarketPrice(new Tick { Value = securityPrice });
 
-            var actual = security.PriceVariationModel.GetMinimumPriceVariation(security, orderPrice);
+            var actual = security.PriceVariationModel.GetMinimumPriceVariation(
+                new GetMinimumPriceVariationParameters(security, orderPrice));
             Assert.AreEqual(expected, actual);
         }
 

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -1060,6 +1060,11 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             {
                 // nop
             }
+
+            public new void RoundOrderPrices(Order order, Security security)
+            {
+                base.RoundOrderPrices(order, security);
+            }
         }
     }
 }


### PR DESCRIPTION

#### Description
- Added `referencePrice` argument to `IPriceVariationModel`
- Updated `EquityPriceVariationModel` and `BrokerageTransactionHandler` to use limit/stop order prices instead of current market prices

#### Related Issue
Closes #3453 

#### Motivation and Context
IB error when submitting limit orders around $1 prices:
```
110 - The price does not conform to the minimum price variation for this contract
```

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`