### PR TITLE
Parallel history requests

### DIFF
--- a/Engine/DataFeeds/SubscriptionUtils.cs
+++ b/Engine/DataFeeds/SubscriptionUtils.cs
@@ -1,0 +1,95 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// Utilities related to data <see cref="Subscription"/>
+    /// </summary>
+    public static class SubscriptionUtils
+    {
+        /// <summary>
+        /// Setups a new <see cref="Subscription"/> which will consume a blocking <see cref="EnqueueableEnumerator{T}"/>
+        /// that will be feed by a worker task
+        /// </summary>
+        /// <param name="request">The subscription data request</param>
+        /// <param name="enumerator">The data enumerator stack</param>
+        /// <param name="lowerThreshold">The lower threshold for the worker task, for which the consumer will trigger the worker
+        /// if it has stopped <see cref="EnqueueableEnumerator{T}.TriggerProducer"/></param>
+        /// <param name="upperThreshold">The upper threshold for the worker task, after which it will stop producing until requested
+        /// by the consumer <see cref="EnqueueableEnumerator{T}.TriggerProducer"/></param>
+        /// <returns>A new subscription instance ready to consume</returns>
+        public static Subscription CreateAndScheduleWorker(
+            SubscriptionRequest request,
+            IEnumerator<BaseData> enumerator,
+            int lowerThreshold,
+            int upperThreshold)
+        {
+            var exchangeHours = request.Security.Exchange.Hours;
+            var enqueueable = new EnqueueableEnumerator<SubscriptionData>(true);
+            var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Security.Exchange.TimeZone, request.StartTimeUtc, request.EndTimeUtc);
+            var subscription = new Subscription(request, enqueueable, timeZoneOffsetProvider);
+
+            Action produce = () =>
+            {
+                var count = 0;
+                while (enumerator.MoveNext())
+                {
+                    // subscription has been removed, no need to continue enumerating
+                    if (enqueueable.HasFinished)
+                    {
+                        enumerator.Dispose();
+                        return;
+                    }
+
+                    var subscriptionData = SubscriptionData.Create(subscription.Configuration, exchangeHours, subscription.OffsetProvider, enumerator.Current);
+
+                    // drop the data into the back of the enqueueable
+                    enqueueable.Enqueue(subscriptionData);
+
+                    count++;
+
+                    // stop executing if we have more data than the upper threshold in the enqueueable, we don't want to fill the ram
+                    if (count > upperThreshold)
+                    {
+                        // we use local count for the outside if, for performance, and adjust here
+                        count = enqueueable.Count;
+                        if (count > upperThreshold)
+                        {
+                            // we will be re scheduled to run by the consumer, see EnqueueableEnumerator
+                            return;
+                        }
+                    }
+                }
+
+                // we made it here because MoveNext returned false, stop the enqueueable
+                enqueueable.Stop();
+                // we have to dispose of the enumerator
+                enumerator.Dispose();
+            };
+
+            enqueueable.SetProducer(produce, lowerThreshold);
+
+            return subscription;
+        }
+    }
+}

--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -62,8 +62,6 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             {
                 var history = _brokerage.GetHistory(request);
                 var subscription = CreateSubscription(request, history);
-
-                subscription.MoveNext(); // prime pump
                 subscriptions.Add(subscription);
             }
 

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -236,6 +236,7 @@
     <Compile Include="DataFeeds\SubscriptionCollection.cs" />
     <Compile Include="DataFeeds\SubscriptionData.cs" />
     <Compile Include="DataFeeds\LiveSynchronizer.cs" />
+    <Compile Include="DataFeeds\SubscriptionUtils.cs" />
     <Compile Include="DataFeeds\Synchronizer.cs" />
     <Compile Include="DataFeeds\TextSubscriptionDataSourceReader.cs" />
     <Compile Include="DataFeeds\CreateStreamReaderErrorEventArgs.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Enable parallel workers for history requests, improving performance.
- Adding SubscriptionUtils to be used by backtesting through the FileSystemDataFeed and
SubscriptionHistoryProvider and live deployments which use the
SubscriptionHistoryProvider in the core
- Fix some timezone issues when using local
start/end time instead of UTC

**Notice: Increases HW resource consumption**

Performance tests
```
public class HorizontalMultidimensionalFlange : QCAlgorithm
{
    public override void Initialize()
    {
        SetStartDate(2018, 01, 01);
        SetEndDate(2018, 01, 02);
        // 1 security test
        AddEquity("SPY", Resolution.Daily);
        // 4 securities test
        AddEquity("AAPL", Resolution.Daily);
        AddEquity("IBM", Resolution.Daily);
        AddEquity("FB", Resolution.Daily);

        // 8 securities test
        AddEquity("MSFT", Resolution.Daily);
        AddEquity("AMZN", Resolution.Daily);
        AddEquity("INTC", Resolution.Daily);
        AddEquity("AMD", Resolution.Daily);
    }

    public override void OnEndOfDay()
    {
        foreach (var data in History(Securities.Keys, 60, Resolution.Daily/Minute))
        {
            var t = data.Count;
        }
    }
}
```
----------------- local MINUTE TESTS ---------------------
1 security - 60 points
`master`
3.64 seconds at 21k data points per second. Processing total of 78,081 data points.
3.63 seconds at 22k data points per second. Processing total of 78,081 data points.
3.65 seconds at 21k data points per second. Processing total of 78,081 data points.
`pr`
3.83 seconds at 20k data points per second. Processing total of 78,081 data points.
3.83 seconds at 20k data points per second. Processing total of 78,081 data points.
3.84 seconds at 20k data points per second. Processing total of 78,081 data points.

1 security - 360 points
`master`
6.04 seconds at 75k data points per second. Processing total of 455,781 data points.
6.03 seconds at 76k data points per second. Processing total of 455,781 data points.
6.04 seconds at 75k data points per second. Processing total of 455,781 data points.
`pr`
5.23 seconds at 87k data points per second. Processing total of 455,781 data points.
5.43 seconds at 84k data points per second. Processing total of 455,781 data points.
5.23 seconds at 87k data points per second. Processing total of 455,781 data points.

4 securities - 60 points
`master`
10.45 seconds at 30k data points per second. Processing total of 308,473 data points.
10.45 seconds at 30k data points per second. Processing total of 308,473 data points.
10.45 seconds at 30k data points per second. Processing total of 308,473 data points.
`pr`
5.85 seconds at 53k data points per second. Processing total of 308,473 data points.
5.44 seconds at 57k data points per second. Processing total of 308,473 data points.
5.44 seconds at 57k data points per second. Processing total of 308,473 data points.

8 securities - 60 points
`master`
18.06 seconds at 34k data points per second. Processing total of 615,636 data points.
18.26 seconds at 34k data points per second. Processing total of 615,636 data points.
18.06 seconds at 34k data points per second. Processing total of 615,636 data points.
`pr`
7.85 seconds at 78k data points per second. Processing total of 615,636 data points.
7.65 seconds at 81k data points per second. Processing total of 615,636 data points.
7.85 seconds at 78k data points per second. Processing total of 615,636 data points.

8 securities - 360 points
`master`
34.12 seconds at 107k data points per second. Processing total of 3,637,358 data points.
34.74 seconds at 105k data points per second. Processing total of 3,637,358 data points.
34.92 seconds at 104k data points per second. Processing total of 3,637,358 data points.
`pr`
15.91 seconds at 229k data points per second. Processing total of 3,637,358 data points.
15.71 seconds at 231k data points per second. Processing total of 3,637,358 data points.
15.69 seconds at 232k data points per second. Processing total of 3,637,358 data points.


----------------- local Daily TESTS ---------------------

1 security - 60 points
`master`
2.05 seconds at 38k data points per second. Processing total of 78,081 data points.
2.03 seconds at 38k data points per second. Processing total of 78,081 data points.
2.03 seconds at 39k data points per second. Processing total of 78,081 data points.
`pr`
1.82 seconds at 43k data points per second. Processing total of 78,081 data points.
1.83 seconds at 43k data points per second. Processing total of 78,081 data points.
1.83 seconds at 43k data points per second. Processing total of 78,081 data points.

1 security - 360 points
`master`
8.04 seconds at 57k data points per second. Processing total of 455,781 data points.
7.84 seconds at 58k data points per second. Processing total of 455,781 data points.
7.84 seconds at 58k data points per second. Processing total of 455,781 data points.
`pr`
6.44 seconds at 71k data points per second. Processing total of 455,781 data points.
6.23 seconds at 73k data points per second. Processing total of 455,781 data points.
6.24 seconds at 73k data points per second. Processing total of 455,781 data points.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3724
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Faster is better
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests, cloud backtesting and live trading
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->