### PR TITLE
Removes always false condition checking in BaseSetupHandler

### DIFF
--- a/Common/Data/HistoryRequestFactory.cs
+++ b/Common/Data/HistoryRequestFactory.cs
@@ -74,6 +74,11 @@ namespace QuantConnect.Data
         /// <summary>
         /// Gets the start time required for the specified bar count in terms of the algorithm's time zone
         /// </summary>
+        /// <param name="symbol">The symbol to select proper <see cref="SubscriptionDataConfig"/> config</param>
+        /// <param name="periods">The number of bars requested</param>
+        /// <param name="resolution">The length of each bar</param>
+        /// <param name="exchange">The exchange hours used for market open hours</param>
+        /// <returns>The start time that would provide the specified number of bars ending at the algorithm's current time</returns>
         public DateTime GetStartTimeAlgoTz(
             Symbol symbol,
             int periods,

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -54,12 +54,6 @@ namespace QuantConnect.Lean.Engine.Setup
             var historyRequests = new List<HistoryRequest>();
             foreach (var cash in cashToUpdate)
             {
-                // if we already added a history request for this security, skip
-                if (historyRequests.Any(x => x.Symbol == cash.ConversionRateSecurity.Symbol))
-                {
-                    continue;
-                }
-
                 var configs = algorithm
                     .SubscriptionManager
                     .SubscriptionDataConfigService


### PR DESCRIPTION
#### Description
1) I noticied, This block of code in BaseSetupHandler.cs is probably always false and can be removed:

if (historyRequests.Any(x => x.Symbol == cash.ConversionRateSecurity.Symbol))
{
  continue;
}

Because if it's ever true -> then some two Cash objects have same ConversionRateSecurity - > then one of these Cash object must be a base currency? But base currency's ConversionRateSecurity is null.

2) Also, adds xml doc for HistoryRequestFactory.GetStartTimeAlgoTz()

#### Related Issue
n/a

#### Motivation and Context
small contribution to make lean code better

#### Requires Documentation Change

#### How Has This Been Tested?

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->