### PR TITLE
Fix Console.OutputEncoding in LEAN Launcher (Windows only)

### DIFF
--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Lean.Launcher
 
             if (OS.IsWindows)
             {
-                Console.OutputEncoding = System.Text.Encoding.Unicode;
+                Console.OutputEncoding = System.Text.Encoding.UTF8;
             }
 
             // expect first argument to be config file name


### PR DESCRIPTION

#### Description
The current setting of `Encoding.Unicode` was preventing LEAN from receiving IBAutomater output and error events when running local LEAN under Windows.
Changing to `Encoding.UTF8` solves the issue.

#### Related Issue
n/a

#### Motivation and Context
IB Automater not working properly in local LEAN under Windows, specifically the error detection methods in the IB Brokerage which rely on the IBAutomater output/error events.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local run of LEAN with IB brokerage.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`