### PR TITLE
Refactor SynchronizingHistoryProvider

### DIFF
--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -16,13 +16,8 @@
 using System.Collections.Generic;
 using NodaTime;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
-using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
-using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
-using QuantConnect.Securities;
-using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Lean.Engine.HistoricalData
@@ -73,61 +68,6 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             }
 
             return CreateSliceEnumerableFromSubscriptions(subscriptions, sliceTimeZone);
-        }
-
-        /// <summary>
-        /// Creates a subscription to process the history request
-        /// </summary>
-        private static Subscription CreateSubscription(HistoryRequest request, IEnumerable<BaseData> history)
-        {
-            // data reader expects these values in local times
-            var start = request.StartTimeUtc.ConvertFromUtc(request.ExchangeHours.TimeZone);
-            var end = request.EndTimeUtc.ConvertFromUtc(request.ExchangeHours.TimeZone);
-
-            var config = new SubscriptionDataConfig(request.DataType,
-                request.Symbol,
-                request.Resolution,
-                request.DataTimeZone,
-                request.ExchangeHours.TimeZone,
-                request.FillForwardResolution.HasValue,
-                request.IncludeExtendedMarketHours,
-                false,
-                request.IsCustomData,
-                request.TickType,
-                true,
-                request.DataNormalizationMode
-                );
-
-            var security = new Security(
-                request.ExchangeHours,
-                config,
-                new Cash(Currencies.NullCurrency, 0, 1m),
-                SymbolProperties.GetDefault(Currencies.NullCurrency),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null,
-                new SecurityCache()
-            );
-
-            var reader = history.GetEnumerator();
-
-            // optionally apply fill forward behavior
-            if (request.FillForwardResolution.HasValue)
-            {
-                // copy forward Bid/Ask bars for QuoteBars
-                if (request.DataType == typeof(QuoteBar))
-                {
-                    reader = new QuoteBarFillForwardEnumerator(reader);
-                }
-
-                var readOnlyRef = Ref.CreateReadOnly(() => request.FillForwardResolution.Value.ToTimeSpan());
-                reader = new FillForwardEnumerator(reader, security.Exchange, readOnlyRef, security.IsExtendedMarketHours, end, config.Increment, config.DataTimeZone, start);
-            }
-
-            var timeZoneOffsetProvider = new TimeZoneOffsetProvider(security.Exchange.TimeZone, start, end);
-            var subscriptionDataEnumerator = new SubscriptionDataEnumerator(config, security.Exchange.Hours, timeZoneOffsetProvider, reader);
-
-            var subscriptionRequest = new SubscriptionRequest(false, null, security, config, start, end);
-            return new Subscription(subscriptionRequest, subscriptionDataEnumerator, timeZoneOffsetProvider);
         }
     }
 }

--- a/Engine/HistoricalData/SynchronizingHistoryProvider.cs
+++ b/Engine/HistoricalData/SynchronizingHistoryProvider.cs
@@ -18,9 +18,13 @@ using System.Collections.Generic;
 using System.Threading;
 using NodaTime;
 using QuantConnect.Data;
+using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+using QuantConnect.Securities;
+using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.HistoricalData
 {
@@ -91,6 +95,61 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             {
                 subscription.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Creates a subscription to process the history request
+        /// </summary>
+        protected Subscription CreateSubscription(HistoryRequest request, IEnumerable<BaseData> history)
+        {
+            // data reader expects these values in local times
+            var start = request.StartTimeUtc.ConvertFromUtc(request.ExchangeHours.TimeZone);
+            var end = request.EndTimeUtc.ConvertFromUtc(request.ExchangeHours.TimeZone);
+
+            var config = new SubscriptionDataConfig(request.DataType,
+                request.Symbol,
+                request.Resolution,
+                request.DataTimeZone,
+                request.ExchangeHours.TimeZone,
+                request.FillForwardResolution.HasValue,
+                request.IncludeExtendedMarketHours,
+                false,
+                request.IsCustomData,
+                request.TickType,
+                true,
+                request.DataNormalizationMode
+            );
+
+            var security = new Security(
+                request.ExchangeHours,
+                config,
+                new Cash(Currencies.NullCurrency, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.NullCurrency),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+
+            var reader = history.GetEnumerator();
+
+            // optionally apply fill forward behavior
+            if (request.FillForwardResolution.HasValue)
+            {
+                // copy forward Bid/Ask bars for QuoteBars
+                if (request.DataType == typeof(QuoteBar))
+                {
+                    reader = new QuoteBarFillForwardEnumerator(reader);
+                }
+
+                var readOnlyRef = Ref.CreateReadOnly(() => request.FillForwardResolution.Value.ToTimeSpan());
+                reader = new FillForwardEnumerator(reader, security.Exchange, readOnlyRef, security.IsExtendedMarketHours, end, config.Increment, config.DataTimeZone, start);
+            }
+
+            var timeZoneOffsetProvider = new TimeZoneOffsetProvider(security.Exchange.TimeZone, start, end);
+            var subscriptionDataEnumerator = new SubscriptionDataEnumerator(config, security.Exchange.Hours, timeZoneOffsetProvider, reader);
+
+            var subscriptionRequest = new SubscriptionRequest(false, null, security, config, start, end);
+            return new Subscription(subscriptionRequest, subscriptionDataEnumerator, timeZoneOffsetProvider);
         }
     }
 }


### PR DESCRIPTION

#### Description
The `CreateSubscription` method has been moved from the `BrokerageHistoryProvider` to the `SynchronizingHistoryProvider` base class, to enable reuse and avoid code duplication.

#### Related Issue
n/a

#### Motivation and Context
Enable more reuse of `SynchronizingHistoryProvider` with less code duplication.

#### Requires Documentation Change
n/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`