### PR TITLE
Adding BaseData.DataTimeZone()

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Algorithm
         /// <returns>The new <see cref="Security"/></returns>
         public Security AddData(PyObject type, string ticker, Resolution resolution = Resolution.Minute)
         {
-            return AddData(type, ticker, resolution, TimeZones.NewYork, false, 1m);
+            return AddData(type, ticker, resolution, null, false, 1m);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace QuantConnect.Algorithm
         /// </remarks>
         public Security AddData(PyObject type, Symbol underlying, Resolution resolution = Resolution.Minute)
         {
-            return AddData(type, underlying, resolution, TimeZones.NewYork, false, 1m);
+            return AddData(type, underlying, resolution, null, false, 1m);
         }
 
         /// <summary>
@@ -205,7 +205,18 @@ namespace QuantConnect.Algorithm
         {
             var alias = symbol.ID.Symbol;
             SymbolCache.Set(alias, symbol);
-            MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, alias, SecurityType.Base, timeZone);
+
+            if (timeZone != null)
+            {
+                // user set time zone
+                MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, alias, SecurityType.Base, timeZone);
+            }
+            else
+            {
+                var baseInstance = dataType.GetBaseDataInstance();
+                baseInstance.Symbol = symbol;
+                MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, alias, SecurityType.Base, baseInstance.DataTimeZone());
+            }
 
             //Add this new generic data as a tradeable security:
             var config = SubscriptionManager.SubscriptionDataConfigService.Add(

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1809,7 +1809,7 @@ namespace QuantConnect.Algorithm
         public Security AddData<T>(string ticker, Resolution resolution, bool fillDataForward, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
-            return AddData<T>(ticker, resolution, TimeZones.NewYork, fillDataForward, leverage);
+            return AddData<T>(ticker, resolution, null, fillDataForward, leverage);
         }
 
         /// <summary>
@@ -1825,7 +1825,7 @@ namespace QuantConnect.Algorithm
         public Security AddData<T>(Symbol underlying, Resolution resolution, bool fillDataForward, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
-            return AddData<T>(underlying, resolution, TimeZones.NewYork, fillDataForward, leverage);
+            return AddData<T>(underlying, resolution, null, fillDataForward, leverage);
         }
 
         /// <summary>

--- a/Common/Data/BaseData.cs
+++ b/Common/Data/BaseData.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using NodaTime;
 using QuantConnect.Util;
 
 namespace QuantConnect.Data
@@ -157,6 +158,21 @@ namespace QuantConnect.Data
         {
             // by default, we'll assume all custom data is sparse data
             return Symbol.SecurityType == SecurityType.Base;
+        }
+
+        /// <summary>
+        /// Specifies the data time zone for this data type. This is useful for custom data types
+        /// </summary>
+        /// <remarks>Will throw <see cref="InvalidOperationException"/> for security types
+        /// other than <see cref="SecurityType.Base"/></remarks>
+        /// <returns>The <see cref="DateTimeZone"/> of this data type</returns>
+        public virtual DateTimeZone DataTimeZone()
+        {
+            if (Symbol.SecurityType != SecurityType.Base)
+            {
+                throw new InvalidOperationException("BaseData.DataTimeZone(): is only valid for base data types");
+            }
+            return TimeZones.NewYork;
         }
 
         /// <summary>

--- a/Common/Data/Custom/Estimize/EstimizeConsensus.cs
+++ b/Common/Data/Custom/Estimize/EstimizeConsensus.cs
@@ -16,6 +16,7 @@
 using Newtonsoft.Json;
 using System;
 using System.IO;
+using NodaTime;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Data.Custom.Estimize
@@ -191,6 +192,15 @@ namespace QuantConnect.Data.Custom.Estimize
         public override bool RequiresMapping()
         {
             return true;
+        }
+
+        /// <summary>
+        /// Specifies the data time zone for this data type. This is useful for custom data types
+        /// </summary>
+        /// <returns>The <see cref="DateTimeZone"/> of this data type</returns>
+        public override DateTimeZone DataTimeZone()
+        {
+            return TimeZones.Utc;
         }
     }
 

--- a/Common/Data/Custom/Estimize/EstimizeEstimate.cs
+++ b/Common/Data/Custom/Estimize/EstimizeEstimate.cs
@@ -16,6 +16,7 @@
 using Newtonsoft.Json;
 using System;
 using System.IO;
+using NodaTime;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Data.Custom.Estimize
@@ -179,6 +180,15 @@ namespace QuantConnect.Data.Custom.Estimize
         public override bool RequiresMapping()
         {
             return true;
+        }
+
+        /// <summary>
+        /// Specifies the data time zone for this data type. This is useful for custom data types
+        /// </summary>
+        /// <returns>The <see cref="DateTimeZone"/> of this data type</returns>
+        public override DateTimeZone DataTimeZone()
+        {
+            return TimeZones.Utc;
         }
     }
 }

--- a/Common/Data/Custom/Estimize/EstimizeRelease.cs
+++ b/Common/Data/Custom/Estimize/EstimizeRelease.cs
@@ -16,6 +16,7 @@
 using Newtonsoft.Json;
 using System;
 using System.IO;
+using NodaTime;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Data.Custom.Estimize
@@ -194,6 +195,15 @@ namespace QuantConnect.Data.Custom.Estimize
         public override bool RequiresMapping()
         {
             return true;
+        }
+
+        /// <summary>
+        /// Specifies the data time zone for this data type. This is useful for custom data types
+        /// </summary>
+        /// <returns>The <see cref="DateTimeZone"/> of this data type</returns>
+        public override DateTimeZone DataTimeZone()
+        {
+            return TimeZones.Utc;
         }
     }
 }

--- a/Common/Data/Custom/PsychSignal/PsychSignalSentimentData.cs
+++ b/Common/Data/Custom/PsychSignal/PsychSignalSentimentData.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using NodaTime;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Data.Custom.PsychSignal
@@ -166,6 +167,15 @@ namespace QuantConnect.Data.Custom.PsychSignal
         public override bool RequiresMapping()
         {
             return true;
+        }
+
+        /// <summary>
+        /// Specifies the data time zone for this data type. This is useful for custom data types
+        /// </summary>
+        /// <returns>The <see cref="DateTimeZone"/> of this data type</returns>
+        public override DateTimeZone DataTimeZone()
+        {
+            return TimeZones.Utc;
         }
     }
 }

--- a/Common/Data/Custom/Tiingo/TiingoDailyData.cs
+++ b/Common/Data/Custom/Tiingo/TiingoDailyData.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using NodaTime;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using static QuantConnect.StringExtensions;
@@ -187,6 +188,15 @@ namespace QuantConnect.Data.Custom.Tiingo
         public override bool RequiresMapping()
         {
             return true;
+        }
+
+        /// <summary>
+        /// Specifies the data time zone for this data type. This is useful for custom data types
+        /// </summary>
+        /// <returns>The <see cref="DateTimeZone"/> of this data type</returns>
+        public override DateTimeZone DataTimeZone()
+        {
+            return TimeZones.Utc;
         }
     }
 }

--- a/Common/Data/Custom/TradingEconomics/TradingEconomicsCalendar.cs
+++ b/Common/Data/Custom/TradingEconomics/TradingEconomicsCalendar.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using NodaTime;
 using QuantConnect.Data.UniverseSelection;
 using static QuantConnect.StringExtensions;
 
@@ -232,6 +233,15 @@ namespace QuantConnect.Data.Custom.TradingEconomics
         {
             var symbol = string.IsNullOrWhiteSpace(TESymbol) ? Ticker : TESymbol;
             return Invariant($"{symbol} ({Country} - {Category}): {Event} : Importance.{Importance}");
+        }
+
+        /// <summary>
+        /// Specifies the data time zone for this data type. This is useful for custom data types
+        /// </summary>
+        /// <returns>The <see cref="DateTimeZone"/> of this data type</returns>
+        public override DateTimeZone DataTimeZone()
+        {
+            return TimeZones.Utc;
         }
     }
 

--- a/Common/Data/Custom/TradingEconomics/TradingEconomicsEarnings.cs
+++ b/Common/Data/Custom/TradingEconomics/TradingEconomicsEarnings.cs
@@ -15,7 +15,7 @@
 
 using Newtonsoft.Json;
 using System;
-using QLNet;
+using NodaTime;
 
 namespace QuantConnect.Data.Custom.TradingEconomics
 {
@@ -101,6 +101,15 @@ namespace QuantConnect.Data.Custom.TradingEconomics
         /// </summary>
         [JsonProperty(PropertyName = "LastUpdate"), JsonConverter(typeof(TradingEconomicsDateTimeConverter))]
         public DateTime LastUpdate { get; set; }
+
+        /// <summary>
+        /// Specifies the data time zone for this data type. This is useful for custom data types
+        /// </summary>
+        /// <returns>The <see cref="DateTimeZone"/> of this data type</returns>
+        public override DateTimeZone DataTimeZone()
+        {
+            return TimeZones.Utc;
+        }
     }
 
     /// <summary>

--- a/Common/Data/Custom/TradingEconomics/TradingEconomicsIndicator.cs
+++ b/Common/Data/Custom/TradingEconomics/TradingEconomicsIndicator.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using NodaTime;
 using QuantConnect.Data.UniverseSelection;
 using static QuantConnect.StringExtensions;
 
@@ -133,5 +134,14 @@ namespace QuantConnect.Data.Custom.TradingEconomics
         /// Formats a string with the Trading Economics Indicator information.
         /// </summary>
         public override string ToString() => Invariant($"{HistoricalDataSymbol} ({Country} - {Category}): {Value}");
+
+        /// <summary>
+        /// Specifies the data time zone for this data type. This is useful for custom data types
+        /// </summary>
+        /// <returns>The <see cref="DateTimeZone"/> of this data type</returns>
+        public override DateTimeZone DataTimeZone()
+        {
+            return TimeZones.Utc;
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding `BaseData.DataTimeZone()` with the objective of allowing custom
data types to determine their data time zone.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3634
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows custom data types to specify their data Timezone
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->