### PR TITLE
Tidy Composer, improve init performance

### DIFF
--- a/Common/Util/Composer.cs
+++ b/Common/Util/Composer.cs
@@ -19,11 +19,11 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
-using System.ComponentModel.Composition.Primitives;
 using System.ComponentModel.Composition.ReflectionModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using QuantConnect.Configuration;
 using QuantConnect.Logging;
@@ -35,13 +35,18 @@ namespace QuantConnect.Util
     /// </summary>
     public class Composer
     {
-        private static string PluginDirectory;
-        private static readonly Lazy<Composer> LazyComposer = new Lazy<Composer>(
-            () =>
-            {
-                PluginDirectory = Config.Get("plugin-directory");
-                return new Composer();
-            });
+        // this is purposefully a computed property to ensure setting 'plugin-directory' config will actually
+        // be used. the only requirement is that the value is set before accessing Composer.Instance
+        private static string PluginDirectory => Config.Get("plugin-directory");
+
+        // grab assemblies from current executing directory if not defined by 'composer-dll-directory' configuration key
+        private static readonly string PrimaryDllLookupDirectory = new DirectoryInfo(
+            Config.Get("composer-dll-directory", AppDomain.CurrentDomain.BaseDirectory)
+        ).FullName;
+
+        private static readonly bool LoadFromPluginDirectory = !string.IsNullOrWhiteSpace(PluginDirectory)
+            && new DirectoryInfo(PluginDirectory).FullName != PrimaryDllLookupDirectory
+            && Directory.Exists(PluginDirectory);
 
         /// <summary>
         /// Gets the singleton instance
@@ -49,79 +54,23 @@ namespace QuantConnect.Util
         /// <remarks>Intentionally using a property so that when its gotten it will
         /// trigger the lazy construction which will be after the right configuration
         /// is loaded. See GH issue 3258</remarks>
-        public static Composer Instance => LazyComposer.Value;
+        public static readonly Composer Instance = new Composer();
+
+        private Task<CompositionContainer> _compositionContainer;
+        private readonly object _exportedValuesLockObject = new object();
+
+        // dictionaries keyed by contract type
+        private readonly Dictionary<Type, IEnumerable> _exportedValues = new Dictionary<Type, IEnumerable>();
+        private readonly ConcurrentDictionary<Type, List<QCExportType>> _qcExportedTypes = new ConcurrentDictionary<Type, List<QCExportType>>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Composer"/> class. This type
         /// is a light wrapper on top of an MEF <see cref="CompositionContainer"/>
         /// </summary>
-        public Composer()
+        private Composer()
         {
-            // grab assemblies from current executing directory if not defined by 'composer-dll-directory' configuration key
-            var primaryDllLookupDirectory = new DirectoryInfo(Config.Get("composer-dll-directory", AppDomain.CurrentDomain.BaseDirectory)).FullName;
-            var loadFromPluginDir = !string.IsNullOrWhiteSpace(PluginDirectory)
-                && Directory.Exists(PluginDirectory) &&
-                new DirectoryInfo(PluginDirectory).FullName != primaryDllLookupDirectory;
-            _composableParts = Task.Run(() =>
-            {
-                var catalogs = new List<ComposablePartCatalog>
-                {
-                    new DirectoryCatalog(primaryDllLookupDirectory, "*.dll"),
-                    new DirectoryCatalog(primaryDllLookupDirectory, "*.exe")
-                };
-                if (loadFromPluginDir)
-                {
-                    catalogs.Add(new DirectoryCatalog(PluginDirectory, "*.dll"));
-                }
-                var aggregate = new AggregateCatalog(catalogs);
-                _compositionContainer = new CompositionContainer(aggregate);
-                return _compositionContainer.Catalog.Parts.ToList();
-            });
-
-            // for performance we will load our assemblies and keep their exported types
-            // which is much faster that using CompositionContainer which uses reflexion
-            var exportedTypes = new ConcurrentBag<Type>();
-            var fileNames = Directory.EnumerateFiles(primaryDllLookupDirectory, $"{nameof(QuantConnect)}.*.dll");
-            if (loadFromPluginDir)
-            {
-                fileNames = fileNames.Concat(Directory.EnumerateFiles(PluginDirectory, $"{nameof(QuantConnect)}.*.dll"));
-            }
-
-            // guarantee file name uniqueness
-            var files = new Dictionary<string, string>();
-            foreach (var filePath in fileNames)
-            {
-                var fileName = Path.GetFileName(filePath);
-                if (!string.IsNullOrEmpty(fileName))
-                {
-                    files[fileName] = filePath;
-                }
-            }
-            Parallel.ForEach(files.Values,
-                file =>
-                {
-                    try
-                    {
-                        foreach (var type in
-                            Assembly.LoadFrom(file).ExportedTypes.Where(type => !type.IsAbstract && !type.IsInterface && !type.IsEnum))
-                        {
-                            exportedTypes.Add(type);
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        // ignored, just in case
-                    }
-                }
-            );
-            _exportedTypes.AddRange(exportedTypes);
+            Initialize();
         }
-
-        private CompositionContainer _compositionContainer;
-        private readonly List<Type> _exportedTypes = new List<Type>();
-        private readonly Task<List<ComposablePartDefinition>> _composableParts;
-        private readonly object _exportedValuesLockObject = new object();
-        private readonly Dictionary<Type, IEnumerable> _exportedValues = new Dictionary<Type, IEnumerable>();
 
         /// <summary>
         /// Gets the export matching the predicate
@@ -181,7 +130,7 @@ namespace QuantConnect.Util
                     var type = typeof(T);
                     if (_exportedValues.TryGetValue(type, out values))
                     {
-                        // if we've alread loaded this part, then just return the same one
+                        // if we've already loaded this part, then just return the same one
                         instance = values.OfType<T>().FirstOrDefault(x => x.GetType().MatchesTypeName(typeName));
                         if (instance != null)
                         {
@@ -189,16 +138,20 @@ namespace QuantConnect.Util
                         }
                     }
 
-                    var typeT = _exportedTypes.FirstOrDefault(type1 => type.IsAssignableFrom(type1) && type1.MatchesTypeName(typeName));
-                    if (typeT != null)
+                    List<QCExportType> qcExports;
+                    if (_qcExportedTypes.TryGetValue(type, out qcExports))
                     {
-                        instance = (T)Activator.CreateInstance(typeT);
+                        var qcExport = qcExports.FirstOrDefault(qce => qce.Implementation.MatchesTypeName(typeName));
+                        if (qcExport != null)
+                        {
+                            instance = qcExport.GetInstance<T>();
+                        }
                     }
 
-                    if(instance == null)
+                    if (instance == null)
                     {
                         // we want to get the requested part without instantiating each one of that type
-                        var selectedPart = _composableParts.Result
+                        var selectedPart = _compositionContainer.GetAwaiter().GetResult().Catalog.Parts
                             .Select(x => new { part = x, Type = ReflectionModelServices.GetPartType(x).Value })
                             .Where(x => type.IsAssignableFrom(x.Type))
                             .Where(x => x.Type.MatchesTypeName(typeName))
@@ -214,7 +167,7 @@ namespace QuantConnect.Util
                         var exportDefinition =
                             selectedPart.ExportDefinitions.First(
                                 x => x.ContractName == AttributedModelServices.GetContractName(type));
-                        instance = (T)selectedPart.CreatePart().GetExportedValue(exportDefinition);
+                        instance = (T) selectedPart.CreatePart().GetExportedValue(exportDefinition);
                     }
 
                     var exportedParts = instance.GetType().GetInterfaces()
@@ -227,13 +180,13 @@ namespace QuantConnect.Util
                         // cache the new value for next time
                         if (exportList == null)
                         {
-                            var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(export));
+                            var list = (IList) Activator.CreateInstance(typeof(List<>).MakeGenericType(export));
                             list.Add(instance);
                             _exportedValues[export] = list;
                         }
                         else
                         {
-                            ((IList)exportList).Add(instance);
+                            ((IList) exportList).Add(instance);
                         }
                     }
 
@@ -248,11 +201,15 @@ namespace QuantConnect.Util
                     Log.Error(exception.ToString());
                 }
 
-                if (err.InnerException != null) Log.Error(err.InnerException);
+                if (err.InnerException != null)
+                {
+                    Log.Error(err.InnerException);
+                }
 
                 throw;
             }
         }
+
         /// <summary>
         /// Gets all exports of type T
         /// </summary>
@@ -263,16 +220,18 @@ namespace QuantConnect.Util
                 lock (_exportedValuesLockObject)
                 {
                     IEnumerable values;
-                    if (_exportedValues.TryGetValue(typeof (T), out values))
+                    if (_exportedValues.TryGetValue(typeof(T), out values))
                     {
                         return values.OfType<T>();
                     }
 
-                    if (!_composableParts.IsCompleted)
+                    List<QCExportType> qcExports;
+                    if (_qcExportedTypes.TryGetValue(typeof(T), out qcExports))
                     {
-                        _composableParts.Wait();
+                        return qcExports.Select(qce => qce.GetInstance<T>());
                     }
-                    values = _compositionContainer.GetExportedValues<T>().ToList();
+
+                    values = _compositionContainer.GetAwaiter().GetResult().GetExportedValues<T>().ToList();
                     _exportedValues[typeof (T)] = values;
                     return values.OfType<T>();
                 }
@@ -296,6 +255,205 @@ namespace QuantConnect.Util
             lock(_exportedValuesLockObject)
             {
                 _exportedValues.Clear();
+
+                // This is excluded to maintain faster tests, but I'm wondering why we can't just
+                // avoid calling Reset() in our tests if we want to reuse the same instances and if
+                // that's not an option, then perhaps adding a different method which supports keeping
+                // some types to make it explicit, since the Composer impl now doesn't provide any
+                // mechanism for actually resetting the state and starting fresh with new instances
+
+                // See: e4fc00efbf876e39280344187017d707c325ca56 and  9865fe63e0da90c85ba26ecd4fb0067b7bbab825
+
+                //_qcExportedTypes.Clear();
+                //Initialize();
+            }
+        }
+
+        /// <summary>
+        /// Performs a hard reset of the composer. This includes completely re-initializing all of the state,
+        /// including resolution of assemblies from disk.
+        /// </summary>
+        public void HardReset()
+        {
+            lock (_exportedValuesLockObject)
+            {
+                _exportedValues.Clear();
+                _qcExportedTypes.Clear();
+                Initialize();
+            }
+        }
+
+        private void Initialize()
+        {
+            // for performance we will load QC assemblies and keep their exported types which is much faster
+            // than using CompositionContainer which tries to handle many more cases than simply invoking the
+            // public default parameterless constructor, such as dependency injection of properties, etc
+            var files = EnumerateFiles(PrimaryDllLookupDirectory, $"{nameof(QuantConnect)}.*.dll")
+                .Concat(EnumerateFiles(PrimaryDllLookupDirectory, $"{nameof(QuantConnect)}.*.exe"));
+
+            if (LoadFromPluginDirectory)
+            {
+                var pluginsDirectory = new DirectoryInfo(PluginDirectory);
+                var executingDirectory = new DirectoryInfo(PrimaryDllLookupDirectory);
+                if (!string.Equals(pluginsDirectory.FullName, executingDirectory.FullName))
+                {
+                    // skip the plugin directory if it's the same as the primary. there's no chance for potential duplicates here since
+                    // we're ensuring they're different directories and above we've ensured that we're loading different file extensions
+                    files = files.Concat(EnumerateFiles(PluginDirectory, $"{nameof(QuantConnect)}.*.dll"));
+                }
+            }
+
+            // load non-qc types in a task, most times we don't even need to evaluate this container, so we'll let
+            // it initialize in the background and if we actually do need to look in it, it will likely be ready by
+            // then or we'll wait for this task to complete
+            _compositionContainer = Task.Run(() =>
+            {
+                // since we've already loaded assemblies matching the pattern: QuantConnect.*{dll|exe}
+                // then we don't need to load them again, so look for assemblies not starting with QuantConnect
+                var assemblyCatalogs = EnumerateFiles(PrimaryDllLookupDirectory, "*.dll")
+                    .Concat(EnumerateFiles(PrimaryDllLookupDirectory, "*.exe"))
+                    .Union(LoadFromPluginDirectory ? EnumerateFiles(PluginDirectory, "*.dll") : Enumerable.Empty<string>())
+                    .AsParallel() // parallelize assembly loading
+                    .Select(TryLoadAssembly)
+                    .Where(assembly => assembly != null)
+                    .Select(assembly => new AssemblyCatalog(assembly));
+
+                // re-seed the composition container, making sure to exclude QuantConnect.*.{dll|exe} since we manually loaded those above
+                return new CompositionContainer(new AggregateCatalog(assemblyCatalogs));
+            });
+
+            Parallel.ForEach(files, file =>
+            {
+                try
+                {
+                    var assembly = TryLoadAssembly(file);
+                    if (assembly == null)
+                    {
+                        return;
+                    }
+
+                    // enumerate types in this assembly that have the [InheritedExport] on themselves or their interfaces
+                    // QCExportType.ForImplementation will generate an export for each contract that has [InheritedExport]
+                    var types = assembly.GetTypes();
+                    for (int i = 0; i < types.Length; i++)
+                    {
+                        var export = QCExportType.ForImplementation(types[i]);
+                        if (export == null)
+                        {
+                            continue;
+                        }
+
+                        // be sure to support requesting types directly by type name
+                        _qcExportedTypes[export.Implementation] = new List<QCExportType> {export};
+
+                        for (var j = 0; j < export.Contracts.Count; j++)
+                        {
+                            var contract = export.Contracts[j];
+
+                            // support requesting types by the contract
+                            lock (contract)
+                            {
+                                _qcExportedTypes.AddOrUpdate(contract,
+                                    c => new List<QCExportType> { export },
+                                    (c, list) => { list.Add(export); return list; }
+                                );
+                            }
+                        }
+                    }
+                }
+                catch (Exception error)
+                {
+                    Log.Error($"Composer.Initialize(): {file}", error);
+                }
+            });
+        }
+
+        private static IEnumerable<string> EnumerateFiles(string directory, string pattern)
+        {
+            return Directory.EnumerateFiles(directory, pattern);
+        }
+
+        private static Assembly TryLoadAssembly(string path)
+        {
+            try
+            {
+                return Assembly.LoadFrom(path);
+            }
+            catch (Exception error)
+            {
+                Log.Error($"Composer.TryLoadAssembly(): {path}", error);
+                return null;
+            }
+        }
+
+        private sealed class QCExportType
+        {
+            private object _instance;
+            private readonly object _sync = new object();
+
+            public readonly Type Implementation;
+            public readonly Func<object> Activator;
+            public readonly IReadOnlyList<Type> Contracts;
+
+            public QCExportType(IEnumerable<Type> contracts, Type implementation, Func<object> activator)
+            {
+                Activator = activator;
+                Contracts = contracts.ToList();
+                Implementation = implementation;
+            }
+
+            public T GetInstance<T>()
+            {
+                if (_instance != null)
+                {
+                    return (T) _instance;
+                }
+
+                lock (_sync)
+                {
+                    _instance = (T) Activator();
+                    return (T) _instance;
+                }
+            }
+
+            public static QCExportType ForImplementation(Type type)
+            {
+                // require 'newable' via public/default constructor since we use the Activator w/ no args
+                if (type.IsAbstract || type.GetConstructor(Type.EmptyTypes) == null)
+                {
+                    return null;
+                }
+
+                if (type.Name.Contains("Export") || type.Name.Contains("MapFileProvider"))
+                {
+
+                }
+
+                var contracts = new List<Type>();
+
+                // inherit only captures base classes, we still need to check interfaces manually
+                foreach (var inter in type.GetInterfaces())
+                {
+                    var attr = inter.GetCustomAttribute<InheritedExportAttribute>();
+                    if (attr != null)
+                    {
+                        contracts.Add(inter);
+                    }
+                }
+
+                if (contracts.Count == 0)
+                {
+                    var attr = type.GetCustomAttribute<InheritedExportAttribute>(inherit: true);
+                    if (attr == null)
+                    {
+                        // we didn't find [InheritedExport] on any interfaces or the implementation type, bail.
+                        return null;
+                    }
+                }
+
+                // everyone exports their own contract, but only if we've found an [InheritedExport]
+                contracts.Add(type);
+                return new QCExportType(contracts, type, () => System.Activator.CreateInstance(type));
             }
         }
     }

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Jupyter
                 SetPandasConverter();
 
                 // Initialize History Provider
-                var composer = new Composer();
+                var composer = Composer.Instance;
                 var algorithmHandlers = LeanEngineAlgorithmHandlers.FromConfiguration(composer);
                 var systemHandlers = LeanEngineSystemHandlers.FromConfiguration(composer);
                 // init the API


### PR DESCRIPTION
This is mostly a clean up/refactoring of the existing logic and behavior.
The only real behavior change is not waiting for the CompositionContainer
to be fully resolved before finishing the init procedures. 90% of the calls
we make to the Composer are QC types and therefore handled by the special
case code that explicitly loads QC assemblies and caches their types.

Another behavior change was made to really trim down the number of types
that were being cached from the QC assemblies. We were caching ALL public
types that weren't abstract/interface/enum, but since it's a proxy for MEF,
we should really have the [InheritedExport] filter added. Adding this cut
down the number of QC types were caching by over 100x. Another perf gain
was in how we store the cached items. The existing code had the cache in
a list with over 10k types in it and then would search that list doing
an IsAssignableFrom and MatchesTypeName. That's a lot of items to hit.
This commit changes the storage to be a dictionarty keyed by the contract
type. We use the type that declared the [InheritedExport] as well as the
implementation type to support requested exact types, but I'm not sure
that this was required but at first glance it seemed to be supported by
the existing implementation.

This change cuts down LEAN's startup time (defined as the time it takes
to go from the top of Main to just following the initialization/resolution
of the algorithm handlers. This section of code's performance is 100%
dominated by the Composer's initialization and resolution functions. Avg
times on 'master' were around 350ms for a hot start and over 1.5s for a
cold start. Cold start meaning first run after fresh build. This change
shows an average hot start time of about 210ms and a cold start time of
about 250ms

This change also adds a Composer.HardReset() method which clears all of
the state within the Composer and re-initializes everything, including
reading assemblies from disk.

Closes #3836


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
