### PR TITLE
Fix error when CoinApi symbol list has duplicates

### DIFF
--- a/ToolBox/CoinApi/CoinApiSymbolMapper.cs
+++ b/ToolBox/CoinApi/CoinApiSymbolMapper.cs
@@ -110,13 +110,13 @@ namespace QuantConnect.ToolBox.CoinApi
             var parts = brokerageSymbol.Split('_');
             if (parts.Length != 4 || parts[1] != "SPOT")
             {
-                Log.Error($"CoinApiSymbolMapper.GetLeanSymbol(): Unsupported SymbolId: {brokerageSymbol}");
+                throw new Exception($"CoinApiSymbolMapper.GetLeanSymbol(): Unsupported SymbolId: {brokerageSymbol}");
             }
 
             string symbolMarket;
             if (!MapExchangeIdsToMarkets.TryGetValue(parts[0], out symbolMarket))
             {
-                Log.Error($"CoinApiSymbolMapper.GetLeanSymbol(): Unsupported SymbolId: {brokerageSymbol}");
+                throw new Exception($"CoinApiSymbolMapper.GetLeanSymbol(): Unsupported ExchangeId: {parts[0]}");
             }
 
             var baseCurrency = ConvertCoinApiCurrencyToLeanCurrency(parts[2], symbolMarket);

--- a/ToolBox/CoinApi/CoinApiSymbolMapper.cs
+++ b/ToolBox/CoinApi/CoinApiSymbolMapper.cs
@@ -165,6 +165,9 @@ namespace QuantConnect.ToolBox.CoinApi
 
             var result = JsonConvert.DeserializeObject<List<CoinApiSymbol>>(json);
 
+            // There were cases of entries in the CoinApiSymbols list with the following pattern:
+            // <Exchange>_SPOT_<BaseCurrency>_<QuoteCurrency>_<ExtraSuffix>
+            // Those cases should be ignored for SPOT prices.
             _symbolMap = result
                 .Where(x => x.SymbolType == "SPOT" && x.SymbolId.Split('_').Length == 4)
                 .ToDictionary(

--- a/ToolBox/CoinApi/CoinApiSymbolMapper.cs
+++ b/ToolBox/CoinApi/CoinApiSymbolMapper.cs
@@ -110,13 +110,13 @@ namespace QuantConnect.ToolBox.CoinApi
             var parts = brokerageSymbol.Split('_');
             if (parts.Length != 4 || parts[1] != "SPOT")
             {
-                throw new Exception($"CoinApiSymbolMapper.GetLeanSymbol(): Unsupported SymbolId: {brokerageSymbol}");
+                Log.Error($"CoinApiSymbolMapper.GetLeanSymbol(): Unsupported SymbolId: {brokerageSymbol}");
             }
 
             string symbolMarket;
             if (!MapExchangeIdsToMarkets.TryGetValue(parts[0], out symbolMarket))
             {
-                throw new Exception($"CoinApiSymbolMapper.GetLeanSymbol(): Unsupported ExchangeId: {parts[0]}");
+                Log.Error($"CoinApiSymbolMapper.GetLeanSymbol(): Unsupported SymbolId: {brokerageSymbol}");
             }
 
             var baseCurrency = ConvertCoinApiCurrencyToLeanCurrency(parts[2], symbolMarket);
@@ -166,7 +166,7 @@ namespace QuantConnect.ToolBox.CoinApi
             var result = JsonConvert.DeserializeObject<List<CoinApiSymbol>>(json);
 
             _symbolMap = result
-                .Where(x => x.SymbolType == "SPOT")
+                .Where(x => x.SymbolType == "SPOT" && x.SymbolId.Split('_').Length == 4)
                 .ToDictionary(
                     x =>
                     {

--- a/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
@@ -83,6 +83,7 @@ namespace QuantConnect.ToolBox.CoinApiDataConverter
             var success = true;
 
             var fileToProcess = _rawDataFolder.EnumerateFiles("*.gz")
+                .Where(f => f.Name.Split('_').Length == 4)
                 .DistinctBy(
                     x =>
                     {

--- a/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
@@ -82,6 +82,9 @@ namespace QuantConnect.ToolBox.CoinApiDataConverter
             var symbolMapper = new CoinApiSymbolMapper();
             var success = true;
 
+            // There were cases of files with with an extra suffix, following pattern:
+            // <TickType>-<ID>-<Exchange>_SPOT_<BaseCurrency>_<QuoteCurrency>_<ExtraSuffix>.csv.gz
+            // Those cases should be ignored for SPOT prices.
             var fileToProcess = _rawDataFolder.EnumerateFiles("*.gz")
                 .Where(f => f.Name.Split('_').Length == 4)
                 .DistinctBy(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Handle cases where the symbol list has duplicated.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3556 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If there are duplicates, they break the crypto data processing.

We assumed CoinAPi symbol list has no duplicates, but they those cases are expected, as we can read in their docs https://docs.coinapi.io/#list-all-symbols

>  In the unlikely event when the "symbol_id" for more than one market is the same. We will append the additional term (prefixed with the "_") at the end of the duplicated identifiers to differentiate them.

After asking CoinApi support,  they inform us that symbols with the extra suffix are for edge cases.
> There could be corner-cases for other data types like FUTURES or OPTIONS, e.g., exchange lists same option but one with American and other with European execution-style

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Processed ten days of Bitfinex data.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->