### PR TITLE
Corrected function calls involving iterator function

### DIFF
--- a/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
+++ b/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.ToolBox.CoarseUniverseGenerator
 
             do
             {
-                ProcessEquityDirectories(dataDirectory, ignoreMaplessSymbols);
+                ProcessEquityDirectories(dataDirectory, ignoreMaplessSymbols).ToList();
             }
             while (WaitUntilTimeInUpdateMode(updateMode, updateTime));
         }

--- a/ToolBox/RandomDataGenerator/RandomDataGeneratorProgram.cs
+++ b/ToolBox/RandomDataGenerator/RandomDataGeneratorProgram.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                 var coarseFiles = CoarseUniverseGenerator.CoarseUniverseGeneratorProgram.ProcessEquityDirectories(
                     Globals.DataFolder,
                     false
-                ).ToList();
+                );
                 output.Info.WriteLine("Coarse data generation completed. Produced the following files:");
                 foreach (var coarseFile in coarseFiles)
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
As identified by @scolemann function call `ProcessEquityDirectories` appears noop in present form. Function call returns enumerator . And unless it's iterated, it will not save files. Calling ToList will do that. It's another question whether this function should yield return in first place. As it's usages doesn't justify that usage.. But, calling ToList will fix issue.

#### Related Issue
#3411 
#### Motivation and Context
As 

#### Requires Documentation Change
NA

#### How Has This Been Tested?
Windows 8/Ubuntu 18.04
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->