### PR TITLE
LEAN-3631: Resolve non-fill-forward data in TimeSlice.Create

### DIFF
--- a/Common/Interfaces/ISecurityPrice.cs
+++ b/Common/Interfaces/ISecurityPrice.cs
@@ -82,11 +82,10 @@ namespace QuantConnect.Interfaces
         /// Updates all of the security properties, such as price/OHLCV/bid/ask based
         /// on the data provided. Data is also stored into the security's data cache
         /// </summary>
-        /// <param name="data">The security update data</param>
         /// <param name="dataType">The data type</param>
-        /// <param name="containsFillForwardData">Flag indicating whether
-        /// <paramref name="data"/> contains any fill forward bar or not</param>
-        void Update(IReadOnlyList<BaseData> data, Type dataType, bool? containsFillForwardData);
+        /// <param name="data">Contains all data for this security at the current time step</param>
+        /// <param name="nonFillForwardData">Contains all non-fill-forward data for this security at the current time step</param>
+        void Update(Type dataType, IReadOnlyList<BaseData> data, IReadOnlyList<BaseData> nonFillForwardData);
 
         /// <summary>
         /// Get the last price update set to the security.

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -596,14 +596,12 @@ namespace QuantConnect.Securities
         /// Updates all of the security properties, such as price/OHLCV/bid/ask based
         /// on the data provided. Data is also stored into the security's data cache
         /// </summary>
-        /// <param name="data">The security update data</param>
         /// <param name="dataType">The data type</param>
-        /// <param name="containsFillForwardData">Flag indicating whether
-        /// <paramref name="data"/> contains any fill forward bar or not</param>
-        public void Update(IReadOnlyList<BaseData> data, Type dataType, bool? containsFillForwardData = null)
+        /// <param name="data">Contains all data for this security at the current time step</param>
+        /// <param name="nonFillForwardData">Contains all non-fill-forward data for this security at the current time step</param>
+        public void Update(Type dataType, IReadOnlyList<BaseData> data, IReadOnlyList<BaseData> nonFillForwardData)
         {
-            Cache.AddDataList(data, dataType, containsFillForwardData);
-
+            Cache.AddDataList(dataType, data, nonFillForwardData);
             UpdateConsumersMarketPrice(data[data.Count - 1]);
         }
 

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -97,23 +97,8 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <remarks>Internally uses <see cref="AddData"/> using the last data point of the provided list
         /// and it stores by type the non fill forward points using <see cref="StoreData"/></remarks>
-        public void AddDataList(IReadOnlyList<BaseData> data, Type dataType, bool? containsFillForwardData = null)
+        public void AddDataList(Type dataType, IReadOnlyList<BaseData> data, IReadOnlyList<BaseData> nonFillForwardData)
         {
-            var nonFillForwardData = data;
-            // maintaining regression requires us to NOT cache FF data
-            if (containsFillForwardData != false)
-            {
-                var dataFiltered = new List<BaseData>(data.Count);
-                for (var i = 0; i < data.Count; i++)
-                {
-                    var dataPoint = data[i];
-                    if (!dataPoint.IsFillForward)
-                    {
-                        dataFiltered.Add(dataPoint);
-                    }
-                }
-                nonFillForwardData = dataFiltered;
-            }
             if (nonFillForwardData.Count != 0)
             {
                 StoreData(nonFillForwardData, dataType);

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -290,7 +290,7 @@ namespace QuantConnect.Lean.Engine
                 {
                     var security = update.Target;
 
-                    security.Update(update.Data, update.DataType, update.ContainsFillForwardData);
+                    security.Update(update.DataType, update.Data, update.NonFillForwardData);
 
                     if (!update.IsInternalConfig)
                     {

--- a/Engine/DataFeeds/SecuritiesUpdateData.cs
+++ b/Engine/DataFeeds/SecuritiesUpdateData.cs
@@ -1,0 +1,47 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// Transport type for securities update data. This derived class is provided to maintain
+    /// separate lists for all data and non-fill forward data for storage in the security cache.
+    /// </summary>
+    public class SecuritiesUpdateData : UpdateData<ISecurityPrice>
+    {
+        /// <summary>
+        /// A list of securities update data where all entries are not <see cref="BaseData.IsFillForward"/>
+        /// </summary>
+        public IReadOnlyList<BaseData> NonFillForwardData { get; }
+
+        public SecuritiesUpdateData(
+            ISecurityPrice target,
+            Type dataType,
+            IReadOnlyList<BaseData> data,
+            IReadOnlyList<BaseData> nonFillForwardData,
+            bool isInternalConfig,
+            bool? containsFillForwardData = null)
+            : base(target, dataType, data, isInternalConfig, containsFillForwardData)
+        {
+            NonFillForwardData = nonFillForwardData;
+        }
+    }
+}

--- a/Engine/DataFeeds/TimeSlice.cs
+++ b/Engine/DataFeeds/TimeSlice.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// Gets the data used to update securities
         /// </summary>
-        public List<UpdateData<ISecurityPrice>> SecuritiesUpdateData { get; }
+        public List<SecuritiesUpdateData> SecuritiesUpdateData { get; }
 
         /// <summary>
         /// Gets the data used to update the consolidators
@@ -84,7 +84,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             int dataPointCount,
             Slice slice,
             List<DataFeedPacket> data,
-            List<UpdateData<ISecurityPrice>> securitiesUpdateData,
+            List<SecuritiesUpdateData> securitiesUpdateData,
             List<UpdateData<SubscriptionDataConfig>> consolidatorUpdateData,
             List<UpdateData<ISecurityPrice>> customData,
             SecurityChanges securityChanges,

--- a/Engine/DataFeeds/TimeSliceFactory.cs
+++ b/Engine/DataFeeds/TimeSliceFactory.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             Dictionary<Universe, BaseDataCollection> universeData)
         {
             int count = 0;
-            var security = new List<UpdateData<ISecurityPrice>>(data.Count);
+            var security = new List<SecuritiesUpdateData>(data.Count);
             List<UpdateData<ISecurityPrice>> custom = null;
             var consolidator = new List<UpdateData<SubscriptionDataConfig>>(data.Count);
             var allDataForAlgorithm = new List<BaseData>(data.Count);
@@ -169,6 +169,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
 
                 var securityUpdate = new List<BaseData>(list.Count);
+                var nonFillForwardSecurityUpdate = new List<BaseData>(list.Count);
                 var consolidatorUpdate = new List<BaseData>(list.Count);
                 var containsFillForwardData = false;
                 for (var i = 0; i < list.Count; i++)
@@ -301,6 +302,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         if (tick != null && tick.Suspicious) continue;
 
                         securityUpdate.Add(baseData);
+                        if (!baseData.IsFillForward)
+                        {
+                            nonFillForwardSecurityUpdate.Add(baseData);
+                        }
 
                         // option underlying security update
                         if (!packet.Configuration.IsInternalFeed
@@ -350,7 +355,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                 if (securityUpdate.Count > 0)
                 {
-                    security.Add(new UpdateData<ISecurityPrice>(packet.Security, packet.Configuration.Type, securityUpdate, packet.Configuration.IsInternalFeed, containsFillForwardData));
+                    security.Add(new SecuritiesUpdateData(packet.Security, packet.Configuration.Type, securityUpdate, nonFillForwardSecurityUpdate, packet.Configuration.IsInternalFeed, containsFillForwardData));
                 }
                 if (consolidatorUpdate.Count > 0)
                 {

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -201,6 +201,7 @@
     <Compile Include="DataFeeds\PendingRemovalsManager.cs" />
     <Compile Include="DataFeeds\RealTimeScheduleEventService.cs" />
     <Compile Include="DataFeeds\PredicateTimeProvider.cs" />
+    <Compile Include="DataFeeds\SecuritiesUpdateData.cs" />
     <Compile Include="DataFeeds\SubscriptionFrontierTimeProvider.cs" />
     <Compile Include="DataFeeds\SingleEntryDataCacheProvider.cs" />
     <Compile Include="DataFeeds\Enumerators\BaseDataCollectionAggregatorEnumerator.cs" />

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -388,7 +388,7 @@ namespace QuantConnect.Tests.Engine
             private readonly List<UpdateData<SubscriptionDataConfig>> _consolidatorUpdateData = new List<UpdateData<SubscriptionDataConfig>>();
             private readonly List<TimeSlice> _timeSlices = new List<TimeSlice>();
             private readonly TimeSpan _frontierStepSize = TimeSpan.FromSeconds(1);
-            private readonly List<UpdateData<ISecurityPrice>> _securitiesUpdateData = new List<UpdateData<ISecurityPrice>>();
+            private readonly List<SecuritiesUpdateData> _securitiesUpdateData = new List<SecuritiesUpdateData>();
             public int Count => _timeSlices.Count;
 
             public NullSynchronizer(IAlgorithm algorithm)
@@ -398,14 +398,14 @@ namespace QuantConnect.Tests.Engine
                 foreach (var kvp in algorithm.Securities)
                 {
                     var security = kvp.Value;
-                    var tick = new Tick
+                    BaseData tick = new Tick
                     {
                         Symbol = security.Symbol,
                         EndTime = _frontierUtc.ConvertFromUtc(security.Exchange.TimeZone)
                     };
                     _data.Add(tick);
-                    _securitiesUpdateData.Add(new UpdateData<ISecurityPrice>(security, typeof(Tick), new BaseData[] { tick }, false));
-                    _consolidatorUpdateData.Add(new UpdateData<SubscriptionDataConfig>(security.Subscriptions.First(), typeof(Tick), new BaseData[] { tick }, false));
+                    _securitiesUpdateData.Add(new SecuritiesUpdateData(security, typeof(Tick), new[] {tick}, new[] {tick}, false));
+                    _consolidatorUpdateData.Add(new UpdateData<SubscriptionDataConfig>(security.Subscriptions.First(), typeof(Tick), new[] { tick }, false));
                 }
 
                 _timeSlices.AddRange(GenerateTimeSlices().Take(int.MaxValue / 1000));


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Using LINQ to filter millions of these lists takes forever and ends up allocating
hella lots of objects to the heap. By doing it this way we make the list once as
part of an existing loop that is already CPU intensive, so it blends right in with
the other stuff vs having the hiccup in the middle of the algo manager time  loop.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Performance fix related to #3631 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I didn't have enough day, but I did have SPY, so I hacked `TradeBar` so I could run the 400 equity symbol benchmark but instead they _all_ read from the SPY data :P

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [O] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [+] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->