### PR TITLE
Ensure that PeriodCountConsolidatorBase classes only consolidate a single symbol

### DIFF
--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -114,6 +114,7 @@ namespace QuantConnect.Data.Consolidators
         /// For example, if time span is 1 minute, we have [10:00, 10:01): so data at 10:01 is not 
         /// included in the bar starting at 10:00.
         /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when multiple symbols are being consolidated.</exception>
         /// <param name="data">The new data for the consolidator</param>
         public override void Update(T data)
         {
@@ -123,7 +124,7 @@ namespace QuantConnect.Data.Consolidators
             }
             else if (symbol != data.Symbol)
             {
-                throw new Exception($"Previous consolidated symbol ({symbol}) is not the same as in the current data ({data.Symbol})");
+                throw new InvalidOperationException($"Previous consolidated symbol ({symbol}) is not the same as in the current data ({data.Symbol})");
             }
 
             if (!ShouldProcess(data))

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -124,7 +124,7 @@ namespace QuantConnect.Data.Consolidators
             }
             else if (symbol != data.Symbol)
             {
-                throw new InvalidOperationException($"Previous consolidated symbol ({symbol}) is not the same as in the current data ({data.Symbol})");
+                throw new InvalidOperationException($"Consolidators can only be used with a single symbol. The previous consolidated symbol ({symbol}) is not the same as in the current data ({data.Symbol}).");
             }
 
             if (!ShouldProcess(data))

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -29,6 +29,8 @@ namespace QuantConnect.Data.Consolidators
         where T : IBaseData
         where TConsolidated : BaseData
     {
+        // The symbol that we are consolidating for.
+        private Symbol symbol;
         //The number of data updates between creating new bars.
         private readonly int? _maxCount;
         //
@@ -115,6 +117,15 @@ namespace QuantConnect.Data.Consolidators
         /// <param name="data">The new data for the consolidator</param>
         public override void Update(T data)
         {
+            if (symbol == null)
+            {
+                symbol = data.Symbol;
+            }
+            else if (symbol != data.Symbol)
+            {
+                throw new Exception($"Previous consolidated symbol ({symbol}) is not the same as in the current data ({data.Symbol})");
+            }
+
             if (!ShouldProcess(data))
             {
                 // first allow the base class a chance to filter out data it doesn't want

--- a/Tests/Common/Data/BaseDataConsolidatorTests.cs
+++ b/Tests/Common/Data/BaseDataConsolidatorTests.cs
@@ -86,6 +86,35 @@ namespace QuantConnect.Tests.Common.Data
         }
 
         [Test]
+        public void DoesNotConsolidateDifferentSymbols()
+        {
+            var consolidator = new BaseDataConsolidator(2);
+
+            var reference = DateTime.Today;
+
+            var tb1 = new Tick
+            {
+                Symbol = Symbols.AAPL,
+                Time = reference,
+                Value = 5,
+                Quantity = 10
+            };
+
+            var tb2 = new Tick
+            {
+                Symbol = Symbols.ZNGA,
+                Time = reference,
+                Value = 2,
+                Quantity = 5
+            };
+
+            consolidator.Update(tb1);
+
+            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(tb2));
+            Assert.That(ex.Message, Is.StringContaining("is not the same"));
+        }
+
+        [Test]
         public void AggregatesTradeBarsProperly()
         {
             TradeBar newTradeBar = null;

--- a/Tests/Common/Data/BaseDataConsolidatorTests.cs
+++ b/Tests/Common/Data/BaseDataConsolidatorTests.cs
@@ -110,7 +110,7 @@ namespace QuantConnect.Tests.Common.Data
 
             consolidator.Update(tb1);
 
-            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(tb2));
+            Exception ex = Assert.Throws<InvalidOperationException>(() => consolidator.Update(tb2));
             Assert.That(ex.Message, Is.StringContaining("is not the same"));
         }
 

--- a/Tests/Common/Data/QuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/QuoteBarConsolidatorTests.cs
@@ -218,7 +218,7 @@ namespace QuantConnect.Tests.Common.Data
 
             consolidator.Update(bar1);
 
-            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(bar2));
+            Exception ex = Assert.Throws<InvalidOperationException>(() => consolidator.Update(bar2));
             Assert.That(ex.Message, Is.StringContaining("is not the same"));
         }
     }

--- a/Tests/Common/Data/QuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/QuoteBarConsolidatorTests.cs
@@ -183,5 +183,43 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(1, quoteBar.Value);
                         
         }
+
+        [Test]
+        public void DoesNotConsolidateDifferentSymbols()
+        {
+            var consolidator = new QuoteBarConsolidator(2);
+
+            var time = DateTime.Today;
+            var period = TimeSpan.FromMinutes(1);
+
+            var bar1 = new QuoteBar
+            {
+                Symbol = Symbols.AAPL,
+                Time = time,
+                Bid = new Bar(1, 2, 0.75m, 1.25m),
+                LastBidSize = 3,
+                Ask = null,
+                LastAskSize = 0,
+                Value = 1,
+                Period = period
+            };
+
+            var bar2 = new QuoteBar
+            {
+                Symbol = Symbols.ZNGA,
+                Time = time,
+                Bid = new Bar(1, 2, 0.75m, 1.25m),
+                LastBidSize = 3,
+                Ask = null,
+                LastAskSize = 0,
+                Value = 1,
+                Period = period
+            };
+
+            consolidator.Update(bar1);
+
+            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(bar2));
+            Assert.That(ex.Message, Is.StringContaining("is not the same"));
+        }
     }
 }

--- a/Tests/Common/Data/TickConsolidatorTests.cs
+++ b/Tests/Common/Data/TickConsolidatorTests.cs
@@ -82,6 +82,36 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(bar1.Quantity + bar2.Quantity + bar3.Quantity + bar4.Quantity, newTradeBar.Volume);
         }
 
+        [Test]
+        public void DoesNotConsolidateDifferentSymbols()
+        {
+            var consolidator = new TickConsolidator(2);
+
+            var reference = DateTime.Today;
+
+            var tick1 = new Tick
+            {
+                Symbol = Symbols.AAPL,
+                Time = reference,
+                BidPrice = 1000,
+                BidSize = 20,
+                TickType = TickType.Quote,
+            };
+
+            var tick2 = new Tick
+            {
+                Symbol = Symbols.ZNGA,
+                Time = reference,
+                BidPrice = 20,
+                BidSize = 30,
+                TickType = TickType.Quote,
+            };
+
+            consolidator.Update(tick1);
+
+            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(tick2));
+            Assert.That(ex.Message, Is.StringContaining("is not the same"));
+        }
 
         [Test]
         public void AggregatesPeriodInCountModeWithDailyData()

--- a/Tests/Common/Data/TickConsolidatorTests.cs
+++ b/Tests/Common/Data/TickConsolidatorTests.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Tests.Common.Data
 
             consolidator.Update(tick1);
 
-            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(tick2));
+            Exception ex = Assert.Throws<InvalidOperationException>(() => consolidator.Update(tick2));
             Assert.That(ex.Message, Is.StringContaining("is not the same"));
         }
 

--- a/Tests/Common/Data/TickQuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/TickQuoteBarConsolidatorTests.cs
@@ -135,7 +135,7 @@ namespace QuantConnect.Tests.Common.Data
 
             consolidator.Update(tick1);
 
-            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(tick2));
+            Exception ex = Assert.Throws<InvalidOperationException>(() => consolidator.Update(tick2));
             Assert.That(ex.Message, Is.StringContaining("is not the same"));
         }
     }

--- a/Tests/Common/Data/TickQuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/TickQuoteBarConsolidatorTests.cs
@@ -107,5 +107,36 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(tick4.AskPrice, quoteBar.Ask.Close);
             Assert.AreEqual(tick4.AskSize, quoteBar.LastAskSize);
         }
+
+        [Test]
+        public void DoesNotConsolidateDifferentSymbols()
+        {
+            var consolidator = new TickQuoteBarConsolidator(2);
+
+            var reference = DateTime.Today;
+
+            var tick1 = new Tick
+            {
+                Symbol = Symbols.AAPL,
+                Time = reference,
+                BidPrice = 1000,
+                BidSize = 20,
+                TickType = TickType.Quote,
+            };
+
+            var tick2 = new Tick
+            {
+                Symbol = Symbols.ZNGA,
+                Time = reference,
+                BidPrice = 20,
+                BidSize = 30,
+                TickType = TickType.Quote,
+            };
+
+            consolidator.Update(tick1);
+
+            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(tick2));
+            Assert.That(ex.Message, Is.StringContaining("is not the same"));
+        }
     }
 }

--- a/Tests/Common/Data/TradeBarConsolidatorTests.cs
+++ b/Tests/Common/Data/TradeBarConsolidatorTests.cs
@@ -225,7 +225,7 @@ namespace QuantConnect.Tests.Common.Data
 
             consolidator.Update(tb1);
 
-            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(tb2));
+            Exception ex = Assert.Throws<InvalidOperationException>(() => consolidator.Update(tb2));
             Assert.That(ex.Message, Is.StringContaining("is not the same"));
         }
 

--- a/Tests/Common/Data/TradeBarConsolidatorTests.cs
+++ b/Tests/Common/Data/TradeBarConsolidatorTests.cs
@@ -195,6 +195,41 @@ namespace QuantConnect.Tests.Common.Data
         }
 
         [Test]
+        public void DoesNotConsolidateDifferentSymbols()
+        {
+            // verifies that the TradeBarConsolidator does not consolidate data with different symbols
+
+            var consolidator = new TradeBarConsolidator(2);
+
+            var tb1 = new TradeBar
+            {
+                Symbol = Symbols.AAPL,
+                Open = 10,
+                High = 100,
+                Low = 1,
+                Close = 50,
+                Volume = 75,
+                DataType = MarketDataType.TradeBar
+            };
+
+            var tb2 = new TradeBar
+            {
+                Symbol = Symbols.ZNGA,
+                Open = 50,
+                High = 123,
+                Low = 35,
+                Close = 75,
+                Volume = 100,
+                DataType = MarketDataType.TradeBar
+            };
+
+            consolidator.Update(tb1);
+
+            Exception ex = Assert.Throws<Exception>(() => consolidator.Update(tb2));
+            Assert.That(ex.Message, Is.StringContaining("is not the same"));
+        }
+
+        [Test]
         public void ConsolidatedTimeIsFromBeginningOfBar()
         {
             // verifies that the consolidated bar uses the time from the beginning of the first bar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Ensures that consolidators derived from the PeriodCountConsolidatorBase class should only consolidate for a single symbol.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3872.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this change it is possible to incorrectly use a consolidator with multiple symbols, which can end up with incorrect data in the consolidator.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Probably not.  The exception should be self-explanatory.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
