### PR TITLE
Improve FineFundamental backtesting performance - static cache

### DIFF
--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
@@ -34,7 +34,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
     [TestFixture]
     public class FineFundamentalSubscriptionEnumeratorFactoryTests
     {
-        [Test, TestCaseSource(nameof(GetFineFundamentalTestParameters))]
+        [TestCaseSource(nameof(GetFineFundamentalTestParametersBacktest))]
+        [TestCaseSource(nameof(GetFineFundamentalTestParametersLive))]
         public void ReadsFineFundamental(FineFundamentalTestParameters parameters)
         {
             var stopwatch = Stopwatch.StartNew();
@@ -51,7 +52,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             var request = new SubscriptionRequest(false, null, security, config, parameters.StartDate, parameters.EndDate);
             var fileProvider = new DefaultDataProvider();
 
-            var factory = new FineFundamentalSubscriptionEnumeratorFactory(false);
+            var factory = new FineFundamentalSubscriptionEnumeratorFactory(parameters.LiveMode);
             var enumerator = factory.CreateEnumerator(request, fileProvider);
             while (enumerator.MoveNext())
             {
@@ -159,7 +160,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             Assert.IsTrue(ramUsageAfterLoop - ramUsageBeforeLoop < 10);
         }
 
-        private static TestCaseData[] GetFineFundamentalTestParameters()
+        private static TestCaseData[] GetFineFundamentalTestParametersBacktest =>
+            GetFineFundamentalTestParameters(false);
+
+        private static TestCaseData[] GetFineFundamentalTestParametersLive =>
+            GetFineFundamentalTestParameters(true);
+
+        private static TestCaseData[] GetFineFundamentalTestParameters(bool liveMode)
         {
             return new List<FineFundamentalTestParameters>
             {
@@ -168,14 +175,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     Symbol = Symbols.AAPL,
                     StartDate = new DateTime(2014, 1, 1),
                     EndDate = new DateTime(2014, 12, 31),
-                    RowCount = 365
+                    RowCount = 365,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-BeforeFirstDate")
                 {
                     Symbol = Symbols.AAPL,
                     StartDate = new DateTime(2014, 2, 20),
                     EndDate = new DateTime(2014, 2, 20),
-                    RowCount = 1
+                    RowCount = 1,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-FirstDate")
                 {
@@ -189,7 +198,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     CostOfRevenue3M = 35748000000m,
                     CostOfRevenue12M = 106606000000m,
                     EquityPerShareGrowth1Y = 0.091652m,
-                    PeRatio = 13.012858m
+                    PeRatio = 13.012858m,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-AfterFirstDate")
                 {
@@ -217,7 +227,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     CostOfRevenue3M = 35748000000m,
                     CostOfRevenue12M = 106606000000m,
                     EquityPerShareGrowth1Y = 0.091652m,
-                    PeRatio = 13.272502m
+                    PeRatio = 13.272502m,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-BeforeLastDate")
                 {
@@ -231,7 +242,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     CostOfRevenue3M = 27699000000m,
                     CostOfRevenue12M = 106606000000m,
                     EquityPerShareGrowth1Y = 0.091652m,
-                    PeRatio = 13.272502m
+                    PeRatio = 13.272502m,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-LastDate")
                 {
@@ -247,7 +259,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     EquityPerShareGrowth1Y = 0.091652m,
                     PeRatio = 13.272502m,
                     // different than AAPL-BeforeLastDate
-                    NetIncomeExtraordinary3M = 3000000
+                    NetIncomeExtraordinary3M = 3000000,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("AAPL-AfterLastDate")
                 {
@@ -263,14 +276,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     EquityPerShareGrowth1Y = 0.091652m,
                     PeRatio = 13.272502m,
                     // different than AAPL-BeforeLastDate
-                    NetIncomeExtraordinary3M = 3000000
+                    NetIncomeExtraordinary3M = 3000000,
+                    LiveMode = liveMode
                 },
                 new FineFundamentalTestParameters("No-Fine")
                 {
                     Symbol = Symbols.EURUSD,
                     StartDate = new DateTime(2014, 5, 10),
                     EndDate = new DateTime(2014, 5, 10),
-                    RowCount = 1
+                    RowCount = 1,
+                    LiveMode = liveMode
                 }
             }.Select(x => new TestCaseData(x).SetName(x.Name)).ToArray();
         }
@@ -278,6 +293,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
         public class FineFundamentalTestParameters
         {
             public string Name { get; }
+            public bool LiveMode { get; set; }
             public Symbol Symbol { get; set; }
             public DateTime StartDate { get; set; }
             public DateTime EndDate { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- For backtesting, adding new private static fine cache that will hold the available dates
for which there is a fine file, reducing the amount of times we
enumerate the files in the directory. Updating unit tests.

`Cloud performance tests 2008 to 2009 selecting 100 symbols => ~50% improvement`
`pr`
77.71 seconds at 22k data points per second. Processing total of 1,721,390 data points.
81.13 seconds at 21k data points per second. Processing total of 1,721,390 data points.
57.76 seconds at 30k data points per second. Processing total of 1,721,390 data points.
`master`
149.77 seconds at 11k data points per second. Processing total of 1,721,390 data points.
150.99 seconds at 11k data points per second. Processing total of 1,721,390 data points.
147.67 seconds at 12k data points per second. Processing total of 1,721,390 data points.

Thanks @AlexCatarino for the help testing this out!

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/Lean/issues/3403
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve FineFundamental backtesting performance
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression and cloud tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->