### PR TITLE
Adds ETF Basket Universe Selection Models

### DIFF
--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -148,6 +148,13 @@
     <Compile Include="Selection\ScheduledUniverseSelectionModel.cs" />
     <Compile Include="Selection\QC500UniverseSelectionModel.cs" />
     <Compile Include="Alphas\HistoricalReturnsAlphaModel.cs" />
+    <Compile Include="Selection\BaseETFUniverseSelectionModel.cs" />
+    <Compile Include="Selection\EnergyETFUniverse.cs" />
+    <Compile Include="Selection\MetalsETFUniverse.cs" />
+    <Compile Include="Selection\SP500SectorsETFUniverse.cs" />
+    <Compile Include="Selection\TechnologyETFUniverse.cs" />
+    <Compile Include="Selection\USTreasuriesETFUniverse.cs" />
+    <Compile Include="Selection\VolatilityETFUniverse.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Algorithm\QuantConnect.Algorithm.csproj">

--- a/Algorithm.Framework/Selection/BaseETFUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/BaseETFUniverseSelectionModel.cs
@@ -1,0 +1,84 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data.UniverseSelection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.Framework.Selection
+{
+    /// <summary>
+    /// Base ETF Universe that accepts a Dictionary of DateTime keyed by String that represent
+    /// the Inception date for each symbol
+    /// </summary>
+    public class BaseETFUniverseSelectionModel : FundamentalUniverseSelectionModel
+    {
+        private readonly Queue<Inception> _queue;
+        private readonly List<Symbol> _symbols;
+
+        /// <summary>
+        /// Initializes a new instance of the BaseETFUniverse class
+        /// </summary>
+        /// <param name="tickersByDate">Dictionary of DateTime keyed by String that represent the Inception date for each symbol</param>
+        public BaseETFUniverseSelectionModel(Dictionary<string, DateTime> tickersByDate) :
+            base(false)
+        {
+            _queue = new Queue<Inception>(tickersByDate.Select(Inception.Create));
+            _symbols = new List<Symbol>();
+        }
+
+        /// <summary>
+        /// Returns all ETF that are trading at current algorithm Time
+        /// </summary>
+        public override IEnumerable<Symbol> SelectCoarse(QCAlgorithm algorithm, IEnumerable<CoarseFundamental> coarse)
+        {
+            var date = algorithm.Time;
+
+            // Move Symbols that are trading from the queue to a list 
+            var added = new List<Symbol>();
+            while (_queue.Count > 0 && _queue.First().Date <= date)
+            {
+                var inception = _queue.Dequeue();
+                added.Add(inception.Symbol);
+            }
+
+            // If no pending for addition found, return Universe Unchanged
+            // Otherwise adds to list of current symbols and return it
+            if (added.Count == 0)
+            {
+                return Universe.Unchanged;
+            }
+
+            _symbols.AddRange(added);
+            return _symbols;
+        }
+
+        internal class Inception
+        {
+            public DateTime Date;
+            public Symbol Symbol;
+
+            public static Inception Create(KeyValuePair<string, DateTime> kvp)
+            {
+                return new Inception()
+                {
+                    Date = kvp.Value,
+                    Symbol = Symbol.Create(kvp.Key, SecurityType.Equity, Market.USA)
+                };
+            }
+        }
+    }
+}

--- a/Algorithm.Framework/Selection/EnergyETFUniverse.cs
+++ b/Algorithm.Framework/Selection/EnergyETFUniverse.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.Framework.Selection
+{
+    /// <summary>
+    /// Universe Selection Model that adds the following Energy ETFs at their inception date
+    /// 1998-12-22   XLE    Energy Select Sector SPDR Fund
+    /// 2000-06-16   IYE    iShares U.S. Energy ETF
+    /// 2004-09-29   VDE    Vanguard Energy ETF
+    /// 2006-04-10   USO    United States Oil Fund
+    /// 2006-06-22   XES    SPDR S&P Oil & Gas Equipment & Services ETF
+    /// 2006-06-22   XOP    SPDR S&P Oil & Gas Exploration & Production ETF
+    /// 2007-04-18   UNG    United States Natural Gas Fund
+    /// 2008-06-25   ICLN   iShares Global Clean Energy ETF
+    /// 2008-11-06   ERX    Direxion Daily Energy Bull 3X Shares
+    /// 2008-11-06   ERY    Direxion Daily Energy Bear 3x Shares
+    /// 2008-11-25   SCO    ProShares UltraShort Bloomberg Crude Oil
+    /// 2008-11-25   UCO    ProShares Ultra Bloomberg Crude Oil
+    /// 2009-06-02   AMJ    JPMorgan Alerian MLP Index ETN
+    /// 2010-06-02   BNO    United States Brent Oil Fund
+    /// 2010-08-25   AMLP   Alerian MLP ETF
+    /// 2011-12-21   OIH    VanEck Vectors Oil Services ETF
+    /// 2012-02-08   DGAZ   VelocityShares 3x Inverse Natural Gas
+    /// 2012-02-08   UGAZ   VelocityShares 3x Long Natural Gas
+    /// 2012-02-15   TAN    Invesco Solar ETF
+    /// </summary>
+	public class EnergyETFUniverse : BaseETFUniverseSelectionModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the EnergyETFUniverse class
+        /// </summary>
+        public EnergyETFUniverse() :
+            base(new Dictionary<string, DateTime>()
+            {
+                {"XLE", new DateTime(1998, 12, 22)},
+                {"IYE", new DateTime(2000,  6, 16)},
+                {"VDE", new DateTime(2004,  9, 29)},
+                {"USO", new DateTime(2006,  4, 10)},
+                {"XES", new DateTime(2006,  6, 22)},
+                {"XOP", new DateTime(2006,  6, 22)},
+                {"UNG", new DateTime(2007,  4, 18)},
+                {"ICLN", new DateTime(2008,  6, 25)},
+                {"ERX", new DateTime(2008, 11,  6)},
+                {"ERY", new DateTime(2008, 11,  6)},
+                {"SCO", new DateTime(2008, 11, 25)},
+                {"UCO", new DateTime(2008, 11, 25)},
+                {"AMJ", new DateTime(2009,  6,  2)},
+                {"BNO", new DateTime(2010,  6,  2)},
+                {"AMLP", new DateTime(2010,  8, 25)},
+                {"OIH", new DateTime(2011, 12, 21)},
+                {"DGAZ", new DateTime(2012,  2,  8)},
+                {"UGAZ", new DateTime(2012,  2,  8)},
+                {"TAN", new DateTime(2012,  2, 15)}
+            })
+        {
+
+        }
+    }
+}

--- a/Algorithm.Framework/Selection/MetalsETFUniverse.cs
+++ b/Algorithm.Framework/Selection/MetalsETFUniverse.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.Framework.Selection
+{
+    /// <summary>
+    /// Universe Selection Model that adds the following Metals ETFs at their inception date
+    /// 2004-11-18   GLD    SPDR Gold Trust
+    /// 2005-01-28   IAU    iShares Gold Trust
+    /// 2006-04-28   SLV    iShares Silver Trust
+    /// 2006-05-22   GDX    VanEck Vectors Gold Miners ETF
+    /// 2008-12-04   AGQ    ProShares Ultra Silver
+    /// 2009-11-11   GDXJ   VanEck Vectors Junior Gold Miners ETF
+    /// 2010-01-08   PPLT   Aberdeen Standard Platinum Shares ETF
+    /// 2010-12-08   NUGT   Direxion Daily Gold Miners Bull 3X Shares
+    /// 2010-12-08   DUST   Direxion Daily Gold Miners Bear 3X Shares
+    /// 2011-10-17   USLV   VelocityShares 3x Long Silver ETN
+    /// 2011-10-17   UGLD   VelocityShares 3x Long Gold ETN
+    /// 2013-10-03   JNUG   Direxion Daily Junior Gold Miners Index Bull 3x Shares
+    /// 2013-10-03   JDST   Direxion Daily Junior Gold Miners Index Bear 3X Shares
+    /// </summary>
+    public class MetalsETFUniverse : BaseETFUniverseSelectionModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the MetalsETFUniverse class
+        /// </summary>
+        public MetalsETFUniverse() :
+            base(new Dictionary<string, DateTime>()
+            {
+                {"GLD", new DateTime(2004, 11, 18)},
+                {"IAU", new DateTime(2005,  1, 28)},
+                {"SLV", new DateTime(2006,  4, 28)},
+                {"GDX", new DateTime(2006,  5, 22)},
+                {"AGQ", new DateTime(2008, 12,  4)},
+                {"GDXJ", new DateTime(2009, 11, 11)},
+                {"PPLT", new DateTime(2010,  1,  8)},
+                {"NUGT", new DateTime(2010, 12,  8)},
+                {"DUST", new DateTime(2010, 12,  8)},
+                {"USLV", new DateTime(2011, 10, 17)},
+                {"UGLD", new DateTime(2011, 10, 17)},
+                {"JNUG", new DateTime(2013, 10,  3)},
+                {"JDST", new DateTime(2013, 10,  3)}
+            })
+        {
+
+        }
+    }
+}

--- a/Algorithm.Framework/Selection/SP500SectorsETFUniverse.cs
+++ b/Algorithm.Framework/Selection/SP500SectorsETFUniverse.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.Framework.Selection
+{
+    /// <summary>
+    /// Universe Selection Model that adds the following SP500 Sectors ETFs at their inception date
+    /// 1998-12-22   XLB   Materials Select Sector SPDR ETF
+    /// 1998-12-22   XLE   Energy Select Sector SPDR Fund
+    /// 1998-12-22   XLF   Financial Select Sector SPDR Fund
+    /// 1998-12-22   XLI   Industrial Select Sector SPDR Fund
+    /// 1998-12-22   XLK   Technology Select Sector SPDR Fund
+    /// 1998-12-22   XLP   Consumer Staples Select Sector SPDR Fund
+    /// 1998-12-22   XLU   Utilities Select Sector SPDR Fund
+    /// 1998-12-22   XLV   Health Care Select Sector SPDR Fund
+    /// 1998-12-22   XLY   Consumer Discretionary Select Sector SPDR Fund
+    /// </summary>
+    public class SP500SectorsETFUniverse : BaseETFUniverseSelectionModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the SP500SectorsETFUniverse class
+        /// </summary>
+        public SP500SectorsETFUniverse() :
+            base(new Dictionary<string, DateTime>()
+            {
+                {"XLB", new DateTime(1998, 12, 22)},
+                {"XLE", new DateTime(1998, 12, 22)},
+                {"XLF", new DateTime(1998, 12, 22)},
+                {"XLI", new DateTime(1998, 12, 22)},
+                {"XLK", new DateTime(1998, 12, 22)},
+                {"XLP", new DateTime(1998, 12, 22)},
+                {"XLU", new DateTime(1998, 12, 22)},
+                {"XLV", new DateTime(1998, 12, 22)},
+                {"XLY", new DateTime(1998, 12, 22)}
+            })
+        {
+
+        }
+    }
+}

--- a/Algorithm.Framework/Selection/TechnologyETFUniverse.cs
+++ b/Algorithm.Framework/Selection/TechnologyETFUniverse.cs
@@ -1,0 +1,69 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.Framework.Selection
+{
+    /// <summary>
+    /// Universe Selection Model that adds the following Technology ETFs at their inception date
+    /// 1998-12-22   XLK    Technology Select Sector SPDR Fund
+    /// 1999-03-10   QQQ    Invesco QQQ
+    /// 2001-07-13   SOXX   iShares PHLX Semiconductor ETF
+    /// 2001-07-13   IGV    iShares Expanded Tech-Software Sector ETF
+    /// 2004-01-30   VGT    Vanguard Information Technology ETF
+    /// 2006-04-25   QTEC   First Trust NASDAQ 100 Technology
+    /// 2006-06-23   FDN    First Trust Dow Jones Internet Index
+    /// 2007-05-10   FXL    First Trust Technology AlphaDEX Fund
+    /// 2008-12-17   TECL   Direxion Daily Technology Bull 3X Shares
+    /// 2008-12-17   TECS   Direxion Daily Technology Bear 3X Shares
+    /// 2010-03-11   SOXL   Direxion Daily Semiconductor Bull 3x Shares
+    /// 2010-03-11   SOXS   Direxion Daily Semiconductor Bear 3x Shares
+    /// 2011-07-06   SKYY   First Trust ISE Cloud Computing Index Fund
+    /// 2011-12-21   SMH    VanEck Vectors Semiconductor ETF
+    /// 2013-08-01   KWEB   KraneShares CSI China Internet ETF
+    /// 2013-10-24   FTEC   Fidelity MSCI Information Technology Index ETF
+    /// </summary>
+    public class TechnologyETFUniverse : BaseETFUniverseSelectionModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the TechnologyETFUniverse class
+        /// </summary>
+        public TechnologyETFUniverse() :
+            base(new Dictionary<string, DateTime>()
+            {
+                {"XLK", new DateTime(1998, 12, 22)},
+                {"QQQ", new DateTime(1999,  3, 10)},
+                {"SOXX", new DateTime(2001,  7, 13)},
+                {"IGV", new DateTime(2001,  7, 13)},
+                {"VGT", new DateTime(2004,  1, 30)},
+                {"QTEC", new DateTime(2006,  4, 25)},
+                {"FND", new DateTime(2006,  6, 23)},
+                {"FXL", new DateTime(2007,  5, 10)},
+                {"TECL", new DateTime(2008, 12, 17)},
+                {"TECS", new DateTime(2008, 12, 17)},
+                {"SOXL", new DateTime(2010,  3, 11)},
+                {"SOXS", new DateTime(2010,  3, 11)},
+                {"SKYY", new DateTime(2011,  7,  6)},
+                {"SMH", new DateTime(2011,  12, 21)},
+                {"KWEB", new DateTime(2013,  8,  1)},
+                {"FTEC", new DateTime(2013,  10, 24)}
+            })
+        {
+
+        }
+    }
+}

--- a/Algorithm.Framework/Selection/USTreasuriesETFUniverse.cs
+++ b/Algorithm.Framework/Selection/USTreasuriesETFUniverse.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.Framework.Selection
+{
+    /// <summary>
+    /// Universe Selection Model that adds the following US Treasuries ETFs at their inception date
+    /// 2002-07-26   IEF    iShares 7-10 Year Treasury Bond ETF
+    /// 2002-07-26   SHY    iShares 1-3 Year Treasury Bond ETF
+    /// 2002-07-26   TLT    iShares 20+ Year Treasury Bond ETF
+    /// 2007-01-11   SHV    iShares Short Treasury Bond ETF
+    /// 2007-01-11   IEI    iShares 3-7 Year Treasury Bond ETF
+    /// 2007-01-11   TLH    iShares 10-20 Year Treasury Bond ETF
+    /// 2007-12-10   EDV    Vanguard Ext Duration Treasury ETF
+    /// 2007-05-30   BIL    SPDR Barclays 1-3 Month T-Bill ETF
+    /// 2007-05-30   SPTL   SPDR Portfolio Long Term Treasury ETF
+    /// 2008-05-01   TBT    UltraShort Barclays 20+ Year Treasury
+    /// 2009-04-16   TMF    Direxion Daily 20-Year Treasury Bull 3X
+    /// 2009-04-16   TMV    Direxion Daily 20-Year Treasury Bear 3X
+    /// 2009-08-20   TBF    ProShares Short 20+ Year Treasury
+    /// 2009-11-23   VGSH   Vanguard Short-Term Treasury ETF
+    /// 2009-11-23   VGIT   Vanguard Intermediate-Term Treasury ETF
+    /// 2009-11-24   VGLT   Vanguard Long-Term Treasury ETF
+    /// 2010-08-06   SCHO   Schwab Short-Term U.S. Treasury ETF
+    /// 2010-08-06   SCHR   Schwab Intermediate-Term U.S. Treasury ETF
+    /// 2011-12-01   SPTS   SPDR Portfolio Short Term Treasury ETF
+    /// 2012-02-24   GOVT   iShares U.S. Treasury Bond ETF
+    /// </summary>
+    public class USTreasuriesETFUniverse : BaseETFUniverseSelectionModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the USTreasuriesETFUniverse class
+        /// </summary>
+        public USTreasuriesETFUniverse() :
+            base(new Dictionary<string, DateTime>()
+            {
+                {"IEF", new DateTime(2002,  7, 26)},
+                {"SHY", new DateTime(2002,  7, 26)},
+                {"TLT", new DateTime(2002,  7, 26)},
+                {"IEI", new DateTime(2007,  1, 11)},
+                {"SHV", new DateTime(2007,  1, 11)},
+                {"TLH", new DateTime(2007,  1, 11)},
+                {"EDV", new DateTime(2007, 12, 10)},
+                {"BIL", new DateTime(2007,  5, 30)},
+                {"SPTL", new DateTime(2007,  5, 30)},
+                {"TBT", new DateTime(2008,  5,  1)},
+                {"TMF", new DateTime(2009,  4, 16)},
+                {"TMV", new DateTime(2009,  4, 16)},
+                {"TBF", new DateTime(2009,  8, 20)},
+                {"VGSH", new DateTime(2009, 11, 23)},
+                {"VGSH", new DateTime(2009, 11, 23)},
+                {"VGIT", new DateTime(2009, 11, 23)},
+                {"VGLT", new DateTime(2009, 11, 24)},
+                {"SCHO", new DateTime(2010,  8,  6)},
+                {"SCHR", new DateTime(2010,  8,  6)},
+                {"SPTS", new DateTime(2011, 12,  1)},
+                {"GOVT", new DateTime(2012,  2, 24)}
+            })
+        {
+
+        }
+    }
+}

--- a/Algorithm.Framework/Selection/VolatilityETFUniverse.cs
+++ b/Algorithm.Framework/Selection/VolatilityETFUniverse.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.Framework.Selection
+{
+    /// <summary>
+    /// Universe Selection Model that adds the following Volatility ETFs at their inception date
+    /// 2010-02-11   SQQQ   ProShares UltraPro ShortQQQ
+    /// 2010-02-11   TQQQ   ProShares UltraProQQQ
+    /// 2010-11-30   TVIX   VelocityShares Daily 2x VIX Short Term ETN
+    /// 2010-12-08   DUST   Direxion Daily Gold Miners Bear 3X Shares
+    /// 2011-01-04   VIXY   ProShares VIX Short-Term Futures ETF
+    /// 2011-05-05   SPLV   Invesco S&P 500® Low Volatility ETF
+    /// 2011-10-04   SVXY   ProShares Short VIX Short-Term Futures
+    /// 2011-10-04   UVXY   ProShares Ultra VIX Short-Term Futures
+    /// 2011-10-20   EEMV   iShares Edge MSCI Min Vol Emerging Markets ETF
+    /// 2011-10-20   EFAV   iShares Edge MSCI Min Vol EAFE ETF
+    /// 2011-10-20   USMV   iShares Edge MSCI Min Vol USA ETF
+    /// </summary>
+    public class VolatilityETFUniverse : BaseETFUniverseSelectionModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the VolatilityETFUniverse class
+        /// </summary>
+        public VolatilityETFUniverse() :
+            base(new Dictionary<string, DateTime>()
+            {
+                {"SQQQ", new DateTime(2010,  2, 11)},
+                {"TQQQ", new DateTime(2010,  2, 11)},
+                {"TVIX", new DateTime(2010,  11, 30)},
+                {"DUST", new DateTime(2010, 12,  8)},
+                {"VIXY", new DateTime(2011,  1,  4)},
+                {"SPLV", new DateTime(2011,  5,  5)},
+                {"SVXY", new DateTime(2011,  10,  4)},
+                {"UVXY", new DateTime(2011,  10,  4)},
+                {"EEMV", new DateTime(2011,  10,  20)},
+                {"EFAV", new DateTime(2011,  10,  20)},
+                {"USMV", new DateTime(2011,  10,  20)}
+            })
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
#### Description
Adds `BaseETFUniverseSelectionModel` that handles the common universe selection logic for all ETF Basket.
Adds the following ETF Baskets:
- Energy
- Precious Metals
- S&P500 Sectors
- Technology
- US Treasuries
- Volatility

#### Related Issue
Closes #3650 

#### Motivation and Context
Add more Universe Selection Models

#### Requires Documentation Change
Yes. Add these models' description to existing documentation.

#### How Has This Been Tested?
Algorithm Lab with a C# and Python algorithm:
```python
class TestETFUniverse(QCAlgorithm):

    def Initialize(self):
        self.SetStartDate(1998, 1, 1)
        self.SetUniverseSelection(EnergyETFUniverse());

    def OnSecuritiesChanged(self, changes):     
        self.Log(f"{self.Time} :: {changes}")
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`