### PR TITLE
Fix EnqueueableEnumerator hang

### DIFF
--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -281,7 +281,12 @@ namespace QuantConnect.Securities
             var maxPrice = _uniqueStrikes[indexMaxPrice];
 
             _allSymbols = _allSymbols
-                .Where(symbol => symbol.ID.StrikePrice >= minPrice && symbol.ID.StrikePrice <= maxPrice)
+                .Where(symbol =>
+                    {
+                        var price = symbol.ID.StrikePrice;
+                        return price >= minPrice && price <= maxPrice;
+                    }
+                )
                 .ToList();
 
             return this;

--- a/Tests/Engine/DataFeeds/SubscriptionUtilsTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionUtilsTests.cs
@@ -1,0 +1,226 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Securities;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture]
+    public class SubscriptionUtilsTests
+    {
+        private Security _security;
+        private SubscriptionDataConfig _config;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _security = new Security(Symbols.SPY,
+                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                new Cash(Currencies.USD, 0, 0),
+                SymbolProperties.GetDefault(Currencies.USD),
+                new IdentityCurrencyConverter(Currencies.USD),
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache());
+
+            _config = new SubscriptionDataConfig(
+                typeof(TradeBar),
+                Symbols.SPY,
+                Resolution.Daily,
+                TimeZones.NewYork,
+                TimeZones.NewYork,
+                true, true, false);
+        }
+
+        [TestCase(1)]
+        [TestCase(5)]
+        [TestCase(20)]
+        public void FirstLoopLimit(int firstLoopLimit)
+        {
+            var dataPoints = 10;
+            var enumerator = new TestDataEnumerator { MoveNextTrueCount = dataPoints };
+
+            var subscription = SubscriptionUtils.CreateAndScheduleWorker(
+                new SubscriptionRequest(
+                    false,
+                    null,
+                    _security,
+                    _config,
+                    DateTime.UtcNow,
+                    Time.EndOfTime
+                ),
+                enumerator,
+                firstLoopLimit: firstLoopLimit);
+
+            var count = 0;
+            var expectedValue = dataPoints - firstLoopLimit - 1;
+            expectedValue = expectedValue > 0 ? expectedValue : -1;
+            while (enumerator.MoveNextTrueCount != expectedValue)
+            {
+                if (count++ > 100)
+                {
+                    Assert.Fail("Timeout waiting for producer");
+                }
+                Thread.Sleep(1);
+            }
+            // producer should only have produced 'firstLoopLimit' data points, lets assert remaining to produce
+            Assert.AreEqual(expectedValue, enumerator.MoveNextTrueCount);
+
+            for (var j = 0; j < dataPoints; j++)
+            {
+                Assert.IsTrue(subscription.MoveNext());
+            }
+            Assert.IsFalse(subscription.MoveNext());
+            subscription.DisposeSafely();
+            Assert.IsTrue(enumerator.Disposed);
+        }
+
+        [Test]
+        public void SubscriptionIsDisposed()
+        {
+            var dataPoints = 10;
+            var enumerator = new TestDataEnumerator { MoveNextTrueCount = dataPoints };
+
+            var subscription = SubscriptionUtils.CreateAndScheduleWorker(
+                new SubscriptionRequest(
+                    false,
+                    null,
+                    _security,
+                    _config,
+                    DateTime.UtcNow,
+                    Time.EndOfTime
+                ),
+                enumerator,
+                firstLoopLimit: 1);
+
+            var count = 0;
+            while (enumerator.MoveNextTrueCount != 8)
+            {
+                if (count++ > 100)
+                {
+                    Assert.Fail("Timeout waiting for producer");
+                }
+                Thread.Sleep(1);
+            }
+
+            subscription.DisposeSafely();
+            Assert.IsFalse(subscription.MoveNext());
+        }
+
+        [Test]
+        public void ThrowingEnumeratorStackDisposesOfSubscription()
+        {
+            var enumerator = new TestDataEnumerator { MoveNextTrueCount = 10, ThrowException = true};
+
+            var subscription = SubscriptionUtils.CreateAndScheduleWorker(
+                new SubscriptionRequest(
+                    false,
+                    null,
+                    _security,
+                    _config,
+                    DateTime.UtcNow,
+                    Time.EndOfTime
+                ),
+                enumerator,
+                firstLoopLimit: 1);
+
+            var count = 0;
+            while (enumerator.MoveNextTrueCount != 9)
+            {
+                if (count++ > 100)
+                {
+                    Assert.Fail("Timeout waiting for producer");
+                }
+                Thread.Sleep(1);
+            }
+
+            Assert.IsFalse(subscription.MoveNext());
+            Assert.IsTrue(subscription.EndOfStream);
+            Assert.IsTrue(enumerator.Disposed);
+        }
+
+        [Test]
+        // This unit tests reproduces GH 3885 where the consumer hanged forever
+        public void ConsumerDoesNotHang()
+        {
+            for (var i = 0; i < 10000; i++)
+            {
+                var dataPoints = 10;
+
+                var enumerator = new TestDataEnumerator {MoveNextTrueCount = dataPoints};
+
+                var subscription = SubscriptionUtils.CreateAndScheduleWorker(
+                    new SubscriptionRequest(
+                        false,
+                        null,
+                        _security,
+                        _config,
+                        DateTime.UtcNow,
+                        Time.EndOfTime
+                    ),
+                    enumerator,
+                    firstLoopLimit: dataPoints / 2);
+
+                for (var j = 0; j < dataPoints; j++)
+                {
+                   Assert.IsTrue(subscription.MoveNext());
+                }
+                Assert.IsFalse(subscription.MoveNext());
+                subscription.DisposeSafely();
+            }
+        }
+
+        private class TestDataEnumerator : IEnumerator<BaseData>
+        {
+            public bool ThrowException { get; set; }
+            public bool Disposed { get; set; }
+            public int MoveNextTrueCount { get; set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public bool MoveNext()
+            {
+                Current = new Tick(DateTime.UtcNow,Symbols.SPY, 1, 2);
+                var result = --MoveNextTrueCount >= 0;
+                if (ThrowException)
+                {
+                    throw new Exception("TestDataEnumerator.MoveNext()");
+                }
+                return result;
+            }
+
+            public void Reset()
+            {
+            }
+
+            public BaseData Current { get; set; }
+
+            object IEnumerator.Current => Current;
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -369,6 +369,7 @@
     <Compile Include="Engine\DataFeeds\PendingRemovalsManagerTests.cs" />
     <Compile Include="Engine\DataFeeds\PredicateTimeProviderTests.cs" />
     <Compile Include="Common\Util\StreamReaderExtensionsTests.cs" />
+    <Compile Include="Engine\DataFeeds\SubscriptionUtilsTests.cs" />
     <Compile Include="Engine\DataFeeds\TextSubscriptionDataSourceReaderTests.cs" />
     <Compile Include="Engine\DataFeeds\Transport\RemoteFileSubscriptionStreamReaderTests.cs" />
     <Compile Include="Engine\DataFeeds\UniverseSelectionTests.cs" />


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding `CancellationTokenSource` to fix a race condition where the worker could stop
after the consumer had already checked on him, see TriggerProducer,
leaving the consumer waiting forever GH issue 3885. This cancellation token
works as a flag for this particular case waking up the consumer.
- Adding unit tests
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3885
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Fix algorithm 10-minute timeouts
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The algorithm which reproduces the issue, unit test which reproduces the issue. Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
