### PR TITLE
Match 'alternative' data paths to SecurityType.Base

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -534,7 +534,7 @@ namespace QuantConnect
         /// <returns>Last 4 character string of string.</returns>
         public static string GetExtension(this string str) {
             var ext = str.Substring(Math.Max(0, str.Length - 4));
-            var allowedExt = new List<string>() { ".zip", ".csv", ".json" };
+            var allowedExt = new List<string> { ".zip", ".csv", ".json", ".tsv" };
             if (!allowedExt.Contains(ext))
             {
                 ext = ".custom";

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -301,6 +301,32 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(date.Date, Parse.DateTime("2016-10-07").Date);
         }
 
+        [TestCase(SecurityType.Base, "alteRNative")]
+        [TestCase(SecurityType.Equity, "Equity")]
+        [TestCase(SecurityType.Cfd, "Cfd")]
+        [TestCase(SecurityType.Commodity, "Commodity")]
+        [TestCase(SecurityType.Crypto, "Crypto")]
+        [TestCase(SecurityType.Forex, "Forex")]
+        [TestCase(SecurityType.Future, "Future")]
+        [TestCase(SecurityType.Option, "Option")]
+        public void ParsesDataSecurityType(SecurityType type, string path)
+        {
+            Assert.AreEqual(type, LeanData.ParseDataSecurityType(path));
+        }
+
+        [Test]
+        public void SecurityTypeAsDataPath()
+        {
+            Assert.IsTrue(LeanData.SecurityTypeAsDataPath.Contains("alternative"));
+            Assert.IsTrue(LeanData.SecurityTypeAsDataPath.Contains("equity"));
+            Assert.IsTrue(LeanData.SecurityTypeAsDataPath.Contains("base"));
+            Assert.IsTrue(LeanData.SecurityTypeAsDataPath.Contains("option"));
+            Assert.IsTrue(LeanData.SecurityTypeAsDataPath.Contains("cfd"));
+            Assert.IsTrue(LeanData.SecurityTypeAsDataPath.Contains("crypto"));
+            Assert.IsTrue(LeanData.SecurityTypeAsDataPath.Contains("future"));
+            Assert.IsTrue(LeanData.SecurityTypeAsDataPath.Contains("forex"));
+        }
+
         private static void AssertBarsAreEqual(IBar expected, IBar actual)
         {
             if (expected == null && actual == null)

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -28,6 +28,18 @@ namespace QuantConnect.Tests.Common.Util
     [TestFixture]
     public class LeanDataTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            SymbolCache.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            SymbolCache.Clear();
+        }
+
         [Test, TestCaseSource(nameof(GetLeanDataTestParameters))]
         public void GenerateZipFileName(LeanDataTestParameters parameters)
         {
@@ -269,6 +281,26 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(resolution, Resolution.Minute);
             Assert.AreEqual(symbol.ID.Symbol.ToLowerInvariant(), "bcousd");
             Assert.AreEqual(date.Date, Parse.DateTime("2016-01-01").Date);
+        }
+
+        [TestCase("Data\\alternative\\estimize\\consensus\\aapl.csv", "aapl", null)]
+        [TestCase("Data\\alternative\\psychsignal\\aapl\\20161007.zip", "aapl", "2016-10-07")]
+        [TestCase("Data\\alternative\\sec\\aapl\\20161007_8K.zip", "aapl", "2016-10-07")]
+        [TestCase("Data\\alternative\\smartinsider\\intentions\\aapl.tsv", "aapl", null)]
+        [TestCase("Data\\alternative\\trading-economics\\calendar\\fdtr\\20161007.zip", "fdtr", "2016-10-07")]
+        [TestCase("Data\\alternative\\ustreasury\\yieldcurverates.zip", "yieldcurverates", null)]
+        public void AlternativePaths_CanBeParsedCorrectly(string path, string expectedSymbol, string expectedDate)
+        {
+            DateTime date;
+            Symbol symbol;
+            Resolution resolution;
+
+            Assert.IsTrue(LeanData.TryParsePath(path, out symbol, out date, out resolution));
+            Assert.AreEqual(SecurityType.Base, symbol.SecurityType);
+            Assert.AreEqual(Market.USA, symbol.ID.Market);
+            Assert.AreEqual(Resolution.Daily, resolution);
+            Assert.AreEqual(expectedSymbol, symbol.ID.Symbol.ToLowerInvariant());
+            Assert.AreEqual(expectedDate == null ? default(DateTime) : Parse.DateTime(expectedDate).Date, date);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- 'alternative' is used in Lean data paths and should be matched to
SecurityType.Base
- Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3608
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- `alternative` is used as a Lean data path and should be matched with `SecurityType.Base`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->