### PR TITLE
Adds support for extending algo time loop for long-running scheduled events

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -177,6 +177,8 @@
     <Compile Include="CoarseSelectionTimeRegressionAlgorithm.cs" />
     <Compile Include="CustomUniverseSelectionRegressionAlgorithm.cs" />
     <Compile Include="OnEndOfDayRegressionAlgorithm.cs" />
+    <Compile Include="TrainingInitializeRegressionAlgorithm.cs" />
+    <Compile Include="TrainingScheduledRegressionAlgorithm.cs" />
     <Compile Include="UniverseUnchangedRegressionAlgorithm.cs" />
     <Compile Include="USTreasuryYieldCurveDataAlgorithm.cs" />
     <Compile Include="SECReportDataAlgorithm.cs" />

--- a/Algorithm.CSharp/TrainingInitializeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TrainingInitializeRegressionAlgorithm.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
             // this should cause the algorithm to fail
             // the regression test sets the time limit to 30 seconds and there's one extra
             // minute in the bucket, so a two minute sleep should result in RuntimeError
-            Schedule.TrainingNow(() => Thread.Sleep(TimeSpan.FromMinutes(2)));
+            Schedule.TrainingNow(() => Thread.Sleep(TimeSpan.FromMinutes(2.5)));
         }
 
         public bool CanRunLocally => true;

--- a/Algorithm.CSharp/TrainingInitializeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TrainingInitializeRegressionAlgorithm.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
             Schedule.TrainingNow(() => Thread.Sleep(TimeSpan.FromMinutes(2.5)));
         }
 
-        public bool CanRunLocally => true;
+        public bool CanRunLocally => false;
         public Language[] Languages => new[] {Language.CSharp};
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>();
     }

--- a/Algorithm.CSharp/TrainingInitializeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TrainingInitializeRegressionAlgorithm.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This regression algorithm is expected to fail and verifies that a training event
+    /// created in Initialize will get run AND it will cause the algorithm to fail if it
+    /// exceeds the "algorithm-manager-time-loop-maximum" config value, which the regression
+    /// test sets to 0.5 minutes.
+    /// </summary>
+    public class TrainingInitializeRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 11);
+
+            AddEquity("SPY", Resolution.Daily);
+
+            // this should cause the algorithm to fail
+            // the regression test sets the time limit to 30 seconds and there's one extra
+            // minute in the bucket, so a two minute sleep should result in RuntimeError
+            Schedule.TrainingNow(() => Thread.Sleep(TimeSpan.FromMinutes(2)));
+        }
+
+        public bool CanRunLocally => true;
+        public Language[] Languages => new[] {Language.CSharp};
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>();
+    }
+}

--- a/Algorithm.CSharp/TrainingScheduledRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TrainingScheduledRegressionAlgorithm.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Algorithm.CSharp
             });
         }
 
-        public bool CanRunLocally => true;
+        public bool CanRunLocally => false;
         public Language[] Languages => new[] {Language.CSharp};
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>();
     }

--- a/Algorithm.CSharp/TrainingScheduledRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TrainingScheduledRegressionAlgorithm.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This regression algorithm is NOT expected to fail and verifies that a periodic training
+    /// event created in OnData will fire and will consume 'minutes' from the leaky bucket
+    /// </summary>
+    public class TrainingScheduledRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 11);
+
+            AddEquity("SPY", Resolution.Daily);
+
+            // DateRules.Tomorrow combined with TimeRules.Noon enforces that this event schedule will
+            // have exactly one time, which will fire between the first data point and the next day at
+            // midnight. So after the first data point, it will run this event and sleep long enough to
+            // exceed the static max algorithm time loop time and begin to consume from the leaky bucket
+            // the regression test sets the "algorithm-manager-time-loop-maximum" value to 30 seconds
+            Schedule.Training(DateRules.Tomorrow, TimeRules.Midnight, () =>
+            {
+                // this will consume the single 'minute' available in the leaky bucket
+                // and the regression test will confirm that the leaky bucket is empty
+                Thread.Sleep(TimeSpan.FromMinutes(1));
+            });
+        }
+
+        public bool CanRunLocally => true;
+        public Language[] Languages => new[] {Language.CSharp};
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>();
+    }
+}

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -74,6 +74,7 @@
     <None Include="SmartInsiderDataAlgorithm.py" />
     <None Include="PandasDataFrameHistoryAlgorithm.py" />
     <None Include="CustomDataAddDataRegressionAlgorithm.py" />
+    <None Include="TrainingExampleAlgorithm.py" />
     <Content Include="Benchmarks\SECReportBenchmarkAlgorithm.py" />
     <Content Include="Benchmarks\SmartInsiderEventBenchmarkAlgorithm.py" />
     <Content Include="CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.py" />

--- a/Algorithm.Python/TrainingExampleAlgorithm.py
+++ b/Algorithm.Python/TrainingExampleAlgorithm.py
@@ -1,0 +1,52 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from time import sleep
+
+### <summary>
+### Example algorithm showing how to use QCAlgorithm.Train method
+### </summary>
+### <meta name="tag" content="using quantconnect" />
+### <meta name="tag" content="training" />
+class TrainingExampleAlgorithm(QCAlgorithm):
+    '''Example algorithm showing how to use QCAlgorithm.Train method'''
+
+    def Initialize(self):
+
+        self.SetStartDate(2013, 10, 7)
+        self.SetEndDate(2013, 10, 14)
+
+        self.AddEquity("SPY", Resolution.Daily)
+
+        # Set TrainingMethod to be executed immediately
+        self.Train(self.TrainingMethod)
+
+        # Set TrainingMethod to be executed at 8:00 am every Sunday
+        self.Train(self.DateRules.Every(DayOfWeek.Sunday), self.TimeRules.At(8 , 0), self.TrainingMethod)
+
+    def TrainingMethod(self):
+
+        self.Log(f'Start training at {self.Time}')
+        # Use the historical data to train the machine learning model
+        history = self.History(["SPY"], 200, Resolution.Daily)
+
+        # ML code:
+        pass

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -27,6 +27,7 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Data.Fundamental;
 using System.Linq;
 using QuantConnect.Brokerages;
+using QuantConnect.Scheduling;
 using QuantConnect.Util;
 
 namespace QuantConnect.Algorithm
@@ -1027,6 +1028,26 @@ namespace QuantConnect.Algorithm
         public IDataConsolidator Consolidate(Symbol symbol, Func<DateTime, CalendarInfo> calendarType, PyObject handler)
         {
             return Consolidate(symbol, calendarType, null, handler);
+        }
+
+        /// <summary>
+        /// Schedules the provided training code to execute immediately
+        /// </summary>
+        /// <param name="trainingCode">The training code to be invoked</param>
+        public ScheduledEvent Train(PyObject trainingCode)
+        {
+            return Schedule.TrainingNow(trainingCode);
+        }
+
+        /// <summary>
+        /// Schedules the training code to run using the specified date and time rules
+        /// </summary>
+        /// <param name="dateRule">Specifies what dates the event should run</param>
+        /// <param name="timeRule">Specifies the times on those dates the event should run</param>
+        /// <param name="trainingCode">The training code to be invoked</param>
+        public ScheduledEvent Train(IDateRule dateRule, ITimeRule timeRule, PyObject trainingCode)
+        {
+            return Schedule.Training(dateRule, timeRule, trainingCode);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -37,7 +37,6 @@ using QuantConnect.Securities.Option;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
 using System.Collections.Concurrent;
-using Python.Runtime;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Crypto;
 using QuantConnect.Algorithm.Framework.Alphas;

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -37,6 +37,7 @@ using QuantConnect.Securities.Option;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
 using System.Collections.Concurrent;
+using Python.Runtime;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Crypto;
 using QuantConnect.Algorithm.Framework.Alphas;
@@ -2148,6 +2149,26 @@ namespace QuantConnect.Algorithm
         public string Download(string address, IEnumerable<KeyValuePair<string, string>> headers, string userName, string password)
         {
             return _api.Download(address, headers, userName, password);
+        }
+
+        /// <summary>
+        /// Schedules the provided training code to execute immediately
+        /// </summary>
+        /// <param name="trainingCode">The training code to be invoked</param>
+        public ScheduledEvent Train(Action trainingCode)
+        {
+            return Schedule.TrainingNow(trainingCode);
+        }
+
+        /// <summary>
+        /// Schedules the training code to run using the specified date and time rules
+        /// </summary>
+        /// <param name="dateRule">Specifies what dates the event should run</param>
+        /// <param name="timeRule">Specifies the times on those dates the event should run</param>
+        /// <param name="trainingCode">The training code to be invoked</param>
+        public ScheduledEvent Train(IDateRule dateRule, ITimeRule timeRule, Action trainingCode)
+        {
+            return Schedule.Training(dateRule, timeRule, trainingCode);
         }
 
         /// <summary>

--- a/Common/IIsolatorLimitResultProvider.cs
+++ b/Common/IIsolatorLimitResultProvider.cs
@@ -26,5 +26,12 @@ namespace QuantConnect
         /// Determines whether or not a custom isolator limit has be reached.
         /// </summary>
         IsolatorLimitResult IsWithinLimit();
+
+        /// <summary>
+        /// Requests additional time from the isolator result provider. This is intended
+        /// to prevent <see cref="IsWithinLimit"/> from returning an error result.
+        /// </summary>
+        /// <param name="minutes">The number of additional minutes to request</param>
+        void RequestAdditionalTime(int minutes);
     }
 }

--- a/Common/IIsolatorLimitResultProvider.cs
+++ b/Common/IIsolatorLimitResultProvider.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System;
+
 namespace QuantConnect
 {
     /// <summary>
@@ -30,8 +32,19 @@ namespace QuantConnect
         /// <summary>
         /// Requests additional time from the isolator result provider. This is intended
         /// to prevent <see cref="IsWithinLimit"/> from returning an error result.
+        /// This method will throw a <see cref="TimeoutException"/> if there is insufficient
+        /// resources available to fulfill the specified number of minutes.
         /// </summary>
         /// <param name="minutes">The number of additional minutes to request</param>
         void RequestAdditionalTime(int minutes);
+
+        /// <summary>
+        /// Attempts to request additional time from the isolator result provider. This is intended
+        /// to prevent <see cref="IsWithinLimit"/> from returning an error result.
+        /// This method will only return false if there is insufficient resources available to fulfill
+        /// the specified number of minutes.
+        /// </summary>
+        /// <param name="minutes">The number of additional minutes to request</param>
+        bool TryRequestAdditionalTime(int minutes);
     }
 }

--- a/Common/IIsolatorLimitResultProvider.cs
+++ b/Common/IIsolatorLimitResultProvider.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect
+{
+    /// <summary>
+    /// Provides an abstraction for managing isolator limit results.
+    /// This is originally intended to be used by the training feature to permit a single
+    /// algorithm time loop to extend past the default of ten minutes
+    /// </summary>
+    public interface IIsolatorLimitResultProvider
+    {
+        /// <summary>
+        /// Determines whether or not a custom isolator limit has be reached.
+        /// </summary>
+        IsolatorLimitResult IsWithinLimit();
+    }
+}

--- a/Common/ITimeProvider.cs
+++ b/Common/ITimeProvider.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@
 
 using System;
 
-namespace QuantConnect.Lean.Engine.DataFeeds
+namespace QuantConnect
 {
     /// <summary>
     /// Provides access to the current time in UTC. This doesn't necessarily

--- a/Common/IsolatorLimitResult.cs
+++ b/Common/IsolatorLimitResult.cs
@@ -44,8 +44,8 @@ namespace QuantConnect
         /// <param name="errorMessage">The error message or an empty string if no error on the current time step</param>
         public IsolatorLimitResult(TimeSpan currentTimeStepElapsed, string errorMessage)
         {
-            CurrentTimeStepElapsed = currentTimeStepElapsed;
             ErrorMessage = errorMessage;
+            CurrentTimeStepElapsed = currentTimeStepElapsed;
         }
     }
 }

--- a/Common/IsolatorLimitResultProvider.cs
+++ b/Common/IsolatorLimitResultProvider.cs
@@ -1,0 +1,100 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using QuantConnect.Logging;
+
+namespace QuantConnect
+{
+    /// <summary>
+    /// Provides access to the <see cref="NullIsolatorLimitResultProvider"/> and can be a place for future
+    /// extension methods of <see cref="IIsolatorLimitResultProvider"/>
+    /// </summary>
+    public static class IsolatorLimitResultProvider
+    {
+        // this just makes the code below prettier
+        private static TimeSpan Second => TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Provides access to a null implementation of <see cref="IIsolatorLimitResultProvider"/>
+        /// </summary>
+        public static readonly IIsolatorLimitResultProvider Null = new NullIsolatorLimitResultProvider();
+
+        /// <summary>
+        /// Executes the provided code block and while the code block is running, continually consume from
+        /// the limit result provided one token each minute. This function allows the code to run for the
+        /// first full second without requesting additional time from the provider. Following that, every
+        /// minute an additional one minute will be requested from the provider.
+        /// </summary>
+        public static void ConsumeWhileExecuting(
+            this IIsolatorLimitResultProvider isolatorLimitProvider,
+            Action code
+            )
+        {
+            isolatorLimitProvider.ConsumeWhileExecuting(string.Empty, code);
+        }
+
+        /// <summary>
+        /// Executes the provided code block and while the code block is running, continually consume from
+        /// the limit result provided one token each minute. This function allows the code to run for the
+        /// first full second without requesting additional time from the provider. Following that, every
+        /// minute an additional one minute will be requested from the provider.
+        /// </summary>
+        public static void ConsumeWhileExecuting(
+            this IIsolatorLimitResultProvider isolatorLimitProvider,
+            string name,
+            Action code
+            )
+        {
+            var codeFinished = new ManualResetEvent(false);
+            Task.Run(() =>
+            {
+                code();
+                codeFinished.Set();
+            });
+
+            // permit up to one second w/out requesting additional time from the provider
+            if (codeFinished.WaitOne(Second))
+            {
+                return;
+            }
+
+            var count = 0;
+            do
+            {
+                if (count % 60 != 0)
+                {
+                    continue;
+                }
+
+                // on the first iteration and every minute following, request additional time
+                Log.Trace($"IsolatorLimitResultProvider.ConsumeWhileExecuting({name}): Requesting additional time. Elapsed minutes: {count / 60}");
+                isolatorLimitProvider.RequestAdditionalTime(minutes: 1);
+
+            } while (!codeFinished.WaitOne(Second));
+        }
+
+
+        private sealed class NullIsolatorLimitResultProvider : IIsolatorLimitResultProvider
+        {
+            private static readonly IsolatorLimitResult OK = new IsolatorLimitResult(TimeSpan.Zero, string.Empty);
+
+            public void RequestAdditionalTime(int minutes) { }
+            public IsolatorLimitResult IsWithinLimit() { return OK; }
+        }
+    }
+}

--- a/Common/IsolatorLimitResultProvider.cs
+++ b/Common/IsolatorLimitResultProvider.cs
@@ -46,13 +46,13 @@ namespace QuantConnect
             }
 
             var timeProvider = RealTimeProvider.Instance;
-            isolatorLimitProvider.Consume(timeProvider, scheduledEvent.Name, () => scheduledEvent.Scan(scanTimeUtc));
+            isolatorLimitProvider.Consume(timeProvider, () => scheduledEvent.Scan(scanTimeUtc));
         }
 
         /// <summary>
         /// Executes the provided code block and while the code block is running, continually consume from
         /// the limit result provided one token each minute. This function allows the code to run for the
-        /// first full second without requesting additional time from the provider. Following that, every
+        /// first full minute without requesting additional time from the provider. Following that, every
         /// minute an additional one minute will be requested from the provider.
         /// </summary>
         /// <remarks>
@@ -63,7 +63,6 @@ namespace QuantConnect
         public static void Consume(
             this IIsolatorLimitResultProvider isolatorLimitProvider,
             ITimeProvider timeProvider,
-            string name,
             Action code
             )
         {

--- a/Common/Packets/Controls.cs
+++ b/Common/Packets/Controls.cs
@@ -90,6 +90,13 @@ namespace QuantConnect.Packets
         public int SecondTimeOut;
 
         /// <summary>
+        /// Sets parameters used for determining the behavior of the leaky bucket algorithm that
+        /// controls how much time is available for an algorithm to use the training feature.
+        /// </summary>
+        [JsonProperty(PropertyName = "oTrainingLimits")]
+        public LeakyBucketControlParameters TrainingLimits;
+
+        /// <summary>
         /// Initializes a new default instance of the <see cref="Controls"/> class
         /// </summary>
         public Controls()
@@ -105,6 +112,9 @@ namespace QuantConnect.Packets
             BacktestingMaxInsights = 10000;
             MaximumDataPointsPerChartSeries = 4000;
             SecondTimeOut = 300;
+
+            // initialize to default leaky bucket values in case they're not specified
+            TrainingLimits = new LeakyBucketControlParameters();
         }
 
         /// <summary>

--- a/Common/Packets/LeakyBucketControlParameters.cs
+++ b/Common/Packets/LeakyBucketControlParameters.cs
@@ -1,0 +1,91 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using Newtonsoft.Json;
+using QuantConnect.Configuration;
+
+namespace QuantConnect.Packets
+{
+    /// <summary>
+    /// Provides parameters that control the behavior of a leaky bucket rate limiting algorithm. The
+    /// parameter names below are phrased in the positive, such that the bucket is filled up over time
+    /// vs leaking out over time.
+    /// </summary>
+    public class LeakyBucketControlParameters
+    {
+        // defaults represent 2 hour max capacity refilling at one seventh the capacity (~17.2 => 18) each day.
+        // rounded up to 18 to prevent a very small decrease in refilling, IOW, if it's defaulting to 17, then
+        // after 7 days have passed, we'll end up being at 119 and not completely refilled, but at 18, on the 6th
+        // day we'll reach 108 and on the seventh day it will top off at 120 since it's not permitted to exceed the max
+        public static int DefaultCapacity => Config.GetInt("scheduled-event-leaky-bucket-capacity", 2 * 60);
+        public static int DefaultTimeInterval => Config.GetInt("scheduled-event-leaky-bucket-time-interval-minutes", 1440);
+        public static int DefaultRefillAmount => Config.GetInt("scheduled-event-leaky-bucket-refill-amount", (int)Math.Ceiling(DefaultCapacity/7.0));
+
+        /// <summary>
+        /// Sets the total capacity of the bucket in a leaky bucket algorithm. This is the maximum
+        /// number of 'units' the bucket can hold and also defines the maximum burst rate, assuming
+        /// instantaneous usage of 'units'. In reality, the usage of 'units' takes times, and so it
+        /// is possible for the bucket to incrementally refill while consuming from the bucket.
+        /// </summary>
+        [JsonProperty("iCapacity")]
+        public int Capacity;
+
+        /// <summary>
+        /// Sets the refill amount of the bucket. This defines the quantity of 'units' that become available
+        /// to a consuming entity after the time interval has elapsed. For example, if the refill amount is
+        /// equal to one, then each time interval one new 'unit' will be made available for a consumer that is
+        /// throttled by the leaky bucket.
+        /// </summary>
+        [JsonProperty("iRefillAmount")]
+        public int RefillAmount;
+
+        /// <summary>
+        /// Sets the time interval for the refill amount of the bucket, in minutes. After this amount of wall-clock
+        /// time has passed, the bucket will refill the refill amount, thereby making more 'units' available
+        /// for a consumer. For example, if the refill amount equals 10 and the time interval is 30 minutes, then
+        /// every 30 minutes, 10 more 'units' become available for a consumer. The available 'units' will
+        /// continue to increase until the bucket capacity is reached.
+        /// </summary>
+        [JsonProperty("iTimeIntervalMinutes")]
+        public int TimeIntervalMinutes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeakyBucketControlParameters"/> using default values
+        /// </summary>
+        public LeakyBucketControlParameters()
+        {
+            Capacity = DefaultCapacity;
+            RefillAmount = DefaultRefillAmount;
+            TimeIntervalMinutes = DefaultTimeInterval;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeakyBucketControlParameters"/> with the specified value
+        /// </summary>
+        /// <param name="capacity">The total capacity of the bucket in minutes</param>
+        /// <param name="refillAmount">The number of additional minutes to add to the bucket
+        /// after <paramref name="timeIntervalMinutes"/> has elapsed</param>
+        /// <param name="timeIntervalMinutes">The interval, in minutes, that must pass before the <paramref name="refillAmount"/>
+        /// is added back to the bucket for reuse</param>
+        public LeakyBucketControlParameters(int capacity, int refillAmount, int timeIntervalMinutes)
+        {
+            Capacity = capacity;
+            RefillAmount = refillAmount;
+            TimeIntervalMinutes = timeIntervalMinutes;
+        }
+    }
+}

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -306,6 +306,7 @@
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />
     <Compile Include="IsolatorLimitResult.cs" />
+    <Compile Include="IsolatorLimitResultProvider.cs" />
     <Compile Include="ITimeProvider.cs" />
     <Compile Include="Orders\Fees\AlphaStreamsFeeModel.cs" />
     <Compile Include="Orders\Fills\Fill.cs" />
@@ -315,11 +316,13 @@
     <Compile Include="Orders\Fees\OrderFeeParameters.cs" />
     <Compile Include="Orders\Slippage\AlphaStreamsSlippageModel.cs" />
     <Compile Include="Packets\Breakpoint.cs" />
+    <Compile Include="Packets\LeakyBucketControlParameters.cs" />
     <Compile Include="Python\BrokerageMessageHandlerPythonWrapper.cs" />
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Python\PythonInitializer.cs" />
     <Compile Include="Python\PythonWrapper.cs" />
     <Compile Include="RealTimeProvider.cs" />
+    <Compile Include="Scheduling\ScheduledEventException.cs" />
     <Compile Include="Securities\BuyingPower.cs" />
     <Compile Include="Securities\BuyingPowerParameters.cs" />
     <Compile Include="Securities\BuyingPowerModel.cs" />
@@ -772,6 +775,7 @@
     <Compile Include="Util\ColorJsonConverter.cs" />
     <Compile Include="Util\PythonUtil.cs" />
     <Compile Include="Util\RateGate.cs" />
+    <Compile Include="Util\RateLimit\TokenBucket.cs" />
     <Compile Include="Util\SecurityExtensions.cs" />
     <Compile Include="Util\SecurityIdentifierJsonConverter.cs" />
     <Compile Include="Util\SeriesJsonConverter.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -290,6 +290,7 @@
     <Compile Include="Data\SubscriptionDataConfigExtensions.cs" />
     <Compile Include="Expiry.cs" />
     <Compile Include="HistoryProviderEvents.cs" />
+    <Compile Include="IIsolatorLimitResultProvider.cs" />
     <Compile Include="Indicators\IIndicatorWarmUpPeriodProvider.cs" />
     <Compile Include="Interfaces\IAccountCurrencyProvider.cs" />
     <Compile Include="Interfaces\IAlgorithmSubscriptionManager.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -306,6 +306,7 @@
     <Compile Include="Interfaces\ISubscriptionDataConfigService.cs" />
     <Compile Include="Interfaces\ITimeKeeper.cs" />
     <Compile Include="IsolatorLimitResult.cs" />
+    <Compile Include="ITimeProvider.cs" />
     <Compile Include="Orders\Fees\AlphaStreamsFeeModel.cs" />
     <Compile Include="Orders\Fills\Fill.cs" />
     <Compile Include="Orders\Fills\FillModelParameters.cs" />
@@ -318,6 +319,7 @@
     <Compile Include="Python\MarginCallModelPythonWrapper.cs" />
     <Compile Include="Python\PythonInitializer.cs" />
     <Compile Include="Python\PythonWrapper.cs" />
+    <Compile Include="RealTimeProvider.cs" />
     <Compile Include="Securities\BuyingPower.cs" />
     <Compile Include="Securities\BuyingPowerParameters.cs" />
     <Compile Include="Securities\BuyingPowerModel.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -758,6 +758,13 @@
     <Compile Include="Util\FixedSizeHashQueue.cs" />
     <Compile Include="Util\FuncTextWriter.cs" />
     <Compile Include="Util\JsonRoundingConverter.cs" />
+    <Compile Include="Util\RateLimit\BusyWaitSleepStrategy.cs" />
+    <Compile Include="Util\RateLimit\FixedIntervalRefillStrategy.cs" />
+    <Compile Include="Util\RateLimit\IRefillStrategy.cs" />
+    <Compile Include="Util\RateLimit\ISleepStrategy.cs" />
+    <Compile Include="Util\RateLimit\ITokenBucket.cs" />
+    <Compile Include="Util\RateLimit\LeakyBucket.cs" />
+    <Compile Include="Util\RateLimit\ThreadSleepStrategy.cs" />
     <Compile Include="Util\LeanData.cs" />
     <Compile Include="Util\LeanDataPathComponents.cs" />
     <Compile Include="Util\ListComparer.cs" />

--- a/Common/RealTimeProvider.cs
+++ b/Common/RealTimeProvider.cs
@@ -16,7 +16,7 @@
 
 using System;
 
-namespace QuantConnect.Lean.Engine.DataFeeds
+namespace QuantConnect
 {
     /// <summary>
     /// Provides an implementation of <see cref="ITimeProvider"/> that

--- a/Common/Scheduling/FuncDateRule.cs
+++ b/Common/Scheduling/FuncDateRule.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,17 +24,17 @@ namespace QuantConnect.Scheduling
     /// </summary>
     public class FuncDateRule : IDateRule
     {
-        private readonly Func<DateTime, DateTime, IEnumerable<DateTime>> _getDatesFuntion;
+        private readonly Func<DateTime, DateTime, IEnumerable<DateTime>> _getDatesFunction;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FuncDateRule"/> class
         /// </summary>
         /// <param name="name">The name of this rule</param>
-        /// <param name="getDatesFuntion">The time applicator function</param>
-        public FuncDateRule(string name, Func<DateTime, DateTime, IEnumerable<DateTime>> getDatesFuntion)
+        /// <param name="getDatesFunction">The time applicator function</param>
+        public FuncDateRule(string name, Func<DateTime, DateTime, IEnumerable<DateTime>> getDatesFunction)
         {
             Name = name;
-            _getDatesFuntion = getDatesFuntion;
+            _getDatesFunction = getDatesFunction;
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace QuantConnect.Scheduling
         /// <returns>All dates in the interval matching this date rule</returns>
         public IEnumerable<DateTime> GetDates(DateTime start, DateTime end)
         {
-            return _getDatesFuntion(start, end);
+            return _getDatesFunction(start, end);
         }
     }
 }

--- a/Common/Scheduling/ScheduleManager.cs
+++ b/Common/Scheduling/ScheduleManager.cs
@@ -243,6 +243,14 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
+        /// Schedules the provided training code to execute immediately
+        /// </summary>
+        public ScheduledEvent TrainingNow(PyObject trainingCode)
+        {
+            return On($"Training: Now: {_securities.UtcTime:O}", DateRules.Today, TimeRules.Now, trainingCode);
+        }
+
+        /// <summary>
         /// Schedules the training code to run using the specified date and time rules
         /// </summary>
         /// <param name="dateRule">Specifies what dates the event should run</param>
@@ -252,6 +260,19 @@ namespace QuantConnect.Scheduling
         {
             var name = $"{dateRule.Name}: {timeRule.Name}";
             return On(name, dateRule, timeRule, (n, time) => trainingCode());
+        }
+
+
+        /// <summary>
+        /// Schedules the training code to run using the specified date and time rules
+        /// </summary>
+        /// <param name="dateRule">Specifies what dates the event should run</param>
+        /// <param name="timeRule">Specifies the times on those dates the event should run</param>
+        /// <param name="trainingCode">The training code to be invoked</param>
+        public ScheduledEvent Training(IDateRule dateRule, ITimeRule timeRule, PyObject trainingCode)
+        {
+            var name = $"{dateRule.Name}: {timeRule.Name}";
+            return On(name, dateRule, timeRule, (n, time) => { using (Py.GIL()) trainingCode.Invoke(); });
         }
 
         /// <summary>

--- a/Common/Scheduling/ScheduleManager.cs
+++ b/Common/Scheduling/ScheduleManager.cs
@@ -231,5 +231,41 @@ namespace QuantConnect.Scheduling
         }
 
         #endregion
+
+        #region Training Events
+
+        /// <summary>
+        /// Schedules the provided training code to execute immediately
+        /// </summary>
+        public ScheduledEvent TrainingNow(Action trainingCode)
+        {
+            return On($"Training: Now: {_securities.UtcTime:O}", DateRules.Today, TimeRules.Now, trainingCode);
+        }
+
+        /// <summary>
+        /// Schedules the training code to run using the specified date and time rules
+        /// </summary>
+        /// <param name="dateRule">Specifies what dates the event should run</param>
+        /// <param name="timeRule">Specifies the times on those dates the event should run</param>
+        /// <param name="trainingCode">The training code to be invoked</param>
+        public ScheduledEvent Training(IDateRule dateRule, ITimeRule timeRule, Action trainingCode)
+        {
+            var name = $"{dateRule.Name}: {timeRule.Name}";
+            return On(name, dateRule, timeRule, (n, time) => trainingCode());
+        }
+
+        /// <summary>
+        /// Schedules the training code to run using the specified date and time rules
+        /// </summary>
+        /// <param name="dateRule">Specifies what dates the event should run</param>
+        /// <param name="timeRule">Specifies the times on those dates the event should run</param>
+        /// <param name="trainingCode">The training code to be invoked</param>
+        public ScheduledEvent Training(IDateRule dateRule, ITimeRule timeRule, Action<DateTime> trainingCode)
+        {
+            var name = $"{dateRule.Name}: {timeRule.Name}";
+            return On(name, dateRule, timeRule, (n, time) => trainingCode(time));
+        }
+
+        #endregion
     }
 }

--- a/Common/Scheduling/ScheduleManager.cs
+++ b/Common/Scheduling/ScheduleManager.cs
@@ -53,7 +53,7 @@ namespace QuantConnect.Scheduling
         public ScheduleManager(SecurityManager securities, DateTimeZone timeZone)
         {
             _securities = securities;
-            DateRules = new DateRules(securities);
+            DateRules = new DateRules(securities, timeZone);
             TimeRules = new TimeRules(securities, timeZone);
 
             // used for storing any events before the event schedule is set

--- a/Common/Scheduling/ScheduledEvent.cs
+++ b/Common/Scheduling/ScheduledEvent.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Scheduling
         public string Name { get; }
 
         /// <summary>
-        /// Initalizes a new instance of the <see cref="ScheduledEvent"/> class
+        /// Initializes a new instance of the <see cref="ScheduledEvent"/> class
         /// </summary>
         /// <param name="name">An identifier for this event</param>
         /// <param name="eventUtcTime">The date time the event should fire</param>
@@ -87,7 +87,7 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
-        /// Initalizes a new instance of the <see cref="ScheduledEvent"/> class
+        /// Initializes a new instance of the <see cref="ScheduledEvent"/> class
         /// </summary>
         /// <param name="name">An identifier for this event</param>
         /// <param name="orderedEventUtcTimes">An enumerable that emits event times</param>
@@ -98,7 +98,7 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
-        /// Initalizes a new instance of the <see cref="ScheduledEvent"/> class
+        /// Initializes a new instance of the <see cref="ScheduledEvent"/> class
         /// </summary>
         /// <param name="name">An identifier for this event</param>
         /// <param name="orderedEventUtcTimes">An enumerator that emits event times</param>
@@ -249,12 +249,8 @@ namespace QuantConnect.Scheduling
                 // don't fire the event if we're turned off
                 if (!Enabled) return;
 
-                if (_callback != null)
-                {
-                    _callback(Name, _orderedEventUtcTimes.Current);
-                }
-                var handler = EventFired;
-                if (handler != null) handler(Name, triggerTime);
+                _callback?.Invoke(Name, _orderedEventUtcTimes.Current);
+                EventFired?.Invoke(Name, triggerTime);
             }
             catch (Exception ex)
             {
@@ -264,28 +260,6 @@ namespace QuantConnect.Scheduling
                 _needsMoveNext = true;
                 throw new ScheduledEventException(Name, ex.Message, ex);
             }
-        }
-    }
-
-    /// <summary>
-    /// Throw this if there is an exception in the callback function of the scheduled event
-    /// </summary>
-    public class ScheduledEventException : Exception
-    {
-        /// <summary>
-        /// Gets the name of the scheduled event
-        /// </summary>
-        public string ScheduledEventName { get; }
-
-        /// <summary>
-        /// ScheduledEventException constructor
-        /// </summary>
-        /// <param name="name">The name of the scheduled event</param>
-        /// <param name="message">The exception as a string</param>
-        /// <param name="innerException">The exception that is the cause of the current exception</param>
-        public ScheduledEventException(string name, string message, Exception innerException) : base(message, innerException)
-        {
-            ScheduledEventName = name;
         }
     }
 }

--- a/Common/Scheduling/ScheduledEvent.cs
+++ b/Common/Scheduling/ScheduledEvent.cs
@@ -195,7 +195,7 @@ namespace QuantConnect.Scheduling
         internal void SkipEventsUntil(DateTime utcTime)
         {
             // check if our next event is in the past
-            if (utcTime < _orderedEventUtcTimes.Current) return;
+            if (utcTime <= _orderedEventUtcTimes.Current) return;
 
             while (_orderedEventUtcTimes.MoveNext())
             {

--- a/Common/Scheduling/ScheduledEventException.cs
+++ b/Common/Scheduling/ScheduledEventException.cs
@@ -1,0 +1,42 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+
+namespace QuantConnect.Scheduling
+{
+    /// <summary>
+    /// Throw this if there is an exception in the callback function of the scheduled event
+    /// </summary>
+    public class ScheduledEventException : Exception
+    {
+        /// <summary>
+        /// Gets the name of the scheduled event
+        /// </summary>
+        public string ScheduledEventName { get; }
+
+        /// <summary>
+        /// ScheduledEventException constructor
+        /// </summary>
+        /// <param name="name">The name of the scheduled event</param>
+        /// <param name="message">The exception as a string</param>
+        /// <param name="innerException">The exception that is the cause of the current exception</param>
+        public ScheduledEventException(string name, string message, Exception innerException) : base(message, innerException)
+        {
+            ScheduledEventName = name;
+        }
+    }
+}

--- a/Common/Scheduling/TimeRules.cs
+++ b/Common/Scheduling/TimeRules.cs
@@ -53,6 +53,21 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
+        /// Specifies an event should fire at the current time
+        /// </summary>
+        public ITimeRule Now => new FuncTimeRule("Now", dates => dates.Select(date => date.Add(_securities.UtcTime.TimeOfDay)));
+
+        /// <summary>
+        /// Convenience property for running a scheduled event at midnight in the algorithm time zone
+        /// </summary>
+        public ITimeRule Midnight => new FuncTimeRule("Midnight", dates => dates.Select(date => date.ConvertFromUtc(_timeZone).Date));
+
+        /// <summary>
+        /// Convenience property for running a scheduled event at noon in the algorithm time zone
+        /// </summary>
+        public ITimeRule Noon => new FuncTimeRule("Noon", dates => dates.Select(date => date.ConvertFromUtc(_timeZone).Date.AddHours(12)));
+
+        /// <summary>
         /// Specifies an event should fire at the specified time of day in the algorithm's time zone
         /// </summary>
         /// <param name="timeOfDay">The time of day in the algorithm's time zone the event should fire</param>
@@ -132,7 +147,6 @@ namespace QuantConnect.Scheduling
             Func<IEnumerable<DateTime>, IEnumerable<DateTime>> applicator = dates => EveryIntervalIterator(dates, interval);
             return new FuncTimeRule(name, applicator);
         }
-
 
         /// <summary>
         /// Specifies an event should fire at market open +- <paramref name="minutesAfterOpen"/>

--- a/Common/Util/RateLimit/BusyWaitSleepStrategy.cs
+++ b/Common/Util/RateLimit/BusyWaitSleepStrategy.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -11,34 +11,26 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
 */
 
-using System;
+using System.Threading;
 
-namespace QuantConnect
+namespace QuantConnect.Util.RateLimit
 {
     /// <summary>
-    /// Provides an implementation of <see cref="ITimeProvider"/> that
-    /// uses <see cref="DateTime.UtcNow"/> to provide the current time
+    /// Provides a CPU intensive means of waiting for more tokens to be available in <see cref="ITokenBucket"/>.
+    /// This strategy is only viable when the requested number of tokens is expected to become available in an
+    /// extremely short period of time. This implementation aims to keep the current thread executing to prevent
+    /// potential content switches arising from a thread yielding or sleeping strategy.
     /// </summary>
-    public sealed class RealTimeProvider : ITimeProvider
+    public class BusyWaitSleepStrategy : ISleepStrategy
     {
         /// <summary>
-        /// Provides a static instance of the <see cref="RealTimeProvider"/>
+        /// Provides a CPU intensive sleep by executing <see cref="Thread.SpinWait"/> for a single spin.
         /// </summary>
-        /// <remarks>
-        /// Since this implementation is stateless, it doesn't make sense to have multiple instances.
-        /// </remarks>
-        public static readonly ITimeProvider Instance = new RealTimeProvider();
-
-        /// <summary>
-        /// Gets the current time in UTC
-        /// </summary>
-        /// <returns>The current time in UTC</returns>
-        public DateTime GetUtcNow()
+        public void Sleep()
         {
-            return DateTime.UtcNow;
+            Thread.SpinWait(1);
         }
     }
 }

--- a/Common/Util/RateLimit/FixedIntervalRefillStrategy.cs
+++ b/Common/Util/RateLimit/FixedIntervalRefillStrategy.cs
@@ -1,0 +1,79 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Util.RateLimit
+{
+    /// <summary>
+    /// Provides a refill strategy that has a constant, quantized refill rate.
+    /// For example, after 1 minute passes add 5 units. If 59 seconds has passed, it will add zero unit,
+    /// but if 2 minutes have passed, then 10 units would be added.
+    /// </summary>
+    public class FixedIntervalRefillStrategy : IRefillStrategy
+    {
+        private readonly object _sync = new object();
+
+        private long _nextRefillTimeTicks;
+
+        private readonly long _refillAmount;
+        private readonly long _refillIntervalTicks;
+        private readonly ITimeProvider _timeProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FixedIntervalRefillStrategy"/> class.
+        /// </summary>
+        /// <param name="timeProvider">Provides the current time used for determining how much time has elapsed
+        /// between invocations of the refill method</param>
+        /// <param name="refillAmount">Defines the constant number of tokens to be made available for consumption
+        /// each time the provided <paramref name="refillInterval"/> has passed</param>
+        /// <param name="refillInterval">The amount of time that must pass before adding the specified <paramref name="refillAmount"/>
+        /// back to the bucket</param>
+        public FixedIntervalRefillStrategy(ITimeProvider timeProvider, long refillAmount, TimeSpan refillInterval)
+        {
+            _timeProvider = timeProvider;
+            _refillAmount = refillAmount;
+            _refillIntervalTicks = refillInterval.Ticks;
+            _nextRefillTimeTicks = _timeProvider.GetUtcNow().Ticks + _refillIntervalTicks;
+        }
+
+        /// <summary>
+        /// Computes the number of new tokens made available to the bucket for consumption by determining the
+        /// number of time intervals that have passed and multiplying by the number of tokens to refill for
+        /// each time interval.
+        /// </summary>
+        public long Refill()
+        {
+            lock (_sync)
+            {
+                var currentTimeTicks = _timeProvider.GetUtcNow().Ticks;
+                if (currentTimeTicks < _nextRefillTimeTicks)
+                {
+                    return 0L;
+                }
+
+                // determine number of time increments that have passed
+                var deltaTimeTicks = currentTimeTicks - _nextRefillTimeTicks;
+                var intervalsElapsed = 1 + Math.Max(deltaTimeTicks / _refillIntervalTicks, 0);
+
+                // update next refill time as quantized via the number of passed intervals
+                _nextRefillTimeTicks += _refillIntervalTicks * intervalsElapsed;
+
+                // refill by the tokens per interval times the number of intervals elapsed
+                return _refillAmount * intervalsElapsed;
+            }
+        }
+    }
+}

--- a/Common/Util/RateLimit/IRefillStrategy.cs
+++ b/Common/Util/RateLimit/IRefillStrategy.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -11,34 +11,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
 */
 
-using System;
-
-namespace QuantConnect
+namespace QuantConnect.Util.RateLimit
 {
     /// <summary>
-    /// Provides an implementation of <see cref="ITimeProvider"/> that
-    /// uses <see cref="DateTime.UtcNow"/> to provide the current time
+    /// Provides a strategy for making tokens available for consumption in the <see cref="ITokenBucket"/>
     /// </summary>
-    public sealed class RealTimeProvider : ITimeProvider
+    public interface IRefillStrategy
     {
         /// <summary>
-        /// Provides a static instance of the <see cref="RealTimeProvider"/>
+        /// Computes the number of new tokens made available, typically via the passing of time.
         /// </summary>
-        /// <remarks>
-        /// Since this implementation is stateless, it doesn't make sense to have multiple instances.
-        /// </remarks>
-        public static readonly ITimeProvider Instance = new RealTimeProvider();
-
-        /// <summary>
-        /// Gets the current time in UTC
-        /// </summary>
-        /// <returns>The current time in UTC</returns>
-        public DateTime GetUtcNow()
-        {
-            return DateTime.UtcNow;
-        }
+        long Refill();
     }
 }

--- a/Common/Util/RateLimit/ISleepStrategy.cs
+++ b/Common/Util/RateLimit/ISleepStrategy.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -11,34 +11,20 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
 */
 
-using System;
-
-namespace QuantConnect
+namespace QuantConnect.Util.RateLimit
 {
     /// <summary>
-    /// Provides an implementation of <see cref="ITimeProvider"/> that
-    /// uses <see cref="DateTime.UtcNow"/> to provide the current time
+    /// Defines a strategy for sleeping the current thread of execution. This is currently used via the
+    /// <see cref="ITokenBucket.Consume"/> in order to wait for new tokens to become available for consumption.
     /// </summary>
-    public sealed class RealTimeProvider : ITimeProvider
+    public interface ISleepStrategy
     {
         /// <summary>
-        /// Provides a static instance of the <see cref="RealTimeProvider"/>
+        /// Sleeps the current thread in an implementation specific way
+        /// and for an implementation specific amount of time
         /// </summary>
-        /// <remarks>
-        /// Since this implementation is stateless, it doesn't make sense to have multiple instances.
-        /// </remarks>
-        public static readonly ITimeProvider Instance = new RealTimeProvider();
-
-        /// <summary>
-        /// Gets the current time in UTC
-        /// </summary>
-        /// <returns>The current time in UTC</returns>
-        public DateTime GetUtcNow()
-        {
-            return DateTime.UtcNow;
-        }
+        void Sleep();
     }
 }

--- a/Common/Util/RateLimit/ITokenBucket.cs
+++ b/Common/Util/RateLimit/ITokenBucket.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Threading;
+
+namespace QuantConnect.Util.RateLimit
+{
+    /// <summary>
+    /// Defines a token bucket for rate limiting
+    /// See: https://en.wikipedia.org/wiki/Token_bucket
+    /// </summary>
+    /// <remarks>
+    /// This code is ported from https://github.com/mxplusb/TokenBucket - since it's a dotnet core
+    /// project, there were issued importing the nuget package directly. The referenced repository
+    /// is provided under the Apache V2 license.
+    /// </remarks>
+    public interface ITokenBucket
+    {
+        /// <summary>
+        /// Gets the total number of currently available tokens for consumption
+        /// </summary>
+        long AvailableTokens { get; }
+
+        /// <summary>
+        /// Blocks until the specified number of tokens are available for consumption
+        /// and then consumes that number of tokens.
+        /// </summary>
+        /// <param name="tokens">The number of tokens to consume</param>
+        /// <param name="timeout">The maximum amount of time, in milliseconds, to block. A <see cref="TimeoutException"/>
+        /// is throw in the event it takes longer than the stated timeout to consume the requested number of tokens.
+        /// The default timeout is set to infinite, which will block forever.</param>
+        void Consume(long tokens, long timeout = Timeout.Infinite);
+
+        /// <summary>
+        /// Attempts to consume the specified number of tokens from the bucket. If the
+        /// requested number of tokens are not immediately available, then this method
+        /// will return false to indicate that zero tokens have been consumed.
+        /// </summary>
+        bool TryConsume(long tokens);
+    }
+}

--- a/Common/Util/RateLimit/ITokenBucket.cs
+++ b/Common/Util/RateLimit/ITokenBucket.cs
@@ -30,6 +30,11 @@ namespace QuantConnect.Util.RateLimit
     public interface ITokenBucket
     {
         /// <summary>
+        /// Gets the maximum capacity of tokens this bucket can hold.
+        /// </summary>
+        long Capacity { get; }
+
+        /// <summary>
         /// Gets the total number of currently available tokens for consumption
         /// </summary>
         long AvailableTokens { get; }

--- a/Common/Util/RateLimit/LeakyBucket.cs
+++ b/Common/Util/RateLimit/LeakyBucket.cs
@@ -1,0 +1,166 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Threading;
+
+namespace QuantConnect.Util.RateLimit
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="ITokenBucket"/> that implements the leaky bucket algorithm
+    /// See: https://en.wikipedia.org/wiki/Leaky_bucket
+    /// </summary>
+    public class LeakyBucket : ITokenBucket
+    {
+        private readonly object _sync = new object();
+
+        private long _available;
+        private readonly long _capacity;
+        private readonly ISleepStrategy _sleep;
+        private readonly IRefillStrategy _refill;
+        private readonly ITimeProvider _timeProvider;
+
+        /// <summary>
+        /// Gets the total number of currently available tokens for consumption
+        /// </summary>
+        public long AvailableTokens
+        {
+            // synchronized read w/ the modification of available tokens in TryConsume
+            get { lock (_sync) return _available; }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeakyBucket"/> class.
+        /// This constructor initializes the bucket using the <see cref="ThreadSleepStrategy.Sleep"/> with a 1 millisecond
+        /// sleep to prevent being CPU intensive and uses the <see cref="FixedIntervalRefillStrategy"/> to refill bucket
+        /// tokens according to the <paramref name="refillAmount"/> and <paramref name="refillInterval"/> parameters.
+        /// </summary>
+        /// <param name="capacity">The maximum number of tokens this bucket can hold</param>
+        /// <param name="refillAmount">The number of tokens to add to the bucket each <paramref name="refillInterval"/></param>
+        /// <param name="refillInterval">The interval which after passing more tokens are added to the bucket</param>
+        public LeakyBucket(long capacity, long refillAmount, TimeSpan refillInterval)
+            : this(capacity, ThreadSleepStrategy.Sleeping(1),
+                new FixedIntervalRefillStrategy(RealTimeProvider.Instance, refillAmount, refillInterval)
+            )
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeakyBucket"/> class
+        /// </summary>
+        /// <param name="capacity">The maximum number of tokens this bucket can hold</param>
+        /// <param name="sleep">Defines the <see cref="ISleepStrategy"/> used when <see cref="Consume"/> is invoked
+        /// but the bucket does not have enough tokens yet</param>
+        /// <param name="refill">Defines the <see cref="IRefillStrategy"/> that computes how many tokens to add
+        /// back to the bucket each time consumption is attempted</param>
+        /// <param name="timeProvider">Defines the <see cref="ITimeProvider"/> used to enforce timeouts when
+        /// invoking <see cref="Consume"/></param>
+        public LeakyBucket(long capacity, ISleepStrategy sleep, IRefillStrategy refill, ITimeProvider timeProvider = null)
+        {
+            _sleep = sleep;
+            _refill = refill;
+            _capacity = capacity;
+            _available = capacity;
+            _timeProvider = timeProvider ?? RealTimeProvider.Instance;
+        }
+
+        /// <summary>
+        /// Blocks until the specified number of tokens are available for consumption
+        /// and then consumes that number of tokens.
+        /// </summary>
+        /// <param name="tokens">The number of tokens to consume</param>
+        /// <param name="timeout">The maximum amount of time, in milliseconds, to block. An exception is
+        /// throw in the event it takes longer than the stated timeout to consume the requested number
+        /// of tokens</param>
+        public void Consume(long tokens, long timeout = Timeout.Infinite)
+        {
+            if (timeout < Timeout.Infinite)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeout),
+                    "Invalid timeout. Use -1 for no timeout, 0 for immediate timeout and a positive number " +
+                    "of milliseconds to indicate a timeout. All other values are out of range."
+                );
+            }
+
+            var startTime = _timeProvider.GetUtcNow();
+
+            while (true)
+            {
+                if (TryConsume(tokens))
+                {
+                    break;
+                }
+
+                if (timeout != Timeout.Infinite)
+                {
+                    // determine if the requested timeout has elapsed
+                    var currentTime = _timeProvider.GetUtcNow();
+                    var elapsedMilliseconds = (currentTime - startTime).TotalMilliseconds;
+                    if (elapsedMilliseconds > timeout)
+                    {
+                        throw new TimeoutException("The operation timed out while waiting for the rate limit to be lifted.");
+                    }
+                }
+
+                _sleep.Sleep();
+            }
+        }
+
+        /// <summary>
+        /// Attempts to consume the specified number of tokens from the bucket. If the
+        /// requested number of tokens are not immediately available, then this method
+        /// will return false to indicate that zero tokens have been consumed.
+        /// </summary>
+        public bool TryConsume(long tokens)
+        {
+            if (tokens <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tokens),
+                    "Number of tokens to consume must be positive"
+                );
+            }
+
+            if (tokens > _capacity)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tokens),
+                    "Number of tokens to consume must be less than or equal to the capacity"
+                );
+            }
+
+            lock (_sync)
+            {
+                // determine how many units have become available since last invocation
+                var refilled = Math.Max(0, _refill.Refill());
+
+                // the number of tokens to add, the max of which is the difference between capacity and currently available
+                var deltaTokens = Math.Min(_capacity - _available, refilled);
+
+                // update the available number of units with the new tokens
+                _available += deltaTokens;
+
+                if (tokens > _available)
+                {
+                    // we don't have enough tokens yet
+                    return false;
+                }
+
+                // subtract the number of tokens consumed
+                _available = _available - tokens;
+                return true;
+            }
+        }
+
+    }
+}

--- a/Common/Util/RateLimit/ThreadSleepStrategy.cs
+++ b/Common/Util/RateLimit/ThreadSleepStrategy.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Threading;
+
+namespace QuantConnect.Util.RateLimit
+{
+    /// <summary>
+    /// Provides a CPU non-intensive means of waiting for more tokens to be available in <see cref="ITokenBucket"/>.
+    /// This strategy should be the most commonly used as it either sleeps or yields the currently executing thread,
+    /// allowing for other threads to execute while the current thread is blocked and waiting for new tokens to become
+    /// available in the bucket for consumption.
+    /// </summary>
+    public class ThreadSleepStrategy : ISleepStrategy
+    {
+        /// <summary>
+        /// Gets an instance of <see cref="ISleepStrategy"/> that yields the current thread
+        /// </summary>
+        public static readonly ISleepStrategy Yielding = new ThreadSleepStrategy(0);
+
+        /// <summary>
+        /// Gets an instance of <see cref="ISleepStrategy"/> that sleeps the current thread for
+        /// the specified number of milliseconds
+        /// </summary>
+        /// <param name="milliseconds">The duration of time to sleep, in milliseconds</param>
+        public static ISleepStrategy Sleeping(int milliseconds) => new ThreadSleepStrategy(milliseconds);
+
+        private readonly int _milliseconds;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThreadSleepStrategy"/> using the specified
+        /// number of <paramref name="milliseconds"/> for each <see cref="Sleep"/> invocation.
+        /// </summary>
+        /// <param name="milliseconds">The duration of time to sleep, in milliseconds</param>
+        public ThreadSleepStrategy(int milliseconds)
+        {
+            _milliseconds = milliseconds;
+        }
+
+        /// <summary>
+        /// Sleeps the current thread using the initialized number of milliseconds
+        /// </summary>
+        public void Sleep()
+        {
+            Thread.Sleep(_milliseconds);
+        }
+    }
+}

--- a/Common/Util/RateLimit/TokenBucket.cs
+++ b/Common/Util/RateLimit/TokenBucket.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Threading;
+
+namespace QuantConnect.Util.RateLimit
+{
+    /// <summary>
+    /// Provides extension methods for interacting with <see cref="ITokenBucket"/> instances as well
+    /// as access to the <see cref="NullTokenBucket"/> via <see cref="TokenBucket.Null"/>
+    /// </summary>
+    public static class TokenBucket
+    {
+        /// <summary>
+        /// Gets an <see cref="ITokenBucket"/> that always permits consumption
+        /// </summary>
+        public static ITokenBucket Null = new NullTokenBucket();
+
+        /// <summary>
+        /// Provides an overload of <see cref="ITokenBucket.Consume"/> that accepts a <see cref="TimeSpan"/> timeout
+        /// </summary>
+        public static void Consume(this ITokenBucket bucket, long tokens, TimeSpan timeout)
+        {
+            bucket.Consume(tokens, (long) timeout.TotalMilliseconds);
+        }
+
+        /// <summary>
+        /// Provides an implementation of <see cref="ITokenBucket"/> that does not enforce rate limiting
+        /// </summary>
+        private class NullTokenBucket : ITokenBucket
+        {
+            public long Capacity => long.MaxValue;
+            public long AvailableTokens => long.MaxValue;
+            public bool TryConsume(long tokens) { return true; }
+            public void Consume(long tokens, long timeout = Timeout.Infinite) { }
+        }
+    }
+}

--- a/Engine/AlgorithmTimeLimitManager.cs
+++ b/Engine/AlgorithmTimeLimitManager.cs
@@ -181,9 +181,10 @@ namespace QuantConnect.Lean.Engine
         {
             var message = $"Algorithm took longer than {_timeLoopMaximum.TotalMinutes} minutes on a single time loop.";
 
-            if (_additionalMinutes > 0)
+            var minutesAboveStandardLimit = _additionalMinutes - (int) _timeLoopMaximum.TotalMinutes;
+            if (minutesAboveStandardLimit > 0)
             {
-                message = $"{message} An additional {_additionalMinutes} minutes were also allocated and consumed.";
+                message = $"{message} An additional {minutesAboveStandardLimit} minutes were also allocated and consumed.";
             }
 
             message = $"{message} CurrentTimeStepElapsed: {currentTimeStepElapsed.TotalMinutes:0.0} minutes";

--- a/Engine/AlgorithmTimeLimitManager.cs
+++ b/Engine/AlgorithmTimeLimitManager.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Lean.Engine
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IIsolatorLimitResultProvider"/> that tracks the algorithm
+    /// manager's time loops and enforces a maximum amount of time that each time loop may take to execute.
+    /// The isolator uses the result provided by <see cref="IsWithinLimit"/> to determine if it should
+    /// terminate the algorithm for violation of the imposed limits.
+    /// </summary>
+    public class AlgorithmTimeLimitManager : IIsolatorLimitResultProvider
+    {
+        private volatile bool _stopped;
+        private DateTime _currentTimeStepTime;
+        private readonly TimeSpan _timeLoopMaximum;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="AlgorithmTimeLimitManager"/> to manage the
+        /// creation of <see cref="IsolatorLimitResult"/> instances as it pertains to the
+        /// algorithm manager's time loop
+        /// </summary>
+        /// <param name="timeLoopMaximum">Specifies the maximum amount of time the algorithm is permitted to
+        /// spend in a single time loop. This value can be overriden if certain actions are taken by the
+        /// algorithm, such as invoking the training methods.</param>
+        public AlgorithmTimeLimitManager(TimeSpan timeLoopMaximum)
+        {
+            _timeLoopMaximum = timeLoopMaximum;
+        }
+
+        /// <summary>
+        /// Gets the current amount of time that has elapsed since the beginning of the
+        /// most recent algorithm manager time loop
+        /// </summary>
+        public TimeSpan CurrentTimeStepElapsed
+        {
+            get
+            {
+                if (_currentTimeStepTime == DateTime.MinValue)
+                {
+                    _currentTimeStepTime = DateTime.UtcNow;
+                    return TimeSpan.Zero;
+                }
+
+                return DateTime.UtcNow - _currentTimeStepTime;
+            }
+        }
+
+        /// <summary>
+        /// Invoked by the algorithm at the start of each time loop. This resets the current time step
+        /// elapsed time.
+        /// </summary>
+        /// <remarks>
+        /// This class is the result of a mechanical refactor with the intention of preserving all existing
+        /// behavior, including setting the <code>_currentTimeStepTime</code> to <see cref="DateTime.MinValue"/>
+        /// </remarks>
+        public void StartNewTimeStep()
+        {
+            // maintains existing implementation behavior to reset the time to min value and then
+            // when the isolator pings IsWithinLimit, invocation of CurrentTimeStepElapsed will cause
+            // it to update to the current time. IIRC, this was done to avoid a potential race
+            _currentTimeStepTime = DateTime.MinValue;
+        }
+
+        /// <summary>
+        /// Stops this instance from tracking the algorithm manager's time loop elapsed time.
+        /// This is invoked at the end of the algorithm to prevent the isolator from terminating
+        /// the algorithm during final clean up and shutdown.
+        /// </summary>
+        public void StopEnforcingTimeLimit()
+        {
+            _stopped = true;
+        }
+
+        /// <summary>
+        /// Determines whether or not the algorithm time loop is considered within the limits
+        /// </summary>
+        public IsolatorLimitResult IsWithinLimit()
+        {
+            if (_stopped)
+            {
+                return new IsolatorLimitResult(TimeSpan.Zero, string.Empty);
+            }
+
+            var message = string.Empty;
+            if (CurrentTimeStepElapsed > _timeLoopMaximum)
+            {
+                message = $"Algorithm took longer than {_timeLoopMaximum.TotalMinutes} minutes on a single time loop.";
+            }
+
+            return new IsolatorLimitResult(CurrentTimeStepElapsed, message);
+        }
+    }
+}

--- a/Engine/AlgorithmTimeLimitManager.cs
+++ b/Engine/AlgorithmTimeLimitManager.cs
@@ -74,7 +74,8 @@ namespace QuantConnect.Lean.Engine
 
             // maintains existing implementation behavior to reset the time to min value and then
             // when the isolator pings IsWithinLimit, invocation of CurrentTimeStepElapsed will cause
-            // it to update to the current time. IIRC, this was done to avoid a potential race
+            // it to update to the current time. This was done as a performance improvement and moved
+            // accessing DateTime.UtcNow from the algorithm manager thread to the isolator thread
             _currentTimeStepTime = DateTime.MinValue;
             Interlocked.Exchange(ref _additionalMinutes, 0L);
         }

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -358,6 +358,8 @@ namespace QuantConnect.Lean.Engine
                     catch (Exception err)
                     {
                         //Error running the user algorithm: purge datafeed, send error messages, set algorithm status to failed.
+                        algorithm.RunTimeError = err;
+                        algorithm.SetStatus(AlgorithmStatus.RuntimeError);
                         HandleAlgorithmError(job, err);
                     }
 

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -320,7 +320,7 @@ namespace QuantConnect.Lean.Engine
                         var isolator = new Isolator();
 
                         // Execute the Algorithm Code:
-                        var complete = isolator.ExecuteWithTimeLimit(AlgorithmHandlers.Setup.MaximumRuntime, algorithmManager.TimeLoopWithinLimits, () =>
+                        var complete = isolator.ExecuteWithTimeLimit(AlgorithmHandlers.Setup.MaximumRuntime, algorithmManager.TimeLimit.IsWithinLimit, () =>
                         {
                             try
                             {

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -279,7 +279,7 @@ namespace QuantConnect.Lean.Engine
 
                     //Load the associated handlers for transaction and realtime events:
                     AlgorithmHandlers.Transactions.Initialize(algorithm, brokerage, AlgorithmHandlers.Results);
-                    AlgorithmHandlers.RealTime.Setup(algorithm, job, AlgorithmHandlers.Results, SystemHandlers.Api);
+                    AlgorithmHandlers.RealTime.Setup(algorithm, job, AlgorithmHandlers.Results, SystemHandlers.Api, algorithmManager.TimeLimit);
 
                     // wire up the brokerage message handler
                     brokerage.Message += (sender, message) =>

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -162,6 +162,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AlgorithmManager.cs" />
+    <Compile Include="AlgorithmTimeLimitManager.cs" />
     <Compile Include="Alphas\ChartingInsightManagerExtension.cs" />
     <Compile Include="Alphas\StatisticsInsightManagerExtension.cs" />
     <Compile Include="DataFeeds\ApiDataProvider.cs" />

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -229,10 +229,8 @@
     <Compile Include="DataFeeds\Enumerators\TradeBarBuilderEnumerator.cs" />
     <Compile Include="DataFeeds\DefaultDataProvider.cs" />
     <Compile Include="DataFeeds\ISubscriptionDataSourceReader.cs" />
-    <Compile Include="DataFeeds\ITimeProvider.cs" />
     <Compile Include="DataFeeds\CollectionSubscriptionDataSourceReader.cs" />
     <Compile Include="DataFeeds\ManualTimeProvider.cs" />
-    <Compile Include="DataFeeds\RealTimeProvider.cs" />
     <Compile Include="DataFeeds\DataFeedPacket.cs" />
     <Compile Include="DataFeeds\SubscriptionCollection.cs" />
     <Compile Include="DataFeeds\SubscriptionData.cs" />

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -115,10 +115,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             // poke each event to see if it has fired, be sure to invoke these in time order
             foreach (var scheduledEvent in GetScheduledEventsSortedByTime())
             {
-                _isolatorLimitProvider.ConsumeWhileExecuting(
-                    scheduledEvent.Name,
-                    () => scheduledEvent.Scan(time)
-                );
+                _isolatorLimitProvider.Consume(scheduledEvent, time);
             }
         }
 
@@ -136,10 +133,7 @@ namespace QuantConnect.Lean.Engine.RealTime
 
                     try
                     {
-                        _isolatorLimitProvider.ConsumeWhileExecuting(
-                            scheduledEvent.Name,
-                            () => scheduledEvent.Scan(scheduledEvent.NextEventUtcTime)
-                        );
+                        _isolatorLimitProvider.Consume(scheduledEvent, scheduledEvent.NextEventUtcTime);
                     }
                     catch (ScheduledEventException scheduledEventException)
                     {

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -113,16 +113,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             // poke each event to see if it has fired, be sure to invoke these in time order
             foreach (var scheduledEvent in GetScheduledEventsSortedByTime())
             {
-                if (scheduledEvent.NextEventUtcTime > time)
-                {
-                    // since they're sorted, we don't need to go through every single one
-                    break;
-                }
-
                 _isolatorLimitProvider.Consume(scheduledEvent, time);
-
-                // since we changed this event's next time, we need to resort all of them
-                _sortingScheduledEventsRequired = true;
             }
         }
 
@@ -134,21 +125,12 @@ namespace QuantConnect.Lean.Engine.RealTime
         {
             foreach (var scheduledEvent in GetScheduledEventsSortedByTime())
             {
-                if (scheduledEvent.NextEventUtcTime > time)
-                {
-                    // since they're sorted, we don't need to go through every single one
-                    break;
-                }
-
                 while (scheduledEvent.NextEventUtcTime < time)
                 {
                     Algorithm.SetDateTime(scheduledEvent.NextEventUtcTime);
 
                     try
                     {
-                        // since we changed this event's next time, we need to resort all of them
-                        _sortingScheduledEventsRequired = true;
-
                         _isolatorLimitProvider.Consume(scheduledEvent, scheduledEvent.NextEventUtcTime);
                     }
                     catch (ScheduledEventException scheduledEventException)

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -17,8 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Logging;
@@ -148,6 +146,9 @@ namespace QuantConnect.Lean.Engine.RealTime
 
                     try
                     {
+                        // since we changed this event's next time, we need to resort all of them
+                        _sortingScheduledEventsRequired = true;
+
                         _isolatorLimitProvider.Consume(scheduledEvent, scheduledEvent.NextEventUtcTime);
                     }
                     catch (ScheduledEventException scheduledEventException)
@@ -163,9 +164,6 @@ namespace QuantConnect.Lean.Engine.RealTime
                         Algorithm.RunTimeError = scheduledEventException;
                     }
                 }
-
-                // since we changed this event's next time, we need to resort all of them
-                _sortingScheduledEventsRequired = true;
             }
         }
 

--- a/Engine/RealTime/IRealTimeHandler.cs
+++ b/Engine/RealTime/IRealTimeHandler.cs
@@ -39,9 +39,9 @@ namespace QuantConnect.Lean.Engine.RealTime
         }
 
         /// <summary>
-        /// Intializes the real time handler for the specified algorithm and job
+        /// Initializes the real time handler for the specified algorithm and job
         /// </summary>
-        void Setup(IAlgorithm algorithm, AlgorithmNodePacket job, IResultHandler resultHandler, IApi api);
+        void Setup(IAlgorithm algorithm, AlgorithmNodePacket job, IResultHandler resultHandler, IApi api, IIsolatorLimitResultProvider isolatorLimitProvider);
 
         /// <summary>
         /// Main entry point to scan and trigger the realtime events.

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -93,7 +93,6 @@ namespace QuantConnect.Lean.Engine.RealTime
             // continue thread until cancellation is requested
             while (!_cancellationTokenSource.IsCancellationRequested)
             {
-
                 var time = DateTime.UtcNow;
 
                 // pause until the next second
@@ -107,10 +106,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                     var scheduledEvent = kvp.Key;
                     try
                     {
-                        _isolatorLimitProvider.ConsumeWhileExecuting(
-                            scheduledEvent.Name,
-                            () => scheduledEvent.Scan(time)
-                        );
+                        _isolatorLimitProvider.Consume(scheduledEvent, time);
                     }
                     catch (ScheduledEventException scheduledEventException)
                     {

--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -120,7 +120,7 @@ namespace QuantConnect.Lean.Launcher
 
             try
             {
-                var algorithmManager = new AlgorithmManager(liveMode);
+                var algorithmManager = new AlgorithmManager(liveMode, job);
 
                 leanEngineSystemHandlers.LeanManager.Initialize(leanEngineSystemHandlers, leanEngineAlgorithmHandlers, job, algorithmManager);
 

--- a/Tests/Common/IsolatorLimitResultProviderTests.cs
+++ b/Tests/Common/IsolatorLimitResultProviderTests.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using NUnit.Framework;
+
+namespace QuantConnect.Tests.Common
+{
+    [TestFixture]
+    public class IsolatorLimitResultProviderTests
+    {
+        [Test]
+        public void ConsumeWhileExecutingRequestsAdditionalTimeAfterOneSecond()
+        {
+            var provider = new FakeIsolatorLimitResultProvider();
+            Action code = () => Thread.Sleep(TimeSpan.FromSeconds(1.01));
+            provider.ConsumeWhileExecuting(code);
+
+            Assert.AreEqual(1, provider.Invocations.Count);
+            Assert.AreEqual(1, provider.Invocations[0]);
+        }
+
+        [Test]
+        public void ConsumeWhileExecutingDoesNotRequestAdditionalTimeBeforeOneSecond()
+        {
+            var provider = new FakeIsolatorLimitResultProvider();
+            Action code = () => Thread.Sleep(TimeSpan.FromSeconds(0.99));
+            provider.ConsumeWhileExecuting(code);
+
+            Assert.IsEmpty(provider.Invocations);
+        }
+
+        private class FakeIsolatorLimitResultProvider : IIsolatorLimitResultProvider
+        {
+            public List<int> Invocations { get; } = new List<int>();
+
+            public IsolatorLimitResult IsWithinLimit()
+            {
+                return new IsolatorLimitResult(TimeSpan.Zero, string.Empty);
+            }
+
+            public void RequestAdditionalTime(int minutes)
+            {
+                Invocations.Add(minutes);
+            }
+        }
+    }
+}

--- a/Tests/Common/IsolatorLimitResultProviderTests.cs
+++ b/Tests/Common/IsolatorLimitResultProviderTests.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Tests.Common
             Task.Run(() =>
             {
                 var name = nameof(ConsumeRequestsAdditionalTimeAfterOneMinute);
-                provider.Consume(timeProvider, name, code);
+                provider.Consume(timeProvider, code);
                 consumeCompleted.Set();
             });
 
@@ -71,7 +71,7 @@ namespace QuantConnect.Tests.Common
                 timeProvider.Advance(TimeSpan.FromMinutes(.99));
                 Thread.Sleep(5);
             };
-            provider.Consume(timeProvider, nameof(ConsumeDoesNotRequestAdditionalTimeBeforeOneMinute), code);
+            provider.Consume(timeProvider, code);
 
             Assert.IsEmpty(provider.Invocations);
         }
@@ -91,7 +91,7 @@ namespace QuantConnect.Tests.Common
                 Thread.Sleep(15);
             };
 
-            provider.Consume(timeProvider, nameof(ConsumeDoesNotRequestAdditionalTimeBeforeOneMinute), code);
+            provider.Consume(timeProvider, code);
 
             Assert.AreEqual(3, provider.Invocations.Count);
             Assert.IsTrue(provider.Invocations.TrueForAll(invoc => invoc == 1));

--- a/Tests/Common/Scheduling/DateRulesTests.cs
+++ b/Tests/Common/Scheduling/DateRulesTests.cs
@@ -266,7 +266,7 @@ namespace QuantConnect.Tests.Common.Scheduling
                     RegisteredSecurityDataTypesProvider.Null
                 )
             );
-            var rules = new DateRules(manager);
+            var rules = new DateRules(manager, TimeZones.NewYork);
             return rules;
         }
     }

--- a/Tests/Common/Scheduling/ScheduleManagerTests.cs
+++ b/Tests/Common/Scheduling/ScheduleManagerTests.cs
@@ -17,7 +17,9 @@
 using System;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
+using QuantConnect.Lean.Engine;
 using QuantConnect.Lean.Engine.RealTime;
+using QuantConnect.Util.RateLimit;
 
 namespace QuantConnect.Tests.Common.Scheduling
 {
@@ -30,7 +32,8 @@ namespace QuantConnect.Tests.Common.Scheduling
             var algorithm = new QCAlgorithm();
 
             var handler = new BacktestingRealTimeHandler();
-            handler.Setup(algorithm, null, null, null);
+            var timeLimitManager = new AlgorithmTimeLimitManager(TokenBucket.Null, TimeSpan.MaxValue);
+            handler.Setup(algorithm, null, null, null, timeLimitManager);
 
             algorithm.Schedule.SetEventSchedule(handler);
 

--- a/Tests/Common/Scheduling/ScheduledEventTests.cs
+++ b/Tests/Common/Scheduling/ScheduledEventTests.cs
@@ -74,6 +74,19 @@ namespace QuantConnect.Tests.Common.Scheduling
         }
 
         [Test]
+        public void SkipEventsUntilDoesNotSkipFirstEventEqualToRequestedTime()
+        {
+            var count = 0;
+            var time = new DateTime(2015, 08, 11, 10, 30, 0);
+            var eventTimes = new[] {time, time.AddSeconds(1)};
+            var sevent = new ScheduledEvent("test", eventTimes, (n, t) => count++);
+            // skips all preceding events, not including the specified time
+            sevent.SkipEventsUntil(time);
+            Assert.AreEqual(time, sevent.NextEventUtcTime);
+            Assert.AreEqual(0, count);
+        }
+
+        [Test]
         public void FiresEventWhenTimeEquals()
         {
             var triggered = false;

--- a/Tests/Common/Util/RateLimit/FixedIntervalRefillStrategyTests.cs
+++ b/Tests/Common/Util/RateLimit/FixedIntervalRefillStrategyTests.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Util.RateLimit;
+
+namespace QuantConnect.Tests.Common.Util.RateLimit
+{
+    [TestFixture]
+    public class FixedIntervalRefillStrategyTests
+    {
+        [Test]
+        public void DoesNotRefillUntilIntervalHasElapsed()
+        {
+            var time = new DateTime(2000, 01, 01);
+            var timeProvider = new ManualTimeProvider(time);
+
+            const int refillAmount = 1;
+            var refillInterval = TimeSpan.FromMinutes(1);
+            var strategy = new FixedIntervalRefillStrategy(timeProvider, refillAmount, refillInterval);
+
+            var refill = strategy.Refill();
+            Assert.AreEqual(0, refill);
+
+            timeProvider.Advance(refillInterval.Subtract(TimeSpan.FromTicks(1)));
+            refill = strategy.Refill();
+            Assert.AreEqual(0, refill);
+
+            timeProvider.Advance(TimeSpan.FromTicks(1));
+            refill = strategy.Refill();
+            Assert.AreEqual(refillAmount, refill);
+        }
+
+        [Test]
+        public void ComputesRefillsBasedOnNumberOfPassedIntervals()
+        {
+            var time = new DateTime(2000, 01, 01);
+            var timeProvider = new ManualTimeProvider(time);
+
+            const int refillAmount = 1;
+            var refillInterval = TimeSpan.FromMinutes(1);
+            var strategy = new FixedIntervalRefillStrategy(timeProvider, refillAmount, refillInterval);
+
+            var intervals = 3.5;
+            var advance = TimeSpan.FromTicks((long) (refillInterval.Ticks * intervals));
+            timeProvider.Advance(advance);
+
+            var refill = strategy.Refill();
+            var expected = (int) intervals * refillAmount;
+            Assert.AreEqual(expected, refill);
+
+            timeProvider.Advance(advance);
+            refill = strategy.Refill();
+            expected = (int) (intervals * 2) * refillAmount - expected;
+            Assert.AreEqual(expected, refill);
+        }
+    }
+}

--- a/Tests/Common/Util/RateLimit/LeakyBucketTests.cs
+++ b/Tests/Common/Util/RateLimit/LeakyBucketTests.cs
@@ -1,0 +1,95 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Util.RateLimit;
+
+namespace QuantConnect.Tests.Common.Util.RateLimit
+{
+    [TestFixture]
+    public class LeakyBucketTests
+    {
+        [Test]
+        public void BucketIsInitializedWithAvailableEqualToCapacity()
+        {
+            var bucket = new LeakyBucket(10, 1, Time.OneSecond);
+            Assert.AreEqual(10, bucket.AvailableTokens);
+        }
+
+        [Test]
+        public void ConsumeBlocksUntilTokensAreAvailable()
+        {
+            var time = new DateTime(2000, 01, 01);
+            var timeProvider = new ManualTimeProvider(time);
+
+            const int refillAmount = 1;
+            var refillInterval = TimeSpan.FromMinutes(1);
+            var refillStrategy = new FixedIntervalRefillStrategy(timeProvider, refillAmount, refillInterval);
+
+            // using spin wait strategy to ensure we update AvailableTokens as quickly as possible
+            var sleepStrategy = new BusyWaitSleepStrategy();
+
+            const int capacity = 10;
+            var bucket = new LeakyBucket(capacity, sleepStrategy, refillStrategy, timeProvider);
+
+            // first remove half the capacity
+            bucket.Consume(capacity/2);
+
+            // we've consumed half of the available tokens
+            Assert.AreEqual(capacity/2, bucket.AvailableTokens);
+
+            var taskStarted = new ManualResetEvent(false);
+            var bucketConsumeCompleted = new ManualResetEvent(false);
+            Task.Run(() =>
+            {
+                taskStarted.Set();
+
+                // this will block until time advances
+                bucket.Consume(capacity);
+                bucketConsumeCompleted.Set();
+            });
+
+            taskStarted.WaitOne();
+
+            // each loop we'll advance one refill increment and when the loop finishes
+            // the bucket's consume operation will succeed
+            var initialAmount = bucket.AvailableTokens;
+
+            for (int i = 0; i < 5; i++)
+            {
+                timeProvider.Advance(refillInterval);
+                Thread.Yield();
+
+                // on the last loop, the bucket will consume all ten
+                if (i != 4)
+                {
+                    // each time we advance the number of available tokens will increment by the refill amount
+                    Assert.AreEqual(initialAmount + (1 + i) * refillAmount, bucket.AvailableTokens,
+                        $"CurrentTime: {timeProvider.GetUtcNow():O}: Iteration: {i}"
+                    );
+                }
+            }
+
+            // now that we've advanced, bucket consumption should have completed
+            // we provide for a small timeout to support non-multi-threaded machines
+            Assert.IsTrue(bucketConsumeCompleted.WaitOne(10));
+            Assert.AreEqual(0, bucket.AvailableTokens);
+        }
+    }
+}

--- a/Tests/Common/Util/RateLimit/LeakyBucketTests.cs
+++ b/Tests/Common/Util/RateLimit/LeakyBucketTests.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Tests.Common.Util.RateLimit
             for (int i = 0; i < 5; i++)
             {
                 timeProvider.Advance(refillInterval);
-                Thread.Yield();
+                Thread.Sleep(1);
 
                 // on the last loop, the bucket will consume all ten
                 if (i != 4)

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -281,7 +281,7 @@ namespace QuantConnect.Tests.Engine
             }
 
             public bool IsActive { get; }
-            public void Setup(IAlgorithm algorithm, AlgorithmNodePacket job, IResultHandler resultHandler, IApi api)
+            public void Setup(IAlgorithm algorithm, AlgorithmNodePacket job, IResultHandler resultHandler, IApi api, IIsolatorLimitResultProvider isolatorLimitProvider)
             {
             }
 

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -33,6 +33,7 @@
     <WarningLevel>4</WarningLevel>
     <LangVersion>6</LangVersion>
     <CodeAnalysisRuleSet>..\QuantConnect.ruleset</CodeAnalysisRuleSet>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -306,6 +306,7 @@
     <Compile Include="Common\Data\Fundamental\MultiPeriodFieldTests.cs" />
     <Compile Include="Common\Data\MockSubscriptionDataConfigProvider.cs" />
     <Compile Include="Common\Data\UniverseSelection\UniverseTests.cs" />
+    <Compile Include="Common\IsolatorLimitResultProviderTests.cs" />
     <Compile Include="Common\IsolatorTests.cs" />
     <Compile Include="Common\Orders\Fees\AlphaStreamsFeeModelTests.cs" />
     <Compile Include="Common\Notifications\NotificationEmailTests.cs" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -337,6 +337,8 @@
     <Compile Include="Common\Util\ConcurrentSetTests.cs" />
     <Compile Include="Common\Util\RateGateTests.cs" />
     <Compile Include="Common\Util\ListComparerTests.cs" />
+    <Compile Include="Common\Util\RateLimit\FixedIntervalRefillStrategyTests.cs" />
+    <Compile Include="Common\Util\RateLimit\LeakyBucketTests.cs" />
     <Compile Include="Common\Util\SeriesJsonConverterTests.cs" />
     <Compile Include="Common\Util\StreamReaderEnumerableTests.cs" />
     <Compile Include="Common\Util\ValidateTests.cs" />

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -47,8 +47,8 @@ namespace QuantConnect.Tests
             if (parameters.Algorithm == "TrainingInitializeRegressionAlgorithm" ||
                 parameters.Algorithm == "TrainingOnDataRegressionAlgorithm")
             {
-                // limit time loop to 30 seconds and set leaky bucket capacity to one minute w/ zero refill
-                Config.Set("algorithm-manager-time-loop-maximum", "0.5");
+                // limit time loop to 90 seconds and set leaky bucket capacity to one minute w/ zero refill
+                Config.Set("algorithm-manager-time-loop-maximum", "1.5");
                 Config.Set("scheduled-event-leaky-bucket-capacity", "1");
                 Config.Set("scheduled-event-leaky-bucket-refill-amount", "0");
             }

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using QuantConnect.Algorithm.CSharp;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
+using QuantConnect.Util;
 
 namespace QuantConnect.Tests
 {
@@ -43,11 +44,37 @@ namespace QuantConnect.Tests
                 Config.Set("symbol-tick-limit", "100");
             }
 
-            AlgorithmRunner.RunLocalBacktest(parameters.Algorithm, parameters.Statistics, parameters.AlphaStatistics, parameters.Language);
+            if (parameters.Algorithm == "TrainingInitializeRegressionAlgorithm" ||
+                parameters.Algorithm == "TrainingOnDataRegressionAlgorithm")
+            {
+                // limit time loop to 30 seconds and set leaky bucket capacity to one minute w/ zero refill
+                Config.Set("algorithm-manager-time-loop-maximum", "0.5");
+                Config.Set("scheduled-event-leaky-bucket-capacity", "1");
+                Config.Set("scheduled-event-leaky-bucket-refill-amount", "0");
+            }
+
+            var algorithmManager = AlgorithmRunner.RunLocalBacktest(
+                parameters.Algorithm,
+                parameters.Statistics,
+                parameters.AlphaStatistics,
+                parameters.Language,
+                parameters.ExpectedFinalStatus
+            );
+
+            if (parameters.Algorithm == "TrainingOnDataRegressionAlgorithm")
+            {
+                // this training algorithm should have consumed the only minute available in the bucket
+                Assert.AreEqual(0, algorithmManager.TimeLimit.AdditionalTimeBucket.AvailableTokens);
+            }
         }
 
         private static TestCaseData[] GetRegressionTestParameters()
         {
+            var nonDefaultStatuses = new Dictionary<string, AlgorithmStatus>
+            {
+                {"TrainingInitializeRegressionAlgorithm", AlgorithmStatus.RuntimeError}
+            };
+
             // find all regression algorithms in Algorithm.CSharp
             return (
                 from type in typeof(BasicTemplateAlgorithm).Assembly.GetTypes()
@@ -55,9 +82,10 @@ namespace QuantConnect.Tests
                 where !type.IsAbstract                          // non-abstract
                 where type.GetConstructor(new Type[0]) != null  // has default ctor
                 let instance = (IRegressionAlgorithmDefinition) Activator.CreateInstance(type)
+                let status = nonDefaultStatuses.GetValueOrDefault(type.Name, AlgorithmStatus.Completed)
                 where instance.CanRunLocally                   // open source has data to run this algorithm
                 from language in instance.Languages
-                select new AlgorithmStatisticsTestParameters(type.Name, instance.ExpectedStatistics, language)
+                select new AlgorithmStatisticsTestParameters(type.Name, instance.ExpectedStatistics, language, status)
             )
             .OrderBy(x => x.Language).ThenBy(x => x.Algorithm)
             // generate test cases from test parameters
@@ -71,12 +99,19 @@ namespace QuantConnect.Tests
             public readonly Dictionary<string, string> Statistics;
             public readonly AlphaRuntimeStatistics AlphaStatistics;
             public readonly Language Language;
+            public readonly AlgorithmStatus ExpectedFinalStatus;
 
-            public AlgorithmStatisticsTestParameters(string algorithm, Dictionary<string, string> statistics, Language language)
+            public AlgorithmStatisticsTestParameters(
+                string algorithm,
+                Dictionary<string, string> statistics,
+                Language language,
+                AlgorithmStatus expectedFinalStatus
+                )
             {
                 Algorithm = algorithm;
                 Statistics = statistics;
                 Language = language;
+                ExpectedFinalStatus = expectedFinalStatus;
             }
         }
     }


### PR DESCRIPTION
#### Description
Adds support for long-running scheduled events. When a scheduled event is detected to have exceed one full second of execution time, we'll start requesting 'minutes' from a leaky bucket implementation managed by the `AlgorithmManager` via a proxy that also controls the delegate provided to the `Isolator`. When a scheduled event calls `AlgorithmTimeLimitManager.RequestAdditionalTime(int minutes)`, it increases the maximum amount of time the algorithm is allowed to spend in a single time loop.


 We restrict each algorithm time loop to a pre-determined amount of time.
Exceeding this limit will cause the algorithm to immediately terminate.
This quickly becomes an issue when considering users running trainable
models that have a long initialization period that exceeds the time loop
maximum.

This change provides a mechanism through which a long-running scheduled
event is permitted to keep running and is permitted to avoid the time loop
permitted by requesting additional time. Requests for additional time are
limited according to a leaky bucket implementation whose parameters are
set via the job's controls structure. The fundamental time unit for the
algorithm is a single minute.

Here's how it works. If a scheduled event takes longer than one full wall
clock second then a request is made to the leaky bucket for one more minute.
If the scheduled event continues to take more time, it will continue to
request additional minutes. Each requested minute will prevent the algorithm's
time loop check from terminating the algorithm. When the bucket is empty and
no more minutes are available to be requested, a TimeoutException is thrown
causing a cascade that ends in the algorithm's termination and status being
flipped to RuntimeError.

Additionally, this applies equally to ALL scheduled events. While some helpers
were added with the naming of Train and TrainNow to the ScheduleManager, these
methods don't do anything special and the infrastructure doesn't otherwise
flag them as different, so this feature becomes part of the core Scheduled
Event feature set.

Further, the live scheduled events were not touched and are still pending
further discussion regarding the value added by enforcing a time restriction
when simulation time and wall clock time are equivalent.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3319

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The aim of this change is to provide a controlled mechanism for users to run ML training that can potentially take a fairly large amount of time (up to 2 hours) without running afoul of the algorithm manager's time loop limit restrictions. We also seek to limit the total amount of time an algorithm can do this through a leaky bucket implementation whose parameters are set via the job packet.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes. We should add the new training methods to the API documentation along with a description of behavior and the default time limits.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added for new components and additional tests added to check certain aspects of the integrated implementation. Also, two regression tests are added to validate throwing and refill behavior when running full stack.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->