### PR TITLE
Updates AlphaStreamsBrokerageModel Leverage

### DIFF
--- a/Common/Brokerages/AlphaStreamsBrokerageModel.cs
+++ b/Common/Brokerages/AlphaStreamsBrokerageModel.cs
@@ -53,13 +53,13 @@ namespace QuantConnect.Brokerages
         /// <returns></returns>
         public override ISlippageModel GetSlippageModel(Security security) => new AlphaStreamsSlippageModel();
         /// <summary>
-        /// Force all security types to be restricted to 1x leverage
-        ///     - Current restriction to 1x is for the AS competition
+        /// Force all security types to be restricted to 1.1x leverage
+        ///     - Current restriction to 1.1x is for the AS competition
         ///     - Will be update in the future
         /// </summary>
         /// <param name="security"></param>
         /// <returns></returns>
-        public override decimal GetLeverage(Security security) => 1m;
+        public override decimal GetLeverage(Security security) => 1.1m;
         /// <summary>
         /// Gets a new settlement model
         /// </summary>


### PR DESCRIPTION
#### Description
Increases leverage value to 1.1 from 1 at `AlphaStreamsBrokerageModel.GetLeverage`.

#### Related Issue
Closes #3776 
Avoids the insufficient margin issue.

#### Requires Documentation Change
N/A. 

#### How Has This Been Tested?
Running the following example algorithm:
[From Research to Production Mean Reversion](https://www.quantconnect.com/forum/discussion/6740/from-research-to-production-mean-reversion)
[From Research to Production Random Forest Regression](https://www.quantconnect.com/forum/discussion/6743/from-research-to-production-random-forest-regression)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`