### PR TITLE
Bug 3905 factor file.apply method removes the factor file first row

### DIFF
--- a/Common/Data/Auxiliary/FactorFile.cs
+++ b/Common/Data/Auxiliary/FactorFile.cs
@@ -318,13 +318,7 @@ namespace QuantConnect.Data.Auxiliary
             var splitsAndDividends = GetSplitsAndDividends(data[0].Symbol, exchangeHours);
 
             var combinedData = splitsAndDividends.Concat(data)
-                .DistinctBy(e =>
-                    {
-                        var asSplit = e as Split;
-                        var eventType = asSplit == null ? "Dividend" : "Split";
-                        return $"{e.Symbol.ID}{eventType}{e.Time.ToStringInvariant(DateFormat.EightCharacter)}{e.Value.SmartRounding().Normalize()}";
-                    }
-                )
+                .DistinctBy(e => $"{e.GetType().Name}{e.Time.ToStringInvariant(DateFormat.EightCharacter)}")
                 .OrderByDescending(d => d.Time.Date);
 
             foreach (var datum in combinedData)

--- a/Common/Data/Auxiliary/FactorFile.cs
+++ b/Common/Data/Auxiliary/FactorFile.cs
@@ -1,17 +1,17 @@
-﻿﻿/*
- * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
- * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+﻿/*
+* QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+* Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
 */
 
 using System;
@@ -200,7 +200,7 @@ namespace QuantConnect.Data.Auxiliary
                 // if the price factors have changed then it's a dividend event
                 if (thisRow.PriceFactor != nextRow.PriceFactor)
                 {
-                    priceFactorRatio = thisRow.PriceFactor/nextRow.PriceFactor;
+                    priceFactorRatio = thisRow.PriceFactor / nextRow.PriceFactor;
                     return true;
                 }
             }
@@ -230,7 +230,7 @@ namespace QuantConnect.Data.Auxiliary
                 // if the split factors have changed then it's a split event
                 if (thisRow.SplitFactor != nextRow.SplitFactor)
                 {
-                    splitFactor = thisRow.SplitFactor/nextRow.SplitFactor;
+                    splitFactor = thisRow.SplitFactor / nextRow.SplitFactor;
                     return true;
                 }
             }
@@ -275,7 +275,7 @@ namespace QuantConnect.Data.Auxiliary
             }
 
             var futureFactorFileRow = SortedFactorFileData.Last().Value;
-            for (var i = SortedFactorFileData.Count - 2; i >= 0 ; i--)
+            for (var i = SortedFactorFileData.Count - 2; i >= 0; i--)
             {
                 var row = SortedFactorFileData.Values[i];
                 var dividend = row.GetDividend(futureFactorFileRow, symbol, exchangeHours);
@@ -285,7 +285,7 @@ namespace QuantConnect.Data.Auxiliary
                 }
 
                 var split = row.GetSplit(futureFactorFileRow, symbol, exchangeHours);
-                if (split.SplitFactor != 1m)
+                if (i == 0 || split.SplitFactor != 1m)
                 {
                     dividendsAndSplits.Add(split);
                 }
@@ -315,7 +315,9 @@ namespace QuantConnect.Data.Auxiliary
             var lastEntry = SortedFactorFileData.Last().Value;
             factorFileRows.Add(lastEntry);
 
-            var combinedData = GetSplitsAndDividends(data[0].Symbol, exchangeHours).Concat(data)
+            var splitsAndDividends = GetSplitsAndDividends(data[0].Symbol, exchangeHours);
+
+            var combinedData = splitsAndDividends.Concat(data)
                 .OrderByDescending(d => d.Time.Date);
 
             foreach (var datum in combinedData)

--- a/Common/Data/Auxiliary/FactorFile.cs
+++ b/Common/Data/Auxiliary/FactorFile.cs
@@ -318,6 +318,13 @@ namespace QuantConnect.Data.Auxiliary
             var splitsAndDividends = GetSplitsAndDividends(data[0].Symbol, exchangeHours);
 
             var combinedData = splitsAndDividends.Concat(data)
+                .DistinctBy(e =>
+                    {
+                        var asSplit = e as Split;
+                        var eventType = asSplit == null ? "Dividend" : "Split";
+                        return $"{e.Symbol.ID}{eventType}{e.Time.ToStringInvariant(DateFormat.EightCharacter)}{e.Value.SmartRounding().Normalize()}";
+                    }
+                )
                 .OrderByDescending(d => d.Time.Date);
 
             foreach (var datum in combinedData)

--- a/Common/Data/Auxiliary/FactorFile.cs
+++ b/Common/Data/Auxiliary/FactorFile.cs
@@ -285,7 +285,7 @@ namespace QuantConnect.Data.Auxiliary
                 }
 
                 var split = row.GetSplit(futureFactorFileRow, symbol, exchangeHours);
-                if (i == 0 || split.SplitFactor != 1m)
+                if (split.SplitFactor != 1m)
                 {
                     dividendsAndSplits.Add(split);
                 }
@@ -312,6 +312,7 @@ namespace QuantConnect.Data.Auxiliary
             }
 
             var factorFileRows = new List<FactorFileRow>();
+            var firstEntry = SortedFactorFileData.First().Value;
             var lastEntry = SortedFactorFileData.Last().Value;
             factorFileRows.Add(lastEntry);
 
@@ -350,6 +351,9 @@ namespace QuantConnect.Data.Auxiliary
                     }
                 }
             }
+
+            var firstFactorFileRow = new FactorFileRow(firstEntry.Date, factorFileRows.Last().PriceFactor, factorFileRows.Last().SplitFactor, firstEntry.ReferencePrice == 0 ? 0 : firstEntry.ReferencePrice);
+            factorFileRows.Add(firstFactorFileRow);
 
             return new FactorFile(Permtick, factorFileRows, FactorFileMinimumDate);
         }

--- a/Common/Data/Auxiliary/FactorFileRow.cs
+++ b/Common/Data/Auxiliary/FactorFileRow.cs
@@ -113,7 +113,6 @@ namespace QuantConnect.Data.Auxiliary
         /// <returns>An enumerable of factor file rows</returns>
         public static List<FactorFileRow> Parse(IEnumerable<string> lines, out DateTime? factorFileMinimumDate)
         {
-            var hasInfEntry = false;
             factorFileMinimumDate = null;
 
             var rows = new List<FactorFileRow>();
@@ -123,18 +122,10 @@ namespace QuantConnect.Data.Auxiliary
             {
                 if (line.Contains("inf") || line.Contains("e+"))
                 {
-                    hasInfEntry = true;
                     continue;
                 }
 
                 var row = Parse(line);
-
-                if (hasInfEntry && rows.Count == 0)
-                {
-                    // special handling for INF values: set minimum date
-                    factorFileMinimumDate = row.Date.AddDays(1);
-                    row = new FactorFileRow(row.Date.AddDays(-1), row.PriceFactor, row.SplitFactor, row.ReferencePrice);
-                }
 
                 // ignore zero factor rows
                 if (row.PriceScaleFactor > 0)

--- a/Common/Data/Auxiliary/FactorFileRow.cs
+++ b/Common/Data/Auxiliary/FactorFileRow.cs
@@ -120,6 +120,9 @@ namespace QuantConnect.Data.Auxiliary
             // parse factor file lines
             foreach (var line in lines)
             {
+                // Exponential notation is treated as inf is because of the loss of precision. In
+                // all cases, the significant part has fewer decimals than the needed for a correct
+                // representation, E.g., 1.6e+6 when the correct factor is 1562500.
                 if (line.Contains("inf") || line.Contains("e+"))
                 {
                     continue;

--- a/Common/Data/Auxiliary/FactorFileRow.cs
+++ b/Common/Data/Auxiliary/FactorFileRow.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.Data.Auxiliary
             // parse factor file lines
             foreach (var line in lines)
             {
-                if (line.Contains("inf"))
+                if (line.Contains("inf") || line.Contains("e+"))
                 {
                     hasInfEntry = true;
                     continue;

--- a/Tests/Common/Data/Auxiliary/FactorFileTests.cs
+++ b/Tests/Common/Data/Auxiliary/FactorFileTests.cs
@@ -41,6 +41,41 @@ namespace QuantConnect.Tests.Common.Data.Auxiliary
         }
 
         [Test]
+        public void ReadsFactorFileWithExponentialNotation()
+        {
+            // Source NEWL factor file at 2019-12-09
+            var lines = new[]
+            {
+                "19980102,0.8116779,1e+07",
+                "20051108,0.8116779,1e+07",
+                "20060217,0.8416761,1e+07",
+                "20060516,0.8644420,1e+07",
+                "20060814,0.8747766,1e+07",
+                "20061115,0.8901232,1e+07",
+                "20070314,0.9082148,1e+07",
+                "20070522,0.9166239,1e+07",
+                "20070814,0.9306799,1e+07",
+                "20071120,0.9534326,1e+07",
+                "20080520,0.9830510,1e+07",
+                "20100802,1.0000000,1e+07",
+                "20131016,1.0000000,1.11111e+06",
+                "20131205,1.0000000,75188",
+                "20140305,1.0000000,25000",
+                "20140514,1.0000000,2500",
+                "20140714,1.0000000,50",
+                "20501231,1.0000000,1"
+            };
+
+            DateTime? factorFileMinimumDate;
+            var factorFile = FactorFileRow.Parse(lines, out factorFileMinimumDate).ToList();
+
+            Assert.AreEqual(5, factorFile.Count);
+
+            Assert.IsNotNull(factorFileMinimumDate);
+            Assert.AreEqual(new DateTime(2013, 12, 06), factorFileMinimumDate.Value);
+        }
+
+        [Test]
         public void ReadsFactorFileWithInfValues()
         {
             var lines = new[]

--- a/Tests/Common/Data/Auxiliary/FactorFileTests.cs
+++ b/Tests/Common/Data/Auxiliary/FactorFileTests.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Tests.Common.Data.Auxiliary
             Assert.AreEqual(5, factorFile.Count);
 
             Assert.IsNotNull(factorFileMinimumDate);
-            Assert.AreEqual(new DateTime(2013, 12, 06), factorFileMinimumDate.Value);
+            Assert.AreEqual(new DateTime(2013, 12, 04), factorFileMinimumDate.Value);
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace QuantConnect.Tests.Common.Data.Auxiliary
             Assert.AreEqual(3, factorFile.Count);
 
             Assert.IsNotNull(factorFileMinimumDate);
-            Assert.AreEqual(new DateTime(2016, 3, 31), factorFileMinimumDate.Value);
+            Assert.AreEqual(new DateTime(2016, 3, 29), factorFileMinimumDate.Value);
         }
 
         [Test]

--- a/Tests/Common/Data/Auxiliary/FactorFileTests.cs
+++ b/Tests/Common/Data/Auxiliary/FactorFileTests.cs
@@ -393,9 +393,6 @@ namespace QuantConnect.Tests.Common.Data.Auxiliary
             Assert.IsEmpty(factorFile.GetSplitsAndDividends(Symbols.SPY, SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork)));
         }
 
-      
-
-
         private static FactorFile GetTestFactorFile(string symbol, DateTime reference)
         {
             var file = new FactorFile(symbol, new List<FactorFileRow>

--- a/Tests/Symbols.cs
+++ b/Tests/Symbols.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Tests
         public static readonly Symbol MSFT = CreateEquitySymbol("MSFT");
         public static readonly Symbol ZNGA = CreateEquitySymbol("ZNGA");
         public static readonly Symbol FXE = CreateEquitySymbol("FXE");
+        public static readonly Symbol LODE = CreateEquitySymbol("LODE");
 
         public static readonly Symbol USDJPY = CreateForexSymbol("USDJPY");
         public static readonly Symbol EURUSD = CreateForexSymbol("EURUSD");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes the `FactorFile.Apply` method. Previously, it removed the first row of the `FactorFile` object after applying a new event.

Also the Apply method now can handle duplicated events.

Finally, This PR adds support for exponential notation in QuantQuote's factor files.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3905 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
First row in factor file is important because the factor files are read backwards.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add new assertion to existing tests and added new tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
