### PR TITLE
Extends EWPCM Rebalancing Options

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFrameworkAlgorithm.cs
@@ -53,7 +53,15 @@ namespace QuantConnect.Algorithm.CSharp
             // set algorithm framework models
             SetUniverseSelection(new ManualUniverseSelectionModel(QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)));
             SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromMinutes(20), 0.025, null));
-            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+
+            // We can define who often the EWPCM will rebalance if no new insight is submitted using:
+            // Resolution Enum:
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel(Resolution.Daily));
+            // TimeSpan
+            // SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel(TimeSpan.FromDays(2)));
+            // A Func<DateTime, DateTime>. In this case, we can use the pre-defined func at Expiry helper class
+            // SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel(Expiry.EndOfWeek));
+
             SetExecution(new ImmediateExecutionModel());
             SetRiskManagement(new MaximumDrawdownPercentPerSecurity(0.01m));
         }

--- a/Algorithm.Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModel.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <summary>
         /// Initialize a new instance of <see cref="InsightWeightingPortfolioConstructionModel"/>
         /// </summary>
-        /// <param name="rebalancingFunc">Rebalancing function</param>
+        /// <param name="rebalancingFunc">For a given algorithm UTC DateTime returns the next expected rebalance time</param>
         public ConfidenceWeightedPortfolioConstructionModel(Func<DateTime, DateTime> rebalancingFunc)
             : base(rebalancingFunc)
         {

--- a/Algorithm.Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModel.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using QuantConnect.Algorithm.Framework.Alphas;
 
 namespace QuantConnect.Algorithm.Framework.Portfolio
@@ -29,6 +30,24 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
     /// </summary>
     public class ConfidenceWeightedPortfolioConstructionModel : InsightWeightingPortfolioConstructionModel
     {
+        /// <summary>
+        /// Initialize a new instance of <see cref="InsightWeightingPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="rebalancingFunc">Rebalancing function</param>
+        public ConfidenceWeightedPortfolioConstructionModel(Func<DateTime, DateTime> rebalancingFunc)
+            : base(rebalancingFunc)
+        {
+        }
+
+        /// <summary>
+        /// Initialize a new instance of <see cref="InsightWeightingPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="timeSpan">Rebalancing frequency</param>
+        public ConfidenceWeightedPortfolioConstructionModel(TimeSpan timeSpan)
+            : base(timeSpan)
+        {
+        }
+
         /// <summary>
         /// Initialize a new instance of <see cref="ConfidenceWeightedPortfolioConstructionModel"/>
         /// </summary>

--- a/Algorithm.Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModel.py
@@ -31,7 +31,8 @@ class ConfidenceWeightedPortfolioConstructionModel(InsightWeightingPortfolioCons
     def __init__(self, rebalancingParam = Resolution.Daily):
         '''Initialize a new instance of ConfidenceWeightedPortfolioConstructionModel
         Args:
-            rebalancingParam: Rebalancing parameter. It can be a function, timedelta or Resolution'''
+            rebalancingParam: Rebalancing parameter. If it is a timedelta or Resolution, it will be converted into a function.
+                              The function returns the next expected rebalance time for a given algorithm UTC DateTime'''
         super().__init__(rebalancingParam)
 
     def ShouldCreateTargetForInsight(self, insight):

--- a/Algorithm.Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModel.py
@@ -28,11 +28,11 @@ class ConfidenceWeightedPortfolioConstructionModel(InsightWeightingPortfolioCons
     percent holdings proportionally so the sum is 1.
     It will ignore Insight that have no Insight.Confidence value.'''
 
-    def __init__(self, resolution = Resolution.Daily):
+    def __init__(self, rebalancingParam = Resolution.Daily):
         '''Initialize a new instance of ConfidenceWeightedPortfolioConstructionModel
         Args:
-            resolution: Rebalancing frequency'''
-        super().__init__(resolution)
+            rebalancingParam: Rebalancing parameter. It can be a function, timedelta or Resolution'''
+        super().__init__(rebalancingParam)
 
     def ShouldCreateTargetForInsight(self, insight):
         '''Method that will determine if the portfolio construction model should create a

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -29,8 +29,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
     /// </summary>
     public class EqualWeightingPortfolioConstructionModel : PortfolioConstructionModel
     {
+        private readonly Func<DateTime, DateTime> _rebalancingFunc;
         private DateTime _rebalancingTime;
-        private readonly TimeSpan _rebalancingPeriod;
         private List<Symbol> _removedSymbols;
         private readonly InsightCollection _insightCollection = new InsightCollection();
         private DateTime? _nextExpiryTime;
@@ -38,10 +38,28 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <summary>
         /// Initialize a new instance of <see cref="EqualWeightingPortfolioConstructionModel"/>
         /// </summary>
+        /// <param name="rebalancingFunc">Rebalancing function</param>
+        public EqualWeightingPortfolioConstructionModel(Func<DateTime, DateTime> rebalancingFunc)
+        {
+            _rebalancingFunc = rebalancingFunc;
+        }
+
+        /// <summary>
+        /// Initialize a new instance of <see cref="EqualWeightingPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="timeSpan">Rebalancing frequency</param>
+        public EqualWeightingPortfolioConstructionModel(TimeSpan timeSpan)
+            : this(dt => dt.Add(timeSpan))
+        {
+        }
+
+        /// <summary>
+        /// Initialize a new instance of <see cref="EqualWeightingPortfolioConstructionModel"/>
+        /// </summary>
         /// <param name="resolution">Rebalancing frequency</param>
         public EqualWeightingPortfolioConstructionModel(Resolution resolution = Resolution.Daily)
+            : this(resolution.ToTimeSpan())
         {
-            _rebalancingPeriod = resolution.ToTimeSpan();
         }
 
         /// <summary>
@@ -140,7 +158,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             targets.AddRange(expiredTargets);
 
             _nextExpiryTime = _insightCollection.GetNextExpiryTime();
-            _rebalancingTime = algorithm.UtcTime.Add(_rebalancingPeriod);
+            _rebalancingTime = _rebalancingFunc(algorithm.UtcTime);
 
             return targets;
         }

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <summary>
         /// Initialize a new instance of <see cref="EqualWeightingPortfolioConstructionModel"/>
         /// </summary>
-        /// <param name="rebalancingFunc">Rebalancing function</param>
+        /// <param name="rebalancingFunc">For a given algorithm UTC DateTime returns the next expected rebalance time</param>
         public EqualWeightingPortfolioConstructionModel(Func<DateTime, DateTime> rebalancingFunc)
         {
             _rebalancingFunc = rebalancingFunc;

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
@@ -32,7 +32,8 @@ class EqualWeightingPortfolioConstructionModel(PortfolioConstructionModel):
     def __init__(self, rebalancingParam = Resolution.Daily):
         '''Initialize a new instance of EqualWeightingPortfolioConstructionModel
         Args:
-            rebalancingParam: Rebalancing parameter. It can be a function, timedelta or Resolution'''
+            rebalancingParam: Rebalancing parameter. If it is a timedelta or Resolution, it will be converted into a function.
+                              The function returns the next expected rebalance time for a given algorithm UTC DateTime'''
         self.insightCollection = InsightCollection()
         self.removedSymbols = []
         self.nextExpiryTime = UTCMIN
@@ -42,7 +43,7 @@ class EqualWeightingPortfolioConstructionModel(PortfolioConstructionModel):
         # If the argument is an instance if Resolution or Timedelta
         # Redefine self.rebalancingFunc
         if isinstance(rebalancingParam, int):
-            self.rebalancingFunc = lambda dt: dt + Extensions.ToTimeSpan(rebalancingParam)
+            rebalancingParam = Extensions.ToTimeSpan(rebalancingParam)
         if isinstance(rebalancingParam, timedelta):
             self.rebalancingFunc = lambda dt: dt + rebalancingParam
 

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <summary>
         /// Initialize a new instance of <see cref="InsightWeightingPortfolioConstructionModel"/>
         /// </summary>
-        /// <param name="rebalancingFunc">Rebalancing function</param>
+        /// <param name="rebalancingFunc">For a given algorithm UTC DateTime returns the next expected rebalance time</param>
         public InsightWeightingPortfolioConstructionModel(Func<DateTime, DateTime> rebalancingFunc)
             : base(rebalancingFunc)
         {

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Algorithm.Framework.Alphas;
@@ -31,6 +32,24 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
     /// </summary>
     public class InsightWeightingPortfolioConstructionModel : EqualWeightingPortfolioConstructionModel
     {
+        /// <summary>
+        /// Initialize a new instance of <see cref="InsightWeightingPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="rebalancingFunc">Rebalancing function</param>
+        public InsightWeightingPortfolioConstructionModel(Func<DateTime, DateTime> rebalancingFunc)
+            : base(rebalancingFunc)
+        {
+        }
+
+        /// <summary>
+        /// Initialize a new instance of <see cref="InsightWeightingPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="timeSpan">Rebalancing frequency</param>
+        public InsightWeightingPortfolioConstructionModel(TimeSpan timeSpan)
+            : base(timeSpan)
+        {
+        }
+
         /// <summary>
         /// Initialize a new instance of <see cref="InsightWeightingPortfolioConstructionModel"/>
         /// </summary>

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
@@ -32,7 +32,8 @@ class InsightWeightingPortfolioConstructionModel(EqualWeightingPortfolioConstruc
     def __init__(self, rebalancingParam = Resolution.Daily):
         '''Initialize a new instance of InsightWeightingPortfolioConstructionModel
         Args:
-            rebalancingParam: Rebalancing parameter. It can be a function, timedelta or Resolution'''
+            rebalancingParam: Rebalancing parameter. If it is a timedelta or Resolution, it will be converted into a function.
+                              The function returns the next expected rebalance time for a given algorithm UTC DateTime'''
         super().__init__(rebalancingParam)
 
     def ShouldCreateTargetForInsight(self, insight):

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
@@ -29,11 +29,11 @@ class InsightWeightingPortfolioConstructionModel(EqualWeightingPortfolioConstruc
     percent holdings proportionally so the sum is 1.
     It will ignore Insight that have no Insight.Weight value.'''
 
-    def __init__(self, resolution = Resolution.Daily):
+    def __init__(self, rebalancingParam = Resolution.Daily):
         '''Initialize a new instance of InsightWeightingPortfolioConstructionModel
         Args:
-            resolution: Rebalancing frequency'''
-        super().__init__(resolution)
+            rebalancingParam: Rebalancing parameter. It can be a function, timedelta or Resolution'''
+        super().__init__(rebalancingParam)
 
     def ShouldCreateTargetForInsight(self, insight):
         '''Method that will determine if the portfolio construction model should create a

--- a/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFrameworkAlgorithm.py
@@ -58,7 +58,15 @@ class BasicTemplateFrameworkAlgorithm(QCAlgorithm):
         # set algorithm framework models
         self.SetUniverseSelection(ManualUniverseSelectionModel(symbols))
         self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(minutes = 20), 0.025, None))
-        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+
+        # We can define who often the EWPCM will rebalance if no new insight is submitted using:
+        # Resolution Enum:
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel(Resolution.Daily))
+        # timedelta
+        # self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel(timedelta(2)))
+        # A lamdda datetime -> datetime. In this case, we can use the pre-defined func at Expiry helper class
+        # self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel(Expiry.EndOfWeek))
+
         self.SetExecution(ImmediateExecutionModel())
         self.SetRiskManagement(MaximumDrawdownPercentPerSecurity(0.01))
 

--- a/Tests/Algorithm/Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModelTests.cs
@@ -354,6 +354,15 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             AssertTargets(actualTargets, new[] {new PortfolioTarget(Symbols.SPY, 0)});
         }
 
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void DoesNotThrowWithAlternativeOverloads(Language language)
+        {
+            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, TimeSpan.FromDays(1)));
+            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Expiry.EndOfWeek));
+        }
+
         private Security GetSecurity(Symbol symbol)
         {
             var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);
@@ -399,6 +408,36 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
             var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
             algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+        }
+
+        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, TimeSpan span)
+        {
+            algorithm.SetPortfolioConstruction(new ConfidenceWeightedPortfolioConstructionModel(span));
+            if (language == Language.Python)
+            {
+                using (Py.GIL())
+                {
+                    var name = nameof(ConfidenceWeightedPortfolioConstructionModel);
+                    var instance = Py.Import(name).GetAttr(name).Invoke(span.ToPython());
+                    var model = new PortfolioConstructionModelPythonWrapper(instance);
+                    algorithm.SetPortfolioConstruction(model);
+                }
+            }
+        }
+
+        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, Func<DateTime, DateTime> func)
+        {
+            algorithm.SetPortfolioConstruction(new ConfidenceWeightedPortfolioConstructionModel(func));
+            if (language == Language.Python)
+            {
+                using (Py.GIL())
+                {
+                    var name = nameof(ConfidenceWeightedPortfolioConstructionModel);
+                    var instance = Py.Import(name).GetAttr(name).Invoke(func.ToPython());
+                    var model = new PortfolioConstructionModelPythonWrapper(instance);
+                    algorithm.SetPortfolioConstruction(model);
+                }
+            }
         }
 
         private void SetUtcTime(DateTime dateTime)

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -331,6 +331,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python)]
         public void DoesNotThrowWithAlternativeOverloads(Language language)
         {
+            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Resolution.Minute));
             Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, TimeSpan.FromDays(1)));
             Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Expiry.EndOfWeek));
         }
@@ -357,15 +358,16 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             return insight;
         }
 
-        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm)
+        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, dynamic paramenter = null)
         {
-            algorithm.SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            paramenter = paramenter ?? Resolution.Daily;
+            algorithm.SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel(paramenter));
             if (language == Language.Python)
             {
                 using (Py.GIL())
                 {
                     var name = nameof(EqualWeightingPortfolioConstructionModel);
-                    var instance = Py.Import(name).GetAttr(name).Invoke();
+                    var instance = Py.Import(name).GetAttr(name).Invoke(((object) paramenter).ToPython());
                     var model = new PortfolioConstructionModelPythonWrapper(instance);
                     algorithm.SetPortfolioConstruction(model);
                 }
@@ -380,36 +382,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
             var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
             algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
-        }
-
-        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, TimeSpan span)
-        {
-            algorithm.SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel(span));
-            if (language == Language.Python)
-            {
-                using (Py.GIL())
-                {
-                    var name = nameof(EqualWeightingPortfolioConstructionModel);
-                    var instance = Py.Import(name).GetAttr(name).Invoke(span.ToPython());
-                    var model = new PortfolioConstructionModelPythonWrapper(instance);
-                    algorithm.SetPortfolioConstruction(model);
-                }
-            }
-        }
-
-        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, Func<DateTime, DateTime> func)
-        {
-            algorithm.SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel(func));
-            if (language == Language.Python)
-            {
-                using (Py.GIL())
-                {
-                    var name = nameof(EqualWeightingPortfolioConstructionModel);
-                    var instance = Py.Import(name).GetAttr(name).Invoke(func.ToPython());
-                    var model = new PortfolioConstructionModelPythonWrapper(instance);
-                    algorithm.SetPortfolioConstruction(model);
-                }
-            }
         }
 
         private void SetUtcTime(DateTime dateTime)

--- a/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
@@ -354,6 +354,15 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             AssertTargets(actualTargets, new[] {new PortfolioTarget(Symbols.SPY, 0)});
         }
 
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void DoesNotThrowWithAlternativeOverloads(Language language)
+        {
+            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, TimeSpan.FromDays(1)));
+            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Expiry.EndOfWeek));
+        }
+
         private Security GetSecurity(Symbol symbol)
         {
             var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);
@@ -399,6 +408,37 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
             var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
             algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+        }
+
+
+        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, TimeSpan span)
+        {
+            algorithm.SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel(span));
+            if (language == Language.Python)
+            {
+                using (Py.GIL())
+                {
+                    var name = nameof(InsightWeightingPortfolioConstructionModel);
+                    var instance = Py.Import(name).GetAttr(name).Invoke(span.ToPython());
+                    var model = new PortfolioConstructionModelPythonWrapper(instance);
+                    algorithm.SetPortfolioConstruction(model);
+                }
+            }
+        }
+
+        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, Func<DateTime, DateTime> func)
+        {
+            algorithm.SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel(func));
+            if (language == Language.Python)
+            {
+                using (Py.GIL())
+                {
+                    var name = nameof(InsightWeightingPortfolioConstructionModel);
+                    var instance = Py.Import(name).GetAttr(name).Invoke(func.ToPython());
+                    var model = new PortfolioConstructionModelPythonWrapper(instance);
+                    algorithm.SetPortfolioConstruction(model);
+                }
+            }
         }
 
         private void SetUtcTime(DateTime dateTime)

--- a/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
@@ -359,6 +359,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python)]
         public void DoesNotThrowWithAlternativeOverloads(Language language)
         {
+            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Resolution.Minute));
             Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, TimeSpan.FromDays(1)));
             Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Expiry.EndOfWeek));
         }
@@ -385,15 +386,16 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             return insight;
         }
 
-        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm)
+        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, dynamic paramenter = null)
         {
-            algorithm.SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel());
+            paramenter = paramenter ?? Resolution.Daily;
+            algorithm.SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel(paramenter));
             if (language == Language.Python)
             {
                 using (Py.GIL())
                 {
                     var name = nameof(InsightWeightingPortfolioConstructionModel);
-                    var instance = Py.Import(name).GetAttr(name).Invoke();
+                    var instance = Py.Import(name).GetAttr(name).Invoke(((object)paramenter).ToPython());
                     var model = new PortfolioConstructionModelPythonWrapper(instance);
                     algorithm.SetPortfolioConstruction(model);
                 }
@@ -408,37 +410,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
             var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
             algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
-        }
-
-
-        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, TimeSpan span)
-        {
-            algorithm.SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel(span));
-            if (language == Language.Python)
-            {
-                using (Py.GIL())
-                {
-                    var name = nameof(InsightWeightingPortfolioConstructionModel);
-                    var instance = Py.Import(name).GetAttr(name).Invoke(span.ToPython());
-                    var model = new PortfolioConstructionModelPythonWrapper(instance);
-                    algorithm.SetPortfolioConstruction(model);
-                }
-            }
-        }
-
-        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, Func<DateTime, DateTime> func)
-        {
-            algorithm.SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel(func));
-            if (language == Language.Python)
-            {
-                using (Py.GIL())
-                {
-                    var name = nameof(InsightWeightingPortfolioConstructionModel);
-                    var instance = Py.Import(name).GetAttr(name).Invoke(func.ToPython());
-                    var model = new PortfolioConstructionModelPythonWrapper(instance);
-                    algorithm.SetPortfolioConstruction(model);
-                }
-            }
         }
 
         private void SetUtcTime(DateTime dateTime)


### PR DESCRIPTION
#### Description
Adds constructor overloads to `EqualWeightingPortfolioConstructionModel` (`EWPCM`) to allow different rebalancing definitions.

It is possible to define rebalancing period with `Resolution`, `TimeSpan` (`timedelta` for Python) or a `Func<DateTime, DateTime>` (`lambda x: x+timedelta(y)` for Python). The last option lets the model use `Expiry` helper class with the members such as `EndOfWeek` and `EndOfMonth`.

#### Related Issue
Closes https://github.com/QuantConnect/Lean/issues/3757

#### Motivation and Context
The current overload limits the rebalancing periods to only the `Resolution` enum.

#### Requires Documentation Change
Yes. Show how `EWPCM` can be used with other overloads.

#### How Has This Been Tested?
Unit tests. Added unit test for the new overloads.
Since the overload that accepts the `Resolution` object is converted into `Func<DateTime, DateTime>` (`lambda x: x+timedelta(y)` for Python), the new overloads are tested by consequence. 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`