### PR TITLE
Add Scheduled Universe Selection

### DIFF
--- a/Algorithm.CSharp/CoarseCustomSelectionTimeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseCustomSelectionTimeRegressionAlgorithm.cs
@@ -1,0 +1,154 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression test algorithm for scheduled universe selection GH 3890
+    /// </summary>
+    public class CoarseCustomSelectionTimeRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private int _monthStartSelection;
+        private int _monthEndSelection;
+        private int _monthStartFineSelection;
+        private readonly Symbol _symbol = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2014, 03, 25);
+            SetEndDate(2014, 05, 10);
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            // Test use case A
+            AddUniverse(CoarseSelectionFunction_MonthStart, DateRules.MonthStart());
+
+            // Test use case B
+            var otherSettings = UniverseSettings.Clone();
+            otherSettings.Schedule.On(DateRules.MonthEnd());
+            AddUniverse(new CoarseFundamentalUniverse(otherSettings, SecurityInitializer, CoarseSelectionFunction_MonthEnd));
+
+            // Test use case C
+            AddUniverse(CoarseSelectionFunction_MonthStart, FineSelectionFunction_MonthStart, DateRules.MonthStart());
+        }
+
+        public IEnumerable<Symbol> CoarseSelectionFunction_MonthStart(IEnumerable<CoarseFundamental> coarse)
+        {
+            _monthStartSelection++;
+            if (Time != new DateTime(2014, 4, 1)
+                && Time != new DateTime(2014, 5, 1))
+            {
+                throw new Exception($"Month Start unexpected selection: {Time}");
+            }
+            return new[] { _symbol };
+        }
+
+        public IEnumerable<Symbol> FineSelectionFunction_MonthStart(IEnumerable<FineFundamental> fine)
+        {
+            _monthStartFineSelection++;
+            if (Time != new DateTime(2014, 4, 1)
+                && Time != new DateTime(2014, 5, 1))
+            {
+                throw new Exception($"Month Start unexpected selection: {Time}");
+            }
+            return new[] { _symbol };
+        }
+
+        public IEnumerable<Symbol> CoarseSelectionFunction_MonthEnd(IEnumerable<CoarseFundamental> coarse)
+        {
+            _monthEndSelection++;
+            if (Time != new DateTime(2014, 3, 31)
+                && Time != new DateTime(2014, 4, 30))
+            {
+                throw new Exception($"Month End unexpected selection: {Time}");
+            }
+            return new[] { _symbol };
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(_symbol, 1);
+                Debug($"Purchased Stock {_symbol}");
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_monthEndSelection != 2)
+            {
+                throw new Exception($"Month End unexpected selection count: {_monthEndSelection}");
+            }
+            if (_monthStartSelection != 4)
+            {
+                throw new Exception($"Month start unexpected selection count: {_monthStartSelection}");
+            }
+            if (_monthStartFineSelection != 2)
+            {
+                throw new Exception($"Month start fine unexpected selection count: {_monthStartFineSelection}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "1.680%"},
+            {"Drawdown", "3.900%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0.210%"},
+            {"Sharpe Ratio", "0.197"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-0.074"},
+            {"Beta", "0.884"},
+            {"Annual Standard Deviation", "0.103"},
+            {"Annual Variance", "0.011"},
+            {"Information Ratio", "-2.359"},
+            {"Tracking Error", "0.037"},
+            {"Treynor Ratio", "0.023"},
+            {"Total Fees", "$2.89"}
+        };
+    }
+}

--- a/Algorithm.CSharp/CoarseCustomSelectionTimeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseCustomSelectionTimeRegressionAlgorithm.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Algorithm.CSharp
             UniverseSettings.Resolution = Resolution.Daily;
 
             // Test use case A
-            AddUniverse(CoarseSelectionFunction_MonthStart, DateRules.MonthStart());
+            AddUniverse(DateRules.MonthStart(), CoarseSelectionFunction_MonthStart);
 
             // Test use case B
             var otherSettings = UniverseSettings.Clone();
@@ -50,7 +50,7 @@ namespace QuantConnect.Algorithm.CSharp
             AddUniverse(new CoarseFundamentalUniverse(otherSettings, SecurityInitializer, CoarseSelectionFunction_MonthEnd));
 
             // Test use case C
-            AddUniverse(CoarseSelectionFunction_MonthStart, FineSelectionFunction_MonthStart, DateRules.MonthStart());
+            AddUniverse(DateRules.MonthStart(), CoarseSelectionFunction_MonthStart, FineSelectionFunction_MonthStart);
         }
 
         public IEnumerable<Symbol> CoarseSelectionFunction_MonthStart(IEnumerable<CoarseFundamental> coarse)

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -160,6 +160,7 @@
     <Compile Include="AltData\TradingEconomicsAlgorithm.cs" />
     <Compile Include="AltData\TiingoNewsAlgorithm.cs" />
     <Compile Include="BasicTemplateConstituentUniverseAlgorithm.cs" />
+    <Compile Include="CoarseCustomSelectionTimeRegressionAlgorithm.cs" />
     <Compile Include="DefaultResolutionRegressionAlgorithm.cs" />
     <Compile Include="BasicPythonIntegrationTemplateAlgorithm.cs" />
     <Compile Include="BasicSetAccountCurrencyAlgorithm.cs" />

--- a/Algorithm.Python/AddRemoveSecurityRegressionAlgorithm.py
+++ b/Algorithm.Python/AddRemoveSecurityRegressionAlgorithm.py
@@ -19,7 +19,7 @@ AddReference("QuantConnect.Algorithm")
 from System import *
 from QuantConnect import *
 from QuantConnect.Orders import *
-from QuantConnect.Algorithm import QCAlgorithm
+from QuantConnect.Algorithm import *
 
 ### <summary>
 ### This algorithm demonstrates the runtime addition and removal of securities from your algorithm.

--- a/Algorithm.Python/CoarseCustomSelectionTimeRegressionAlgorithm.py
+++ b/Algorithm.Python/CoarseCustomSelectionTimeRegressionAlgorithm.py
@@ -40,7 +40,7 @@ class CoarseCustomSelectionTimeRegressionAlgorithm(QCAlgorithm):
         self.UniverseSettings.Resolution = Resolution.Daily
 
         # Test use case A
-        self.AddUniverse(self.CoarseSelectionFunction_MonthStart, self.DateRules.MonthStart());
+        self.AddUniverse(self.DateRules.MonthStart(), self.CoarseSelectionFunction_MonthStart);
 
         # Test use case B
         otherSettings = self.UniverseSettings.Clone();
@@ -48,7 +48,7 @@ class CoarseCustomSelectionTimeRegressionAlgorithm(QCAlgorithm):
         self.AddUniverse(CoarseFundamentalUniverse(otherSettings, self.SecurityInitializer, self.CoarseSelectionFunction_MonthEnd));
 
         # Test use case C
-        self.AddUniverse(self.CoarseSelectionFunction_MonthStart, self.FineSelectionFunction_MonthStart, self.DateRules.MonthStart());
+        self.AddUniverse(self.DateRules.MonthStart(), self.CoarseSelectionFunction_MonthStart, self.FineSelectionFunction_MonthStart);
 
     def CoarseSelectionFunction_MonthStart(self, coarse):
         self._monthStartSelection += 1

--- a/Algorithm.Python/CoarseCustomSelectionTimeRegressionAlgorithm.py
+++ b/Algorithm.Python/CoarseCustomSelectionTimeRegressionAlgorithm.py
@@ -1,0 +1,86 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Data.UniverseSelection import CoarseFundamentalUniverse
+from datetime import *
+
+### <summary>
+### Regression test algorithm for scheduled universe selection GH 3890
+### </summary>
+class CoarseCustomSelectionTimeRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        self._monthStartSelection = 0
+        self._monthStartFineSelection = 0
+        self._monthEndSelection = 0
+        self._symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA)
+
+        self.SetStartDate(2014, 3, 25)
+        self.SetEndDate(2014, 5, 10)
+        self.UniverseSettings.Resolution = Resolution.Daily
+
+        # Test use case A
+        self.AddUniverse(self.CoarseSelectionFunction_MonthStart, self.DateRules.MonthStart());
+
+        # Test use case B
+        otherSettings = self.UniverseSettings.Clone();
+        otherSettings.Schedule.On(self.DateRules.MonthEnd());
+        self.AddUniverse(CoarseFundamentalUniverse(otherSettings, self.SecurityInitializer, self.CoarseSelectionFunction_MonthEnd));
+
+        # Test use case C
+        self.AddUniverse(self.CoarseSelectionFunction_MonthStart, self.FineSelectionFunction_MonthStart, self.DateRules.MonthStart());
+
+    def CoarseSelectionFunction_MonthStart(self, coarse):
+        self._monthStartSelection += 1
+        if self.Time != datetime(2014, 4, 1) and self.Time != datetime(2014, 5, 1):
+            raise ValueError("Month Start unexpected selection: " + str(self.Time));
+        return [ self._symbol ]
+
+    def CoarseSelectionFunction_MonthEnd(self, coarse):
+        self._monthEndSelection += 1
+        if self.Time != datetime(2014, 3, 31) and self.Time != datetime(2014, 4, 30):
+            raise ValueError("Month End unexpected selection: " + str(self.Time));
+        return [ self._symbol ]
+
+    def FineSelectionFunction_MonthStart(self, fine):
+        self._monthStartFineSelection += 1
+        if self.Time != datetime(2014, 4, 1) and self.Time != datetime(2014, 5, 1):
+            raise ValueError("Month Start Fine unexpected selection: " + str(self.Time));
+        return [ self._symbol ]
+
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+
+        Arguments:
+            data: Slice object keyed by symbol containing the stock data
+        '''
+        if not self.Portfolio.Invested:
+            self.SetHoldings(self._symbol, 1)
+
+    def OnEndOfAlgorithm(self):
+        if self._monthEndSelection != 2:
+            raise ValueError("Month End unexpected selection count: " + str(self._monthEndSelection))
+        if self._monthStartFineSelection != 2:
+            raise ValueError("Month Start Fine unexpected selection count: " + str(self._monthEndSelection))
+        if self._monthStartSelection != 4:
+            raise ValueError("Month Start unexpected selection count: " + str(self._monthStartSelection))

--- a/Algorithm.Python/IndicatorSuiteAlgorithm.py
+++ b/Algorithm.Python/IndicatorSuiteAlgorithm.py
@@ -23,7 +23,7 @@ from QuantConnect import *
 from QuantConnect.Indicators import *
 from QuantConnect.Data import *
 from QuantConnect.Data.Market import *
-from QuantConnect.Data.Custom import *
+from QuantConnect.Data.Custom import Quandl
 from QuantConnect.Algorithm import *
 
 ### <summary>

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -79,6 +79,7 @@
     <Content Include="BasicTemplateConstituentUniverseAlgorithm.py" />
     <Content Include="Benchmarks\SECReportBenchmarkAlgorithm.py" />
     <Content Include="Benchmarks\SmartInsiderEventBenchmarkAlgorithm.py" />
+    <Content Include="CoarseCustomSelectionTimeRegressionAlgorithm.py" />
     <Content Include="CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.py" />
     <Content Include="CustomDataAddDataCoarseSelectionRegressionAlgorithm.py" />
     <Content Include="DynamicSecurityDataAlgorithm.py" />

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -371,37 +371,50 @@ namespace QuantConnect.Algorithm
 
         /// <summary>
         /// Creates a new universe and adds it to the algorithm. This is for coarse fundamental US Equity data and
-        /// will be executed on day changes in the NewYork time zone (<see cref="TimeZones.NewYork"/>
+        /// will be executed on day changes in the NewYork time zone (<see cref="TimeZones.NewYork"/>)
         /// </summary>
         /// <param name="selector">Defines an initial coarse selection</param>
-        /// <param name="dateRule">Date rule that will be used to set the <see cref="Data.UniverseSelection.UniverseSettings.Schedule"/></param>
-        public void AddUniverse(Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> selector,
-            IDateRule dateRule = null)
+        public void AddUniverse(Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> selector)
         {
-            if (dateRule != null)
-            {
-                UniverseSettings.Schedule.On(dateRule);
-            }
-
             AddUniverse(new CoarseFundamentalUniverse(UniverseSettings, SecurityInitializer, selector));
         }
 
         /// <summary>
+        /// Creates a new universe and adds it to the algorithm. This is for coarse fundamental US Equity data and
+        /// will be executed based on the provided <see cref="IDateRule"/> in the NewYork time zone (<see cref="TimeZones.NewYork"/>)
+        /// </summary>
+        /// <param name="dateRule">Date rule that will be used to set the <see cref="Data.UniverseSelection.UniverseSettings.Schedule"/></param>
+        /// <param name="selector">Defines an initial coarse selection</param>
+        public void AddUniverse(IDateRule dateRule, Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> selector)
+        {
+            UniverseSettings.Schedule.On(dateRule);
+            AddUniverse(selector);
+        }
+
+        /// <summary>
         /// Creates a new universe and adds it to the algorithm. This is for coarse and fine fundamental US Equity data and
-        /// will be executed on day changes in the NewYork time zone (<see cref="TimeZones.NewYork"/>
+        /// will be executed based on the provided <see cref="IDateRule"/> in the NewYork time zone (<see cref="TimeZones.NewYork"/>)
+        /// </summary>
+        /// <param name="dateRule">Date rule that will be used to set the <see cref="Data.UniverseSelection.UniverseSettings.Schedule"/></param>
+        /// <param name="coarseSelector">Defines an initial coarse selection</param>
+        /// <param name="fineSelector">Defines a more detailed selection with access to more data</param>
+        public void AddUniverse(IDateRule dateRule,
+            Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> coarseSelector,
+            Func<IEnumerable<FineFundamental>, IEnumerable<Symbol>> fineSelector)
+        {
+            UniverseSettings.Schedule.On(dateRule);
+            AddUniverse(coarseSelector, fineSelector);
+        }
+
+        /// <summary>
+        /// Creates a new universe and adds it to the algorithm. This is for coarse and fine fundamental US Equity data and
+        /// will be executed on day changes in the NewYork time zone (<see cref="TimeZones.NewYork"/>)
         /// </summary>
         /// <param name="coarseSelector">Defines an initial coarse selection</param>
         /// <param name="fineSelector">Defines a more detailed selection with access to more data</param>
-        /// <param name="dateRule">Date rule that will be used to set the <see cref="Data.UniverseSelection.UniverseSettings.Schedule"/></param>
         public void AddUniverse(Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> coarseSelector,
-            Func<IEnumerable<FineFundamental>, IEnumerable<Symbol>> fineSelector,
-            IDateRule dateRule = null)
+            Func<IEnumerable<FineFundamental>, IEnumerable<Symbol>> fineSelector)
         {
-            if (dateRule != null)
-            {
-                UniverseSettings.Schedule.On(dateRule);
-            }
-
             var coarse = new CoarseFundamentalUniverse(UniverseSettings, SecurityInitializer, coarseSelector);
 
             AddUniverse(new FineFundamentalFilteredUniverse(coarse, fineSelector));
@@ -409,7 +422,7 @@ namespace QuantConnect.Algorithm
 
         /// <summary>
         /// Creates a new universe and adds it to the algorithm. This is for fine fundamental US Equity data and
-        /// will be executed on day changes in the NewYork time zone (<see cref="TimeZones.NewYork"/>
+        /// will be executed on day changes in the NewYork time zone (<see cref="TimeZones.NewYork"/>)
         /// </summary>
         /// <param name="universe">The universe to be filtered with fine fundamental selection</param>
         /// <param name="fineSelector">Defines a more detailed selection with access to more data</param>

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Scheduling;
 using QuantConnect.Securities;
 using QuantConnect.Util;
 
@@ -373,8 +374,15 @@ namespace QuantConnect.Algorithm
         /// will be executed on day changes in the NewYork time zone (<see cref="TimeZones.NewYork"/>
         /// </summary>
         /// <param name="selector">Defines an initial coarse selection</param>
-        public void AddUniverse(Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> selector)
+        /// <param name="dateRule">Date rule that will be used to set the <see cref="Data.UniverseSelection.UniverseSettings.Schedule"/></param>
+        public void AddUniverse(Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> selector,
+            IDateRule dateRule = null)
         {
+            if (dateRule != null)
+            {
+                UniverseSettings.Schedule.On(dateRule);
+            }
+
             AddUniverse(new CoarseFundamentalUniverse(UniverseSettings, SecurityInitializer, selector));
         }
 
@@ -384,8 +392,16 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="coarseSelector">Defines an initial coarse selection</param>
         /// <param name="fineSelector">Defines a more detailed selection with access to more data</param>
-        public void AddUniverse(Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> coarseSelector, Func<IEnumerable<FineFundamental>, IEnumerable<Symbol>> fineSelector)
+        /// <param name="dateRule">Date rule that will be used to set the <see cref="Data.UniverseSelection.UniverseSettings.Schedule"/></param>
+        public void AddUniverse(Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> coarseSelector,
+            Func<IEnumerable<FineFundamental>, IEnumerable<Symbol>> fineSelector,
+            IDateRule dateRule = null)
         {
+            if (dateRule != null)
+            {
+                UniverseSettings.Schedule.On(dateRule);
+            }
+
             var coarse = new CoarseFundamentalUniverse(UniverseSettings, SecurityInitializer, coarseSelector);
 
             AddUniverse(new FineFundamentalFilteredUniverse(coarse, fineSelector));

--- a/Common/Data/UniverseSelection/Schedule.cs
+++ b/Common/Data/UniverseSelection/Schedule.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Scheduling;
+
+namespace QuantConnect.Data.UniverseSelection
+{
+    /// <summary>
+    /// Entity in charge of managing a schedule
+    /// </summary>
+    public class Schedule
+    {
+        private IDateRule _dateRule;
+
+        /// <summary>
+        /// Set a <see cref="IDateRule"/> for this schedule
+        /// </summary>
+        public void On(IDateRule dateRule)
+        {
+            _dateRule = dateRule;
+        }
+
+        /// <summary>
+        /// Gets the current schedule for a given start time
+        /// </summary>
+        public IEnumerable<DateTime> Get(DateTime startTime)
+        {
+            return _dateRule?.GetDates(startTime, Time.EndOfTime);
+        }
+
+        /// <summary>
+        /// Creates a new instance holding the same schedule if any
+        /// </summary>
+        public Schedule Clone()
+        {
+            return new Schedule { _dateRule = _dateRule };
+        }
+    }
+}

--- a/Common/Data/UniverseSelection/UniverseSettings.cs
+++ b/Common/Data/UniverseSelection/UniverseSettings.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using QuantConnect.Scheduling;
 
 namespace QuantConnect.Data.UniverseSelection
 {
@@ -36,6 +37,13 @@ namespace QuantConnect.Data.UniverseSelection
         /// True to fill data forward, false otherwise
         /// </summary>
         public bool FillForward;
+
+        /// <summary>
+        /// If configured, will be used to determine universe selection schedule and filter or skip selection data
+        /// that does not fit the schedule
+        /// </summary>
+        /// <remarks>Currently only supported for <see cref="CoarseFundamental"/> selection</remarks>
+        public Schedule Schedule;
 
         /// <summary>
         /// True to allow extended market hours data, false otherwise
@@ -65,7 +73,8 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="extendedMarketHours">True to allow extended market hours data, false otherwise</param>
         /// <param name="minimumTimeInUniverse">Defines the minimum amount of time a security must remain in the universe before being removed</param>
         /// <param name="dataNormalizationMode">Defines how universe data is normalized before being send into the algorithm</param>
-        public UniverseSettings(Resolution resolution, decimal leverage, bool fillForward, bool extendedMarketHours, TimeSpan minimumTimeInUniverse, DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted)
+        /// <param name="selectionDateRule">If provided, will be used to determine universe selection schedule</param>
+        public UniverseSettings(Resolution resolution, decimal leverage, bool fillForward, bool extendedMarketHours, TimeSpan minimumTimeInUniverse, DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted, IDateRule selectionDateRule = null)
         {
             Resolution = resolution;
             Leverage = leverage;
@@ -73,6 +82,31 @@ namespace QuantConnect.Data.UniverseSelection
             ExtendedMarketHours = extendedMarketHours;
             MinimumTimeInUniverse = minimumTimeInUniverse;
             DataNormalizationMode = dataNormalizationMode;
+            Schedule = new Schedule();
+            if (selectionDateRule != null)
+            {
+                Schedule.On(selectionDateRule);
+            }
+        }
+
+        /// <summary>
+        /// Clones the current settings into a new instance
+        /// </summary>
+        /// <returns>A new instance</returns>
+        public UniverseSettings Clone()
+        {
+            var otherSettings = new UniverseSettings(
+                Resolution,
+                Leverage,
+                FillForward,
+                ExtendedMarketHours,
+                MinimumTimeInUniverse,
+                DataNormalizationMode)
+            {
+                Schedule = Schedule.Clone()
+            };
+
+            return otherSettings;
         }
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -302,6 +302,7 @@
     <Compile Include="Data\SubscriptionDataConfigExtensions.cs" />
     <Compile Include="Data\UniverseSelection\ConstituentsUniverse.cs" />
     <Compile Include="Data\UniverseSelection\ConstituentsUniverseData.cs" />
+    <Compile Include="Data\UniverseSelection\Schedule.cs" />
     <Compile Include="Expiry.cs" />
     <Compile Include="DataProviderEvents.cs" />
     <Compile Include="IIsolatorLimitResultProvider.cs" />

--- a/Engine/DataFeeds/Enumerators/ScheduledEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/ScheduledEnumerator.cs
@@ -1,0 +1,149 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NodaTime;
+using QuantConnect.Data;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
+{
+    /// <summary>
+    /// This enumerator will filter out data of the underlying enumerator based on a provided schedule
+    /// </summary>
+    public class ScheduledEnumerator : IEnumerator<BaseData>
+    {
+        private readonly IEnumerator<BaseData> _underlyingEnumerator;
+        private readonly IEnumerator<DateTime> _scheduledTimes;
+        private readonly ITimeProvider _frontierTimeProvider;
+        private readonly DateTimeZone _scheduleTimeZone;
+        private bool _scheduledTimesEnded;
+        private BaseData _underlyingCandidateDataPoint;
+
+        /// <summary>
+        /// The current data point
+        /// </summary>
+        public BaseData Current { get; private set; }
+
+        object IEnumerator.Current => Current;
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="underlyingEnumerator">The underlying enumerator to filter</param>
+        /// <param name="scheduledTimes">The scheduled times to emit new data points</param>
+        /// <param name="frontierTimeProvider"></param>
+        /// <param name="scheduleTimeZone"></param>
+        public ScheduledEnumerator(IEnumerator<BaseData> underlyingEnumerator,
+            IEnumerable<DateTime> scheduledTimes, 
+            ITimeProvider frontierTimeProvider,
+            DateTimeZone scheduleTimeZone)
+        {
+            _scheduleTimeZone = scheduleTimeZone;
+            _frontierTimeProvider = frontierTimeProvider;
+            _underlyingEnumerator = underlyingEnumerator;
+            _scheduledTimes = scheduledTimes.GetEnumerator();
+            if (!_scheduledTimes.MoveNext())
+            {
+                throw new ArgumentException("ScheduledEnumerator(): There should be at least 1 provided schedule time");
+            }
+        }
+
+        /// <summary>
+        /// Disposes of the underlying enumerator
+        /// </summary>
+        public void Dispose()
+        {
+            _scheduledTimes.Dispose();
+            _underlyingEnumerator.Dispose();
+        }
+
+        /// <summary>
+        /// Advances the enumerator to the next element of the collection.
+        /// </summary>
+        /// <returns> True if the enumerator was successfully advanced to the next element;
+        /// false if the enumerator has passed the end of the collection.
+        /// </returns>
+        public bool MoveNext()
+        {
+            if (_scheduledTimesEnded)
+            {
+                Current = null;
+                return false;
+            }
+
+            // lets get our candidate data point to emit
+            if (_underlyingCandidateDataPoint == null && _underlyingEnumerator.Current != null)
+            {
+                _underlyingCandidateDataPoint = _underlyingEnumerator.Current;
+            }
+
+            // lets try to get a better candidate
+            if (_underlyingEnumerator.Current == null
+                || _underlyingEnumerator.Current.EndTime < _scheduledTimes.Current)
+            {
+                bool pullAgain;
+                do
+                {
+                    pullAgain = false;
+                    if (!_underlyingEnumerator.MoveNext())
+                    {
+                        if (_underlyingCandidateDataPoint != null)
+                        {
+                            // if we still have a candidate wait till we emit him before stopping
+                            break;
+                        }
+                        Current = null;
+                        return false;
+                    }
+
+                    if (_underlyingEnumerator.Current != null
+                        && _underlyingEnumerator.Current.EndTime <= _scheduledTimes.Current)
+                    {
+                        // we got another data point which is a newer candidate to emit so let use it instead
+                        // and drop the previous
+                        _underlyingCandidateDataPoint = _underlyingEnumerator.Current;
+
+                        // lets try again
+                        pullAgain = true;
+                    }
+                } while (pullAgain);
+            }
+
+            // if we are at or past the schedule time we try to emit
+            if (_underlyingCandidateDataPoint != null
+                && _scheduledTimes.Current.ConvertToUtc(_scheduleTimeZone) <= _frontierTimeProvider.GetUtcNow())
+            {
+                Current = _underlyingCandidateDataPoint;
+                _scheduledTimesEnded = !_scheduledTimes.MoveNext();
+                _underlyingCandidateDataPoint = null;
+                return true;
+            }
+
+            Current = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Resets the underlying enumerator
+        /// </summary>
+        public void Reset()
+        {
+            _underlyingEnumerator.Reset();
+        }
+    }
+}

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -490,10 +490,18 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     enqueable.Enqueue(data);
 
                     subscription.OnNewDataAvailable();
-
                 });
 
                 enumerator = GetConfiguredFrontierAwareEnumerator(enqueable, tzOffsetProvider);
+
+                var schedule = request.Universe.UniverseSettings.Schedule.Get(request.StartTimeLocal);
+                if (schedule != null)
+                {
+                    enumerator = new ScheduledEnumerator(enumerator,
+                        schedule,
+                        _frontierTimeProvider,
+                        request.Configuration.ExchangeTimeZone);
+                }
             }
             else if (request.Universe is OptionChainUniverse)
             {

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -173,6 +173,7 @@
     <Compile Include="DataFeeds\CachingOptionChainProvider.cs" />
     <Compile Include="DataFeeds\CurrencySubscriptionDataConfigManager.cs" />
     <Compile Include="DataFeeds\DataChannelProvider.cs" />
+    <Compile Include="DataFeeds\Enumerators\ScheduledEnumerator.cs" />
     <Compile Include="DataFeeds\IDataChannelProvider.cs" />
     <Compile Include="DataFeeds\IndexSubscriptionDataSourceReader.cs" />
     <Compile Include="DataFeeds\DataManager.cs" />

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactoryTests.cs
@@ -23,6 +23,7 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories;
 using QuantConnect.Logging;
+using QuantConnect.Scheduling;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
@@ -125,5 +126,54 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 Assert.IsNotNull(enumerator.Current);
             }
         }
+
+
+        [Test]
+        public void RespectsScheduleIfProvided()
+        {
+            var dateStart = new DateTime(2014, 3, 26);
+            var dateEnd = new DateTime(2014, 3, 30);
+
+            var symbol = CoarseFundamental.CreateUniverseSymbol(Market.USA);
+            var config = new SubscriptionDataConfig(typeof(CoarseFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(Currencies.USD, 0, 1),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+
+            var universeSettings = new UniverseSettings(Resolution.Daily, 2m, true, false, TimeSpan.FromDays(1));
+            universeSettings.Schedule.On(
+                new FuncDateRule("test",
+                    // a single schedule 2 days after start date
+                    (time, dateTime) => new List<DateTime> { dateStart.AddDays(2) }));
+
+            var securityInitializer = new BrokerageModelSecurityInitializer(new DefaultBrokerageModel(), SecuritySeeder.Null);
+            var universe = new CoarseFundamentalUniverse(universeSettings, securityInitializer, x => new List<Symbol> { Symbols.AAPL });
+
+            var fileProvider = new DefaultDataProvider();
+
+            var factory = new BaseDataCollectionSubscriptionEnumeratorFactory();
+
+            var request = new SubscriptionRequest(true, universe, security, config, dateStart, dateEnd);
+
+            using (var enumerator = factory.CreateEnumerator(request, fileProvider))
+            {
+                Assert.IsTrue(enumerator.MoveNext());
+
+                var current = enumerator.Current as BaseDataCollection;
+                Assert.IsNotNull(current);
+                Assert.AreEqual(dateStart.AddDays(2), current.Time);
+                Assert.AreEqual(dateStart.AddDays(2), current.EndTime);
+
+                Assert.IsFalse(enumerator.MoveNext());
+                Assert.IsNotNull(enumerator.Current);
+            }
+        }
     }
 }
+;

--- a/Tests/Engine/DataFeeds/Enumerators/ScheduledEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/ScheduledEnumeratorTests.cs
@@ -1,0 +1,229 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+
+namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
+{
+    [TestFixture]
+    public class ScheduledEnumeratorTests
+    {
+        [Test]
+        public void EmptyScheduleThrowsException()
+        {
+            Assert.Throws<ArgumentException>(() => new ScheduledEnumerator(
+                new TestEnumerator(),
+                new List<DateTime>(),
+                new ManualTimeProvider(new DateTime(2019, 1, 1)),
+                TimeZones.Utc));
+        }
+
+        [Test]
+        public void ReturnsTrueEvenIfUnderlyingIsNullButReturnsTrue()
+        {
+            var underlyingEnumerator = new TestEnumerator { MoveNextReturn = true };
+            var timeProvider = new ManualTimeProvider(new DateTime(2019, 1, 1));
+
+            var enumerator = new ScheduledEnumerator(
+                underlyingEnumerator,
+                new List<DateTime> { new DateTime(2019, 2, 1) },
+                timeProvider,
+                TimeZones.Utc);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+        }
+
+        [Test]
+        public void ReturnsFalseWhenUnderlyingReturnsFalse()
+        {
+            var underlyingEnumerator = new TestEnumerator { MoveNextReturn = false };
+            var timeProvider = new ManualTimeProvider(new DateTime(2019, 1, 1));
+
+            var enumerator = new ScheduledEnumerator(
+                underlyingEnumerator,
+                new List<DateTime> { new DateTime(2019, 2, 1) },
+                timeProvider,
+                TimeZones.Utc);
+
+            Assert.IsFalse(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+        }
+
+        [Test]
+        public void UpdatesCurrentBasedOnSchedule()
+        {
+            var underlyingEnumerator = new TestEnumerator
+            {
+                MoveNextReturn = true,
+                MoveNextNewValues = new Queue<BaseData>(new List<BaseData>
+                {
+                    new Tick(new DateTime(2019, 1, 15), Symbols.SPY, 1, 1)
+                })
+            };
+            var timeProvider = new ManualTimeProvider(new DateTime(2019, 1, 1));
+
+            var enumerator = new ScheduledEnumerator(
+                underlyingEnumerator,
+                new List<DateTime> { new DateTime(2019, 2, 1) },
+                timeProvider,
+                TimeZones.Utc);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            // still null since frontier is still behind schedule
+            Assert.IsNull(enumerator.Current);
+
+            timeProvider.SetCurrentTimeUtc(new DateTime(2019, 2, 1));
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.AreEqual(enumerator.Current.Time, new DateTime(2019, 1, 15));
+            Assert.AreEqual((enumerator.Current as Tick).BidPrice, 1);
+
+            // schedule ended so enumerator will end to
+            Assert.IsFalse(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+        }
+
+        [Test]
+        public void WillUseLatestDataPoint()
+        {
+            var underlyingEnumerator = new TestEnumerator
+            {
+                MoveNextReturn = true,
+                MoveNextNewValues = new Queue<BaseData>(new List<BaseData>
+                {
+                    new Tick(new DateTime(2019, 1, 15), Symbols.SPY, 1, 1),
+                    new Tick(new DateTime(2019, 1, 20), Symbols.SPY, 2, 1),
+                    new Tick(new DateTime(2019, 1, 25), Symbols.SPY, 3, 1)
+                })
+            };
+            var timeProvider = new ManualTimeProvider(new DateTime(2019, 1, 1));
+
+            var enumerator = new ScheduledEnumerator(
+                underlyingEnumerator,
+                new List<DateTime> { new DateTime(2019, 2, 1) },
+                timeProvider,
+                TimeZones.Utc);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            // still null since frontier is still behind schedule
+            Assert.IsNull(enumerator.Current);
+
+            // frontier is now a month after the scheduled time!
+            timeProvider.SetCurrentTimeUtc(new DateTime(2019, 3, 1));
+
+            Assert.IsTrue(enumerator.MoveNext());
+            // it uses the last available data point in the enumerator
+            Assert.AreEqual(enumerator.Current.Time, new DateTime(2019, 1, 25));
+            Assert.AreEqual((enumerator.Current as Tick).BidPrice, 3);
+
+            Assert.IsNull(underlyingEnumerator.Current);
+        }
+
+        [Test]
+        public void WillUseLatestDataPointOnlyIfBeforeOrAtSchedule()
+        {
+            var underlyingEnumerator = new TestEnumerator
+            {
+                MoveNextReturn = true,
+                MoveNextNewValues = new Queue<BaseData>(new List<BaseData>
+                {
+                    new Tick(new DateTime(2019, 1, 20), Symbols.SPY, 2, 1),
+                    new Tick(new DateTime(2019, 1, 25), Symbols.SPY, 3, 1),
+                    // this guys is in 2020
+                    new Tick(new DateTime(2020, 1, 1), Symbols.SPY, 4, 1)
+                })
+            };
+            var timeProvider = new ManualTimeProvider(new DateTime(2019, 1, 1));
+
+            var enumerator = new ScheduledEnumerator(
+                underlyingEnumerator,
+                new List<DateTime> { new DateTime(2019, 2, 1), new DateTime(2020, 2, 1) },
+                timeProvider,
+                TimeZones.Utc);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            // still null since frontier is still behind schedule
+            Assert.IsNull(enumerator.Current);
+
+            // frontier is now a month after the scheduled time!
+            timeProvider.SetCurrentTimeUtc(new DateTime(2019, 3, 1));
+
+            Assert.IsTrue(enumerator.MoveNext());
+            // it uses the last available data point in the enumerator that is before the schedule
+            Assert.AreEqual(enumerator.Current.Time, new DateTime(2019, 1, 25));
+            Assert.AreEqual((enumerator.Current as Tick).BidPrice, 3);
+
+            // the underlying enumerator hold the next data point
+            Assert.AreEqual(new DateTime(2020, 1, 1), underlyingEnumerator.Current.Time);
+
+            // now lets test fetching the last data point
+            timeProvider.SetCurrentTimeUtc(new DateTime(2021, 3, 1));
+
+            // the underlying will end but should still emit the data point it has
+            underlyingEnumerator.MoveNextReturn = false;
+
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.AreEqual(enumerator.Current.Time, new DateTime(2020, 1, 1));
+            Assert.AreEqual((enumerator.Current as Tick).BidPrice, 4);
+
+            Assert.IsNull(underlyingEnumerator.Current);
+            Assert.IsFalse(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+        }
+
+        private class TestEnumerator : IEnumerator<BaseData>
+        {
+            public Queue<BaseData> MoveNextNewValues { get; set; }
+            public BaseData Current { get; private set; }
+
+            object IEnumerator.Current => Current;
+
+            public bool MoveNextReturn { get; set; }
+
+            public bool MoveNext()
+            {
+                if (MoveNextNewValues != null && MoveNextNewValues.Count > 0)
+                {
+                    Current = MoveNextNewValues.Dequeue();
+                }
+                else
+                {
+                    Current = null;
+                }
+                return MoveNextReturn;
+            }
+
+            public void Reset()
+            {
+            }
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Engine\DataFeeds\Enumerators\AuxiliaryDataEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\MappingEventProviderTests.cs" />
     <Compile Include="Engine\DataFeeds\Enumerators\PriceScaleFactorEnumeratorTests.cs" />
+    <Compile Include="Engine\DataFeeds\Enumerators\ScheduledEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\IndexSubscriptionDataSourceReaderTests.cs" />
     <Compile Include="Engine\DataFeeds\LiveCoarseUniverseTests.cs" />
     <Compile Include="Engine\DataFeeds\MockDataFeed.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adding `UniverseSettings.Schedule` that will allow users to
specify a custom selection schedule that is independent of the
underlying data frequency. For now only implemented for Coarse
selection.
- Adding unit and regression tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3890
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve user experience
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
