### PR TITLE
Fix pythonnet Python.Runtime.dll version in QuantConnect.Jupyter project

### DIFF
--- a/Jupyter/QuantConnect.Jupyter.csproj
+++ b/Jupyter/QuantConnect.Jupyter.csproj
@@ -111,7 +111,7 @@
           <Link>jupyter\clr.cpython-36m-darwin.so</Link>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-        <Content Include="..\packages\QuantConnect.pythonnet.1.0.5.23\lib\osx\jupyter\Python.Runtime.dll">
+        <Content Include="..\packages\QuantConnect.pythonnet.1.0.5.24\lib\osx\jupyter\Python.Runtime.dll">
           <Link>jupyter\Python.Runtime.dll</Link>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the pythonnet Python.Runtime.dll version in QuantConnect.Jupyter project

#### Description
<!--- Describe your changes in detail -->
Fix the pythonnet Python.Runtime.dll version in QuantConnect.Jupyter project

#### Related Issue
[3606](https://github.com/QuantConnect/Lean/issues/3606)

#### Motivation and Context
The QuantConnect.Jupyter project fails to build on OSX because as part of the build, the file Python.Runtime.dll is attempted to be copied from the solution local NuGet packages directory to the output directory. The file can't be copied because the wrong version is specified in QuantConnect.Jupyter.csproj.

#### How Has This Been Tested?

Tested by building the QuantConnect.Lean solution on OSX.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->