### PR TITLE
Make Consolidators Trigger Deterministically 

### DIFF
--- a/Common/Util/ConcurrentSet.cs
+++ b/Common/Util/ConcurrentSet.cs
@@ -15,23 +15,35 @@
 
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Specialized;
 
 namespace QuantConnect.Util
 {
     /// <summary>
     /// Provides a thread-safe set collection that mimics the behavior of <see cref="HashSet{T}"/>
+    /// and will be keep insertion order
     /// </summary>
     /// <typeparam name="T">The item type</typeparam>
     public class ConcurrentSet<T> : ISet<T>
     {
-        private readonly ConcurrentDictionary<T, T> _set = new ConcurrentDictionary<T, T>();
+        private readonly OrderedDictionary _set = new OrderedDictionary();
+        // for performance we will keep a enumerator list which we will refresh only if required
+        private readonly List<T> _enumerator = new List<T>();
+        private bool _refreshEnumerator;
 
         /// <summary>Gets the number of elements contained in the <see cref="T:System.Collections.Generic.ICollection`1" />.</summary>
         /// <returns>The number of elements contained in the <see cref="T:System.Collections.Generic.ICollection`1" />.</returns>
-        public int Count => _set.Count;
+        public int Count
+        {
+            get
+            {
+                lock (_set)
+                {
+                    return _set.Count;
+                }
+            }
+        }
 
         /// <summary>Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.</summary>
         /// <returns>true if the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only; otherwise, false.</returns>
@@ -47,7 +59,10 @@ namespace QuantConnect.Util
                 throw new ArgumentNullException(nameof(item));
             }
 
-            _set.TryAdd(item, item);
+            lock (_set)
+            {
+                AddImpl(item);
+            }
         }
 
         /// <summary>Modifies the current set so that it contains all elements that are present in either the current set or the specified collection.</summary>
@@ -56,10 +71,15 @@ namespace QuantConnect.Util
         /// <paramref name="other" /> is null.</exception>
         public void UnionWith(IEnumerable<T> other)
         {
-            foreach (var item in other)
+            var otherSet = other.ToHashSet();
+
+            lock (_set)
             {
-                // don't overwrite existing references of same key
-                _set.TryAdd(item, item);
+                foreach (var item in otherSet)
+                {
+                    // wont overwrite existing references of same key
+                    AddImpl(item);
+                }
             }
         }
 
@@ -71,13 +91,16 @@ namespace QuantConnect.Util
         {
             var otherSet = other.ToHashSet();
 
-            // remove items in '_set' that are not in 'other'
-            foreach (var kvp in _set)
+            lock (_set)
             {
-                if (!otherSet.Contains(kvp.Key))
+                // remove items in '_set' that are not in 'other'
+                // enumerating this and not '_set' so its safe to modify
+                foreach (var item in this)
                 {
-                    T value;
-                    _set.TryRemove(kvp.Key, out value);
+                    if (!otherSet.Contains(item))
+                    {
+                        RemoveImpl(item);
+                    }
                 }
             }
         }
@@ -88,11 +111,15 @@ namespace QuantConnect.Util
         /// <paramref name="other" /> is null.</exception>
         public void ExceptWith(IEnumerable<T> other)
         {
-            // remove items from 'other'
-            foreach (var item in other)
+            var otherSet = other.ToHashSet();
+
+            lock (_set)
             {
-                T value;
-                _set.TryRemove(item, out value);
+                // remove items from 'other'
+                foreach (var item in otherSet)
+                {
+                    RemoveImpl(item);
+                }
             }
         }
 
@@ -104,14 +131,15 @@ namespace QuantConnect.Util
         {
             var otherSet = other.ToHashSet();
 
-            foreach (var item in otherSet)
+            lock (_set)
             {
-                T value;
-                // remove items in both collections
-                if (!_set.TryRemove(item, out value))
+                foreach (var item in otherSet)
                 {
-                    // add items only in 'other'
-                    _set[item] = item;
+                    if (!AddImpl(item))
+                    {
+                        // remove items in both collections
+                        RemoveImpl(item);
+                    }
                 }
             }
         }
@@ -123,17 +151,20 @@ namespace QuantConnect.Util
         /// <paramref name="other" /> is null.</exception>
         public bool IsSubsetOf(IEnumerable<T> other)
         {
-            var keys = _set.Keys.ToHashSet();
-            foreach (var item in other)
+            var otherSet = other.ToHashSet();
+            lock (_set)
             {
-                if (!_set.ContainsKey(item))
+                foreach (var item in otherSet)
                 {
-                    return false;
+                    if (!_set.Contains(item))
+                    {
+                        return false;
+                    }
                 }
-            }
 
-            // non-strict subset can be equal
-            return keys.Count == 0;
+                // non-strict subset can be equal
+                return _set.Keys.Count == 0;
+            }
         }
 
         /// <summary>Determines whether the current set is a superset of a specified collection.</summary>
@@ -144,11 +175,14 @@ namespace QuantConnect.Util
         public bool IsSupersetOf(IEnumerable<T> other)
         {
             var otherSet = other.ToHashSet();
-            foreach (var kvp in _set)
+            lock (_set)
             {
-                if (!otherSet.Remove(kvp.Key))
+                foreach (DictionaryEntry item in _set)
                 {
-                    return false;
+                    if (!otherSet.Remove((T)item.Key))
+                    {
+                        return false;
+                    }
                 }
             }
 
@@ -165,14 +199,17 @@ namespace QuantConnect.Util
         {
             var hasOther = false;
             var otherSet = other.ToHashSet();
-            foreach (var kvp in _set)
+            lock (_set)
             {
-                if (!otherSet.Remove(kvp.Key))
+                foreach (DictionaryEntry item in _set)
                 {
-                    return false;
-                }
+                    if (!otherSet.Remove((T)item.Key))
+                    {
+                        return false;
+                    }
 
-                hasOther = true;
+                    hasOther = true;
+                }
             }
 
             // to be a strict superset, _set must contain extra elements and contain all of other
@@ -187,19 +224,22 @@ namespace QuantConnect.Util
         public bool IsProperSubsetOf(IEnumerable<T> other)
         {
             var hasOther = false;
-            var keys = _set.Keys.ToHashSet();
-            foreach (var item in other)
+            var otherSet = other.ToHashSet();
+            lock (_set)
             {
-                if (!_set.ContainsKey(item))
+                foreach (var item in otherSet)
                 {
-                    return false;
+                    if (!_set.Contains(item))
+                    {
+                        return false;
+                    }
+
+                    hasOther = true;
                 }
 
-                hasOther = true;
+                // to be a strict subset, other must contain extra elements and _set must contain all of other
+                return hasOther && _set.Keys.Count == 0;
             }
-
-            // to be a strict subset, other must contain extra elements and _set must contain all of other
-            return hasOther && keys.Count == 0;
         }
 
         /// <summary>Determines whether the current set overlaps with the specified collection.</summary>
@@ -209,11 +249,16 @@ namespace QuantConnect.Util
         /// <paramref name="other" /> is null.</exception>
         public bool Overlaps(IEnumerable<T> other)
         {
-            foreach (var item in other)
+            var otherSet = other.ToHashSet();
+
+            lock (_set)
             {
-                if (_set.ContainsKey(item))
+                foreach (var item in otherSet)
                 {
-                    return true;
+                    if (_set.Contains(item))
+                    {
+                        return true;
+                    }
                 }
             }
 
@@ -228,11 +273,14 @@ namespace QuantConnect.Util
         public bool SetEquals(IEnumerable<T> other)
         {
             var otherSet = other.ToHashSet();
-            foreach (var kvp in _set)
+            lock (_set)
             {
-                if (!otherSet.Remove(kvp.Key))
+                foreach (DictionaryEntry item in _set)
                 {
-                    return false;
+                    if (!otherSet.Remove((T) item.Key))
+                    {
+                        return false;
+                    }
                 }
             }
 
@@ -244,14 +292,21 @@ namespace QuantConnect.Util
         /// <param name="item">The element to add to the set.</param>
         bool ISet<T>.Add(T item)
         {
-            return _set.TryAdd(item, item);
+            lock (_set)
+            {
+                return AddImpl(item);
+            }
         }
 
         /// <summary>Removes all items from the <see cref="T:System.Collections.Generic.ICollection`1" />.</summary>
         /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only. </exception>
         public void Clear()
         {
-            _set.Clear();
+            lock (_set)
+            {
+                _refreshEnumerator = true;
+                _set.Clear();
+            }
         }
 
         /// <summary>Determines whether the <see cref="T:System.Collections.Generic.ICollection`1" /> contains a specific value.</summary>
@@ -259,7 +314,10 @@ namespace QuantConnect.Util
         /// <param name="item">The object to locate in the <see cref="T:System.Collections.Generic.ICollection`1" />.</param>
         public bool Contains(T item)
         {
-            return _set.ContainsKey(item);
+            lock (_set)
+            {
+                return item != null && _set.Contains(item);
+            }
         }
 
         /// <summary>Copies the elements of the <see cref="T:System.Collections.Generic.ICollection`1" /> to an <see cref="T:System.Array" />, starting at a particular <see cref="T:System.Array" /> index.</summary>
@@ -272,9 +330,12 @@ namespace QuantConnect.Util
         /// <exception cref="T:System.ArgumentException">The number of elements in the source <see cref="T:System.Collections.Generic.ICollection`1" /> is greater than the available space from <paramref name="arrayIndex" /> to the end of the destination <paramref name="array" />.</exception>
         public void CopyTo(T[] array, int arrayIndex)
         {
-            foreach (var kvp in _set)
+            lock (_set)
             {
-                array[arrayIndex++] = kvp.Key;
+                foreach (DictionaryEntry item in _set)
+                {
+                    array[arrayIndex++] = (T) item.Key;
+                }
             }
         }
 
@@ -284,24 +345,64 @@ namespace QuantConnect.Util
         /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.</exception>
         public bool Remove(T item)
         {
-            T value;
-            return _set.TryRemove(item, out value);
+            lock (_set)
+            {
+                if (item != null && _set.Contains(item))
+                {
+                    RemoveImpl(item);
+                    return true;
+                }
+                return false;
+            }
         }
 
         /// <summary>Returns an enumerator that iterates through the collection.</summary>
+        /// <remarks>For thread safety will return a snapshot of the collection</remarks>
         /// <returns>A <see cref="T:System.Collections.Generic.IEnumerator`1" /> that can be used to iterate through the collection.</returns>
         /// <filterpriority>1</filterpriority>
         public IEnumerator<T> GetEnumerator()
         {
-            return _set.Select(kvp => kvp.Key).GetEnumerator();
+            lock (_set)
+            {
+                if (_refreshEnumerator)
+                {
+                    _enumerator.Clear();
+                    foreach (DictionaryEntry item in _set)
+                    {
+                        _enumerator.Add((T)item.Key);
+                    }
+
+                    _refreshEnumerator = false;
+                }
+                return _enumerator.GetEnumerator();
+            }
         }
 
         /// <summary>Returns an enumerator that iterates through a collection.</summary>
+        /// <remarks>For thread safety will return a snapshot of the collection</remarks>
         /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
         /// <filterpriority>2</filterpriority>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        private bool AddImpl(T item)
+        {
+            if (!_set.Contains(item))
+            {
+                _refreshEnumerator = true;
+                _set.Add(item, item);
+                return true;
+            }
+
+            return false;
+        }
+
+        private void RemoveImpl(T item)
+        {
+            _refreshEnumerator = true;
+            _set.Remove(item);
         }
     }
 }

--- a/Tests/Common/Util/ConcurrentSetTests.cs
+++ b/Tests/Common/Util/ConcurrentSetTests.cs
@@ -16,6 +16,8 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
 using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Common.Util
@@ -29,7 +31,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 1, 2, 3, 4 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.UnionWith(other); return s; });
+            CompareWithHashSet(set, s => { s.UnionWith(other); return s; });
         }
 
         [Test]
@@ -38,7 +40,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 1, 2, 3, 4 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IntersectWith(other); return s; });
+            CompareWithHashSet(set, s => { s.IntersectWith(other); return s; });
         }
 
         [Test]
@@ -47,7 +49,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 1, 2, 3, 4 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.ExceptWith(other); return s; });
+            CompareWithHashSet(set, s => { s.ExceptWith(other); return s; });
         }
 
         [Test]
@@ -56,7 +58,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 1, 2, 3, 4 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.SymmetricExceptWith(other); return s; });
+            CompareWithHashSet(set, s => { s.SymmetricExceptWith(other); return s; });
         }
 
         [Test]
@@ -65,7 +67,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5, 6 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -74,7 +76,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -83,7 +85,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5, 6, 7 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -92,7 +94,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5, 6 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -101,7 +103,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5, 6, 7 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -110,7 +112,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -119,7 +121,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5, 6, 7 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -128,7 +130,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5, 6 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -137,7 +139,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -146,7 +148,7 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5, 6 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
@@ -155,24 +157,134 @@ namespace QuantConnect.Tests.Common.Util
             var set = new ConcurrentSet<int> { 4, 5 };
             var other = new HashSet<int> { 4, 5, 6 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
         [Test]
         public void Overlaps_Matches_HashSet_False()
         {
             var set = new ConcurrentSet<int> { 4, 5 };
-            var other = new HashSet<int> { 6,7 };
+            var other = new HashSet<int> { 6, 7 };
 
-            CompareWithHashSet(set, other, s => { s.IsSubsetOf(other); return s; });
+            CompareWithHashSet(set, s => { s.IsSubsetOf(other); return s; });
         }
 
-        private void CompareWithHashSet<T>(ConcurrentSet<T> set, HashSet<T> other, Func<ISet<T>, ISet<T>> func)
+        [Test]
+        public void KeepsInsertionOrder_UnionWith()
+        {
+            var set = new ConcurrentSet<int> { 0, 4, 2, 5 };
+            var other = new HashSet<int> { 6, 7, 1, 3 };
+
+            set.UnionWith(other);
+            CollectionAssert.AreEqual(set, new[] { 0, 4, 2, 5, 6, 7, 1, 3 });
+        }
+
+        [Test]
+        public void KeepsInsertionOrder_Add()
+        {
+            var set = new ConcurrentSet<int> { 0, 4, 2, 5 };
+
+            set.Add(-1);
+            set.Add(11);
+            CollectionAssert.AreEqual(set, new[] { 0, 4, 2, 5, -1, 11 });
+        }
+
+        [Test]
+        public void IgnoresDuplicates()
+        {
+            var set = new ConcurrentSet<int> { 0, 4, 2, 5 };
+
+            set.Add(-1);
+            set.Add(-1);
+            set.Add(-1);
+            CollectionAssert.AreEqual(set, new[] { 0, 4, 2, 5, -1 });
+        }
+
+        [Test]
+        public void RemoveItem()
+        {
+            var set = new ConcurrentSet<int> { 0, 4, 2, 5 };
+
+            set.Remove(4);
+            set.Remove(4);
+            CollectionAssert.AreEqual(set, new[] { 0, 2, 5 });
+        }
+
+        [Test]
+        public void ClearCollection()
+        {
+            var set = new ConcurrentSet<int> { 0, 4, 2, 5 };
+
+            set.Clear();
+            CollectionAssert.AreEqual(set, new int[] { });
+        }
+
+        [Test]
+        public void KeepsInsertionOrder_Remove()
+        {
+            var set = new ConcurrentSet<int> { 0, 4, 2, 5 };
+
+            set.Remove(2);
+            CollectionAssert.AreEqual(set, new[] { 0, 4, 5 });
+        }
+
+        [Test]
+        public void KeepsInsertionOrder()
+        {
+            var set = new ConcurrentSet<int> { 0, 4, 2, 5, 6, 7, 1, 3 };
+
+            CollectionAssert.AreEqual(set, new[] { 0, 4, 2, 5, 6, 7, 1, 3 });
+        }
+
+        [Test]
+        public void EnumerableIsThreadSafe()
+        {
+            var set = new ConcurrentSet<int> { 0, 4, 2, 5, 6, 7, 1, 3 };
+
+            foreach (var value in set)
+            {
+                set.Remove(value);
+            }
+        }
+
+        [Test]
+        public void ConsolidatorsEnumeratedInOrder()
+        {
+            var set = new ConcurrentSet<IDataConsolidator>();
+            for (var i = 0; i < 500; i++)
+            {
+                set.Add(new TestConsolidator(i));
+            }
+
+            var j = 0;
+            foreach (var value in set)
+            {
+                Assert.AreEqual(j, (value as TestConsolidator).Id);
+                j++;
+            }
+        }
+
+        private void CompareWithHashSet<T>(ConcurrentSet<T> set, Func<ISet<T>, ISet<T>> func)
         {
             var asHashSet = set.ToHashSet();
             var expected = func(asHashSet);
             var actual = func(set);
             CollectionAssert.AreEquivalent(expected, actual);
+        }
+
+        private class TestConsolidator : PeriodCountConsolidatorBase<QuoteBar, QuoteBar>
+        {
+            public int Id { get; }
+
+            public TestConsolidator(int maxCount) : base(maxCount)
+            {
+                Id = maxCount;
+            }
+
+            protected override void AggregateBar(ref QuoteBar workingBar, QuoteBar data)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `ConcurrentSet` will use a `OrderedDictionary` internally so that items
are ordered deterministically, **respecting insertion order**.
- Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3756
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve user experience
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->