### PR TITLE
Lazy OnEndOfDay ScheduledEvent

### DIFF
--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -48,6 +48,11 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         private readonly IAlgorithm _baseAlgorithm;
 
         /// <summary>
+        /// True if the underlying python algorithm implements "OnEndOfDay"
+        /// </summary>
+        public bool IsOnEndOfDayImplemented { get; }
+
+        /// <summary>
         /// <see cref = "AlgorithmPythonWrapper"/> constructor.
         /// Creates and wraps the algorithm written in python.
         /// </summary>
@@ -90,6 +95,8 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
                             _onMarginCall = pyAlgorithm.GetPythonMethod("OnMarginCall");
 
                             _onOrderEvent = pyAlgorithm.GetAttr("OnOrderEvent");
+
+                            IsOnEndOfDayImplemented = pyAlgorithm.GetPythonMethod("OnEndOfDay") != null;
                         }
                         attr.Dispose();
                     }

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataCollectionSubscriptionEnumeratorFactory.cs
@@ -63,7 +63,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 foreach (var date in tradableDays)
                 {
                     var source = sourceFactory.GetSource(configuration, date, false);
-                    var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, configuration, date, false);
+                    var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, configuration, date, false, sourceFactory);
                     var coarseFundamentalForDate = factory.Read(source);
                     //  shift all date of emitting the file forward one day to model emitting coarse midnight the next day.
                     yield return new BaseDataCollection(date.AddDays(1), configuration.Symbol, coarseFundamentalForDate);

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                         request.Configuration.MappedSymbol = GetMappedSymbol(request.Configuration, date);
                     }
                     var source = sourceFactory.GetSource(request.Configuration, date, _isLiveMode);
-                    var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, request.Configuration, date, _isLiveMode);
+                    var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, request.Configuration, date, _isLiveMode, sourceFactory);
                     var entriesForDate = factory.Read(source);
                     foreach (var entry in entriesForDate)
                     {

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 var source = sourceFactory.GetSource(config, localDate, true);
 
                 // fetch the new source and enumerate the data source reader
-                var enumerator = EnumerateDataSourceReader(config, dataProvider, frontier, source, localDate);
+                var enumerator = EnumerateDataSourceReader(config, dataProvider, frontier, source, localDate, sourceFactory);
 
                 if (SourceRequiresFastForward(source))
                 {
@@ -127,12 +127,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             return refresher;
         }
 
-        private IEnumerator<BaseData> EnumerateDataSourceReader(SubscriptionDataConfig config, IDataProvider dataProvider, Ref<DateTime> localFrontier, SubscriptionDataSource source, DateTime localDate)
+        private IEnumerator<BaseData> EnumerateDataSourceReader(SubscriptionDataConfig config, IDataProvider dataProvider, Ref<DateTime> localFrontier, SubscriptionDataSource source, DateTime localDate, BaseData baseDataInstance)
         {
             using (var dataCacheProvider = new SingleEntryDataCacheProvider(dataProvider))
             {
                 var newLocalFrontier = localFrontier.Value;
-                var dataSourceReader = GetSubscriptionDataSourceReader(source, dataCacheProvider, config, localDate);
+                var dataSourceReader = GetSubscriptionDataSourceReader(source, dataCacheProvider, config, localDate, baseDataInstance);
                 foreach (var datum in dataSourceReader.Read(source))
                 {
                     // always skip past all times emitted on the previous invocation of this enumerator
@@ -177,10 +177,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         protected virtual ISubscriptionDataSourceReader GetSubscriptionDataSourceReader(SubscriptionDataSource source,
             IDataCacheProvider dataCacheProvider,
             SubscriptionDataConfig config,
-            DateTime date
+            DateTime date,
+            BaseData baseDataInstance
             )
         {
-            return SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, true);
+            return SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, true, baseDataInstance);
         }
 
         private bool SourceRequiresFastForward(SubscriptionDataSource source)

--- a/Engine/DataFeeds/IndexSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/IndexSubscriptionDataSourceReader.cs
@@ -104,7 +104,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             DataCacheProvider,
                             _config,
                             _date,
-                            IsLiveMode);
+                            IsLiveMode,
+                            _factory);
 
                         var enumerator = dataReader.Read(dataSource).GetEnumerator();
                         while (enumerator.MoveNext())

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -469,7 +469,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     // save off for comparison next time
                     _source = newSource;
-                    var subscriptionFactory = CreateSubscriptionFactory(newSource);
+                    var subscriptionFactory = CreateSubscriptionFactory(newSource, _dataFactory);
                     _subscriptionFactoryEnumerator = subscriptionFactory.Read(newSource).GetEnumerator();
                     return true;
                 }
@@ -488,9 +488,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             while (true);
         }
 
-        private ISubscriptionDataSourceReader CreateSubscriptionFactory(SubscriptionDataSource source)
+        private ISubscriptionDataSourceReader CreateSubscriptionFactory(SubscriptionDataSource source, BaseData baseDataInstance)
         {
-            var factory = SubscriptionDataSourceReader.ForSource(source, _dataCacheProvider, _config, _tradeableDates.Current, _isLiveMode);
+            var factory = SubscriptionDataSourceReader.ForSource(source, _dataCacheProvider, _config, _tradeableDates.Current, _isLiveMode, baseDataInstance);
             AttachEventHandlers(factory, source);
             return factory;
         }

--- a/Engine/DataFeeds/SubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataSourceReader.cs
@@ -35,8 +35,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="config">The configuration of the subscription</param>
         /// <param name="date">The date to be processed</param>
         /// <param name="isLiveMode">True for live mode, false otherwise</param>
+        /// <param name="factory">The base data instance factory</param>
         /// <returns>A new <see cref="ISubscriptionDataSourceReader"/> that can read the specified <paramref name="source"/></returns>
-        public static ISubscriptionDataSourceReader ForSource(SubscriptionDataSource source, IDataCacheProvider dataCacheProvider, SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+        public static ISubscriptionDataSourceReader ForSource(SubscriptionDataSource source, IDataCacheProvider dataCacheProvider, SubscriptionDataConfig config, DateTime date, bool isLiveMode, BaseData factory)
         {
             ISubscriptionDataSourceReader reader;
             TextSubscriptionDataSourceReader textReader = null;
@@ -64,7 +65,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // wire up event handlers for logging missing files
             if (source.TransportMedium == SubscriptionTransportMedium.LocalFile)
             {
-                var factory = config.GetBaseDataInstance();
                 if (!factory.IsSparseData())
                 {
                     reader.InvalidSource += (sender, args) => Log.Error($"SubscriptionDataSourceReader.InvalidSource(): File not found: {args.Source.Source}");

--- a/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/TextSubscriptionDataSourceReader.cs
@@ -34,9 +34,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     public class TextSubscriptionDataSourceReader : BaseSubscriptionDataSourceReader
     {
         private readonly bool _implementsStreamReader;
-        private readonly BaseData _factory;
         private readonly DateTime _date;
         private readonly SubscriptionDataConfig _config;
+        private BaseData _factory;
         private bool _shouldCacheDataPoints;
         private static readonly MemoryCache BaseDataSourceCache = new MemoryCache("BaseDataSourceCache",
             // Cache can use up to 70% of the installed physical memory
@@ -77,7 +77,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             _date = date;
             _config = config;
-            _factory = config.GetBaseDataInstance();
             _shouldCacheDataPoints = !_config.IsCustomData && _config.Resolution >= Resolution.Hour
                 && _config.Type != typeof(FineFundamental) && _config.Type != typeof(CoarseFundamental)
                 && !DataCacheProvider.IsDataEphemeral;
@@ -113,6 +112,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     {
                         OnCreateStreamReaderError(_date, source);
                         yield break;
+                    }
+
+                    if (_factory == null)
+                    {
+                        // only create a factory if the stream isn't null
+                        _factory = _config.GetBaseDataInstance();
                     }
                     // while the reader has data
                     while (!reader.EndOfStream)

--- a/Engine/RealTime/BacktestingRealTimeHandler.cs
+++ b/Engine/RealTime/BacktestingRealTimeHandler.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.Lean.Engine.RealTime
 
             // create events for algorithm's end of tradeable dates
             // set up the events for each security to fire every tradeable date before market close
-            base.Setup(Algorithm.StartDate, Algorithm.EndDate);
+            base.Setup(Algorithm.StartDate, Algorithm.EndDate, job.Language);
 
             foreach (var scheduledEvent in GetScheduledEventsSortedByTime())
             {

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                 RefreshMarketHoursToday(triggerTime.ConvertFromUtc(Algorithm.TimeZone).Date);
             }));
 
-            base.Setup(todayInAlgorithmTimeZone, Time.EndOfTime, DateTime.UtcNow);
+            base.Setup(todayInAlgorithmTimeZone, Time.EndOfTime, job.Language, DateTime.UtcNow);
 
             foreach (var scheduledEvent in ScheduledEvents)
             {

--- a/Tests/Common/Data/Custom/EstimizeTests.cs
+++ b/Tests/Common/Data/Custom/EstimizeTests.cs
@@ -143,7 +143,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             var data = new EstimizeRelease();
             var date = new DateTime(2019, 6, 10);
             var source = data.GetSource(config, date, false);
-            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false);
+            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data);
 
             var rows = factory.Read(source).ToList();
 
@@ -226,7 +226,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             var data = new EstimizeEstimate();
             var date = new DateTime(2019, 6, 10);
             var source = data.GetSource(config, date, false);
-            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false);
+            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data);
 
             var rows = factory.Read(source).ToList();
 
@@ -254,7 +254,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             var data = new EstimizeConsensus();
             var date = new DateTime(2019, 6, 10);
             var source = data.GetSource(config, date, false);
-            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false);
+            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data);
 
             var rows = factory.Read(source).ToList();
 

--- a/Tests/Common/Data/Custom/QuandlTests.cs
+++ b/Tests/Common/Data/Custom/QuandlTests.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             var config = new SubscriptionDataConfig(typeof(HistoryAlgorithm.QuandlFuture), Symbol.Create(ticker, SecurityType.Base, QuantConnect.Market.USA), Resolution.Daily, DateTimeZone.Utc, DateTimeZone.Utc, false, false, false, true);
             var source = data.GetSource(config, date, false);
             var dataCacheProvider = new SingleEntryDataCacheProvider(new DefaultDataProvider());
-            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false);
+            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data);
 
             var rows = factory.Read(source).ToList();
 

--- a/Tests/Common/Scheduling/ScheduleManagerTests.cs
+++ b/Tests/Common/Scheduling/ScheduleManagerTests.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Lean.Engine;
 using QuantConnect.Lean.Engine.RealTime;
+using QuantConnect.Packets;
 using QuantConnect.Util.RateLimit;
 
 namespace QuantConnect.Tests.Common.Scheduling
@@ -33,7 +34,7 @@ namespace QuantConnect.Tests.Common.Scheduling
 
             var handler = new BacktestingRealTimeHandler();
             var timeLimitManager = new AlgorithmTimeLimitManager(TokenBucket.Null, TimeSpan.MaxValue);
-            handler.Setup(algorithm, null, null, null, timeLimitManager);
+            handler.Setup(algorithm, new AlgorithmNodePacket(PacketType.BacktestNode), null, null, timeLimitManager);
 
             algorithm.Schedule.SetEventSchedule(handler);
 

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -491,7 +491,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             protected override ISubscriptionDataSourceReader GetSubscriptionDataSourceReader(SubscriptionDataSource source,
                 IDataCacheProvider dataCacheProvider,
                 SubscriptionDataConfig config,
-                DateTime date)
+                DateTime date,
+                BaseData baseData)
             {
                 return _dataSourceReader;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Only add OnEndOfDay ScheduledEvent if the algorithm implements the
method. **Improves performance in the algorithm thread**. Adding unit tests
- Avoid creating a new baseData instance at
`SubscriptionDataSourceReader`
- Adding static `FineFundamental` instance since creating new ones is
expensive

Performance tests
```PR```
39.67 seconds at 8k data points per second. Processing total of 330,502 data points.
42.38 seconds at 8k data points per second. Processing total of 330,502 data points.
39.26 seconds at 8k data points per second. Processing total of 330,502 data points.

```PR + OnEndOfDay(Symbol) method```
47.81 seconds at 7k data points per second. Processing total of 330,502 data points.
49.88 seconds at 7k data points per second. Processing total of 330,502 data points.
49.62 seconds at 7k data points per second. Processing total of 330,502 data points.

```MASTER + OnEndOfDay(Symbol) method```
49.02 seconds at 7k data points per second. Processing total of 330,502 data points.
46.49 seconds at 7k data points per second. Processing total of 330,502 data points.
45.73 seconds at 7k data points per second. Processing total of 330,502 data points.

- Algorithm used, all daily data reading `SPY`
```
public class EmptyMinute400EquityBenchmark : QCAlgorithm
{
    public override void Initialize()
    {
        SetStartDate(2015, 1, 1);
        SetEndDate(2016, 6, 1);
        foreach (var symbolToAdd in Symbols.Equity.All.Take(100))
        {
            var symbol = AddSecurity(SecurityType.Equity, symbolToAdd, Resolution.Daily, false).Symbol;
            AddData<TiingoNews>(symbol);
        }
    }
    private long _tiingoCount;
    public override void OnData(Slice slice)
    {
        _tiingoCount += slice.Get<TiingoNews>().Count;
    }
    public override void OnEndOfAlgorithm()
    {
        Log($"TiingoCount {_tiingoCount}");
    }
}
```
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3925
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve performance
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression and performance tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
