### PR TITLE
Allow Option BidPrice or AskPrice to have zero value

### DIFF
--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -174,6 +174,16 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
+        /// Gets the most recent bid price if available
+        /// </summary>
+        public override decimal BidPrice => Cache.BidPrice;
+
+        /// <summary>
+        /// Gets the most recent ask price if available
+        /// </summary>
+        public override decimal AskPrice => Cache.AskPrice;
+
+        /// <summary>
         /// When the holder of an equity option exercises one contract, or when the writer of an equity option is assigned
         /// an exercise notice on one contract, this unit of trade, usually 100 shares of the underlying security, changes hands.
         /// </summary>


### PR DESCRIPTION

#### Description
- The `BidPrice` and `AskPrice` of the `Security` class have been overridden in the `Option` class to allow an option contract to have a zero value.

#### Related Issue
Closes #3689 

#### Motivation and Context
- Fixes incorrect prices returned by `security.BidPrice` or `security.AskPrice`

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Tested with the example code with the IB brokerage in live mode.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`