### PR TITLE
Adds New Static Members to LiquidETFUniverse

### DIFF
--- a/Algorithm.CSharp/LiquidETFUniverseFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/LiquidETFUniverseFrameworkAlgorithm.cs
@@ -49,7 +49,6 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(1000000);
 
             // Add a relevant benchmark, with the default being SPY
-            AddEquity("SPY");
             SetBenchmark("SPY");
 
             // Use the Alpha Streams Brokerage Model, developed in conjunction with
@@ -86,7 +85,6 @@ namespace QuantConnect.Algorithm.CSharp
         public override void OnSecuritiesChanged(SecurityChanges changes)
         {
             // Set symbols as the Inverse Energy ETFs
-            _symbols.Clear();
             foreach (var security in changes.AddedSecurities)
             {
                 if (LiquidETFUniverse.Energy.Inverse.Contains(security.Symbol))

--- a/Algorithm.CSharp/LiquidETFUniverseFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/LiquidETFUniverseFrameworkAlgorithm.cs
@@ -1,0 +1,107 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Basic template framework algorithm uses framework components to define the algorithm.
+    /// Liquid ETF Competition template
+    /// </summary>
+    /// <meta name="tag" content="competition" />
+    /// <meta name="tag" content="alpha stream" />
+    /// <meta name="tag" content="using quantconnect" />
+    public class LiquidETFUniverseFrameworkAlgorithm : QCAlgorithm
+    {
+        // List of symbols we want to trade. Set it in OnSecuritiesChanged
+        private readonly List<Symbol> _symbols = new List<Symbol>();
+
+        public override void Initialize()
+        {
+            // Set Start Date so that backtest has 5+ years of data
+            SetStartDate(2014, 11, 1);
+            // No need to set End Date as the final submission will be tested
+            // up until the review date
+
+            // Set $1m Strategy Cash to trade significant AUM
+            SetCash(1000000);
+
+            // Add a relevant benchmark, with the default being SPY
+            AddEquity("SPY");
+            SetBenchmark("SPY");
+
+            // Use the Alpha Streams Brokerage Model, developed in conjunction with
+            // funds to model their actual fees, costs, etc.
+            // Please do not add any additional reality modelling, such as Slippage, Fees, Buying Power, etc.
+            SetBrokerageModel(new AlphaStreamsBrokerageModel());
+
+            // Use the LiquidETFUniverse with minute-resolution data
+            UniverseSettings.Resolution = Resolution.Minute;
+            SetUniverseSelection(new LiquidETFUniverse());
+
+            // Optional
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (_symbols.All(x => Portfolio[x].Invested))
+            {
+                return;
+            }
+
+            var insights = _symbols.Where(x => Securities[x].Price > 0)
+                .Select(x => Insight.Price(x, TimeSpan.FromDays(1), InsightDirection.Up))
+                .ToArray();
+
+            if (insights.Length > 0)
+            {
+                EmitInsights(insights);
+            }
+        }
+
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            // Set symbols as the Inverse Energy ETFs
+            _symbols.Clear();
+            foreach (var security in changes.AddedSecurities)
+            {
+                if (LiquidETFUniverse.Energy.Inverse.Contains(security.Symbol))
+                {
+                    _symbols.Add(security.Symbol);
+                }
+            }
+
+            // Print out the information about the groups
+            Log($"Energy: {LiquidETFUniverse.Energy}");
+            Log($"Metals: {LiquidETFUniverse.Metals}");
+            Log($"Technology: {LiquidETFUniverse.Technology}");
+            Log($"Treasuries: {LiquidETFUniverse.Treasuries}");
+            Log($"Volatility: {LiquidETFUniverse.Volatility}");
+            Log($"SP500Sectors: {LiquidETFUniverse.SP500Sectors}");
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -171,6 +171,7 @@
     <Compile Include="ConfidenceWeightedFrameworkAlgorithm.cs" />
     <Compile Include="FreePortfolioValueRegressionAlgorithm.cs" />
     <Compile Include="LeveragePrecedenceRegressionAlgorithm.cs" />
+    <Compile Include="LiquidETFUniverseFrameworkAlgorithm.cs" />
     <Compile Include="MarginRemainingRegressionAlgorithm.cs" />
     <Compile Include="SetHoldingsMultipleTargetsRegressionAlgorithm.cs" />
     <Compile Include="SmartInsiderDataAlgorithm.cs" />

--- a/Algorithm.Framework/Selection/LiquidETFUniverse.cs
+++ b/Algorithm.Framework/Selection/LiquidETFUniverse.cs
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace QuantConnect.Algorithm.Framework.Selection
@@ -21,103 +21,135 @@ namespace QuantConnect.Algorithm.Framework.Selection
     /// <summary>
     /// Universe Selection Model that adds the following ETFs at their inception date
     /// </summary>
-	public class LiquidETFUniverse : InceptionDateUniverseSelectionModel
+    public class LiquidETFUniverse : InceptionDateUniverseSelectionModel
     {
         /// <summary>
-        /// Initializes a new instance of the EnergyETFUniverse class
+        /// Represents the Energy ETF Category which can be used to access the list of Long and Inverse symbols
+        /// </summary>
+        public static Grouping Energy = new Grouping(
+            new[]
+            {
+                "VDE", "USO", "XES", "XOP", "UNG", "ICLN", "ERX",
+                "UCO", "AMJ", "BNO", "AMLP", "DGAZ", "TAN"
+            },
+            new[] {"ERY", "SCO", "UGAZ"}
+        );
+
+        /// <summary>
+        /// Represents the Metals ETF Category which can be used to access the list of Long and Inverse symbols
+        /// </summary>
+        public static Grouping Metals = new Grouping(
+            new[] {"GLD", "IAU", "SLV", "GDX", "AGQ", "PPLT", "NUGT", "USLV", "UGLD", "JNUG"},
+            new[] {"DUST", "JDST"}
+        );
+
+        /// <summary>
+        /// Represents the Technology ETF Category which can be used to access the list of Long and Inverse symbols
+        /// </summary>
+        public static Grouping Technology = new Grouping(
+            new[] {"QQQ", "IGV", "QTEC", "FDN", "FXL", "TECL", "SOXL", "SKYY", "KWEB"},
+            new[] {"TECS", "SOXS"}
+        );
+
+        /// <summary>
+        /// Represents the Treasuries ETF Category which can be used to access the list of Long and Inverse symbols
+        /// </summary>
+        public static Grouping Treasuries = new Grouping(
+            new[]
+            {
+                "IEF", "SHY", "TLT", "IEI", "SHV", "TLH", "BIL", "SPTL",
+                "TBT", "TMF", "TBF", "SCHO", "SCHR", "SPTS", "GOVT"
+            },
+            new[] { "TMV" }
+        );
+
+        /// <summary>
+        /// Represents the Volatility ETF Category which can be used to access the list of Long and Inverse symbols
+        /// </summary>
+        public static Grouping Volatility = new Grouping(
+            new[] {"VIXY", "SPLV", "UVXY", "EEMV", "EFAV", "USMV"},
+            new[] {"TVIX", "SVXY"}
+        );
+
+        /// <summary>
+        /// Represents the SP500 Sectors ETF Category which can be used to access the list of Long and Inverse symbols
+        /// </summary>
+        public static Grouping SP500Sectors = new Grouping(
+            new[] {"XLB", "XLE", "XLF", "XLI", "XLK", "XLP", "XLU", "XLV", "XLY"},
+            new string[0]
+        );
+
+        /// <summary>
+        /// Initializes a new instance of the LiquidETFUniverse class
         /// </summary>
         public LiquidETFUniverse() :
             base(
                 "qc-liquid-etf-basket",
-                new Dictionary<string, DateTime>()
-                {
-                    // Energy
-                    {"VDE", new DateTime(2004, 9, 29)},
-                    {"USO", new DateTime(2006, 4, 10)},
-                    {"XES", new DateTime(2006, 6, 22)},
-                    {"XOP", new DateTime(2006, 6, 22)},
-                    {"UNG", new DateTime(2007, 4, 18)},
-                    {"ICLN", new DateTime(2008, 6, 25)},
-                    {"ERX", new DateTime(2008, 11, 6)},
-                    {"ERY", new DateTime(2008, 11, 6)},
-                    {"SCO", new DateTime(2008, 11, 25)},
-                    {"UCO", new DateTime(2008, 11, 25)},
-                    {"AMJ", new DateTime(2009, 6, 2)},
-                    {"BNO", new DateTime(2010, 6, 2)},
-                    {"AMLP", new DateTime(2010, 8, 25)},
-                    {"DGAZ", new DateTime(2012, 2, 8)},
-                    {"UGAZ", new DateTime(2012, 2, 8)},
-                    {"TAN", new DateTime(2012, 2, 15)},
-
-                    // Metals
-                    {"GLD", new DateTime(2004, 11, 18)},
-                    {"IAU", new DateTime(2005, 1, 28)},
-                    {"SLV", new DateTime(2006, 4, 28)},
-                    {"GDX", new DateTime(2006, 5, 22)},
-                    {"AGQ", new DateTime(2008, 12, 4)},
-                    {"PPLT", new DateTime(2010, 1, 8)},
-                    {"NUGT", new DateTime(2010, 12, 8)},
-                    {"DUST", new DateTime(2010, 12, 8)},
-                    {"USLV", new DateTime(2011, 10, 17)},
-                    {"UGLD", new DateTime(2011, 10, 17)},
-                    {"JNUG", new DateTime(2013, 10, 3)},
-                    {"JDST", new DateTime(2013, 10, 3)},
-
-                    // Technology
-                    {"QQQ", new DateTime(1999, 3, 10)},
-                    {"IGV", new DateTime(2001, 7, 13)},
-                    {"QTEC", new DateTime(2006, 4, 25)},
-                    {"FDN", new DateTime(2006, 6, 23)},
-                    {"FXL", new DateTime(2007, 5, 10)},
-                    {"TECL", new DateTime(2008, 12, 17)},
-                    {"TECS", new DateTime(2008, 12, 17)},
-                    {"SOXL", new DateTime(2010, 3, 11)},
-                    {"SOXS", new DateTime(2010, 3, 11)},
-                    {"SKYY", new DateTime(2011, 7, 6)},
-                    {"KWEB", new DateTime(2013, 8, 1)},
-
-                    // US Treasuries
-                    {"IEF", new DateTime(2002, 7, 26)},
-                    {"SHY", new DateTime(2002, 7, 26)},
-                    {"TLT", new DateTime(2002, 7, 26)},
-                    {"IEI", new DateTime(2007, 1, 11)},
-                    {"SHV", new DateTime(2007, 1, 11)},
-                    {"TLH", new DateTime(2007, 1, 11)},
-                    {"BIL", new DateTime(2007, 5, 30)},
-                    {"SPTL", new DateTime(2007, 5, 30)},
-                    {"TBT", new DateTime(2008, 5, 1)},
-                    {"TMF", new DateTime(2009, 4, 16)},
-                    {"TMV", new DateTime(2009, 4, 16)},
-                    {"TBF", new DateTime(2009, 8, 20)},
-                    {"SCHO", new DateTime(2010, 8, 6)},
-                    {"SCHR", new DateTime(2010, 8, 6)},
-                    {"SPTS", new DateTime(2011, 12, 1)},
-                    {"GOVT", new DateTime(2012, 2, 24)},
-
-                    // Volatility
-                    {"TVIX", new DateTime(2010, 11, 30)},
-                    {"VIXY", new DateTime(2011, 1, 4)},
-                    {"SPLV", new DateTime(2011, 5, 5)},
-                    {"SVXY", new DateTime(2011, 10, 4)},
-                    {"UVXY", new DateTime(2011, 10, 4)},
-                    {"EEMV", new DateTime(2011, 10, 20)},
-                    {"EFAV", new DateTime(2011, 10, 20)},
-                    {"USMV", new DateTime(2011, 10, 20)},
-		    
-		    //Sp500 Sectors:
-		    {"XLB", new DateTime(1998, 12, 22)},
-                    {"XLE", new DateTime(1998, 12, 22)},
-                    {"XLF", new DateTime(1998, 12, 22)},
-                    {"XLI", new DateTime(1998, 12, 22)},
-                    {"XLK", new DateTime(1998, 12, 22)},
-                    {"XLP", new DateTime(1998, 12, 22)},
-                    {"XLU", new DateTime(1998, 12, 22)},
-                    {"XLV", new DateTime(1998, 12, 22)},
-                    {"XLY", new DateTime(1998, 12, 22)}
-                }
+                SP500Sectors
+                    .Concat(Energy)
+                    .Concat(Metals)
+                    .Concat(Technology)
+                    .Concat(Treasuries)
+                    .Concat(Volatility)
+                    // Convert the concatenated list of Symbol into a Dictionary of DateTime keyed by Symbol
+                    // For equities, Symbol.ID is the first date the security is traded.
+                    .ToDictionary(x => x.Value, x => x.ID.Date)
             )
         {
 
+        }
+
+        /// <summary>
+        /// Represent a collection of ETF symbols that is grouped according to a given criteria
+        /// </summary>
+        public class Grouping : List<Symbol>
+        {
+            /// <summary>
+            /// List of Symbols that follow the components direction
+            /// </summary>
+            public readonly List<Symbol> Long;
+
+            /// <summary>
+            /// List of Symbols that follow the components inverse direction
+            /// </summary>
+            public readonly List<Symbol> Inverse;
+
+            /// <summary>
+            /// Creates a new instance of <see cref="Grouping"/>.
+            /// </summary>
+            /// <param name="longTickers">List of tickers of ETFs that follows the components direction</param>
+            /// <param name="inverseTickers">List of tickers of ETFs that follows the components inverse direction</param>
+            public Grouping(IEnumerable<string> longTickers, IEnumerable<string> inverseTickers)
+            {
+                Long = longTickers.Select(x => Symbol.Create(x, SecurityType.Equity, Market.USA)).ToList();
+                Inverse = inverseTickers.Select(x => Symbol.Create(x, SecurityType.Equity, Market.USA)).ToList();
+                AddRange(Long);
+                AddRange(Inverse);
+            }
+
+            /// <summary>
+            /// Returns a string that represents the current object.
+            /// </summary>
+            /// <returns>
+            /// A string that represents the current object.
+            /// </returns>
+            public override string ToString()
+            {
+                if (Count == 0)
+                {
+                    return "No Symbols";
+                }
+
+                var longSymbols = Long.Count == 0
+                    ? string.Empty
+                    : $" Long: {string.Join(",", Long.Select(x => x.Value))}";
+
+                var inverseSymbols = Inverse.Count == 0
+                    ? string.Empty
+                    : $" Inverse: {string.Join(",", Inverse.Select(x => x.Value))}";
+
+                return $"{Count} symbols:{longSymbols}{inverseSymbols}";
+            }
         }
     }
 }

--- a/Algorithm.Python/LiquidETFUniverseFrameworkAlgorithm.py
+++ b/Algorithm.Python/LiquidETFUniverseFrameworkAlgorithm.py
@@ -19,16 +19,14 @@ AddReference("QuantConnect.Common")
 
 from System import *
 from QuantConnect import *
-from QuantConnect.Orders import *
-from QuantConnect.Algorithm import *
-from QuantConnect.Algorithm.Framework import *
 from QuantConnect.Algorithm.Framework.Alphas import *
 from QuantConnect.Algorithm.Framework.Execution import *
 from QuantConnect.Algorithm.Framework.Portfolio import *
-from QuantConnect.Algorithm.Framework.Risk import *
 from QuantConnect.Algorithm.Framework.Selection import *
+from QuantConnect.Brokerages import *
+from QuantConnect.Data import *
+from QuantConnect.Data.UniverseSelection import *
 from datetime import timedelta
-import numpy as np
 
 ### <summary>
 ### Basic template framework algorithm uses framework components to define the algorithm.
@@ -50,7 +48,6 @@ class LiquidETFUniverseFrameworkAlgorithm(QCAlgorithm):
         self.SetCash(1000000)
 
         # Add a relevant benchmark, with the default being SPY
-        self.AddEquity('SPY')
         self.SetBenchmark('SPY')
 
         # Use the Alpha Streams Brokerage Model, developed in conjunction with
@@ -70,25 +67,24 @@ class LiquidETFUniverseFrameworkAlgorithm(QCAlgorithm):
         self.symbols = []
 
     def OnData(self, slice):
-        
+
         if all([self.Portfolio[x].Invested for x in self.symbols]):
             return
-        
+
         # Emit insights
         insights = [Insight.Price(x, timedelta(1), InsightDirection.Up)
             for x in self.symbols if self.Securities[x].Price > 0]
-            
+
         if len(insights) > 0:
             self.EmitInsights(insights)
 
     def OnSecuritiesChanged(self, changes):
-        
+
         # Set symbols as the Inverse Energy ETFs
-        self.symbols.clear()
         for security in changes.AddedSecurities:
             if security.Symbol in LiquidETFUniverse.Energy.Inverse:
                 self.symbols.append(security.Symbol)
-        
+
         # Print out the information about the groups
         self.Log(f'Energy: {LiquidETFUniverse.Energy}')
         self.Log(f'Metals: {LiquidETFUniverse.Metals}')

--- a/Algorithm.Python/LiquidETFUniverseFrameworkAlgorithm.py
+++ b/Algorithm.Python/LiquidETFUniverseFrameworkAlgorithm.py
@@ -1,0 +1,98 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from datetime import timedelta
+import numpy as np
+
+### <summary>
+### Basic template framework algorithm uses framework components to define the algorithm.
+### Liquid ETF Competition template
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="using quantconnect" />
+### <meta name="tag" content="trading and orders" />
+class LiquidETFUniverseFrameworkAlgorithm(QCAlgorithm):
+    '''Basic template framework algorithm uses framework components to define the algorithm.'''
+
+    def Initialize(self):
+        # Set Start Date so that backtest has 5+ years of data
+        self.SetStartDate(2014, 11, 1)
+        # No need to set End Date as the final submission will be tested
+        # up until the review date
+
+        # Set $1m Strategy Cash to trade significant AUM
+        self.SetCash(1000000)
+
+        # Add a relevant benchmark, with the default being SPY
+        self.AddEquity('SPY')
+        self.SetBenchmark('SPY')
+
+        # Use the Alpha Streams Brokerage Model, developed in conjunction with
+        # funds to model their actual fees, costs, etc.
+        # Please do not add any additional reality modelling, such as Slippage, Fees, Buying Power, etc.
+        self.SetBrokerageModel(AlphaStreamsBrokerageModel())
+
+        # Use the LiquidETFUniverse with minute-resolution data
+        self.UniverseSettings.Resolution = Resolution.Minute
+        self.SetUniverseSelection(LiquidETFUniverse())
+
+        # Optional
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+
+        # List of symbols we want to trade. Set it in OnSecuritiesChanged
+        self.symbols = []
+
+    def OnData(self, slice):
+        
+        if all([self.Portfolio[x].Invested for x in self.symbols]):
+            return
+        
+        # Emit insights
+        insights = [Insight.Price(x, timedelta(1), InsightDirection.Up)
+            for x in self.symbols if self.Securities[x].Price > 0]
+            
+        if len(insights) > 0:
+            self.EmitInsights(insights)
+
+    def OnSecuritiesChanged(self, changes):
+        
+        # Set symbols as the Inverse Energy ETFs
+        self.symbols.clear()
+        for security in changes.AddedSecurities:
+            if security.Symbol in LiquidETFUniverse.Energy.Inverse:
+                self.symbols.append(security.Symbol)
+        
+        # Print out the information about the groups
+        self.Log(f'Energy: {LiquidETFUniverse.Energy}')
+        self.Log(f'Metals: {LiquidETFUniverse.Metals}')
+        self.Log(f'Technology: {LiquidETFUniverse.Technology}')
+        self.Log(f'Treasuries: {LiquidETFUniverse.Treasuries}')
+        self.Log(f'Volatility: {LiquidETFUniverse.Volatility}')
+        self.Log(f'SP500Sectors: {LiquidETFUniverse.SP500Sectors}')

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -84,6 +84,7 @@
     <Content Include="KerasNeuralNetworkAlgorithm.py" />
     <None Include="PsychSignalSentimentRegressionAlgorithm.py" />
     <Content Include="CustomDataUsingMapFileRegressionAlgorithm.py" />
+    <Content Include="LiquidETFUniverseFrameworkAlgorithm.py" />
     <Content Include="SetHoldingsMultipleTargetsRegressionAlgorithm.py" />
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />


### PR DESCRIPTION
#### Description
New members represent different ETF categories:
- `LiquidETFUniverse.Energy`
- `LiquidETFUniverse.Metals`
- `LiquidETFUniverse.Technology`
- `LiquidETFUniverse.Tresuries`
- `LiquidETFUniverse.Volatility`
- `LiquidETFUniverse.SP500Sectors`

Each one has a `List<Symbol>` for `Long` and `Inverse` ETFs.

#### Related Issue
Closes #3806

#### Motivation and Context
Add helpers to identify the ETF category.

#### Requires Documentation Change
Yes. This feature should be presented.

#### How Has This Been Tested?
Added algorithms in QC Cloud.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`