### PR TITLE
Fixes issue in SmartInsider where we could not choose where the final processed directory is

### DIFF
--- a/Configuration/ToolboxArgumentParser.cs
+++ b/Configuration/ToolboxArgumentParser.cs
@@ -63,7 +63,7 @@ namespace QuantConnect.Configuration
                                                                                    + " CoinApiDataConverter, NseMarketDataConverter, QuantQuoteConverter, SECDataConverter, PsychSignalDataConverter, USTreasuryYieldCurveConverter, SmartInsiderConverter]"),
                 new CommandLineOption("destination-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter, "
                                                                                         + "NseMarketDataConverter, QuantQuoteConverter, SECDataDownloader, SECDataConverter, PsychSignalDataDownloader, PsychSignalDataConverter, USTreasuryYieldCurveDownloader, USTreasuryYieldCurveConverter, SmartInsiderConverter]"),
-                new CommandLineOption("source-meta-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter]"),
+                new CommandLineOption("source-meta-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter. OPTIONAL for SmartInsiderConverter]"),
                 new CommandLineOption("start", CommandOptionType.SingleValue, "[REQUIRED for RandomDataGenerator. Format yyyyMMdd Example: --start=20010101]"),
                 new CommandLineOption("end", CommandOptionType.SingleValue, "[REQUIRED for RandomDataGenerator. Format yyyyMMdd Example: --end=20020101]"),
                 new CommandLineOption("market", CommandOptionType.SingleValue, "[OPTIONAL for RandomDataGenerator. Market of generated symbols. Defaults to default market for security type: Example: --market=usa]"),

--- a/ToolBox/Program.cs
+++ b/ToolBox/Program.cs
@@ -261,7 +261,8 @@ namespace QuantConnect.ToolBox
                         SmartInsiderProgram.SmartInsiderConverter(
                             DateTime.ParseExact(GetParameterOrExit(optionsObject, "date"), "yyyyMMdd", CultureInfo.InvariantCulture),
                             GetParameterOrExit(optionsObject, "source-dir"),
-                            GetParameterOrExit(optionsObject, "destination-dir"));
+                            GetParameterOrExit(optionsObject, "destination-dir"),
+                            GetParameterOrDefault(optionsObject, "source-meta-dir", Path.Combine(Globals.DataFolder, "alternative", "smartinsider")));
                         break;
 
                     default:

--- a/ToolBox/Program.cs
+++ b/ToolBox/Program.cs
@@ -262,7 +262,7 @@ namespace QuantConnect.ToolBox
                             DateTime.ParseExact(GetParameterOrExit(optionsObject, "date"), "yyyyMMdd", CultureInfo.InvariantCulture),
                             GetParameterOrExit(optionsObject, "source-dir"),
                             GetParameterOrExit(optionsObject, "destination-dir"),
-                            GetParameterOrDefault(optionsObject, "source-meta-dir", Path.Combine(Globals.DataFolder, "alternative", "smartinsider")));
+                            GetParameterOrDefault(optionsObject, "source-meta-dir", null));
                         break;
 
                     default:

--- a/ToolBox/SmartInsider/SmartInsiderConverter.cs
+++ b/ToolBox/SmartInsider/SmartInsiderConverter.cs
@@ -249,7 +249,7 @@ namespace QuantConnect.ToolBox.SmartInsider
 
                 if (processedFile.Exists)
                 {
-                    Log.Trace($"SmartInsiderConverter.WriteToFile(): Writing to existing file: {finalFile.FullName}");
+                    Log.Trace($"SmartInsiderConverter.WriteToFile(): Writing from existing processed contents to file: {finalFile.FullName}");
                     fileContents = File.ReadAllLines(processedFile.FullName)
                         .Select(x => (T)CreateSmartInsiderInstance<T>(x))
                         .ToList();

--- a/ToolBox/SmartInsider/SmartInsiderConverter.cs
+++ b/ToolBox/SmartInsider/SmartInsiderConverter.cs
@@ -234,7 +234,7 @@ namespace QuantConnect.ToolBox.SmartInsider
         /// <summary>
         /// Writes to a temp file and moves the content to the final directory
         /// </summary>
-        /// <param name="finalFile">Final file to write to</param>
+        /// <param name="destinationDirectory">Directory to write final file to</param>
         /// <param name="contents">Contents to write to file</param>
         private void WriteToFile<T>(DirectoryInfo destinationDirectory, Dictionary<string, List<T>> contents)
             where T : SmartInsiderEvent

--- a/ToolBox/SmartInsider/SmartInsiderConverter.cs
+++ b/ToolBox/SmartInsider/SmartInsiderConverter.cs
@@ -37,8 +37,9 @@ namespace QuantConnect.ToolBox.SmartInsider
         /// <summary>
         /// Creates an instance of the converter
         /// </summary>
-        /// <param name="sourceFile"></param>
-        /// <param name="destinationFile"></param>
+        /// <param name="sourceDirectory">Directory to read raw data from</param>
+        /// <param name="destinationDirectory">Directory to write processed data to</param>
+        /// <param name="processedFilesDirectory">Directory to read existing processed data from</param>
         public SmartInsiderConverter(DirectoryInfo sourceDirectory, DirectoryInfo destinationDirectory, DirectoryInfo processedFilesDirectory)
         {
             _sourceDirectory = sourceDirectory;

--- a/ToolBox/SmartInsider/SmartInsiderProgram.cs
+++ b/ToolBox/SmartInsider/SmartInsiderProgram.cs
@@ -23,9 +23,19 @@ namespace QuantConnect.ToolBox.SmartInsider
         /// <summary>
         /// Converts Smart Insider data
         /// </summary>
-        public static void SmartInsiderConverter(DateTime date, string sourceDirectory, string destinationDirectory)
+        public static void SmartInsiderConverter(DateTime date, string sourceDirectory, string destinationDirectory, string processedFileDirectory = null)
         {
-            var converter = new SmartInsiderConverter(new DirectoryInfo(sourceDirectory), new DirectoryInfo(destinationDirectory));
+            // Default to the Data Folder Smart Insider data directory if no argument is passed
+            if (string.IsNullOrEmpty(processedFileDirectory))
+            {
+                processedFileDirectory = Path.Combine(Globals.DataFolder, "alternative", "smartinsider");
+            }
+
+            var converter = new SmartInsiderConverter(
+                new DirectoryInfo(sourceDirectory),
+                new DirectoryInfo(destinationDirectory),
+                new DirectoryInfo(processedFileDirectory));
+
             converter.Convert(date);
         }
     }

--- a/ToolBox/SmartInsider/SmartInsiderProgram.cs
+++ b/ToolBox/SmartInsider/SmartInsiderProgram.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.ToolBox.SmartInsider
         public static void SmartInsiderConverter(DateTime date, string sourceDirectory, string destinationDirectory, string processedFileDirectory = null)
         {
             // Default to the Data Folder Smart Insider data directory if no argument is passed
-            if (string.IsNullOrEmpty(processedFileDirectory))
+            if (string.IsNullOrWhiteSpace(processedFileDirectory))
             {
                 processedFileDirectory = Path.Combine(Globals.DataFolder, "alternative", "smartinsider");
             }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Enables the ability to choose the source directory for the processed files
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3613 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure data integrity and consistency
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes - ToolBox configuration has been updated
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Offline local testing
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->