### PR TITLE
SubscriptionDataReader wont emit beyond tradable date

### DIFF
--- a/Tests/Engine/DataFeeds/SubscriptionDataReaderTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionDataReaderTests.cs
@@ -1,0 +1,106 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture]
+    public class SubscriptionDataReaderTests
+    {
+        // this is the core of this unit test:
+        // the stream will have two data points one of which does not correspond to the tradable date,
+        // and it shouldn't be emitted because we have a new source for the next tradable date
+        [TestCase(@"25980000,1679600,1679700,1679600,1679700,200
+                99900000,1679400,1679400,1679200,1679200,600", false, Resolution.Minute)]
+        // this test case has two data point which should be emitted because they correspond to the same tradable date
+        [TestCase(@"25980000,1679600,1679700,1679600,1679700,200
+                30980000,1679400,1679400,1679200,1679200,600", true, Resolution.Minute)]
+        // even if the second data point is another tradable date we emit it because daily resolution
+        // always uses the same source
+        [TestCase(@"20191209 00:00,956900,959700,947200,958100,3647000
+                20191211 00:00,956900,959700,947200,958100,3647000", true, Resolution.Daily)]
+        public void DoesNotEmitDataBeyondTradableDate(string data, bool shouldEmitSecondDataPoint, Resolution dataResolution)
+        {
+            var start = new DateTime(2019, 12, 9);
+            var end = new DateTime(2019, 12, 12);
+
+            var mapFileProvider = new LocalDiskMapFileProvider();
+            var mapFileResolver = new MapFileResolver(mapFileProvider.Get(Market.USA));
+
+            var dataReader = new SubscriptionDataReader(
+                new SubscriptionDataConfig(typeof(TradeBar),
+                    Symbols.SPY,
+                    dataResolution,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    false,
+                    false,
+                    false),
+                start,
+                end,
+                mapFileResolver,
+                new LocalDiskFactorFileProvider(mapFileProvider),
+                LinqExtensions.Range(start, end, time => time + TimeSpan.FromDays(1)),
+                false,
+                new TestDataCacheProvider
+                { Data = data }
+                );
+
+            Assert.IsTrue(dataReader.MoveNext());
+            Assert.AreEqual(shouldEmitSecondDataPoint, dataReader.MoveNext());
+
+        }
+
+        private class TestDataCacheProvider : IDataCacheProvider
+        {
+            private bool _alreadyEmitted;
+
+            public string Data { get; set; }
+            public void Dispose()
+            {
+            }
+
+            public bool IsDataEphemeral => true;
+            public Stream Fetch(string key)
+            {
+                if (_alreadyEmitted)
+                {
+                    return null;
+                }
+                _alreadyEmitted = true;
+
+                var stream = new MemoryStream();
+                var writer = new StreamWriter(stream);
+                writer.Write(Data);
+                writer.Flush();
+                stream.Position = 0;
+                return stream;
+            }
+            public void Store(string key, byte[] data)
+            {
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -370,6 +370,7 @@
     <Compile Include="Engine\DataFeeds\PendingRemovalsManagerTests.cs" />
     <Compile Include="Engine\DataFeeds\PredicateTimeProviderTests.cs" />
     <Compile Include="Common\Util\StreamReaderExtensionsTests.cs" />
+    <Compile Include="Engine\DataFeeds\SubscriptionDataReaderTests.cs" />
     <Compile Include="Engine\DataFeeds\SubscriptionUtilsTests.cs" />
     <Compile Include="Engine\DataFeeds\TextSubscriptionDataSourceReaderTests.cs" />
     <Compile Include="Engine\DataFeeds\Transport\RemoteFileSubscriptionStreamReaderTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `SubscriptionDataReader` will not emit data point which are beyond the
current tradable date if the data source has changed.
- Adding unit test

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3912
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix issue with hourly data in some cases
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
