### PR TITLE
Benchmark Symbol will not be added to cache

### DIFF
--- a/Algorithm.CSharp/CustomBenchmarkAlgorithm.cs
+++ b/Algorithm.CSharp/CustomBenchmarkAlgorithm.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
@@ -50,6 +51,12 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 SetHoldings("SPY", 1);
                 Debug("Purchased Stock");
+            }
+
+            Symbol symbol;
+            if (SymbolCache.TryGetSymbol("AAPL", out symbol))
+            {
+                throw new Exception("Benchmark Symbol is not expected to be added to the Symbol cache");
             }
         }
 

--- a/Algorithm.CSharp/CustomUniverseWithBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomUniverseWithBenchmarkRegressionAlgorithm.cs
@@ -60,6 +60,14 @@ namespace QuantConnect.Algorithm.CSharp
 
             // internal daily resolution
             SetBenchmark("SPY");
+
+            Symbol symbol;
+            if (!SymbolCache.TryGetSymbol("SPY", out symbol)
+                || !ReferenceEquals(_spy, symbol))
+            {
+                throw new Exception("We expected 'SPY' to be added to the Symbol cache," +
+                                    " since the algorithm is also using it");
+            }
         }
 
         /// <summary>

--- a/Algorithm.Python/CustomBenchmarkAlgorithm.py
+++ b/Algorithm.Python/CustomBenchmarkAlgorithm.py
@@ -43,3 +43,7 @@ class CustomBenchmarkAlgorithm(QCAlgorithm):
         if not self.Portfolio.Invested:
             self.SetHoldings("SPY", 1)
             self.Debug("Purchased Stock")
+
+        tupleResult = SymbolCache.TryGetSymbol("AAPL", None)
+        if tupleResult[0]:
+            raise Exception("Benchmark Symbol is not expected to be added to the Symbol cache")

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -551,7 +551,8 @@ namespace QuantConnect.Algorithm
 
                 var security = Securities.CreateSecurity(_benchmarkSymbol,
                     new List<SubscriptionDataConfig>(),
-                    leverage: 1);
+                    leverage: 1,
+                    addToSymbolCache:false);
 
                 Benchmark = new SecurityBenchmark(security);
             }

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -50,6 +50,8 @@ namespace QuantConnect.Tests
             var algorithmManager = new AlgorithmManager(false);
 
             Composer.Instance.Reset();
+            SymbolCache.Clear();
+
             var ordersLogFile = string.Empty;
             var logFile = $"./regression/{algorithm}.{language.ToLower()}.log";
             Directory.CreateDirectory(Path.GetDirectoryName(logFile));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Benchmark Symbol will not be added to cache
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to PR https://github.com/QuantConnect/Lean/pull/3431, issues https://github.com/QuantConnect/Lean/issues/2260 and https://github.com/QuantConnect/Lean/issues/2381
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Do not add the benchmark symbol to the cache
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->