### PR TITLE
Algorithm Portfolio is Updated Before New Order Event is Triggered

### DIFF
--- a/Common/Algorithm/Framework/Alphas/OrderBasedInsightGenerator.cs
+++ b/Common/Algorithm/Framework/Alphas/OrderBasedInsightGenerator.cs
@@ -72,11 +72,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 }
             }
 
-            var insightDirection = securityHolding.IsLong
-                ? InsightDirection.Up
-                : securityHolding.IsShort
-                    ? InsightDirection.Down
-                    : InsightDirection.Flat;
+            var insightDirection = (InsightDirection) Math.Sign(securityHolding.Quantity);
 
             var insight = Insight.Price(orderEvent.Symbol,
                 Time.EndOfTime,

--- a/Common/Securities/IOrderEventProvider.cs
+++ b/Common/Securities/IOrderEventProvider.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Event fired when there is a new <see cref="QuantConnect.Orders.OrderEvent"/>
         /// </summary>
-        /// <remarks>Will be called before the <see cref="SecurityPortfolioManager"/></remarks>
+        /// <remarks>Will be called after the <see cref="SecurityPortfolioManager"/></remarks>
         event EventHandler<OrderEvent> NewOrderEvent;
     }
 }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -999,15 +999,15 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
                     try
                     {
-                        // to be called before updating the Portfolio
-                        NewOrderEvent?.Invoke(this, fill);
-
                         _algorithm.Portfolio.ProcessFill(fill);
                         _algorithm.TradeBuilder.ProcessFill(
                             fill,
                             securityConversionRate,
                             feeInAccountCurrency,
                             multiplier);
+
+                        // to be called after updating the Portfolio
+                        NewOrderEvent?.Invoke(this, fill);
                     }
                     catch (Exception err)
                     {

--- a/Tests/Algorithm/Framework/Alphas/OrderBasedInsightGeneratorTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/OrderBasedInsightGeneratorTests.cs
@@ -76,6 +76,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         public void NoExistingHoldings(OrderDirection direction)
         {
             var insightGenerator = new OrderBasedInsightGenerator();
+
+            var holding =
+                new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
+
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                     1,
                     Symbols.SPY,
@@ -86,7 +91,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
                     direction == OrderDirection.Buy ? 1 : -1,
                     OrderFee.Zero
                 ),
-                new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol)));
+                holding);
 
             Assert.AreEqual(1, insight.Confidence);
             Assert.AreEqual(direction == OrderDirection.Buy
@@ -101,7 +106,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding =
                 new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? -1 : 1);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                     1,
@@ -127,7 +132,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding =
                 new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? -1 : 1);
+            holding.SetHoldings(1, 0);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
@@ -152,7 +157,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding =
                 new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 2 : -2);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
@@ -178,7 +183,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding =
                 new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? -2 : 2);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? -1 : 1);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
@@ -204,6 +209,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding = new SecurityHolding(_security,
                 new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 2 : -2);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
@@ -220,7 +226,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
             Assert.AreEqual(direction == OrderDirection.Buy
                 ? InsightDirection.Up : InsightDirection.Down, insight.Direction);
 
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? 2 : -2);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
             insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
                 Symbols.SPY,
@@ -236,7 +242,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
             Assert.AreEqual(direction == OrderDirection.Buy
                 ? InsightDirection.Up : InsightDirection.Down, insight.Direction);
 
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? .5m : -.5m);
             insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
                 Symbols.SPY,


### PR DESCRIPTION
#### Description
In `BrokerageTransactionHandler.HandleOrderEvent`, when a fill order event is handled, the `IAlgorithm.Portfolio` will be updated before the NewOrderEvent event handler is called.

Due to this change, subscribers to `IOrderEventProvider.NewOrderEvent` will have a `IAlgorithm.Portfolio` that reflects the latest fill.

- Updates OrderBasedInsightGenerator to Reflect Changes in BrokerageTransactionHandler
  - Logic in `OrderBasedInsightGenerator.GenerateInsightFromFill` was changed to assumed that `SecurityHolding` reflects  the order event.

#### Related Issue
Required for #3539

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`