### PR TITLE
Improve chart streaming

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -52,6 +52,23 @@ namespace QuantConnect
             = new Dictionary<IntPtr, PythonActivator>();
 
         /// <summary>
+        /// Returns true if the specified <see cref="Series"/> instance holds no <see cref="ChartPoint"/>
+        /// </summary>
+        public static bool IsEmpty(this Series series)
+        {
+            return series.Values.Count == 0;
+        }
+
+        /// <summary>
+        /// Returns if the specified <see cref="Chart"/> instance  holds no <see cref="Series"/>
+        /// or they are all empty <see cref="IsEmpty(Series)"/>
+        /// </summary>
+        public static bool IsEmpty(this Chart chart)
+        {
+            return chart.Series.Values.All(IsEmpty);
+        }
+
+        /// <summary>
         /// Gets a python method by name
         /// </summary>
         /// <param name="instance">The object instance to search the method in</param>

--- a/Common/Packets/LiveResultPacket.cs
+++ b/Common/Packets/LiveResultPacket.cs
@@ -136,17 +136,20 @@ namespace QuantConnect.Packets
         /// <summary>
         /// Holdings dictionary of algorithm holdings information
         /// </summary>
-        public IDictionary<string, Holding> Holdings = new Dictionary<string, Holding>();
+        [JsonProperty(PropertyName = "Holdings", NullValueHandling = NullValueHandling.Ignore)]
+        public IDictionary<string, Holding> Holdings;
 
         /// <summary>
         /// Cashbook for the algorithm's live results.
         /// </summary>
+        [JsonProperty(PropertyName = "Cash", NullValueHandling = NullValueHandling.Ignore)]
         public CashBook Cash;
 
         /// <summary>
         /// Server status information, including CPU/RAM usage, ect...
         /// </summary>
-        public IDictionary<string, string> ServerStatistics = new Dictionary<string, string>();
+        [JsonProperty(PropertyName = "ServerStatistics", NullValueHandling = NullValueHandling.Ignore)]
+        public IDictionary<string, string> ServerStatistics;
 
         /// <summary>
         /// Default Constructor

--- a/Common/Result.cs
+++ b/Common/Result.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using QuantConnect.Orders;
 using QuantConnect.Packets;
 
@@ -30,32 +31,38 @@ namespace QuantConnect
         /// <summary>
         /// Contains population averages scores over the life of the algorithm
         /// </summary>
+        [JsonProperty(PropertyName = "AlphaRuntimeStatistics", NullValueHandling = NullValueHandling.Ignore)]
         public AlphaRuntimeStatistics AlphaRuntimeStatistics;
 
         /// <summary>
         /// Charts updates for the live algorithm since the last result packet
         /// </summary>
-        public IDictionary<string, Chart> Charts = new Dictionary<string, Chart>();
+        [JsonProperty(PropertyName = "Charts", NullValueHandling = NullValueHandling.Ignore)]
+        public IDictionary<string, Chart> Charts;
 
         /// <summary>
         /// Order updates since the last result packet
         /// </summary>
-        public IDictionary<int, Order> Orders = new Dictionary<int, Order>();
+        [JsonProperty(PropertyName = "Orders", NullValueHandling = NullValueHandling.Ignore)]
+        public IDictionary<int, Order> Orders;
 
         /// <summary>
         /// Trade profit and loss information since the last algorithm result packet
         /// </summary>
-        public IDictionary<DateTime, decimal> ProfitLoss = new Dictionary<DateTime, decimal>();
+        [JsonProperty(PropertyName = "ProfitLoss", NullValueHandling = NullValueHandling.Ignore)]
+        public IDictionary<DateTime, decimal> ProfitLoss;
 
         /// <summary>
         /// Statistics information sent during the algorithm operations.
         /// </summary>
         /// <remarks>Intended for update mode -- send updates to the existing statistics in the result GUI. If statistic key does not exist in GUI, create it</remarks>
-        public IDictionary<string, string> Statistics = new Dictionary<string, string>();
+        [JsonProperty(PropertyName = "Statistics", NullValueHandling = NullValueHandling.Ignore)]
+        public IDictionary<string, string> Statistics;
 
         /// <summary>
         /// Runtime banner/updating statistics in the title banner of the live algorithm GUI.
         /// </summary>
-        public IDictionary<string, string> RuntimeStatistics = new Dictionary<string, string>();
+        [JsonProperty(PropertyName = "RuntimeStatistics", NullValueHandling = NullValueHandling.Ignore)]
+        public IDictionary<string, string> RuntimeStatistics;
     }
 }

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -768,14 +768,6 @@ namespace QuantConnect.Lean.Engine.Results
         }
 
         /// <summary>
-        /// Set the chart subscription we want data for. Not used in backtesting.
-        /// </summary>
-        public void SetChartSubscription(string symbol)
-        {
-            //NOP.
-        }
-
-        /// <summary>
         /// Process the synchronous result events, sampling and message reading.
         /// This method is triggered from the algorithm manager thread.
         /// </summary>

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -217,12 +217,6 @@ namespace QuantConnect.Lean.Engine.Results
         void SendStatusUpdate(AlgorithmStatus status, string message = "");
 
         /// <summary>
-        /// Set the chart name:
-        /// </summary>
-        /// <param name="symbol">Symbol of the chart we want.</param>
-        void SetChartSubscription(string symbol);
-
-        /// <summary>
         /// Set a dynamic runtime statistic to show in the (live) algorithm header
         /// </summary>
         /// <param name="key">Runtime headline statistic name</param>

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -56,7 +56,6 @@ namespace QuantConnect.Lean.Engine.Results
         private DateTime _nextStatusUpdate;
         private readonly object _statusUpdateLock;
         private int _lastOrderId;
-        private string _subscription;
 
         //Log Message Store:
         private readonly object _logStoreLock;
@@ -102,7 +101,6 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         public LiveTradingResultHandler()
         {
-            _subscription = "Strategy Equity";
             _logStoreLock = new object();
             _statusUpdateLock = new object();
             _logStore = new List<LogEntry>();
@@ -222,9 +220,14 @@ namespace QuantConnect.Lean.Engine.Results
                         //Get the updates since the last chart
                         foreach (var chart in Charts)
                         {
-                            // remove directory pathing characters from chart names
-                            var safeName = chart.Value.Name.Replace('/', '-');
-                            DictionarySafeAdd(deltaCharts, safeName, chart.Value.GetUpdates(), "deltaCharts");
+                            var chartUpdates = chart.Value.GetUpdates();
+                            // we only want to stream charts that have new updates
+                            if (!chartUpdates.IsEmpty())
+                            {
+                                // remove directory pathing characters from chart names
+                                var safeName = chart.Value.Name.Replace('/', '-');
+                                DictionarySafeAdd(deltaCharts, safeName, chartUpdates, "deltaCharts");
+                            }
 
                             if (AlgorithmPerformanceCharts.Contains(chart.Key))
                             {
@@ -474,32 +477,29 @@ namespace QuantConnect.Lean.Engine.Results
             // First add send charts
 
             // Loop through all the charts, add them to packets to be sent.
-            // Group three charts to a packets, and add in the data to the chart depending on the subscription.
-
+            // Group three charts per packet
             foreach (var deltaChart in deltaCharts.Values)
             {
-                var chart = new Chart(deltaChart.Name);
-                current.Add(deltaChart.Name, chart);
+                current.Add(deltaChart.Name, deltaChart);
 
-                if (deltaChart.Name == _subscription || (_subscription == "*" && deltaChart.Name == "Strategy Equity"))
-                {
-                    chart.Series = deltaChart.Series;
-                }
-
-                // If there is room left in the group. add the subscription
-                // to the packet unless it is a wildcard subscription
-                if (current.Count >= groupSize && _subscription != "*")
+                if (current.Count >= groupSize)
                 {
                     // Add the micro packet to transport.
                     chartPackets.Add(new LiveResultPacket(_job, new LiveResult { Charts = current }));
+
                     // Reset the carrier variable.
                     current = new Dictionary<string, Chart>();
+                    if (chartPackets.Count >= 4)
+                    {
+                        // stream a maximum number of charts: 3 * 4 = 12
+                        break;
+                    }
                 }
             }
 
             // Add whatever is left over here too
             // unless it is a wildcard subscription
-            if (current.Count > 0 && _subscription != "*")
+            if (current.Count > 0)
             {
                 chartPackets.Add(new LiveResultPacket(_job, new LiveResult { Charts = current }));
             }
@@ -1064,15 +1064,6 @@ namespace QuantConnect.Lean.Engine.Results
         protected virtual string CreateSafeChartName(string chartName)
         {
             return Uri.EscapeDataString(chartName);
-        }
-
-
-        /// <summary>
-        /// Set the chart name that we want data from.
-        /// </summary>
-        public void SetChartSubscription(string symbol)
-        {
-            _subscription = symbol;
         }
 
         /// <summary>

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -31,6 +31,44 @@ namespace QuantConnect.Tests.Common.Util
     public class ExtensionsTests
     {
         [Test]
+        public void SeriesIsNotEmpty()
+        {
+            var series = new Series("SadSeries")
+                { Values = new List<ChartPoint> { new ChartPoint(1, 1) } };
+
+            Assert.IsFalse(series.IsEmpty());
+        }
+
+        [Test]
+        public void SeriesIsEmpty()
+        {
+            Assert.IsTrue((new Series("Cat")).IsEmpty());
+        }
+
+        [Test]
+        public void ChartIsEmpty()
+        {
+            Assert.IsTrue((new Chart("HappyChart")).IsEmpty());
+        }
+
+        [Test]
+        public void ChartIsEmptyWithEmptySeries()
+        {
+            Assert.IsTrue((new Chart("HappyChart")
+                { Series = new Dictionary<string, Series> { { "SadSeries", new Series("SadSeries") } }}).IsEmpty());
+        }
+
+        [Test]
+        public void ChartIsNotEmptyWithNonEmptySeries()
+        {
+            var series = new Series("SadSeries")
+                { Values = new List<ChartPoint> { new ChartPoint(1, 1) } };
+
+            Assert.IsFalse((new Chart("HappyChart")
+                { Series = new Dictionary<string, Series> { { "SadSeries", series } } }).IsEmpty());
+        }
+
+        [Test]
         public void IsSubclassOfGenericWorksWorksForNonGenericType()
         {
             Assert.IsTrue(typeof(Derived2).IsSubclassOfGeneric(typeof(Derived1)));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Remove chart subscription logic. Will stream all chart updates if any
(wont stream empty updates)
- Only serialize properties which are not null
- Adding Chart and Series `IsEmtpy()` extension. Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3842
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve chart streaming
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression tests and cloud live and backtests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->