### PR TITLE
Exclude expired options from IB GetAccountHoldings

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -38,6 +38,7 @@ using NodaTime;
 using QuantConnect.IBAutomater;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.TimeInForces;
+using QuantConnect.Securities.Option;
 using Bar = QuantConnect.Data.Market.Bar;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
@@ -501,7 +502,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 Connect();
             }
 
-            var holdings = _accountData.AccountHoldings.Select(x => ObjectActivator.Clone(x.Value)).Where(x => x.Quantity != 0).ToList();
+            var utcNow = DateTime.UtcNow;
+            var holdings = _accountData.AccountHoldings
+                .Select(x => ObjectActivator.Clone(x.Value))
+                .Where(x => x.Quantity != 0 && !OptionSymbol.IsOptionContractExpired(x.Symbol, utcNow))
+                .ToList();
 
             return holdings;
         }

--- a/Common/Securities/Option/OptionSymbol.cs
+++ b/Common/Securities/Option/OptionSymbol.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
 
 namespace QuantConnect.Securities.Option
 {
@@ -12,7 +23,7 @@ namespace QuantConnect.Securities.Option
     public static class OptionSymbol
     {
         /// <summary>
-        /// Returns true is the option is a standard contract that expire 3rd Friday of the month
+        /// Returns true if the option is a standard contract that expires 3rd Friday of the month
         /// </summary>
         /// <param name="symbol">Option symbol</param>
         /// <returns></returns>
@@ -32,7 +43,7 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Returns lat trading date for the option contract
+        /// Returns the last trading date for the option contract
         /// </summary>
         /// <param name="symbol">Option symbol</param>
         /// <returns></returns>
@@ -63,5 +74,28 @@ namespace QuantConnect.Securities.Option
 
             return symbolDateTime.AddDays(daysBefore).Date;
         }
+
+        /// <summary>
+        /// Returns true if the option contract is expired at the specified time
+        /// </summary>
+        /// <param name="symbol">The option contract symbol</param>
+        /// <param name="currentTimeUtc">The current time (UTC)</param>
+        /// <returns>True if the option contract is expired at the specified time, false otherwise</returns>
+        public static bool IsOptionContractExpired(Symbol symbol, DateTime currentTimeUtc)
+        {
+            if (symbol.SecurityType != SecurityType.Option)
+            {
+                return false;
+            }
+
+            var exchangeHours = MarketHoursDatabase.FromDataFolder()
+                .GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+
+            var currentTime = currentTimeUtc.ConvertFromUtc(exchangeHours.TimeZone);
+            var expiryTime = exchangeHours.GetNextMarketClose(symbol.ID.Date, false);
+
+            return currentTime >= expiryTime;
+        }
+
     }
 }

--- a/Tests/Common/Securities/Options/OptionSymbolTests.cs
+++ b/Tests/Common/Securities/Options/OptionSymbolTests.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Tests.Common.Securities.Options
+{
+    [TestFixture]
+    public class OptionSymbolTests
+    {
+        [Test]
+        public void IsOptionContractExpiredReturnsFalseForNonOptionSymbol()
+        {
+            Assert.IsFalse(OptionSymbol.IsOptionContractExpired(Symbols.SPY, DateTime.UtcNow));
+        }
+
+        [Test]
+        public void IsOptionContractExpiredReturnsTrueIfExpiredContract()
+        {
+            var symbol = Symbol.CreateOption(
+                "BHP",
+                Market.USA,
+                OptionStyle.American,
+                OptionRight.Call,
+                55m,
+                new DateTime(2019, 9, 20));
+
+            Assert.IsTrue(OptionSymbol.IsOptionContractExpired(symbol, DateTime.UtcNow));
+        }
+
+        [Test]
+        public void IsOptionContractExpiredReturnsFalseIfActiveContract()
+        {
+            var symbol = Symbol.CreateOption(
+                "BHP",
+                Market.USA,
+                OptionStyle.American,
+                OptionRight.Call,
+                55m,
+                new DateTime(2019, 9, 20));
+
+            Assert.IsFalse(OptionSymbol.IsOptionContractExpired(symbol, new DateTime(2019, 1, 1)));
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -323,6 +323,7 @@
     <Compile Include="Common\Securities\IdentityCurrencyConverterTests.cs" />
     <Compile Include="Common\Securities\AccountCurrencyImmediateSettlementModelTests.cs" />
     <Compile Include="Common\Securities\Options\OptionPortfolioModelTests.cs" />
+    <Compile Include="Common\Securities\Options\OptionSymbolTests.cs" />
     <Compile Include="Common\Securities\ProcessVolatilityHistoryRequirementsTests.cs" />
     <Compile Include="Common\Securities\DynamicSecurityDataTests.cs" />
     <Compile Include="Common\Securities\SecurityHoldingTests.cs" />


### PR DESCRIPTION

#### Description
- The `InteractiveBrokersBrokerage.GetAccountHoldings()` method has been updated to filter out expired option holdings returned by IB.

#### Related Issue
Closes #3728 

#### Motivation and Context
Runtime error when deploying an algorithm to IB account with expired option holdings:
```
ErrorCode: 200 - No security definition has been found for the request.
```

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Live algorithm with IB + new unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`