### PR TITLE
Fix tick emit logic bugs in IB DataQueueHandler

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2581,7 +2581,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             var symbol = entry.Symbol;
 
             var securityType = symbol.ID.SecurityType;
-            var quantity = AdjustQuantity(securityType, e.Size);
+
+            // negative size (-1) means no quantity available, normalize to zero
+            var quantity = e.Size < 0 ? 0 : AdjustQuantity(securityType, e.Size);
 
             Tick tick;
             switch (e.Field)


### PR DESCRIPTION
#### Description
1. **Only emit quote ticks when both the price and size messages have been received**
Market data for trades and quotes are received by the IB API callbacks as separate messages, the price is always received before the size. Previously we were emitting ticks on both price and size messages.

2. **Do not emit half-quotes (if both quotes available)**
Even in very liquid instruments, we were previously sending quote ticks with e.g. only bid price and size but zero ask price and size. For consistency with other `IDataQueueHandler` implementations we now always emit complete quote ticks (for cases where there is no bid price available such as far OTM options, we'll emit the half-quote with zero for bid price and size).

3. **The tick Quantity field is now set only for Trade ticks**
Previously it was also being set for Quote ticks.

4. **Removed the possibility of emitting ticks with BidPrice >= AskPrice**
Previously this could happen.

#### Related Issue
n/a

#### Motivation and Context
Consistency and correctness of emitted ticks.

#### Requires Documentation Change
n/a

#### How Has This Been Tested?
- A live algorithm running locally with extensive logging of both IB messages received, ticks emitted and ticks/bars in `OnData` slices (for all security types, especially futures and options where this code is used in the cloud). 
- Manual inspection of the above logs has shown expected behavior.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.