### PR TITLE
Add support for custom data mapping v2

### DIFF
--- a/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
@@ -1,0 +1,146 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Custom.SEC;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders.Fees;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm demonstrating use of map files with custom data
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="custom data" />
+    /// <meta name="tag" content="regression test" />
+    /// <meta name="tag" content="SEC" />
+    /// <meta name="tag" content="rename event" />
+    /// <meta name="tag" content="map" />
+    /// <meta name="tag" content="mapping" />
+    /// <meta name="tag" content="map files" />
+    public class CustomDataUsingMapFileRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+        private bool _changedSymbol;
+        private bool _properSymbolBeforeRename;
+        private bool _properSymbolAfterRename;
+
+        /// <summary>
+        /// Ticker we use for testing
+        /// </summary>
+        public const string Ticker = "TWX";
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2001, 1, 1);
+            SetEndDate(2003, 12, 31);
+            SetCash(100000);
+
+            // AOL renames to TWX in 2003
+            _symbol = AddData<SECReport8K>(Ticker, Resolution.Daily).Symbol;
+            AddEquity(Ticker, Resolution.Daily);
+        }
+
+        /// <summary>
+        /// Checks to see if the stock has been renamed, and places an order once the symbol has changed
+        /// </summary>
+        /// <param name="slice"></param>
+        public override void OnData(Slice slice)
+        {
+            if (slice.SymbolChangedEvents.ContainsKey(_symbol))
+            {
+                // Check to see if it was renamed on the 16th
+                _changedSymbol = Time.Date == new DateTime(2003, 10, 16);
+                Log($"{Time} - Ticker changed from: {slice.SymbolChangedEvents[_symbol].OldSymbol} to {slice.SymbolChangedEvents[_symbol].NewSymbol}");
+            }
+
+            foreach (var report in slice.Get<SECReport8K>())
+            {
+                if (!_properSymbolBeforeRename)
+                {
+                    _properSymbolBeforeRename = report.Key.Value == "AOL" && Time < new DateTime(2003, 10, 16);
+                }
+                if (!_properSymbolAfterRename)
+                {
+                    _properSymbolAfterRename = report.Key.Value == "TWX" && Time >= new DateTime(2003, 10, 16);
+                }
+
+                Log($"{Time} - Received 8-K report for {report.Key.Value}");
+            }
+        }
+        
+        /// <summary>
+        /// Final step of the algorithm
+        /// </summary>
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_changedSymbol)
+            {
+                throw new Exception("The ticker did not rename throughout the course of its life even though it should have");
+            }
+            if (!_properSymbolBeforeRename)
+            {
+                throw new Exception("The SEC report data never renamed to its old ticker");
+            }
+            if (!_properSymbolAfterRename)
+            {
+                throw new Exception("The SEC report data never renamed back to its present-day ticker");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = false;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+        };
+    }
+}

--- a/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
@@ -135,16 +135,16 @@ namespace QuantConnect.Algorithm.CSharp
         };
 
         /// <summary>
-        /// Test example custom data showing how to enable the use of map files.
+        /// Test example custom data showing how to enable the use of mapping.
         /// Implemented as a wrapper of existing NWSA->FOXA equity
         /// </summary>
         private class CustomDataUsingMapping : TradeBar
         {
             /// <summary>
-            /// Indicates if there is support for map files
+            /// Indicates if there is support for mapping
             /// </summary>
-            /// <returns>True indicates map files should be used</returns>
-            public override bool UsesMapFiles()
+            /// <returns>True indicates mapping should be done</returns>
+            public override bool RequiresMapping()
             {
                 return true;
             }

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -165,6 +165,7 @@
     <Compile Include="UniverseUnchangedRegressionAlgorithm.cs" />
     <Compile Include="USTreasuryYieldCurveDataAlgorithm.cs" />
     <Compile Include="SECReportDataAlgorithm.cs" />
+    <Compile Include="CustomDataUsingMapFileRegressionAlgorithm.cs" />
     <Compile Include="G10CurrencySelectionModelFrameworkAlgorithm.cs" />
     <Compile Include="ExpiryHelperAlphaModelFrameworkAlgorithm.cs" />
     <Compile Include="CfdTimeZonesRegressionAlgorithm.cs" />

--- a/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
@@ -1,0 +1,78 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Data.Custom.SEC import *
+
+from datetime import datetime
+
+### <summary>
+### Demonstration algorithm showing how to use and access SEC data
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="custom data" />
+### <meta name="tag" content="regression test" />
+### <meta name="tag" content="SEC" />
+### <meta name="tag" content="rename event" />
+### <meta name="tag" content="map" />
+### <meta name="tag" content="mapping" />
+### <meta name="tag" content="map files" />
+class CustomDataUsingMapFileRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        # Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        self.SetStartDate(2001, 1, 1)
+        self.SetEndDate(2003, 12, 31)
+        self.SetCash(100000)
+
+        self.proper_symbol_before_rename = False
+        self.proper_symbol_after_rename = False
+
+        self.ticker = "TWX"
+        self.symbol = self.AddData(SECReport8K, self.ticker).Symbol
+        self.AddEquity(self.ticker, Resolution.Daily)
+
+    def OnData(self, slice):
+        if slice.SymbolChangedEvents.ContainsKey(self.symbol):
+            self.changed_symbol = True
+            self.Log("{0} - Ticker changed from: {1} to {2}".format(str(self.Time), slice.SymbolChangedEvents[self.symbol].OldSymbol, slice.SymbolChangedEvents[self.symbol].NewSymbol))
+        
+        if not slice.ContainsKey(self.symbol):
+            return
+            
+        data = slice[self.symbol]
+
+        if not isinstance(data, SECReport8K):
+            return
+
+        report = data.Report
+
+        if not self.proper_symbol_before_rename:
+            self.proper_symbol_before_rename = data.Symbol.Value == "AOL" and self.Time < datetime(2003, 10, 16)
+        if not self.proper_symbol_after_rename:
+            self.proper_symbol_after_rename = data.Symbol.Value == "TWX" and self.Time >= datetime(2003, 10, 16)
+
+        self.Log(f"{str(self.Time)} - Received 8-K report for {data.Symbol.Value}")
+
+    def OnEndOfAlgorithm(self):
+        if not self.changed_symbol:
+            raise Exception("The ticker did not rename throughout the course of its life even though it should have")
+
+

--- a/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
@@ -74,5 +74,9 @@ class CustomDataUsingMapFileRegressionAlgorithm(QCAlgorithm):
     def OnEndOfAlgorithm(self):
         if not self.changed_symbol:
             raise Exception("The ticker did not rename throughout the course of its life even though it should have")
+        if not self.proper_symbol_before_rename:
+            raise Exception("The SEC report data never renamed to its old ticker")
+        if not self.proper_symbol_after_rename:
+            raise Exception("The SEC report data never renamed to its present-day ticker")
 
 

--- a/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
@@ -70,6 +70,9 @@ class CustomDataUsingMapFileRegressionAlgorithm(QCAlgorithm):
             raise Exception("The ticker did not rename throughout the course of its life even though it should have")
 
 class CustomDataUsingMapping(PythonData):
+    '''Test example custom data showing how to enable the use of mapping.
+    Implemented as a wrapper of existing NWSA->FOXA equity'''
+
     def GetSource(self, config, date, isLiveMode):
         return TradeBar().GetSource(SubscriptionDataConfig(config, CustomDataUsingMapping,
             # create a new symbol as equity so we find the existing data files
@@ -80,5 +83,6 @@ class CustomDataUsingMapping(PythonData):
     def Reader(self, config, line, date, isLiveMode):
         return TradeBar.ParseEquity(config, line, date)
 
-    def UsesMapFiles(self):
+    def RequiresMapping(self):
+        '''True indicates mapping should be done'''
         return True

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -66,6 +66,7 @@
     <None Include="SmartInsiderDataAlgorithm.py" />
     <Content Include="KerasNeuralNetworkAlgorithm.py" />
     <None Include="PsychSignalSentimentRegressionAlgorithm.py" />
+    <Content Include="CustomDataUsingMapFileRegressionAlgorithm.py" />
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />
     <Content Include="SECReportDataAlgorithm.py" />

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Algorithm
             MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, symbol, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
-            var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA), symbol);
+            var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA, SubscriptionDataConfig.MapFileTypes.Contains(dataType)), symbol);
 
             //Add this new generic data as a tradeable security:
             var config = SubscriptionManager.SubscriptionDataConfigService.Add(dataType,

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Algorithm
             MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, symbol, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
-            var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA, SubscriptionDataConfig.MapFileTypes.Contains(dataType)), symbol);
+            var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA, dataType.GetBaseDataInstance().UsesMapFiles()), symbol);
 
             //Add this new generic data as a tradeable security:
             var config = SubscriptionManager.SubscriptionDataConfigService.Add(dataType,

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Algorithm
             MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, symbol, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
-            var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA, dataType.GetBaseDataInstance().UsesMapFiles()), symbol);
+            var symbolObject = new Symbol(SecurityIdentifier.GenerateBase(symbol, Market.USA, dataType.GetBaseDataInstance().RequiresMapping()), symbol);
 
             //Add this new generic data as a tradeable security:
             var config = SubscriptionManager.SubscriptionDataConfigService.Add(dataType,

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1809,7 +1809,7 @@ namespace QuantConnect.Algorithm
             MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, ticker, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
-            var symbol = new Symbol(SecurityIdentifier.GenerateBase(ticker, Market.USA, typeof(T).GetBaseDataInstance().UsesMapFiles()), ticker);
+            var symbol = new Symbol(SecurityIdentifier.GenerateBase(ticker, Market.USA, typeof(T).GetBaseDataInstance().RequiresMapping()), ticker);
 
             //Add this new generic data as a tradeable security:
             var config = SubscriptionManager.SubscriptionDataConfigService.Add(typeof(T),

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -39,7 +39,6 @@ using QuantConnect.Util;
 using System.Collections.Concurrent;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Crypto;
-using System.Net;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Algorithm.Framework.Alphas.Analysis.Providers;
 using QuantConnect.Algorithm.Framework.Execution;
@@ -1810,7 +1809,7 @@ namespace QuantConnect.Algorithm
             MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, ticker, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
-            var symbol = new Symbol(SecurityIdentifier.GenerateBase(ticker, Market.USA, SubscriptionDataConfig.MapFileTypes.Contains(typeof(T))), ticker);
+            var symbol = new Symbol(SecurityIdentifier.GenerateBase(ticker, Market.USA, typeof(T).GetBaseDataInstance().UsesMapFiles()), ticker);
 
             //Add this new generic data as a tradeable security:
             var config = SubscriptionManager.SubscriptionDataConfigService.Add(typeof(T),

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1810,7 +1810,7 @@ namespace QuantConnect.Algorithm
             MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, ticker, SecurityType.Base, timeZone);
 
             //Add this to the data-feed subscriptions
-            var symbol = new Symbol(SecurityIdentifier.GenerateBase(ticker, Market.USA), ticker);
+            var symbol = new Symbol(SecurityIdentifier.GenerateBase(ticker, Market.USA, SubscriptionDataConfig.MapFileTypes.Contains(typeof(T))), ticker);
 
             //Add this new generic data as a tradeable security:
             var config = SubscriptionManager.SubscriptionDataConfigService.Add(typeof(T),

--- a/Common/Data/BaseData.cs
+++ b/Common/Data/BaseData.cs
@@ -184,10 +184,10 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// Indicates if there is support for map files
+        /// Indicates if there is support for mapping
         /// </summary>
-        /// <returns>True indicates map files should be used</returns>
-        public virtual bool UsesMapFiles()
+        /// <returns>True indicates mapping should be used</returns>
+        public virtual bool RequiresMapping()
         {
             return Symbol.SecurityType == SecurityType.Equity || Symbol.SecurityType == SecurityType.Option;
         }

--- a/Common/Data/BaseData.cs
+++ b/Common/Data/BaseData.cs
@@ -184,6 +184,15 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
+        /// Indicates if there is support for map files
+        /// </summary>
+        /// <returns>True indicates map files should be used</returns>
+        public virtual bool UsesMapFiles()
+        {
+            return Symbol.SecurityType == SecurityType.Equity || Symbol.SecurityType == SecurityType.Option;
+        }
+
+        /// <summary>
         /// Updates this base data with a new trade
         /// </summary>
         /// <param name="lastTrade">The price of the last trade</param>

--- a/Common/Data/Custom/Quandl.cs
+++ b/Common/Data/Custom/Quandl.cs
@@ -142,15 +142,6 @@ namespace QuantConnect.Data.Custom
         }
 
         /// <summary>
-        /// Indicates if there is support for map files
-        /// </summary>
-        /// <returns>True indicates map files should be used</returns>
-        public override bool UsesMapFiles()
-        {
-            return true;
-        }
-
-        /// <summary>
         /// Set the auth code for the quandl set to the QuantConnect auth code.
         /// </summary>
         /// <param name="authCode"></param>

--- a/Common/Data/Custom/Quandl.cs
+++ b/Common/Data/Custom/Quandl.cs
@@ -142,6 +142,15 @@ namespace QuantConnect.Data.Custom
         }
 
         /// <summary>
+        /// Indicates if there is support for map files
+        /// </summary>
+        /// <returns>True indicates map files should be used</returns>
+        public override bool UsesMapFiles()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Set the auth code for the quandl set to the QuantConnect auth code.
         /// </summary>
         /// <param name="authCode"></param>

--- a/Common/Data/Custom/SEC/SECReport10K.cs
+++ b/Common/Data/Custom/SEC/SECReport10K.cs
@@ -101,10 +101,10 @@ namespace QuantConnect.Data.Custom.SEC
         }
 
         /// <summary>
-        /// Indicates if there is support for map files
+        /// Indicates if there is support for mapping
         /// </summary>
-        /// <returns>True indicates map files should be used</returns>
-        public override bool UsesMapFiles()
+        /// <returns>True indicates mapping should be used</returns>
+        public override bool RequiresMapping()
         {
             return true;
         }

--- a/Common/Data/Custom/SEC/SECReport10K.cs
+++ b/Common/Data/Custom/SEC/SECReport10K.cs
@@ -101,6 +101,15 @@ namespace QuantConnect.Data.Custom.SEC
         }
 
         /// <summary>
+        /// Indicates if there is support for map files
+        /// </summary>
+        /// <returns>True indicates map files should be used</returns>
+        public override bool UsesMapFiles()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Clones the current object into a new object
         /// </summary>
         /// <returns>BaseData clone of the current object</returns>

--- a/Common/Data/Custom/SEC/SECReport10Q.cs
+++ b/Common/Data/Custom/SEC/SECReport10Q.cs
@@ -101,10 +101,10 @@ namespace QuantConnect.Data.Custom.SEC
         }
 
         /// <summary>
-        /// Indicates if there is support for map files
+        /// Indicates if there is support for mapping
         /// </summary>
-        /// <returns>True indicates map files should be used</returns>
-        public override bool UsesMapFiles()
+        /// <returns>True indicates mapping should be used</returns>
+        public override bool RequiresMapping()
         {
             return true;
         }

--- a/Common/Data/Custom/SEC/SECReport10Q.cs
+++ b/Common/Data/Custom/SEC/SECReport10Q.cs
@@ -101,6 +101,15 @@ namespace QuantConnect.Data.Custom.SEC
         }
 
         /// <summary>
+        /// Indicates if there is support for map files
+        /// </summary>
+        /// <returns>True indicates map files should be used</returns>
+        public override bool UsesMapFiles()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Clones the current object into a new object
         /// </summary>
         /// <returns>BaseData clone of the current object</returns>

--- a/Common/Data/Custom/SEC/SECReport8K.cs
+++ b/Common/Data/Custom/SEC/SECReport8K.cs
@@ -101,10 +101,10 @@ namespace QuantConnect.Data.Custom.SEC
         }
 
         /// <summary>
-        /// Indicates if there is support for map files
+        /// Indicates if there is support for mapping
         /// </summary>
-        /// <returns>True indicates map files should be used</returns>
-        public override bool UsesMapFiles()
+        /// <returns>True indicates mapping should be used</returns>
+        public override bool RequiresMapping()
         {
             return true;
         }

--- a/Common/Data/Custom/SEC/SECReport8K.cs
+++ b/Common/Data/Custom/SEC/SECReport8K.cs
@@ -101,6 +101,15 @@ namespace QuantConnect.Data.Custom.SEC
         }
 
         /// <summary>
+        /// Indicates if there is support for map files
+        /// </summary>
+        /// <returns>True indicates map files should be used</returns>
+        public override bool UsesMapFiles()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Clones the current object into a new object
         /// </summary>
         /// <returns>BaseData clone of the current object</returns>

--- a/Common/Data/Custom/Tiingo/TiingoDailyData.cs
+++ b/Common/Data/Custom/Tiingo/TiingoDailyData.cs
@@ -178,5 +178,14 @@ namespace QuantConnect.Data.Custom.Tiingo
 
             return new BaseDataCollection(date, config.Symbol, list);
         }
+
+        /// <summary>
+        /// Indicates if there is support for map files
+        /// </summary>
+        /// <returns>True indicates map files should be used</returns>
+        public override bool UsesMapFiles()
+        {
+            return true;
+        }
     }
 }

--- a/Common/Data/Custom/Tiingo/TiingoDailyData.cs
+++ b/Common/Data/Custom/Tiingo/TiingoDailyData.cs
@@ -180,10 +180,10 @@ namespace QuantConnect.Data.Custom.Tiingo
         }
 
         /// <summary>
-        /// Indicates if there is support for map files
+        /// Indicates if there is support for mapping
         /// </summary>
-        /// <returns>True indicates map files should be used</returns>
-        public override bool UsesMapFiles()
+        /// <returns>True indicates mapping should be used</returns>
+        public override bool RequiresMapping()
         {
             return true;
         }

--- a/Common/Data/IBaseData.cs
+++ b/Common/Data/IBaseData.cs
@@ -94,6 +94,12 @@ namespace QuantConnect.Data
         string GetSource(SubscriptionDataConfig config, DateTime date, DataFeedEndpoint datafeed);
 
         /// <summary>
+        /// Indicates if there is support for map files
+        /// </summary>
+        /// <returns>True indicates map files should be used</returns>
+        bool UsesMapFiles();
+
+        /// <summary>
         /// Return a new instance clone of this object
         /// </summary>
         /// <returns></returns>

--- a/Common/Data/IBaseData.cs
+++ b/Common/Data/IBaseData.cs
@@ -94,10 +94,10 @@ namespace QuantConnect.Data
         string GetSource(SubscriptionDataConfig config, DateTime date, DataFeedEndpoint datafeed);
 
         /// <summary>
-        /// Indicates if there is support for map files
+        /// Indicates if there is support for mapping
         /// </summary>
-        /// <returns>True indicates map files should be used</returns>
-        bool UsesMapFiles();
+        /// <returns>True indicates mapping should be used</returns>
+        bool RequiresMapping();
 
         /// <summary>
         /// Return a new instance clone of this object

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -19,9 +19,6 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using NodaTime;
 using QuantConnect.Data.Consolidators;
-using QuantConnect.Data.Custom;
-using QuantConnect.Data.Custom.SEC;
-using QuantConnect.Data.Custom.Tiingo;
 using QuantConnect.Securities;
 using QuantConnect.Util;
 
@@ -117,24 +114,6 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// Some custom data sources should support symbol mapping because the custom data
-        /// is directly related to symbols/tickers. For example, SEC data and sentiment data on US equities.
-        /// </summary>
-        public static HashSet<Type> MapFileTypes = new HashSet<Type>
-        {
-            typeof(TiingoDailyData),
-            typeof(Quandl),
-            typeof(SECReport8K),
-            typeof(SECReport10K),
-            typeof(SECReport10Q),
-        };
-        
-        /// <summary>
-        /// Indicates if there is support for map files.
-        /// </summary>
-        public bool UsesMapFiles { get; }
-
-        /// <summary>
         /// Gets the market / scope of the symbol
         /// </summary>
         public readonly string Market;
@@ -210,7 +189,6 @@ namespace QuantConnect.Data
             IsFilteredSubscription = isFilteredSubscription;
             Consolidators = new HashSet<IDataConsolidator>();
             DataNormalizationMode = dataNormalizationMode;
-            UsesMapFiles = SecurityType == SecurityType.Equity || SecurityType == SecurityType.Option || MapFileTypes.Contains(Type);
 
             TickType = tickType ?? LeanData.GetCommonTickTypeForCommonDataTypes(objectType, SecurityType);
 
@@ -287,7 +265,6 @@ namespace QuantConnect.Data
             PriceScaleFactor = config.PriceScaleFactor;
             SumOfDividends = config.SumOfDividends;
             Consolidators = config.Consolidators;
-            UsesMapFiles = config.UsesMapFiles;
         }
 
         /// <summary>
@@ -334,8 +311,7 @@ namespace QuantConnect.Data
                 && IsCustomData == other.IsCustomData
                 && DataTimeZone.Equals(other.DataTimeZone)
                 && ExchangeTimeZone.Equals(other.ExchangeTimeZone)
-                && IsFilteredSubscription == other.IsFilteredSubscription
-                && UsesMapFiles == other.UsesMapFiles;
+                && IsFilteredSubscription == other.IsFilteredSubscription;
         }
 
         /// <summary>
@@ -374,7 +350,6 @@ namespace QuantConnect.Data
                 hashCode = (hashCode*397) ^ DataTimeZone.Id.GetHashCode();// timezone hash is expensive, use id instead
                 hashCode = (hashCode*397) ^ ExchangeTimeZone.Id.GetHashCode();// timezone hash is expensive, use id instead
                 hashCode = (hashCode*397) ^ IsFilteredSubscription.GetHashCode();
-                hashCode = (hashCode*397) ^ UsesMapFiles.GetHashCode();
                 return hashCode;
             }
         }

--- a/Common/Data/SubscriptionDataConfigExtensions.cs
+++ b/Common/Data/SubscriptionDataConfigExtensions.cs
@@ -105,5 +105,21 @@ namespace QuantConnect.Data
                 subscription.DataNormalizationMode = mode;
             }
         }
+
+        /// <summary>
+        /// Will determine if map files should be used for this subscription configuration
+        /// </summary>
+        /// <param name="config">The subscription data configuration we are processing</param>
+        /// <remarks>One of the objectives of this method is to normalize the 'use map file'
+        /// check and void code duplication and related issues</remarks>
+        /// <returns>True if map files should be used</returns>
+        public static bool ShouldUseMapFiles(this SubscriptionDataConfig config)
+        {
+            // we create an instance of the data type, if it is a custom type
+            // it can override UsesMapFiles else it will use security type
+            var instance = config.Type.GetBaseDataInstance();
+            instance.Symbol = config.Symbol;
+            return instance.UsesMapFiles();
+        }
     }
 }

--- a/Common/Data/SubscriptionDataConfigExtensions.cs
+++ b/Common/Data/SubscriptionDataConfigExtensions.cs
@@ -107,19 +107,19 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// Will determine if map files should be used for this subscription configuration
+        /// Will determine if mapping should be used for this subscription configuration
         /// </summary>
         /// <param name="config">The subscription data configuration we are processing</param>
-        /// <remarks>One of the objectives of this method is to normalize the 'use map file'
+        /// <remarks>One of the objectives of this method is to normalize the 'use mapping'
         /// check and void code duplication and related issues</remarks>
-        /// <returns>True if map files should be used</returns>
-        public static bool ShouldUseMapFiles(this SubscriptionDataConfig config)
+        /// <returns>True if ticker should be mapped</returns>
+        public static bool TickerShouldBeMapped(this SubscriptionDataConfig config)
         {
             // we create an instance of the data type, if it is a custom type
-            // it can override UsesMapFiles else it will use security type
+            // it can override RequiresMapping else it will use security type
             var instance = config.Type.GetBaseDataInstance();
             instance.Symbol = config.Symbol;
-            return instance.UsesMapFiles();
+            return instance.RequiresMapping();
         }
     }
 }

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -44,10 +44,10 @@ namespace QuantConnect
     {
         /// <summary>
         /// Given a type will create a new instance using the parameterless constructor
-        /// and assert the type implements <see cref="IBaseData"/>
+        /// and assert the type implements <see cref="BaseData"/>
         /// </summary>
         /// <remarks>One of the objectives of this method is to normalize the creation of the
-        /// IBaseData instances while reducing code duplication</remarks>
+        /// BaseData instances while reducing code duplication</remarks>
         public static BaseData GetBaseDataInstance(this Type type)
         {
             var objectActivator = ObjectActivator.GetActivator(type);

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -29,8 +29,10 @@ using Newtonsoft.Json;
 using NodaTime;
 using Python.Runtime;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Data;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
+using QuantConnect.Util;
 using Timer = System.Timers.Timer;
 
 namespace QuantConnect
@@ -40,6 +42,36 @@ namespace QuantConnect
     /// </summary>
     public static class Extensions
     {
+        /// <summary>
+        /// Given a type will create a new instance using the parameterless constructor
+        /// and assert the type implements <see cref="IBaseData"/>
+        /// </summary>
+        /// <remarks>One of the objectives of this method is to normalize the creation of the
+        /// IBaseData instances while reducing code duplication</remarks>
+        public static IBaseData GetBaseDataInstance(this Type type)
+        {
+            var objectActivator = ObjectActivator.GetActivator(type);
+            if (objectActivator == null)
+            {
+                throw new ArgumentException($"Data type \'{type.Name}\' missing parameterless constructor " +
+                    $"E.g. public {type.Name}() {{ }}");
+            }
+
+            var instance = objectActivator.Invoke(new object[] { type });
+            if(instance == null)
+            {
+                // shouldn't happen but just in case...
+                throw new ArgumentException($"Failed to create instance of type \'{type.Name}\'");
+            }
+
+            var result = instance as IBaseData;
+            if (result == null)
+            {
+                throw new ArgumentException($"Data type \'{type.Name}\' does not inherit required {nameof(IBaseData)}");
+            }
+            return result;
+        }
+
         /// <summary>
         /// Helper method that will cast the provided <see cref="PyObject"/>
         /// to a T type and dispose of it.

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -48,7 +48,7 @@ namespace QuantConnect
         /// </summary>
         /// <remarks>One of the objectives of this method is to normalize the creation of the
         /// IBaseData instances while reducing code duplication</remarks>
-        public static IBaseData GetBaseDataInstance(this Type type)
+        public static BaseData GetBaseDataInstance(this Type type)
         {
             var objectActivator = ObjectActivator.GetActivator(type);
             if (objectActivator == null)
@@ -64,10 +64,12 @@ namespace QuantConnect
                 throw new ArgumentException($"Failed to create instance of type \'{type.Name}\'");
             }
 
-            var result = instance as IBaseData;
+            // we expect 'instance' to inherit BaseData in most cases so we use 'as' versus 'IsAssignableFrom'
+            // since it is slightly cheaper
+            var result = instance as BaseData;
             if (result == null)
             {
-                throw new ArgumentException($"Data type \'{type.Name}\' does not inherit required {nameof(IBaseData)}");
+                throw new ArgumentException($"Data type \'{type.Name}\' does not inherit required {nameof(BaseData)}");
             }
             return result;
         }

--- a/Common/Python/PythonData.cs
+++ b/Common/Python/PythonData.cs
@@ -26,6 +26,7 @@ namespace QuantConnect.Python
     public class PythonData : DynamicData
     {
         private readonly dynamic _pythonData;
+        private readonly bool _usesMapFiles;
 
         /// <summary>
         /// Constructor for initialising the PythonData class
@@ -42,6 +43,13 @@ namespace QuantConnect.Python
         public PythonData(PyObject pythonData)
         {
             _pythonData = pythonData;
+            using (Py.GIL())
+            {
+                if (pythonData.HasAttr("UsesMapFiles"))
+                {
+                    _usesMapFiles = _pythonData.UsesMapFiles();
+                }
+            }
         }
 
         /// <summary>
@@ -75,6 +83,15 @@ namespace QuantConnect.Python
                 var data = _pythonData.Reader(config, line, date, isLiveMode);
                 return (data as PyObject).GetAndDispose<BaseData>();
             }
+        }
+
+        /// <summary>
+        /// Indicates if there is support for map files
+        /// </summary>
+        /// <returns>True indicates map files should be used</returns>
+        public override bool UsesMapFiles()
+        {
+            return _usesMapFiles;
         }
 
         /// <summary>

--- a/Common/Python/PythonData.cs
+++ b/Common/Python/PythonData.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Python
     public class PythonData : DynamicData
     {
         private readonly dynamic _pythonData;
-        private readonly bool _usesMapFiles;
+        private readonly bool _requiresMapping;
 
         /// <summary>
         /// Constructor for initialising the PythonData class
@@ -45,9 +45,9 @@ namespace QuantConnect.Python
             _pythonData = pythonData;
             using (Py.GIL())
             {
-                if (pythonData.HasAttr("UsesMapFiles"))
+                if (pythonData.HasAttr("RequiresMapping"))
                 {
-                    _usesMapFiles = _pythonData.UsesMapFiles();
+                    _requiresMapping = _pythonData.RequiresMapping();
                 }
             }
         }
@@ -86,12 +86,12 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
-        /// Indicates if there is support for map files
+        /// Indicates if there is support for mapping
         /// </summary>
-        /// <returns>True indicates map files should be used</returns>
-        public override bool UsesMapFiles()
+        /// <returns>True indicates mapping should be used</returns>
+        public override bool RequiresMapping()
         {
-            return _usesMapFiles;
+            return _requiresMapping;
         }
 
         /// <summary>

--- a/Common/SecurityIdentifier.cs
+++ b/Common/SecurityIdentifier.cs
@@ -407,7 +407,7 @@ namespace QuantConnect
                 case SecurityType.Equity:
                     return GenerateEquity(firstDate, symbol, market);
                 case SecurityType.Base:
-                    return GenerateBase(firstDate, symbol, market);
+                    return Generate(firstDate, symbol, SecurityType.Base, market);
                 default:
                     // Should never happen because we previously filtered non-base or non-equity SecurityType
                     throw new Exception("SecurityType is not Base or Equity even though we've previously filtered them");
@@ -443,17 +443,6 @@ namespace QuantConnect
         public static SecurityIdentifier GenerateBase(string symbol, string market, bool mapSymbol = false)
         {
             return GenerateWithFirstDate(symbol, market, SecurityType.Base, mapSymbol);
-        }
-
-        /// <summary>
-        /// Generates a new <see cref="SecurityIdentifier"/> for a custom security
-        /// </summary>
-        /// <param name="symbol">The ticker symbol of this security</param>
-        /// <param name="market">The security's market</param>
-        /// <returns>A new <see cref="SecurityIdentifier"/> representing the specified base security</returns>
-        public static SecurityIdentifier GenerateBase(DateTime date, string symbol, string market)
-        {
-            return Generate(date, symbol, SecurityType.Base, market);
         }
 
         /// <summary>

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -35,7 +35,7 @@ namespace QuantConnect
 
         /// <summary>
         /// Provides a convience method for creating a Symbol for most security types.
-        /// This method currently does not support Option, Commodity, and Future
+        /// This method currently does not support Commodities
         /// </summary>
         /// <param name="ticker">The string ticker symbol</param>
         /// <param name="securityType">The security type of the ticker. If securityType == Option, then a canonical symbol is created</param>

--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -18,7 +18,6 @@ using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds.Transport;
-using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -48,7 +47,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _date = date;
             _config = config;
             _isLiveMode = isLiveMode;
-            _factory = (BaseData)ObjectActivator.GetActivator(config.Type).Invoke(new object[] { config.Type });
+            _factory = _config.Type.GetBaseDataInstance();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
         {
             var sourceFactory = request.Configuration.Type.GetBaseDataInstance();
-            var useMapFiles = request.Configuration.ShouldUseMapFiles();
+            var useMapFiles = request.Configuration.TickerShouldBeMapped();
 
             using (var dataCacheProvider = new SingleEntryDataCacheProvider(dataProvider))
             {

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
@@ -70,12 +70,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
         {
             var sourceFactory = (BaseData)ObjectActivator.GetActivator(request.Configuration.Type).Invoke(new object[] { request.Configuration.Type });
+            var useMapFiles = request.Configuration.ShouldUseMapFiles();
 
             using (var dataCacheProvider = new SingleEntryDataCacheProvider(dataProvider))
             {
                 foreach (var date in _tradableDaysProvider(request))
                 {
-                    request.Configuration.MappedSymbol = GetMappedSymbol(request, date);
+                    if (useMapFiles)
+                    {
+                        request.Configuration.MappedSymbol = GetMappedSymbol(request.Configuration, date);
+                    }
                     var source = sourceFactory.GetSource(request.Configuration, date, _isLiveMode);
                     var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, request.Configuration, date, _isLiveMode);
                     var entriesForDate = factory.Read(source);
@@ -87,18 +91,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             }
         }
 
-        private string GetMappedSymbol(SubscriptionRequest request, DateTime date)
+        private string GetMappedSymbol(SubscriptionDataConfig config, DateTime date)
         {
-            var config = request.Configuration;
-            if (config.UsesMapFiles)
-            {
-                var mapFile = config.Symbol.HasUnderlying ?
-                        _mapFileResolver.ResolveMapFile(config.Symbol.Underlying.ID.Symbol, config.Symbol.Underlying.ID.Date) :
-                        _mapFileResolver.ResolveMapFile(config.Symbol.ID.Symbol, config.Symbol.ID.Date);
+            var mapFile = config.Symbol.HasUnderlying ?
+                    _mapFileResolver.ResolveMapFile(config.Symbol.Underlying.ID.Symbol, config.Symbol.Underlying.ID.Date) :
+                    _mapFileResolver.ResolveMapFile(config.Symbol.ID.Symbol, config.Symbol.ID.Date);
 
-                return mapFile.GetMappedSymbol(date, config.MappedSymbol);
-            }
-            return config.MappedSymbol;
+            return mapFile.GetMappedSymbol(date, config.MappedSymbol);
         }
     }
 }

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
@@ -90,8 +90,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private string GetMappedSymbol(SubscriptionRequest request, DateTime date)
         {
             var config = request.Configuration;
-            if (config.Symbol.ID.SecurityType == SecurityType.Option ||
-                config.Symbol.ID.SecurityType == SecurityType.Equity )
+            if (config.UsesMapFiles)
             {
                 var mapFile = config.Symbol.HasUnderlying ?
                         _mapFileResolver.ResolveMapFile(config.Symbol.Underlying.ID.Symbol, config.Symbol.Underlying.ID.Date) :

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
@@ -20,7 +20,6 @@ using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Interfaces;
-using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
 {
@@ -69,7 +68,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <returns>An enumerator reading the subscription request</returns>
         public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
         {
-            var sourceFactory = (BaseData)ObjectActivator.GetActivator(request.Configuration.Type).Invoke(new object[] { request.Configuration.Type });
+            var sourceFactory = request.Configuration.Type.GetBaseDataInstance();
             var useMapFiles = request.Configuration.ShouldUseMapFiles();
 
             using (var dataCacheProvider = new SingleEntryDataCacheProvider(dataProvider))

--- a/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
@@ -80,34 +80,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             MapFileResolver mapFileResolver)
         {
             var mapFileToUse = new MapFile(config.Symbol.Value, new List<MapFileRow>());
+            var hasUnderlying = config.Symbol.HasUnderlying;
 
-            // load up the map and factor files for equities
-            if (!config.IsCustomData && config.SecurityType == SecurityType.Equity)
+            // load up the map and factor files for equities, options, and custom data
+            if (config.UsesMapFiles)
             {
                 try
                 {
-                    var mapFile = mapFileResolver.ResolveMapFile(
-                        config.Symbol.ID.Symbol,
-                        config.Symbol.ID.Date);
+                    var symbol = hasUnderlying ? config.Symbol.Underlying.ID.Symbol : config.Symbol.ID.Symbol;
+                    var date = hasUnderlying ? config.Symbol.Underlying.ID.Date : config.Symbol.ID.Date;
 
-                    // only take the resolved map file if it has data, otherwise we'll use the empty one we defined above
-                    if (mapFile.Any()) mapFileToUse = mapFile;
-                }
-                catch (Exception err)
-                {
-                    Log.Error(err, "CorporateEventEnumeratorFactory.GetMapFileToUse():" +
-                        " Map File: " + config.Symbol.ID + ": ");
-                }
-            }
-
-            // load up the map and factor files for underlying of equity option
-            if (!config.IsCustomData && config.SecurityType == SecurityType.Option)
-            {
-                try
-                {
-                    var mapFile = mapFileResolver.ResolveMapFile(
-                        config.Symbol.Underlying.ID.Symbol,
-                        config.Symbol.Underlying.ID.Date);
+                    var mapFile = mapFileResolver.ResolveMapFile(symbol, date);
 
                     // only take the resolved map file if it has data, otherwise we'll use the empty one we defined above
                     if (mapFile.Any()) mapFileToUse = mapFile;

--- a/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             var hasUnderlying = config.Symbol.HasUnderlying;
 
             // load up the map and factor files for equities, options, and custom data
-            if (config.UsesMapFiles)
+            if (config.ShouldUseMapFiles())
             {
                 try
                 {
@@ -93,7 +93,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                     var mapFile = mapFileResolver.ResolveMapFile(symbol, date);
 
                     // only take the resolved map file if it has data, otherwise we'll use the empty one we defined above
-                    if (mapFile.Any()) mapFileToUse = mapFile;
+                    if (mapFile.Any())
+                    {
+                        mapFileToUse = mapFile;
+                    }
                 }
                 catch (Exception err)
                 {

--- a/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/CorporateEventEnumeratorFactory.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             var hasUnderlying = config.Symbol.HasUnderlying;
 
             // load up the map and factor files for equities, options, and custom data
-            if (config.ShouldUseMapFiles())
+            if (config.TickerShouldBeMapped())
             {
                 try
                 {

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             // also provides some immediate fast-forward to handle spooling through remote files quickly
             var frontier = Ref.Create(request.StartTimeLocal);
             var lastSourceRefreshTime = DateTime.MinValue;
-            var sourceFactory = (BaseData) ObjectActivator.GetActivator(config.Type).Invoke(new object[] {config.Type});
+            var sourceFactory = config.Type.GetBaseDataInstance();
 
             // this is refreshing the enumerator stack for each new source
             var refresher = new RefreshEnumerator<BaseData>(() =>

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -74,8 +74,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <returns>An enumerator reading the subscription request</returns>
         public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
         {
-            var mapFileResolver = request.Configuration.SecurityType == SecurityType.Equity ||
-                                  request.Configuration.SecurityType == SecurityType.Option
+            var mapFileResolver = request.Configuration.UsesMapFiles 
                                     ? _mapFileProvider.Get(request.Security.Symbol.ID.Market)
                                     : MapFileResolver.Empty;
 

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <returns>An enumerator reading the subscription request</returns>
         public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
         {
-            var mapFileResolver = request.Configuration.ShouldUseMapFiles()
+            var mapFileResolver = request.Configuration.TickerShouldBeMapped()
                                     ? _mapFileProvider.Get(request.Security.Symbol.ID.Market)
                                     : MapFileResolver.Empty;
 

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <returns>An enumerator reading the subscription request</returns>
         public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
         {
-            var mapFileResolver = request.Configuration.UsesMapFiles 
+            var mapFileResolver = request.Configuration.ShouldUseMapFiles()
                                     ? _mapFileProvider.Get(request.Security.Symbol.ID.Market)
                                     : MapFileResolver.Empty;
 

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -213,7 +213,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             // load up the map files for equities, options, and custom data if it supports it.
             // Only load up factor files for equities
-            if (_config.ShouldUseMapFiles())
+            if (_config.TickerShouldBeMapped())
             {
                 try
                 {

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -169,7 +169,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             //Save the type of data we'll be getting from the source.
             try
             {
-                _dataFactory = (BaseData) _config.Type.GetBaseDataInstance();
+                _dataFactory = _config.Type.GetBaseDataInstance();
             }
             catch (ArgumentException exception)
             {

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -21,7 +21,6 @@ using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds.Transport;
-using QuantConnect.Util;
 using System.Runtime.Caching;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
@@ -82,7 +81,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _date = date;
             _config = config;
             _isLiveMode = isLiveMode;
-            _factory = (BaseData) ObjectActivator.GetActivator(config.Type).Invoke(new object[] { config.Type });
+            _factory = config.Type.GetBaseDataInstance();
             _shouldCacheDataPoints = !_config.IsCustomData && _config.Resolution >= Resolution.Hour
                 && _config.Type != typeof(FineFundamental) && _config.Type != typeof(CoarseFundamental)
 		&& !_dataCacheProvider.IsDataEphemeral;

--- a/Engine/DataFeeds/ZipEntryNameSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/ZipEntryNameSubscriptionDataSourceReader.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _config = config;
             _date = date;
             _isLiveMode = isLiveMode;
-            _factory = _factory = (BaseData)ObjectActivator.GetActivator(config.Type).Invoke(new object[] { config.Type });
+            _factory = _factory = config.Type.GetBaseDataInstance();
         }
 
         /// <summary>

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -104,12 +104,11 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 SymbolProperties.GetDefault(Currencies.NullCurrency),
                 ErrorCurrencyConverter.Instance
             );
-            var mapFileResolver = config.UsesMapFiles
-                ? _mapFileProvider.Get(config.Market)
-                : MapFileResolver.Empty;
 
-            if (config.UsesMapFiles)
+            var mapFileResolver = MapFileResolver.Empty;
+            if (config.ShouldUseMapFiles())
             {
+                mapFileResolver = _mapFileProvider.Get(config.Market);
                 var mapFile = mapFileResolver.ResolveMapFile(config.Symbol.ID.Symbol, config.Symbol.ID.Date);
                 config.MappedSymbol = mapFile.GetMappedSymbol(start, config.MappedSymbol);
             }

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -106,7 +106,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             );
 
             var mapFileResolver = MapFileResolver.Empty;
-            if (config.ShouldUseMapFiles())
+            if (config.TickerShouldBeMapped())
             {
                 mapFileResolver = _mapFileProvider.Get(config.Market);
                 var mapFile = mapFileResolver.ResolveMapFile(config.Symbol.ID.Symbol, config.Symbol.ID.Date);

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -104,11 +104,11 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 SymbolProperties.GetDefault(Currencies.NullCurrency),
                 ErrorCurrencyConverter.Instance
             );
-            var mapFileResolver = config.SecurityType == SecurityType.Equity
+            var mapFileResolver = config.UsesMapFiles
                 ? _mapFileProvider.Get(config.Market)
                 : MapFileResolver.Empty;
 
-            if (config.SecurityType == SecurityType.Equity)
+            if (config.UsesMapFiles)
             {
                 var mapFile = mapFileResolver.ResolveMapFile(config.Symbol.ID.Symbol, config.Symbol.ID.Date);
                 config.MappedSymbol = mapFile.GetMappedSymbol(start, config.MappedSymbol);

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -213,6 +213,17 @@ namespace QuantConnect.Tests.Algorithm
             Assert.DoesNotThrow(() => qcAlgorithm.SubscriptionManager.AddConsolidator("SCF/CME_CL1_ON", quandlConsolidator));
         }
 
+        [Test]
+        public void AddingInvalidDataTypeThrows()
+        {
+            var qcAlgorithm = new QCAlgorithm();
+            qcAlgorithm.SubscriptionManager.SetDataManager(new DataManagerStub(qcAlgorithm));
+            Assert.Throws<ArgumentException>(() => qcAlgorithm.AddData(typeof(double),
+                "double",
+                Resolution.Daily,
+                DateTimeZone.Utc));
+        }
+
         private static SubscriptionDataConfig GetMatchingSubscription(Security security, Type type)
         {
             // find a subscription matchin the requested type with a higher resolution than requested

--- a/Tests/Common/Securities/SecurityIdentifierTests.cs
+++ b/Tests/Common/Securities/SecurityIdentifierTests.cs
@@ -253,7 +253,7 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void DeserializesFromSimpleStringWithinContainerClass()
         {
-            var sid = new Container{sid =SPY};
+            var sid = new Container { sid = SPY };
             var str =
 @"
 {
@@ -302,6 +302,32 @@ namespace QuantConnect.Tests.Common.Securities
         public void ThrowsOnInvalidSymbolCharacters(string input)
         {
             new SecurityIdentifier(input, 0);
+        }
+
+        [Test]
+        public void GenerateEquityWithTickerUsingMapFile()
+        {
+            var expectedFirstDate = new DateTime(1998, 1, 2);
+            var sid = SecurityIdentifier.GenerateWithFirstDate("TWX", Market.USA, SecurityType.Equity, true);
+
+            Assert.AreEqual(sid.Date, expectedFirstDate);
+            Assert.AreEqual(sid.Symbol, "AOL");
+        }
+        
+        [Test]
+        public void GenerateBaseDataWithTickerUsingMapFile()
+        {
+            var expectedFirstDate = new DateTime(1998, 1, 2);
+            var sid = SecurityIdentifier.GenerateWithFirstDate("TWX", Market.USA, SecurityType.Base);
+
+            Assert.AreEqual(sid.Date, expectedFirstDate);
+            Assert.AreEqual(sid.Symbol, "AOL");
+        }
+        
+        [Test]
+        public void AttemptToGenerateFromMapFileWithNotSupportedSecurityType()
+        {
+            Assert.Throws<ArgumentException>(() => { SecurityIdentifier.GenerateWithFirstDate("CL", Market.USA, SecurityType.Future); });
         }
 
         class Container

--- a/Tests/Common/Securities/SecurityIdentifierTests.cs
+++ b/Tests/Common/Securities/SecurityIdentifierTests.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using QuantConnect.Data.Auxiliary;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -308,7 +309,7 @@ namespace QuantConnect.Tests.Common.Securities
         public void GenerateEquityWithTickerUsingMapFile()
         {
             var expectedFirstDate = new DateTime(1998, 1, 2);
-            var sid = SecurityIdentifier.GenerateWithFirstDate("TWX", Market.USA, SecurityType.Equity, true);
+            var sid = SecurityIdentifier.GenerateEquity("TWX", Market.USA, mapSymbol: true, mapFileProvider: new LocalDiskMapFileProvider());
 
             Assert.AreEqual(sid.Date, expectedFirstDate);
             Assert.AreEqual(sid.Symbol, "AOL");
@@ -318,18 +319,12 @@ namespace QuantConnect.Tests.Common.Securities
         public void GenerateBaseDataWithTickerUsingMapFile()
         {
             var expectedFirstDate = new DateTime(1998, 1, 2);
-            var sid = SecurityIdentifier.GenerateWithFirstDate("TWX", Market.USA, SecurityType.Base);
+            var sid = SecurityIdentifier.GenerateBase("TWX", Market.USA, mapSymbol: true);
 
             Assert.AreEqual(sid.Date, expectedFirstDate);
             Assert.AreEqual(sid.Symbol, "AOL");
         }
         
-        [Test]
-        public void AttemptToGenerateFromMapFileWithNotSupportedSecurityType()
-        {
-            Assert.Throws<ArgumentException>(() => { SecurityIdentifier.GenerateWithFirstDate("CL", Market.USA, SecurityType.Future); });
-        }
-
         class Container
         {
             public SecurityIdentifier sid;

--- a/Tests/Engine/HistoricalData/SubscriptionDataReaderHistoryProviderTests.cs
+++ b/Tests/Engine/HistoricalData/SubscriptionDataReaderHistoryProviderTests.cs
@@ -1,0 +1,120 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.HistoricalData;
+using QuantConnect.Securities;
+using HistoryRequest = QuantConnect.Data.HistoryRequest;
+
+namespace QuantConnect.Tests.Engine.HistoricalData
+{
+    [TestFixture]
+    public class SubscriptionDataReaderHistoryProviderTests
+    {
+        [Test]
+        public void OptionsAreMappedCorrectly()
+        {
+            var historyProvider = new SubscriptionDataReaderHistoryProvider();
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(
+                null,
+                null,
+                new DefaultDataProvider(),
+                new ZipDataCacheProvider(new DefaultDataProvider()), 
+                new LocalDiskMapFileProvider(),
+                new LocalDiskFactorFileProvider(),
+                null));
+            var symbol = Symbol.CreateOption(
+                "FOXA",
+                Market.USA,
+                OptionStyle.American,
+                OptionRight.Call,
+                32,
+                new DateTime(2013, 07, 20));
+
+            var result = historyProvider.GetHistory(
+                new[]
+                {
+                    new HistoryRequest(new DateTime(2013, 06,28),
+                        new DateTime(2013, 07,03),
+                        typeof(QuoteBar),
+                        symbol,
+                        Resolution.Minute,
+                        SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                        TimeZones.NewYork,
+                        null,
+                        false,
+                        false,
+                        DataNormalizationMode.Raw,
+                        TickType.Quote)
+                },
+                TimeZones.NewYork).ToList();
+
+            Assert.IsNotEmpty(result);
+
+            // assert we fetch the data for the previous and new symbol
+            var firstBar = result.First().Values.Single();
+            var lastBar = result.Last().Values.Single();
+
+            Assert.IsTrue(firstBar.Symbol.Value.Contains("NWSA"));
+            Assert.AreEqual(28, firstBar.Time.Date.Day);
+            Assert.IsTrue(lastBar.Symbol.Value.Contains("FOXA"));
+            Assert.AreEqual(2, lastBar.Time.Date.Day);
+        }
+
+        [Test]
+        public void EquitiesAreMappedCorrectly()
+        {
+            var historyProvider = new SubscriptionDataReaderHistoryProvider();
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(
+                null,
+                null,
+                new DefaultDataProvider(),
+                new ZipDataCacheProvider(new DefaultDataProvider()),
+                new LocalDiskMapFileProvider(),
+                new LocalDiskFactorFileProvider(),
+                null));
+            var symbol = Symbol.Create("WM",SecurityType.Equity,Market.USA);
+
+            var result = historyProvider.GetHistory(
+                new[]
+                {
+                    new HistoryRequest(new DateTime(2000, 01,01),
+                        new DateTime(2000, 01,05),
+                        typeof(TradeBar),
+                        symbol,
+                        Resolution.Daily,
+                        SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                        TimeZones.NewYork,
+                        null,
+                        false,
+                        false,
+                        DataNormalizationMode.Raw,
+                        TickType.Trade)
+                },
+                TimeZones.NewYork).ToList();
+
+            var firstBar = result.First().Values.Single();
+            Assert.IsTrue(firstBar.Symbol.Value.Contains("WMI"));
+            Assert.IsNotEmpty(result);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -346,6 +346,7 @@
     <Compile Include="Engine\DataFeeds\Transport\RemoteFileSubscriptionStreamReaderTests.cs" />
     <Compile Include="Engine\DataFeeds\UniverseSelectionTests.cs" />
     <Compile Include="Engine\DataFeeds\SubscriptionTests.cs" />
+    <Compile Include="Engine\HistoricalData\SubscriptionDataReaderHistoryProviderTests.cs" />
     <Compile Include="Engine\RealTime\BacktestingRealTimeHandlerTests.cs" />
     <Compile Include="Indicators\PythonIndicatorNoinheritanceTests.cs" />
     <Compile Include="Indicators\PythonIndicatorTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
**Changes on top of PR https://github.com/QuantConnect/Lean/pull/3338** - Thank you @gsalaz98
 
 Slightly different approach in the sense that each custom data type will define whether or not it should use map files:
- Moving `UsesMapFiles` to each custom data type (instead of a 3rd static entity)
- Updating regression test with sample custom data using map files,
which can run locally
- Adding unit tests for the `SubscriptionDataReaderHistoryProvider`,
checking it maps equities and options correctly (bug in `master` - good catch @gsalaz98!)
- Adding unit test which asserts `Algorithm.AddData()` throws if provided an invalid data type (bug in `master`)

**Note:** With the help of @gsalaz98 it was noted that `FillForward` enumerators will ignore new mappings while filling forward, since it will continue to use the `previous` emitted bar (with the old Symbol value) 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3296
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows using map files for custom data.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->