### PR TITLE
LiveTrading stores Series color and unit

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -234,7 +234,11 @@ namespace QuantConnect.Lean.Engine.Results
                     {
                         var chart = kvp.Value;
 
-                        deltaCharts.Add(chart.Name, chart.GetUpdates());
+                        var updates = chart.GetUpdates();
+                        if (!updates.IsEmpty())
+                        {
+                            deltaCharts.Add(chart.Name, updates);
+                        }
 
                         if (AlgorithmPerformanceCharts.Contains(kvp.Key))
                         {
@@ -303,12 +307,9 @@ namespace QuantConnect.Lean.Engine.Results
             var splitPackets = new List<BacktestResultPacket>();
             foreach (var chart in deltaCharts.Values)
             {
-                //Don't add packet if the series is empty:
-                if (chart.Series.Values.Aggregate(0, (i, x) => i + x.Values.Count) == 0) continue;
-
                 splitPackets.Add(new BacktestResultPacket(_job, new BacktestResult
                 {
-                    Charts = new Dictionary<string, Chart>()
+                    Charts = new Dictionary<string, Chart>
                     {
                         {chart.Name, chart}
                     }

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -1032,11 +1032,11 @@ namespace QuantConnect.Lean.Engine.Results
             foreach (var kvp in result.Charts)
             {
                 var chart = kvp.Value;
-                var newChart = new Chart(chart.Name, chart.ChartType);
+                var newChart = new Chart(chart.Name);
                 charts.Add(kvp.Key, newChart);
                 foreach (var series in chart.Series.Values)
                 {
-                    var newSeries = new Series(series.Name, series.SeriesType);
+                    var newSeries = new Series(series.Name, series.SeriesType, series.Unit, series.Color);
                     newSeries.Values.AddRange(series.Values.Where(chartPoint => chartPoint.x >= unixDateStart && chartPoint.x <= unixDateStop));
                     newChart.AddSeries(newSeries);
                 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- LiveTradingResultHandler will store `Series` color and unit

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3854
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- LiveTradingResultHandler was unsetting Series color and unit
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Live deployment
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
