### PR TITLE
Fix Issue In Estimize Where Symbol Would Not Be Set In Reader

### DIFF
--- a/Common/Data/Custom/Estimize/EstimizeConsensus.cs
+++ b/Common/Data/Custom/Estimize/EstimizeConsensus.cs
@@ -174,7 +174,10 @@ namespace QuantConnect.Data.Custom.Estimize
         /// </returns>
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
-            return new EstimizeConsensus(line);
+            return new EstimizeConsensus(line)
+            {
+                Symbol = config.Symbol
+            };
         }
 
         /// <summary>

--- a/Common/Data/Custom/Estimize/EstimizeEstimate.cs
+++ b/Common/Data/Custom/Estimize/EstimizeEstimate.cs
@@ -165,7 +165,10 @@ namespace QuantConnect.Data.Custom.Estimize
         /// </returns>
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
-            return new EstimizeEstimate(line);
+            return new EstimizeEstimate(line)
+            {
+                Symbol = config.Symbol
+            };
         }
 
         /// <summary>

--- a/Common/Data/Custom/Estimize/EstimizeRelease.cs
+++ b/Common/Data/Custom/Estimize/EstimizeRelease.cs
@@ -181,7 +181,10 @@ namespace QuantConnect.Data.Custom.Estimize
         /// </returns>
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
-            return new EstimizeRelease(line);
+            return new EstimizeRelease(line)
+            {
+                Symbol = config.Symbol
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Assign symbol inside `Reader` now for all Estimize data sources
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3466 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are able to distinguish data by Symbol in backtesting
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->