### PR TITLE
Implements AssetsUnderManagementCapacityManager

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -124,6 +124,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-29.745"},
             {"Tracking Error", "0.277"},
             {"Treynor Ratio", "-6.438"},
+            {"AUM Capacity", "0.001"},
             {"Total Fees", "$15207.00"},
             {"Fitness Score", "0.033"},
             {"Kelly Criterion Estimate", "-36.472"},

--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -124,7 +124,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-29.745"},
             {"Tracking Error", "0.277"},
             {"Treynor Ratio", "-6.438"},
-            {"AUM Capacity", "0.001"},
+            {"AUM Capacity", "$2600"},
             {"Total Fees", "$15207.00"},
             {"Fitness Score", "0.033"},
             {"Kelly Criterion Estimate", "-36.472"},

--- a/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
@@ -129,6 +129,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
+            {"AUM Capacity", "0.004"},
             {"Total Fees", "$778.00"}
         };
     }

--- a/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
@@ -129,7 +129,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"AUM Capacity", "0.004"},
+            {"AUM Capacity", "$200"},
             {"Total Fees", "$778.00"}
         };
     }

--- a/Algorithm.CSharp/ConvertToFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/ConvertToFrameworkAlgorithm.cs
@@ -144,6 +144,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-0.399"},
             {"Tracking Error", "0.278"},
             {"Treynor Ratio", "0.164"},
+            {"AUM Capacity", "33790.197"},
             {"Total Fees", "$755.20"},
             {"Total Insights Generated", "85"},
             {"Total Insights Closed", "85"},

--- a/Algorithm.CSharp/ConvertToFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/ConvertToFrameworkAlgorithm.cs
@@ -144,7 +144,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-0.399"},
             {"Tracking Error", "0.278"},
             {"Treynor Ratio", "0.164"},
-            {"AUM Capacity", "33790.197"},
+            {"AUM Capacity", "$174393400"},
             {"Total Fees", "$755.20"},
             {"Total Insights Generated", "85"},
             {"Total Insights Closed", "85"},

--- a/Algorithm.CSharp/DropboxBaseDataUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/DropboxBaseDataUniverseSelectionAlgorithm.cs
@@ -202,6 +202,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-1.021"},
             {"Tracking Error", "0.103"},
             {"Treynor Ratio", "0.471"},
+            {"AUM Capacity", "99139.97"},
             {"Total Fees", "$251.12"}
         };
     }

--- a/Algorithm.CSharp/DropboxBaseDataUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/DropboxBaseDataUniverseSelectionAlgorithm.cs
@@ -202,7 +202,6 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-1.021"},
             {"Tracking Error", "0.103"},
             {"Treynor Ratio", "0.471"},
-            {"AUM Capacity", "99139.97"},
             {"Total Fees", "$251.12"}
         };
     }

--- a/Algorithm.CSharp/MACDTrendAlgorithm.cs
+++ b/Algorithm.CSharp/MACDTrendAlgorithm.cs
@@ -116,6 +116,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-0.395"},
             {"Tracking Error", "0.149"},
             {"Treynor Ratio", "0.09"},
+            {"AUM Capacity", "68106.612"},
             {"Total Fees", "$443.50"}
         };
     }

--- a/Algorithm.CSharp/MACDTrendAlgorithm.cs
+++ b/Algorithm.CSharp/MACDTrendAlgorithm.cs
@@ -116,7 +116,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-0.395"},
             {"Tracking Error", "0.149"},
             {"Treynor Ratio", "0.09"},
-            {"AUM Capacity", "68106.612"},
+            {"AUM Capacity", "$351716800"},
             {"Total Fees", "$443.50"}
         };
     }

--- a/Algorithm.CSharp/RegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionAlgorithm.cs
@@ -104,6 +104,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-0.604"},
             {"Tracking Error", "0.184"},
             {"Treynor Ratio", "-319.842"},
+            {"AUM Capacity", "1956.742"},
             {"Total Fees", "$5433.00"}
         };
     }

--- a/Algorithm.CSharp/RegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionAlgorithm.cs
@@ -104,7 +104,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "-0.604"},
             {"Tracking Error", "0.184"},
             {"Treynor Ratio", "-319.842"},
-            {"AUM Capacity", "1956.742"},
+            {"AUM Capacity", "$6847400"},
             {"Total Fees", "$5433.00"}
         };
     }

--- a/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
@@ -90,6 +90,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "5.499"},
             {"Tracking Error", "0.254"},
             {"Treynor Ratio", "-33.451"},
+            {"AUM Capacity", "3003.653"},
             {"Total Fees", "$230.20"},
             {"Total Insights Generated", "5"},
             {"Total Insights Closed", "3"},

--- a/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "5.499"},
             {"Tracking Error", "0.254"},
             {"Treynor Ratio", "-33.451"},
-            {"AUM Capacity", "3003.653"},
+            {"AUM Capacity", "$18228000"},
             {"Total Fees", "$230.20"},
             {"Total Insights Generated", "5"},
             {"Total Insights Closed", "3"},

--- a/Algorithm.CSharp/TotalPortfolioValueRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TotalPortfolioValueRegressionAlgorithm.cs
@@ -132,6 +132,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0.21"},
             {"Tracking Error", "0.903"},
             {"Treynor Ratio", "0.064"},
+            {"AUM Capacity", "136014.487"},
             {"Total Fees", "$19980.73"}
         };
     }

--- a/Algorithm.CSharp/TotalPortfolioValueRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TotalPortfolioValueRegressionAlgorithm.cs
@@ -132,7 +132,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0.21"},
             {"Tracking Error", "0.903"},
             {"Treynor Ratio", "0.064"},
-            {"AUM Capacity", "136014.487"},
+            {"AUM Capacity", "$527118600"},
             {"Total Fees", "$19980.73"}
         };
     }

--- a/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
@@ -92,6 +92,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "3.713"},
             {"Tracking Error", "0.264"},
             {"Treynor Ratio", "89.584"},
+            {"AUM Capacity", "2953.758"},
             {"Total Fees", "$506.02"},
             {"Total Insights Generated", "5"},
             {"Total Insights Closed", "3"},

--- a/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "3.713"},
             {"Tracking Error", "0.264"},
             {"Treynor Ratio", "89.584"},
-            {"AUM Capacity", "2953.758"},
+            {"AUM Capacity", "$15241900"},
             {"Total Fees", "$506.02"},
             {"Total Insights Generated", "5"},
             {"Total Insights Closed", "3"},

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -691,6 +691,7 @@
     <Compile Include="Algorithm\Framework\Alphas\InsightDirection.cs" />
     <Compile Include="Algorithm\Framework\Alphas\InsightType.cs" />
     <Compile Include="Statistics\AlgorithmPerformance.cs" />
+    <Compile Include="Statistics\AssetsUnderManagementCapacityManager.cs" />
     <Compile Include="Statistics\FitnessScoreManager.cs" />
     <Compile Include="Statistics\KellyCriterionManager.cs" />
     <Compile Include="Statistics\PortfolioStatistics.cs" />

--- a/Common/Securities/IOrderEventProvider.cs
+++ b/Common/Securities/IOrderEventProvider.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Event fired when there is a new <see cref="QuantConnect.Orders.OrderEvent"/>
         /// </summary>
-        /// <remarks>Will be called before the <see cref="SecurityPortfolioManager"/></remarks>
+        /// <remarks>Will be called after the <see cref="SecurityPortfolioManager"/></remarks>
         event EventHandler<OrderEvent> NewOrderEvent;
     }
 }

--- a/Common/Statistics/AssetsUnderManagementCapacityManager.cs
+++ b/Common/Statistics/AssetsUnderManagementCapacityManager.cs
@@ -1,0 +1,238 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+using QuantConnect.Logging;
+using QuantConnect.Util;
+
+namespace QuantConnect.Statistics
+{
+    /// <summary>
+    /// Class in charge of calculating the Assets Under Management (AUM) Capacity values.
+    /// Will use the sample values of the last year.
+    /// </summary>
+    /// <remarks>See https://www.quantconnect.com/forum/discussion/6194/insight-scoring-metric/p1 </remarks>
+    public class AssetsUnderManagementCapacityManager
+    {
+        private readonly object _lock = new object();
+
+        private readonly decimal _maximumTradeableVolume;
+        private readonly SecurityPortfolioManager _portfolio;
+        private readonly ISubscriptionDataConfigProvider _subscriptionDataConfigProvider;
+
+        private readonly Dictionary<Symbol, decimal> _maximumSymbolCapacity;
+        private readonly RollingWindow<decimal> _historicalPortfolioCapacity;
+        private DateTime _previousInputTime;
+
+        /// <summary>
+        /// Assets Under Management (AUM) Capacity
+        /// </summary>
+        public decimal AumCapacity =>
+            _historicalPortfolioCapacity.Count == 0 ? 0 : _historicalPortfolioCapacity.Average();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssetsUnderManagementCapacityManager"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="subscriptionDataConfigProvider">Provides access to registered <see cref="SubscriptionDataConfig"/></param>
+        /// <param name="orderEventProvider">Provides access to the order events</param>
+        public AssetsUnderManagementCapacityManager(
+            SecurityPortfolioManager portfolio,
+            ISubscriptionDataConfigProvider subscriptionDataConfigProvider,
+            IOrderEventProvider orderEventProvider)
+        {
+            _maximumTradeableVolume = PortfolioStatistics.GetMaximumTradeableVolume();
+            _portfolio = portfolio;
+            _subscriptionDataConfigProvider = subscriptionDataConfigProvider;
+
+            _maximumSymbolCapacity = new Dictionary<Symbol, decimal>();
+            _historicalPortfolioCapacity = new RollingWindow<decimal>(30);
+            _previousInputTime = DateTime.MinValue;
+
+            orderEventProvider.NewOrderEvent += (sender, orderEvent) =>
+            {
+                var symbol = orderEvent.Symbol;
+
+                var configs = _subscriptionDataConfigProvider.GetSubscriptionDataConfigs(symbol);
+                if (configs.IsNullOrEmpty())
+                {
+                    Log.Error($"AssetsUnderManagementCapacityManager: Could not find {symbol} in Portfolio");
+                }
+
+                try
+                {
+                    var consolidator = default(IDataConsolidator);
+                    var security = _portfolio.Securities[symbol];
+                    BaseData lastData = security.Cache.GetData<TradeBar>();
+
+                    // For high resolution data, create a consolidator that will compute
+                    // the AUM Capacity after a 5-minute period bar is closed
+                    foreach (var config in configs.Where(x => x.Resolution < Resolution.Hour))
+                    {
+                        if (config.Type.IsAssignableFrom(typeof(TradeBar)))
+                        {
+                            consolidator = new TradeBarConsolidator(TimeSpan.FromMinutes(5));
+                        }
+
+                        if (config.Type.IsAssignableFrom(typeof(Tick)) &&
+                            config.TickType == TickType.Trade)
+                        {
+                            consolidator = new TickConsolidator(TimeSpan.FromMinutes(5));
+                            lastData = security.Cache.GetData<Tick>();
+                        }
+
+                        if (consolidator == null)
+                        {
+                            continue;
+                        }
+
+                        // Warm up the consolidator to mark the begging of the period
+                        if (lastData != null)
+                        {
+                            consolidator.Update(lastData);
+                        }
+
+                        config.Consolidators.Add(consolidator);
+                        consolidator.DataConsolidated += (s, data) =>  Update(s, data, orderEvent.OrderId);
+                        return;
+                    }
+
+                    // For low resolution, use the last data available
+                    if (lastData != null)
+                    {
+                        Update(sender, lastData, orderEvent.OrderId);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"AssetsUnderManagementCapacityManager: {e}");
+                }
+            };
+        }
+
+        /// <summary>
+        /// Updates the AUM Capacity with the latest data available after a order fill
+        /// </summary>
+        /// <param name="sender">For high resolution, sender object represents the data consolidator</param>
+        /// <param name="data">Last price trade bar available or consolidated</param>
+        /// <param name="orderId">Order fill ID</param>
+        /// <remarks>
+        /// The whole method body is locked, since order events can be triggered at any time in live mode
+        /// </remarks>
+        private void Update(object sender, IBaseData data, int orderId)
+        {
+            lock (_lock)
+            {
+                try
+                {
+                    var symbol = data.Symbol;
+                    var security = _portfolio.Securities[symbol];
+
+                    var holdingsTurnover = 1m;
+                    var holdingsValue = security.Holdings.AbsoluteHoldingsValue;
+
+                    if (holdingsValue != 0)
+                    {
+                        var order = _portfolio.Transactions.GetOrderById(orderId);
+                        var orderValue = Math.Abs(order.GetValue(security));
+                        holdingsTurnover = orderValue / holdingsValue;
+
+                        if (holdingsTurnover == 0)
+                        {
+                            RemoveConsolidator(sender, symbol);
+                            return;
+                        }
+                    }
+
+                    var totalMarketVolume = GetTotalMarketVolume(data);
+                    var totalTradeVolumeCapacity = _maximumTradeableVolume * totalMarketVolume / holdingsTurnover;
+
+                    // If it is a new day, we discard the previous day data
+                    var utcDate = data.EndTime.ConvertToUtc(security.Exchange.TimeZone).Date;
+                    if (_previousInputTime != utcDate)
+                    {
+                        _previousInputTime = utcDate;
+                        _maximumSymbolCapacity.Clear();
+                        _historicalPortfolioCapacity.Add(0m);
+                    }
+
+                    // Updates AUM Capacity if there is new information or lower total trade volume capacity for the security
+                    decimal capacity;
+                    if (!_maximumSymbolCapacity.TryGetValue(symbol, out capacity) ||
+                        totalTradeVolumeCapacity < capacity)
+                    {
+                        _maximumSymbolCapacity[symbol] = totalTradeVolumeCapacity;
+                        _historicalPortfolioCapacity[0] = _maximumSymbolCapacity.Sum(x => x.Value);
+                    }
+
+                    RemoveConsolidator(sender, symbol);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"AssetsUnderManagementCapacityManager.Update: {e}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the total market volume which is a fraction of the current trade bar volume
+        /// </summary>
+        /// <param name="data">Last price trade bar available or consolidated</param>
+        private static decimal GetTotalMarketVolume(IBaseData data)
+        {
+            var tradeBar = (TradeBar) data;
+
+            var factor = tradeBar.Period == Time.OneDay
+                ? .025m
+                : .050m;
+
+            return factor * tradeBar.Volume;
+        }
+
+        /// <summary>
+        /// Remove consolidator for a given symbol
+        /// </summary>
+        /// <param name="sender">Consolidator to be removed</param>
+        /// <param name="symbol">Symbol associated with the consolidator</param>
+        private void RemoveConsolidator(object sender, Symbol symbol)
+        {
+            var consolidator = sender as IDataConsolidator;
+            if (consolidator == null)
+            {
+                return;
+            }
+
+            var configs = _subscriptionDataConfigProvider.GetSubscriptionDataConfigs(symbol);
+            foreach (var config in configs)
+            {
+                if (config.Consolidators.Remove(consolidator))
+                {
+                    break;
+                }
+            }
+
+            consolidator.DisposeSafely();
+        }
+    }
+}

--- a/Common/Statistics/PortfolioStatistics.cs
+++ b/Common/Statistics/PortfolioStatistics.cs
@@ -28,6 +28,7 @@ namespace QuantConnect.Statistics
     public class PortfolioStatistics
     {
         private const decimal RiskFreeRate = 0;
+        private const decimal MaximumTradeableVolume = 0.025m;
 
         /// <summary>
         /// The average rate of return for winning trades
@@ -233,6 +234,14 @@ namespace QuantConnect.Statistics
         public static decimal GetRiskFreeRate()
         {
             return RiskFreeRate;
+        }
+
+        /// <summary>
+        /// Gets the current defined maximum tradeable volume
+        /// </summary>
+        public static decimal GetMaximumTradeableVolume()
+        {
+            return MaximumTradeableVolume;
         }
 
         /// <summary>

--- a/Common/Statistics/PortfolioStatistics.cs
+++ b/Common/Statistics/PortfolioStatistics.cs
@@ -28,7 +28,6 @@ namespace QuantConnect.Statistics
     public class PortfolioStatistics
     {
         private const decimal RiskFreeRate = 0;
-        private const decimal MaximumTradeableVolume = 0.025m;
 
         /// <summary>
         /// The average rate of return for winning trades
@@ -234,14 +233,6 @@ namespace QuantConnect.Statistics
         public static decimal GetRiskFreeRate()
         {
             return RiskFreeRate;
-        }
-
-        /// <summary>
-        /// Gets the current defined maximum tradeable volume
-        /// </summary>
-        public static decimal GetMaximumTradeableVolume()
-        {
-            return MaximumTradeableVolume;
         }
 
         /// <summary>

--- a/Common/Statistics/StatisticsBuilder.cs
+++ b/Common/Statistics/StatisticsBuilder.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using QuantConnect.Logging;
 using QuantConnect.Util;
@@ -184,7 +183,7 @@ namespace QuantConnect.Statistics
                 { "Information Ratio", Math.Round((double)totalPerformance.PortfolioStatistics.InformationRatio, 3).ToStringInvariant() },
                 { "Tracking Error", Math.Round((double)totalPerformance.PortfolioStatistics.TrackingError, 3).ToStringInvariant() },
                 { "Treynor Ratio", Math.Round((double)totalPerformance.PortfolioStatistics.TreynorRatio, 3).ToStringInvariant() },
-                { "AUM Capacity", Math.Round((double)aumCapacity, 3).ToStringInvariant() },
+                { "AUM Capacity", $"${Math.Round(aumCapacity/100).ToStringInvariant()}00" },
                 { "Total Fees", "$" + totalFees.ToStringInvariant("0.00") }
             };
         }

--- a/Common/Statistics/StatisticsBuilder.cs
+++ b/Common/Statistics/StatisticsBuilder.cs
@@ -38,6 +38,7 @@ namespace QuantConnect.Statistics
         /// <param name="startingCapital">The algorithm starting capital</param>
         /// <param name="totalFees">The total fees</param>
         /// <param name="totalTransactions">The total number of transactions</param>
+        /// <param name="aumCapacity">Asset under management capacity</param>
         /// <returns>Returns a <see cref="StatisticsResults"/> object</returns>
         public static StatisticsResults Generate(
             List<Trade> trades,
@@ -47,7 +48,8 @@ namespace QuantConnect.Statistics
             List<ChartPoint> pointsBenchmark,
             decimal startingCapital,
             decimal totalFees,
-            int totalTransactions)
+            int totalTransactions,
+            decimal aumCapacity)
         {
             var equity = ChartPointToDictionary(pointsEquity);
 
@@ -56,7 +58,7 @@ namespace QuantConnect.Statistics
 
             var totalPerformance = GetAlgorithmPerformance(firstDate, lastDate, trades, profitLoss, equity, pointsPerformance, pointsBenchmark, startingCapital);
             var rollingPerformances = GetRollingPerformances(firstDate, lastDate, trades, profitLoss, equity, pointsPerformance, pointsBenchmark, startingCapital);
-            var summary = GetSummary(totalPerformance, totalFees, totalTransactions);
+            var summary = GetSummary(totalPerformance, totalFees, totalTransactions, aumCapacity);
 
             return new StatisticsResults(totalPerformance, rollingPerformances, summary);
         }
@@ -160,7 +162,7 @@ namespace QuantConnect.Statistics
         /// <summary>
         /// Returns a summary of the algorithm performance as a dictionary
         /// </summary>
-        private static Dictionary<string, string> GetSummary(AlgorithmPerformance totalPerformance, decimal totalFees, int totalTransactions)
+        private static Dictionary<string, string> GetSummary(AlgorithmPerformance totalPerformance, decimal totalFees, int totalTransactions, decimal aumCapacity)
         {
             return new Dictionary<string, string>
             {
@@ -182,6 +184,7 @@ namespace QuantConnect.Statistics
                 { "Information Ratio", Math.Round((double)totalPerformance.PortfolioStatistics.InformationRatio, 3).ToStringInvariant() },
                 { "Tracking Error", Math.Round((double)totalPerformance.PortfolioStatistics.TrackingError, 3).ToStringInvariant() },
                 { "Treynor Ratio", Math.Round((double)totalPerformance.PortfolioStatistics.TreynorRatio, 3).ToStringInvariant() },
+                { "AUM Capacity", Math.Round((double)aumCapacity, 3).ToStringInvariant() },
                 { "Total Fees", "$" + totalFees.ToStringInvariant("0.00") }
             };
         }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -545,7 +545,8 @@ namespace QuantConnect.Lean.Engine
                         var timeKeeper = algorithm.TimeKeeper;
                         foreach (var update in timeSlice.ConsolidatorUpdateData)
                         {
-                            var consolidators = update.Target.Consolidators;
+                            // Creates a list from the hashset to enable item removal in the IDataConsolidator.Update callback
+                            var consolidators = update.Target.Consolidators.ToList();
                             foreach (var consolidator in consolidators)
                             {
                                 foreach (var dataPoint in update.Data)

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -432,6 +432,12 @@ namespace QuantConnect.Lean.Engine.Results
             Algorithm = algorithm;
             StartingPortfolioValue = startingPortfolioValue;
 
+            AssetsUnderManagementCapacityManager = new AssetsUnderManagementCapacityManager(
+                Algorithm.Portfolio,
+                Algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                TransactionHandler
+            );
+
             //Get the resample period:
             var totalMinutes = (_job.PeriodFinish - _job.PeriodStart).TotalMinutes;
             var resampleMinutes = totalMinutes < MinimumSamplePeriod * Samples ? MinimumSamplePeriod : totalMinutes / Samples; // Space out the sampling every

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -91,6 +91,11 @@ namespace QuantConnect.Lean.Engine.Results
         protected AlphaRuntimeStatistics AlphaRuntimeStatistics { get; set; }
 
         /// <summary>
+        /// Gets or sets the current AUM Capacity Manager
+        /// </summary>
+        protected AssetsUnderManagementCapacityManager AssetsUnderManagementCapacityManager { get; set; }
+
+        /// <summary>
         /// Creates a new instance
         /// </summary>
         protected BaseResultsHandler()
@@ -210,7 +215,7 @@ namespace QuantConnect.Lean.Engine.Results
                     var trades = Algorithm.TradeBuilder.ClosedTrades;
 
                     statisticsResults = StatisticsBuilder.Generate(trades, profitLoss, equity, performance, benchmark,
-                        StartingPortfolioValue, Algorithm.Portfolio.TotalFees, totalTransactions);
+                        StartingPortfolioValue, Algorithm.Portfolio.TotalFees, totalTransactions, AssetsUnderManagementCapacityManager.AumCapacity);
                 }
             }
             catch (Exception err)

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -213,9 +213,10 @@ namespace QuantConnect.Lean.Engine.Results
                     var benchmark = charts[benchmarkKey].Series[benchmarkKey].Values;
 
                     var trades = Algorithm.TradeBuilder.ClosedTrades;
+                    var aumCapacity = AssetsUnderManagementCapacityManager?.AumCapacity ?? 0m;
 
                     statisticsResults = StatisticsBuilder.Generate(trades, profitLoss, equity, performance, benchmark,
-                        StartingPortfolioValue, Algorithm.Portfolio.TotalFees, totalTransactions, AssetsUnderManagementCapacityManager.AumCapacity);
+                        StartingPortfolioValue, Algorithm.Portfolio.TotalFees, totalTransactions, aumCapacity);
                 }
             }
             catch (Exception err)

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -756,6 +756,12 @@ namespace QuantConnect.Lean.Engine.Results
             Algorithm = algorithm;
             StartingPortfolioValue = startingPortfolioValue;
 
+            AssetsUnderManagementCapacityManager = new AssetsUnderManagementCapacityManager(
+                Algorithm.Portfolio,
+                Algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                TransactionHandler
+            );
+
             var types = new List<SecurityType>();
             foreach (var kvp in Algorithm.Securities)
             {

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -999,15 +999,15 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
                     try
                     {
-                        // to be called before updating the Portfolio
-                        NewOrderEvent?.Invoke(this, fill);
-
                         _algorithm.Portfolio.ProcessFill(fill);
                         _algorithm.TradeBuilder.ProcessFill(
                             fill,
                             securityConversionRate,
                             feeInAccountCurrency,
                             multiplier);
+
+                        // to be called after updating the Portfolio
+                        NewOrderEvent?.Invoke(this, fill);
                     }
                     catch (Exception err)
                     {

--- a/Tests/Algorithm/Framework/Alphas/OrderBasedInsightGeneratorTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/OrderBasedInsightGeneratorTests.cs
@@ -76,6 +76,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         public void NoExistingHoldings(OrderDirection direction)
         {
             var insightGenerator = new OrderBasedInsightGenerator();
+
+            var holding =
+                new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
+
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                     1,
                     Symbols.SPY,
@@ -86,7 +91,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
                     direction == OrderDirection.Buy ? 1 : -1,
                     OrderFee.Zero
                 ),
-                new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol)));
+                holding);
 
             Assert.AreEqual(1, insight.Confidence);
             Assert.AreEqual(direction == OrderDirection.Buy
@@ -101,7 +106,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding =
                 new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? -1 : 1);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                     1,
@@ -127,7 +132,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding =
                 new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? -1 : 1);
+            holding.SetHoldings(1, 0);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
@@ -152,7 +157,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding =
                 new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 2 : -2);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
@@ -178,7 +183,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding =
                 new SecurityHolding(_security, new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? -2 : 2);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? -1 : 1);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
@@ -204,6 +209,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
             var holding = new SecurityHolding(_security,
                 new IdentityCurrencyConverter(_security.QuoteCurrency.Symbol));
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 2 : -2);
 
             var insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
@@ -220,7 +226,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
             Assert.AreEqual(direction == OrderDirection.Buy
                 ? InsightDirection.Up : InsightDirection.Down, insight.Direction);
 
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? 2 : -2);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
             insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
                 Symbols.SPY,
@@ -236,7 +242,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
             Assert.AreEqual(direction == OrderDirection.Buy
                 ? InsightDirection.Up : InsightDirection.Down, insight.Direction);
 
-            holding.SetHoldings(1, direction == OrderDirection.Buy ? 1 : -1);
+            holding.SetHoldings(1, direction == OrderDirection.Buy ? .5m : -.5m);
             insight = insightGenerator.GenerateInsightFromFill(new OrderEvent(
                 1,
                 Symbols.SPY,

--- a/Tests/Common/Statistics/AssetsUnderManagementCapacityManagerTests.cs
+++ b/Tests/Common/Statistics/AssetsUnderManagementCapacityManagerTests.cs
@@ -1,0 +1,304 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using QuantConnect.Statistics;
+using QuantConnect.Tests.Engine.DataFeeds;
+using System;
+using System.Linq;
+using Moq;
+using QuantConnect.Brokerages.Backtesting;
+using QuantConnect.Data;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Tests.Engine;
+
+namespace QuantConnect.Tests.Common.Statistics
+{
+    [TestFixture]
+    public class AssetsUnderManagementCapacityManagerTests
+    {
+        [TestCase(Resolution.Tick)]
+        [TestCase(Resolution.Second)]
+        [TestCase(Resolution.Minute)]
+        public void ComputeCapacityForOneSymbolInOneDay_HighResolution(Resolution resolution)
+        {
+            var algorithm = GetAlgorithm(resolution);
+            var portfolio = algorithm.Portfolio;
+            var subscriptionDataConfigProvider = algorithm.SubscriptionManager.SubscriptionDataConfigService;
+            var orderEventProvider = new MockOrderEventProvider();
+
+            var security = portfolio.Securities[Symbols.SPY];
+
+            var manager = new AssetsUnderManagementCapacityManager(
+                portfolio,
+                subscriptionDataConfigProvider,
+                orderEventProvider
+            );
+
+            // 50% of SPY. Volume of 50mi.
+            var orderEvent = CreateOrderEvent(algorithm, Symbols.SPY, .5m, 50);
+            orderEventProvider.OnNewOrderEvent(orderEvent);
+
+            var config = subscriptionDataConfigProvider.GetSubscriptionDataConfigs(orderEvent.Symbol).First();
+            Assert.AreEqual(1, config.Consolidators.Count);
+
+            // Push data to the consolidator
+            var data = security.GetLastData();
+            data.Time = data.Time.AddMinutes(5);
+            config.Consolidators.First().Update(data);
+
+            const double expected = 50000000 * .025 / .5;
+            Assert.AreEqual(expected * GetFactor(resolution), manager.AumCapacity);
+            Assert.AreEqual(0, config.Consolidators.Count);
+        }
+
+        [TestCase(Resolution.Hour)]
+        [TestCase(Resolution.Daily)]
+        public void ComputeCapacityForOneSymbolInOneDay(Resolution resolution)
+        {
+            var algorithm = GetAlgorithm(resolution);
+            var orderEventProvider = new MockOrderEventProvider();
+
+            var manager = new AssetsUnderManagementCapacityManager(
+                algorithm.Portfolio,
+                algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                orderEventProvider
+            );
+
+            // 50% of SPY. Volume of 50mi.
+            var orderEvent = CreateOrderEvent(algorithm, Symbols.SPY, .5m, 50);
+            orderEventProvider.OnNewOrderEvent(orderEvent);
+
+            const double expected = 50000000 * .025 / .5;
+            Assert.AreEqual(expected * GetFactor(resolution), manager.AumCapacity);
+        }
+
+        [TestCase(Resolution.Hour)]
+        [TestCase(Resolution.Daily)]
+        public void ComputeCapacityForTwoSymbolsInOneDay(Resolution resolution)
+        {
+            var algorithm = GetAlgorithm(resolution);
+            var orderEventProvider = new MockOrderEventProvider();
+
+            var manager = new AssetsUnderManagementCapacityManager(
+                algorithm.Portfolio,
+                algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                orderEventProvider
+            );
+
+            // 50% of SPY. Volume of 50mi.
+            var OrderEvent1 = CreateOrderEvent(algorithm, Symbols.SPY, .5m, 50);
+            orderEventProvider.OnNewOrderEvent(OrderEvent1);
+
+            // 50% of AAPL. Volume of 40mi.
+            var orderEvent2 = CreateOrderEvent(algorithm, Symbols.AAPL, .5m, 40);
+            orderEventProvider.OnNewOrderEvent(orderEvent2);
+
+            const double expected = 50000000 * .025 / .5 + 40000000 * .025 / .5;
+            Assert.AreEqual(expected * GetFactor(resolution), manager.AumCapacity);
+        }
+
+        [TestCase(Resolution.Hour)]
+        [TestCase(Resolution.Daily)]
+        public void ComputeCapacityForOneSymbolInTwoDays(Resolution resolution)
+        {
+            var algorithm = GetAlgorithm(resolution);
+            var orderEventProvider = new MockOrderEventProvider();
+
+            var manager = new AssetsUnderManagementCapacityManager(
+                algorithm.Portfolio,
+                algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                orderEventProvider
+            );
+
+            // 50% of SPY. Volume of 50mi.
+            algorithm.SetDateTime(new DateTime(2018, 1, 9, 12, 05, 0));
+            var OrderEvent1 = CreateOrderEvent(algorithm, Symbols.SPY, .5m, 50);
+            orderEventProvider.OnNewOrderEvent(OrderEvent1);
+
+            // 50% of SPY. Volume of 40mi.
+            algorithm.SetDateTime(new DateTime(2018, 1, 10, 12, 05, 0));
+            var orderEvent2 = CreateOrderEvent(algorithm, Symbols.SPY, .5m, 40);
+            orderEventProvider.OnNewOrderEvent(orderEvent2);
+
+            const double expected = (50000000 * .025 / .5 + 40000000 * .025 / .5) / 2;
+            Assert.AreEqual(expected * GetFactor(resolution), manager.AumCapacity);
+        }
+
+        [Test]
+        public void ComputeCapacityForComplexCase()
+        {
+            var algorithm = GetAlgorithm(Resolution.Hour);
+            var orderEventProvider = new MockOrderEventProvider();
+            var factor = GetFactor(Resolution.Hour);
+
+            var manager = new AssetsUnderManagementCapacityManager(
+                algorithm.Portfolio,
+                algorithm.SubscriptionManager.SubscriptionDataConfigService,
+                orderEventProvider
+            );
+
+            //// 2018-01-09 12:05
+            algorithm.SetDateTime(new DateTime(2018, 1, 9, 12, 05, 0));
+
+            // 50% of SPY. Volume of 50mi.
+            orderEventProvider
+                .OnNewOrderEvent(CreateOrderEvent(algorithm, Symbols.SPY, .5m, 50));
+
+            var expected = factor * 2500000; // Capacity = 2500000 = 50000000 * .025 / .5
+            Assert.AreEqual(expected, manager.AumCapacity);
+
+            // 25% of AAPL. Volume of 45mi.
+            orderEventProvider
+                .OnNewOrderEvent(CreateOrderEvent(algorithm, Symbols.AAPL, .25m, 45));
+
+            expected += factor * 45000000 * .025 / .25; // Capacity = 45000000 * .025 / .25 + previous value from SPY
+            Assert.AreEqual(expected, manager.AumCapacity);
+
+            //// 2018-01-09 13:05
+            algorithm.SetDateTime(new DateTime(2018, 1, 9, 13, 05, 0));
+
+            // 75% of SPY. Volume of 55mi.
+            orderEventProvider
+                .OnNewOrderEvent(CreateOrderEvent(algorithm, Symbols.SPY, .75m, 55));
+
+            // Capacity = 55000000 * .025 / .75  + 45000000 * .025 / .25 from AAPL
+            expected = factor * (55000000 * .025 / .75 + 45000000 * .025 / .25);
+            Assert.AreEqual(Math.Round(expected, 2), Math.Round(manager.AumCapacity, 2));
+
+            // 65% of AAPL. Volume of 47mi.
+            orderEventProvider
+                .OnNewOrderEvent(CreateOrderEvent(algorithm, Symbols.AAPL, .65m, 47));
+
+            // Capacity = 55000000 * .025 / .75  + 47000000 * .025 / .65 from AAPL
+            expected = factor * (55000000 * .025 / .75 + 47000000 * .025 / .65);
+            Assert.AreEqual(Math.Round(expected, 2), Math.Round(manager.AumCapacity, 2));
+
+            //// 2018-01-09 13:05
+            algorithm.SetDateTime(new DateTime(2018, 2, 9, 10, 0, 0));
+
+            // 30% of SPY. Volume of 58mi.
+            orderEventProvider
+                .OnNewOrderEvent(CreateOrderEvent(algorithm, Symbols.SPY, .30m, 58));
+
+            // Capacity = (58000000 * .025 / .30 + value from day before) / 2
+            var previousDay = expected;
+            expected = (previousDay + factor * 58000000 * .025 / .30) / 2;
+            Assert.AreEqual(Math.Round(expected, 2), Math.Round(manager.AumCapacity, 2));
+
+            // 30% of AAPL. Volume of 31mi.
+            orderEventProvider
+                .OnNewOrderEvent(CreateOrderEvent(algorithm, Symbols.AAPL, .30m, 31));
+
+            // Capacity = (31000000 * .025 / .30 + 483333.33 from SPY + value from day before) / 2
+            expected = (previousDay + factor * (31000000 * .025 / .30 + 58000000 * .025 / .30)) / 2;
+            Assert.AreEqual(Math.Round(expected, 2), Math.Round(manager.AumCapacity, 2));
+        }
+
+        private static QCAlgorithm GetAlgorithm(Resolution resolution)
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+            algorithm.SetDateTime(DateTime.UtcNow);
+            algorithm.AddEquity("SPY", resolution);
+            algorithm.AddEquity("AAPL", resolution);
+            algorithm.SetFinishedWarmingUp();
+
+            var transactionHandler = new BrokerageTransactionHandler();
+            transactionHandler.Initialize(
+                algorithm,
+                new BacktestingBrokerage(algorithm),
+                new TestResultHandler(Console.WriteLine)
+            );
+
+            algorithm.Transactions.SetOrderProcessor(transactionHandler);
+            return algorithm;
+        }
+
+        private static OrderEvent CreateOrderEvent(IAlgorithm algorithm, Symbol symbol, decimal turnover, decimal volume)
+        {
+            const decimal price = 100;
+            const decimal quantity = 100;
+            var size = volume * 1000000;
+
+            var reference = algorithm.Time;
+            var resolution = algorithm.SubscriptionManager.SubscriptionDataConfigService
+                .GetSubscriptionDataConfigs(symbol).GetHighestResolution();
+
+            // Sets Market Price and Holdings
+            var security = algorithm.Securities[symbol];
+
+            BaseData data = new Tick(reference, symbol, price, price) { TickType = TickType.Trade, Quantity = size };
+            if (resolution > Resolution.Tick)
+            {
+                data = new TradeBar(reference, symbol, price, price, price, price, size, resolution.ToTimeSpan());
+            }
+
+            security.SetMarketPrice(data);
+            security.Holdings.SetHoldings(price, quantity);
+            var holdingsValue = security.Holdings.AbsoluteHoldingsValue;
+
+            // Add amount to cash book to maintain the initial TotalPortfolioValue
+            var cash = algorithm.Portfolio.CashBook["USD"];
+            cash.AddAmount(holdingsValue - algorithm.Portfolio.TotalPortfolioValue);
+
+            var orderQuantity = quantity * turnover;
+
+            var ticket = algorithm.Transactions.AddOrder(
+                new SubmitOrderRequest(
+                    OrderType.Market,
+                    security.Type,
+                    security.Symbol,
+                    orderQuantity,
+                    0,
+                    0,
+                    DateTime.Now,
+                    ""
+                )
+            );
+
+            var orderEvent = new OrderEvent(
+                ticket.OrderId,
+                symbol,
+                reference,
+                OrderStatus.Filled,
+                quantity > 0 ? OrderDirection.Buy : OrderDirection.Sell,
+                price,
+                orderQuantity,
+                OrderFee.Zero,
+                ""
+            );
+
+            ticket.AddOrderEvent(orderEvent);
+
+            return orderEvent;
+        }
+
+        private double GetFactor(Resolution resolution) => resolution == Resolution.Daily ? .025 : .05;
+
+        private class MockOrderEventProvider : IOrderEventProvider
+        {
+            public event EventHandler<OrderEvent> NewOrderEvent;
+
+            public void OnNewOrderEvent(OrderEvent e) => NewOrderEvent?.Invoke(this, e);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -322,6 +322,7 @@
     <Compile Include="Common\Securities\SecurityHoldingTests.cs" />
     <Compile Include="Common\Securities\SecurityServiceTests.cs" />
     <Compile Include="Common\Securities\TestAccountCurrencyProvider.cs" />
+    <Compile Include="Common\Statistics\AssetsUnderManagementCapacityManagerTests.cs" />
     <Compile Include="Common\Statistics\FitnessScoreManagerTests.cs" />
     <Compile Include="Common\Statistics\KellyCriterionManagerTests.cs" />
     <Compile Include="Common\ParseTests.cs" />


### PR DESCRIPTION
#### Description
Calculate an estimate of the capacity of the strategy backtest/live trade. This will provide funds with an understanding of the maximum dollar allocation they can make to the strategy to maximize its return potential without moving the market.

- Implements `AssetsUnderManagementCapacityManager`
- Adds an instance of `AssetsUnderManagementCapacityManager` in the result handlers to include AUM Capacity to algorithm statistics
- Adds "AUM Capacity" entry to `ExpectedStatistics` of regression algorithms with a considerable amount of orders.

Performance test over 10 executions of RegressionAlgorithm (5433 trades):
`master` :: Mean: `7.71` Std: `0.16`
`new` :: Mean: `7.853` Std: `0.22`
Speed decrease of 1.85%.

#### Related Issue
Closes #3539
This pull request was created on top of #3571

#### Motivation and Context
Include statistics that can be used to improve algorithms. 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests and regression algorithms.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`