### PR TITLE
Bug cloud 536 live history requests

### DIFF
--- a/Common/Data/HistoryProviderInitializeParameters.cs
+++ b/Common/Data/HistoryProviderInitializeParameters.cs
@@ -60,6 +60,11 @@ namespace QuantConnect.Data
         public Action<int> StatusUpdateAction { get; }
 
         /// <summary>
+        /// True is live mode
+        /// </summary>
+        public bool LiveMode { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="HistoryProviderInitializeParameters"/> class from the specified parameters
         /// </summary>
         /// <param name="job">The job</param>
@@ -69,6 +74,7 @@ namespace QuantConnect.Data
         /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
         /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
         /// <param name="statusUpdateAction">Function used to send status updates</param>
+        /// <param name="liveMode">True if live mode</param>
         public HistoryProviderInitializeParameters(
             AlgorithmNodePacket job,
             IApi api,
@@ -76,7 +82,8 @@ namespace QuantConnect.Data
             IDataCacheProvider dataCacheProvider,
             IMapFileProvider mapFileProvider,
             IFactorFileProvider factorFileProvider,
-            Action<int> statusUpdateAction)
+            Action<int> statusUpdateAction,
+            bool liveMode)
         {
             Job = job;
             Api = api;
@@ -85,6 +92,7 @@ namespace QuantConnect.Data
             MapFileProvider = mapFileProvider;
             FactorFileProvider = factorFileProvider;
             StatusUpdateAction = statusUpdateAction;
+            LiveMode = liveMode;
         }
     }
 }

--- a/Common/Data/HistoryProviderInitializeParameters.cs
+++ b/Common/Data/HistoryProviderInitializeParameters.cs
@@ -60,9 +60,11 @@ namespace QuantConnect.Data
         public Action<int> StatusUpdateAction { get; }
 
         /// <summary>
-        /// True is live mode
+        /// True if parallel history requests are enabled
         /// </summary>
-        public bool LiveMode { get; }
+        /// <remarks>Parallel history requests are faster but require more ram and cpu usage
+        /// and are not compatible with some <see cref="IDataCacheProvider"/></remarks>
+        public bool ParallelHistoryRequestsEnabled { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HistoryProviderInitializeParameters"/> class from the specified parameters
@@ -74,7 +76,7 @@ namespace QuantConnect.Data
         /// <param name="mapFileProvider">Provider used to get a map file resolver to handle equity mapping</param>
         /// <param name="factorFileProvider">Provider used to get factor files to handle equity price scaling</param>
         /// <param name="statusUpdateAction">Function used to send status updates</param>
-        /// <param name="liveMode">True if live mode</param>
+        /// <param name="parallelHistoryRequestsEnabled">True if parallel history requests are enabled</param>
         public HistoryProviderInitializeParameters(
             AlgorithmNodePacket job,
             IApi api,
@@ -83,7 +85,7 @@ namespace QuantConnect.Data
             IMapFileProvider mapFileProvider,
             IFactorFileProvider factorFileProvider,
             Action<int> statusUpdateAction,
-            bool liveMode)
+            bool parallelHistoryRequestsEnabled)
         {
             Job = job;
             Api = api;
@@ -92,7 +94,7 @@ namespace QuantConnect.Data
             MapFileProvider = mapFileProvider;
             FactorFileProvider = factorFileProvider;
             StatusUpdateAction = statusUpdateAction;
-            LiveMode = liveMode;
+            ParallelHistoryRequestsEnabled = parallelHistoryRequestsEnabled;
         }
     }
 }

--- a/Engine/DataFeeds/SubscriptionUtils.cs
+++ b/Engine/DataFeeds/SubscriptionUtils.cs
@@ -29,6 +29,28 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     public static class SubscriptionUtils
     {
         /// <summary>
+        /// Creates a new <see cref="Subscription"/> which will directly consume the provided enumerator
+        /// </summary>
+        /// <param name="request">The subscription data request</param>
+        /// <param name="enumerator">The data enumerator stack</param>
+        /// <returns>A new subscription instance ready to consume</returns>
+        public static Subscription Create(
+            SubscriptionRequest request,
+            IEnumerator<BaseData> enumerator)
+        {
+            var exchangeHours = request.Security.Exchange.Hours;
+            var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Security.Exchange.TimeZone, request.StartTimeUtc, request.EndTimeUtc);
+            var dataEnumerator = new SubscriptionDataEnumerator(
+                request.Configuration,
+                exchangeHours,
+                timeZoneOffsetProvider,
+                enumerator
+            );
+            return new Subscription(request, dataEnumerator, timeZoneOffsetProvider);
+        }
+
+
+        /// <summary>
         /// Setups a new <see cref="Subscription"/> which will consume a blocking <see cref="EnqueueableEnumerator{T}"/>
         /// that will be feed by a worker task
         /// </summary>

--- a/Engine/DataFeeds/SubscriptionUtils.cs
+++ b/Engine/DataFeeds/SubscriptionUtils.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+using QuantConnect.Logging;
 using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
@@ -81,38 +82,46 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var firstLoop = Ref.Create(true);
             Action produce = () =>
             {
-                var count = 0;
-                while (enumerator.MoveNext())
+                try
                 {
-                    // subscription has been removed, no need to continue enumerating
-                    if (enqueueable.HasFinished)
+                    var count = 0;
+                    while (enumerator.MoveNext())
                     {
-                        enumerator.Dispose();
-                        return;
-                    }
-
-                    var subscriptionData = SubscriptionData.Create(subscription.Configuration, exchangeHours, subscription.OffsetProvider, enumerator.Current);
-
-                    // drop the data into the back of the enqueueable
-                    enqueueable.Enqueue(subscriptionData);
-
-                    count++;
-
-                    // stop executing if we have more data than the upper threshold in the enqueueable, we don't want to fill the ram
-                    if (count > upperThreshold || count > 50 && firstLoop.Value)
-                    {
-                        // we use local count for the outside if, for performance, and adjust here
-                        count = enqueueable.Count;
-                        if (count > upperThreshold || firstLoop.Value)
+                        // subscription has been removed, no need to continue enumerating
+                        if (enqueueable.HasFinished)
                         {
-                            firstLoop.Value = false;
-                            // we will be re scheduled to run by the consumer, see EnqueueableEnumerator
+                            enumerator.Dispose();
                             return;
+                        }
+
+                        var subscriptionData = SubscriptionData.Create(subscription.Configuration, exchangeHours,
+                            subscription.OffsetProvider, enumerator.Current);
+
+                        // drop the data into the back of the enqueueable
+                        enqueueable.Enqueue(subscriptionData);
+
+                        count++;
+
+                        // stop executing if we have more data than the upper threshold in the enqueueable, we don't want to fill the ram
+                        if (count > upperThreshold || count > 50 && firstLoop.Value)
+                        {
+                            // we use local count for the outside if, for performance, and adjust here
+                            count = enqueueable.Count;
+                            if (count > upperThreshold || firstLoop.Value)
+                            {
+                                firstLoop.Value = false;
+                                // we will be re scheduled to run by the consumer, see EnqueueableEnumerator
+                                return;
+                            }
                         }
                     }
                 }
+                catch (Exception exception)
+                {
+                    Log.Error(exception, $"Subscription worker task exception {request.Configuration}.");
+                }
 
-                // we made it here because MoveNext returned false, stop the enqueueable
+                // we made it here because MoveNext returned false or we exploded, stop the enqueueable
                 enqueueable.Stop();
                 // we have to dispose of the enumerator
                 enumerator.Dispose();

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -198,7 +198,8 @@ namespace QuantConnect.Lean.Engine
                                     AlgorithmHandlers.Results.SendStatusUpdate(AlgorithmStatus.History,
                                         Invariant($"Processing history {progress}%..."));
                                 }
-                            }
+                            },
+                            _liveMode
                         )
                     );
 

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -199,7 +199,8 @@ namespace QuantConnect.Lean.Engine
                                         Invariant($"Processing history {progress}%..."));
                                 }
                             },
-                            _liveMode
+                            // disable parallel history requests for live trading
+                            parallelHistoryRequestsEnabled: !_liveMode
                         )
                     );
 

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -41,6 +41,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         private IMapFileProvider _mapFileProvider;
         private IFactorFileProvider _factorFileProvider;
         private IDataCacheProvider _dataCacheProvider;
+        private bool _liveMode;
 
         /// <summary>
         /// Initializes this history provider to work for the specified job
@@ -51,6 +52,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             _mapFileProvider = parameters.MapFileProvider;
             _factorFileProvider = parameters.FactorFileProvider;
             _dataCacheProvider = parameters.DataCacheProvider;
+            _liveMode = parameters.LiveMode;
         }
 
         /// <summary>
@@ -168,6 +170,11 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             });
             var subscriptionRequest = new SubscriptionRequest(false, null, security, config, request.StartTimeUtc, request.EndTimeUtc);
 
+            if (_liveMode)
+            {
+                // for live mode we wont use workers due to their resource consumption, specifically ram
+                return SubscriptionUtils.Create(subscriptionRequest, reader);
+            }
             return SubscriptionUtils.CreateAndScheduleWorker(subscriptionRequest, reader);
         }
 

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         private IMapFileProvider _mapFileProvider;
         private IFactorFileProvider _factorFileProvider;
         private IDataCacheProvider _dataCacheProvider;
-        private bool _liveMode;
+        private bool _parallelHistoryRequestsEnabled;
 
         /// <summary>
         /// Initializes this history provider to work for the specified job
@@ -52,7 +52,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             _mapFileProvider = parameters.MapFileProvider;
             _factorFileProvider = parameters.FactorFileProvider;
             _dataCacheProvider = parameters.DataCacheProvider;
-            _liveMode = parameters.LiveMode;
+            _parallelHistoryRequestsEnabled = parameters.ParallelHistoryRequestsEnabled;
         }
 
         /// <summary>
@@ -170,12 +170,11 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             });
             var subscriptionRequest = new SubscriptionRequest(false, null, security, config, request.StartTimeUtc, request.EndTimeUtc);
 
-            if (_liveMode)
+            if (_parallelHistoryRequestsEnabled)
             {
-                // for live mode we wont use workers due to their resource consumption, specifically ram
-                return SubscriptionUtils.Create(subscriptionRequest, reader);
+                return SubscriptionUtils.CreateAndScheduleWorker(subscriptionRequest, reader);
             }
-            return SubscriptionUtils.CreateAndScheduleWorker(subscriptionRequest, reader);
+            return SubscriptionUtils.Create(subscriptionRequest, reader);
         }
 
         private class FilterEnumerator<T> : IEnumerator<T>

--- a/Engine/HistoricalData/SynchronizingHistoryProvider.cs
+++ b/Engine/HistoricalData/SynchronizingHistoryProvider.cs
@@ -151,11 +151,9 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 reader = new FillForwardEnumerator(reader, security.Exchange, readOnlyRef, request.IncludeExtendedMarketHours, end, config.Increment, config.DataTimeZone, start);
             }
 
-            var timeZoneOffsetProvider = new TimeZoneOffsetProvider(security.Exchange.TimeZone, request.StartTimeUtc, request.EndTimeUtc);
-            var subscriptionDataEnumerator = new SubscriptionDataEnumerator(config, security.Exchange.Hours, timeZoneOffsetProvider, reader);
-
             var subscriptionRequest = new SubscriptionRequest(false, null, security, config, request.StartTimeUtc, request.EndTimeUtc);
-            return new Subscription(subscriptionRequest, subscriptionDataEnumerator, timeZoneOffsetProvider);
+
+            return SubscriptionUtils.Create(subscriptionRequest, reader);
         }
     }
 }

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -113,7 +113,8 @@ namespace QuantConnect.Jupyter
                         _dataCacheProvider,
                         mapFileProvider,
                         algorithmHandlers.FactorFileProvider,
-                        null
+                        null,
+                        false
                     )
                 );
 

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Jupyter
                         mapFileProvider,
                         algorithmHandlers.FactorFileProvider,
                         null,
-                        false
+                        true
                     )
                 );
 

--- a/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Tests.Brokerages.Alpaca
             {
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false));
 
                 var now = DateTime.UtcNow;
 

--- a/Tests/Brokerages/Bitfinex/BitfinexBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexBrokerageHistoryProviderTests.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Tests.Brokerages.Bitfinex
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false));
 
                 var now = DateTime.UtcNow.RoundDown(resolution.ToTimeSpan());
 

--- a/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Fxcm/FxcmBrokerageHistoryProviderTests.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false));
 
                 var now = DateTime.UtcNow;
 
@@ -129,7 +129,7 @@ namespace QuantConnect.Tests.Brokerages.Fxcm
 
             var historyProvider = new BrokerageHistoryProvider();
             historyProvider.SetBrokerage(brokerage);
-            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false));
 
             var stopwatch = Stopwatch.StartNew();
 

--- a/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageHistoryProviderTests.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
             var historyProvider = new BrokerageHistoryProvider();
             historyProvider.SetBrokerage(brokerage);
-            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false));
 
             var now = DateTime.UtcNow;
 

--- a/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Oanda/OandaBrokerageHistoryProviderTests.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Tests.Brokerages.Oanda
 
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);
-                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
+                historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false));
 
                 var now = DateTime.UtcNow;
 

--- a/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
+++ b/Tests/Common/Securities/BrokerageModelSecurityInitializerTests.cs
@@ -73,7 +73,8 @@ namespace QuantConnect.Tests.Common.Securities
                     new SingleEntryDataCacheProvider(new DefaultDataProvider()),
                     new LocalDiskMapFileProvider(),
                     new LocalDiskFactorFileProvider(),
-                    null
+                    null,
+                    true
                 )
             );
 

--- a/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
+++ b/Tests/Engine/DataFeeds/IEXDataQueueHandlerTests.cs
@@ -254,7 +254,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void IEXCouldGetHistory(Symbol symbol, Resolution resolution, TimeSpan period, bool received)
         {
             var historyProvider = new IEXDataQueueHandler();
-            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null));
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false));
 
             var now = DateTime.UtcNow;
 

--- a/Tests/Engine/HistoricalData/SubscriptionDataReaderHistoryProviderTests.cs
+++ b/Tests/Engine/HistoricalData/SubscriptionDataReaderHistoryProviderTests.cs
@@ -41,7 +41,8 @@ namespace QuantConnect.Tests.Engine.HistoricalData
                 new ZipDataCacheProvider(new DefaultDataProvider()), 
                 new LocalDiskMapFileProvider(),
                 new LocalDiskFactorFileProvider(),
-                null));
+                null,
+                false));
             var symbol = Symbol.CreateOption(
                 "FOXA",
                 Market.USA,
@@ -91,7 +92,8 @@ namespace QuantConnect.Tests.Engine.HistoricalData
                 new ZipDataCacheProvider(new DefaultDataProvider()),
                 new LocalDiskMapFileProvider(),
                 new LocalDiskFactorFileProvider(),
-                null));
+                null,
+                false));
             var symbol = Symbol.Create("WM",SecurityType.Equity,Market.USA);
 
             var result = historyProvider.GetHistory(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Disabling live parallel history requests
- Adding `try/catch` around a subscription worker, this is to avoid a potential condition in which the consumer might wait for ever if the worker died and never disposed of the enqueueable

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/LeanCloud/issues/536
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve live trading support
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Live trading deployments
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x]  I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
