### PR TITLE
Dockerfile-foundation: install hmmlearn globally

### DIFF
--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -48,7 +48,7 @@ RUN wget https://cdn.quantconnect.com/miniconda/${CONDA} && \
     ln -s /opt/miniconda3/lib/libpython3.6m.so /usr/lib/libpython3.6m.so
 
 # Install supported third party python packages
-RUN conda update -y conda pip 
+RUN conda update -y conda pip
 RUN conda install -y python=3.6.8   \
     blaze=0.11.3                    \
     cvxopt=1.2.0                    \
@@ -97,7 +97,7 @@ RUN pip install gym==0.13.1         \
     theano==1.0.4                   \
     tsfresh==0.12.0                 \
     xgboost==0.90
-RUN pip install --upgrade --user hmmlearn==0.2.2
+RUN pip install --upgrade hmmlearn==0.2.2
 RUN python -c "import nltk; nltk.download('punkt')"
 RUN conda clean -y --all
 


### PR DESCRIPTION
Fixes #3684

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Installs `hmmlearn` py dependency globally, as requested in #3684 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See #3684; tl;dr: all dependencies should be installed globally so regular (ie non-root) users could be used instead of root.

#### How Has This Been Tested?
This is a non-functional change.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->