### PR TITLE
Fixes failing CBOE History request by removing duplicate property

### DIFF
--- a/Common/Data/Custom/CBOE/CBOE.cs
+++ b/Common/Data/Custom/CBOE/CBOE.cs
@@ -25,11 +25,6 @@ namespace QuantConnect.Data.Custom.CBOE
     public class CBOE : TradeBar
     {
         /// <summary>
-        /// Market data type
-        /// </summary>
-        public new MarketDataType DataType;
-
-        /// <summary>
         /// Creates a new instance of the object
         /// </summary>
         public CBOE()


### PR DESCRIPTION
#### Description
When custom data classes inherited from market data classes such as `TradeBar`, it created duplicate entries. Therefore, we need to exclude the common properties in the private field `PandasData._members`.

#### Related Issue
Closes #3745 

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
Unit tests and running `CachedAlternativeDataAlgorithm.py` with
```python
df = self.History([self.cboeVix], 50, Resolution.Daily)
```
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`