### PR TITLE
Crypto reader will ignore ticks with wrong prices

### DIFF
--- a/ToolBox/CoinApiDataConverter/CoinApiDataReader.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiDataReader.cs
@@ -121,9 +121,12 @@ namespace QuantConnect.ToolBox.CoinApiDataConverter
             while ((line = reader.ReadLine()) != null)
             {
                 var lineParts = line.Split(';');
+                var price = lineParts[columnPrice].ToDecimal();
+
+                // Occasionally, crypto exchanges have outages, in those cases CoinApi sends tick with -1 price, we skip those bad ticks.
+                if (price <= 0) continue;
 
                 var time = DateTime.Parse(lineParts[columnTime], CultureInfo.InvariantCulture);
-                var price = lineParts[columnPrice].ToDecimal();
                 var quantity = lineParts[columnQuantity].ToDecimal();
 
                 yield return new Tick
@@ -165,6 +168,9 @@ namespace QuantConnect.ToolBox.CoinApiDataConverter
                 var askSize = lineParts[columnAskSize].ToDecimal();
                 var bidPrice = lineParts[columnBidPrice].ToDecimal();
                 var bidSize = lineParts[columnBidSize].ToDecimal();
+
+                // Occasionally, crypto exchanges have outages, in those cases CoinApi sends tick with -1 price, we skip those bad ticks.
+                if (askPrice <= 0 || bidPrice <= 0) continue;
 
                 if (askPrice == previousAskPrice && bidPrice == previousBidPrice)
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Occasionally, crypto exchanges have outages, in those cases, CoinApi sends tick with -1 price. This Pr filter those bad ticks at processing time.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3457 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Parsing data of exchanges outages as they come form CoinApi generate data with unexpected behavior, affecting in great deal backtesting quality. 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Processing 2019-04-11 data for GDAX

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->