### PR TITLE
Fix market price initialization in LiveTradingResultHandler

### DIFF
--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -1125,7 +1125,7 @@ namespace QuantConnect.Lean.Engine.Results
                                 // we haven't gotten data yet so just spoof a tick to push through the system to start with
                                 if (price > 0)
                                 {
-                                    security.SetMarketPrice(new Tick(time, symbol, price, price) { TickType = tickType });
+                                    security.SetMarketPrice(new Tick(time, symbol, price, 0, 0) { TickType = TickType.Trade });
                                 }
                             }
 


### PR DESCRIPTION

#### Description
This change prevents the security from being initialized with a quote tick, causing the bid price and ask price to be equal (and potentially remain so -- as can happen with OTM options).

#### Related Issue
Closes #3689 

#### Motivation and Context
- OTM options with no actual bid prices are incorrectly being initialized with bid prices equal to ask prices.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Live deployment of this testing algorithm: https://github.com/QuantConnect/Lean/issues/3689#issuecomment-551244746

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`