### PR TITLE
Feature 3618 add sparse data flag

### DIFF
--- a/Algorithm.CSharp/EstimizeDataAlgorithm.cs
+++ b/Algorithm.CSharp/EstimizeDataAlgorithm.cs
@@ -34,6 +34,9 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2017, 1, 1);
             SetEndDate(2017, 12, 31);
 
+            // be sure to add the underlying data source for our estimize data as it requires the mappings
+            AddEquity("AAPL");
+
             AddData<EstimizeRelease>("AAPL");
             AddData<EstimizeEstimate>("AAPL");
             AddData<EstimizeConsensus>("AAPL");

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -141,11 +141,12 @@ namespace QuantConnect.Algorithm
         /// <returns>The new <see cref="Security"/></returns>
         public Security AddData(Type dataType, string ticker, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
         {
+            // NOTE: Invoking methods on BaseData w/out setting the symbol may provide unexpected behavior
             var baseInstance = dataType.GetBaseDataInstance();
             if (!baseInstance.RequiresMapping())
             {
                 var symbol = new Symbol(
-                    SecurityIdentifier.GenerateBase(dataType, ticker, Market.USA, dataType.GetBaseDataInstance().RequiresMapping()),
+                    SecurityIdentifier.GenerateBase(dataType, ticker, Market.USA, baseInstance.RequiresMapping()),
                     ticker);
                 return AddDataImpl(dataType, symbol, resolution, timeZone, fillDataForward, leverage);
             }

--- a/Common/Data/BaseData.cs
+++ b/Common/Data/BaseData.cs
@@ -150,6 +150,16 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
+        /// Indicates that the data set is expected to be sparse
+        /// </summary>
+        /// <returns>True if the data set represented by this type is expected to be sparse</returns>
+        public virtual bool IsSparseData()
+        {
+            // by default, we'll assume all custom data is sparse data
+            return Symbol.SecurityType == SecurityType.Base;
+        }
+
+        /// <summary>
         /// Updates this base data with a new trade
         /// </summary>
         /// <param name="lastTrade">The price of the last trade</param>

--- a/Common/Data/BaseData.cs
+++ b/Common/Data/BaseData.cs
@@ -27,51 +27,24 @@ namespace QuantConnect.Data
     /// </summary>
     public abstract class BaseData : IBaseData
     {
-        private MarketDataType _dataType = MarketDataType.Base;
-        private DateTime _time;
-        private Symbol _symbol = Symbol.Empty;
         private decimal _value;
-        private bool _isFillForward;
 
         /// <summary>
         /// Market Data Type of this data - does it come in individual price packets or is it grouped into OHLC.
         /// </summary>
         /// <remarks>Data is classed into two categories - streams of instantaneous prices and groups of OHLC data.</remarks>
-        public MarketDataType DataType
-        {
-            get
-            {
-                return _dataType;
-            }
-            set
-            {
-                _dataType = value;
-            }
-        }
+        public MarketDataType DataType { get; set; } = MarketDataType.Base;
 
         /// <summary>
         /// True if this is a fill forward piece of data
         /// </summary>
-        public bool IsFillForward
-        {
-            get { return _isFillForward; }
-        }
+        public bool IsFillForward { get; private set; }
 
         /// <summary>
         /// Current time marker of this data packet.
         /// </summary>
         /// <remarks>All data is timeseries based.</remarks>
-        public DateTime Time
-        {
-            get
-            {
-                return _time;
-            }
-            set
-            {
-                _time = value;
-            }
-        }
+        public DateTime Time { get; set; }
 
         /// <summary>
         /// The end time of this data. Some data covers spans (trade bars) and as such we want
@@ -79,24 +52,14 @@ namespace QuantConnect.Data
         /// </summary>
         public virtual DateTime EndTime
         {
-            get { return _time; }
-            set { _time = value; }
+            get { return Time; }
+            set { Time = value; }
         }
 
         /// <summary>
         /// Symbol representation for underlying Security
         /// </summary>
-        public Symbol Symbol
-        {
-            get
-            {
-                return _symbol;
-            }
-            set
-            {
-                _symbol = value;
-            }
-        }
+        public Symbol Symbol { get; set; } = Symbol.Empty;
 
         /// <summary>
         /// Value representation of this data packet. All data requires a representative value for this moment in time.
@@ -117,13 +80,7 @@ namespace QuantConnect.Data
         /// <summary>
         /// As this is a backtesting platform we'll provide an alias of value as price.
         /// </summary>
-        public decimal Price
-        {
-            get
-            {
-                return Value;
-            }
-        }
+        public decimal Price => Value;
 
         /// <summary>
         /// Constructor for initialising the dase data class
@@ -259,7 +216,7 @@ namespace QuantConnect.Data
         public virtual BaseData Clone(bool fillForward)
         {
             var clone = Clone();
-            clone._isFillForward = fillForward;
+            clone.IsFillForward = fillForward;
             return clone;
         }
 

--- a/Common/Data/SubscriptionDataConfigExtensions.cs
+++ b/Common/Data/SubscriptionDataConfigExtensions.cs
@@ -116,10 +116,18 @@ namespace QuantConnect.Data
         public static bool TickerShouldBeMapped(this SubscriptionDataConfig config)
         {
             // we create an instance of the data type, if it is a custom type
-            // it can override RequiresMapping else it will use security type
+            // it can override RequiresMapping else it will use security type\
+            return config.GetBaseDataInstance().RequiresMapping();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseData"/> type defined in <paramref name="config"/> with the symbol properly set
+        /// </summary>
+        public static BaseData GetBaseDataInstance(this SubscriptionDataConfig config)
+        {
             var instance = config.Type.GetBaseDataInstance();
             instance.Symbol = config.Symbol;
-            return instance.RequiresMapping();
+            return instance;
         }
     }
 }

--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _date = date;
             _config = config;
             _isLiveMode = isLiveMode;
-            _factory = _config.Type.GetBaseDataInstance();
+            _factory = _config.GetBaseDataInstance();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/CollectionSubscriptionDataSourceReader.cs
@@ -96,6 +96,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     yield break;
                 }
 
+                if (reader.EndOfStream)
+                {
+                    OnInvalidSource(source, new Exception($"The reader was empty for source: ${source.Source}"));
+                    yield break;
+                }
+
                 var raw = "";
                 while (!reader.EndOfStream)
                 {

--- a/Engine/DataFeeds/DefaultDataProvider.cs
+++ b/Engine/DataFeeds/DefaultDataProvider.cs
@@ -41,9 +41,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 if (exception is DirectoryNotFoundException
                     || exception is FileNotFoundException)
                 {
-                    Log.Error("DefaultDataProvider.Fetch(): The specified file was not found: {0}", key);
                     return null;
                 }
+
                 throw;
             }
         }

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
@@ -68,14 +68,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <returns>An enumerator reading the subscription request</returns>
         public IEnumerator<BaseData> CreateEnumerator(SubscriptionRequest request, IDataProvider dataProvider)
         {
-            var sourceFactory = request.Configuration.Type.GetBaseDataInstance();
-            var useMapFiles = request.Configuration.TickerShouldBeMapped();
+            var sourceFactory = request.Configuration.GetBaseDataInstance();
 
             using (var dataCacheProvider = new SingleEntryDataCacheProvider(dataProvider))
             {
                 foreach (var date in _tradableDaysProvider(request))
                 {
-                    if (useMapFiles)
+                    if (sourceFactory.RequiresMapping())
                     {
                         request.Configuration.MappedSymbol = GetMappedSymbol(request.Configuration, date);
                     }

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             // also provides some immediate fast-forward to handle spooling through remote files quickly
             var frontier = Ref.Create(request.StartTimeLocal);
             var lastSourceRefreshTime = DateTime.MinValue;
-            var sourceFactory = config.Type.GetBaseDataInstance();
+            var sourceFactory = config.GetBaseDataInstance();
 
             // this is refreshing the enumerator stack for each new source
             var refresher = new RefreshEnumerator<BaseData>(() =>

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -169,7 +169,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             //Save the type of data we'll be getting from the source.
             try
             {
-                _dataFactory = _config.Type.GetBaseDataInstance();
+                _dataFactory = _config.GetBaseDataInstance();
             }
             catch (ArgumentException exception)
             {
@@ -213,7 +213,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             // load up the map files for equities, options, and custom data if it supports it.
             // Only load up factor files for equities
-            if (_config.TickerShouldBeMapped())
+            if (_dataFactory.RequiresMapping())
             {
                 try
                 {

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -448,16 +448,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
         private void AttachEventHandlers(ISubscriptionDataSourceReader dataSourceReader, SubscriptionDataSource source)
         {
+            // NOTE: There seems to be some overlap in InvalidSource and CreateStreamReaderError
+            //       this may be worthy of further investigation and potential consolidation of events.
+
             // handle missing files
             dataSourceReader.InvalidSource += (sender, args) =>
             {
                 switch (args.Source.TransportMedium)
                 {
-                    case SubscriptionTransportMedium.LocalFile:
-                        // the local uri doesn't exist, write an error and return null so we we don't try to get data for today
-                        // Log.Trace(string.Format("SubscriptionDataReader.GetReader(): Could not find QC Data, skipped: {0}", source));
-                        break;
-
                     case SubscriptionTransportMedium.RemoteFile:
                         OnDownloadFailed(
                             new DownloadFailedEventArgs(
@@ -479,7 +477,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 var textSubscriptionFactory = (TextSubscriptionDataSourceReader)dataSourceReader;
                 textSubscriptionFactory.CreateStreamReaderError += (sender, args) =>
                 {
-                    //Log.Error(string.Format("Failed to get StreamReader for data source({0}), symbol({1}). Skipping date({2}). Reader is null.", args.Source.Source, _mappedSymbol, args.Date.ToShortDateString()));
                     if (_config.IsCustomData)
                     {
                         OnDownloadFailed(

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _date = date;
             _config = config;
             _isLiveMode = isLiveMode;
-            _factory = config.Type.GetBaseDataInstance();
+            _factory = config.GetBaseDataInstance();
             _shouldCacheDataPoints = !_config.IsCustomData && _config.Resolution >= Resolution.Hour
                 && _config.Type != typeof(FineFundamental) && _config.Type != typeof(CoarseFundamental)
 		&& !_dataCacheProvider.IsDataEphemeral;

--- a/Engine/DataFeeds/ZipEntryNameSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/ZipEntryNameSubscriptionDataSourceReader.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _config = config;
             _date = date;
             _isLiveMode = isLiveMode;
-            _factory = _factory = config.Type.GetBaseDataInstance();
+            _factory = _factory = config.GetBaseDataInstance();
         }
 
         /// <summary>

--- a/Tests/Common/Data/BaseDataTests.cs
+++ b/Tests/Common/Data/BaseDataTests.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Data;
+
+namespace QuantConnect.Tests.Common.Data
+{
+    [TestFixture]
+    public class BaseDataTests
+    {
+        [Test]
+        public void IsSparseData_ReturnsTrue_WhenSecurityTypeIsBase()
+        {
+            var baseData = new DataType {Symbol = Symbol.Create("ticker", SecurityType.Base, QuantConnect.Market.USA)};
+            Assert.IsTrue(baseData.IsSparseData());
+        }
+
+        [Test]
+        public void IsSparseData_ReturnsFalse_WhenSecurityTypeIsNotBase()
+        {
+            var securityTypes = Enum.GetValues(typeof(SecurityType))
+                .Cast<SecurityType>()
+                .Where(type => type != SecurityType.Base);
+
+            foreach (var securityType in securityTypes)
+            {
+                var baseData = new DataType();
+
+                try { baseData.Symbol = Symbol.Create("ticker", securityType, QuantConnect.Market.USA); }
+                catch (NotImplementedException) { continue; }
+
+                Assert.IsFalse(baseData.IsSparseData(), securityType.ToString());
+            }
+        }
+
+        private class DataType : BaseData { }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -295,6 +295,7 @@
     <Compile Include="Brokerages\Alpaca\AlpacaBrokerageTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileTests.cs" />
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
+    <Compile Include="Common\Data\BaseDataTests.cs" />
     <Compile Include="Common\Data\CalendarConsolidatorsTests.cs" />
     <Compile Include="Common\Data\Custom\EstimizeTests.cs" />
     <Compile Include="Common\Data\Fundamental\MultiPeriodFieldTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Adds a new `BaseData.IsSparseData()` flag method. We're currently only using this flag to control whether or not to emit file not found errors. By default, all custom data is set to be sparse data and can be overridden where appropriate.

NOTE: I've left this as a method `IsSparseData()` but think it would be beneficial to look into collapsing these _options_ into a `[Flags]` enum. Also, leaving as a method over concerns about python being able to easily override properties.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #3618

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevents log spam which causes slow backtests.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing unit tests cover these changes fairly well and it's hard to directly test actions taken against `Log`. I manually ran algorithms with invalid symbols to observe generated error messages. I confirmed that for default data (equity/etc) we get the error messages as desired but for custom data we do not get the error messages.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->