### PR TITLE
Fix Alpaca "Authorization Violation" error when using external data feed

### DIFF
--- a/Brokerages/Alpaca/AlpacaBrokerage.DataQueueHandler.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.DataQueueHandler.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/Brokerages/Alpaca/AlpacaBrokerageFactory.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerageFactory.cs
@@ -89,7 +89,9 @@ namespace QuantConnect.Brokerages.Alpaca
                 throw new Exception("Available trading mode: paper/live");
             }
 
-            var brokerage = new AlpacaBrokerage(algorithm.Transactions, algorithm.Portfolio, keyId, secretKey, tradingMode);
+            var handlesMarketData = job.DataQueueHandler.EndsWith("AlpacaBrokerage");
+
+            var brokerage = new AlpacaBrokerage(algorithm.Transactions, algorithm.Portfolio, keyId, secretKey, tradingMode, handlesMarketData);
             Composer.Instance.AddPart<IDataQueueHandler>(brokerage);
 
             return brokerage;

--- a/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
@@ -63,7 +63,7 @@ namespace QuantConnect.Tests.Brokerages.Alpaca
             var secretKey = Config.Get("alpaca-secret-key");
             var tradingMode = Config.Get("alpaca-trading-mode");
 
-            using (var brokerage = new AlpacaBrokerage(null, null, keyId, secretKey, tradingMode))
+            using (var brokerage = new AlpacaBrokerage(null, null, keyId, secretKey, tradingMode, false))
             {
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);

--- a/Tests/Brokerages/Alpaca/AlpacaBrokerageTests.cs
+++ b/Tests/Brokerages/Alpaca/AlpacaBrokerageTests.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Tests.Brokerages.Alpaca
             var secretKey = Config.Get("alpaca-secret-key");
             var tradingMode = Config.Get("alpaca-trading-mode");
 
-            return new AlpacaBrokerage(orderProvider, securityProvider, keyId, secretKey, tradingMode);
+            return new AlpacaBrokerage(orderProvider, securityProvider, keyId, secretKey, tradingMode, false);
         }
 
         /// <summary>


### PR DESCRIPTION

#### Description
- Added conditional usage of the Alpaca `NatsClient` for market data depending on the `IDataQueueHandler` used.

#### Related Issue
Closes #3938 

#### Motivation and Context
- Unable to deploy QC algorithms to Alpaca Paper Only accounts:
  - https://www.quantconnect.com/forum/discussion/5950/alpaca-paper-trading-giving-quot-authorization-violation-quot-during-algorithm-initialization/p1
  - https://github.com/alpacahq/alpaca-trade-api-js/issues/13

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Tested deployment locally and in QC cloud

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`