### PR TITLE
Allow Python universe selection to return unchanged

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Benchmarks\StatelessCoarseUniverseSelectionBenchmark.cs" />
     <Compile Include="CapmAlphaRankingFrameworkAlgorithm.cs" />
     <Compile Include="OnEndOfDayRegressionAlgorithm.cs" />
+    <Compile Include="UniverseUnchangedRegressionAlgorithm.cs" />
     <Compile Include="USTreasuryYieldCurveDataAlgorithm.cs" />
     <Compile Include="SECReportDataAlgorithm.cs" />
     <Compile Include="G10CurrencySelectionModelFrameworkAlgorithm.cs" />

--- a/Algorithm.CSharp/UniverseUnchangedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UniverseUnchangedRegressionAlgorithm.cs
@@ -1,0 +1,124 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm used to test a fine and coarse selection methods
+    /// returning <see cref="Universe.Unchanged"/>
+    /// </summary>
+    public class UniverseUnchangedRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private const int NumberOfSymbolsFine = 2;
+
+        public override void Initialize()
+        {
+            UniverseSettings.Resolution = Resolution.Daily;
+            SetStartDate(2014, 03, 24);
+            SetEndDate(2014, 04, 07);
+
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromDays(1), 0.025, null));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            AddUniverse(CoarseSelectionFunction, FineSelectionFunction);
+        }
+
+        public IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
+        {
+            // the first and second selection
+            if (Time.Date <= new DateTime(2014, 3, 25))
+            {
+                return new List<Symbol>
+                {
+                    QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA),
+                    QuantConnect.Symbol.Create("AIG", SecurityType.Equity, Market.USA),
+                    QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA)
+                };
+            }
+            // will skip fine selection
+            return Universe.Unchanged;
+        }
+
+        public IEnumerable<Symbol> FineSelectionFunction(IEnumerable<FineFundamental> fine)
+        {
+            // just the first selection
+            if (Time.Date == new DateTime(2014, 3, 24))
+            {
+                var sortedByPeRatio = fine.OrderByDescending(x => x.ValuationRatios.PERatio);
+                var topFine = sortedByPeRatio.Take(NumberOfSymbolsFine);
+                return topFine.Select(x => x.Symbol);
+            }
+            // the second selection will return unchanged, in the following fine selection will be skipped
+            return Universe.Unchanged;
+        }
+
+        // assert security changes, throw if called more than once
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            if (changes.AddedSecurities.Count != 2
+                || Time != new DateTime(2014, 3, 25)
+                || changes.AddedSecurities.All(security => security.Symbol != QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA))
+                || changes.AddedSecurities.All(security => security.Symbol != QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA)))
+            {
+                throw new Exception("Unexpected security changes");
+            }
+            Log($"OnSecuritiesChanged({Time:o}):: {changes}");
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "11"},
+            {"Average Win", "0.01%"},
+            {"Average Loss", "0.00%"},
+            {"Compounding Annual Return", "-5.642%"},
+            {"Drawdown", "2.100%"},
+            {"Expectancy", "1.171"},
+            {"Net Profit", "-0.238%"},
+            {"Sharpe Ratio", "-0.305"},
+            {"Loss Rate", "40%"},
+            {"Win Rate", "60%"},
+            {"Profit-Loss Ratio", "2.62"},
+            {"Alpha", "-0.428"},
+            {"Beta", "22.405"},
+            {"Annual Standard Deviation", "0.137"},
+            {"Annual Variance", "0.019"},
+            {"Information Ratio", "-0.431"},
+            {"Tracking Error", "0.136"},
+            {"Treynor Ratio", "-0.002"},
+            {"Total Fees", "$14.03"}
+        };
+    }
+}

--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.py
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.py
@@ -63,7 +63,9 @@ class ConstantAlphaModel(AlphaModel):
         insights = []
 
         for security in self.securities:
-            if self.ShouldEmitInsight(algorithm.UtcTime, security.Symbol):
+            # security price could be zero until we get the first data point. e.g. this could happen
+            # when adding both forex and equities, we will first get a forex data point
+            if security.Price != 0 and self.ShouldEmitInsight(algorithm.UtcTime, security.Symbol):
                 insights.append(Insight(security.Symbol, self.period, self.type, self.direction, self.magnitude, self.confidence))
 
         return insights

--- a/Algorithm.Framework/Selection/CoarseFundamentalUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/CoarseFundamentalUniverseSelectionModel.cs
@@ -56,10 +56,10 @@ namespace QuantConnect.Algorithm.Framework.Selection
             )
             : base(false, universeSettings, securityInitializer)
         {
-            Func<IEnumerable<CoarseFundamental>, Symbol[]> func;
+            Func<IEnumerable<CoarseFundamental>, object> func;
             if (coarseSelector.TryConvertToDelegate(out func))
             {
-                _coarseSelector = func;
+                _coarseSelector = func.ConvertToUniverseSelectionSymbolDelegate();
             }
         }
 

--- a/Algorithm.Framework/Selection/FineFundamentalUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/FineFundamentalUniverseSelectionModel.cs
@@ -64,13 +64,13 @@ namespace QuantConnect.Algorithm.Framework.Selection
             )
             : base(true, universeSettings, securityInitializer)
         {
-            Func<IEnumerable<FineFundamental>, Symbol[]> fineFunc;
-            Func<IEnumerable<CoarseFundamental>, Symbol[]> coarseFunc;
+            Func<IEnumerable<FineFundamental>, object> fineFunc;
+            Func<IEnumerable<CoarseFundamental>, object> coarseFunc;
             if (fineSelector.TryConvertToDelegate(out fineFunc) &&
                 coarseSelector.TryConvertToDelegate(out coarseFunc))
             {
-                _fineSelector = fineFunc;
-                _coarseSelector = coarseFunc;
+                _fineSelector = fineFunc.ConvertToUniverseSelectionSymbolDelegate();
+                _coarseSelector = coarseFunc.ConvertToUniverseSelectionSymbolDelegate();
             }
         }
 

--- a/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
@@ -40,7 +40,7 @@ class QC500UniverseSelectionModel(FundamentalUniverseSelectionModel):
         The stock must have positive previous-day close price
         The stock must have positive volume on the previous trading day'''
         if algorithm.Time.month == self.lastMonth: 
-            return self.symbols
+            return Universe.Unchanged
 
         filtered = [x for x in coarse if x.HasFundamentalData and x.Volume > 0 and x.Price > 0]
         sortedByDollarVolume = sorted(filtered, key = lambda x: x.DollarVolume, reverse=True)[:self.numberOfSymbolsCoarse]

--- a/Algorithm.Framework/Selection/ScheduledUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ScheduledUniverseSelectionModel.cs
@@ -81,14 +81,8 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="settings">Universe settings for subscriptions added via this universe, null will default to algorithm's universe settings</param>
         /// <param name="initializer">Security initializer for new securities created via this universe, null will default to algorithm's security initializer</param>
         public ScheduledUniverseSelectionModel(IDateRule dateRule, ITimeRule timeRule, PyObject selector, UniverseSettings settings = null, ISecurityInitializer initializer = null)
+            : this(null, dateRule, timeRule, selector, settings, initializer)
         {
-            Func<DateTime, Symbol[]> func;
-            selector.TryConvertToDelegate(out func);
-            _dateRule = dateRule;
-            _timeRule = timeRule;
-            _selector = func;
-            _settings = settings;
-            _initializer = initializer;
         }
 
         /// <summary>
@@ -102,12 +96,12 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="initializer">Security initializer for new securities created via this universe, null will default to algorithm's security initializer</param>
         public ScheduledUniverseSelectionModel(DateTimeZone timeZone, IDateRule dateRule, ITimeRule timeRule, PyObject selector, UniverseSettings settings = null, ISecurityInitializer initializer = null)
         {
-            Func<DateTime, Symbol[]> func;
+            Func<DateTime, object> func;
             selector.TryConvertToDelegate(out func);
             _timeZone = timeZone;
             _dateRule = dateRule;
             _timeRule = timeRule;
-            _selector = func;
+            _selector = func.ConvertToUniverseSelectionSymbolDelegate();
             _settings = settings;
             _initializer = initializer;
         }

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -60,6 +60,7 @@
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />
     <Content Include="SECReportDataAlgorithm.py" />
+    <Content Include="UniverseUnchangedRegressionAlgorithm.py" />
     <Content Include="USEnergyInformationAdministrationAlgorithm.py" />
     <None Include="NLTKSentimentTradingAlgorithm.py" />
     <None Include="PytorchNeuralNetworkAlgorithm.py" />

--- a/Algorithm.Python/UniverseUnchangedRegressionAlgorithm.py
+++ b/Algorithm.Python/UniverseUnchangedRegressionAlgorithm.py
@@ -1,0 +1,69 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System.Core")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import QCAlgorithm
+from QuantConnect.Data.UniverseSelection import Universe
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from datetime import date, timedelta
+
+### <summary>
+### Regression algorithm used to test a fine and coarse selection methods returning Universe.Unchanged
+### </summary>
+class UniverseUnchangedRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.UniverseSettings.Resolution = Resolution.Daily
+        self.SetStartDate(2014,3,24)
+        self.SetEndDate(2014,4,7)
+
+        self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(days = 1), 0.025, None))
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+
+        self.AddUniverse(self.CoarseSelectionFunction, self.FineSelectionFunction)
+
+        self.numberOfSymbolsFine = 2
+
+    def CoarseSelectionFunction(self, coarse):
+        # the first and second selection
+        if self.Time.date() <= date(2014, 3, 25):
+            tickers = [ "AAPL", "AIG", "IBM" ]
+            return [ Symbol.Create(x, SecurityType.Equity, Market.USA) for x in tickers ]
+
+        # will skip fine selection
+        return Universe.Unchanged
+
+    def FineSelectionFunction(self, fine):
+        if self.Time.date() == date(2014, 3, 24):
+            sortedByPeRatio = sorted(fine, key=lambda x: x.ValuationRatios.PERatio, reverse=True)
+            return [ x.Symbol for x in sortedByPeRatio[:self.numberOfSymbolsFine] ]
+
+        # the second selection will return unchanged, in the following fine selection will be skipped
+        return Universe.Unchanged
+
+    # assert security changes, throw if called more than once
+    def OnSecuritiesChanged(self, changes):
+        addedSymbols = [ x.Symbol for x in changes.AddedSecurities ]
+        if (len(changes.AddedSecurities) != 2
+            or self.Time.date() != date(2014, 3, 25)
+            or Symbol.Create("AAPL", SecurityType.Equity, Market.USA) not in addedSymbols
+            or Symbol.Create("IBM", SecurityType.Equity, Market.USA) not in addedSymbols):
+            raise ValueError("Unexpected security changes")
+        self.Log(f"OnSecuritiesChanged({self.Time}):: {changes}")

--- a/Common/Data/UniverseSelection/CoarseFundamentalUniverse.cs
+++ b/Common/Data/UniverseSelection/CoarseFundamentalUniverse.cs
@@ -54,14 +54,8 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="securityInitializer">Initializes securities when they're added to the universe</param>
         /// <param name="selector">Returns the symbols that should be included in the universe</param>
         public CoarseFundamentalUniverse(UniverseSettings universeSettings, ISecurityInitializer securityInitializer, PyObject selector)
-            : base(CreateConfiguration(CoarseFundamental.CreateUniverseSymbol(QuantConnect.Market.USA)), securityInitializer)
+            : this(CoarseFundamental.CreateUniverseSymbol(QuantConnect.Market.USA), universeSettings,  securityInitializer, selector)
         {
-            _universeSettings = universeSettings;
-            Func<IEnumerable<CoarseFundamental>, Symbol[]> func;
-            if (selector.TryConvertToDelegate(out func))
-            {
-                _selector = func;
-            }
         }
 
         /// <summary>
@@ -89,10 +83,10 @@ namespace QuantConnect.Data.UniverseSelection
             : base(CreateConfiguration(symbol), securityInitializer)
         {
             _universeSettings = universeSettings;
-            Func<IEnumerable<CoarseFundamental>, Symbol[]> func;
+            Func<IEnumerable<CoarseFundamental>, object> func;
             if (selector.TryConvertToDelegate(out func))
             {
-                _selector = func;
+                _selector = func.ConvertToUniverseSelectionSymbolDelegate();
             }
         }
 

--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -80,11 +80,11 @@ namespace QuantConnect.Data.UniverseSelection
         public ScheduledUniverse(DateTimeZone timeZone, IDateRule dateRule, ITimeRule timeRule, PyObject selector, UniverseSettings settings = null, ISecurityInitializer securityInitializer = null)
             : base(CreateConfiguration(timeZone, dateRule, timeRule))
         {
-            Func<DateTime, Symbol[]> func;
+            Func<DateTime, object> func;
             selector.TryConvertToDelegate(out func);
             _dateRule = dateRule;
             _timeRule = timeRule;
-            _selector = func;
+            _selector = func.ConvertToUniverseSelectionSymbolDelegate();
             UniverseSettings = settings;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- We will now check if python selection method returned `Universe.Unchanged`
- Removing `ToList()` call on fine and coarse data before sending it to
the python algorithm
- Adding regression algorithms


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3455
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow python universe selection methods to return `Universe.Unchanged`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->