### PR TITLE
Preserve converting null to default values in ConvertInvariant

### DIFF
--- a/Tests/Common/StringExtensionsTests.cs
+++ b/Tests/Common/StringExtensionsTests.cs
@@ -27,6 +27,7 @@ namespace QuantConnect.Tests.Common
         [TestCase(typeof(string), "123", typeof(int), 123)]
         [TestCase(typeof(string), "123", typeof(decimal), 123)]
         [TestCase(typeof(long), "123", typeof(decimal), 123)]
+        [TestCase(typeof(string), null, typeof(decimal), 0)]
         public void ConvertInvariant(Type sourceType, string sourceString, Type conversionType, object expected)
         {
             // we can't put a decimal in the attribute, so this ensure the runtime types are correct
@@ -34,10 +35,27 @@ namespace QuantConnect.Tests.Common
             Assert.IsInstanceOf(conversionType, expected);
 
             var source = Convert.ChangeType(sourceString, sourceType, CultureInfo.InvariantCulture);
-            Assert.IsInstanceOf(sourceType, source);
+            if (sourceString == null)
+            {
+                Assert.IsNull(source);
+            }
+            else
+            {
+                Assert.IsInstanceOf(sourceType, source);
+            }
 
-            var converted = source.ConvertInvariant(conversionType);
+            var converted = ((IConvertible)source).ConvertInvariant(conversionType);
             Assert.AreEqual(expected, converted);
+            Assert.IsInstanceOf(conversionType, converted);
+        }
+
+        [Test]
+        public void ConvertInvariant_ThrowsFormatException_WhenConvertingEmptyString()
+        {
+            const string input = "";
+            Assert.Throws<FormatException>(
+                () => input.ConvertInvariant<decimal>()
+            );
         }
 
         [Test]


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Many places in the code were updated from using Convert.ToXXX to ConvertInvariant<T>.
The existing ConvertInvariant<T> implementation would throw an error when attempting
to convert a null value into a value type, such as null -> decimal. This change
preserves the null conversion behavior by delegating to the appropriate Convert.ToXXX
method under the hood.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3584

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Preserving old behavior and avoiding errors being thrown. This issue was originally raised via `InteractiveBrokersBrokerage.ConvertHolding`'s usage attempting to convert a null `Multiplier` value to decimal and depending on that conversion to return `0` while the updated code caused it to throw an `InvalidCastException`.
```
Algorithm.Initialize() Error: Null object cannot be converted to a value type. Stack Trace: System.Exception: Null object cannot be converted to a value type. ---> System.InvalidCastException: Null object cannot be converted to a value type.
  at System.Convert.ChangeType (System.Object value, System.Type conversionType, System.IFormatProvider provider) [0x00029] in :0 
  at QuantConnect.StringExtensions.ConvertInvariant (System.Object convertible, System.Type conversionType) [0x00007] in :0 
  at QuantConnect.StringExtensions.ConvertInvariant[T] (System.Object convertible) [0x00000] in :0 
  at QuantConnect.Brokerages.InteractiveBrokers.InteractiveBrokersBrokerage.CreateHolding (QuantConnect.Brokerages.InteractiveBrokers.Client.UpdatePortfolioEventArgs e) [0x00029] in :0 
  at QuantConnect.Brokerages.InteractiveBrokers.InteractiveBrokersBrokerage.HandlePortfolioUpdates (System.Object sender, QuantConnect.Brokerages.InteractiveBrokers.Client.UpdatePortfolioEventArgs e) [0x0000c] in :0 
   --- End of inner exception stack trace ---
  at QuantConnect.Brokerages.InteractiveBrokers.InteractiveBrokersBrokerage.Connect () [0x00289] in :0 
  at QuantConnect.Lean.Engine.HistoricalData.BrokerageHistoryProvider.Initialize (QuantConnect.Data.HistoryProviderInitializeParameters parameters) [0x00000] in :0 
  at QuantConnect.Lean.Engine.Engine.Run (QuantConnect.Packets.AlgorithmNodePacket job, QuantConnect.Lean.Engine.AlgorithmManager manager, System.String assemblyPath) [0x003d5] in :0 
```

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test added to confirm we can convert from a null string to a value type and that it returns the default value.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->