### PR TITLE
Update CoinApiDataQueueHandler to use CoinApi's NuGet package

### DIFF
--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -49,6 +49,9 @@
     <StartupObject>QuantConnect.ToolBox.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CoinAPI.WebSocket.V1, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CoinAPI.WebSocket.V1.1.6.0\lib\net45\CoinAPI.WebSocket.V1.dll</HintPath>
+    </Reference>
     <Reference Include="DotNetZip, Version=1.13.3.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetZip.1.13.3\lib\net40\DotNetZip.dll</HintPath>
     </Reference>
@@ -177,12 +180,21 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.4.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Utf8Json, Version=1.3.7.0, Culture=neutral, PublicKeyToken=8a73d3ba7e392e27, processorArchitecture=MSIL">
+      <HintPath>..\packages\Utf8Json.1.3.7\lib\net45\Utf8Json.dll</HintPath>
+    </Reference>
     <Reference Include="websocket-sharp, Version=1.0.4.0, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
       <HintPath>..\packages\WebSocketSharpFork.1.0.4.0\lib\net35\websocket-sharp.dll</HintPath>
     </Reference>

--- a/ToolBox/packages.config
+++ b/ToolBox/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CoinAPI.WebSocket.V1" version="1.6.0" targetFramework="net452" />
   <package id="DotNetZip" version="1.13.3" targetFramework="net452" />
   <package id="EngineIoClientDotNet" version="1.0.7" targetFramework="net452" />
   <package id="ICSharpCode.SharpZipLib.dll" version="0.85.4.369" targetFramework="net452" />
@@ -7,6 +8,7 @@
   <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.3" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.3" targetFramework="net452" />
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.3" targetFramework="net452" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net452" />
   <package id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" targetFramework="net452" />
   <package id="Microsoft.NetCore.Analyzers" version="2.9.3" targetFramework="net452" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.3" targetFramework="net452" />
@@ -19,6 +21,11 @@
   <package id="StringInterpolationBridgeStrong" version="0.9.1" targetFramework="net452" />
   <package id="SuperSocket.ClientEngine.Core" version="0.10.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net452" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
+  <package id="Utf8Json" version="1.3.7" targetFramework="net452" />
   <package id="WebSocket4Net" version="0.15.2" targetFramework="net452" />
   <package id="WebSocketSharpFork" version="1.0.4.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION

#### Description
- The `CoinApiDataQueueHandler` implementation has been updated to use the new `CoinApi.WebSockets` NuGet package for C#.
NuGet: https://www.nuget.org/packages/CoinAPI.WebSocket.V1
Source: https://github.com/coinapi/coinapi-sdk/tree/master/csharp-ws

#### Related Issue
Closes #3644 

#### Motivation and Context
- Improved stability and handling of disconnections.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local live algorithms and back-end streaming software.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`