### PR TITLE
Add First loop check

### DIFF
--- a/Engine/DataFeeds/SubscriptionUtils.cs
+++ b/Engine/DataFeeds/SubscriptionUtils.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -53,6 +54,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Security.Exchange.TimeZone, request.StartTimeUtc, request.EndTimeUtc);
             var subscription = new Subscription(request, enqueueable, timeZoneOffsetProvider);
 
+            var fistLoop = Ref.Create(true);
             Action produce = () =>
             {
                 var count = 0;
@@ -73,12 +75,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     count++;
 
                     // stop executing if we have more data than the upper threshold in the enqueueable, we don't want to fill the ram
-                    if (count > upperThreshold)
+                    if (count > upperThreshold || count > 50 && fistLoop.Value)
                     {
                         // we use local count for the outside if, for performance, and adjust here
                         count = enqueueable.Count;
-                        if (count > upperThreshold)
+                        if (count > upperThreshold || fistLoop.Value)
                         {
+                            fistLoop.Value = false;
                             // we will be re scheduled to run by the consumer, see EnqueueableEnumerator
                             return;
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Subscription workers will stop after adding 50 data points in the
first loop. Note that if a consumer needs more data points it will trigger
a new worker

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3879
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Improve user experience, avoid unnecessary timeouts
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests. Cloud testing with the algorithm which reproduces the issue
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
