### PR TITLE
Replace WebSocketSharp library with System.Net.WebSockets

### DIFF
--- a/Api/QuantConnect.Api.csproj
+++ b/Api/QuantConnect.Api.csproj
@@ -117,10 +117,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="websocket-sharp, Version=1.0.4.0, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebSocketSharpFork.1.0.4.0\lib\net35\websocket-sharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs">

--- a/Api/packages.config
+++ b/Api/packages.config
@@ -13,5 +13,4 @@
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
   <package id="RestSharp" version="106.6.10" targetFramework="net452" />
   <package id="StringInterpolationBridgeStrong" version="0.9.1" targetFramework="net452" />
-  <package id="WebSocketSharpFork" version="1.0.4.0" targetFramework="net45" />
 </packages>

--- a/Brokerages/BaseWebsocketsBrokerage.cs
+++ b/Brokerages/BaseWebsocketsBrokerage.cs
@@ -21,16 +21,15 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
+using QuantConnect.Util;
 
 namespace QuantConnect.Brokerages
 {
-
     /// <summary>
     /// Provides shared brokerage websockets implementation
     /// </summary>
     public abstract class BaseWebsocketsBrokerage : Brokerage
     {
-
         #region Declarations
         /// <summary>
         /// The list of queued ticks
@@ -270,6 +269,14 @@ namespace QuantConnect.Brokerages
             }
         }
 
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public override void Dispose()
+        {
+            WebSocket.DisposeSafely();
+        }
+
         private void Wait(int timeout, Func<bool> state)
         {
             var StartTime = Environment.TickCount;
@@ -321,7 +328,5 @@ namespace QuantConnect.Brokerages
             /// </summary>
             public string Symbol { get; set; }
         }
-
     }
-
 }

--- a/Brokerages/IWebSocket.cs
+++ b/Brokerages/IWebSocket.cs
@@ -12,17 +12,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
 using System;
 
 namespace QuantConnect.Brokerages
 {
-
     /// <summary>
-    /// Wrapper for WebSocket4Net to enhance testability
+    /// Wrapper for ClientWebSocket to enhance testability
     /// </summary>
-    public interface IWebSocket
+    public interface IWebSocket : IDisposable
     {
-
         /// <summary>
         /// Wraps constructor
         /// </summary>

--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -311,10 +311,10 @@
     <Compile Include="IWebSocket.cs" />
     <Compile Include="GDAX\Messages.cs" />
     <Compile Include="ApiPriceProvider.cs" />
+    <Compile Include="WebSocketWrapper.cs" />
     <Compile Include="WebSocketCloseData.cs" />
     <Compile Include="WebSocketError.cs" />
     <Compile Include="WebSocketMessage.cs" />
-    <Compile Include="WebSocketWrapper.cs" />
     <Compile Include="InteractiveBrokers\Client\AccountDownloadEndEventArgs.cs" />
     <Compile Include="InteractiveBrokers\Client\AccountSummaryEventArgs.cs" />
     <Compile Include="InteractiveBrokers\Client\ActionSide.cs" />

--- a/Brokerages/WebSocketCloseData.cs
+++ b/Brokerages/WebSocketCloseData.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System.Net.WebSockets;
+
 namespace QuantConnect.Brokerages
 {
     /// <summary>
@@ -23,7 +25,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Gets the status code for the connection close.
         /// </summary>
-        public ushort Code { get; }
+        public WebSocketCloseStatus Code { get; }
 
         /// <summary>
         /// Gets the reason for the connection close.
@@ -31,21 +33,14 @@ namespace QuantConnect.Brokerages
         public string Reason { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the connection has been closed cleanly.
-        /// </summary>
-        public bool WasClean { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="WebSocketCloseData"/> class
         /// </summary>
         /// <param name="code">The status code for the connection close</param>
-        /// <param name="reason">The reaspn for the connection close</param>
-        /// <param name="wasClean">True if the connection has been closed cleanly, false otherwise</param>
-        public WebSocketCloseData(ushort code, string reason, bool wasClean)
+        /// <param name="reason">The reason for the connection close</param>
+        public WebSocketCloseData(WebSocketCloseStatus code, string reason)
         {
             Code = code;
             Reason = reason;
-            WasClean = wasClean;
         }
     }
 }

--- a/Launcher/app.config
+++ b/Launcher/app.config
@@ -14,10 +14,6 @@
         <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-0.1.25.0" newVersion="0.1.25.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebSocket4Net" publicKeyToken="eb4e154b696bf72a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.15.2.0" newVersion="0.15.2.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -426,7 +426,7 @@ namespace QuantConnect.Tests.Brokerages
             // now go net short
             var order = PlaceOrderWaitForStatus(parameters.CreateShortOrder(2 * GetDefaultQuantity()), parameters.ExpectedStatus);
 
-            if (parameters.ModifyUntilFilled)
+            if (order.Type != OrderType.Market && parameters.ModifyUntilFilled)
             {
                 ModifyOrderUntilFilled(order, parameters);
             }
@@ -444,14 +444,14 @@ namespace QuantConnect.Tests.Brokerages
             // now go long
             var order = PlaceOrderWaitForStatus(parameters.CreateLongOrder(2 * GetDefaultQuantity()), parameters.ExpectedStatus);
 
-            if (parameters.ModifyUntilFilled)
+            if (order.Type != OrderType.Market && parameters.ModifyUntilFilled)
             {
                 ModifyOrderUntilFilled(order, parameters);
             }
         }
 
         [Test]
-        public void GetCashBalanceContainsUSD()
+        public virtual void GetCashBalanceContainsUsd()
         {
             Log.Trace("");
             Log.Trace("GET CASH BALANCE");
@@ -461,7 +461,7 @@ namespace QuantConnect.Tests.Brokerages
         }
 
         [Test]
-        public void GetAccountHoldings()
+        public virtual void GetAccountHoldings()
         {
             Log.Trace("");
             Log.Trace("GET ACCOUNT HOLDINGS");

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -193,10 +193,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="websocket-sharp, Version=1.0.4.0, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebSocketSharpFork.1.0.4.0\lib\net35\websocket-sharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="WebSocket4Net, Version=0.15.2.11, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
       <HintPath>..\packages\WebSocket4Net.0.15.2\lib\net45\WebSocket4Net.dll</HintPath>
       <Private>True</Private>

--- a/Tests/app.config
+++ b/Tests/app.config
@@ -18,10 +18,6 @@
         <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebSocket4Net" publicKeyToken="eb4e154b696bf72a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.15.2.11" newVersion="0.15.2.11" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -21,5 +21,4 @@
   <package id="QuantConnect.pythonnet" version="1.0.5.20" targetFramework="net452" />
   <package id="RestSharp" version="106.6.10" targetFramework="net452" />
   <package id="StringInterpolationBridgeStrong" version="0.9.1" targetFramework="net452" />
-  <package id="WebSocketSharpFork" version="1.0.4.0" targetFramework="net45" />
 </packages>

--- a/ToolBox/CoinApi/CoinApiDataQueueHandler.cs
+++ b/ToolBox/CoinApi/CoinApiDataQueueHandler.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.ToolBox.CoinApi
 
             _webSocket.Connect();
 
-            new Thread(new ThreadStart(MessagesProcessorThread)).Start();
+            new Thread(MessagesProcessorThread).Start();
         }
 
         private void MessagesProcessorThread()
@@ -206,6 +206,8 @@ namespace QuantConnect.ToolBox.CoinApi
             {
                 _webSocket.Close();
             }
+
+            _webSocket.DisposeSafely();
         }
 
         /// <summary>

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -183,9 +183,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="websocket-sharp, Version=1.0.4.0, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebSocketSharpFork.1.0.4.0\lib\net35\websocket-sharp.dll</HintPath>
-    </Reference>
     <Reference Include="WebSocket4Net, Version=0.15.2.11, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
       <HintPath>..\packages\WebSocket4Net.0.15.2\lib\net45\WebSocket4Net.dll</HintPath>
     </Reference>

--- a/ToolBox/packages.config
+++ b/ToolBox/packages.config
@@ -20,5 +20,4 @@
   <package id="SuperSocket.ClientEngine.Core" version="0.10.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net452" />
   <package id="WebSocket4Net" version="0.15.2" targetFramework="net452" />
-  <package id="WebSocketSharpFork" version="1.0.4.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION

#### Description
- The `WebSocketSharp` library reference has been removed and replaced with the usage of the standard `System.Net.WebSocket` classes in the LEAN `WebSocketWrapper` class.
- The `IWebSocket` interface now inherits from `IDisposable`.
- The GDAX Brokerage unit tests, which require a real account and for this reason are excluded from Travis build, have been updated and fixed -- they were failing on current master.

#### Related Issue
n/a

#### Motivation and Context
- Increase the stability of the crypto live data feeds

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Local testing with crypto brokerages
- Brokerage unit tests
- QC back-end software

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.