### PR TITLE
Remove custom data when underlying security is deselected

### DIFF
--- a/Algorithm.CSharp/CustomDataAddDataCoarseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataAddDataCoarseSelectionRegressionAlgorithm.cs
@@ -75,6 +75,7 @@ namespace QuantConnect.Algorithm.CSharp
             foreach (var symbol in symbols)
             {
                 _customSymbols.Add(AddData<SECReport8K>(symbol, Resolution.Daily).Symbol);
+                _customSymbols.Add(AddData<SECReport10K>(symbol, Resolution.Daily).Symbol);
             }
 
             return symbols;
@@ -101,15 +102,10 @@ namespace QuantConnect.Algorithm.CSharp
         {
             foreach (var removed in changes.RemovedSecurities.Where(x => x.Symbol.SecurityType == SecurityType.Equity))
             {
-                // we search for the custom data which uses the removed security as underlying
-                var customDataSymbol = Securities.Keys.FirstOrDefault(symbol => symbol.ID.SecurityType == SecurityType.Base
-                                                                                && symbol.HasUnderlying
-                                                                                && symbol.Underlying == removed.Symbol);
-                // remove the custom data from our algorithm and collection
-                if (customDataSymbol != default(Symbol)
-                    && RemoveSecurity(customDataSymbol))
+                foreach (var removedCustomDataSymbol in RemoveCustomSecurities(removed.Symbol, typeof(SECReport8K), typeof(SECReport10K)))
                 {
-                    _customSymbols.Remove(customDataSymbol);
+                    // remove the custom data from our test collection
+                    _customSymbols.Remove(removedCustomDataSymbol);
                 }
             }
         }

--- a/Algorithm.CSharp/CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.cs
@@ -91,19 +91,15 @@ namespace QuantConnect.Algorithm.CSharp
             foreach (var added in changes.AddedSecurities.Where(x => x.Symbol.SecurityType == SecurityType.Equity))
             {
                 _customSymbols.Add(AddData<SECReport8K>(added.Symbol, Resolution.Daily).Symbol);
+                _customSymbols.Add(AddData<SECReport10K>(added.Symbol, Resolution.Daily).Symbol);
             }
 
             foreach (var removed in changes.RemovedSecurities.Where(x => x.Symbol.SecurityType == SecurityType.Equity))
             {
-                // we search for the custom data which uses the removed security as underlying
-                var customDataSymbol = Securities.Keys.FirstOrDefault(symbol => symbol.ID.SecurityType == SecurityType.Base
-                                                                                && symbol.HasUnderlying
-                                                                                && symbol.Underlying == removed.Symbol);
-                // remove the custom data from our algorithm and collection
-                if (customDataSymbol != default(Symbol)
-                    && RemoveSecurity(customDataSymbol))
+                foreach (var removedCustomDataSymbol in RemoveCustomSecurities(removed.Symbol, typeof(SECReport8K), typeof(SECReport10K)))
                 {
-                    _customSymbols.Remove(customDataSymbol);
+                    // remove the custom data from our test collection
+                    _customSymbols.Remove(removedCustomDataSymbol);
                 }
             }
         }

--- a/Algorithm.CSharp/CustomDataTemplateAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataTemplateAlgorithm.cs
@@ -1,0 +1,124 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Custom.SEC;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Template algorithm combining coarse selection with custom data
+    /// </summary>
+    public class CustomDataTemplateAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private const int NumberOfSymbols = 3;
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 03, 25);  //Set Start Date
+            SetEndDate(2014, 04, 07);    //Set End Date
+            SetCash(50000);             //Set Strategy Cash
+
+            // what resolution should the data *added* to the universe be?
+            UniverseSettings.Resolution = Resolution.Daily;
+            // this add universe method accepts a single parameter that is a function that
+            // accepts an IEnumerable<CoarseFundamental> and returns IEnumerable<Symbol>
+            AddUniverse(CoarseSelectionFunction);
+        }
+
+        // sort the data by daily dollar volume and take the top 'NumberOfSymbols'
+        public static IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
+        {
+            // sort descending by daily dollar volume
+            var sortedByDollarVolume = coarse.OrderByDescending(x => x.DollarVolume);
+
+            // take the top entries from our sorted collection
+            var top = sortedByDollarVolume.Take(NumberOfSymbols);
+
+            // we need to return only the symbol objects
+            return top.Select(x => x.Symbol);
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            // Trading logic could be place here
+        }
+
+        /// <summary>
+        /// Here we will add and remove our custom data types based on the securities being added by
+        /// the coarse selection method
+        /// </summary>
+        /// <remarks>We want to make sure we remove our custom data types to avoid unnecessary
+        /// resource consumption</remarks>
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            foreach (var added in changes.AddedSecurities.Where(x => x.Symbol.SecurityType == SecurityType.Equity))
+            {
+                AddData<SECReport8K>(added.Symbol, Resolution.Daily);
+                AddData<SECReport10K>(added.Symbol, Resolution.Daily);
+            }
+
+            foreach (var removed in changes.RemovedSecurities.Where(x => x.Symbol.SecurityType == SecurityType.Equity))
+            {
+                RemoveCustomSecurities(removed.Symbol, typeof(SECReport8K), typeof(SECReport10K));
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -156,6 +156,7 @@
     <Compile Include="CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.cs" />
     <Compile Include="CustomDataAddDataCoarseSelectionRegressionAlgorithm.cs" />
     <Compile Include="CustomDataAddDataRegressionAlgorithm.cs" />
+    <Compile Include="CustomDataTemplateAlgorithm.cs" />
     <Compile Include="SmartInsiderDataAlgorithm.cs" />
     <Compile Include="BasicTemplateAlgorithm.cs" />
     <Compile Include="Benchmarks\StatefulCoarseUniverseSelectionBenchmark.cs" />

--- a/Algorithm.Python/CustomDataAddDataCoarseSelectionRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataAddDataCoarseSelectionRegressionAlgorithm.py
@@ -54,6 +54,7 @@ class CustomDataAddDataCoarseSelectionRegressionAlgorithm(QCAlgorithm):
 
         for symbol in symbols:
             self.customSymbols.append(self.AddData(SECReport8K, symbol, Resolution.Daily).Symbol)
+            self.customSymbols.append(self.AddData(SECReport10K, symbol, Resolution.Daily).Symbol)
 
         return symbols
 
@@ -68,11 +69,6 @@ class CustomDataAddDataCoarseSelectionRegressionAlgorithm(QCAlgorithm):
 
     def OnSecuritiesChanged(self, changes):
         for removed in [i for i in changes.RemovedSecurities if i.Symbol.SecurityType == SecurityType.Equity]:
-            # we search for the custom data which uses the removed security as underlying
-            customDataSymbol = next((symbol for symbol in self.Securities.Keys if
-                                     symbol.ID.SecurityType == SecurityType.Base
-                                     and symbol.HasUnderlying
-                                     and symbol.Underlying == removed.Symbol), None)
-            # remove the custom data from our algorithm and collection
-            if customDataSymbol and self.RemoveSecurity(customDataSymbol):
-                self.customSymbols.remove(customDataSymbol)
+            for removedCustomDataSymbol in self.RemoveCustomSecurities(removed.Symbol, SECReport8K, SECReport10K):
+                # remove the custom data from our test collection
+                self.customSymbols.remove(removedCustomDataSymbol)

--- a/Algorithm.Python/CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.py
@@ -65,13 +65,9 @@ class CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm(QCAlgorithm):
     def OnSecuritiesChanged(self, changes):
         for added in [i for i in changes.AddedSecurities if i.Symbol.SecurityType == SecurityType.Equity]:
             self.customSymbols.append(self.AddData(SECReport8K, added.Symbol, Resolution.Daily).Symbol)
+            self.customSymbols.append(self.AddData(SECReport10K, added.Symbol, Resolution.Daily).Symbol)
 
         for removed in [i for i in changes.RemovedSecurities if i.Symbol.SecurityType == SecurityType.Equity]:
-            # we search for the custom data which uses the removed security as underlying
-            customDataSymbol = next((symbol for symbol in self.Securities.Keys if
-                                     symbol.ID.SecurityType == SecurityType.Base
-                                     and symbol.HasUnderlying
-                                     and symbol.Underlying == removed.Symbol), None)
-            # remove the custom data from our algorithm and collection
-            if customDataSymbol and self.RemoveSecurity(customDataSymbol):
-                self.customSymbols.remove(customDataSymbol)
+            for removedCustomDataSymbol in self.RemoveCustomSecurities(removed.Symbol, SECReport8K, SECReport10K):
+                # remove the custom data from our test collection
+                self.customSymbols.remove(removedCustomDataSymbol)

--- a/Algorithm.Python/CustomDataTemplateAlgorithm.py
+++ b/Algorithm.Python/CustomDataTemplateAlgorithm.py
@@ -1,0 +1,73 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Data import *
+from QuantConnect.Data.Custom.SEC import *
+from QuantConnect.Data.UniverseSelection import *
+
+### <summary>
+### Template algorithm combining coarse selection with custom data
+### </summary>
+class CustomTemplateAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        self.SetStartDate(2014,3,25)    #Set Start Date
+        self.SetEndDate(2014,4,7)      #Set End Date
+        self.SetCash(50000)            #Set Strategy Cash
+
+        # what resolution should the data *added* to the universe be?
+        self.UniverseSettings.Resolution = Resolution.Daily
+
+        # this add universe method accepts a single parameter that is a function that
+        # accepts an IEnumerable<CoarseFundamental> and returns IEnumerable<Symbol>
+        self.AddUniverse(self.CoarseSelectionFunction)
+
+        self.__numberOfSymbols = 3
+
+    # sort the data by daily dollar volume and take the top 'NumberOfSymbols'
+    def CoarseSelectionFunction(self, coarse):
+        # sort descending by daily dollar volume
+        sortedByDollarVolume = sorted(coarse, key=lambda x: x.DollarVolume, reverse=True)
+
+        # return the symbol objects of the top entries from our sorted collection
+        return [ x.Symbol for x in sortedByDollarVolume[:self.__numberOfSymbols] ]
+
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+
+        Arguments:
+            data: Slice object keyed by symbol containing the stock data
+        '''
+        # Trading logic could be place here
+        pass
+
+    def OnSecuritiesChanged(self, changes):
+        '''Here we will add and remove our custom data types based on the securities being added by
+            the coarse selection method.
+            We want to make sure we remove our custom data types to avoid unnecessary resource consumption
+        '''
+        for added in [i for i in changes.AddedSecurities if i.Symbol.SecurityType == SecurityType.Equity]:
+            self.AddData(SECReport8K, added.Symbol, Resolution.Daily)
+            self.AddData(SECReport10K, added.Symbol, Resolution.Daily)
+
+        for removed in [i for i in changes.RemovedSecurities if i.Symbol.SecurityType == SecurityType.Equity]:
+            self.RemoveCustomSecurities(removed.Symbol, SECReport8K, SECReport10K)

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -68,6 +68,7 @@
     <None Include="CustomDataAddDataRegressionAlgorithm.py" />
     <Content Include="CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.py" />
     <Content Include="CustomDataAddDataCoarseSelectionRegressionAlgorithm.py" />
+    <Content Include="CustomDataTemplateAlgorithm.py" />
     <Content Include="KerasNeuralNetworkAlgorithm.py" />
     <None Include="PsychSignalSentimentRegressionAlgorithm.py" />
     <Content Include="CustomDataUsingMapFileRegressionAlgorithm.py" />

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1694,6 +1694,35 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Will remove the custom <see cref="SecurityType.Base"/> securities which use the provided <see cref="Symbol"/>
+        /// as underlying for the given data types
+        /// </summary>
+        /// <param name="underlyingSymbol">The underlying <see cref="Symbol"/></param>
+        /// <param name="dataTypes">The data types we want to remove</param>
+        /// <returns>The <see cref="Symbol"/> of the removed <see cref="Security"/> if any</returns>
+        public List<Symbol> RemoveCustomSecurities(Symbol underlyingSymbol, params Type[] dataTypes)
+        {
+            var result = new List<Symbol>();
+            // we search for the custom data securities that use the provided symbol as underlying
+            // and verify the type matches with one of the requested 'dataTypes'
+            foreach (var symbol in Securities.Keys
+                .Where(symbol => symbol.ID.SecurityType == SecurityType.Base
+                                 && symbol.HasUnderlying
+                                 && symbol.Underlying == underlyingSymbol
+                                 // this will check the data type is the right one
+                                 && dataTypes.Any(type => SecurityIdentifier.GenerateBaseSymbol(type, underlyingSymbol.ID.Symbol) == symbol.ID.Symbol)))
+            {
+                // remove the custom data from our algorithm and collection
+                if (RemoveSecurity(symbol))
+                {
+                    result.Add(symbol);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Removes the security with the specified symbol. This will cancel all
         /// open orders and then liquidate any existing holdings
         /// </summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add `QCAlgorithm.RemoveCustomSecurities()` helper method that will
remove custom securities from the algorithm which use the provided
underlying Symbol and match the requested data types
- Adding `CustomDataTemplateAlgorithm` as a use case example for users

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
These regression algorithms were added in PR https://github.com/QuantConnect/Lean/pull/3588
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- If the custom data is not removed from the regression algorithm after each selection, the algorithms subscriptions will grow affecting performance
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executing the regression algorithms
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->