### PR TITLE
Add missing reference in Algorithm.FSharp

### DIFF
--- a/Algorithm.FSharp/QuantConnect.Algorithm.FSharp.fsproj
+++ b/Algorithm.FSharp/QuantConnect.Algorithm.FSharp.fsproj
@@ -48,6 +48,9 @@
     <Reference Include="NodaTime">
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
+    <Reference Include="StringInterpolationBridge">
+      <HintPath>..\packages\StringInterpolationBridgeStrong.0.9.1\lib\net40\StringInterpolationBridge.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/Algorithm.FSharp/packages.config
+++ b/Algorithm.FSharp/packages.config
@@ -7,4 +7,5 @@
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
   <package id="QuantConnect.pythonnet" version="1.0.5.25" targetFramework="net452" />
+  <package id="StringInterpolationBridgeStrong" version="0.9.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION

#### Description
- The missing reference to `StringInterpolationBridgeStrong` has been added to the `Algorithm.FSharp` project

#### Related Issue
n/a

#### Motivation and Context
Although the `Algorithm.FSharp` project is excluded from the default Lean build, the reference to `StringInterpolationBridgeStrong` is required to build the project.


#### Requires Documentation Change
No.

#### How Has This Been Tested?
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.