### PR TITLE
Allows Custom Data With BitfinexBrokerageModel

### DIFF
--- a/Common/Brokerages/BitfinexBrokerageModel.cs
+++ b/Common/Brokerages/BitfinexBrokerageModel.cs
@@ -15,11 +15,8 @@
 
 using System;
 using System.Collections.Generic;
-using QuantConnect.Orders;
 using QuantConnect.Securities;
-using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Fees;
-using System.Linq;
 using QuantConnect.Util;
 
 namespace QuantConnect.Brokerages
@@ -39,7 +36,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="BitfinexBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to <see cref="AccountType.Margin"/></param>
+        /// <param name="accountType">The type of account to be modeled, defaults to <see cref="AccountType.Margin"/></param>
         public BitfinexBrokerageModel(AccountType accountType = AccountType.Margin)
             : base(accountType)
         {
@@ -66,19 +63,17 @@ namespace QuantConnect.Brokerages
         /// <returns></returns>
         public override decimal GetLeverage(Security security)
         {
-            if (AccountType == AccountType.Cash || security.IsInternalFeed())
+            if (AccountType == AccountType.Cash || security.IsInternalFeed() || security.Type == SecurityType.Base)
             {
                 return 1m;
             }
 
-            switch (security.Type)
+            if (security.Type == SecurityType.Crypto)
             {
-                case SecurityType.Crypto:
-                    return _maxLeverage;
-
-                default:
-                    throw new ArgumentException($"Invalid security type: {security.Type}", nameof(security));
+                return _maxLeverage;
             }
+
+            throw new ArgumentException($"Invalid security type: {security.Type}", nameof(security));
         }
 
         /// <summary>

--- a/Tests/Common/Brokerages/BitfinexBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BitfinexBrokerageModelTests.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using NUnit.Framework;
 using QuantConnect.Brokerages;
 using QuantConnect.Data;
@@ -62,6 +63,54 @@ namespace QuantConnect.Tests.Common.Brokerages
             BitfinexBrokerageModel model = new BitfinexBrokerageModel(AccountType.Margin);
             Assert.IsInstanceOf<SecurityMarginModel>(model.GetBuyingPowerModel(Security));
             Assert.AreEqual(3.3M, model.GetLeverage(Security));
+        }
+
+        [Test]
+        public void GetEquityLeverage_ThrowsArgumentException_Test()
+        {
+            var equity = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbols.SPY,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    false,
+                    false,
+                    false
+                ),
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance
+            );
+
+            var model = new BitfinexBrokerageModel();
+            Assert.Throws<ArgumentException>(() => model.GetLeverage(equity));
+        }
+
+        [Test]
+        public void GetCustomDataLeverageTest()
+        {
+            var dummy = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    QuantConnect.Symbol.Create("DUMMY", SecurityType.Base, Market.Bitfinex),
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    false,
+                    false,
+                    false
+                ),
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance
+            );
+
+            var model = new BitfinexBrokerageModel();
+            Assert.AreEqual(1M, model.GetLeverage(dummy));
         }
     }
 }


### PR DESCRIPTION
#### Description
Changes `BitfinexBrokerageModel.GetLeverage(Security)` to not throw exception for custom data types (`SecurityType.Base`).

#### Related Issue
Closes #3557 

#### Motivation and Context
Custom Data can be used with every brokerage model.

#### How Has This Been Tested?
New unit tests and test algorithm from issue #3557.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`