### PR TITLE
Implements Backward Compatibility for Python Custom Indicator

### DIFF
--- a/Indicators/PythonIndicator.cs
+++ b/Indicators/PythonIndicator.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Indicators
         {
             using (Py.GIL())
             {
-                _isReady = _indicator.Update(input);
+                _isReady = _indicator.Update(input) ?? _indicator.IsReady;
                 return _indicator.Value;
             }
         }

--- a/Tests/Indicators/PythonIndicatorNoinheritanceTestsLegacy.cs
+++ b/Tests/Indicators/PythonIndicatorNoinheritanceTestsLegacy.cs
@@ -24,10 +24,10 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class PythonIndicatorNoinheritanceTests : PythonIndicatorTests
+    public class PythonIndicatorNoinheritanceTestsLegacy : PythonIndicatorTests
     {
         /// <summary>
-        /// In this Custom Indicator, Update returns a boolean
+        /// In this Custom Indicator, Update returns void
         /// </summary>
         protected override IndicatorBase<IBaseData> CreateIndicator()
         {
@@ -53,7 +53,6 @@ class CustomSimpleMovingAverage():
         count = len(self.queue)
         self.Value = sum(self.queue) / count
         self.IsReady = count == self.queue.maxlen
-        return self.IsReady
 "
                 );
                 var indicator = module.GetAttr("CustomSimpleMovingAverage")

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -355,6 +355,7 @@
     <Compile Include="Engine\DataFeeds\SubscriptionTests.cs" />
     <Compile Include="Engine\HistoricalData\SubscriptionDataReaderHistoryProviderTests.cs" />
     <Compile Include="Engine\RealTime\BacktestingRealTimeHandlerTests.cs" />
+    <Compile Include="Indicators\PythonIndicatorNoinheritanceTestsLegacy.cs" />
     <Compile Include="Indicators\PythonIndicatorNoinheritanceTests.cs" />
     <Compile Include="Indicators\PythonIndicatorTests.cs" />
     <Compile Include="PythonSetup.cs" />


### PR DESCRIPTION
#### Description
In `PythonIndicator.ComputeNextValue`, if the `Update` method from the python indicator returns null/void, we use `IsReady` from the python indicator to set `PythonIndicator.IsReady`.

#### Related Issue
Closes #3671

#### Motivation and Context
Buf fix. Backward Compatibility.

#### How Has This Been Tested?
New unit tests. Algorithm provided in [this forum thread](https://www.quantconnect.com/forum/discussion/6634/quot-runtime-error-cannot-convert-null-to-039-bool-039-quot/p1).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`