### PR TITLE
Update macOS instructions to include exact working version of Python@3.6.6

### DIFF
--- a/Algorithm.Python/readme.md
+++ b/Algorithm.Python/readme.md
@@ -17,6 +17,7 @@ Before we enable python support, follow the [installation instructions](https://
 5. Reboot computer to ensure changes are propogated. 
 
 #### [macOS](https://github.com/QuantConnect/Lean#macos)
+
 1. Use the macOS x86-64 package installer from [Anaconda](https://repo.anaconda.com/archive/Anaconda3-5.2.0-MacOSX-x86_64.pkg) and follow "[Installing on macOS](https://docs.anaconda.com/anaconda/install/mac-os)" instructions from Anaconda documentation page.
 2. Install [pandas](https://pandas.pydata.org/) and its [dependencies](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies).
 
@@ -31,6 +32,7 @@ Before we enable python support, follow the [installation instructions](https://
     <dllmap dll="python3.6m" target="{the path in step 1 including libpython3.6m.dylib}" os="!windows"/>
 </configuration>
 ```
+3. Consider specifying the install of 3.6.6 exactly, e.g. with conda `conda install python=3.6.6` as this is a known compatible version and other versions may have issues as of this writing.
 
 #### [Linux](https://github.com/QuantConnect/Lean#linux-debian-ubuntu)
 By default, **miniconda** is installed in the users home directory (`$HOME`):

--- a/Algorithm.Python/readme.md
+++ b/Algorithm.Python/readme.md
@@ -32,7 +32,7 @@ Before we enable python support, follow the [installation instructions](https://
     <dllmap dll="python3.6m" target="{the path in step 1 including libpython3.6m.dylib}" os="!windows"/>
 </configuration>
 ```
-3. Consider specifying the install of 3.6.6 exactly, e.g. with conda `conda install python=3.6.6` as this is a known compatible version and other versions may have issues as of this writing.
+Note: Specify the install of v3.6.6 _exactly_, i.e. if with conda `conda install python=3.6.6` as this is a known compatible version and other versions may have issues as of this writing. 
 
 #### [Linux](https://github.com/QuantConnect/Lean#linux-debian-ubuntu)
 By default, **miniconda** is installed in the users home directory (`$HOME`):


### PR DESCRIPTION
#### Description
After a long debugging session, 3.6.6 but not 3.6.9 works flawlessly. I've added notes to this documentation to help future readers.

#### Motivation and Context
Installation difficulty alleviation.

#### Requires Documentation Change
A change to the installation docs.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. (Not applicable. Only docs changes.)
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>` (Not applicable. Change from fork.)