### PR TITLE
Add DynamicSecurityData and cache derivative custom data in underlying

### DIFF
--- a/Algorithm.CSharp/DynamicSecurityDataAlgorithm.cs
+++ b/Algorithm.CSharp/DynamicSecurityDataAlgorithm.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using Newtonsoft.Json;
+using QuantConnect.Data;
+using QuantConnect.Data.Custom.SEC;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Provides an example algorithm showcasing the <see cref="Security.Data"/> features
+    /// </summary>
+    public class DynamicSecurityDataAlgorithm : QCAlgorithm
+    {
+        private Security GOOGL;
+        private const string Ticker = "GOOGL";
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 10, 22);
+            SetEndDate(2015, 10, 30);
+
+            GOOGL = AddEquity(Ticker, Resolution.Daily);
+
+            AddData<SECReport8K>(Ticker);
+            AddData<SECReport10Q>(Ticker);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            dynamic securityData = GOOGL.Data;
+
+            // check if a particular type of data is available
+            if (GOOGL.Data.HasData<SECReport8K>())
+            {
+                // access data using C# generics for strong typing
+                // GetAll<T> returns an IReadOnlyList<T>
+                var sec8k = GOOGL.Data.GetAll<SECReport8K>();
+                Log($"GOOGL.Data.GetAll<SECReport8K>(): {sec8k}");
+
+                // access data using dynamic access. this is the recommended access
+                // pattern for python as well.
+                sec8k = securityData.SECReport8K;
+                Log($"GOOGL.Data.SECReport8K: {sec8k}");
+            }
+
+            // you can access data of all types in this manner, even for TradeBar data
+            if (GOOGL.Data.HasData<TradeBar>())
+            {
+                // Get<T> returns the last item in the list
+                var tradeBar = GOOGL.Data.Get<TradeBar>();
+                Log($"GOOGL.Data.Get<TradeBar>(): {JsonConvert.SerializeObject(tradeBar, Formatting.Indented)}");
+
+                // the dynamic accessors always returns an IReadOnlyList<T>
+                var tradeBars = securityData.TradeBar;
+                Log($"GOOGL.Data.TradeBar: {JsonConvert.SerializeObject(tradeBar, Formatting.Indented)}");
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -156,6 +156,7 @@
     <Compile Include="CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.cs" />
     <Compile Include="CustomDataAddDataCoarseSelectionRegressionAlgorithm.cs" />
     <Compile Include="CustomDataAddDataRegressionAlgorithm.cs" />
+    <Compile Include="DynamicSecurityDataAlgorithm.cs" />
     <Compile Include="SmartInsiderDataAlgorithm.cs" />
     <Compile Include="BasicTemplateAlgorithm.cs" />
     <Compile Include="Benchmarks\StatefulCoarseUniverseSelectionBenchmark.cs" />

--- a/Algorithm.Python/DynamicSecurityDataAlgorithm.py
+++ b/Algorithm.Python/DynamicSecurityDataAlgorithm.py
@@ -1,0 +1,63 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Data.Custom.SEC import *
+
+### <summary>
+### Provides an example algorithm showcasing the Security.Data features
+### </summary>
+class DynamicSecurityDataAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.Ticker = "GOOGL";
+
+        self.SetStartDate(2015, 10, 22)
+        self.SetEndDate(2015, 10, 30)
+
+        self.GOOGL = self.AddEquity(self.Ticker, Resolution.Daily)
+
+        self.AddData(SECReport8K, self.Ticker, Resolution.Daily)
+        self.AddData(SECReport10K, self.Ticker, Resolution.Daily)
+        self.AddData(SECReport10Q, self.Ticker, Resolution.Daily)
+
+    def OnData(self, data):
+
+        # The Security object's Data property provides convenient access
+        # to the various types of data related to that security. You can
+        # access not only the security's price data, but also any custom
+        # data that is mapped to the security, such as our SEC reports.
+
+        # 1. Get the most recent data point of a particular type:
+        # 1.a Using the generic method, Get(T): => T
+        googlSec8kReport = self.GOOGL.Data.Get(SECReport8K)
+        googlSec10kReport = self.GOOGL.Data.Get(SECReport10K)
+        self.Log("{}:  8K: {}".format(self.Time, googlSec8kReport))
+        self.Log("{}: 10K: {}".format(self.Time, googlSec10kReport))
+
+        # 2. Get the list of data points of a particular type for the most recent time step:
+        # 2.a Using the generic method, GetAll(T): => IReadOnlyList<T>
+        googlSec8kReports = self.GOOGL.Data.GetAll(SECReport8K)
+        googlSec10kReports = self.GOOGL.Data.GetAll(SECReport10K)
+        self.Log("{}:  8K: {}".format(self.Time, len(googlSec8kReports)))
+        self.Log("{}: 10K: {}".format(self.Time, len(googlSec10kReports)))
+
+        if not self.Portfolio.Invested:
+            self.Buy(self.GOOGL.Symbol, 10)

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -68,6 +68,7 @@
     <None Include="CustomDataAddDataRegressionAlgorithm.py" />
     <Content Include="CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.py" />
     <Content Include="CustomDataAddDataCoarseSelectionRegressionAlgorithm.py" />
+    <Content Include="DynamicSecurityDataAlgorithm.py" />
     <Content Include="KerasNeuralNetworkAlgorithm.py" />
     <None Include="PsychSignalSentimentRegressionAlgorithm.py" />
     <Content Include="CustomDataUsingMapFileRegressionAlgorithm.py" />

--- a/Common/AlphaRuntimeStatistics.cs
+++ b/Common/AlphaRuntimeStatistics.cs
@@ -245,7 +245,7 @@ namespace QuantConnect
                 {"Long Insight Count", $"{Invariant(LongCount)}"},
                 {"Short Insight Count", $"{Invariant(ShortCount)}"},
                 {"Long/Short Ratio", $"{Invariant(Math.Round(100*LongShortRatio, 2))}%"},
-                {"Estimated Monthly Alpha Value", $"{accountCurrencySymbol}{Invariant(Invariant(EstimatedMonthlyAlphaValue.SmartRounding()))}"},
+                {"Estimated Monthly Alpha Value", $"{accountCurrencySymbol}{Invariant(EstimatedMonthlyAlphaValue.SmartRounding())}"},
                 {"Total Accumulated Estimated Alpha Value", $"{accountCurrencySymbol}{Invariant(TotalAccumulatedEstimatedAlphaValue.SmartRounding())}"},
                 {"Mean Population Estimated Insight Value", $"{accountCurrencySymbol}{Invariant(MeanPopulationEstimatedInsightValue.SmartRounding())}"},
                 {"Mean Population Direction", $"{Invariant(Math.Round(100 * MeanPopulationScore.Direction, 4))}%"},

--- a/Common/Data/GetSetPropertyDynamicMetaObject.cs
+++ b/Common/Data/GetSetPropertyDynamicMetaObject.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Dynamic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace QuantConnect.Data
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="DynamicMetaObject"/> that uses get/set methods to update
+    /// values in the dynamic object.
+    /// </summary>
+    public class GetSetPropertyDynamicMetaObject : DynamicMetaObject
+    {
+        private readonly MethodInfo _setPropertyMethodInfo;
+        private readonly MethodInfo _getPropertyMethodInfo;
+
+        public GetSetPropertyDynamicMetaObject(
+            Expression expression,
+            object value,
+            MethodInfo setPropertyMethodInfo,
+            MethodInfo getPropertyMethodInfo
+            )
+            : base(expression, BindingRestrictions.Empty, value)
+        {
+            _setPropertyMethodInfo = setPropertyMethodInfo;
+            _getPropertyMethodInfo = getPropertyMethodInfo;
+        }
+
+        public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
+        {
+            // we need to build up an expression tree that represents accessing our instance
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, LimitType);
+
+            var args = new Expression[]
+            {
+                // this is the name of the property to set
+                Expression.Constant(binder.Name),
+
+                // this is the value
+                Expression.Convert(value.Expression, typeof (object))
+            };
+
+            // set the 'this' reference
+            var self = Expression.Convert(Expression, LimitType);
+
+            var call = Expression.Call(self, _setPropertyMethodInfo, args);
+
+            return new DynamicMetaObject(call, restrictions);
+        }
+
+        public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
+        {
+            // we need to build up an expression tree that represents accessing our instance
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, LimitType);
+
+            // arguments for 'call'
+            var args = new Expression[]
+            {
+                // this is the name of the property to set
+                Expression.Constant(binder.Name)
+            };
+
+            // set the 'this' reference
+            var self = Expression.Convert(Expression, LimitType);
+
+            var call = Expression.Call(self, _getPropertyMethodInfo, args);
+
+            return new DynamicMetaObject(call, restrictions);
+        }
+    }
+}

--- a/Common/Data/Market/Bar.cs
+++ b/Common/Data/Market/Bar.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -85,6 +85,17 @@ namespace QuantConnect.Data.Market
         public Bar Clone()
         {
             return new Bar(Open, High, Low, Close);
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        /// <filterpriority>2</filterpriority>
+        public override string ToString()
+        {
+            return $"O: {Open.SmartRounding()} " +
+                   $"H: {High.SmartRounding()} " +
+                   $"L: {Low.SmartRounding()} " +
+                   $"C: {Close.SmartRounding()}";
         }
     }
 }

--- a/Common/Data/Market/QuoteBar.cs
+++ b/Common/Data/Market/QuoteBar.cs
@@ -556,5 +556,18 @@ namespace QuantConnect.Data.Market
                 Period = Period
             };
         }
+
+        public override string ToString()
+        {
+            return $"{Symbol}: " +
+                   $"Bid: O: {Bid?.Open.SmartRounding()} " +
+                   $"Bid: H: {Bid?.High.SmartRounding()} " +
+                   $"Bid: L: {Bid?.Low.SmartRounding()} " +
+                   $"Bid: C: {Bid?.Close.SmartRounding()} " +
+                   $"Ask: O: {Ask?.Open.SmartRounding()} " +
+                   $"Ask: H: {Ask?.High.SmartRounding()} " +
+                   $"Ask: L: {Ask?.Low.SmartRounding()} " +
+                   $"Ask: C: {Ask?.Close.SmartRounding()} ";
+        }
     }
 }

--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -429,10 +429,31 @@ namespace QuantConnect.Data.Market
             return new Tick(this);
         }
 
+        /// <summary>
+        /// Formats a string with the symbol and value.
+        /// </summary>
+        /// <returns>string - a string formatted as SPY: 167.753</returns>
+        public override string ToString()
+        {
+            switch (TickType)
+            {
+                case TickType.Trade:
+                    return $"{Symbol}: Price: {Price} Quantity: {Quantity}";
+
+                case TickType.Quote:
+                    return $"{Symbol}: Bid: {BidSize}@{BidPrice} Ask: {AskSize}@{AskPrice}";
+
+                case TickType.OpenInterest:
+                    return $"{Symbol}: OpenInterest: {Value}";
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
         private static decimal GetScaleFactor(SecurityType securityType)
         {
             return securityType == SecurityType.Equity || securityType == SecurityType.Option ? 10000m : 1;
         }
-
-    } // End Tick Class:
+    }
 }

--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -631,6 +631,20 @@ namespace QuantConnect.Data.Market
         }
 
         /// <summary>
+        /// Formats a string with the symbol and value.
+        /// </summary>
+        /// <returns>string - a string formatted as SPY: 167.753</returns>
+        public override string ToString()
+        {
+            return $"{Symbol}: " +
+                   $"O: {Open.SmartRounding()} " +
+                   $"H: {High.SmartRounding()} " +
+                   $"L: {Low.SmartRounding()} " +
+                   $"C: {Close.SmartRounding()} " +
+                   $"V: {Volume.SmartRounding()}";
+        }
+
+        /// <summary>
         /// Initializes this bar with a first data point
         /// </summary>
         /// <param name="value">The seed value for this bar</param>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -308,8 +308,7 @@ namespace QuantConnect
             }
 
             // this is good for forex and other small numbers
-            var d = (double)input;
-            return (decimal)d.RoundToSignificantDigits(7);
+            return input.RoundToSignificantDigits(7).Normalize();
         }
 
         /// <summary>

--- a/Common/Interfaces/ISecurityPrice.cs
+++ b/Common/Interfaces/ISecurityPrice.cs
@@ -14,6 +14,7 @@
  *
 */
 
+using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Securities;
 
@@ -75,6 +76,13 @@ namespace QuantConnect.Interfaces
         /// </summary>
         /// <param name="data">New data packet from LEAN</param>
         void SetMarketPrice(BaseData data);
+
+        /// <summary>
+        /// Updates all of the security properties, such as price/OHLCV/bid/ask based
+        /// on the data provided. Data is also stored into the security's data cache
+        /// </summary>
+        /// <param name="data">The security update data</param>
+        void Update(IEnumerable<BaseData> data);
 
         /// <summary>
         /// Get the last price update set to the security.

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -317,6 +317,8 @@
     <Compile Include="Securities\GetMinimumPriceVariationParameters.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPosition.cs" />
     <Compile Include="Securities\ReservedBuyingPowerForPositionParameters.cs" />
+    <Compile Include="Securities\SecurityCacheDataStoredEventArgs.cs" />
+    <Compile Include="Securities\DynamicSecurityData.cs" />
     <Compile Include="Securities\SecurityService.cs" />
     <Compile Include="Securities\Volatility\BaseVolatilityModel.cs" />
     <Compile Include="Series.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -264,6 +264,7 @@
     <Compile Include="Data\Custom\USEnergyInformation.cs" />
     <Compile Include="Data\Custom\USTreasury\USTreasuryYieldCurveRate.cs" />
     <Compile Include="Data\Fundamental\AssetClassificationHelper.cs" />
+    <Compile Include="Data\GetSetPropertyDynamicMetaObject.cs" />
     <Compile Include="Data\HistoryProviderBase.cs" />
     <Compile Include="Data\HistoryProviderInitializeParameters.cs" />
     <Compile Include="Data\HistoryRequestFactory.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -304,6 +304,7 @@
     <Compile Include="Securities\BuyingPowerParameters.cs" />
     <Compile Include="Securities\BuyingPowerModel.cs" />
     <Compile Include="Securities\BuyingPowerModelExtensions.cs" />
+    <Compile Include="Securities\RegisteredSecurityDataTypesProvider.cs" />
     <Compile Include="Securities\ErrorCurrencyConverter.cs" />
     <Compile Include="Securities\GetMaximumOrderQuantityForTargetValueParameters.cs" />
     <Compile Include="Securities\HasSufficientBuyingPowerForOrderParameters.cs" />
@@ -312,6 +313,7 @@
     <Compile Include="Securities\CashAmount.cs" />
     <Compile Include="Securities\IdentityCurrencyConverter.cs" />
     <Compile Include="Securities\AccountCurrencyImmediateSettlementModel.cs" />
+    <Compile Include="Securities\IRegisteredSecurityDataTypesProvider.cs" />
     <Compile Include="Securities\InitialMarginRequiredForOrderParameters.cs" />
     <Compile Include="Securities\IOrderEventProvider.cs" />
     <Compile Include="Securities\GetMinimumPriceVariationParameters.cs" />

--- a/Common/Securities/Cfd/Cfd.cs
+++ b/Common/Securities/Cfd/Cfd.cs
@@ -35,7 +35,13 @@ namespace QuantConnect.Securities.Cfd
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
         /// instances into units of the account currency</param>
-        public Cfd(SecurityExchangeHours exchangeHours, Cash quoteCurrency, SubscriptionDataConfig config, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Cfd(SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            SubscriptionDataConfig config,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -50,7 +56,8 @@ namespace QuantConnect.Securities.Cfd
                 new SecurityMarginModel(50m),
                 new CfdDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             Holdings = new CfdHolding(this, currencyConverter);
@@ -65,7 +72,13 @@ namespace QuantConnect.Securities.Cfd
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
         /// instances into units of the account currency</param>
-        public Cfd(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Cfd(Symbol symbol,
+            SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -80,7 +93,8 @@ namespace QuantConnect.Securities.Cfd
                 new SecurityMarginModel(50m),
                 new CfdDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             Holdings = new CfdHolding(this, currencyConverter);

--- a/Common/Securities/Crypto/Crypto.cs
+++ b/Common/Securities/Crypto/Crypto.cs
@@ -38,7 +38,13 @@ namespace QuantConnect.Securities.Crypto
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
         /// instances into units of the account currency</param>
-        public Crypto(SecurityExchangeHours exchangeHours, Cash quoteCurrency, SubscriptionDataConfig config, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Crypto(SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            SubscriptionDataConfig config,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -53,7 +59,8 @@ namespace QuantConnect.Securities.Crypto
                 new CashBuyingPowerModel(),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             Holdings = new CryptoHolding(this, currencyConverter);
@@ -73,7 +80,13 @@ namespace QuantConnect.Securities.Crypto
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
         /// instances into units of the account currency</param>
-        public Crypto(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Crypto(Symbol symbol,
+            SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -88,7 +101,8 @@ namespace QuantConnect.Securities.Crypto
                 new CashBuyingPowerModel(),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             Holdings = new CryptoHolding(this, currencyConverter);

--- a/Common/Securities/DynamicSecurityData.cs
+++ b/Common/Securities/DynamicSecurityData.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
@@ -34,7 +35,7 @@ namespace QuantConnect.Securities
         private static readonly MethodInfo GetPropertyMethodInfo = typeof(DynamicSecurityData).GetMethod("GetProperty");
 
         private readonly IRegisteredSecurityDataTypesProvider _registeredTypes;
-        private readonly Dictionary<string, object> _storage = new Dictionary<string, object>();
+        private readonly ConcurrentDictionary<string, object> _storage = new ConcurrentDictionary<string, object>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicSecurityData"/> class

--- a/Common/Securities/DynamicSecurityData.cs
+++ b/Common/Securities/DynamicSecurityData.cs
@@ -1,0 +1,144 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using QuantConnect.Data;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Provides access to a security's data via it's type. This implementation supports dynamic access
+    /// by type name.
+    /// </summary>
+    public class DynamicSecurityData : IDynamicMetaObjectProvider
+    {
+        private static readonly MethodInfo SetPropertyMethodInfo = typeof(DynamicSecurityData).GetMethod("SetProperty");
+        private static readonly MethodInfo GetPropertyMethodInfo = typeof(DynamicSecurityData).GetMethod("GetProperty");
+
+        private readonly Dictionary<string, object> _storage = new Dictionary<string, object>();
+
+        /// <summary>Returns the <see cref="T:System.Dynamic.DynamicMetaObject" /> responsible for binding operations performed on this object.</summary>
+        /// <returns>The <see cref="T:System.Dynamic.DynamicMetaObject" /> to bind this object.</returns>
+        /// <param name="parameter">The expression tree representation of the runtime value.</param>
+        public DynamicMetaObject GetMetaObject(Expression parameter)
+        {
+            return new GetSetPropertyDynamicMetaObject(parameter, this, SetPropertyMethodInfo, GetPropertyMethodInfo);
+        }
+
+        /// <summary>
+        /// Gets whether or not this dynamic data instance has data stored for the specified type
+        /// </summary>
+        public bool HasData<T>()
+        {
+            return _storage.ContainsKey(typeof(T).Name);
+        }
+
+        /// <summary>
+        /// Gets whether or not this dynamic data instance has a property with the specified name.
+        /// This is a case-insensitve search.
+        /// </summary>
+        /// <param name="name">The property name to check for</param>
+        /// <returns>True if the property exists, false otherwise</returns>
+        public bool HasProperty(string name)
+        {
+            return _storage.ContainsKey(name);
+        }
+
+        /// <summary>
+        /// Stores the list of data using <paramref name="dataType"/>'s <see cref="Type.Name"/> as the key
+        /// </summary>
+        /// <typeparam name="T">Statically known type of each item in the list. This may just be BaseData
+        /// which is why this method supports explicitly providing the data type to use for the key</typeparam>
+        /// <param name="dataType">The runtime type of each item in the list. The name of this type is used
+        /// as the key for the data</param>
+        /// <param name="data">The data to be stored</param>
+        public void StoreData<T>(Type dataType, IReadOnlyList<T> data)
+        {
+            // this would, for example, be 'Bitcoin' or 'TradeBar'
+            SetProperty(dataType.Name, data);
+        }
+
+        /// <summary>
+        /// Gets the last item in the data list for the specified type
+        /// </summary>
+        public T Get<T>()
+        {
+            var list = GetAll<T>();
+            return list.LastOrDefault();
+        }
+
+        /// <summary>
+        /// Gets the data list for the specified type
+        /// </summary>
+        public IReadOnlyList<T> GetAll<T>()
+        {
+            var data = GetProperty(typeof(T).Name);
+
+            var list = data as IReadOnlyList<T>;
+            if (list != null)
+            {
+                return list;
+            }
+
+            var baseDataList = data as IReadOnlyList<BaseData>;
+            if (baseDataList != null)
+            {
+                list = new List<T>(baseDataList.OfType<T>());
+                StoreData(typeof(T), list);
+                return list;
+            }
+
+            throw new InvalidOperationException(
+                $"Expected a list with type '{typeof(IReadOnlyList<T>).GetBetterTypeName()}' " +
+                $"but found type '{data.GetType().GetBetterTypeName()}"
+            );
+        }
+
+        /// <summary>
+        /// Sets the property with the specified name to the value. This is a case-insensitve search.
+        /// </summary>
+        /// <param name="name">The property name to set</param>
+        /// <param name="value">The new property value</param>
+        /// <returns>Returns the input value back to the caller</returns>
+        public object SetProperty(string name, object value)
+        {
+            _storage[name] = value;
+            return value;
+        }
+
+        /// <summary>
+        /// Gets the property's value with the specified name. This is a case-insensitve search.
+        /// </summary>
+        /// <param name="name">The property name to access</param>
+        /// <returns>object value of BaseData</returns>
+        public object GetProperty(string name)
+        {
+            object value;
+            if (_storage.TryGetValue(name, out value))
+            {
+                return value;
+            }
+
+            var keys = _storage.Keys.OrderBy(k => k);
+            throw new KeyNotFoundException($"Property with name '{name}' does not exist. Properties: {string.Join(", ", keys)}");
+
+        }
+    }
+}

--- a/Common/Securities/Equity/Equity.cs
+++ b/Common/Securities/Equity/Equity.cs
@@ -40,7 +40,12 @@ namespace QuantConnect.Securities.Equity
         /// <summary>
         /// Construct the Equity Object
         /// </summary>
-        public Equity(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        public Equity(Symbol symbol,
+            SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -55,7 +60,8 @@ namespace QuantConnect.Securities.Equity
                 new SecurityMarginModel(2m),
                 new EquityDataFilter(),
                 new AdjustedPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             Holdings = new EquityHolding(this, currencyConverter);
@@ -64,7 +70,12 @@ namespace QuantConnect.Securities.Equity
         /// <summary>
         /// Construct the Equity Object
         /// </summary>
-        public Equity(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        public Equity(SecurityExchangeHours exchangeHours,
+            SubscriptionDataConfig config,
+            Cash quoteCurrency,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
             : base(
                 config,
                 quoteCurrency,
@@ -80,7 +91,8 @@ namespace QuantConnect.Securities.Equity
                 new SecurityMarginModel(2m),
                 new EquityDataFilter(),
                 new AdjustedPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             Holdings = new EquityHolding(this, currencyConverter);

--- a/Common/Securities/Forex/Forex.cs
+++ b/Common/Securities/Forex/Forex.cs
@@ -36,7 +36,13 @@ namespace QuantConnect.Securities.Forex
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
         /// instances into units of the account currency</param>
-        public Forex(SecurityExchangeHours exchangeHours, Cash quoteCurrency, SubscriptionDataConfig config, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Forex(SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            SubscriptionDataConfig config,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -51,7 +57,8 @@ namespace QuantConnect.Securities.Forex
                 new SecurityMarginModel(50m),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             Holdings = new ForexHolding(this, currencyConverter);
@@ -71,7 +78,13 @@ namespace QuantConnect.Securities.Forex
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
         /// instances into units of the account currency</param>
-        public Forex(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Forex(Symbol symbol,
+            SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -86,7 +99,8 @@ namespace QuantConnect.Securities.Forex
                 new SecurityMarginModel(50m),
                 new ForexDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             Holdings = new ForexHolding(this, currencyConverter);

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -48,7 +48,14 @@ namespace QuantConnect.Securities.Future
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
         /// instances into units of the account currency</param>
-        public Future(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Future(SecurityExchangeHours exchangeHours,
+            SubscriptionDataConfig config,
+            Cash quoteCurrency,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes
+            )
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -63,7 +70,8 @@ namespace QuantConnect.Securities.Future
                 new FutureMarginModel(),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             // for now all futures are cash settled as we don't allow underlying (Live Cattle?) to be posted on the account
@@ -81,8 +89,15 @@ namespace QuantConnect.Securities.Future
         /// <param name="quoteCurrency">The cash object that represent the quote currency</param>
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
-        /// instances into units of the account currency</param>
-        public Future(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        ///     instances into units of the account currency</param>
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Future(Symbol symbol,
+            SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes
+            )
             : base(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -97,7 +112,8 @@ namespace QuantConnect.Securities.Future
                 new FutureMarginModel(),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             // for now all futures are cash settled as we don't allow underlying (Live Cattle?) to be posted on the account

--- a/Common/Securities/IRegisteredSecurityDataTypesProvider.cs
+++ b/Common/Securities/IRegisteredSecurityDataTypesProvider.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Provides the set of base data types registered in the algorithm
+    /// </summary>
+    public interface IRegisteredSecurityDataTypesProvider
+    {
+        /// <summary>
+        /// Registers the specified type w/ the provider
+        /// </summary>
+        /// <returns>True if the type was previously not registered</returns>
+        bool RegisterType(Type type);
+
+        /// <summary>
+        /// Removes the registration for the specified type
+        /// </summary>
+        /// <returns>True if the type was previously registered</returns>
+        bool UnregisterType(Type type);
+
+        /// <summary>
+        /// Gets an enumerable of data types registered with the algorithm
+        /// </summary>
+        IEnumerable<Type> GetRegisteredDataTypes();
+    }
+}

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -51,7 +51,13 @@ namespace QuantConnect.Securities.Option
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
         /// instances into units of the account currency</param>
-        public Option(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, OptionSymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Option(SecurityExchangeHours exchangeHours,
+            SubscriptionDataConfig config,
+            Cash quoteCurrency,
+            OptionSymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
             : base(config,
                 quoteCurrency,
                 symbolProperties,
@@ -66,7 +72,8 @@ namespace QuantConnect.Securities.Option
                 new OptionMarginModel(),
                 new OptionDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypes
                 )
         {
             ExerciseSettlement = SettlementType.PhysicalDelivery;
@@ -87,7 +94,13 @@ namespace QuantConnect.Securities.Option
         /// <param name="symbolProperties">The symbol properties for this security</param>
         /// <param name="currencyConverter">Currency converter used to convert <see cref="CashAmount"/>
         /// instances into units of the account currency</param>
-        public Option(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, OptionSymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        /// <param name="registeredTypes">Provides all data types registered in the algorithm</param>
+        public Option(Symbol symbol,
+            SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            OptionSymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
            : base(symbol,
                quoteCurrency,
                symbolProperties,
@@ -102,7 +115,8 @@ namespace QuantConnect.Securities.Option
                new OptionMarginModel(),
                new OptionDataFilter(),
                new SecurityPriceVariationModel(),
-               currencyConverter
+               currencyConverter,
+               registeredTypes
                )
         {
             ExerciseSettlement = SettlementType.PhysicalDelivery;

--- a/Common/Securities/RegisteredSecurityDataTypesProvider.cs
+++ b/Common/Securities/RegisteredSecurityDataTypesProvider.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IRegisteredSecurityDataTypesProvider"/> that permits the
+    /// consumer to modify the expected types
+    /// </summary>
+    public class RegisteredSecurityDataTypesProvider : IRegisteredSecurityDataTypesProvider
+    {
+        /// <summary>
+        /// Provides a reference to an instance of <see cref="IRegisteredSecurityDataTypesProvider"/> that contains no registered types
+        /// </summary>
+        public static readonly IRegisteredSecurityDataTypesProvider Null = new RegisteredSecurityDataTypesProvider();
+
+        private readonly HashSet<Type> _types = new HashSet<Type>();
+
+        /// <summary>
+        /// Registers the specified type w/ the provider
+        /// </summary>
+        /// <returns>True if the type was previously not registered</returns>
+        public bool RegisterType(Type type)
+        {
+            return _types.Add(type);
+        }
+
+        /// <summary>
+        /// Removes the registration for the specified type
+        /// </summary>
+        /// <returns>True if the type was previously registered</returns>
+        public bool UnregisterType(Type type)
+        {
+            return _types.Remove(type);
+        }
+
+        /// <summary>
+        /// Gets an enumerable of data types expected to be contained in a <see cref="DynamicSecurityData"/> instance
+        /// </summary>
+        public IEnumerable<Type> GetRegisteredDataTypes()
+        {
+            return _types;
+        }
+    }
+}

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -262,6 +262,14 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Provides dynamic access to data in the cache
+        /// </summary>
+        public DynamicSecurityData Data
+        {
+            get;
+        }
+
+        /// <summary>
         /// Construct a new security vehicle based on the user options.
         /// </summary>
         public Security(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
@@ -356,6 +364,8 @@ namespace QuantConnect.Securities
             SettlementModel = settlementModel;
             VolatilityModel = volatilityModel;
             Holdings = new SecurityHolding(this, currencyConverter);
+            Data = new DynamicSecurityData();
+            Cache.DataStored += (sender, args) => Data.StoreData(args.DataType, args.Data);
 
             UpdateSubscriptionProperties();
         }

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -560,6 +560,24 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Updates all of the security properties, such as price/OHLCV/bid/ask based
+        /// on the data provided. Data is also stored into the security's data cache
+        /// </summary>
+        /// <param name="data">The security update data</param>
+        public void Update(IEnumerable<BaseData> data)
+        {
+            foreach (var grp in data.GroupBy(d => d.GetType()))
+            {
+                // use the last of each type to set market price
+                SetMarketPrice(grp.Last());
+
+                // maintaining regression requires us to NOT cache FF data
+                var nonFillForward = grp.Where(d => !d.IsFillForward).ToList();
+                Cache.StoreData(nonFillForward.ToList());
+            }
+        }
+
+        /// <summary>
         /// Update any security properties based on the latest realtime data and time
         /// </summary>
         /// <param name="data">New data packet from LEAN</param>

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -264,7 +264,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Provides dynamic access to data in the cache
         /// </summary>
-        public DynamicSecurityData Data
+        public dynamic Data
         {
             get;
         }
@@ -272,7 +272,13 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Construct a new security vehicle based on the user options.
         /// </summary>
-        public Security(SecurityExchangeHours exchangeHours, SubscriptionDataConfig config, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        public Security(SecurityExchangeHours exchangeHours,
+            SubscriptionDataConfig config,
+            Cash quoteCurrency,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypesProvider
+            )
             : this(config,
                 quoteCurrency,
                 symbolProperties,
@@ -287,7 +293,8 @@ namespace QuantConnect.Securities
                 new SecurityMarginModel(),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypesProvider
                 )
         {
         }
@@ -295,7 +302,13 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Construct a new security vehicle based on the user options.
         /// </summary>
-        public Security(Symbol symbol, SecurityExchangeHours exchangeHours, Cash quoteCurrency, SymbolProperties symbolProperties, ICurrencyConverter currencyConverter)
+        public Security(Symbol symbol,
+            SecurityExchangeHours exchangeHours,
+            Cash quoteCurrency,
+            SymbolProperties symbolProperties,
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypesProvider
+            )
             : this(symbol,
                 quoteCurrency,
                 symbolProperties,
@@ -310,7 +323,8 @@ namespace QuantConnect.Securities
                 new SecurityMarginModel(),
                 new SecurityDataFilter(),
                 new SecurityPriceVariationModel(),
-                currencyConverter
+                currencyConverter,
+                registeredTypesProvider
                 )
         {
         }
@@ -332,7 +346,8 @@ namespace QuantConnect.Securities
             IBuyingPowerModel buyingPowerModel,
             ISecurityDataFilter dataFilter,
             IPriceVariationModel priceVariationModel,
-            ICurrencyConverter currencyConverter
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypesProvider
             )
         {
             if (symbolProperties == null)
@@ -364,7 +379,7 @@ namespace QuantConnect.Securities
             SettlementModel = settlementModel;
             VolatilityModel = volatilityModel;
             Holdings = new SecurityHolding(this, currencyConverter);
-            Data = new DynamicSecurityData();
+            Data = new DynamicSecurityData(registeredTypesProvider);
             Cache.DataStored += (sender, args) => Data.StoreData(args.DataType, args.Data);
 
             UpdateSubscriptionProperties();
@@ -388,7 +403,8 @@ namespace QuantConnect.Securities
             IBuyingPowerModel buyingPowerModel,
             ISecurityDataFilter dataFilter,
             IPriceVariationModel priceVariationModel,
-            ICurrencyConverter currencyConverter
+            ICurrencyConverter currencyConverter,
+            IRegisteredSecurityDataTypesProvider registeredTypesProvider
             )
             : this(config.Symbol,
                 quoteCurrency,
@@ -404,7 +420,8 @@ namespace QuantConnect.Securities
                 buyingPowerModel,
                 dataFilter,
                 priceVariationModel,
-                currencyConverter
+                currencyConverter,
+                registeredTypesProvider
                 )
         {
             SubscriptionsBag.Add(config);

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -32,6 +32,11 @@ namespace QuantConnect.Securities
     /// </remarks>
     public class SecurityCache
     {
+        /// <summary>
+        /// Event raised each time this cache stores data
+        /// </summary>
+        public event EventHandler<SecurityCacheDataStoredEventArgs> DataStored;
+
         // this is used to prefer quote bar data over the tradebar data
         private DateTime _lastQuoteBarUpdate;
         private BaseData _lastData;
@@ -216,7 +221,9 @@ namespace QuantConnect.Securities
             }
 #endif
 
-            _dataByType[data[0].GetType()] = data;
+            var dataType = data[0].GetType();
+            _dataByType[dataType] = data;
+            OnDataStored(dataType, data);
         }
 
         /// <summary>
@@ -266,6 +273,14 @@ namespace QuantConnect.Securities
         public void Reset()
         {
             _dataByType.Clear();
+        }
+
+        /// <summary>
+        /// Event invocator for the <see cref="DataStored"/> event
+        /// </summary>
+        protected virtual void OnDataStored(Type dataType, IReadOnlyList<BaseData> data)
+        {
+            DataStored?.Invoke(this, new SecurityCacheDataStoredEventArgs(dataType, data));
         }
     }
 }

--- a/Common/Securities/SecurityCacheDataStoredEventArgs.cs
+++ b/Common/Securities/SecurityCacheDataStoredEventArgs.cs
@@ -1,0 +1,49 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Event args for <see cref="SecurityCache.DataStored"/> event
+    /// </summary>
+    public class SecurityCacheDataStoredEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The type of data that was stored, such as <see cref="TradeBar"/>
+        /// </summary>
+        public Type DataType { get; }
+
+        /// <summary>
+        /// The list of data points stored
+        /// </summary>
+        public IReadOnlyList<BaseData> Data { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityCacheDataStoredEventArgs"/> class
+        /// </summary>
+        /// <param name="dataType">The type of data</param>
+        /// <param name="data">The list of data points</param>
+        public SecurityCacheDataStoredEventArgs(Type dataType, IReadOnlyList<BaseData> data)
+        {
+            Data = data;
+            DataType = dataType;
+        }
+    }
+}

--- a/Common/Securities/SecurityService.cs
+++ b/Common/Securities/SecurityService.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Securities
         private readonly CashBook _cashBook;
         private readonly MarketHoursDatabase _marketHoursDatabase;
         private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase;
+        private readonly IRegisteredSecurityDataTypesProvider _registeredTypes;
         private readonly ISecurityInitializerProvider _securityInitializerProvider;
         private bool _isLiveMode;
 
@@ -38,9 +39,11 @@ namespace QuantConnect.Securities
         public SecurityService(CashBook cashBook,
             MarketHoursDatabase marketHoursDatabase,
             SymbolPropertiesDatabase symbolPropertiesDatabase,
-            ISecurityInitializerProvider securityInitializerProvider)
+            ISecurityInitializerProvider securityInitializerProvider,
+            IRegisteredSecurityDataTypesProvider registeredTypes)
         {
             _cashBook = cashBook;
+            _registeredTypes = registeredTypes;
             _marketHoursDatabase = marketHoursDatabase;
             _symbolPropertiesDatabase = symbolPropertiesDatabase;
             _securityInitializerProvider = securityInitializerProvider;
@@ -117,33 +120,33 @@ namespace QuantConnect.Securities
             switch (symbol.ID.SecurityType)
             {
                 case SecurityType.Equity:
-                    security = new Equity.Equity(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    security = new Equity.Equity(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook, _registeredTypes);
                     break;
 
                 case SecurityType.Option:
                     if (addToSymbolCache) SymbolCache.Set(symbol.Underlying.Value, symbol.Underlying);
-                    security = new Option.Option(symbol, exchangeHours, quoteCash, new Option.OptionSymbolProperties(symbolProperties), _cashBook);
+                    security = new Option.Option(symbol, exchangeHours, quoteCash, new Option.OptionSymbolProperties(symbolProperties), _cashBook, _registeredTypes);
                     break;
 
                 case SecurityType.Future:
-                    security = new Future.Future(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    security = new Future.Future(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook, _registeredTypes);
                     break;
 
                 case SecurityType.Forex:
-                    security = new Forex.Forex(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    security = new Forex.Forex(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook, _registeredTypes);
                     break;
 
                 case SecurityType.Cfd:
-                    security = new Cfd.Cfd(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    security = new Cfd.Cfd(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook, _registeredTypes);
                     break;
 
                 case SecurityType.Crypto:
-                    security = new Crypto.Crypto(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    security = new Crypto.Crypto(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook, _registeredTypes);
                     break;
 
                 default:
                 case SecurityType.Base:
-                    security = new Security(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook);
+                    security = new Security(symbol, exchangeHours, quoteCash, symbolProperties, _cashBook, _registeredTypes);
                     break;
             }
 

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -317,9 +317,16 @@ namespace QuantConnect.Lean.Engine
                 foreach (var update in timeSlice.SecuritiesUpdateData)
                 {
                     var security = update.Target;
-                    foreach (var data in update.Data)
+                    security.Update(update.Data);
+
+                    // set custom derivative data in the underlying's cache
+                    if (security.Symbol.SecurityType == SecurityType.Base && security.Symbol.HasUnderlying)
                     {
-                        security.SetMarketPrice(data);
+                        Security underlyingSecurity;
+                        if (algorithm.Securities.TryGetValue(security.Symbol.Underlying, out underlyingSecurity))
+                        {
+                            underlyingSecurity.Cache.StoreData(update.Data);
+                        }
                     }
 
                     if (!update.IsInternalConfig)
@@ -339,7 +346,7 @@ namespace QuantConnect.Lean.Engine
                             Security security;
                             if (algorithm.Securities.TryGetValue(data.Symbol, out security))
                             {
-                                security.Cache.StoreData(data);
+                                security.Cache.StoreData(new[] {data});
                             }
                         }
                     }

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -134,10 +134,12 @@ namespace QuantConnect.Lean.Engine
 
                     var symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
 
+                    var registeredTypesProvider = new RegisteredSecurityDataTypesProvider();
                     var securityService = new SecurityService(algorithm.Portfolio.CashBook,
                         marketHoursDatabase,
                         symbolPropertiesDatabase,
-                        (ISecurityInitializerProvider)algorithm);
+                        algorithm,
+                        registeredTypesProvider);
 
                     algorithm.Securities.SetSecurityService(securityService);
 
@@ -148,7 +150,8 @@ namespace QuantConnect.Lean.Engine
                         algorithm,
                         algorithm.TimeKeeper,
                         marketHoursDatabase,
-                        _liveMode);
+                        _liveMode,
+                        registeredTypesProvider);
 
                     AlgorithmHandlers.Results.SetDataManager(dataManager);
                     algorithm.SubscriptionManager.SetDataManager(dataManager);

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -103,7 +103,8 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 config,
                 new Cash(Currencies.NullCurrency, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.NullCurrency),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var reader = history.GetEnumerator();

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -102,7 +102,8 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 config,
                 new Cash(Currencies.NullCurrency, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.NullCurrency),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var mapFileResolver = MapFileResolver.Empty;

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -427,7 +427,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="algorithm">Algorithm we're working on.</param>
         /// <param name="startingPortfolioValue">Algorithm starting capital for statistics calculations</param>
         /// <remarks>While setting the algorithm the backtest result handler.</remarks>
-        public void SetAlgorithm(IAlgorithm algorithm, decimal startingPortfolioValue)
+        public virtual void SetAlgorithm(IAlgorithm algorithm, decimal startingPortfolioValue)
         {
             Algorithm = algorithm;
             StartingPortfolioValue = startingPortfolioValue;
@@ -611,7 +611,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         /// <param name="time">Current backtest date.</param>
         /// <param name="value">Current daily performance value.</param>
-        public void SamplePerformance(DateTime time, decimal value)
+        public virtual void SamplePerformance(DateTime time, decimal value)
         {
             //Added a second chart to equity plot - daily perforamnce:
             Sample("Strategy Equity", "Daily Performance", 1, SeriesType.Bar, time, value, "%");
@@ -770,7 +770,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// This method is triggered from the algorithm manager thread.
         /// </summary>
         /// <remarks>Prime candidate for putting into a base class. Is identical across all result handlers.</remarks>
-        public void ProcessSynchronousEvents(bool forceProcess = false)
+        public virtual void ProcessSynchronousEvents(bool forceProcess = false)
         {
             if (Algorithm == null) return;
 

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -77,7 +77,8 @@ namespace QuantConnect.Jupyter
                 _dataCacheProvider = new ZipDataCacheProvider(algorithmHandlers.DataProvider);
 
                 var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
-                var securityService = new SecurityService(Portfolio.CashBook, MarketHoursDatabase, symbolPropertiesDataBase, this);
+                var registeredTypes = new RegisteredSecurityDataTypesProvider();
+                var securityService = new SecurityService(Portfolio.CashBook, MarketHoursDatabase, symbolPropertiesDataBase, this, registeredTypes);
                 Securities.SetSecurityService(securityService);
                 SubscriptionManager.SetDataManager(
                     new DataManager(new NullDataFeed(),
@@ -85,7 +86,8 @@ namespace QuantConnect.Jupyter
                         this,
                         TimeKeeper,
                         MarketHoursDatabase,
-                        false));
+                        false,
+                        registeredTypes));
 
                 var mapFileProvider = algorithmHandlers.MapFileProvider;
                 HistoryProvider = composer.GetExportedValueByTypeName<IHistoryProvider>(Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider"));

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -175,9 +175,9 @@ algo = QCAlgorithm()
 
 marketHoursDatabase = MarketHoursDatabase.FromDataFolder()
 symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder()
-securityService =  SecurityService(algo.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDatabase, algo)
+securityService =  SecurityService(algo.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDatabase, algo, RegisteredSecurityDataTypesProvider.Null)
 algo.Securities.SetSecurityService(securityService)
-dataManager = DataManager(None, UniverseSelection(algo, securityService), algo, algo.TimeKeeper, marketHoursDatabase, False)
+dataManager = DataManager(None, UniverseSelection(algo, securityService), algo, algo.TimeKeeper, marketHoursDatabase, False, RegisteredSecurityDataTypesProvider.Null)
 algo.SubscriptionManager.SetDataManager(dataManager)
 
 

--- a/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
+++ b/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
@@ -98,17 +98,20 @@ namespace QuantConnect.Tests.Algorithm
                         algorithm.Portfolio.CashBook,
                         marketHoursDatabase,
                         symbolPropertiesDatabase,
-                        algorithm)),
+                        algorithm,
+                        RegisteredSecurityDataTypesProvider.Null)),
                 algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase,
-                false);
+                false,
+                RegisteredSecurityDataTypesProvider.Null);
 
             var securityService = new SecurityService(
                 algorithm.Portfolio.CashBook,
                 marketHoursDatabase,
                 symbolPropertiesDatabase,
-                algorithm);
+                algorithm,
+                RegisteredSecurityDataTypesProvider.Null);
 
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             algorithm.Securities.SetSecurityService(securityService);

--- a/Tests/Algorithm/Framework/Alphas/OrderBasedInsightGeneratorTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/OrderBasedInsightGeneratorTests.cs
@@ -45,7 +45,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
 

--- a/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
@@ -207,7 +207,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 config,
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
 

--- a/Tests/Algorithm/Framework/Portfolio/DuplicateKeyPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/DuplicateKeyPortfolioConstructionModelTests.cs
@@ -54,7 +54,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 ),
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             security.SetMarketPrice(new Tick(algorithm.Time, symbol, 1m, 1m));

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -335,7 +335,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 config,
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
 

--- a/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
@@ -362,7 +362,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 config,
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
 

--- a/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
+++ b/Tests/Algorithm/Framework/Risk/MaximumDrawdownPercentPerSecurityTests.cs
@@ -50,7 +50,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Risk
                 SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.Setup(m => m.Invested).Returns(invested);
 

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -104,7 +104,7 @@ namespace QuantConnect.Tests
                             systemHandlers.LeanManager.Initialize(systemHandlers, algorithmHandlers, job, algorithmManager);
 
                             engine.Run(job, algorithmManager, algorithmPath);
-                            ordersLogFile = ((RegressionResultHandler)algorithmHandlers.Results).OrdersLogFilePath;
+                            ordersLogFile = ((RegressionResultHandler)algorithmHandlers.Results).LogFilePath;
                         }
                         catch (Exception e)
                         {

--- a/Tests/Brokerages/Bitfinex/BitfinexFeeModelTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexFeeModelTests.cs
@@ -46,7 +46,8 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
                     ),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
                 security.SetMarketPrice(new Tick(DateTime.UtcNow, Symbol, LowPrice, HighPrice));
 

--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -195,7 +195,8 @@ namespace QuantConnect.Tests.Brokerages
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
 

--- a/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
+++ b/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
@@ -33,7 +33,8 @@ namespace QuantConnect.Tests.Brokerages.GDAX
                 CreateConfig(securityType, resolution),
                 new Cash(Currencies.USD, 1000, price),
                 new SymbolProperties("BTCUSD", Currencies.USD, 1, 1, 0.01m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
 

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -129,7 +129,8 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var brokerage = new InteractiveBrokersBrokerage(new QCAlgorithm(), new OrderProvider(_orders), securityProvider);

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageTests.cs
@@ -59,7 +59,8 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             _interactiveBrokersBrokerage = new InteractiveBrokersBrokerage(new QCAlgorithm(), new OrderProvider(_orders), securityProvider);
@@ -711,7 +712,7 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             var algorithm = new QCAlgorithm();
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
-            var securityService = new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm);
+            var securityService = new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm, RegisteredSecurityDataTypesProvider.Null);
             algorithm.Securities.SetSecurityService(securityService);
             algorithm.SetLiveMode(true);
 

--- a/Tests/Brokerages/Paper/PaperBrokerageTests.cs
+++ b/Tests/Brokerages/Paper/PaperBrokerageTests.cs
@@ -89,11 +89,12 @@ namespace QuantConnect.Tests.Brokerages.Paper
             var dataManager = new DataManager(feed,
                 new UniverseSelection(
                     algorithm,
-                    new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm)),
+                    new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm, RegisteredSecurityDataTypesProvider.Null)),
                 algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase,
-                true);
+                true,
+                RegisteredSecurityDataTypesProvider.Null);
             var synchronizer = new NullSynchronizer(algorithm, dividend);
 
             algorithm.SubscriptionManager.SetDataManager(dataManager);

--- a/Tests/Common/Benchmarks/SecurityBenchmarkTests.cs
+++ b/Tests/Common/Benchmarks/SecurityBenchmarkTests.cs
@@ -39,7 +39,8 @@ namespace QuantConnect.Tests.Common.Benchmarks
                     true, true, false),
                 new Cash(Currencies.USD, 0, conversionRate),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var price = 25;
             security.SetMarketPrice(new Tick { Value = price });

--- a/Tests/Common/Brokerages/BitfinexBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BitfinexBrokerageModelTests.cs
@@ -44,7 +44,8 @@ namespace QuantConnect.Tests.Common.Brokerages
                     ),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
             }
         }
@@ -82,7 +83,8 @@ namespace QuantConnect.Tests.Common.Brokerages
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var model = new BitfinexBrokerageModel();
@@ -106,7 +108,8 @@ namespace QuantConnect.Tests.Common.Brokerages
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var model = new BitfinexBrokerageModel();

--- a/Tests/Common/Brokerages/FxcmBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/FxcmBrokerageModelTests.cs
@@ -73,7 +73,8 @@ namespace QuantConnect.Tests.Common.Brokerages
                 ),
                 new Cash(symbol.SecurityType == SecurityType.Equity ? properties.QuoteCurrency : quoteCurrency, 0, 1m),
                 properties,
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
 

--- a/Tests/Common/Data/DynamicDataTests.cs
+++ b/Tests/Common/Data/DynamicDataTests.cs
@@ -1,0 +1,68 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Data;
+
+namespace QuantConnect.Tests.Common.Data
+{
+    [TestFixture]
+    public class DynamicDataTests
+    {
+        [Test]
+        public void StoresValues_Using_LowerCaseKeys()
+        {
+            dynamic data = new DataType();
+            data.Property = 1;
+
+            Assert.AreEqual(1, data.Property);
+            Assert.AreEqual(data.Property, data.property);
+        }
+
+        [Test]
+        public void StoresBaseDataValues_Using_BaseDataProperties()
+        {
+            var value = 1234.567890m;
+            var time = new DateTime(2000, 1, 2, 3, 4, 5, 6);
+            var symbol = Symbol.Create("ticker", SecurityType.Base, QuantConnect.Market.USA, baseDataType: typeof(DataType));
+            dynamic data = new DataType();
+            data.Time = time;
+            data.Value = value;
+            data.Symbol = symbol;
+
+            BaseData baseData = data;
+            Assert.AreEqual(time, baseData.Time);
+            Assert.AreEqual(value, baseData.Value);
+            Assert.AreEqual(value, baseData.Price);
+            Assert.AreEqual(symbol, baseData.Symbol);
+        }
+
+        [Test]
+        public void AccessingPropertyThatDoesNotExist_ThrowsKeyNotFoundException()
+        {
+            dynamic data = new DataType();
+            Assert.Throws<KeyNotFoundException>(() =>
+            {
+                var _ = data.UndefinedPropertyName;
+            });
+        }
+
+        private class DataType : DynamicData
+        {
+        }
+    }
+}

--- a/Tests/Common/Data/UniverseSelection/UniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/UniverseTests.cs
@@ -49,7 +49,8 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
                 _config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance);
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null);
         }
 
         [Test]

--- a/Tests/Common/Orders/Fees/AlphaStreamsFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/AlphaStreamsFeeModelTests.cs
@@ -61,7 +61,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 SecurityExchangeHours.AlwaysOpen(tz),
                 new Cash("USD", 0, 0),
                 SymbolProperties.GetDefault("USD"),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
 
@@ -87,7 +88,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 SecurityExchangeHours.AlwaysOpen(tz),
                 new Cash("USD", 0, 0),
                 new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
 
@@ -113,7 +115,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 SecurityExchangeHours.AlwaysOpen(tz),
                 new Cash("USD", 0, 0),
                 new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
 
@@ -140,7 +143,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 new Cash("USD", 0, 1),
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURUSD, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("EURUSD", "USD", 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
 
@@ -168,7 +172,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 new Cash("GBP", 0, conversionRate),
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURGBP, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("EURGBP", "GBP", 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
 
@@ -197,7 +202,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                         new Cash("EUR", 0, 0),
                         new SubscriptionDataConfig(typeof(QuoteBar), Symbols.DE30EUR, Resolution.Minute, tz, tz, true, false, false),
                         new SymbolProperties("DE30EUR", "EUR", 1, 0.01m, 1m),
-                        ErrorCurrencyConverter.Instance
+                        ErrorCurrencyConverter.Instance,
+                        RegisteredSecurityDataTypesProvider.Null
                     );
                     security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 12000, 12000));
 

--- a/Tests/Common/Orders/Fees/BitfinexFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/BitfinexFeeModelTests.cs
@@ -40,7 +40,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 new Cash(Currencies.USD, 0, 1),
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCUSD, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("BTCUSD", Currencies.USD, 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             _btcusd.SetMarketPrice(new Tick(DateTime.UtcNow, _btcusd.Symbol, 100, 100));
 
@@ -49,7 +50,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 new Cash("EUR", 0, 10),
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCEUR, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("BTCEUR", "EUR", 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             _btceur.SetMarketPrice(new Tick(DateTime.UtcNow, _btceur.Symbol, 100, 100));
         }

--- a/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
@@ -40,7 +40,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 new Cash(Currencies.USD, 0, 1),
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCUSD, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("BTCUSD", Currencies.USD, 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             _btcusd.SetMarketPrice(new Tick(DateTime.UtcNow, _btcusd.Symbol, 100, 100));
 
@@ -49,7 +50,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 new Cash("EUR", 0, 10),
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCEUR, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("BTCEUR", "EUR", 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             _btceur.SetMarketPrice(new Tick(DateTime.UtcNow, _btceur.Symbol, 100, 100));
         }

--- a/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
@@ -75,7 +75,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 SecurityExchangeHours.AlwaysOpen(tz),
                 new Cash("USD", 0, 0),
                 SymbolProperties.GetDefault("USD"),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
                 );
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
 
@@ -98,7 +99,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 SecurityExchangeHours.AlwaysOpen(tz),
                 new Cash("USD", 0, 0),
                 new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
 
@@ -121,7 +123,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 SecurityExchangeHours.AlwaysOpen(tz),
                 new Cash("USD", 0, 0),
                 new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
 
@@ -145,7 +148,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 new Cash("GBP", 0, 0),
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURGBP, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("EURGBP", "GBP", 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 100, 100));
 
@@ -172,7 +176,8 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                         new Cash("EUR", 0, 0),
                         new SubscriptionDataConfig(typeof(QuoteBar), Symbols.DE30EUR, Resolution.Minute, tz, tz, true, false, false),
                         new SymbolProperties("DE30EUR", "EUR", 1, 0.01m, 1m),
-                        ErrorCurrencyConverter.Instance
+                        ErrorCurrencyConverter.Instance,
+                        RegisteredSecurityDataTypesProvider.Null
                     );
                     security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 12000, 12000));
 

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -45,7 +45,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.123m));
@@ -71,7 +72,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.123m));
@@ -97,7 +99,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
@@ -133,7 +136,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
@@ -169,7 +173,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 100m));
@@ -217,7 +222,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
@@ -265,7 +271,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
@@ -305,7 +312,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
@@ -346,7 +354,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             var time = reference;
@@ -394,7 +403,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             var time = reference;
@@ -439,7 +449,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var quoteCash = new Cash(Currencies.USD, 1000, 1);
             var symbolProperties = SymbolProperties.GetDefault(Currencies.USD);
             var config = new SubscriptionDataConfig(typeof(Tick), symbol, Resolution.Tick, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
-            var security = new Forex(exchangeHours, quoteCash, config, symbolProperties, ErrorCurrencyConverter.Instance);
+            var security = new Forex(exchangeHours, quoteCash, config, symbolProperties, ErrorCurrencyConverter.Instance, RegisteredSecurityDataTypesProvider.Null);
 
             var reference = DateTime.Now;
             var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
@@ -479,7 +489,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, noon, 101.123m));
@@ -515,7 +526,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, noon, 101.123m));
@@ -552,7 +564,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
@@ -606,7 +619,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
@@ -660,7 +674,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
@@ -711,7 +726,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.123m));

--- a/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/LatestPriceFillModelTests.cs
@@ -127,7 +127,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
 

--- a/Tests/Common/Orders/Fills/PartialMarketFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/PartialMarketFillModelTests.cs
@@ -103,7 +103,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             model = new PartialMarketFillModel(algorithm.Transactions, 2);

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -54,7 +54,8 @@ namespace QuantConnect.Tests.Common.Orders
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick {Value = price});
 
@@ -65,7 +66,8 @@ namespace QuantConnect.Tests.Common.Orders
                 gbpCash,
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURGBP, Resolution.Minute, tz, tz, true, false, false),
                 properties,
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             forex.SetMarketPrice(new Tick {Value= price});
 
@@ -76,7 +78,8 @@ namespace QuantConnect.Tests.Common.Orders
                 eurCash,
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.DE10YBEUR, Resolution.Minute, tz, tz, true, false, false),
                 properties,
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             cfd.SetMarketPrice(new Tick { Value = price });
             var multiplierTimesConversionRate = properties.ContractMultiplier*eurCash.ConversionRate;
@@ -95,7 +98,8 @@ namespace QuantConnect.Tests.Common.Orders
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             option.SetMarketPrice(new Tick { Value = price });
 

--- a/Tests/Common/Orders/Slippage/SlippageModelsTests.cs
+++ b/Tests/Common/Orders/Slippage/SlippageModelsTests.cs
@@ -40,7 +40,8 @@ namespace QuantConnect.Tests.Common.Orders.Slippage
                 SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             _equity.SetMarketPrice(new TradeBar(DateTime.Now, Symbols.SPY, 100m, 100m, 100m, 100m, 1));
@@ -53,7 +54,8 @@ namespace QuantConnect.Tests.Common.Orders.Slippage
                 SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             _forex.SetMarketPrice(new TradeBar(DateTime.Now, Symbols.EURUSD, 100m, 100m, 100m, 100m, 0));

--- a/Tests/Common/Orders/TimeInForces/TimeInForceTests.cs
+++ b/Tests/Common/Orders/TimeInForces/TimeInForceTests.cs
@@ -48,7 +48,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var timeInForce = new GoodTilCanceledTimeInForce();
@@ -82,7 +83,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -129,7 +131,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                     true
                 ),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -178,7 +181,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                     true
                 ),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -230,7 +234,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                     true
                 ),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.Utc);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -276,7 +281,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -337,7 +343,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                     true
                 ),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -397,7 +404,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                     true
                 ),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.Utc);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -457,7 +465,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -504,7 +513,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                     true
                 ),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -553,7 +563,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                     true
                 ),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.NewYork);
             security.SetLocalTimeKeeper(localTimeKeeper);
@@ -605,7 +616,8 @@ namespace QuantConnect.Tests.Common.Orders.TimeInForces
                     true
                 ),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var localTimeKeeper = new LocalTimeKeeper(utcTime, TimeZones.Utc);
             security.SetLocalTimeKeeper(localTimeKeeper);

--- a/Tests/Common/Scheduling/DateRulesTests.cs
+++ b/Tests/Common/Scheduling/DateRulesTests.cs
@@ -262,7 +262,8 @@ namespace QuantConnect.Tests.Common.Scheduling
                     config,
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             var rules = new DateRules(manager);

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -227,7 +227,8 @@ namespace QuantConnect.Tests.Common.Scheduling
                     config,
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             var rules = new TimeRules(manager, dateTimeZone);

--- a/Tests/Common/Securities/AccountCurrencyImmediateSettlementModelTests.cs
+++ b/Tests/Common/Securities/AccountCurrencyImmediateSettlementModelTests.cs
@@ -40,7 +40,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             portfolio.SetCash(1000);
@@ -80,7 +81,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 portfolio.CashBook["EUR"],
                 SymbolProperties.GetDefault("EUR"),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             Assert.AreEqual(1000, portfolio.Cash);

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -84,7 +84,8 @@ namespace QuantConnect.Tests.Common.Securities
                 _tradeBarConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             _quoteBarSecurity = new Security(
@@ -92,7 +93,8 @@ namespace QuantConnect.Tests.Common.Securities
                 _quoteBarConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             _brokerageInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(),

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -70,7 +70,8 @@ namespace QuantConnect.Tests.Common.Securities
                 _portfolio.CashBook[Currencies.USD],
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCUSD, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("BTCUSD", Currencies.USD, 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             _ethusd = new Crypto(
@@ -78,7 +79,8 @@ namespace QuantConnect.Tests.Common.Securities
                 _portfolio.CashBook[Currencies.USD],
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.ETHUSD, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("ETHUSD", Currencies.USD, 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             _btceur = new Crypto(
@@ -86,7 +88,8 @@ namespace QuantConnect.Tests.Common.Securities
                 _portfolio.CashBook["EUR"],
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.BTCEUR, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("BTCEUR", "EUR", 1, 0.01m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             _ethbtc = new Crypto(
@@ -94,7 +97,8 @@ namespace QuantConnect.Tests.Common.Securities
                 _portfolio.CashBook["BTC"],
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.ETHBTC, Resolution.Minute, tz, tz, true, false, false),
                 new SymbolProperties("ETHBTC", "BTC", 1, 0.00001m, 0.00000001m),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             _buyingPowerModel = new CashBuyingPowerModel();

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -103,7 +103,8 @@ namespace QuantConnect.Tests.Common.Securities
                     abcConfig,
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    cashBook));
+                    cashBook,
+                    RegisteredSecurityDataTypesProvider.Null));
             cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService, cashBook.AccountCurrency);
 
             Assert.AreEqual(1, subscriptions.SubscriptionDataConfigService.GetSubscriptionDataConfigs(Symbols.USDJPY, includeInternalConfigs:true).Count);
@@ -130,10 +131,11 @@ namespace QuantConnect.Tests.Common.Securities
                     abcConfig,
                     new Cash(cashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
-            var usdjpy = new Security(Symbols.USDJPY, SecurityExchangeHours, new Cash("JPY", 0, 0), SymbolProperties.GetDefault("JPY"), ErrorCurrencyConverter.Instance);
+            var usdjpy = new Security(Symbols.USDJPY, SecurityExchangeHours, new Cash("JPY", 0, 0), SymbolProperties.GetDefault("JPY"), ErrorCurrencyConverter.Instance, RegisteredSecurityDataTypesProvider.Null);
             var changes = new SecurityChanges(new[] { usdjpy }, Enumerable.Empty<Security>());
             var addedSecurity = cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, changes, dataManager.SecurityService, cashBook.AccountCurrency);
 
@@ -163,7 +165,8 @@ namespace QuantConnect.Tests.Common.Securities
                     subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone),
                     new Cash(cashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -173,7 +176,8 @@ namespace QuantConnect.Tests.Common.Securities
                     subscriptions.Add(Symbols.EURUSD, minimumResolution, TimeZone, TimeZone),
                     new Cash(cashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -201,7 +205,8 @@ namespace QuantConnect.Tests.Common.Securities
                     subscriptions.Add(Symbols.EURUSD, Resolution.Minute, TimeZone, TimeZone),
                     new Cash(cashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -230,7 +235,8 @@ namespace QuantConnect.Tests.Common.Securities
                     subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone),
                     new Cash(cashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -278,7 +284,8 @@ namespace QuantConnect.Tests.Common.Securities
                         subscriptions.Add(symbol, Resolution.Minute, TimeZone, TimeZone),
                         new Cash(cashBook.AccountCurrency, 0, 1m),
                         SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                        ErrorCurrencyConverter.Instance
+                        ErrorCurrencyConverter.Instance,
+                        RegisteredSecurityDataTypesProvider.Null
                     )
                 }
             };
@@ -324,7 +331,8 @@ namespace QuantConnect.Tests.Common.Securities
                     subscriptions.Add(symbol, Resolution.Minute, TimeZone, TimeZone),
                     new Cash(cashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -362,7 +370,8 @@ namespace QuantConnect.Tests.Common.Securities
                     subscriptions.Add(symbol, Resolution.Minute, TimeZone, TimeZone),
                     new Cash(cashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -445,7 +454,8 @@ namespace QuantConnect.Tests.Common.Securities
                     subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone),
                     new Cash(cashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -479,7 +489,8 @@ namespace QuantConnect.Tests.Common.Securities
                     subscriptions.Add(Symbols.GBPUSD, Resolution.Minute, TimeZone, TimeZone),
                     new Cash(cashBook.AccountCurrency, 0, 1m),
                     SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 

--- a/Tests/Common/Securities/Cfd/CfdTests.cs
+++ b/Tests/Common/Securities/Cfd/CfdTests.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Tests.Common.Securities.Cfd
             var symbol = Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda);
             var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.Utc, TimeZones.NewYork, true, true, true);
             var symbolProperties = new SymbolProperties("Dax German index", "EUR", 1, 1, 1);
-            var cfd = new QuantConnect.Securities.Cfd.Cfd(SecurityExchangeHours.AlwaysOpen(config.DataTimeZone), new Cash("EUR", 0, 0), config, symbolProperties, ErrorCurrencyConverter.Instance);
+            var cfd = new QuantConnect.Securities.Cfd.Cfd(SecurityExchangeHours.AlwaysOpen(config.DataTimeZone), new Cash("EUR", 0, 0), config, symbolProperties, ErrorCurrencyConverter.Instance, RegisteredSecurityDataTypesProvider.Null);
             Assert.AreEqual("EUR", cfd.QuoteCurrency.Symbol);
         }
 

--- a/Tests/Common/Securities/Cryptos/CryptoTests.cs
+++ b/Tests/Common/Securities/Cryptos/CryptoTests.cs
@@ -39,7 +39,8 @@ namespace QuantConnect.Tests.Common.Securities.Cryptos
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault(quote),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             Assert.AreEqual(symbol.Value.RemoveFromEnd(quote), crypto.BaseCurrencySymbol);
@@ -68,7 +69,8 @@ namespace QuantConnect.Tests.Common.Securities.Cryptos
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault(quote),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             Assert.AreEqual(symbol.Value.RemoveFromEnd(quote), crypto.BaseCurrencySymbol);

--- a/Tests/Common/Securities/DelayedSettlementModelTests.cs
+++ b/Tests/Common/Securities/DelayedSettlementModelTests.cs
@@ -41,7 +41,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             portfolio.SetCash(3000);
@@ -94,7 +95,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             portfolio.SetCash(3000);

--- a/Tests/Common/Securities/DynamicSecurityDataTests.cs
+++ b/Tests/Common/Securities/DynamicSecurityDataTests.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class DynamicSecurityDataTests
+    {
+        [Test]
+        public void StoreData_UsesTypeName_AsKey()
+        {
+            var data = new DynamicSecurityData();
+            data.StoreData(typeof(int), new[] {1});
+
+            Assert.IsTrue(data.HasProperty(typeof(int).Name));
+
+            var arr = (IReadOnlyList<int>) data.GetProperty(typeof(int).Name);
+            Assert.AreEqual(1, arr.Count);
+            Assert.AreEqual(1, arr[0]);
+        }
+
+        [Test]
+        public void Get_UsesTypeName_AsKey_And_ReturnsLastItem()
+        {
+            var data = new DynamicSecurityData();
+            data.StoreData(typeof(int), new[] {1, 2, 3});
+
+            var item = data.Get<int>();
+            Assert.AreEqual(3, item);
+        }
+
+        [Test]
+        public void GetAll_UsesTypeName_AsKey()
+        {
+            var data = new DynamicSecurityData();
+            data.SetProperty(typeof(int).Name, new[] {1});
+
+            var arr = data.GetAll<int>();
+            Assert.AreEqual(1, arr.Count);
+            Assert.AreEqual(1, arr[0]);
+        }
+
+        [Test]
+        public void AccessesDataDynamically()
+        {
+            var securityData = new DynamicSecurityData();
+            var data = new List<TradeBar>
+            {
+                new TradeBar(DateTime.UtcNow, Symbols.SPY, 10m, 20m, 5m, 15m, 10000)
+            };
+            securityData.StoreData(typeof(TradeBar), data);
+
+            dynamic dynamicSecurityData = securityData;
+            var tradeBars = dynamicSecurityData.TradeBar;
+            Assert.IsInstanceOf<IReadOnlyList<TradeBar>>(tradeBars);
+        }
+    }
+}

--- a/Tests/Common/Securities/Forex/ForexHoldingTest.cs
+++ b/Tests/Common/Securities/Forex/ForexHoldingTest.cs
@@ -45,10 +45,20 @@ namespace QuantConnect.Tests.Common.Securities.Forex
                                                           TimeZones.NewYork, TimeZones.NewYork, fillForward: true,
                                                           extendedHours: true, isInternalFeed: true);
 
-            var pair = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                                                               cash, subscription,
-                                                               new SymbolProperties("", pairQuoteCurrency, 1,
-                                                                                    minimumPriceVariation, lotSize), ErrorCurrencyConverter.Instance);
+            var pair = new QuantConnect.Securities.Forex.Forex(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                cash,
+                subscription,
+                new SymbolProperties(
+                    "",
+                    pairQuoteCurrency,
+                    1,
+                    minimumPriceVariation,
+                    lotSize
+                ),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
             pair.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             pair.SetFeeModel(new ConstantFeeModel(decimal.Zero));
             var forexHolding = new ForexHolding(pair, new IdentityCurrencyConverter(Currencies.USD));

--- a/Tests/Common/Securities/Forex/ForexTests.cs
+++ b/Tests/Common/Securities/Forex/ForexTests.cs
@@ -57,7 +57,7 @@ namespace QuantConnect.Tests.Common.Securities.Forex
         public void ConstructorDecomposesBaseAndQuoteCurrencies()
         {
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.EURUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true);
-            var forex = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours.AlwaysOpen(config.DataTimeZone), new Cash(Currencies.USD, 0, 0), config, SymbolProperties.GetDefault(Currencies.USD), ErrorCurrencyConverter.Instance);
+            var forex = new QuantConnect.Securities.Forex.Forex(SecurityExchangeHours.AlwaysOpen(config.DataTimeZone), new Cash(Currencies.USD, 0, 0), config, SymbolProperties.GetDefault(Currencies.USD), ErrorCurrencyConverter.Instance, RegisteredSecurityDataTypesProvider.Null);
             Assert.AreEqual("EUR", forex.BaseCurrencySymbol);
             Assert.AreEqual(Currencies.USD, forex.QuoteCurrency.Symbol);
         }

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -55,7 +55,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
@@ -80,7 +81,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance);
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null);
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
@@ -105,7 +107,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);

--- a/Tests/Common/Securities/ImmediateSettlementModelTests.cs
+++ b/Tests/Common/Securities/ImmediateSettlementModelTests.cs
@@ -40,7 +40,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             portfolio.SetCash(1000);

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -255,7 +255,8 @@ namespace QuantConnect.Tests.Common.Securities
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
     }

--- a/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
@@ -59,7 +59,8 @@ namespace QuantConnect.Tests.Common.Securities
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var buyingPowerModel = new OptionMarginModel();
 
@@ -81,7 +82,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
@@ -99,7 +101,8 @@ namespace QuantConnect.Tests.Common.Securities
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;
@@ -119,7 +122,8 @@ namespace QuantConnect.Tests.Common.Securities
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
@@ -144,7 +148,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
@@ -162,7 +167,8 @@ namespace QuantConnect.Tests.Common.Securities
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
@@ -187,7 +193,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
@@ -205,7 +212,8 @@ namespace QuantConnect.Tests.Common.Securities
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
@@ -230,7 +238,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
@@ -248,7 +257,8 @@ namespace QuantConnect.Tests.Common.Securities
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;
@@ -273,7 +283,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
@@ -291,7 +302,8 @@ namespace QuantConnect.Tests.Common.Securities
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
@@ -316,7 +328,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
 
@@ -326,7 +339,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), optionPutSymbol, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;
@@ -353,7 +367,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPriceStart });
 
@@ -363,7 +378,8 @@ namespace QuantConnect.Tests.Common.Securities
                 new SubscriptionDataConfig(typeof(TradeBar), optionPutSymbol, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionPut.SetMarketPrice(new Tick { Value = optionPriceStart });
             optionPut.Underlying = equity;

--- a/Tests/Common/Securities/OptionPriceModelTests.cs
+++ b/Tests/Common/Securities/OptionPriceModelTests.cs
@@ -46,7 +46,8 @@ namespace QuantConnect.Tests.Common
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
@@ -58,7 +59,8 @@ namespace QuantConnect.Tests.Common
                 new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionCall.Underlying = equity;
 
@@ -69,7 +71,8 @@ namespace QuantConnect.Tests.Common
                 new SubscriptionDataConfig(typeof(TradeBar), SPY_P_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionPut.Underlying = equity;
 
@@ -104,7 +107,8 @@ namespace QuantConnect.Tests.Common
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
@@ -116,7 +120,8 @@ namespace QuantConnect.Tests.Common
                 new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
@@ -149,7 +154,8 @@ namespace QuantConnect.Tests.Common
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
@@ -169,7 +175,8 @@ namespace QuantConnect.Tests.Common
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
@@ -207,7 +214,8 @@ namespace QuantConnect.Tests.Common
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
@@ -227,7 +235,8 @@ namespace QuantConnect.Tests.Common
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionCall.SetMarketPrice(new Tick { Value = price });
             optionCall.Underlying = equity;
@@ -259,7 +268,8 @@ namespace QuantConnect.Tests.Common
                 new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.SetMarketPrice(new Tick { Value = underlyingPrice });
             equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
@@ -279,7 +289,8 @@ namespace QuantConnect.Tests.Common
                 ),
                 new Cash(Currencies.USD, 0, 1m),
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             optionPut.SetMarketPrice(new Tick { Value = price });
             optionPut.Underlying = equity;

--- a/Tests/Common/Securities/Options/OptionPortfolioModelTests.cs
+++ b/Tests/Common/Securities/Options/OptionPortfolioModelTests.cs
@@ -42,7 +42,8 @@ namespace QuantConnect.Tests.Common.Securities.Options
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 new OptionSymbolProperties(SymbolProperties.GetDefault("EUR")),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             option.Underlying = security;
             security.SetMarketPrice(new Tick { Value = 1000 });
@@ -75,7 +76,8 @@ namespace QuantConnect.Tests.Common.Securities.Options
                 CreateTradeBarConfig(),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick { Value = 100 });
             var timeKeeper = new TimeKeeper(reference);

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -294,7 +294,8 @@ namespace QuantConnect.Tests.Common.Securities
                 CreateTradeBarConfig(),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             TimeKeeper.SetUtcDateTime(newLocalTime.ConvertToUtc(security.Exchange.TimeZone));
             security.Exchange.SetLocalDateTimeFrontier(newLocalTime);

--- a/Tests/Common/Securities/PriceVariationModelsTests.cs
+++ b/Tests/Common/Securities/PriceVariationModelsTests.cs
@@ -99,7 +99,8 @@ namespace QuantConnect.Tests.Common.Securities.Equity
                     ),
                     new Cash(Currencies.USD, 0, 1m),
                     symbolProperties,
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
             }
             else
@@ -118,7 +119,8 @@ namespace QuantConnect.Tests.Common.Securities.Equity
                         false
                     ),
                     symbolProperties,
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
             }
 

--- a/Tests/Common/Securities/RelativeStandardDeviationVolatilityModelTests.cs
+++ b/Tests/Common/Securities/RelativeStandardDeviationVolatilityModelTests.cs
@@ -41,7 +41,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 0),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
@@ -82,7 +83,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 0),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
@@ -121,7 +123,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 0),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
@@ -150,7 +153,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 0),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 

--- a/Tests/Common/Securities/SecurityCacheTests.cs
+++ b/Tests/Common/Securities/SecurityCacheTests.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using QuantConnect.Algorithm.CSharp;
 using QuantConnect.Data;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.Market;
@@ -221,6 +222,22 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(securityCache.BidPrice, 0m);
             Assert.AreEqual(securityCache.AskPrice, 0m);
             Assert.AreEqual(securityCache.Volume, volume);
+        }
+
+        [Test]
+        public void GetAllData_ReturnsListOfData()
+        {
+            var cache = new SecurityCache();
+            cache.StoreData(new []
+            {
+                new CustomDataBitcoinAlgorithm.Bitcoin{Ask = 1m},
+                new CustomDataBitcoinAlgorithm.Bitcoin{Ask = 2m}
+            });
+
+            var data = cache.GetAll<CustomDataBitcoinAlgorithm.Bitcoin>().ToList();
+            Assert.AreEqual(2, data.Count);
+            Assert.AreEqual(1m, data[0].Ask);
+            Assert.AreEqual(2m, data[1].Ask);
         }
 
         private void AddDataAndAssertChanges(SecurityCache cache, SecuritySeedData seedType, SecuritySeedData dataType, BaseData data, Dictionary<string, string> cacheToBaseDataPropertyMap = null)

--- a/Tests/Common/Securities/SecurityHoldingTests.cs
+++ b/Tests/Common/Securities/SecurityHoldingTests.cs
@@ -67,7 +67,8 @@ namespace QuantConnect.Tests.Common.Securities
                 subscriptionDataConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var reference = DateTime.Now;

--- a/Tests/Common/Securities/SecurityManagerTests.cs
+++ b/Tests/Common/Securities/SecurityManagerTests.cs
@@ -50,7 +50,8 @@ namespace QuantConnect.Tests.Common.Securities
                 CreateTradeBarConfig(),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             manager.CollectionChanged += (sender, args) =>
             {
@@ -79,7 +80,8 @@ namespace QuantConnect.Tests.Common.Securities
                 CreateTradeBarConfig(),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             manager.CollectionChanged += (sender, args) =>
             {
@@ -108,7 +110,8 @@ namespace QuantConnect.Tests.Common.Securities
                 CreateTradeBarConfig(),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             manager.Add(security.Symbol, security);
             manager.CollectionChanged += (sender, args) =>

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -94,7 +94,8 @@ namespace QuantConnect.Tests.Common.Securities
                 subscriptions.Add(CASH, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLeverage(10m);
             securities.Add(CASH, security);
@@ -175,7 +176,8 @@ namespace QuantConnect.Tests.Common.Securities
                 jwbCash,
                 subscriptions.Add(MCHJWB, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork),
                 SymbolProperties.GetDefault(jwbCash.Symbol),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             mchJwbSecurity.SetLeverage(10m);
             var mchUsdSecurity = new QuantConnect.Securities.Forex.Forex(
@@ -183,7 +185,8 @@ namespace QuantConnect.Tests.Common.Securities
                 usdCash,
                 subscriptions.Add(MCHUSD, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork),
                 SymbolProperties.GetDefault(usdCash.Symbol),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             mchUsdSecurity.SetLeverage(10m);
             var usdJwbSecurity = new QuantConnect.Securities.Forex.Forex(
@@ -191,7 +194,8 @@ namespace QuantConnect.Tests.Common.Securities
                 mchCash,
                 subscriptions.Add(USDJWB, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork),
                 SymbolProperties.GetDefault(mchCash.Symbol),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             usdJwbSecurity.SetLeverage(10m);
 
@@ -204,7 +208,7 @@ namespace QuantConnect.Tests.Common.Securities
             securities.Add(usdJwbSecurity);
             securities.Add(mchUsdSecurity);
 
-            var securityService = new SecurityService(portfolio.CashBook, MarketHoursDatabase.FromDataFolder(), SymbolPropertiesDatabase.FromDataFolder(), dataManager.Algorithm);
+            var securityService = new SecurityService(portfolio.CashBook, MarketHoursDatabase.FromDataFolder(), SymbolPropertiesDatabase.FromDataFolder(), dataManager.Algorithm, RegisteredSecurityDataTypesProvider.Null);
 
             portfolio.CashBook.EnsureCurrencyDataFeeds(securities, subscriptions, DefaultBrokerageModel.DefaultMarketMap, SecurityChanges.None, securityService);
 
@@ -279,7 +283,8 @@ namespace QuantConnect.Tests.Common.Securities
                     config,
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             var security = securities[Symbols.AAPL];
@@ -397,7 +402,8 @@ namespace QuantConnect.Tests.Common.Securities
                     config1,
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.AAPL].SetLeverage(2m);
@@ -411,7 +417,8 @@ namespace QuantConnect.Tests.Common.Securities
                     usdCash,
                     config2,
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.EURUSD].SetLeverage(100m);
@@ -425,7 +432,8 @@ namespace QuantConnect.Tests.Common.Securities
                     gbpCash,
                     config3,
                     SymbolProperties.GetDefault(gbpCash.Symbol),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.EURGBP].SetLeverage(100m);
@@ -461,7 +469,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Future, Symbols.Fut_SPY_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -493,7 +502,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Future, Symbols.Fut_SPY_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     new SymbolProperties("", Currencies.USD, 50, 0.01m, 1),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -525,7 +535,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Future, Symbols.Fut_SPY_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     new SymbolProperties("", Currencies.USD, 50, 0.01m, 1),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -557,7 +568,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Cfd, Symbols.DE30EUR),
                     portfolio.CashBook["EUR"],
                     SymbolProperties.GetDefault("EUR"),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -590,7 +602,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Cfd, Symbols.DE30EUR),
                     portfolio.CashBook["EUR"],
                     SymbolProperties.GetDefault("EUR"),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.DE30EUR].SettlementModel = new AccountCurrencyImmediateSettlementModel();
@@ -629,7 +642,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Cfd, Symbols.DE30EUR),
                     portfolio.CashBook["EUR"],
                     SymbolProperties.GetDefault("EUR"),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -661,7 +675,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -687,7 +702,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.AAPL].Holdings.SetHoldings(100, 100);
@@ -714,7 +730,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.AAPL].Holdings.SetHoldings(100, -100);
@@ -743,7 +760,8 @@ namespace QuantConnect.Tests.Common.Securities
                     portfolio.CashBook[Currencies.USD],
                     CreateTradeBarDataConfig(SecurityType.Forex, Symbols.EURUSD),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             var security = securities[Symbols.EURUSD];
@@ -779,7 +797,8 @@ namespace QuantConnect.Tests.Common.Securities
                         Symbols.BTCUSD
                     ),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             var security = securities[Symbols.BTCUSD];
@@ -811,7 +830,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.AAPL),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             var security = securities[Symbols.AAPL];
@@ -874,7 +894,8 @@ namespace QuantConnect.Tests.Common.Securities
                     config,
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             var security = securities[Symbols.AAPL];
@@ -941,7 +962,8 @@ namespace QuantConnect.Tests.Common.Securities
                     config,
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             var security = securities[Symbols.AAPL];
@@ -1011,7 +1033,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1021,7 +1044,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 1);
@@ -1071,7 +1095,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1081,7 +1106,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 100);
@@ -1130,7 +1156,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1140,7 +1167,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, 100);
@@ -1190,7 +1218,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1200,7 +1229,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, 1);
@@ -1251,7 +1281,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1261,7 +1292,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 2);
@@ -1310,7 +1342,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1320,7 +1353,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, -1);
@@ -1377,7 +1411,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1387,7 +1422,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -1);
@@ -1440,7 +1476,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1450,7 +1487,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -2);
@@ -1503,7 +1541,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1513,7 +1552,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
@@ -1562,7 +1602,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1572,7 +1613,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 190 });
@@ -1620,7 +1662,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1630,7 +1673,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 189 });
@@ -1679,7 +1723,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1689,7 +1734,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
@@ -1739,7 +1785,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1749,7 +1796,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
@@ -1798,7 +1846,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1808,7 +1857,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
@@ -1858,7 +1908,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1868,7 +1919,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
@@ -1920,7 +1972,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1930,7 +1983,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_C_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_C_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 10 });
@@ -1984,7 +2038,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -1994,7 +2049,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 189 });
@@ -2048,7 +2104,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities.Add(
@@ -2058,7 +2115,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY_P_192_Feb19_2016),
                     new Cash(Currencies.USD, 0, 1m),
                     GetOptionSymbolProperties(Symbols.SPY_P_192_Feb19_2016),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 189 });
@@ -2181,7 +2239,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             Assert.Throws<InvalidOperationException>(() => portfolio.SetAccountCurrency(Currencies.USD));

--- a/Tests/Common/Securities/SecurityPortfolioModelTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioModelTests.cs
@@ -207,7 +207,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.Holdings.SetHoldings(50m, 100);
             portfolio.Securities.Add(equity);
@@ -247,7 +248,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             equity.Holdings.SetHoldings(50m, -100);
             portfolio.Securities.Add(equity);
@@ -287,7 +289,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             portfolio.Securities.Add(equity);
 
@@ -332,7 +335,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             portfolio.Securities.Add(equity);
 
@@ -377,7 +381,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             future.Holdings.SetHoldings(50m, 100);
             portfolio.Securities.Add(future);
@@ -418,7 +423,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             future.Holdings.SetHoldings(50m, -100);
             portfolio.Securities.Add(future);
@@ -459,7 +465,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             portfolio.Securities.Add(future);
 
@@ -504,7 +511,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             portfolio.Securities.Add(future);
 
@@ -550,7 +558,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             crypto.Holdings.SetHoldings(50m, 100);
             portfolio.Securities.Add(crypto);
@@ -588,7 +597,8 @@ namespace QuantConnect.Tests.Common.Securities
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 cash,
                 SymbolProperties.GetDefault("EUR"),
-                portfolio.CashBook
+                portfolio.CashBook,
+                RegisteredSecurityDataTypesProvider.Null
             );
             portfolio.Securities.Add(crypto);
 
@@ -618,7 +628,8 @@ namespace QuantConnect.Tests.Common.Securities
                 CreateTradeBarConfig(),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetMarketPrice(new Tick { Value = 100 });
             var timeKeeper = new TimeKeeper(reference);

--- a/Tests/Common/Securities/StandardDeviationOfReturnsVolatilityModelTests.cs
+++ b/Tests/Common/Securities/StandardDeviationOfReturnsVolatilityModelTests.cs
@@ -40,7 +40,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 0),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
@@ -79,7 +80,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 0),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
@@ -123,7 +125,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 0),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
@@ -154,7 +157,8 @@ namespace QuantConnect.Tests.Common.Securities
                 config,
                 new Cash(Currencies.USD, 0, 0),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 

--- a/Tests/Common/Securities/TradingCalendarTests.cs
+++ b/Tests/Common/Securities/TradingCalendarTests.cs
@@ -42,7 +42,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
@@ -55,7 +56,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Option, option1),
                     new Cash(Currencies.USD, 0, 1m),
                     new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -67,7 +69,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Option, option2),
                     new Cash(Currencies.USD, 0, 1m),
                     new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -79,7 +82,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Future, future1),
                     new Cash(Currencies.USD, 0, 1m),
                     new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -91,7 +95,8 @@ namespace QuantConnect.Tests.Common.Securities
                     CreateTradeBarDataConfig(SecurityType.Future, future2),
                     new Cash(Currencies.USD, 0, 1m),
                     new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -57,11 +57,12 @@ namespace QuantConnect.Tests.Engine
             var dataManager = new DataManager(feed,
                 new UniverseSelection(
                     algorithm,
-                    new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm)),
+                    new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm, RegisteredSecurityDataTypesProvider.Null)),
                 algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase,
-                false);
+                false,
+                RegisteredSecurityDataTypesProvider.Null);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             var transactions = new BacktestingTransactionHandler();
             var results = new BacktestingResultHandler();

--- a/Tests/Engine/BasicOptionAssignmentSimulationTests.cs
+++ b/Tests/Engine/BasicOptionAssignmentSimulationTests.cs
@@ -53,7 +53,8 @@ namespace QuantConnect.Tests.Engine
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
@@ -66,7 +67,8 @@ namespace QuantConnect.Tests.Engine
                     CreateTradeBarDataConfig(SecurityType.Equity, option1),
                     new Cash(Currencies.USD, 0, 1m),
                     new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -78,7 +80,8 @@ namespace QuantConnect.Tests.Engine
                     CreateTradeBarDataConfig(SecurityType.Equity, option2),
                     new Cash(Currencies.USD, 0, 1m),
                     new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -90,7 +93,8 @@ namespace QuantConnect.Tests.Engine
                     CreateTradeBarDataConfig(SecurityType.Equity, option3),
                     new Cash(Currencies.USD, 0, 1m),
                     new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
 
@@ -160,7 +164,8 @@ namespace QuantConnect.Tests.Engine
                         CreateTradeBarDataConfig(SecurityType.Option, symbol),
                         new Cash(Currencies.USD, 0, 1m),
                         new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                        ErrorCurrencyConverter.Instance
+                        ErrorCurrencyConverter.Instance,
+                        RegisteredSecurityDataTypesProvider.Null
                     );
                     securities.Add(symbol, option);
 
@@ -177,7 +182,8 @@ namespace QuantConnect.Tests.Engine
                     CreateTradeBarDataConfig(SecurityType.Equity, Symbols.SPY),
                     new Cash(Currencies.USD, 0, 1m),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 )
             );
             securities[Symbols.SPY].SetMarketPrice(new Tick { Symbol = Symbols.SPY, AskPrice = 217.94m, BidPrice = 217.86m, Value = 217.90m, Time = securities.UtcTime });

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -897,7 +897,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var algorithm = new QCAlgorithm();
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
-            var securityService = new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm);
+            var securityService = new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm, RegisteredSecurityDataTypesProvider.Null);
             algorithm.Securities.SetSecurityService(securityService);
             algorithm.SetLiveMode(true);
 

--- a/Tests/Engine/DataFeeds/DataManagerStub.cs
+++ b/Tests/Engine/DataFeeds/DataManagerStub.cs
@@ -73,7 +73,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 new SecurityService(algorithm.Portfolio.CashBook,
                     marketHoursDatabase,
                     symbolPropertiesDatabase,
-                    algorithm))
+                    algorithm,
+                    RegisteredSecurityDataTypesProvider.Null))
         {
         }
 
@@ -83,7 +84,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 algorithm,
                 timeKeeper,
                 marketHoursDatabase,
-                false)
+                false,
+                RegisteredSecurityDataTypesProvider.Null)
         {
             SecurityService = securityService;
             algorithm.Securities.SetSecurityService(securityService);

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactoryTests.cs
@@ -41,7 +41,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 config,
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var universeSettings = new UniverseSettings(Resolution.Daily, 2m, true, false, TimeSpan.FromDays(1));
@@ -85,7 +86,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 config,
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var universeSettings = new UniverseSettings(Resolution.Daily, 2m, true, false, TimeSpan.FromDays(1));

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactoryTests.cs
@@ -41,7 +41,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 config,
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var mapFileProvider = new LocalDiskMapFileProvider();

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FineFundamentalSubscriptionEnumeratorFactoryTests.cs
@@ -47,7 +47,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 config,
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var request = new SubscriptionRequest(false, null, security, config, parameters.StartDate, parameters.EndDate);
             var fileProvider = new DefaultDataProvider();
@@ -98,7 +99,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 config,
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var request = new SubscriptionRequest(false, null, security, config, startDate, endDate);
             var fileProvider = new DefaultDataProvider();
@@ -135,7 +137,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 config,
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var request = new SubscriptionRequest(false, null, security, config, startDate, endDate);
             var fileProvider = new DefaultDataProvider();

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FuturesChainUniverseSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FuturesChainUniverseSubscriptionEnumeratorFactoryTests.cs
@@ -64,7 +64,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 exchangeHours,
                 quoteCurrency,
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var universeSettings = new UniverseSettings(Resolution.Minute, 0, true, false, TimeSpan.Zero);

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -68,7 +68,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     exchangeHours,
                     quoteCurrency,
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
                 var request = new SubscriptionRequest(false, null, security, config, _referenceUtc.AddSeconds(-1), _referenceUtc.AddDays(1));
 
@@ -148,7 +149,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     exchangeHours,
                     quoteCurrency,
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
                 var request = new SubscriptionRequest(false, null, security, config, _referenceUtc.AddSeconds(-4), _referenceUtc.AddDays(1));
 
@@ -235,7 +237,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     exchangeHours,
                     quoteCurrency,
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
                 var request = new SubscriptionRequest(false, null, security, config, _referenceUtc.AddSeconds(-6), _referenceUtc.AddDays(1));
 
@@ -317,7 +320,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                     exchangeHours,
                     quoteCurrency,
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
                 var request = new SubscriptionRequest(false, null, security, config, _referenceUtc.AddDays(-2), _referenceUtc.AddDays(1));
 

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
@@ -64,7 +64,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 exchangeHours,
                 quoteCurrency,
                 new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var fillForwardResolution = Ref.CreateReadOnly(() => Resolution.Minute.ToTimeSpan());

--- a/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
@@ -48,11 +48,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var dataManager = new DataManager(feed,
                 new UniverseSelection(
                     algorithm,
-                    new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm)),
+                    new SecurityService(algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algorithm, RegisteredSecurityDataTypesProvider.Null)),
                 algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase,
-                false);
+                false,
+                RegisteredSecurityDataTypesProvider.Null);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             var synchronizer = new Synchronizer();
             synchronizer.Initialize(algorithm, dataManager);

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -870,14 +870,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 algorithm.Portfolio.CashBook,
                 marketHoursDatabase,
                 symbolPropertiesDataBase,
-                algorithm);
+                algorithm,
+                RegisteredSecurityDataTypesProvider.Null);
             algorithm.Securities.SetSecurityService(securityService);
             var dataManager = new DataManager(feed,
                 new UniverseSelection(algorithm, securityService),
                 algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase,
-                true);
+                true,
+                RegisteredSecurityDataTypesProvider.Null);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             var synchronizer = new TestableLiveSynchronizer();
             synchronizer.Initialize(algorithm, dataManager);
@@ -1110,14 +1112,15 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var fileProvider = new DefaultDataProvider();
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
-            var securityService = new SecurityService(_algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, _algorithm);
+            var securityService = new SecurityService(_algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, _algorithm, RegisteredSecurityDataTypesProvider.Null);
             _algorithm.Securities.SetSecurityService(securityService);
             _dataManager = new DataManager(feed,
                 new UniverseSelection(_algorithm, securityService),
                 _algorithm,
                 _algorithm.TimeKeeper,
                 marketHoursDatabase,
-                true);
+                true,
+                RegisteredSecurityDataTypesProvider.Null);
             _algorithm.SubscriptionManager.SetDataManager(_dataManager);
             _algorithm.AddSecurities(resolution, equities, forex, crypto);
             _synchronizer = new TestableLiveSynchronizer(_manualTimeProvider);
@@ -1404,14 +1407,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 algorithm.Portfolio.CashBook,
                 marketHoursDatabase,
                 symbolPropertiesDataBase,
-                algorithm);
+                algorithm,
+                RegisteredSecurityDataTypesProvider.Null);
             algorithm.Securities.SetSecurityService(securityService);
             var dataManager = new DataManager(feed,
                 new UniverseSelection(algorithm, securityService),
                 algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase,
-                true);
+                true,
+                RegisteredSecurityDataTypesProvider.Null);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
             algorithm.SetLiveMode(true);
 

--- a/Tests/Engine/DataFeeds/SubscriptionCollectionTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionCollectionTests.cs
@@ -49,7 +49,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                 new Cash(Currencies.USD, 0, 1),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(DateTimeZone.Utc, start, end);
             var enumerator = new EnqueueableEnumerator<BaseData>();
@@ -360,7 +361,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                     new Cash(Currencies.USD, 0, 1),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
             }
             else if (type == SecurityType.Option)
@@ -373,7 +375,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                     new Cash(Currencies.USD, 0, 1),
                     new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
             }
             else if (type == SecurityType.Future)
@@ -384,7 +387,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
                     new Cash(Currencies.USD, 0, 1),
                     SymbolProperties.GetDefault(Currencies.USD),
-                    ErrorCurrencyConverter.Instance
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
                 );
             }
             else

--- a/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionSynchronizerTests.cs
@@ -56,14 +56,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 algorithm.Portfolio.CashBook,
                 marketHoursDatabase,
                 symbolPropertiesDataBase,
-                algorithm);
+                algorithm,
+                RegisteredSecurityDataTypesProvider.Null);
             algorithm.Securities.SetSecurityService(securityService);
             var dataManager = new DataManager(feed,
                 new UniverseSelection(algorithm, securityService),
                 algorithm,
                 algorithm.TimeKeeper,
                 marketHoursDatabase,
-                false);
+                false,
+                RegisteredSecurityDataTypesProvider.Null);
             algorithm.SubscriptionManager.SetDataManager(dataManager);
 
             algorithm.Initialize();

--- a/Tests/Engine/DataFeeds/TimeSliceTests.cs
+++ b/Tests/Engine/DataFeeds/TimeSliceTests.cs
@@ -60,7 +60,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 subscriptionDataConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             DateTime refTime = DateTime.UtcNow;
@@ -109,7 +110,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 subscriptionDataConfig1,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var security2 = new Security(
@@ -117,7 +119,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 subscriptionDataConfig1,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var timeSlice = _timeSliceFactory.Create(DateTime.UtcNow,
@@ -185,7 +188,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 subscriptionDataConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var timeSlice = _timeSliceFactory.Create(DateTime.UtcNow,
@@ -217,7 +221,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 subscriptionDataConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
             var refTime = DateTime.UtcNow;
 

--- a/Tests/Engine/RealTimePriceUpdateTests.cs
+++ b/Tests/Engine/RealTimePriceUpdateTests.cs
@@ -69,11 +69,12 @@ namespace QuantConnect.Tests.Engine
             var dataManager = new DataManager(_liveTradingDataFeed,
                 new UniverseSelection(
                     algo,
-                    new SecurityService(algo.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algo)),
+                    new SecurityService(algo.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, algo, RegisteredSecurityDataTypesProvider.Null)),
                 algo,
                 algo.TimeKeeper,
                 marketHoursDatabase,
-                true);
+                true,
+                RegisteredSecurityDataTypesProvider.Null);
             algo.SubscriptionManager.SetDataManager(dataManager);
             var synchronizer = new LiveSynchronizer();
             synchronizer.Initialize(algo, dataManager);
@@ -114,7 +115,8 @@ namespace QuantConnect.Tests.Engine
                 _exchangeHours,
                 new Cash("USA", 100m, 1m),
                 SymbolProperties.GetDefault("USA"),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var subscriptionRequest = new SubscriptionRequest(false, null, security, _config, DateTime.MinValue, DateTime.MaxValue);
@@ -130,7 +132,8 @@ namespace QuantConnect.Tests.Engine
                 _exchangeHours,
                 new Cash("USA", 100m, 1m),
                 SymbolProperties.GetDefault("USA"),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
 
             var subscriptionRequest = new SubscriptionRequest(false, null, security, _config, DateTime.MinValue, DateTime.MaxValue);

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -998,7 +998,8 @@ def Test(dataFrame, symbol):
                 subscriptionDataConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
 

--- a/Tests/Python/SecurityCustomModelTests.cs
+++ b/Tests/Python/SecurityCustomModelTests.cs
@@ -143,7 +143,8 @@ class CustomBuyingPowerModel(SecurityMarginModel):
                 subscriptionDataConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
             );
         }
     }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -298,6 +298,7 @@
     <Compile Include="Common\Data\BaseDataTests.cs" />
     <Compile Include="Common\Data\CalendarConsolidatorsTests.cs" />
     <Compile Include="Common\Data\Custom\EstimizeTests.cs" />
+    <Compile Include="Common\Data\DynamicDataTests.cs" />
     <Compile Include="Common\Data\Fundamental\MultiPeriodFieldTests.cs" />
     <Compile Include="Common\Data\MockSubscriptionDataConfigProvider.cs" />
     <Compile Include="Common\Data\UniverseSelection\UniverseTests.cs" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -321,6 +321,7 @@
     <Compile Include="Common\Securities\AccountCurrencyImmediateSettlementModelTests.cs" />
     <Compile Include="Common\Securities\Options\OptionPortfolioModelTests.cs" />
     <Compile Include="Common\Securities\ProcessVolatilityHistoryRequirementsTests.cs" />
+    <Compile Include="Common\Securities\DynamicSecurityDataTests.cs" />
     <Compile Include="Common\Securities\SecurityHoldingTests.cs" />
     <Compile Include="Common\Securities\SecurityServiceTests.cs" />
     <Compile Include="Common\Securities\TestAccountCurrencyProvider.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
NOTE: Many changes are due to updating `Security`'s constructor, as well as `DataManager` and `SecurityService` to accept the new `IRegisteredSecurityDataTypesProvider`. The `DynamicSecurityData` implementation uses this to determine whether or not we can return a default value of an empty list (of the correct type) in case we haven't received data yet. This is as opposed to throwing a `KeyNotFoundException` immediately. See `DynamicSecurityData.GetProperty(name)` for implementation details.

#### Description
<!--- Describe your changes in detail -->
Adds a new system of accessing data related to a particular security. This logic is encapsulated in the dynamic implementation of `DynamicSecurityData` and is accessible via the `security.Data` property. `DynamicSecurityData` provides a type-centric view of the security's cache which provides access to data by type. There's two separate access patterns here. The first is type-safe via C# generics:
``` csharp
Security security = Securities["GOOGL"];

// returns a single item of type T
TradeBar mostRecentTradeBar = security.Data.Get<TradeBar>();

// returns a list of type T, useful for data types where multiple data points
// may be available at a single time step, such as ticks
List<Tick> mostRecentTicks = security.Data.GetAll<Tick>();

// you can equally access derivative custom data, such as from AddData<SECReport8K>("GOOGL")
SECReport8K sec8k = security.Get<SECReport8K>();
```
We can also access the list version (`GetAll<T>`) via the usage of dynamics. This is also the recommended access pattern for python:
``` csharp
var security = Securities["GOOGL"];

// access dynamically by type name: security.Data.TypeName
List<TradeBar> mostRecentTradeBars = security.Data.TradeBar;
List<Tick> mostRecentTicks = security.Data.Tick;

// derivative custom data is also now accessible via the underlying security
// for example, if using AddData<SECReport8K>("GOOGL")
// the dynamic accessors will ALWAYS return a list, and if no data available,
// it will return an empty list provided it's a valid and registered type name
List<SECReport8K> sec8k = security.Data.SECReport8K;
```

In order to support returning the default value of an empty list in the case where we haven't received data yet, a new abstraction was added: `IRegisteredSecurityDataTypesProvider`. There's a single instance of the registered type provider per algorithm and it is owned by the `ISecurityService` since he's in charge of creating security objects. When creating securities, the data type from the configuration is added to a set to track all unique data types for the algorithm. When the algorithm attempts to access `security.Data.InvalidPropertyName`, we'll first check to see if `InvalidPropertyName` is one of the registered type names, and if so, we'll return a new empty list, and if not, we'll throw a `KeyNotFoundException`.

In addition to the security data accessors detailed above, this PR also includes several enhancements to the local regression test/debug system. Currently, we write log and order files to `./passed` and `./regression`. The passed folder is for (you guessed it!) algorithms that pass and regression contains the most recent run. This allows you to do a directory diff between `./passed` and `./regression`. This is an incredibly useful aid when trying to determine the root cause of a regression test failure. While working this issue I found that not enough data was being put into the `orders.log` files. This PR changes it to a `details.log` and saves off way more data, including daily snapshots of holdings quantity/price/value, cashbook statements, alpha runtime stats as they change and even logging of every piece of data (exception option/future contracts) that comes through in each slice object.

This makes identifying the underlying cause of a regression failure as easy as popping open a diff window :)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3620

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, users would need to manage their own mapping of derivative custom data (such as SEC report, tiingo, psychsignal, etc) to the security they were describing (underlying). This removes all of that and makes all of a security's data immediately accessible directly from the underlying security itself.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes!

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added for `DynamicSecurityData` type and a test added to `SecurityTests` to ensure the `SecurityCache`'s event handler is wired up properly.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->