### PR TITLE
Silences Order Quantity Rounding to Zero Message

### DIFF
--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Gets the margin currently alloted to the specified holding
+        /// Gets the margin currently allocated to the specified holding
         /// </summary>
         /// <param name="security">The security to compute maintenance margin for</param>
         /// <returns>The maintenance margin required for the </returns>
@@ -379,7 +379,7 @@ namespace QuantConnect.Securities
                     var amountOfOrdersToRemove = (orderValue - targetOrderValue) / currentOrderValuePerUnit;
                     if (amountOfOrdersToRemove < parameters.Security.SymbolProperties.LotSize)
                     {
-                        // we will always substract at leat 1 LotSize
+                        // we will always subtract at least 1 LotSize
                         amountOfOrdersToRemove = parameters.Security.SymbolProperties.LotSize;
                     }
 
@@ -392,7 +392,8 @@ namespace QuantConnect.Securities
                     return new GetMaximumOrderQuantityForTargetValueResult(0,
                         Invariant($"The order quantity is less than the lot size of {parameters.Security.SymbolProperties.LotSize} ") +
                         Invariant($"and has been rounded to zero.Target order value {targetOrderValue}. Order fees ") +
-                        Invariant($"{orderFees}. Order quantity {orderQuantity}.")
+                        Invariant($"{orderFees}. Order quantity {orderQuantity}."),
+                        false
                     );
                 }
 
@@ -457,7 +458,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Gets the buying power available for a trade
         /// </summary>
-        /// <param name="parameters">A parameters object containing the algorithm's potrfolio, security, and order direction</param>
+        /// <param name="parameters">A parameters object containing the algorithm's portfolio, security, and order direction</param>
         /// <returns>The buying power available for the trade</returns>
         public virtual BuyingPower GetBuyingPower(BuyingPowerParameters parameters)
         {


### PR DESCRIPTION
#### Description
Sets `GetMaximumOrderQuantityForTargetValueResult.IsError` to false to silence the logging for order quantity rounding to zero in `BuyingPowerModel.GetMaximumOrderQuantityForTargetValue`.

Bonus: some typos in comments were fixed. :-)

#### Related Issue
Closes #3583 

#### Motivation and Context
A genuine result from the method should not be logged.

#### Requires Documentation Change
We should improve documentation to explain the different possible results for some helper methods. For instance, if `QCAlgorithm.SetHoldings` is called with insufficient funds, it will not generate an order and some users don't understand what is happening.

#### How Has This Been Tested?
Algorithm provided in #3583.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`