### PR TITLE
Move order count control to job packet

### DIFF
--- a/Common/Packets/Controls.cs
+++ b/Common/Packets/Controls.cs
@@ -72,6 +72,12 @@ namespace QuantConnect.Packets
         public int BacktestingMaxInsights;
 
         /// <summary>
+        /// Maximimum number of orders we'll allow in a backtest.
+        /// </summary>
+        [JsonProperty(PropertyName = "iBacktestingMaxOrders")]
+        public int BacktestingMaxOrders { get; set; }
+
+        /// <summary>
         /// Limits the amount of data points per chart series. Applies only for backtesting
         /// </summary>
         [JsonProperty(PropertyName = "iMaximumDataPointsPerChartSeries")]
@@ -87,6 +93,7 @@ namespace QuantConnect.Packets
             TickLimit = 30;
             RamAllocation = 1024;
             BacktestLogLimit = 10000;
+            BacktestingMaxOrders = int.MaxValue;
             DailyLogLimit = 3000000;
             RemainingLogAllowance = 10000;
             BacktestingMaxInsights = 10000;

--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -237,6 +237,8 @@ namespace QuantConnect.Lean.Engine.Setup
                 _maxRuntime += _maxRuntime;
             }
 
+            _maxOrders = job.Controls.BacktestingMaxOrders;
+
             //Set back to the algorithm,
             algorithm.SetMaximumOrders(_maxOrders);
 


### PR DESCRIPTION
Provider fine-grained control to the maximum orders count.

#### Motivation and Context
Standardize the backtest controls into the job Control packet

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Yes.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).