### PR TITLE
Fix NullReferenceException during warmup in live mode

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -948,11 +948,6 @@ namespace QuantConnect.Lean.Engine
 
             foreach (var timeSlice in synchronizer.StreamData(cancellationToken))
             {
-                if (timeSlice.IsTimePulse)
-                {
-                    continue;
-                }
-
                 if (!setStartTime)
                 {
                     setStartTime = true;
@@ -960,6 +955,11 @@ namespace QuantConnect.Lean.Engine
                 }
                 if (algorithm.LiveMode && algorithm.IsWarmingUp)
                 {
+                    if (timeSlice.IsTimePulse)
+                    {
+                        continue;
+                    }
+
                     // this is hand-over logic, we spin up the data feed first and then request
                     // the history for warmup, so there will be some overlap between the data
                     if (lastHistoryTimeUtc.HasValue)

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -948,6 +948,11 @@ namespace QuantConnect.Lean.Engine
 
             foreach (var timeSlice in synchronizer.StreamData(cancellationToken))
             {
+                if (timeSlice.IsTimePulse)
+                {
+                    continue;
+                }
+
                 if (!setStartTime)
                 {
                     setStartTime = true;


### PR DESCRIPTION

#### Description
- Added `timeSlice.IsTimePulse` check in `AlgorithmManager.Stream` 

#### Related Issue
Closes #3487 

#### Motivation and Context
Null reference exception during warmup.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Test algorithm in #3487 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`