### PR TITLE
Fix IB Forex zero conversion rates

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2173,7 +2173,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             var securityType = ConvertSecurityType(contract);
             var ibSymbol = securityType == SecurityType.Forex ? contract.Symbol + contract.Currency : contract.Symbol;
-            var market = securityType == SecurityType.Forex ? Market.FXCM : Market.USA;
+            var market = securityType == SecurityType.Forex ? Market.Oanda : Market.USA;
 
             if (securityType == SecurityType.Future)
             {
@@ -2479,7 +2479,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             return
                 (securityType == SecurityType.Equity && market == Market.USA) ||
-                (securityType == SecurityType.Forex && market == Market.FXCM) ||
+                (securityType == SecurityType.Forex && market == Market.Oanda) ||
                 (securityType == SecurityType.Option && market == Market.USA) ||
                 (securityType == SecurityType.Future);
         }

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2173,7 +2173,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             var securityType = ConvertSecurityType(contract);
             var ibSymbol = securityType == SecurityType.Forex ? contract.Symbol + contract.Currency : contract.Symbol;
-            var market = securityType == SecurityType.Forex ? Market.Oanda : Market.USA;
+
+            var market = InteractiveBrokersBrokerageModel.DefaultMarketMap[securityType];
 
             if (securityType == SecurityType.Future)
             {

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -21,6 +21,7 @@ using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.TimeInForces;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Forex;
+using QuantConnect.Util;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Brokerages
@@ -30,6 +31,19 @@ namespace QuantConnect.Brokerages
     /// </summary>
     public class InteractiveBrokersBrokerageModel : DefaultBrokerageModel
     {
+        /// <summary>
+        /// The default markets for the IB brokerage
+        /// </summary>
+        public new static readonly IReadOnlyDictionary<SecurityType, string> DefaultMarketMap = new Dictionary<SecurityType, string>
+        {
+            {SecurityType.Base, Market.USA},
+            {SecurityType.Equity, Market.USA},
+            {SecurityType.Option, Market.USA},
+            {SecurityType.Future, Market.USA},
+            {SecurityType.Forex, Market.Oanda},
+            {SecurityType.Cfd, Market.Oanda}
+        }.ToReadOnlyDictionary();
+
         private readonly Type[] _supportedTimeInForces =
         {
             typeof(GoodTilCanceledTimeInForce),
@@ -46,6 +60,11 @@ namespace QuantConnect.Brokerages
             : base(accountType)
         {
         }
+
+        /// <summary>
+        /// Gets a map of the default markets to be used for each security type
+        /// </summary>
+        public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets => DefaultMarketMap;
 
         /// <summary>
         /// Gets a new fee model that represents this brokerage's fee structure

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -61,8 +61,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _currencySubscriptionDataConfigManager = new CurrencySubscriptionDataConfigManager(algorithm.Portfolio.CashBook,
                 algorithm.Securities,
                 algorithm.SubscriptionManager,
-                _securityService,
-                algorithm.BrokerageModel);
+                _securityService);
         }
 
         /// <summary>
@@ -399,7 +398,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
             }
 
-            if (_currencySubscriptionDataConfigManager.UpdatePendingSubscriptionDataConfigs())
+            if (_currencySubscriptionDataConfigManager.UpdatePendingSubscriptionDataConfigs(_algorithm.BrokerageModel))
             {
                 foreach (var subscriptionDataConfig in _currencySubscriptionDataConfigManager
                     .GetPendingSubscriptionDataConfigs())
@@ -422,7 +421,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public void EnsureCurrencyDataFeeds(SecurityChanges securityChanges)
         {
-            _currencySubscriptionDataConfigManager.EnsureCurrencySubscriptionDataConfigs(securityChanges);
+            _currencySubscriptionDataConfigManager.EnsureCurrencySubscriptionDataConfigs(securityChanges, _algorithm.BrokerageModel);
         }
 
         private void RemoveSecurityFromUniverse(

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -756,7 +756,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\FredVixData.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="TestData\fxVolumeDaily.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION

#### Description
- Updated `InteractiveBrokersBrokerage` and `InteractiveBrokersBrokerageModel` to use `Market.Oanda` instead of `Market.FXCM` when generating Forex symbols.
- Fixed a bug where the default brokerage model was being cached in the  `CurrencySubscriptionDataConfigManager` instead of the actual brokerage model set in the algorithm.

#### Related Issue
Closes #3811 

#### Motivation and Context
- Algorithm runtime error at cash sync time with algorithm deployed to IB with `SGD` or `HUF` cash in the account.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Converted some cash to SGD in the IB account
- Verified that the conversion rate is zero and the exception is thrown with current `master` code
- Verified that the conversion rate is non-zero and no exception is thrown using the PR code

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`