### PR TITLE
Fixes failing EstimizeConsensus parsing in Reader

### DIFF
--- a/Common/Data/Custom/Estimize/EstimizeConsensus.cs
+++ b/Common/Data/Custom/Estimize/EstimizeConsensus.cs
@@ -122,8 +122,8 @@ namespace QuantConnect.Data.Custom.Estimize
             UpdatedAt = Parse.DateTimeExact(csv[0], "yyyyMMdd HH:mm:ss");
             Time = UpdatedAt;
             Id = csv[1];
-            Source = csv[2].ConvertInvariant<Source>();
-            Type = csv[3].IfNotNullOrEmpty(s => s.ConvertInvariant<Type>());
+            Source = (Source)Enum.Parse(typeof(Source), csv[2]);
+            Type = csv[3].IfNotNullOrEmpty(s => (Type)Enum.Parse(typeof(Type), s));
             Mean = csv[4].IfNotNullOrEmpty<decimal?>(s => Parse.Decimal(s));
             High = csv[5].IfNotNullOrEmpty<decimal?>(s => Parse.Decimal(s));
             Low = csv[6].IfNotNullOrEmpty<decimal?>(s => Parse.Decimal(s));

--- a/Tests/Common/Data/Custom/EstimizeTests.cs
+++ b/Tests/Common/Data/Custom/EstimizeTests.cs
@@ -103,6 +103,26 @@ namespace QuantConnect.Tests.Common.Data.Custom
             Assert.IsTrue(content.Contains("\"eps\":1.2"));
         }
 
+        [Test]
+        public void EstimizeConsensusReaderDoesNotThrow()
+        {
+            var data = "20100101 12:00:00,abcdef123456789deadbeef,Estimize,Revenue,100.00,100,100,50,2010,1,100";
+            var instance = new EstimizeConsensus();
+
+            var fakeConfig = new SubscriptionDataConfig(
+                typeof(EstimizeConsensus),
+                Symbol.Create("AAPL", SecurityType.Base, "USA"),
+                Resolution.Daily,
+                TimeZones.Utc,
+                TimeZones.Utc,
+                false,
+                false,
+                false
+            );
+
+            Assert.DoesNotThrow(() => { instance.Reader(fakeConfig, data, DateTime.MinValue, false); });
+        }
+
         [Test, Ignore("Requires Estimize data")]
         public void EstimizeReleaseReaderTest()
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fixes issue where EstimizeConsensus would fail to parse data on disk due to enum parsing failing
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3899 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Alt data works
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
