### PR TITLE
Add BaseData.DefaultResolution and SupportedResolutions

### DIFF
--- a/Algorithm.CSharp/AdjustResolutionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AdjustResolutionRegressionAlgorithm.cs
@@ -1,0 +1,118 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data.Custom;
+using QuantConnect.Data.Custom.CBOE;
+using QuantConnect.Data.Custom.Fred;
+using QuantConnect.Data.Custom.SEC;
+using QuantConnect.Data.Custom.Tiingo;
+using QuantConnect.Data.Custom.USEnergy;
+using QuantConnect.Data.Custom.USTreasury;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This regression algorithm tests the performance related GH issue 3772, AssertResolution
+    /// </summary>
+    public class AdjustResolutionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 11);
+            SetEndDate(2013, 10, 12);
+            var spy = AddEquity("SPY").Symbol;
+
+            var types = new[]
+            {
+                typeof(SECReport8K),
+                typeof(SECReport10K),
+                typeof(SECReport10Q),
+                typeof(USTreasuryYieldCurveRate),
+                typeof(USEnergy),
+                typeof(CBOE),
+                typeof(TiingoPrice),
+                typeof(Fred)
+            };
+
+            foreach (var type in types)
+            {
+                var custom = AddData(type, spy, Resolution.Hour, null);
+                if (SubscriptionManager.SubscriptionDataConfigService
+                    .GetSubscriptionDataConfigs(custom.Symbol)
+                    .Any(config => config.Resolution != Resolution.Daily))
+                {
+                    throw new Exception("Was expecting resolution to be adjusted to Daily");
+                }
+            }
+
+            var security = AddData<USEnergyAPI>(spy, Resolution.Tick, null);
+            if (SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(security.Symbol)
+                .Any(config => config.Resolution != Resolution.Hour))
+            {
+                throw new Exception("Was expecting resolution to be adjusted to Hour");
+            }
+
+            var option = AddOption("AAPL", Resolution.Daily);
+            if (SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(option.Symbol)
+                .Any(config => config.Resolution != Resolution.Minute))
+            {
+                throw new Exception("Was expecting resolution to be adjusted to Minute");
+            }
+
+            Quit();
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+        };
+    }
+}

--- a/Algorithm.CSharp/AltData/CachedAlternativeDataAlgorithm.cs
+++ b/Algorithm.CSharp/AltData/CachedAlternativeDataAlgorithm.cs
@@ -35,11 +35,11 @@ namespace QuantConnect.Algorithm.CSharp.AltData
             // QuantConnect caches a small subset of alternative data for easy consumption for the community.
             // You can use this in your algorithm as demonstrated below:
 
-            _cboeVix = AddData<CBOE>("VIX").Symbol;
+            _cboeVix = AddData<CBOE>("VIX", Resolution.Daily).Symbol;
             // United States EIA data: https://eia.gov/
-            _usEnergy = AddData<USEnergy>(USEnergy.Petroleum.UnitedStates.WeeklyGrossInputsIntoRefineries).Symbol;
+            _usEnergy = AddData<USEnergy>(USEnergy.Petroleum.UnitedStates.WeeklyGrossInputsIntoRefineries, Resolution.Daily).Symbol;
             // FRED data
-            _fredPeakToTrough = AddData<Fred>(Fred.OECDRecessionIndicators.UnitedStatesFromPeakThroughTheTrough).Symbol;
+            _fredPeakToTrough = AddData<Fred>(Fred.OECDRecessionIndicators.UnitedStatesFromPeakThroughTheTrough, Resolution.Daily).Symbol;
         }
 
         public override void OnData(Slice data)

--- a/Algorithm.CSharp/AltData/SECReport8KAlgorithm.cs
+++ b/Algorithm.CSharp/AltData/SECReport8KAlgorithm.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Algorithm.CSharp
             // Request underlying equity data.
             var ibm = AddEquity("IBM", Resolution.Minute).Symbol;
             // Add SEC report 10-Q data for the underlying IBM asset
-            var earningsFiling = AddData<SECReport10Q>(ibm).Symbol;
+            var earningsFiling = AddData<SECReport10Q>(ibm, Resolution.Daily).Symbol;
             // Request 120 days of history with the SECReport10Q IBM custom data Symbol.
             var history = History<SECReport10Q>(earningsFiling, 120, Resolution.Daily);
 

--- a/Algorithm.CSharp/AltData/USTreasuryYieldCurveRateAlgorithm.cs
+++ b/Algorithm.CSharp/AltData/USTreasuryYieldCurveRateAlgorithm.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
 
             _spy = AddEquity("SPY", Resolution.Hour).Symbol;
-            _yieldCurve = AddData<USTreasuryYieldCurveRate>("USTYCR").Symbol;
+            _yieldCurve = AddData<USTreasuryYieldCurveRate>("USTYCR", Resolution.Daily).Symbol;
 
             // Request 60 days of history with the USTreasuryYieldCurveRate custom data Symbol.
             var history = History<USTreasuryYieldCurveRate>(_yieldCurve, 60, Resolution.Daily);

--- a/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
@@ -47,7 +47,15 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 07, 02);
 
             var foxa = QuantConnect.Symbol.Create("FOXA", SecurityType.Equity, Market.USA);
-            _symbol = AddData<CustomDataUsingMapping>(foxa).Symbol;
+            _symbol = AddData<CustomDataUsingMapping>(foxa, Resolution.Tick).Symbol;
+
+            foreach (var config in SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(_symbol))
+            {
+                if (config.Resolution != Resolution.Minute)
+                {
+                    throw new Exception("Expected resolution to be adjust to Minute");
+                }
+            }
         }
 
         /// <summary>
@@ -163,6 +171,11 @@ namespace QuantConnect.Algorithm.CSharp
             public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
             {
                 return ParseEquity(config, line, date);
+            }
+
+            public override Resolution AdjustResolution(Resolution resolution)
+            {
+                return Resolution.Minute;
             }
         }
     }

--- a/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
@@ -47,13 +47,13 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 07, 02);
 
             var foxa = QuantConnect.Symbol.Create("FOXA", SecurityType.Equity, Market.USA);
-            _symbol = AddData<CustomDataUsingMapping>(foxa, Resolution.Tick).Symbol;
+            _symbol = AddData<CustomDataUsingMapping>(foxa).Symbol;
 
             foreach (var config in SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(_symbol))
             {
                 if (config.Resolution != Resolution.Minute)
                 {
-                    throw new Exception("Expected resolution to be adjust to Minute");
+                    throw new Exception("Expected resolution to be set to Minute");
                 }
             }
         }
@@ -78,7 +78,7 @@ namespace QuantConnect.Algorithm.CSharp
 
                     _initialMapping = true;
                 }
-                else if(Time.Date == new DateTime(2013, 06, 29))
+                else if (Time.Date == new DateTime(2013, 06, 29))
                 {
                     if (mappingEvent.NewSymbol != "FOXA"
                         || mappingEvent.OldSymbol != "NWSA")
@@ -173,9 +173,24 @@ namespace QuantConnect.Algorithm.CSharp
                 return ParseEquity(config, line, date);
             }
 
-            public override Resolution AdjustResolution(Resolution resolution)
+            /// <summary>
+            /// Gets the default resolution for this data and security type
+            /// </summary>
+            /// <remarks>This is a method and not a property so that python
+            /// custom data types can override it</remarks>
+            public override Resolution DefaultResolution()
             {
                 return Resolution.Minute;
+            }
+
+            /// <summary>
+            /// Gets the supported resolution for this data and security type
+            /// </summary>
+            /// <remarks>This is a method and not a property so that python
+            /// custom data types can override it</remarks>
+            public override List<Resolution> SupportedResolutions()
+            {
+                return new List<Resolution> { Resolution.Minute };
             }
         }
     }

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -158,6 +158,7 @@
     <Compile Include="AltData\PsychSignalSentimentAlgorithm.cs" />
     <Compile Include="AltData\TradingEconomicsAlgorithm.cs" />
     <Compile Include="AltData\TiingoNewsAlgorithm.cs" />
+    <Compile Include="AdjustResolutionRegressionAlgorithm.cs" />
     <Compile Include="BasicPythonIntegrationTemplateAlgorithm.cs" />
     <Compile Include="BasicSetAccountCurrencyAlgorithm.cs" />
     <Compile Include="Benchmarks\SECReportBenchmarkAlgorithm.cs" />

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -158,7 +158,7 @@
     <Compile Include="AltData\PsychSignalSentimentAlgorithm.cs" />
     <Compile Include="AltData\TradingEconomicsAlgorithm.cs" />
     <Compile Include="AltData\TiingoNewsAlgorithm.cs" />
-    <Compile Include="AdjustResolutionRegressionAlgorithm.cs" />
+    <Compile Include="DefaultResolutionRegressionAlgorithm.cs" />
     <Compile Include="BasicPythonIntegrationTemplateAlgorithm.cs" />
     <Compile Include="BasicSetAccountCurrencyAlgorithm.cs" />
     <Compile Include="Benchmarks\SECReportBenchmarkAlgorithm.cs" />

--- a/Algorithm.CSharp/SECReportDataAlgorithm.cs
+++ b/Algorithm.CSharp/SECReportDataAlgorithm.cs
@@ -40,8 +40,8 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2019, 1, 31);
             SetCash(100000);
 
-            _symbol = AddData<SECReport10Q>(Ticker).Symbol;
-            AddData<SECReport8K>(Ticker);
+            _symbol = AddData<SECReport10Q>(Ticker, Resolution.Daily).Symbol;
+            AddData<SECReport8K>(Ticker, Resolution.Daily);
         }
 
         public override void OnData(Slice slice)

--- a/Algorithm.CSharp/USEnergyInformationAdministrationAlgorithm.cs
+++ b/Algorithm.CSharp/USEnergyInformationAdministrationAlgorithm.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.Algorithm.CSharp
             USEnergyAPI.SetAuthCode("my-us-energy-information-api-token");
 
             _tiingoSymbol = AddData<TiingoPrice>(tiingoTicker, Resolution.Daily).Symbol;
-            _energySymbol = AddData<USEnergyAPI>(energyTicker).Symbol;
+            _energySymbol = AddData<USEnergyAPI>(energyTicker, Resolution.Hour).Symbol;
 
             _emaFast = EMA(_tiingoSymbol, 5);
             _emaSlow = EMA(_tiingoSymbol, 10);

--- a/Algorithm.CSharp/USTreasuryYieldCurveDataAlgorithm.cs
+++ b/Algorithm.CSharp/USTreasuryYieldCurveDataAlgorithm.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
 
             // Since yield data isn't associated with any ticker, we must put a placeholder ticker
-            AddData<USTreasuryYieldCurveRate>("USTYC");
+            AddData<USTreasuryYieldCurveRate>("USTYC", Resolution.Daily);
         }
 
         public override void OnData(Slice slice)

--- a/Algorithm.Python/AltData/CachedAlternativeDataAlgorithm.py
+++ b/Algorithm.Python/AltData/CachedAlternativeDataAlgorithm.py
@@ -36,11 +36,11 @@ class CachedAlternativeDataAlgorithm(QCAlgorithm):
         # QuantConnect caches a small subset of alternative data for easy consumption for the community.
         # You can use this in your algorithm as demonstrated below:
 
-        self.cboeVix = self.AddData(CBOE, "VIX").Symbol
+        self.cboeVix = self.AddData(CBOE, "VIX", Resolution.Daily).Symbol
         # United States EIA data: https://eia.gov/
-        self.usEnergy = self.AddData(USEnergy, USEnergy.Petroleum.UnitedStates.WeeklyGrossInputsIntoRefineries).Symbol
+        self.usEnergy = self.AddData(USEnergy, USEnergy.Petroleum.UnitedStates.WeeklyGrossInputsIntoRefineries, Resolution.Daily).Symbol
         # FRED data
-        self.fredPeakToTrough = self.AddData(Fred, Fred.OECDRecessionIndicators.UnitedStatesFromPeakThroughTheTrough).Symbol
+        self.fredPeakToTrough = self.AddData(Fred, Fred.OECDRecessionIndicators.UnitedStatesFromPeakThroughTheTrough, Resolution.Daily).Symbol
 
     def OnData(self, data):
         if data.ContainsKey(self.cboeVix):

--- a/Algorithm.Python/AltData/SECReport8KAlgorithm.py
+++ b/Algorithm.Python/AltData/SECReport8KAlgorithm.py
@@ -37,7 +37,7 @@ class SECReport8KAlgorithm(QCAlgorithm):
         # Request underlying equity data.
         ibm = self.AddEquity("IBM", Resolution.Minute).Symbol
         # Add news data for the underlying IBM asset
-        earningsFiling = self.AddData(SECReport10Q, ibm).Symbol
+        earningsFiling = self.AddData(SECReport10Q, ibm, Resolution.Daily).Symbol
         # Request 120 days of history with the SECReport10Q IBM custom data Symbol
         history = self.History(SECReport10Q, earningsFiling, 120, Resolution.Daily)
 

--- a/Algorithm.Python/AltData/USTreasuryYieldCurveRateAlgorithm.py
+++ b/Algorithm.Python/AltData/USTreasuryYieldCurveRateAlgorithm.py
@@ -33,7 +33,7 @@ class USTreasuryYieldCurveRateAlgorithm(QCAlgorithm):
         self.SetCash(100000)
 
         self.spy = self.AddEquity("SPY", Resolution.Hour).Symbol
-        self.yieldCurve = self.AddData(USTreasuryYieldCurveRate, "USTYCR").Symbol
+        self.yieldCurve = self.AddData(USTreasuryYieldCurveRate, "USTYCR", Resolution.Daily).Symbol
         self.lastInversion = datetime(1, 1, 1)
 
         # Request 60 days of history with the USTreasuryYieldCurveRate custom data Symbol.

--- a/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
@@ -44,7 +44,11 @@ class CustomDataUsingMapFileRegressionAlgorithm(QCAlgorithm):
         self.initialMapping = False
         self.executionMapping = False
         self.foxa = Symbol.Create("FOXA", SecurityType.Equity, Market.USA)
-        self.symbol = self.AddData(CustomDataUsingMapping, self.foxa).Symbol
+        self.symbol = self.AddData(CustomDataUsingMapping, self.foxa, Resolution.Tick).Symbol
+
+        for config in self.SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(self.symbol):
+            if config.Resolution != Resolution.Minute:
+                raise ValueError("Expected resolution to be adjust to Minute")
 
     def OnData(self, slice):
         date = self.Time.date()
@@ -87,3 +91,7 @@ class CustomDataUsingMapping(PythonData):
     def RequiresMapping(self):
         '''True indicates mapping should be done'''
         return True
+
+    def AdjustResolution(self, resolution):
+        '''Adjust resolution'''
+        return Resolution.Minute

--- a/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataUsingMapFileRegressionAlgorithm.py
@@ -44,11 +44,11 @@ class CustomDataUsingMapFileRegressionAlgorithm(QCAlgorithm):
         self.initialMapping = False
         self.executionMapping = False
         self.foxa = Symbol.Create("FOXA", SecurityType.Equity, Market.USA)
-        self.symbol = self.AddData(CustomDataUsingMapping, self.foxa, Resolution.Tick).Symbol
+        self.symbol = self.AddData(CustomDataUsingMapping, self.foxa).Symbol
 
         for config in self.SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(self.symbol):
             if config.Resolution != Resolution.Minute:
-                raise ValueError("Expected resolution to be adjust to Minute")
+                raise ValueError("Expected resolution to be set to Minute")
 
     def OnData(self, slice):
         date = self.Time.date()
@@ -92,6 +92,14 @@ class CustomDataUsingMapping(PythonData):
         '''True indicates mapping should be done'''
         return True
 
-    def AdjustResolution(self, resolution):
-        '''Adjust resolution'''
+    def IsSparseData(self):
+        '''Indicates that the data set is expected to be sparse'''
+        return True
+
+    def DefaultResolution(self):
+        '''Gets the default resolution for this data and security type'''
         return Resolution.Minute
+
+    def SupportedResolutions(self):
+        '''Gets the supported resolution for this data and security type'''
+        return [ Resolution.Minute ]

--- a/Algorithm.Python/SECReportDataAlgorithm.py
+++ b/Algorithm.Python/SECReportDataAlgorithm.py
@@ -37,8 +37,8 @@ class SECReportDataAlgorithm(QCAlgorithm):
         self.SetCash(100000)
 
         self.ticker = "AAPL"
-        self.symbol = self.AddData(SECReport10Q, self.ticker).Symbol
-        self.AddData(SECReport8K, self.ticker)
+        self.symbol = self.AddData(SECReport10Q, self.ticker, Resolution.Daily).Symbol
+        self.AddData(SECReport8K, self.ticker, Resolution.Daily)
 
     def OnData(self, slice):
         # OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.

--- a/Algorithm.Python/USEnergyInformationAdministrationAlgorithm.py
+++ b/Algorithm.Python/USEnergyInformationAdministrationAlgorithm.py
@@ -46,7 +46,7 @@ class USEnergyInformationAdministrationAlgorithm(QCAlgorithm):
         self.tiingoTicker = "AAPL"
         self.energyTicker = "NUC_STATUS.OUT.US.D"
         self.tiingoSymbol = self.AddData(TiingoDailyData, self.tiingoTicker, Resolution.Daily).Symbol
-        self.energySymbol = self.AddData(USEnergyAPI, self.energyTicker).Symbol
+        self.energySymbol = self.AddData(USEnergyAPI, self.energyTicker, Resolution.Hour).Symbol
 
 
         self.emaFast = self.EMA(self.tiingoSymbol, 5)

--- a/Algorithm.Python/USTreasuryYieldCurveDataAlgorithm.py
+++ b/Algorithm.Python/USTreasuryYieldCurveDataAlgorithm.py
@@ -35,7 +35,7 @@ class USTreasuryYieldCurveDataAlgorithm(QCAlgorithm):
         self.SetCash(100000)
 
         # Define the symbol and "type" of our generic data:
-        self.symbol = self.AddData(USTreasuryYieldCurveRate, "USTYC").Symbol
+        self.symbol = self.AddData(USTreasuryYieldCurveRate, "USTYC", Resolution.Daily).Symbol
 
     def OnData(self, slice):
         if not slice.ContainsKey(self.symbol):

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">Key/Ticker for data</param>
         /// <param name="resolution">Resolution of the data</param>
         /// <returns>The new <see cref="Security"/></returns>
-        public Security AddData(PyObject type, string ticker, Resolution resolution = Resolution.Minute)
+        public Security AddData(PyObject type, string ticker, Resolution? resolution = null)
         {
             return AddData(type, ticker, resolution, null, false, 1m);
         }
@@ -79,7 +79,7 @@ namespace QuantConnect.Algorithm
         /// Adding the three unused parameters makes it choose the correct method when using a string or Symbol. This is
         /// due to pythonnet's method precedence, as viewable here: https://github.com/QuantConnect/pythonnet/blob/9e29755c54e6008cb016e3dd9d75fbd8cd19fcf7/src/runtime/methodbinder.cs#L215
         /// </remarks>
-        public Security AddData(PyObject type, Symbol underlying, Resolution resolution = Resolution.Minute)
+        public Security AddData(PyObject type, Symbol underlying, Resolution? resolution = null)
         {
             return AddData(type, underlying, resolution, null, false, 1m);
         }
@@ -96,7 +96,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
-        public Security AddData(PyObject type, string ticker, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData(PyObject type, string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
         {
             return AddData(type.CreateType(), ticker, resolution, timeZone, fillDataForward, leverage);
         }
@@ -121,7 +121,7 @@ namespace QuantConnect.Algorithm
         /// Adding the three unused parameters makes it choose the correct method when using a string or Symbol. This is
         /// due to pythonnet's method precedence, as viewable here: https://github.com/QuantConnect/pythonnet/blob/9e29755c54e6008cb016e3dd9d75fbd8cd19fcf7/src/runtime/methodbinder.cs#L215
         /// </remarks>
-        public Security AddData(PyObject type, Symbol underlying, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData(PyObject type, Symbol underlying, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
         {
             return AddData(type.CreateType(), underlying, resolution, timeZone, fillDataForward, leverage);
         }
@@ -138,7 +138,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
-        public Security AddData(Type dataType, string ticker, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData(Type dataType, string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
         {
             // NOTE: Invoking methods on BaseData w/out setting the symbol may provide unexpected behavior
             var baseInstance = dataType.GetBaseDataInstance();
@@ -182,7 +182,7 @@ namespace QuantConnect.Algorithm
         /// Adding the three unused parameters makes it choose the correct method when using a string or Symbol. This is
         /// due to pythonnet's method precedence, as viewable here: https://github.com/QuantConnect/pythonnet/blob/9e29755c54e6008cb016e3dd9d75fbd8cd19fcf7/src/runtime/methodbinder.cs#L215
         /// </remarks>
-        public Security AddData(Type dataType, Symbol underlying, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData(Type dataType, Symbol underlying, Resolution? resolution = null, DateTimeZone timeZone = null, bool fillDataForward = false, decimal leverage = 1.0m)
         {
             var symbol = QuantConnect.Symbol.CreateBase(dataType, underlying, Market.USA);
             return AddDataImpl(dataType, symbol, resolution, timeZone, fillDataForward, leverage);
@@ -200,7 +200,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
-        private Security AddDataImpl(Type dataType, Symbol symbol, Resolution resolution, DateTimeZone timeZone, bool fillDataForward, decimal leverage)
+        private Security AddDataImpl(Type dataType, Symbol symbol, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward, decimal leverage)
         {
             var alias = symbol.ID.Symbol;
             SymbolCache.Set(alias, symbol);

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1404,7 +1404,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">Resolution of the Data Required</param>
         /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="extendedMarketHours">Show the after market data as well</param>
-        public Security AddSecurity(SecurityType securityType, string ticker, Resolution resolution = Resolution.Minute, bool fillDataForward = true, bool extendedMarketHours = false)
+        public Security AddSecurity(SecurityType securityType, string ticker, Resolution? resolution = null, bool fillDataForward = true, bool extendedMarketHours = false)
         {
             return AddSecurity(securityType, ticker, resolution, fillDataForward, Security.NullLeverage, extendedMarketHours);
         }
@@ -1419,7 +1419,7 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">Custom leverage per security</param>
         /// <param name="extendedMarketHours">Extended market hours</param>
         /// <remarks> AddSecurity(SecurityType securityType, Symbol symbol, Resolution resolution, bool fillDataForward, decimal leverage, bool extendedMarketHours)</remarks>
-        public Security AddSecurity(SecurityType securityType, string ticker, Resolution resolution, bool fillDataForward, decimal leverage, bool extendedMarketHours)
+        public Security AddSecurity(SecurityType securityType, string ticker, Resolution? resolution, bool fillDataForward, decimal leverage, bool extendedMarketHours)
         {
             return AddSecurity(securityType, ticker, resolution, null, fillDataForward, leverage, extendedMarketHours);
         }
@@ -1434,7 +1434,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice.</param>
         /// <param name="leverage">leverage for this security</param>
         /// <param name="extendedMarketHours">ExtendedMarketHours send in data from 4am - 8pm, not used for FOREX</param>
-        public Security AddSecurity(SecurityType securityType, string ticker, Resolution resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours)
+        public Security AddSecurity(SecurityType securityType, string ticker, Resolution? resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours)
         {
             // if AddSecurity method is called to add an option or a future, we delegate a call to respective methods
             if (securityType == SecurityType.Option)
@@ -1488,7 +1488,7 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">True to send data during pre and post market sessions. Default is <value>false</value></param>
         /// <returns>The new <see cref="Equity"/> security</returns>
-        public Equity AddEquity(string ticker, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage, bool extendedMarketHours = false)
+        public Equity AddEquity(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage, bool extendedMarketHours = false)
         {
             return AddSecurity<Equity>(SecurityType.Equity, ticker, resolution, market, fillDataForward, leverage, extendedMarketHours);
         }
@@ -1502,7 +1502,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Option"/> security</returns>
-        public Option AddOption(string underlying, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Option AddOption(string underlying, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
         {
             if (market == null)
             {
@@ -1535,7 +1535,7 @@ namespace QuantConnect.Algorithm
             Universe universe;
             if (!UniverseManager.TryGetValue(canonicalSymbol, out universe) && _pendingUniverseAdditions.All(u => u.Configuration.Symbol != canonicalSymbol))
             {
-                var settings = new UniverseSettings(resolution, leverage, true, false, TimeSpan.Zero);
+                var settings = new UniverseSettings(configs.Resolution, leverage, true, false, TimeSpan.Zero);
                 universe = new OptionChainUniverse(canonicalSecurity, settings, LiveMode);
                 _pendingUniverseAdditions.Add(universe);
             }
@@ -1552,7 +1552,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Future"/> security</returns>
-        public Future AddFuture(string ticker, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Future AddFuture(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
         {
             if (market == null)
             {
@@ -1583,7 +1583,7 @@ namespace QuantConnect.Algorithm
             Universe universe;
             if (!UniverseManager.TryGetValue(canonicalSymbol, out universe) && _pendingUniverseAdditions.All(u => u.Configuration.Symbol != canonicalSymbol))
             {
-                var settings = new UniverseSettings(resolution, leverage, true, false, TimeSpan.Zero);
+                var settings = new UniverseSettings(configs[0].Resolution, leverage, true, false, TimeSpan.Zero);
                 universe = new FuturesChainUniverse(canonicalSecurity, settings);
                 _pendingUniverseAdditions.Add(universe);
             }
@@ -1599,7 +1599,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Future"/> security</returns>
-        public Future AddFutureContract(Symbol symbol, Resolution resolution = Resolution.Minute, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
         {
             var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward);
             var future = (Future)Securities.CreateSecurity(symbol, configs, leverage);
@@ -1616,7 +1616,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Option"/> security</returns>
-        public Option AddOptionContract(Symbol symbol, Resolution resolution = Resolution.Minute, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
         {
             var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward);
             var option = (Option)Securities.CreateSecurity(symbol, configs, leverage);
@@ -1667,7 +1667,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Forex"/> security</returns>
-        public Forex AddForex(string ticker, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Forex AddForex(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
         {
             return AddSecurity<Forex>(SecurityType.Forex, ticker, resolution, market, fillDataForward, leverage, false);
         }
@@ -1681,7 +1681,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Cfd"/> security</returns>
-        public Cfd AddCfd(string ticker, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Cfd AddCfd(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
         {
             return AddSecurity<Cfd>(SecurityType.Cfd, ticker, resolution, market, fillDataForward, leverage, false);
         }
@@ -1695,7 +1695,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Crypto"/> security</returns>
-        public Crypto AddCrypto(string ticker, Resolution resolution = Resolution.Minute, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Crypto AddCrypto(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
         {
             return AddSecurity<Crypto>(SecurityType.Crypto, ticker, resolution, market, fillDataForward, leverage, false);
         }
@@ -1774,7 +1774,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">Resolution of the data</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
-        public Security AddData<T>(string ticker, Resolution resolution = Resolution.Minute)
+        public Security AddData<T>(string ticker, Resolution? resolution = null)
             where T : IBaseData, new()
         {
             //Add this new generic data as a tradeable security:
@@ -1792,7 +1792,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">Resolution of the data</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
-        public Security AddData<T>(Symbol underlying, Resolution resolution = Resolution.Minute)
+        public Security AddData<T>(Symbol underlying, Resolution? resolution = null)
             where T : IBaseData, new()
         {
             //Add this new generic data as a tradeable security:
@@ -1813,7 +1813,7 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
-        public Security AddData<T>(string ticker, Resolution resolution, bool fillDataForward, decimal leverage = 1.0m)
+        public Security AddData<T>(string ticker, Resolution? resolution, bool fillDataForward, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
             return AddData<T>(ticker, resolution, null, fillDataForward, leverage);
@@ -1829,7 +1829,7 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
-        public Security AddData<T>(Symbol underlying, Resolution resolution, bool fillDataForward, decimal leverage = 1.0m)
+        public Security AddData<T>(Symbol underlying, Resolution? resolution, bool fillDataForward, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
             return AddData<T>(underlying, resolution, null, fillDataForward, leverage);
@@ -1845,7 +1845,7 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
-        public Security AddData<T>(string ticker, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData<T>(string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
             return AddData(typeof(T), ticker, resolution, timeZone, fillDataForward, leverage);
@@ -1861,7 +1861,7 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
-        public Security AddData<T>(Symbol underlying, Resolution resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData<T>(Symbol underlying, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
             return AddData(typeof(T), underlying, resolution, timeZone, fillDataForward, leverage);
@@ -2057,7 +2057,7 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// Creates and adds a new <see cref="Security"/> to the algorithm
         /// </summary>
-        private T AddSecurity<T>(SecurityType securityType, string ticker, Resolution resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours)
+        private T AddSecurity<T>(SecurityType securityType, string ticker, Resolution? resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours)
             where T : Security
         {
             if (market == null)

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -395,12 +395,12 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// </summary>
         /// <param name="securityType">SecurityType Enum: Equity, Commodity, FOREX or Future</param>
         /// <param name="symbol">Symbol Representation of the MarketType, e.g. AAPL</param>
-        /// <param name="resolution">Resolution of the MarketType required: MarketData, Second or Minute</param>
+        /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily.</param>
         /// <param name="market">The market the requested security belongs to, such as 'usa' or 'fxcm'</param>
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice.</param>
         /// <param name="leverage">leverage for this security</param>
         /// <param name="extendedMarketHours">ExtendedMarketHours send in data from 4am - 8pm, not used for FOREX</param>
-        public Security AddSecurity(SecurityType securityType, string symbol, Resolution resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours)
+        public Security AddSecurity(SecurityType securityType, string symbol, Resolution? resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours)
             => _baseAlgorithm.AddSecurity(securityType, symbol, resolution, market, fillDataForward, leverage, extendedMarketHours);
 
         /// <summary>
@@ -411,7 +411,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Future"/> security</returns>
-        public Future AddFutureContract(Symbol symbol, Resolution resolution = Resolution.Minute, bool fillDataForward = true, decimal leverage = 0m)
+        public Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = 0m)
             => _baseAlgorithm.AddFutureContract(symbol, resolution, fillDataForward, leverage);
 
         /// <summary>
@@ -422,7 +422,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Option"/> security</returns>
-        public Option AddOptionContract(Symbol symbol, Resolution resolution = Resolution.Minute, bool fillDataForward = true, decimal leverage = 0m)
+        public Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = 0m)
             => _baseAlgorithm.AddOptionContract(symbol, resolution, fillDataForward, leverage);
 
         /// <summary>

--- a/Common/Data/BaseData.cs
+++ b/Common/Data/BaseData.cs
@@ -31,6 +31,22 @@ namespace QuantConnect.Data
         private decimal _value;
 
         /// <summary>
+        /// A list of all <see cref="Resolution"/>
+        /// </summary>
+        protected static readonly List<Resolution> AllResolutions =
+            Enum.GetValues(typeof(Resolution)).Cast<Resolution>().ToList();
+
+        /// <summary>
+        /// A list of <see cref="Resolution.Daily"/>
+        /// </summary>
+        protected static readonly List<Resolution> DailyResolution = new List<Resolution> { Resolution.Daily };
+
+        /// <summary>
+        /// A list of <see cref="Resolution.Minute"/>
+        /// </summary>
+        protected static readonly List<Resolution> MinuteResolution = new List<Resolution> { Resolution.Minute };
+
+        /// <summary>
         /// Market Data Type of this data - does it come in individual price packets or is it grouped into OHLC.
         /// </summary>
         /// <remarks>Data is classed into two categories - streams of instantaneous prices and groups of OHLC data.</remarks>
@@ -155,6 +171,8 @@ namespace QuantConnect.Data
         /// Indicates that the data set is expected to be sparse
         /// </summary>
         /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <remarks>This is a method and not a property so that python
+        /// custom data types can override it</remarks>
         /// <returns>True if the data set represented by this type is expected to be sparse</returns>
         public virtual bool IsSparseData()
         {
@@ -163,14 +181,29 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
+        /// </summary>
+        /// <remarks>This is a method and not a property so that python
+        /// custom data types can override it</remarks>
+        public virtual Resolution DefaultResolution()
+        {
+            return Resolution.Minute;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
         /// </summary>
         /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public virtual Resolution AdjustResolution(Resolution resolution)
+        /// <remarks>This is a method and not a property so that python
+        /// custom data types can override it</remarks>
+        public virtual List<Resolution> SupportedResolutions()
         {
-            return Symbol.SecurityType == SecurityType.Option ? Resolution.Minute : resolution;
+            if (Symbol.SecurityType == SecurityType.Option)
+            {
+                return MinuteResolution;
+            }
+
+            return AllResolutions;
         }
 
         /// <summary>

--- a/Common/Data/BaseData.cs
+++ b/Common/Data/BaseData.cs
@@ -144,6 +144,7 @@ namespace QuantConnect.Data
         /// <summary>
         /// Indicates if there is support for mapping
         /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
         /// <returns>True indicates mapping should be used</returns>
         public virtual bool RequiresMapping()
         {
@@ -153,11 +154,23 @@ namespace QuantConnect.Data
         /// <summary>
         /// Indicates that the data set is expected to be sparse
         /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
         /// <returns>True if the data set represented by this type is expected to be sparse</returns>
         public virtual bool IsSparseData()
         {
             // by default, we'll assume all custom data is sparse data
             return Symbol.SecurityType == SecurityType.Base;
+        }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public virtual Resolution AdjustResolution(Resolution resolution)
+        {
+            return Symbol.SecurityType == SecurityType.Option ? Resolution.Minute : resolution;
         }
 
         /// <summary>

--- a/Common/Data/Custom/CBOE/CBOE.cs
+++ b/Common/Data/Custom/CBOE/CBOE.cs
@@ -15,6 +15,7 @@
 
 using QuantConnect.Data.Market;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -126,14 +127,19 @@ namespace QuantConnect.Data.Custom.CBOE
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
         /// </summary>
-        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public override Resolution AdjustResolution(Resolution resolution)
+        public override Resolution DefaultResolution()
         {
             return Resolution.Daily;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
+        /// </summary>
+        public override List<Resolution> SupportedResolutions()
+        {
+            return DailyResolution;
         }
     }
 }

--- a/Common/Data/Custom/CBOE/CBOE.cs
+++ b/Common/Data/Custom/CBOE/CBOE.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using NodaTime;
 using QuantConnect.Data.Market;
 using System;
 using System.Globalization;
@@ -124,6 +123,17 @@ namespace QuantConnect.Data.Custom.CBOE
         public override string ToString()
         {
             return $"{Symbol} - O: {Open}, H: {High}, L: {Low}, C: {Close}";
+        }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public override Resolution AdjustResolution(Resolution resolution)
+        {
+            return Resolution.Daily;
         }
     }
 }

--- a/Common/Data/Custom/Fred/Fred.cs
+++ b/Common/Data/Custom/Fred/Fred.cs
@@ -114,5 +114,16 @@ namespace QuantConnect.Data.Custom.Fred
         {
             return $"{Symbol} - {Value}";
         }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public override Resolution AdjustResolution(Resolution resolution)
+        {
+            return Resolution.Daily;
+        }
     }
 }

--- a/Common/Data/Custom/Fred/Fred.cs
+++ b/Common/Data/Custom/Fred/Fred.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace QuantConnect.Data.Custom.Fred
@@ -116,14 +117,19 @@ namespace QuantConnect.Data.Custom.Fred
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
         /// </summary>
-        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public override Resolution AdjustResolution(Resolution resolution)
+        public override Resolution DefaultResolution()
         {
             return Resolution.Daily;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
+        /// </summary>
+        public override List<Resolution> SupportedResolutions()
+        {
+            return DailyResolution;
         }
     }
 }

--- a/Common/Data/Custom/SEC/SECReport10K.cs
+++ b/Common/Data/Custom/SEC/SECReport10K.cs
@@ -121,5 +121,16 @@ namespace QuantConnect.Data.Custom.SEC
                 Symbol = Symbol
             };
         }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public override Resolution AdjustResolution(Resolution resolution)
+        {
+            return Resolution.Daily;
+        }
     }
 }

--- a/Common/Data/Custom/SEC/SECReport10K.cs
+++ b/Common/Data/Custom/SEC/SECReport10K.cs
@@ -123,14 +123,19 @@ namespace QuantConnect.Data.Custom.SEC
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
         /// </summary>
-        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public override Resolution AdjustResolution(Resolution resolution)
+        public override Resolution DefaultResolution()
         {
             return Resolution.Daily;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
+        /// </summary>
+        public override List<Resolution> SupportedResolutions()
+        {
+            return DailyResolution;
         }
     }
 }

--- a/Common/Data/Custom/SEC/SECReport10Q.cs
+++ b/Common/Data/Custom/SEC/SECReport10Q.cs
@@ -121,6 +121,17 @@ namespace QuantConnect.Data.Custom.SEC
                 Symbol = Symbol
             };
         }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public override Resolution AdjustResolution(Resolution resolution)
+        {
+            return Resolution.Daily;
+        }
     }
 }
 

--- a/Common/Data/Custom/SEC/SECReport10Q.cs
+++ b/Common/Data/Custom/SEC/SECReport10Q.cs
@@ -123,14 +123,19 @@ namespace QuantConnect.Data.Custom.SEC
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
         /// </summary>
-        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public override Resolution AdjustResolution(Resolution resolution)
+        public override Resolution DefaultResolution()
         {
             return Resolution.Daily;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
+        /// </summary>
+        public override List<Resolution> SupportedResolutions()
+        {
+            return DailyResolution;
         }
     }
 }

--- a/Common/Data/Custom/SEC/SECReport8K.cs
+++ b/Common/Data/Custom/SEC/SECReport8K.cs
@@ -121,5 +121,16 @@ namespace QuantConnect.Data.Custom.SEC
                 Symbol = Symbol
             };
         }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public override Resolution AdjustResolution(Resolution resolution)
+        {
+            return Resolution.Daily;
+        }
     }
 }

--- a/Common/Data/Custom/SEC/SECReport8K.cs
+++ b/Common/Data/Custom/SEC/SECReport8K.cs
@@ -123,14 +123,19 @@ namespace QuantConnect.Data.Custom.SEC
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
         /// </summary>
-        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public override Resolution AdjustResolution(Resolution resolution)
+        public override Resolution DefaultResolution()
         {
             return Resolution.Daily;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
+        /// </summary>
+        public override List<Resolution> SupportedResolutions()
+        {
+            return DailyResolution;
         }
     }
 }

--- a/Common/Data/Custom/Tiingo/TiingoPrice.cs
+++ b/Common/Data/Custom/Tiingo/TiingoPrice.cs
@@ -202,14 +202,19 @@ namespace QuantConnect.Data.Custom.Tiingo
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
         /// </summary>
-        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public override Resolution AdjustResolution(Resolution resolution)
+        public override Resolution DefaultResolution()
         {
             return Resolution.Daily;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
+        /// </summary>
+        public override List<Resolution> SupportedResolutions()
+        {
+            return DailyResolution;
         }
     }
 }

--- a/Common/Data/Custom/Tiingo/TiingoPrice.cs
+++ b/Common/Data/Custom/Tiingo/TiingoPrice.cs
@@ -200,5 +200,16 @@ namespace QuantConnect.Data.Custom.Tiingo
         {
             return TimeZones.Utc;
         }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public override Resolution AdjustResolution(Resolution resolution)
+        {
+            return Resolution.Daily;
+        }
     }
 }

--- a/Common/Data/Custom/USEnergy/USEnergy.cs
+++ b/Common/Data/Custom/USEnergy/USEnergy.cs
@@ -110,5 +110,16 @@ namespace QuantConnect.Data.Custom.USEnergy
         {
             return $"{Symbol} - {Value}";
         }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public override Resolution AdjustResolution(Resolution resolution)
+        {
+            return Resolution.Daily;
+        }
     }
 }

--- a/Common/Data/Custom/USEnergy/USEnergy.cs
+++ b/Common/Data/Custom/USEnergy/USEnergy.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace QuantConnect.Data.Custom.USEnergy
@@ -112,14 +113,19 @@ namespace QuantConnect.Data.Custom.USEnergy
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
         /// </summary>
-        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public override Resolution AdjustResolution(Resolution resolution)
+        public override Resolution DefaultResolution()
         {
             return Resolution.Daily;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
+        /// </summary>
+        public override List<Resolution> SupportedResolutions()
+        {
+            return DailyResolution;
         }
     }
 }

--- a/Common/Data/Custom/USEnergy/USEnergyAPI.cs
+++ b/Common/Data/Custom/USEnergy/USEnergyAPI.cs
@@ -16,6 +16,7 @@
 using Newtonsoft.Json.Linq;
 using QuantConnect.Data.UniverseSelection;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
@@ -28,6 +29,7 @@ namespace QuantConnect.Data.Custom
     /// </summary>
     public class USEnergyAPI : BaseData
     {
+        private static readonly List<Resolution> _supportedResolutions = new List<Resolution> { Resolution.Hour, Resolution.Daily };
         private TimeSpan _period = TimeSpan.Zero;
         private string _previousContent = string.Empty;
         private DateTime _previousDate = DateTime.MinValue;
@@ -229,14 +231,19 @@ namespace QuantConnect.Data.Custom
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
         /// </summary>
-        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public override Resolution AdjustResolution(Resolution resolution)
+        public override Resolution DefaultResolution()
         {
-            return resolution < Resolution.Hour ? Resolution.Hour : resolution;
+            return Resolution.Hour;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
+        /// </summary>
+        public override List<Resolution> SupportedResolutions()
+        {
+            return _supportedResolutions;
         }
     }
 }

--- a/Common/Data/Custom/USEnergy/USEnergyAPI.cs
+++ b/Common/Data/Custom/USEnergy/USEnergyAPI.cs
@@ -227,5 +227,16 @@ namespace QuantConnect.Data.Custom
 
             return dates[1];
         }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public override Resolution AdjustResolution(Resolution resolution)
+        {
+            return resolution < Resolution.Hour ? Resolution.Hour : resolution;
+        }
     }
 }

--- a/Common/Data/Custom/USTreasury/USTreasuryYieldCurveRate.cs
+++ b/Common/Data/Custom/USTreasury/USTreasuryYieldCurveRate.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -181,14 +182,19 @@ namespace QuantConnect.Data.Custom.USTreasury
         }
 
         /// <summary>
-        /// Will adjust the requested resolution to match a supported one
-        /// for the current data and security type
+        /// Gets the default resolution for this data and security type
         /// </summary>
-        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
-        /// <param name="resolution">The resolution to check support</param>
-        public override Resolution AdjustResolution(Resolution resolution)
+        public override Resolution DefaultResolution()
         {
             return Resolution.Daily;
+        }
+
+        /// <summary>
+        /// Gets the supported resolution for this data and security type
+        /// </summary>
+        public override List<Resolution> SupportedResolutions()
+        {
+            return DailyResolution;
         }
     }
 }

--- a/Common/Data/Custom/USTreasury/USTreasuryYieldCurveRate.cs
+++ b/Common/Data/Custom/USTreasury/USTreasuryYieldCurveRate.cs
@@ -179,5 +179,16 @@ namespace QuantConnect.Data.Custom.USTreasury
                 Symbol = Symbol
             };
         }
+
+        /// <summary>
+        /// Will adjust the requested resolution to match a supported one
+        /// for the current data and security type
+        /// </summary>
+        /// <remarks>Relies on the <see cref="Symbol"/> property value</remarks>
+        /// <param name="resolution">The resolution to check support</param>
+        public override Resolution AdjustResolution(Resolution resolution)
+        {
+            return Resolution.Daily;
+        }
     }
 }

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -50,6 +50,24 @@ namespace QuantConnect
             = new Dictionary<IntPtr, PythonActivator>();
 
         /// <summary>
+        /// Gets a python method by name
+        /// </summary>
+        /// <param name="instance">The object instance to search the method in</param>
+        /// <param name="name">The name of the method</param>
+        /// <returns>The python method or null if not defined or CSharp implemented</returns>
+        public static dynamic GetPythonMethod(this PyObject instance, string name)
+        {
+            using (Py.GIL())
+            {
+                var method = instance.GetAttr(name);
+                var pythonType = method.GetPythonType();
+                var isPythonDefined = pythonType.Repr().Equals("<class \'method\'>");
+
+                return isPythonDefined ? method : null;
+            }
+        }
+
+        /// <summary>
         /// Given a type will create a new instance using the parameterless constructor
         /// and assert the type implements <see cref="BaseData"/>
         /// </summary>

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -532,7 +532,7 @@ namespace QuantConnect.Interfaces
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice.</param>
         /// <param name="leverage">leverage for this security</param>
         /// <param name="extendedMarketHours">ExtendedMarketHours send in data from 4am - 8pm, not used for FOREX</param>
-        Security AddSecurity(SecurityType securityType, string symbol, Resolution resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours);
+        Security AddSecurity(SecurityType securityType, string symbol, Resolution? resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours);
 
         /// <summary>
         /// Creates and adds a new single <see cref="Future"/> contract to the algorithm
@@ -542,7 +542,7 @@ namespace QuantConnect.Interfaces
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Future"/> security</returns>
-        Future AddFutureContract(Symbol symbol, Resolution resolution = Resolution.Minute, bool fillDataForward = true, decimal leverage = 0m);
+        Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = 0m);
 
         /// <summary>
         /// Creates and adds a new single <see cref="Option"/> contract to the algorithm
@@ -552,7 +552,7 @@ namespace QuantConnect.Interfaces
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Option"/> security</returns>
-        Option AddOptionContract(Symbol symbol, Resolution resolution = Resolution.Minute, bool fillDataForward = true, decimal leverage = 0m);
+        Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = 0m);
 
         /// <summary>
         /// Removes the security with the specified symbol. This will cancel all

--- a/Common/Interfaces/ISubscriptionDataConfigService.cs
+++ b/Common/Interfaces/ISubscriptionDataConfigService.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Interfaces
         SubscriptionDataConfig Add(
             Type dataType,
             Symbol symbol,
-            Resolution resolution,
+            Resolution? resolution = null,
             bool fillForward = true,
             bool extendedMarketHours = false,
             bool isFilteredSubscription = true,
@@ -50,7 +50,7 @@ namespace QuantConnect.Interfaces
         /// </summary>
         List<SubscriptionDataConfig> Add(
             Symbol symbol,
-            Resolution resolution,
+            Resolution? resolution = null,
             bool fillForward = true,
             bool extendedMarketHours = false,
             bool isFilteredSubscription = true,

--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -33,11 +33,6 @@ namespace QuantConnect.Orders.Fees
         private readonly Dictionary<string, Func<decimal, decimal, CashAmount>> _optionFee =
             new Dictionary<string, Func<decimal, decimal, CashAmount>>();
 
-        private readonly Dictionary<string, EquityFee> _equityFee =
-            new Dictionary<string, EquityFee> {
-                { Market.USA, new EquityFee("USD", feePerShare: 0.005m, minimumFee: 1, maximumFeeRate: 0.005m) }
-            };
-
         private readonly Dictionary<string, CashAmount> _futureFee =
             //                                                               IB fee + exchange fee
             new Dictionary<string, CashAmount> { { Market.USA, new CashAmount(0.85m + 1, "USD") } };
@@ -126,9 +121,13 @@ namespace QuantConnect.Orders.Fees
 
                 case SecurityType.Equity:
                     EquityFee equityFee;
-                    if (!_equityFee.TryGetValue(market, out equityFee))
+                    switch (market)
                     {
-                        throw new KeyNotFoundException($"InteractiveBrokersFeeModel(): unexpected equity Market {market}");
+                        case Market.USA:
+                            equityFee = new EquityFee("USD", feePerShare: 0.005m, minimumFee: 1, maximumFeeRate: 0.005m);
+                            break;
+                        default:
+                            throw new KeyNotFoundException($"InteractiveBrokersFeeModel(): unexpected equity Market {market}");
                     }
                     var tradeValue = Math.Abs(order.GetValue(security));
 

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -463,6 +463,10 @@ namespace QuantConnect.Securities
                 foreach (var kvp in Securities)
                 {
                     var security = kvp.Value;
+                    if (security.Holdings.Quantity == 0)
+                    {
+                        continue;
+                    }
                     var context = new ReservedBuyingPowerForPositionParameters(security);
                     var reservedBuyingPower = security.BuyingPowerModel.GetReservedBuyingPowerForPosition(context);
                     sum += reservedBuyingPower.Value;

--- a/Logging/ConsoleLogHandler.cs
+++ b/Logging/ConsoleLogHandler.cs
@@ -56,9 +56,13 @@ namespace QuantConnect.Logging
         /// <param name="text">The error text to log</param>
         public void Error(string text)
         {
+#if DEBUG
             Console.ForegroundColor = ConsoleColor.Red;
+#endif
             _error.WriteLine(DateTime.Now.ToString(_dateFormat, CultureInfo.InvariantCulture) + " ERROR:: " + text);
+#if DEBUG
             Console.ResetColor();
+#endif
         }
 
         /// <summary>

--- a/Logging/QuantConnect.Logging.csproj
+++ b/Logging/QuantConnect.Logging.csproj
@@ -30,13 +30,16 @@
     <DebugType>full</DebugType>
     <Optimize>$(SelectedOptimization)</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\QuantConnect.Logging.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>6</LangVersion>
     <CodeAnalysisRuleSet>..\QuantConnect.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' AND '$(SelectedOptimization)' == ''">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -164,8 +164,8 @@ namespace QuantConnect.Tests.Algorithm
             var symbol2 = Symbol.CreateOption(testHistoryProvider.underlyingSymbol, Market.USA, OptionStyle.American,
                 OptionRight.Put, 1, new DateTime(2015, 12, 24));
 
-            var optionContract = qcAlgorithm.AddOptionContract(symbol, Resolution.Daily);
-            var optionContract2 = qcAlgorithm.AddOptionContract(symbol2, Resolution.Minute);
+            var optionContract = qcAlgorithm.AddOptionContract(symbol);
+            var optionContract2 = qcAlgorithm.AddOptionContract(symbol2);
 
             qcAlgorithm.OnEndOfTimeStep();
             var data = qcAlgorithm.Securities[testHistoryProvider.underlyingSymbol].GetLastData();
@@ -394,7 +394,7 @@ namespace QuantConnect.Tests.Algorithm
             var qcAlgorithm = new QCAlgorithm();
             qcAlgorithm.SubscriptionManager.SetDataManager(new DataManagerStub(qcAlgorithm));
 
-            var asset = qcAlgorithm.AddOption(ticker, Resolution.Daily);
+            var asset = qcAlgorithm.AddOption(ticker);
 
             // Dummy here is meant to try to corrupt the SymbolCache. Ideally, SymbolCache should return non-custom data types with higher priority
             // in case we want to add two custom data types, but still have them associated with the equity from the cache if we're using it.
@@ -427,7 +427,7 @@ namespace QuantConnect.Tests.Algorithm
             var qcAlgorithm = new QCAlgorithm();
             qcAlgorithm.SubscriptionManager.SetDataManager(new DataManagerStub(qcAlgorithm));
 
-            var asset = qcAlgorithm.AddOption(ticker, Resolution.Daily);
+            var asset = qcAlgorithm.AddOption(ticker);
 
             // Dummy here is meant to try to corrupt the SymbolCache. Ideally, SymbolCache should return non-custom data types with higher priority
             // in case we want to add two custom data types, but still have them associated with the equity from the cache if we're using it.
@@ -458,7 +458,7 @@ namespace QuantConnect.Tests.Algorithm
             var qcAlgorithm = new QCAlgorithm();
             qcAlgorithm.SubscriptionManager.SetDataManager(new DataManagerStub(qcAlgorithm));
 
-            var asset = qcAlgorithm.AddOption(ticker, Resolution.Daily);
+            var asset = qcAlgorithm.AddOption(ticker);
 
             // Dummy here is meant to try to corrupt the SymbolCache. Ideally, SymbolCache should return non-custom data types with higher priority
             // in case we want to add two custom data types, but still have them associated with the equity from the cache if we're using it.

--- a/Tests/Common/Data/Custom/PythonCustomDataTests.cs
+++ b/Tests/Common/Data/Custom/PythonCustomDataTests.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+
+namespace QuantConnect.Tests.Common.Data.Custom
+{
+    [TestFixture]
+    public class PythonCustomDataTests
+    {
+        [TestCase("True", true)]
+        [TestCase("False", false)]
+        public void OverridesIsSparseData(string value, bool booleanValue)
+        {
+            dynamic instance;
+            using (Py.GIL())
+            {
+                PyObject test = PythonEngine.ModuleFromString("testModule",
+                    @"
+from clr import AddReference
+AddReference(""System"")
+AddReference(""QuantConnect.Common"")
+
+from QuantConnect.Python import *
+
+class Test(PythonData):
+    def IsSparseData(self):
+        return " + $"{value}").GetAttr("Test");
+                instance = test.CreateType().GetBaseDataInstance();
+            }
+
+            Assert.AreEqual(booleanValue, instance.IsSparseData());
+        }
+
+        [Test]
+        public void OverridesAdjustResolution()
+        {
+            dynamic instance;
+            using (Py.GIL())
+            {
+                PyObject test = PythonEngine.ModuleFromString("testModule",
+                    @"
+from clr import AddReference
+AddReference(""System"")
+AddReference(""QuantConnect.Common"")
+
+from QuantConnect import *
+from QuantConnect.Python import *
+
+class Test(PythonData):
+    def AdjustResolution(self, resolution):
+        return Resolution.Tick").GetAttr("Test");
+                instance = test.CreateType().GetBaseDataInstance();
+            }
+
+            Assert.AreEqual(Resolution.Tick, instance.AdjustResolution(Resolution.Daily));
+        }
+    }
+}

--- a/Tests/Common/Securities/SecurityServiceTests.cs
+++ b/Tests/Common/Securities/SecurityServiceTests.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var optionSymbol = Symbol.Create("GOOG", SecurityType.Option, Market.USA);
 
-            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(typeof(ZipEntryName), optionSymbol, Resolution.Second, false, false, false);
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(typeof(ZipEntryName), optionSymbol, Resolution.Minute, false, false, false);
             var option = _securityService.CreateSecurity(optionSymbol, configs, 1.0m, false);
 
             Assert.AreEqual(option.Subscriptions.Count(), 1);
@@ -139,7 +139,7 @@ namespace QuantConnect.Tests.Common.Securities
                 new Tuple<Type, TickType>(typeof(OpenInterest), TickType.OpenInterest)
             };
 
-            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(optionSymbol, Resolution.Second, false, false, false, false, false, subscriptionTypes);
+            var configs = _subscriptionManager.SubscriptionDataConfigService.Add(optionSymbol, Resolution.Minute, false, false, false, false, false, subscriptionTypes);
             var security = _securityService.CreateSecurity(optionSymbol, configs, 1.0m, false);
 
             Assert.IsFalse(optionSymbol.IsCanonical());

--- a/Tests/Engine/DataFeeds/DataManagerStub.cs
+++ b/Tests/Engine/DataFeeds/DataManagerStub.cs
@@ -38,8 +38,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
         }
 
-        public DataManagerStub(IAlgorithm algorithm, IDataFeed dataFeed)
-            : this(dataFeed, algorithm, new TimeKeeper(DateTime.UtcNow, TimeZones.NewYork))
+        public DataManagerStub(IAlgorithm algorithm, IDataFeed dataFeed, bool liveMode = false)
+            : this(dataFeed, algorithm, new TimeKeeper(DateTime.UtcNow, TimeZones.NewYork), liveMode)
         {
 
         }
@@ -62,30 +62,31 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
         }
 
-        public DataManagerStub(IDataFeed dataFeed, IAlgorithm algorithm, ITimeKeeper timeKeeper)
-            : this(dataFeed, algorithm, timeKeeper, MarketHoursDatabase.FromDataFolder(), SymbolPropertiesDatabase.FromDataFolder())
+        public DataManagerStub(IDataFeed dataFeed, IAlgorithm algorithm, ITimeKeeper timeKeeper, bool liveMode = false)
+            : this(dataFeed, algorithm, timeKeeper, MarketHoursDatabase.FromDataFolder(), SymbolPropertiesDatabase.FromDataFolder(), liveMode)
         {
 
         }
 
-        public DataManagerStub(IDataFeed dataFeed, IAlgorithm algorithm, ITimeKeeper timeKeeper, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase)
-            : this(dataFeed, algorithm, timeKeeper, marketHoursDatabase, symbolPropertiesDatabase,
+        public DataManagerStub(IDataFeed dataFeed, IAlgorithm algorithm, ITimeKeeper timeKeeper, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase, bool liveMode = false)
+            : this(dataFeed, algorithm, timeKeeper, marketHoursDatabase,
                 new SecurityService(algorithm.Portfolio.CashBook,
                     marketHoursDatabase,
                     symbolPropertiesDatabase,
                     algorithm,
                     RegisteredSecurityDataTypesProvider.Null,
-                    new SecurityCacheProvider(algorithm.Portfolio)))
+                    new SecurityCacheProvider(algorithm.Portfolio)),
+                liveMode)
         {
         }
 
-        public DataManagerStub(IDataFeed dataFeed, IAlgorithm algorithm, ITimeKeeper timeKeeper, MarketHoursDatabase marketHoursDatabase, SymbolPropertiesDatabase symbolPropertiesDatabase, SecurityService securityService)
+        public DataManagerStub(IDataFeed dataFeed, IAlgorithm algorithm, ITimeKeeper timeKeeper, MarketHoursDatabase marketHoursDatabase, SecurityService securityService, bool liveMode = false)
             : base(dataFeed,
                 new UniverseSelection(algorithm, securityService),
                 algorithm,
                 timeKeeper,
                 marketHoursDatabase,
-                false,
+                liveMode,
                 RegisteredSecurityDataTypesProvider.Null)
         {
             SecurityService = securityService;

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -376,7 +376,7 @@ namespace QuantConnect.Tests.Engine.Setup
             public TestAlgorithm(Action beforePostInitializeAction = null)
             {
                 _beforePostInitializeAction = beforePostInitializeAction;
-                SubscriptionManager.SetDataManager(new DataManagerStub(this, new MockDataFeed()));
+                SubscriptionManager.SetDataManager(new DataManagerStub(this, new MockDataFeed(), liveMode:true));
             }
 
             public override void Initialize() { }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -300,6 +300,7 @@
     <Compile Include="Common\Data\BaseDataTests.cs" />
     <Compile Include="Common\Data\CalendarConsolidatorsTests.cs" />
     <Compile Include="Common\Data\Custom\FredApiTest.cs" />
+    <Compile Include="Common\Data\Custom\PythonCustomDataTests.cs" />
     <Compile Include="Common\Data\Custom\SECReportTests.cs" />
     <Compile Include="Common\Data\Custom\SmartInsiderTests.cs" />
     <Compile Include="Common\Data\Custom\EstimizeTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding `DefaultResolution` and `SupportedResolutions`. This allows us to set a limitation which is useful to avoid invalid data requests or unnecessary fill forward situations.
- Making `Resolution` nullable for `Algorithm.AddData` methods
- The `ISubscriptionDataConfigService` will set the default resolution
if none was provided and assert it is supported
- Fix bug with `PythonData` `IsSparseData` and `RequiresMapping`
- Adding unit and regression test
- Updating example algorithms custom data resolution
- Some performance improvements. Wont change console color if
`SelectedOptimization` is defined

> Tested with algorithm https://www.quantconnect.com/forum/discussion/6770/slow-truncated-backtest-when-non-price-data-is-used/p1/comment-19298

`master`
271.67 seconds at 5k data points per second. Processing total of 1,340,946 data points.
`pr`
3.12 seconds at 2k data points per second. Processing total of 6,305 data points.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3772
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve performance for custom data
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests. Cloud backtesting.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->