### PR TITLE
Prevents Warning of Price Rounding When Increment is Non-Positive

### DIFF
--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1126,71 +1126,69 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 return;
             }
 
-            var limitPrice = 0m;
-            var stopPrice = 0m;
-            var limitRound = 0m;
-            var stopRound = 0m;
-
             switch (order.Type)
             {
                 case OrderType.Limit:
                     {
-                        limitPrice = ((LimitOrder) order).LimitPrice;
+                        var limitPrice = ((LimitOrder) order).LimitPrice;
                         var increment = security.PriceVariationModel.GetMinimumPriceVariation(
                             new GetMinimumPriceVariationParameters(security, limitPrice));
                         if (increment > 0)
                         {
-                            limitRound = Math.Round(limitPrice / increment) * increment;
+                            var limitRound = Math.Round(limitPrice / increment) * increment;
                             ((LimitOrder) order).LimitPrice = limitRound;
+                            SendWarningOnPriceChange("Limit", limitRound, limitPrice);
                         }
                     }
                     break;
 
                 case OrderType.StopMarket:
                     {
-                        stopPrice = ((StopMarketOrder) order).StopPrice;
+                        var stopPrice = ((StopMarketOrder) order).StopPrice;
                         var increment = security.PriceVariationModel.GetMinimumPriceVariation(
                             new GetMinimumPriceVariationParameters(security, stopPrice));
                         if (increment > 0)
                         {
-                            stopRound = Math.Round(stopPrice / increment) * increment;
+                            var stopRound = Math.Round(stopPrice / increment) * increment;
                             ((StopMarketOrder) order).StopPrice = stopRound;
+                            SendWarningOnPriceChange("Stop", stopRound, stopPrice);
                         }
                     }
                     break;
 
                 case OrderType.StopLimit:
                     {
-                        limitPrice = ((StopLimitOrder) order).LimitPrice;
+                        var limitPrice = ((StopLimitOrder) order).LimitPrice;
                         var increment = security.PriceVariationModel.GetMinimumPriceVariation(
                             new GetMinimumPriceVariationParameters(security, limitPrice));
                         if (increment > 0)
                         {
-                            limitRound = Math.Round(limitPrice / increment) * increment;
+                            var limitRound = Math.Round(limitPrice / increment) * increment;
                             ((StopLimitOrder) order).LimitPrice = limitRound;
+                            SendWarningOnPriceChange("Limit", limitRound, limitPrice);
                         }
 
-                        stopPrice = ((StopLimitOrder) order).StopPrice;
+                        var stopPrice = ((StopLimitOrder) order).StopPrice;
                         increment = security.PriceVariationModel.GetMinimumPriceVariation(
                             new GetMinimumPriceVariationParameters(security, stopPrice));
                         if (increment > 0)
                         {
-                            stopRound = Math.Round(stopPrice / increment) * increment;
+                            var stopRound = Math.Round(stopPrice / increment) * increment;
                             ((StopLimitOrder) order).StopPrice = stopRound;
+                            SendWarningOnPriceChange("Stop", stopRound, stopPrice);
                         }
                     }
                     break;
             }
+        }
 
-            var format = "Warning: To meet brokerage precision requirements, order {0}Price was rounded to {1} from {2}";
-
-            if (!limitPrice.Equals(limitRound))
+        private void SendWarningOnPriceChange(string priceType, decimal priceRound, decimal priceOriginal)
+        {
+            if (!priceOriginal.Equals(priceRound))
             {
-                _algorithm.Error(string.Format(format, "Limit", limitRound, limitPrice));
-            }
-            if (!stopPrice.Equals(stopRound))
-            {
-                _algorithm.Error(string.Format(format, "Stop", stopRound, stopPrice));
+                _algorithm.Error(
+                    $"Warning: To meet brokerage precision requirements, order {priceType}Price was rounded to {priceRound} from {priceOriginal}"
+                );
             }
         }
     }


### PR DESCRIPTION
#### Description
Moves the logic of sending warning message of price rounding inside the if-condition of valid increment value.

#### Related Issue
Closes #3482 

#### Motivation and Context
Bug fix.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`