### PR TITLE
Fix LiveTradingDataFeed stack for future/option chain universe

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2837,11 +2837,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
             else if (securityType == SecurityType.Future)
             {
-                if (!IsConnected)
-                {
-                    Connect();
-                }
-
                 // processing request
                 var results = FindContracts(contract, contract.Symbol);
 
@@ -2884,7 +2879,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             if (securityType == SecurityType.Future)
             {
                 // we need to call the IB API only for futures
-                return !IsWithinScheduledServerResetTimes();
+                return !IsWithinScheduledServerResetTimes() && IsConnected;
             }
 
             return true;

--- a/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumerator.cs
@@ -136,8 +136,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 Current.Underlying = Underlying.Current;
                 Current.Time = Underlying.Current.EndTime;
                 Current.EndTime = Underlying.Current.EndTime;
-
-                _lastEmitTime = Current.EndTime;
             }
 
             return true;

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -493,11 +493,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     throw new NotSupportedException("The DataQueueHandler does not support Options.");
                 }
 
-                var enumeratorFactory = new OptionChainUniverseSubscriptionEnumeratorFactory(configure, symbolUniverse, _timeProvider);
+                var timeProvider = new PredicateTimeProvider(_timeProvider,
+                    time => symbolUniverse.CanAdvanceTime(config.SecurityType));
+
+                var enumeratorFactory = new OptionChainUniverseSubscriptionEnumeratorFactory(configure, symbolUniverse, timeProvider);
                 enumerator = enumeratorFactory.CreateEnumerator(request, _dataProvider);
 
-                enumerator = GetConfiguredFrontierAwareEnumerator(enumerator, tzOffsetProvider,
-                    time => symbolUniverse.CanAdvanceTime(config.SecurityType));
+                enumerator = new FrontierAwareEnumerator(enumerator, _frontierTimeProvider, tzOffsetProvider);
             }
             else if (request.Universe is FuturesChainUniverse)
             {
@@ -509,11 +511,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     throw new NotSupportedException("The DataQueueHandler does not support Futures.");
                 }
 
-                var enumeratorFactory = new FuturesChainUniverseSubscriptionEnumeratorFactory(symbolUniverse, _timeProvider);
+                var timeProvider = new PredicateTimeProvider(_timeProvider,
+                    time => symbolUniverse.CanAdvanceTime(config.SecurityType));
+
+                var enumeratorFactory = new FuturesChainUniverseSubscriptionEnumeratorFactory(symbolUniverse, timeProvider);
                 enumerator = enumeratorFactory.CreateEnumerator(request, _dataProvider);
 
-                enumerator = GetConfiguredFrontierAwareEnumerator(enumerator, tzOffsetProvider,
-                    time => symbolUniverse.CanAdvanceTime(config.SecurityType));
+                enumerator = new FrontierAwareEnumerator(enumerator, _frontierTimeProvider, tzOffsetProvider);
             }
             else
             {

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -1883,7 +1883,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
                     var isValidTime = time.Hour >= 1 && time.Hour < 23;
 
-                    Log.Debug($"LookupSymbols() called at {time} ({algorithmTimeZone}) - valid: {isValidTime}");
+                    Log.Trace($"LookupSymbols() called at {time} ({algorithmTimeZone}) - valid: {isValidTime}");
 
                     if (!isValidTime)
                     {
@@ -1912,7 +1912,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 secType =>
                 {
                     var time = timeProvider.GetUtcNow().ConvertFromUtc(algorithmTimeZone);
-                    var result = time.Hour >= 1 && time.Hour < 23;
+                    var result = time.Hour >= 1 && time.Hour < 23 && time.Day != 21;
 
                     Log.Debug($"CanAdvanceTime() called at {time} ({algorithmTimeZone}), returning {result}");
 
@@ -2104,7 +2104,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 throw lookupSymbolsException;
             }
 
-            Assert.AreEqual(3, lookupCount, "LookupSymbols call count mismatch");
+            Assert.AreEqual(2, lookupCount, "LookupSymbols call count mismatch");
 
             if (securityType == SecurityType.Future)
             {


### PR DESCRIPTION

#### Description
- Fixes a bug in the `LiveTradingDataFeed` where the `PredicateTimeProvider` was incorrectly used too late in the stack.

#### Related Issue
Closes #3870 

#### Motivation and Context
#3870 was not completely fixed by #3874 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Local testing with IB
- Updated unit tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`