### PR TITLE
Limit LiveTrading parallel history workers queue

### DIFF
--- a/Engine/DataFeeds/Enumerators/AuxiliaryDataEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/AuxiliaryDataEnumerator.cs
@@ -106,7 +106,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <returns>Always true</returns>
         public virtual bool MoveNext()
         {
-            Current = _auxiliaryData.Any() ? _auxiliaryData.Dequeue() : null;
+            Current = _auxiliaryData.Count != 0 ? _auxiliaryData.Dequeue() : null;
             return true;
         }
 

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -101,10 +101,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var enumerator = enumeratorFactory.CreateEnumerator(request, _dataProvider);
             enumerator = ConfigureEnumerator(request, false, enumerator);
 
-            return SubscriptionUtils.CreateAndScheduleWorker(request,
-                enumerator,
-                GetLowerThreshold(request.Configuration.Resolution),
-                GetUpperThreshold(request.Configuration.Resolution));
+            return SubscriptionUtils.CreateAndScheduleWorker(request, enumerator);
         }
 
         /// <summary>
@@ -133,23 +130,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="request">The subscription request</param>
         private Subscription CreateUniverseSubscription(SubscriptionRequest request)
         {
-            // grab the relevant exchange hours
-            var config = request.Configuration;
-
             // define our data enumerator
             var enumerator = GetEnumeratorFactory(request).CreateEnumerator(request, _dataProvider);
 
-            var lowerThreshold = GetLowerThreshold(config.Resolution);
-            var upperThreshold = GetUpperThreshold(config.Resolution);
-            if (config.Type == typeof (CoarseFundamental))
-            {
-                // the lower threshold will be when we start the worker again, if he is stopped
-                lowerThreshold = 200;
-                // the upper threshold will stop the worker from loading more data. This is roughly 1 GB
-                upperThreshold = 500;
-            }
-
-            return SubscriptionUtils.CreateAndScheduleWorker(request, enumerator, lowerThreshold, upperThreshold);
+            return SubscriptionUtils.CreateAndScheduleWorker(request, enumerator);
         }
 
         /// <summary>
@@ -249,42 +233,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             return enumerator;
-        }
-
-        private static int GetLowerThreshold(Resolution resolution)
-        {
-            switch (resolution)
-            {
-                case Resolution.Tick:
-                    return 500;
-
-                case Resolution.Second:
-                case Resolution.Minute:
-                case Resolution.Hour:
-                case Resolution.Daily:
-                    return 250;
-
-                default:
-                    throw new ArgumentOutOfRangeException("resolution", resolution, null);
-            }
-        }
-
-        private static int GetUpperThreshold(Resolution resolution)
-        {
-            switch (resolution)
-            {
-                case Resolution.Tick:
-                    return 10000;
-
-                case Resolution.Second:
-                case Resolution.Minute:
-                case Resolution.Hour:
-                case Resolution.Daily:
-                    return 5000;
-
-                default:
-                    throw new ArgumentOutOfRangeException("resolution", resolution, null);
-            }
         }
     }
 }

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -168,7 +168,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             });
             var subscriptionRequest = new SubscriptionRequest(false, null, security, config, request.StartTimeUtc, request.EndTimeUtc);
 
-            return SubscriptionUtils.CreateAndScheduleWorker(subscriptionRequest, reader, 0, int.MaxValue);
+            return SubscriptionUtils.CreateAndScheduleWorker(subscriptionRequest, reader);
         }
 
         private class FilterEnumerator<T> : IEnumerator<T>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Limit workers queue size for parallel history requests
- Small performance fix, use `queue.count` instead of `any`. Performance test `EmptyMinute400EquityBenchmark`

`master`
![image](https://user-images.githubusercontent.com/18473240/68960514-0dc66b00-07af-11ea-9e55-95ed874ddff4.png)
`pr`
![image](https://user-images.githubusercontent.com/18473240/68960530-1a4ac380-07af-11ea-9c72-759f67416c94.png)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3851
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevent out of memory exceptions
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests, live deployment, backtests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
