### PR TITLE
Added initial CashAmount property to BacktestNodePacket

### DIFF
--- a/Algorithm.CSharp/SetAccountCurrencyCashBuyingPowerModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SetAccountCurrencyCashBuyingPowerModelRegressionAlgorithm.cs
@@ -64,15 +64,11 @@ namespace QuantConnect.Algorithm.CSharp
                 throw new Exception("This regression algorithm is expected to test the CashBuyingPowerModel");
             }
 
-            try
+            // Second call to change account currency will be ignored
+            SetAccountCurrency("ARG");
+            if (AccountCurrency != "EUR")
             {
-                // Change account currency after adding a security will throw
-                SetAccountCurrency("ARG");
-                throw new Exception("Calling SetAccountCurrency() after adding a Security should throw");
-            }
-            catch (InvalidOperationException)
-            {
-                // expected
+                throw new Exception($"Unexpected account currency value {AccountCurrency}");
             }
         }
 

--- a/Common/Packets/BacktestNodePacket.cs
+++ b/Common/Packets/BacktestNodePacket.cs
@@ -87,6 +87,11 @@ namespace QuantConnect.Packets
         public bool IsDebugging => Breakpoints.Any();
 
         /// <summary>
+        /// Optional initial cash amount if set
+        /// </summary>
+        [JsonProperty(PropertyName = "decCashAmount")]
+        public decimal? CashAmount;
+        /// <summary>
         /// Default constructor for JSON
         /// </summary>
         public BacktestNodePacket()
@@ -112,6 +117,7 @@ namespace QuantConnect.Packets
             ProjectId = projectId;
             UserPlan = userPlan;
             Name = name;
+            CashAmount = startingCapital;
             Language = Language.CSharp;
             Controls = new Controls
             {

--- a/Common/Packets/BacktestNodePacket.cs
+++ b/Common/Packets/BacktestNodePacket.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Packets
 {
@@ -89,8 +90,8 @@ namespace QuantConnect.Packets
         /// <summary>
         /// Optional initial cash amount if set
         /// </summary>
-        [JsonProperty(PropertyName = "decCashAmount")]
-        public decimal? CashAmount;
+        public CashAmount? CashAmount;
+
         /// <summary>
         /// Default constructor for JSON
         /// </summary>
@@ -109,7 +110,15 @@ namespace QuantConnect.Packets
         /// Initialize the backtest task packet.
         /// </summary>
         public BacktestNodePacket(int userId, int projectId, string sessionId, byte[] algorithmData, decimal startingCapital, string name, UserPlan userPlan = UserPlan.Free) 
-            : base (PacketType.BacktestNode)
+            : this (userId, projectId, sessionId, algorithmData, name, userPlan, new CashAmount(startingCapital, Currencies.USD))
+        {
+        }
+
+        /// <summary>
+        /// Initialize the backtest task packet.
+        /// </summary>
+        public BacktestNodePacket(int userId, int projectId, string sessionId, byte[] algorithmData, string name, UserPlan userPlan = UserPlan.Free, CashAmount? startingCapital = null)
+            : base(PacketType.BacktestNode)
         {
             UserId = userId;
             Algorithm = algorithmData;

--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -180,6 +180,9 @@ namespace QuantConnect.Lean.Engine.Setup
                     // set the object store
                     algorithm.SetObjectStore(parameters.ObjectStore);
 
+                    // before we call initialize
+                    BaseSetupHandler.LoadBacktestJobAccountCurrency(algorithm, job);
+
                     //Initialise the algorithm, get the required data:
                     algorithm.Initialize();
 
@@ -193,11 +196,8 @@ namespace QuantConnect.Lean.Engine.Setup
                         algorithm.SetEndDate(job.PeriodFinish.Value);
                     }
 
-                    //set initial cash, if present in the job
-                    if (job.CashAmount.HasValue)
-                    {
-                        algorithm.SetCash(job.CashAmount.Value);
-                    }
+                    // after we call initialize
+                    BaseSetupHandler.LoadBacktestJobCashAmount(algorithm, job);
 
                     // finalize initialization
                     algorithm.PostInitialize();

--- a/Engine/Setup/BacktestingSetupHandler.cs
+++ b/Engine/Setup/BacktestingSetupHandler.cs
@@ -193,6 +193,12 @@ namespace QuantConnect.Lean.Engine.Setup
                         algorithm.SetEndDate(job.PeriodFinish.Value);
                     }
 
+                    //set initial cash, if present in the job
+                    if (job.CashAmount.HasValue)
+                    {
+                        algorithm.SetCash(job.CashAmount.Value);
+                    }
+
                     // finalize initialization
                     algorithm.PostInitialize();
                 }

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -112,5 +112,37 @@ namespace QuantConnect.Lean.Engine.Setup
                 sleepIntervalMillis: 100,
                 workerThread: workerThread);
         }
+
+        /// <summary>
+        /// Sets the initial cash for the algorithm if set in the job packet.
+        /// </summary>
+        /// <remarks>Should be called after initialize <see cref="LoadBacktestJobAccountCurrency"/></remarks>
+        public static void LoadBacktestJobCashAmount(IAlgorithm algorithm, BacktestNodePacket job)
+        {
+            // set initial cash, if present in the job
+            if (job.CashAmount.HasValue)
+            {
+                // Zero the CashBook - we'll populate directly from job
+                foreach (var kvp in algorithm.Portfolio.CashBook)
+                {
+                    kvp.Value.SetAmount(0);
+                }
+
+                algorithm.SetCash(job.CashAmount.Value.Amount);
+            }
+        }
+
+        /// <summary>
+        /// Sets the account currency the algorithm should use if set in the job packet
+        /// </summary>
+        /// <remarks>Should be called before initialize <see cref="LoadBacktestJobCashAmount"/></remarks>
+        public static void LoadBacktestJobAccountCurrency(IAlgorithm algorithm, BacktestNodePacket job)
+        {
+            // set account currency if present in the job
+            if (job.CashAmount.HasValue)
+            {
+                algorithm.SetAccountCurrency(job.CashAmount.Value.Currency);
+            }
+        }
     }
 }

--- a/Engine/Setup/ConsoleSetupHandler.cs
+++ b/Engine/Setup/ConsoleSetupHandler.cs
@@ -181,6 +181,12 @@ namespace QuantConnect.Lean.Engine.Setup
                         algorithm.SetEndDate(backtestJob.PeriodFinish.Value);
                     }
 
+                    //set initial cash, if present in the job
+                    if (backtestJob.CashAmount.HasValue)
+                    {
+                        algorithm.SetCash(backtestJob.CashAmount.Value);
+                    }
+
                     //Finalize Initialization
                     algorithm.PostInitialize();
 

--- a/Engine/Setup/ConsoleSetupHandler.cs
+++ b/Engine/Setup/ConsoleSetupHandler.cs
@@ -161,6 +161,9 @@ namespace QuantConnect.Lean.Engine.Setup
                     // set the object store
                     algorithm.SetObjectStore(parameters.ObjectStore);
 
+                    // before we call initialize
+                    BaseSetupHandler.LoadBacktestJobAccountCurrency(algorithm, backtestJob);
+
                     var isolator = new Isolator();
                     isolator.ExecuteWithTimeLimit(TimeSpan.FromMinutes(5),
                         () =>
@@ -181,11 +184,8 @@ namespace QuantConnect.Lean.Engine.Setup
                         algorithm.SetEndDate(backtestJob.PeriodFinish.Value);
                     }
 
-                    //set initial cash, if present in the job
-                    if (backtestJob.CashAmount.HasValue)
-                    {
-                        algorithm.SetCash(backtestJob.CashAmount.Value);
-                    }
+                    // after we call initialize
+                    BaseSetupHandler.LoadBacktestJobCashAmount(algorithm, backtestJob);
 
                     //Finalize Initialization
                     algorithm.PostInitialize();

--- a/Queues/JobQueue.cs
+++ b/Queues/JobQueue.cs
@@ -147,7 +147,7 @@ namespace QuantConnect.Queues
             }
 
             //Default run a backtesting job.
-            var backtestJob = new BacktestNodePacket(0, 0, "", new byte[] {}, 10000, "local")
+            var backtestJob = new BacktestNodePacket(0, 0, "", new byte[] {}, "local")
             {
                 Type = PacketType.BacktestNode,
                 Algorithm = File.ReadAllBytes(AlgorithmLocation),

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -32,6 +32,7 @@ using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Lean.Engine.Setup;
 using QuantConnect.Logging;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 using QuantConnect.Tests.Common.Securities;
 using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
@@ -51,7 +52,7 @@ namespace QuantConnect.Tests
             AlgorithmStatus expectedFinalStatus,
             DateTime? startDate = null,
             DateTime? endDate = null,
-            string setupHandler = "RegressionSetupHandlerWrapper"),
+            string setupHandler = "RegressionSetupHandlerWrapper",
             decimal? initialCash = null)
         {
             AlgorithmManager algorithmManager = null;
@@ -113,7 +114,7 @@ namespace QuantConnect.Tests
                             job.PeriodFinish = endDate;
                             if (initialCash.HasValue)
                             {
-                                job.CashAmount = initialCash.Value;
+                                job.CashAmount = new CashAmount(initialCash.Value, Currencies.USD);
                             }
                             algorithmManager = new AlgorithmManager(false, job);
 

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -51,7 +51,8 @@ namespace QuantConnect.Tests
             AlgorithmStatus expectedFinalStatus,
             DateTime? startDate = null,
             DateTime? endDate = null,
-            string setupHandler = "RegressionSetupHandlerWrapper")
+            string setupHandler = "RegressionSetupHandlerWrapper"),
+            decimal? initialCash = null)
         {
             AlgorithmManager algorithmManager = null;
             var statistics = new Dictionary<string, string>();
@@ -110,6 +111,10 @@ namespace QuantConnect.Tests
                             job.BacktestId = algorithm;
                             job.PeriodStart = startDate;
                             job.PeriodFinish = endDate;
+                            if (initialCash.HasValue)
+                            {
+                                job.CashAmount = initialCash.Value;
+                            }
                             algorithmManager = new AlgorithmManager(false, job);
 
                             systemHandlers.LeanManager.Initialize(systemHandlers, algorithmHandlers, job, algorithmManager);

--- a/Tests/Common/Packets/BacktestNodePacketTests.cs
+++ b/Tests/Common/Packets/BacktestNodePacketTests.cs
@@ -102,5 +102,16 @@ namespace QuantConnect.Tests.Common.Packets
             Assert.AreEqual(job.PeriodStart, job2.PeriodStart);
             Assert.AreEqual(job.PeriodFinish, job2.PeriodFinish);
         }
+        [Test]
+        public void InitialCashAmount()
+        {
+            var job = new BacktestNodePacket(1, 2, "3", null, 9m, $"{nameof(BacktestNodePacketTests)}.Pepe");
+            Assert.AreEqual(job.CashAmount.Value,9m);
+
+            job.CashAmount = 10m;
+            var serialized = JsonConvert.SerializeObject(job);
+            var job2 = JsonConvert.DeserializeObject<BacktestNodePacket>(serialized);
+            Assert.AreEqual(job.CashAmount, job2.CashAmount);
+        }
     }
 }

--- a/Tests/Common/Packets/BacktestNodePacketTests.cs
+++ b/Tests/Common/Packets/BacktestNodePacketTests.cs
@@ -67,7 +67,8 @@ namespace QuantConnect.Tests.Common.Packets
                 parameter.Language,
                 parameter.ExpectedFinalStatus,
                 startDate: new DateTime(2008, 10, 10),
-                endDate: new DateTime(2010, 10, 10));
+                endDate: new DateTime(2010, 10, 10),
+                initialCash: 100000);
         }
 
         [Test]

--- a/Tests/Common/Packets/BacktestNodePacketTests.cs
+++ b/Tests/Common/Packets/BacktestNodePacketTests.cs
@@ -20,6 +20,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Algorithm.CSharp;
 using QuantConnect.Configuration;
+using QuantConnect.Interfaces;
 using QuantConnect.Packets;
 
 namespace QuantConnect.Tests.Common.Packets
@@ -67,8 +68,7 @@ namespace QuantConnect.Tests.Common.Packets
                 parameter.Language,
                 parameter.ExpectedFinalStatus,
                 startDate: new DateTime(2008, 10, 10),
-                endDate: new DateTime(2010, 10, 10),
-                initialCash: 100000);
+                endDate: new DateTime(2010, 10, 10));
         }
 
         [Test]
@@ -103,16 +103,125 @@ namespace QuantConnect.Tests.Common.Packets
             Assert.AreEqual(job.PeriodStart, job2.PeriodStart);
             Assert.AreEqual(job.PeriodFinish, job2.PeriodFinish);
         }
+
         [Test]
-        public void InitialCashAmount()
+        public void RoundTripWithInitialCashAmount()
         {
             var job = new BacktestNodePacket(1, 2, "3", null, 9m, $"{nameof(BacktestNodePacketTests)}.Pepe");
-            Assert.AreEqual(job.CashAmount.Value,9m);
+            Assert.AreEqual(9m, job.CashAmount.Value.Amount);
+            Assert.AreEqual(Currencies.USD, job.CashAmount.Value.Currency);
 
-            job.CashAmount = 10m;
             var serialized = JsonConvert.SerializeObject(job);
             var job2 = JsonConvert.DeserializeObject<BacktestNodePacket>(serialized);
             Assert.AreEqual(job.CashAmount, job2.CashAmount);
+        }
+
+        [Test]
+        public void RoundTripWithNullInitialCashAmount()
+        {
+            var job = new BacktestNodePacket(1, 2, "3", null, $"{nameof(BacktestNodePacketTests)}.Pepe");
+            Assert.IsNull(job.CashAmount);
+
+            var serialized = JsonConvert.SerializeObject(job);
+            var job2 = JsonConvert.DeserializeObject<BacktestNodePacket>(serialized);
+            Assert.AreEqual(job.CashAmount, job2.CashAmount);
+        }
+
+        [Test]
+        public void InitialCashAmountIsRespected()
+        {
+            var parameter = new RegressionTests.AlgorithmStatisticsTestParameters(nameof(BasicTemplateDailyAlgorithm),
+                new Dictionary<string, string> {
+                    {"Total Trades", "1"},
+                    {"Average Win", "0%"},
+                    {"Average Loss", "0%"},
+                    {"Compounding Annual Return", "246.519%"},
+                    {"Drawdown", "1.100%"},
+                    {"Expectancy", "0"},
+                    {"Net Profit", "3.463%"},
+                    {"Sharpe Ratio", "6.033"},
+                    {"Loss Rate", "0%"},
+                    {"Win Rate", "0%"},
+                    {"Profit-Loss Ratio", "0"},
+                    {"Alpha", "0.012"},
+                    {"Beta", "0.992"},
+                    {"Annual Standard Deviation", "0.16"},
+                    {"Annual Variance", "0.026"},
+                    {"Information Ratio", "2.734"},
+                    {"Tracking Error", "0.002"},
+                    {"Treynor Ratio", "0.974"},
+                    {"Total Fees", "$32.59"} // 10x times more than original BasicTemplateDailyAlgorithm
+                },
+                Language.CSharp,
+                AlgorithmStatus.Completed);
+
+            AlgorithmRunner.RunLocalBacktest(parameter.Algorithm,
+                parameter.Statistics,
+                parameter.AlphaStatistics,
+                parameter.Language,
+                parameter.ExpectedFinalStatus,
+                initialCash: 1000000); // 1M vs 100K that is set in BasicTemplateDailyAlgorithm (10x)
+        }
+
+        [Test]
+        public void ClearsOtherCashAmounts()
+        {
+            var parameter = new RegressionTests.AlgorithmStatisticsTestParameters(nameof(TestInitialCashAmountAlgorithm),
+                new Dictionary<string, string> {
+                    {"Total Trades", "1"},
+                    {"Average Win", "0%"},
+                    {"Average Loss", "0%"},
+                    {"Compounding Annual Return", "244.737%"},
+                    {"Drawdown", "1.100%"},
+                    {"Expectancy", "0"},
+                    {"Net Profit", "3.463%"},
+                    {"Sharpe Ratio", "5.713"},
+                    {"Loss Rate", "0%"},
+                    {"Win Rate", "0%"},
+                    {"Profit-Loss Ratio", "0"},
+                    {"Alpha", "0.011"},
+                    {"Beta", "0.992"},
+                    {"Annual Standard Deviation", "0.152"},
+                    {"Annual Variance", "0.023"},
+                    {"Information Ratio", "2.606"},
+                    {"Tracking Error", "0.002"},
+                    {"Treynor Ratio", "0.876"},
+                    {"Total Fees", "$32.59"} // 10x times more than original BasicTemplateDailyAlgorithm
+                },
+                Language.CSharp,
+                AlgorithmStatus.Completed);
+
+            AlgorithmRunner.RunLocalBacktest(parameter.Algorithm,
+                parameter.Statistics,
+                parameter.AlphaStatistics,
+                parameter.Language,
+                parameter.ExpectedFinalStatus,
+                initialCash: 1000000, // 1M vs 100K that is set in BasicTemplateDailyAlgorithm (10x)
+                setupHandler: "TestInitialCashAmountSetupHandler");
+
+            Assert.AreEqual(0, TestInitialCashAmountSetupHandler.TestAlgorithm.Portfolio.CashBook["EUR"].Amount);
+            Assert.AreEqual(Currencies.USD, TestInitialCashAmountSetupHandler.TestAlgorithm.AccountCurrency);
+        }
+
+        internal class TestInitialCashAmountAlgorithm : BasicTemplateDailyAlgorithm
+        {
+            public override void Initialize()
+            {
+                SetAccountCurrency("EUR");
+                base.Initialize();
+                SetCash("EUR", 1000000);
+            }
+        }
+
+        internal class TestInitialCashAmountSetupHandler : AlgorithmRunner.RegressionSetupHandlerWrapper
+        {
+            public static TestInitialCashAmountAlgorithm TestAlgorithm { get; set; }
+
+            public override IAlgorithm CreateAlgorithmInstance(AlgorithmNodePacket algorithmNodePacket, string assemblyPath)
+            {
+                 Algorithm = TestAlgorithm = new TestInitialCashAmountAlgorithm();
+                return Algorithm;
+            }
         }
     }
 }


### PR DESCRIPTION
#### Description
- Added optional `CashAmount` property to `BacktestNodePacket` class.
- Adding unit tests

#### Related Issue
Closes #3895 
#### Motivation and Context
By adding this property, able to set initial cash amount for algorithms without modifying alorithms

#### Requires Documentation Change
NA
#### How Has This Been Tested?
Added unit test, regression tests, cloud backtest

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
