### PR TITLE
Added AccumulativeInsightPortfolioConstructionModel.

### DIFF
--- a/Algorithm.Framework/Portfolio/AccumulativeInsightPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/AccumulativeInsightPortfolioConstructionModel.cs
@@ -1,0 +1,244 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Algorithm.Framework.Portfolio
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IPortfolioConstructionModel"/> that allocates percent of account
+    /// to each insight, defaulting to 3%.
+    /// For insights of direction <see cref="InsightDirection.Up"/>, long targets are returned and
+    /// for insights of direction <see cref="InsightDirection.Down"/>, short targets are returned.
+    /// No rebalancing shall be done, as a new insight or the age of the insight shall determine whether to exit
+    /// the positions.
+    /// Rules:
+    ///    1. On Up insight, increase position size by percent
+    ///    2. On Down insight, decrease position size by percent
+    ///    3. On Flat insight, move by percent towards 0
+    ///    4. On expired insight, perform a Flat insight'''
+    /// </summary>
+    public class AccumulativeInsightPortfolioConstructionModel : PortfolioConstructionModel
+    {
+        private DateTime _rebalancingTime;
+        private List<Symbol> _removedSymbols = new List<Symbol>();
+        private readonly InsightCollection _insightCollection = new InsightCollection();
+        private DateTime? _nextExpiryTime;
+        private double _percent;
+        private Dictionary<Insight, int> usedInsight = new Dictionary<Insight, int>();
+        private Dictionary<Insight, int> expiredList = new Dictionary<Insight, int>();
+        private Dictionary<Symbol, double> positionSizes = new Dictionary<Symbol, double>();
+                
+        /// <summary>
+        /// Initialize a new instance of <see cref="AccumulativeInsightPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="percent">The amount of portfolio to allocate to a single insight</param>
+        public AccumulativeInsightPortfolioConstructionModel(double percent = 0.03)
+        {
+            _percent = Math.Abs(percent);
+        }
+
+       
+        /// <summary>
+        /// Method that will determine if the portfolio construction model should create a
+        /// target for this insight
+        /// </summary>
+        /// <param name="insight">The insight to create a target for</param>
+        /// <returns>True if the portfolio should create a target for the insight</returns>
+        public virtual bool ShouldCreateTargetForInsight(Insight insight)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Will determine the target percent for each insight
+        /// </summary>
+        /// <param name="activeInsights">The active insights to generate a target for</param>
+        /// <returns>A target percent for each insight</returns>
+        public Dictionary<Insight, double> DetermineTargetPercent(ICollection<Insight> activeInsights)
+        {
+            var result = new Dictionary<Insight, double>();
+
+            foreach (var insight in activeInsights)
+            {
+                if (usedInsight.ContainsKey(insight))
+                {
+                   continue;
+                }
+                usedInsight[insight] = 1;
+                if (positionSizes.ContainsKey(insight.Symbol))
+                {
+                   positionSizes[insight.Symbol] += _percent * (int)insight.Direction;
+                }
+                else
+                {
+                     positionSizes[insight.Symbol] = _percent * (int)insight.Direction;
+                }
+
+                if (insight.Direction == 0)
+                {
+                   // We received a Flat
+
+                   // if adding or subtracting will push past 0, then make it 0
+                   if (Math.Abs(positionSizes[insight.Symbol]) < _percent)
+                   {
+                      positionSizes[insight.Symbol] = 0;
+                   }
+
+                   // otherwise, we flatten by percent
+                   if (positionSizes[insight.Symbol] > 0)
+                   {
+                        positionSizes[insight.Symbol] -= _percent;
+                   }
+                   if (positionSizes[insight.Symbol] < 0)
+                   {
+                      positionSizes[insight.Symbol] += _percent;
+                   }
+                }
+            
+                result[insight] = positionSizes[insight.Symbol];
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Will determine the target percent for each expired insight (since expired insights
+        /// will remove the amount accumulated in portfolio)
+        /// </summary>
+        /// <param name ="activeInsights">The insights that are expiring and must be updated
+        /// <returns>A target percent for each insight</returns>
+        public Dictionary<Insight, double> UpdateExpiredInsights(ICollection<Insight> activeInsights)
+        {
+                var result = new Dictionary<Insight, double>();
+        
+                foreach (var insight in activeInsights)
+                {
+                        if (expiredList.ContainsKey(insight))
+                        {
+                                continue;
+                        }
+                        expiredList[insight] = 1;
+
+                        // if an expiring insight pushes it past 0, then flatten to 0
+                        if ( (Math.Abs(positionSizes[insight.Symbol]) < _percent) && (insight.Direction != 0) )
+                        {
+                                positionSizes[insight.Symbol] = 0;
+                        }
+                        else
+                        {
+                                positionSizes[insight.Symbol] -= _percent * (int)insight.Direction;
+                        }
+                        result[insight] = positionSizes[insight.Symbol];
+                }
+        
+                return result;
+        }
+                
+        /// <summary>
+        /// Create portfolio targets from the specified insights
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="insights">The insights to create portfolio targets from</param>
+        /// <returns>An enumerable of portfolio targets to be sent to the execution model</returns>
+        public override IEnumerable<IPortfolioTarget> CreateTargets(QCAlgorithm algorithm, Insight[] insights)
+        {
+            var targets = new List<IPortfolioTarget>();
+
+            if (algorithm.UtcTime <= _nextExpiryTime &&
+                insights.Length == 0 &&
+                _removedSymbols == null)
+            {
+                return targets;
+            }
+
+            // Validate we should create a target for this insight
+            _insightCollection.AddRange(insights.Where(ShouldCreateTargetForInsight));
+
+            // Create flatten target for each security that was removed from the universe
+            if (_removedSymbols != null)
+            {
+                var universeDeselectionTargets = _removedSymbols.Select(symbol => new PortfolioTarget(symbol, 0));
+                targets.AddRange(universeDeselectionTargets);
+                _removedSymbols = null;
+            }
+
+            // Get insight that haven't expired of each symbol that is still in the universe
+            var activeInsights = _insightCollection.GetActiveInsights(algorithm.UtcTime);
+
+            // Get the last generated active insight for each symbol
+            var lastActiveInsights = (from insight in activeInsights
+                                      group insight by insight.Symbol into g
+                                      select g.OrderBy(x => x.GeneratedTimeUtc).Last()).ToList();
+
+            var errorSymbols = new HashSet<Symbol>();
+
+            // Determine target percent for the given insights
+            var percents = DetermineTargetPercent(lastActiveInsights);
+
+            foreach (var insight in percents.Keys)
+            {
+                var target = PortfolioTarget.Percent(algorithm, insight.Symbol, percents[insight]);
+                if (target != null)
+                {
+                    targets.Add(target);
+                }
+                else
+                {
+                    errorSymbols.Add(insight.Symbol);
+                }
+            }
+
+            // Get expired insights and create flatten targets for each symbol
+            var expiredInsights = _insightCollection.RemoveExpiredInsights(algorithm.UtcTime);
+
+                        percents = UpdateExpiredInsights(expiredInsights);
+
+            foreach (var insight in percents.Keys)
+            {
+                var target = PortfolioTarget.Percent(algorithm, insight.Symbol, percents[insight]);
+                if (target != null)
+                {
+                    targets.Add(target);
+                }
+                else
+                {
+                    errorSymbols.Add(insight.Symbol);
+                }
+            }
+
+            _nextExpiryTime = _insightCollection.GetNextExpiryTime();
+
+            return targets;
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
+        /// <param name="changes">The security additions and removals from the algorithm</param>
+        public override void OnSecuritiesChanged(QCAlgorithm algorithm, SecurityChanges changes)
+        {
+            // Get removed symbol and invalidate them in the insight collection
+            _removedSymbols = changes.RemovedSecurities.Select(x => x.Symbol).ToList();
+            _insightCollection.Clear(_removedSymbols.ToArray());
+        }
+    }
+}
+
+

--- a/Algorithm.Framework/Portfolio/AccumulativeInsightPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/AccumulativeInsightPortfolioConstructionModel.py
@@ -1,0 +1,176 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm.Framework")
+
+from QuantConnect import Resolution, Extensions
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from itertools import groupby
+from datetime import datetime, timedelta
+from pytz import utc
+UTCMIN = datetime.min.replace(tzinfo=utc)
+
+
+class AccumulativeInsightPortfolioConstructionModel(PortfolioConstructionModel):
+    '''Provides an implementation of IPortfolioConstructionModel that allocates percent of account
+    to each insight, defaulting to 3%.
+    For insights of direction InsightDirection.Up, long targets are returned and
+    for insights of direction InsightDirection.Down, short targets are returned.
+    No rebalancing shall be done, as a new insight or the age of the insight shall determine whether to exit
+    the positions.
+    Rules:
+        1. On Up insight, increase position size by percent
+        2. On Down insight, decrease position size by percent
+        3. On Flat insight, move by percent towards 0
+        4. On expired insight, perform a Flat insight'''
+
+    def __init__(self, percent = 0.03):
+        '''Initialize a new instance of AccumulativeInsightPortfolioConstructionModel
+        Args:
+            percent: percent of portfolio to allocate to each position'''
+        self.insightCollection = InsightCollection()
+        self.removedSymbols = []
+        self.nextExpiryTime = UTCMIN
+        self.percent = abs(percent)
+        self.positionSizes = {}
+        self.usedInsight = {}
+        self.expiredList = {}
+
+    def ShouldCreateTargetForInsight(self, insight):
+        '''Method that will determine if the portfolio construction model should create a
+        target for this insight
+        Args:
+            insight: The insight to create a target for'''
+        # We can probably use this to do something smarter
+        return True
+
+    def DetermineTargetPercent(self, activeInsights):
+        '''Will determine the target percent for each insight
+        Args:
+            activeInsights: The active insights to generate a target for'''
+        result = {}
+        
+        for insight in activeInsights:
+            if insight in self.usedInsight:
+                continue
+            self.usedInsight[insight] = 1
+            if insight.Symbol in self.positionSizes:
+                self.positionSizes[insight.Symbol] += self.percent * insight.Direction
+            else:
+                self.positionSizes[insight.Symbol] = self.percent * insight.Direction
+            
+            if insight.Direction == 0:
+                # We received a Flat
+                
+                # if adding or subtracting will push past 0, then make it 0
+                if abs(self.positionSizes[insight.Symbol]) < self.percent:
+                    self.positionSizes[insight.Symbol] = 0
+                
+                # otherwise, we flatten by percent
+                if self.positionSizes[insight.Symbol] > 0:
+                    self.positionSizes[insight.Symbol] -= self.percent
+                if self.positionSizes[insight.Symbol] < 0:
+                    self.positionSizes[insight.Symbol] += self.percent
+                    
+            result[insight] = self.positionSizes[insight.Symbol]
+        return result
+
+    def UpdateExpiredInsights(self, activeInsights):
+        '''Will determine the target percent for each insight
+        Args:
+            activeInsights: The active insights to generate a target for'''
+        result = {}
+        
+        for insight in activeInsights:
+            if insight in self.expiredList:
+                continue
+            self.expiredList[insight] = 1
+            
+            # if an expiring insight pushes it past 0, then flatten to 0
+            if abs(self.positionSizes[insight.Symbol]) < self.percent and insight.Direction != 0:
+                self.positionSizes[insight.Symbol] = 0
+            else:
+                self.positionSizes[insight.Symbol] -= self.percent * insight.Direction
+            result[insight] = self.positionSizes[insight.Symbol]
+        return result
+
+    def CreateTargets(self, algorithm, insights):
+        '''Create portfolio targets from the specified insights
+        Args:
+            algorithm: The algorithm instance
+            insights: The insights to create portfolio targets from
+        Returns:
+            An enumerable of portfolio targets to be sent to the execution model'''
+
+        targets = []
+
+        if (algorithm.UtcTime <= self.nextExpiryTime and len(insights) == 0 and self.removedSymbols is None):
+            return targets
+
+        for insight in insights:
+            if self.ShouldCreateTargetForInsight(insight):
+                self.insightCollection.Add(insight)
+
+        # Create flatten target for each security that was removed from the universe
+        if self.removedSymbols is not None:
+            universeDeselectionTargets = [ PortfolioTarget(symbol, 0) for symbol in self.removedSymbols ]
+            targets.extend(universeDeselectionTargets)
+            self.removedSymbols = None
+
+        # Get insight that haven't expired of each symbol that is still in the universe
+        activeInsights = self.insightCollection.GetActiveInsights(algorithm.UtcTime)
+
+        # Get the last generated active insight for each symbol
+        lastActiveInsights = []
+        for symbol, g in groupby(activeInsights, lambda x: x.Symbol):
+            lastActiveInsights.append(sorted(g, key = lambda x: x.GeneratedTimeUtc)[-1])
+
+        # Determine target percent for the given insights
+        percents = self.DetermineTargetPercent(lastActiveInsights)
+
+        errorSymbols = {}
+        for insight in percents:
+            target = PortfolioTarget.Percent(algorithm, insight.Symbol, percents[insight])
+            if not target is None:
+                targets.append(target)
+            else:
+                errorSymbols[insight.Symbol] = insight.Symbol
+
+        # Get expired insights and create flatten targets for each symbol
+        expiredInsights = self.insightCollection.RemoveExpiredInsights(algorithm.UtcTime)
+
+        percents = self.UpdateExpiredInsights(expiredInsights)
+        for insight in percents:
+            target = PortfolioTarget.Percent(algorithm, insight.Symbol, percents[insight])
+            if not target is None:
+                targets.append(target)
+            else:
+                errorSymbols[insight.Symbol] = insight.Symbol
+                
+        self.nextExpiryTime = self.insightCollection.GetNextExpiryTime()
+        if self.nextExpiryTime is None:
+            self.nextExpiryTime = UTCMIN
+        return targets
+
+    def OnSecuritiesChanged(self, algorithm, changes):
+        '''Event fired each time the we add/remove securities from the data feed
+        Args:
+            algorithm: The algorithm instance that experienced the change in securities
+            changes: The security additions and removals from the algorithm'''
+
+        # Get removed symbol and invalidate them in the insight collection
+        self.removedSymbols = [x.Symbol for x in changes.RemovedSecurities]
+        self.insightCollection.Clear(self.removedSymbols)

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Portfolio\MeanVarianceOptimizationPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\MinimumVariancePortfolioOptimizer.cs" />
     <Compile Include="Portfolio\EqualWeightingPortfolioConstructionModel.cs" />
+    <Compile Include="Portfolio\AccumulativeInsightPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\ReturnsSymbolData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Risk\MaximumDrawdownPercentPortfolio.cs" />
@@ -178,6 +179,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Portfolio\ConfidenceWeightedPortfolioConstructionModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Portfolio\AccumulativeInsightPortfolioConstructionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Portfolio\InsightWeightingPortfolioConstructionModel.py">

--- a/Algorithm.Python/AccumulativeInsightPortfolioConstructionModel.py
+++ b/Algorithm.Python/AccumulativeInsightPortfolioConstructionModel.py
@@ -1,0 +1,59 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Execution import *
+from QuantConnect.Algorithm.Framework.Portfolio import *
+from QuantConnect.Algorithm.Framework.Risk import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from datetime import timedelta
+
+### <summary>
+### Test algorithm using 'AccumulativeInsightPortfolioConstructionModel.py' and 'ConstantAlphaModel'
+### generating a constant 'Insight' 
+### </summary>
+class ConfidenceWeightedFrameworkAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        ''' Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        # Set requested data resolution
+        self.UniverseSettings.Resolution = Resolution.Minute
+
+        self.SetStartDate(2013,10,7)   #Set Start Date
+        self.SetEndDate(2013,10,11)    #Set End Date
+        self.SetCash(100000)           #Set Strategy Cash
+
+        symbols = [ Symbol.Create("SPY", SecurityType.Equity, Market.USA) ]
+
+        # set algorithm framework models
+        self.SetUniverseSelection(ManualUniverseSelectionModel(symbols))
+        self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(minutes = 20)))
+        self.SetPortfolioConstruction(AccumulativeInsightPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+
+    def OnEndOfAlgorithm(self):
+        # holdings value should be 0.25 - to avoid price fluctuation issue we compare with 0.28 and 0.23
+        if (self.Portfolio.TotalHoldingsValue > self.Portfolio.TotalPortfolioValue * 0.28
+            or self.Portfolio.TotalHoldingsValue < self.Portfolio.TotalPortfolioValue * 0.23):
+            raise ValueError("Unexpected Total Holdings Value: " + str(self.Portfolio.TotalHoldingsValue))

--- a/Tests/Algorithm/Framework/Portfolio/AccumulativeInsightPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/AccumulativeInsightPortfolioConstructionModelTests.cs
@@ -1,0 +1,329 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NodaTime;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Equity;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
+{
+    [TestFixture]
+    public class AccumulativeInsightPortfolioConstructionModelTests
+    {
+        private QCAlgorithm _algorithm;
+        private const decimal _startingCash = 100000;
+        private const double DefaultPercent = 0.03;
+
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            _algorithm = new QCAlgorithm();
+            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
+
+            var prices = new Dictionary<Symbol, decimal>
+            {
+                { Symbol.Create("AIG", SecurityType.Equity, Market.USA), 55.22m },
+                { Symbol.Create("IBM", SecurityType.Equity, Market.USA), 145.17m },
+                { Symbol.Create("SPY", SecurityType.Equity, Market.USA), 281.79m },
+            };
+
+            foreach (var kvp in prices)
+            {
+                var symbol = kvp.Key;
+                var security = GetSecurity(symbol);
+                security.SetMarketPrice(new Tick(_algorithm.Time, symbol, kvp.Value, kvp.Value));
+                _algorithm.Securities.Add(symbol, security);
+            }
+        }
+
+
+        [Test]
+        [TestCase(Language.Python)]
+        [TestCase(Language.CSharp)]
+        public void EmptyInsightsReturnsEmptyTargets(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
+
+            Assert.AreEqual(0, actualTargets.Count());
+        }
+
+        [Test]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        public void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)DefaultPercent;
+            var expectedTargets = _algorithm.Securities
+                .Select(x => new PortfolioTarget(x.Key, (int)direction
+                                                        * Math.Floor(amount / x.Value.Price)));
+
+            var insights = _algorithm.Securities.Keys.Select(x => GetInsight(x, direction, _algorithm.UtcTime));
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
+            
+            AssertTargets( expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.Python)]
+        [TestCase(Language.CSharp)]
+        public void LongTermInsightCanceledByNew(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            // First emit long term insight
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
+            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            var expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, -1m * (decimal)DefaultPercent) };
+            AssertTargets(expectedTargets, targets);
+
+            // One minute later, emits short term insight to cancel long
+            SetUtcTime(_algorithm.UtcTime.AddMinutes(1));
+            insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, _algorithm.UtcTime, Time.OneMinute) };
+            targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, 0) };
+            AssertTargets(expectedTargets, targets);
+
+            // One minute later, emit empty insights array, should stay 0 after the long expires
+            SetUtcTime(_algorithm.UtcTime.AddMinutes(1.1));
+
+            expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, 0) };
+
+            // Create target from an empty insights array
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        public void LongTermInsightAccumulatesByNew(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            // First emit long term insight
+            var insights = new[] { GetInsight(Symbols.SPY, direction, _algorithm.UtcTime) };
+            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            var expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, (int)direction * 1m * (decimal)DefaultPercent) };
+            AssertTargets(expectedTargets, targets);
+
+            // One minute later, emits short term insight to add long
+            SetUtcTime(_algorithm.UtcTime.AddMinutes(1));
+            insights = new[] { GetInsight(Symbols.SPY, direction, _algorithm.UtcTime, Time.OneMinute) };
+            targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+
+            expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, (int)direction * 1m * 2 * (decimal)DefaultPercent) };
+            AssertTargets(expectedTargets, targets);
+
+            // One minute later, emit empty insights array, should return to nomral after the long expires
+            SetUtcTime(_algorithm.UtcTime.AddMinutes(1.1));
+
+            expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, (int)direction * 1m * (decimal)DefaultPercent) };
+
+            // Create target from an empty insights array
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        public void FlatUndoesAccumulation(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            // First emit long term insight
+            var insights = new[] { GetInsight(Symbols.SPY, direction, _algorithm.UtcTime) };
+            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            var expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, (int)direction * 1m * (decimal)DefaultPercent) };
+            AssertTargets(expectedTargets, targets);
+
+            // One minute later, emits insight to add to portfolio
+            SetUtcTime(_algorithm.UtcTime.AddMinutes(1));
+            insights = new[] { GetInsight(Symbols.SPY, direction, _algorithm.UtcTime) };
+            targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+
+            expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, (int)direction * 1m * 2 * (decimal)DefaultPercent) };
+            AssertTargets(expectedTargets, targets);
+
+            // One minute later, emits flat insight
+            SetUtcTime(_algorithm.UtcTime.AddMinutes(1));
+            insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Flat, _algorithm.UtcTime) };
+            targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+
+            expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, (int)direction * 1m * (decimal)DefaultPercent) };
+
+            AssertTargets(expectedTargets, targets);
+        }
+
+
+        [Test]
+        [TestCase(Language.Python)]
+        [TestCase(Language.CSharp)]
+        public void WeightsProportionally(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var insights = new[]
+            {
+                GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime),
+                GetInsight(Symbol.Create("IBM", SecurityType.Equity, Market.USA),
+                    InsightDirection.Down, _algorithm.UtcTime)
+            };
+
+            // they will each share, proportionally, the total portfolio value
+            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)DefaultPercent;
+
+            var expectedTargets = _algorithm.Securities.Where(pair => insights.Any(insight => pair.Key == insight.Symbol))
+                .Select(x => new PortfolioTarget(x.Key, (int)InsightDirection.Down * Math.Floor(amount / x.Value.Price)));
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            Assert.AreEqual(2, actualTargets.Count);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.Python)]
+        [TestCase(Language.CSharp)]
+        public void GeneratesTargetsForInsightsWithNoConfidence(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var insights = new[]
+            {
+                GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime, confidence:null)
+            };
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            Assert.AreEqual(1, actualTargets.Count);
+        }
+
+        [Test]
+        [TestCase(Language.Python)]
+        [TestCase(Language.CSharp)]
+        public void GeneratesNormalTargetForZeroInsightConfidence(Language language)
+        {
+            SetPortfolioConstruction(language, _algorithm);
+
+            var insights = new[]
+            {
+                GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime, confidence:0)
+            };
+
+            // they will each share, proportionally, the total portfolio value
+            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)DefaultPercent;
+
+            var expectedTargets = _algorithm.Securities.Where(pair => insights.Any(insight => pair.Key == insight.Symbol))
+                .Select(x => new PortfolioTarget(x.Key, (int)InsightDirection.Down * Math.Floor(amount / x.Value.Price)));
+
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+
+        private Security GetSecurity(Symbol symbol)
+        {
+            var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);
+            return new Equity(
+                symbol,
+                config,
+                new Cash(Currencies.USD, 0, 1),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+        }
+
+        private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? confidence = DefaultPercent)
+        {
+            period = period ?? TimeSpan.FromDays(1);
+            var insight = Insight.Price(symbol, period.Value, direction, confidence: confidence);
+            insight.GeneratedTimeUtc = generatedTimeUtc;
+            insight.CloseTimeUtc = generatedTimeUtc.Add(period.Value);
+            return insight;
+        }
+
+        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm)
+        {
+            algorithm.SetPortfolioConstruction(new AccumulativeInsightPortfolioConstructionModel());
+            if (language == Language.Python)
+            {
+                using (Py.GIL())
+                {
+                    var name = nameof(AccumulativeInsightPortfolioConstructionModel);
+                    var instance = Py.Import(name).GetAttr(name).Invoke();
+                    var model = new PortfolioConstructionModelPythonWrapper(instance);
+                    algorithm.SetPortfolioConstruction(model);
+                }
+            }
+
+            foreach (var kvp in _algorithm.Portfolio)
+            {
+                kvp.Value.SetHoldings(kvp.Value.Price, 0);
+            }
+            _algorithm.Portfolio.SetCash(_startingCash);
+            SetUtcTime(new DateTime(2018, 7, 31));
+
+            var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
+            algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+        }
+
+        private void SetUtcTime(DateTime dateTime)
+        {
+            _algorithm.SetDateTime(dateTime.ConvertToUtc(_algorithm.TimeZone));
+        }
+
+        private void AssertTargets(IEnumerable<IPortfolioTarget> expectedTargets, IEnumerable<IPortfolioTarget> actualTargets)
+        {
+            var list = actualTargets.ToList();
+            Assert.AreEqual(expectedTargets.Count(), list.Count);
+
+            foreach (var expected in expectedTargets)
+            {
+                var actual = list.FirstOrDefault(x => x.Symbol == expected.Symbol);
+                Assert.IsNotNull(actual);
+                Assert.AreEqual(expected.Quantity, actual.Quantity);
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -277,6 +277,7 @@
     <Compile Include="Algorithm\Framework\InsightTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\DuplicateKeyPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\BlackLittermanOptimizationPortfolioConstructionModelTests.cs" />
+    <Compile Include="Algorithm\Framework\Portfolio\AccumulativeInsightPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\ConfidenceWeightedPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\InsightWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
See PR#3751

This commit aims to add a portfolio model that can be used for the competition. The model works as follows:
For insights of direction InsightDirection.Up, long targets are returned and
for insights of direction InsightDirection.Down, short targets are returned.
No rebalancing shall be done, as a new insight or the age of the insight shall determine whether to exit
the positions.
Rules:
1. On Up insight, increase position size by percent
2. On Down insight, decrease position size by percent
3. On Flat insight, move by percent towards 0
4. On expired insight, perform a Flat insight

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

See PR#3751

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

There currently is no portfolio model that can be used to test alphas directly related to insight production. They all involve rebalancing or equal weighting. This portfolio will initiate a new trade with every new insight. So 20 Up insights will generate 20 longs. They will be sold when the insight expires. They will be sold when a Flat insight is generated for the symbol. This is the most simple and direct approach for testing alphas. Of course a real portfolio would be more sophisticated and smarter about risk management.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

I tried to keep all the inline documentation updated, but the site documentation could include how to use this model.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested on backtest algorithms using QuantConnect online while designing it. Several key components are added to the CI testing framework that cover proper long/short/flat scenarios. More complicated tests could of course be added later.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
