### PR TITLE
Add streaming custom data support to LiveTradingDataFeed

### DIFF
--- a/Common/Data/Custom/PsychSignal/PsychSignalSentiment.cs
+++ b/Common/Data/Custom/PsychSignal/PsychSignalSentiment.cs
@@ -84,8 +84,7 @@ namespace QuantConnect.Data.Custom.PsychSignal
         {
             if (isLiveMode)
             {
-                // this data type is streamed in live mode
-                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.Streaming);
+                throw new InvalidOperationException();
             }
 
             return new SubscriptionDataSource(

--- a/Common/Data/Custom/PsychSignal/PsychSignalSentiment.cs
+++ b/Common/Data/Custom/PsychSignal/PsychSignalSentiment.cs
@@ -82,6 +82,12 @@ namespace QuantConnect.Data.Custom.PsychSignal
         /// <returns></returns>
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
+            if (isLiveMode)
+            {
+                // this data type is streamed in live mode
+                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.Streaming);
+            }
+
             return new SubscriptionDataSource(
                 Path.Combine(
                     Globals.DataFolder,

--- a/Common/Data/Custom/Tiingo/TiingoNews.cs
+++ b/Common/Data/Custom/Tiingo/TiingoNews.cs
@@ -102,6 +102,12 @@ namespace QuantConnect.Data.Custom.Tiingo
         /// <returns>The <see cref="SubscriptionDataSource"/> instance to use</returns>
         public override SubscriptionDataSource GetSourceForAnIndex(SubscriptionDataConfig config, DateTime date, string index, bool isLiveMode)
         {
+            if (isLiveMode)
+            {
+                // this data type is streamed in live mode
+                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.Streaming);
+            }
+
             var source = Path.Combine(
                 Globals.DataFolder,
                 "alternative",

--- a/Common/Data/Custom/Tiingo/TiingoNews.cs
+++ b/Common/Data/Custom/Tiingo/TiingoNews.cs
@@ -132,12 +132,8 @@ namespace QuantConnect.Data.Custom.Tiingo
         {
             if (isLiveMode)
             {
-                var tiingoTicker = TiingoSymbolMapper.GetTiingoTicker(config.Symbol);
-                var url = Invariant($"https://api.tiingo.com/tiingo/news?tickers={tiingoTicker}&startDate={date:yyyy-MM-dd}&token={Tiingo.AuthCode}&sortBy=crawlDate");
-
-                return new SubscriptionDataSource(url,
-                    SubscriptionTransportMedium.Rest,
-                    FileFormat.Collection);
+                // this data type is streamed in live mode
+                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.Streaming);
             }
 
             var source = Path.Combine(

--- a/Common/Data/Market/OpenInterest.cs
+++ b/Common/Data/Market/OpenInterest.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -80,13 +80,13 @@ namespace QuantConnect.Data.Market
 
             Time = (config.Resolution == Resolution.Daily || config.Resolution == Resolution.Hour) ?
                 // hourly and daily have different time format, and can use slow, robust c# parser.
-                DateTime.ParseExact(csv[0], DateFormat.TwelveCharacter, 
+                DateTime.ParseExact(csv[0], DateFormat.TwelveCharacter,
                     System.Globalization.CultureInfo.InvariantCulture)
                     .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone)
                 :
                 // Using custom "ToDecimal" conversion for speed on high resolution data.
                 baseDate.Date.AddMilliseconds(csv[0].ToInt32()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
-            
+
             Value = csv[1].ToDecimal();
         }
 
@@ -131,8 +131,8 @@ namespace QuantConnect.Data.Market
         {
             if (isLiveMode)
             {
-                // Currently ticks aren't sourced through GetSource in live mode
-                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.LocalFile);
+                // this data type is streamed in live mode
+                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.Streaming);
             }
 
             var source = LeanData.GenerateZipFilePath(Globals.DataFolder, config.Symbol, date, config.Resolution, config.TickType);

--- a/Common/Data/Market/QuoteBar.cs
+++ b/Common/Data/Market/QuoteBar.cs
@@ -511,7 +511,8 @@ namespace QuantConnect.Data.Market
         {
             if (isLiveMode)
             {
-                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.LocalFile);
+                // this data type is streamed in live mode
+                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.Streaming);
             }
 
             var source = LeanData.GenerateZipFilePath(Globals.DataFolder, config.Symbol, date, config.Resolution, config.TickType);

--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -377,8 +377,8 @@ namespace QuantConnect.Data.Market
         {
             if (isLiveMode)
             {
-                // Currently ticks aren't sourced through GetSource in live mode
-                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.LocalFile);
+                // this data type is streamed in live mode
+                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.Streaming);
             }
 
             var source = LeanData.GenerateZipFilePath(Globals.DataFolder, config.Symbol, date, config.Resolution, config.TickType);

--- a/Common/Data/Market/TradeBar.cs
+++ b/Common/Data/Market/TradeBar.cs
@@ -592,7 +592,8 @@ namespace QuantConnect.Data.Market
         {
             if (isLiveMode)
             {
-                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.LocalFile);
+                // this data type is streamed in live mode
+                return new SubscriptionDataSource(string.Empty, SubscriptionTransportMedium.Streaming);
             }
 
             var source = LeanData.GenerateZipFilePath(Globals.DataFolder, config.Symbol, date, config.Resolution, config.TickType);

--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -582,7 +582,12 @@ namespace QuantConnect
         /// <summary>
         /// The subscription's data comes from a rest call that is polled and returns a single line/data point of information
         /// </summary>
-        Rest
+        Rest,
+
+        /// <summary>
+        /// The subscription's data is streamed
+        /// </summary>
+        Streaming
     }
 
     /// <summary>

--- a/Common/Packets/LiveNodePacket.cs
+++ b/Common/Packets/LiveNodePacket.cs
@@ -49,6 +49,12 @@ namespace QuantConnect.Packets
         public string DataQueueHandler = "";
 
         /// <summary>
+        /// String name of the DataChannelProvider we're running with
+        /// </summary>
+        [JsonProperty(PropertyName = "sDataChannelProvider")]
+        public string DataChannelProvider = "";
+
+        /// <summary>
         /// Gets flag indicating whether or not the message should be acknowledged and removed from the queue
         /// </summary>
         [JsonProperty(PropertyName = "DisableAcknowledgement")]

--- a/Engine/DataFeeds/DataChannelProvider.cs
+++ b/Engine/DataFeeds/DataChannelProvider.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Data;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// Specifies data channel settings
+    /// </summary>
+    public class DataChannelProvider : IDataChannelProvider
+    {
+        /// <summary>
+        /// True if this subscription request should be streamed
+        /// </summary>
+        public virtual bool ShouldStreamSubscription(SubscriptionDataConfig config)
+        {
+            return IsStreamingType(config) || !config.IsCustomData;
+        }
+
+        /// <summary>
+        /// Returns true if the data type for the given subscription configuration supports streaming
+        /// </summary>
+        protected static bool IsStreamingType(SubscriptionDataConfig configuration)
+        {
+            var dataTypeInstance = configuration.Type.GetBaseDataInstance();
+            return dataTypeInstance.GetSource(configuration, DateTime.UtcNow, true)
+                       .TransportMedium == SubscriptionTransportMedium.Streaming;
+        }
+    }
+}

--- a/Engine/DataFeeds/IDataChannelProvider.cs
+++ b/Engine/DataFeeds/IDataChannelProvider.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+
+using QuantConnect.Data;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// Specifies data channel settings
+    /// </summary>
+    public interface IDataChannelProvider
+    {
+        /// <summary>
+        /// True if this subscription configuration should be streamed
+        /// </summary>
+        bool ShouldStreamSubscription(SubscriptionDataConfig config);
+    }
+}

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -172,6 +172,8 @@
     <Compile Include="DataFeeds\CachingFutureChainProvider.cs" />
     <Compile Include="DataFeeds\CachingOptionChainProvider.cs" />
     <Compile Include="DataFeeds\CurrencySubscriptionDataConfigManager.cs" />
+    <Compile Include="DataFeeds\DataChannelProvider.cs" />
+    <Compile Include="DataFeeds\IDataChannelProvider.cs" />
     <Compile Include="DataFeeds\IndexSubscriptionDataSourceReader.cs" />
     <Compile Include="DataFeeds\DataManager.cs" />
     <Compile Include="DataFeeds\Enumerators\DelistingEventProvider.cs" />

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -40,6 +40,7 @@
   "factor-file-provider": "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider",
   "data-provider": "QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider",
   "alpha-handler": "QuantConnect.Lean.Engine.Alphas.DefaultAlphaHandler",
+  "data-channel-provider": "DataChannelProvider",
 
   // limits on number of symbols to allow
   "symbol-minute-limit": 10000,

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -35,6 +35,7 @@ namespace QuantConnect.Queues
         private const string PaperBrokerageTypeName = "PaperBrokerage";
         private const string DefaultHistoryProvider = "SubscriptionDataReaderHistoryProvider";
         private const string DefaultDataQueueHandler = "LiveDataQueue";
+        private const string DefaultDataChannelProvider = "DataChannelProvider";
         private bool _liveMode = Config.GetBool("live-mode");
         private static readonly string AccessToken = Config.Get("api-access-token");
         private static readonly int UserId = Config.GetInt("job-user-id", 0);
@@ -119,6 +120,7 @@ namespace QuantConnect.Queues
                     Brokerage = Config.Get("live-mode-brokerage", PaperBrokerageTypeName),
                     HistoryProvider = Config.Get("history-provider", DefaultHistoryProvider),
                     DataQueueHandler = Config.Get("data-queue-handler", DefaultDataQueueHandler),
+                    DataChannelProvider = Config.Get("data-channel-provider", DefaultDataChannelProvider),
                     Channel = AccessToken,
                     UserToken = AccessToken,
                     UserId = UserId,

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -1218,57 +1218,57 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             // Equity - Hourly resolution
             // We expect 7 hourly bars for 6.5 hours in open market hours
             // We expect only 1 dividend at midnight
-            new TestCaseData(Symbols.SPY, Resolution.Hour, 1, 0, 7, 0, 1),
+            new TestCaseData(Symbols.SPY, Resolution.Hour, 1, 0, 7, 0, 1, 0),
 
             // Equity - Minute resolution
             // We expect 30 minute bars for 0.5 hours in open market hours
-            new TestCaseData(Symbols.SPY, Resolution.Minute, 1, 0, (int)(0.5 * 60), 0, 0),
+            new TestCaseData(Symbols.SPY, Resolution.Minute, 1, 0, (int)(0.5 * 60), 0, 0, 0),
 
             // Equity - Tick resolution
             // In this test we only emit ticks once per hour
             // We expect only 6 ticks -- the 4 PM tick is not received because it's outside market hours
             // We expect only 1 dividend at midnight
-            new TestCaseData(Symbols.SPY, Resolution.Tick, 1, 7 - 1, 0, 0, 1),
+            new TestCaseData(Symbols.SPY, Resolution.Tick, 1, 7 - 1, 0, 0, 1, 0),
 
             // Forex - FXCM
-            new TestCaseData(Symbols.EURUSD, Resolution.Hour, 1, 0, 0, 24, 0),
-            new TestCaseData(Symbols.EURUSD, Resolution.Minute, 1, 0, 0, 1 * 60, 0),
-            new TestCaseData(Symbols.EURUSD, Resolution.Tick, 1, 24, 0, 0, 0),
+            new TestCaseData(Symbols.EURUSD, Resolution.Hour, 1, 0, 0, 24, 0, 0),
+            new TestCaseData(Symbols.EURUSD, Resolution.Minute, 1, 0, 0, 1 * 60, 0, 0),
+            new TestCaseData(Symbols.EURUSD, Resolution.Tick, 1, 24, 0, 0, 0, 0),
 
             // Forex - Oanda
-            new TestCaseData(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), Resolution.Hour, 1, 0, 0, 24, 0),
-            new TestCaseData(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), Resolution.Minute, 1, 0, 0, 1 * 60, 0),
-            new TestCaseData(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), Resolution.Tick, 1, 24, 0, 0, 0),
+            new TestCaseData(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), Resolution.Hour, 1, 0, 0, 24, 0, 0),
+            new TestCaseData(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), Resolution.Minute, 1, 0, 0, 1 * 60, 0, 0),
+            new TestCaseData(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), Resolution.Tick, 1, 24, 0, 0, 0, 0),
 
             // CFD - FXCM
-            new TestCaseData(Symbols.DE30EUR, Resolution.Hour, 1, 0, 0, 14, 0),
-            new TestCaseData(Symbols.DE30EUR, Resolution.Minute, 1, 0, 0, 1 * 60, 0),
-            new TestCaseData(Symbols.DE30EUR, Resolution.Tick, 1, 14, 0, 0, 0),
+            new TestCaseData(Symbols.DE30EUR, Resolution.Hour, 1, 0, 0, 14, 0, 0),
+            new TestCaseData(Symbols.DE30EUR, Resolution.Minute, 1, 0, 0, 1 * 60, 0, 0),
+            new TestCaseData(Symbols.DE30EUR, Resolution.Tick, 1, 14, 0, 0, 0, 0),
 
             // CFD - Oanda
-            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda), Resolution.Hour, 1, 0, 0, 14, 0),
-            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda), Resolution.Minute, 1, 0, 0, 1 * 60, 0),
-            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda), Resolution.Tick, 1, 14, 0, 0, 0),
+            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda), Resolution.Hour, 1, 0, 0, 14, 0, 0),
+            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda), Resolution.Minute, 1, 0, 0, 1 * 60, 0, 0),
+            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda), Resolution.Tick, 1, 14, 0, 0, 0, 0),
 
             // Crypto
-            new TestCaseData(Symbols.BTCUSD, Resolution.Hour, 1, 0, 24, 24, 0),
-            new TestCaseData(Symbols.BTCUSD, Resolution.Minute, 1, 0, 1 * 60, 1 * 60, 0),
+            new TestCaseData(Symbols.BTCUSD, Resolution.Hour, 1, 0, 24, 24, 0, 0),
+            new TestCaseData(Symbols.BTCUSD, Resolution.Minute, 1, 0, 1 * 60, 1 * 60, 0, 0),
             // x2 because counting trades and quotes
-            new TestCaseData(Symbols.BTCUSD, Resolution.Tick, 1, 24 * 2, 0, 0, 0),
+            new TestCaseData(Symbols.BTCUSD, Resolution.Tick, 1, 24 * 2, 0, 0, 0, 0),
 
             // Futures
             // ES has two session breaks totalling 1h 15m, so total trading hours = 22.75
-            new TestCaseData(Symbols.Future_ESZ18_Dec2018, Resolution.Hour, 1, 0, 23, 23, 0),
-            new TestCaseData(Symbols.Future_ESZ18_Dec2018, Resolution.Minute, 1, 0, 1 * 60, 1 * 60, 0),
+            new TestCaseData(Symbols.Future_ESZ18_Dec2018, Resolution.Hour, 1, 0, 23, 23, 0, 0),
+            new TestCaseData(Symbols.Future_ESZ18_Dec2018, Resolution.Minute, 1, 0, 1 * 60, 1 * 60, 0, 0),
             // x2 because counting trades and quotes
-            new TestCaseData(Symbols.Future_ESZ18_Dec2018, Resolution.Tick, 1, 23 * 2, 0, 0, 0),
+            new TestCaseData(Symbols.Future_ESZ18_Dec2018, Resolution.Tick, 1, 23 * 2, 0, 0, 0, 0),
 
             // Options
-            new TestCaseData(Symbols.SPY_C_192_Feb19_2016, Resolution.Hour, 1, 0, 7, 7, 0),
+            new TestCaseData(Symbols.SPY_C_192_Feb19_2016, Resolution.Hour, 1, 0, 7, 7, 0, 0),
             // We expect 30 minute bars for 0.5 hours in open market hours
-            new TestCaseData(Symbols.SPY_C_192_Feb19_2016, Resolution.Minute, 1, 0, (int)(0.5 * 60), (int)(0.5 * 60), 0),
+            new TestCaseData(Symbols.SPY_C_192_Feb19_2016, Resolution.Minute, 1, 0, (int)(0.5 * 60), (int)(0.5 * 60), 0, 0),
             // x2 because counting trades and quotes
-            new TestCaseData(Symbols.SPY_C_192_Feb19_2016, Resolution.Tick, 1, (7 - 1) * 2, 0, 0, 0),
+            new TestCaseData(Symbols.SPY_C_192_Feb19_2016, Resolution.Tick, 1, (7 - 1) * 2, 0, 0, 0, 0),
 
             // Custom data (streaming)
             new TestCaseData(Symbol.CreateBase(typeof(PsychSignalSentiment), Symbols.AAPL, Market.USA), Resolution.Hour, 1, 0, 0, 0, 0, 24 * 2),
@@ -1285,7 +1285,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             int expectedTradeBarsReceived,
             int expectedQuoteBarsReceived,
             int expectedAuxPointsReceived,
-            int expectedCustomPointsReceived = 0)
+            int expectedCustomPointsReceived)
         {
             // startDate and endDate are in algorithm time zone
             var startDate = new DateTime(2019, 6, 3);

--- a/Tests/Engine/RealTimePriceUpdateTests.cs
+++ b/Tests/Engine/RealTimePriceUpdateTests.cs
@@ -22,13 +22,13 @@ using QuantConnect.Algorithm;
 using QuantConnect.Brokerages;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
-using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Packets;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Common.Securities;
+using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Engine
 {
@@ -142,17 +142,6 @@ namespace QuantConnect.Tests.Engine
             var subscriptionRequest = new SubscriptionRequest(false, null, security, _config, DateTime.MinValue, DateTime.MaxValue);
             var subscription = new Subscription(subscriptionRequest, null, new TimeZoneOffsetProviderNeverOpen());
             Assert.IsTrue(_liveTradingDataFeed.UpdateRealTimePrice(subscription, new TimeZoneOffsetProviderAlwaysOpen(), _exchangeHours));
-        }
-
-        class TestableLiveTradingDataFeed : LiveTradingDataFeed
-        {
-            public bool UpdateRealTimePrice(
-                Subscription subscription,
-                TimeZoneOffsetProvider timeZoneOffsetProvider,
-                SecurityExchangeHours exchangeHours)
-            {
-                return UpdateSubscriptionRealTimePrice(subscription, timeZoneOffsetProvider, exchangeHours, new Tick());
-            }
         }
 
         class TimeZoneOffsetProviderNeverOpen : TimeZoneOffsetProvider


### PR DESCRIPTION

#### Description
- Added `SubscriptionTransportMedium.Streaming`
- Set `SubscriptionTransportMedium.Streaming` in live mode for the following classes:
  - `Tick`, `TradeBar`, `QuoteBar`, `OpenInterest`, `TiingoNews`, `PsychSignalSentiment`
- Updated `LiveTradingDataFeed` to handle streaming of live custom data

#### Related Issue
Closes #3785 

#### Motivation and Context
Enable streaming of custom data in the cloud.

#### Requires Documentation Change
No,

#### How Has This Been Tested?
- New unit tests
- Live algorithm receiving PsychSignal custom data

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`