### PR TITLE
Add missing Invariant usages in alpha models and unit tests

### DIFF
--- a/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.cs
@@ -20,6 +20,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Indicators;
 using QuantConnect.Securities;
+using static System.FormattableString;
 
 namespace QuantConnect.Algorithm.Framework.Alphas
 {
@@ -60,7 +61,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             _pairs = new Dictionary<Tuple<Symbol, Symbol>, PairData>();
 
             Securities = new HashSet<Security>();
-            Name = $"{nameof(BasePairsTradingAlphaModel)}({_lookback},{_resolution},{_threshold.Normalize()})";
+            Name = Invariant($"{nameof(BasePairsTradingAlphaModel)}({_lookback},{_resolution},{_threshold.Normalize()})");
         }
 
         /// <summary>

--- a/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/ConstantAlphaModel.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
+using static System.FormattableString;
 
 namespace QuantConnect.Algorithm.Framework.Alphas
 {
@@ -72,12 +73,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             Name = $"{nameof(ConstantAlphaModel)}({type},{direction},{period}";
             if (magnitude.HasValue)
             {
-                Name += $",{magnitude.Value}";
+                Name += Invariant($",{magnitude.Value}");
             }
 
             if (confidence.HasValue)
             {
-                Name += $",{confidence.Value}";
+                Name += Invariant($",{confidence.Value}");
             }
 
             Name += ")";

--- a/Tests/Algorithm/Framework/Alphas/ConstantAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/ConstantAlphaModelTests.cs
@@ -19,6 +19,7 @@ using QuantConnect.Algorithm.Framework.Alphas;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using static System.FormattableString;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 {
@@ -50,7 +51,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
         protected override string GetExpectedModelName(IAlphaModel model)
         {
-            return $"{nameof(ConstantAlphaModel)}({_type},{_direction},{_period},{_magnitude})";
+            return Invariant($"{nameof(ConstantAlphaModel)}({_type},{_direction},{_period},{_magnitude})");
         }
     }
 }

--- a/Tests/Common/StringExtensionsTests.cs
+++ b/Tests/Common/StringExtensionsTests.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.Tests.Common
             string format
             )
         {
-            var formattable = (IFormattable) Convert.ChangeType(value, typeCode, null);
+            var formattable = (IFormattable) Convert.ChangeType(value, typeCode, CultureInfo.InvariantCulture);
             var formatted = formattable.ToStringInvariant(format);
             var expected = formattable.ToString(format, CultureInfo.InvariantCulture);
             Assert.AreEqual(expected, formatted, $"Failed on type code: {typeCode}");

--- a/Tests/Configuration/ConfigTests.cs
+++ b/Tests/Configuration/ConfigTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,11 +14,10 @@
 */
 
 using System;
-using System.IO;
-using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using QuantConnect.Configuration;
+using static System.FormattableString;
 
 namespace QuantConnect.Tests.Configuration
 {
@@ -87,7 +86,7 @@ namespace QuantConnect.Tests.Configuration
 
         private void GetValueHandles<T>(T value)
         {
-            var configValue = value.ToString();
+            var configValue = Invariant($"{value}");
             Config.Set("temp-value", configValue);
             var actual = Config.GetValue<T>("temp-value");
             Assert.AreEqual(value, actual);


### PR DESCRIPTION

#### Description
- Added missing `Invariant()` usages in alpha models and unit tests

#### Related Issue
Closes #3639 

#### Motivation and Context
Failing unit tests.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`