### PR TITLE
Alpaca Brokerage - Enable Margin Trading + bug fixes

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -979,7 +979,7 @@ namespace QuantConnect.Algorithm
         /// <param name="accountType">The account type (Cash or Margin)</param>
         public void SetBrokerageModel(BrokerageName brokerage, AccountType accountType = AccountType.Margin)
         {
-            SetBrokerageModel(Brokerages.BrokerageModel.Create(this, brokerage, accountType));
+            SetBrokerageModel(Brokerages.BrokerageModel.Create(Transactions, brokerage, accountType));
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -979,7 +979,7 @@ namespace QuantConnect.Algorithm
         /// <param name="accountType">The account type (Cash or Margin)</param>
         public void SetBrokerageModel(BrokerageName brokerage, AccountType accountType = AccountType.Margin)
         {
-            SetBrokerageModel(Brokerages.BrokerageModel.Create(brokerage, accountType));
+            SetBrokerageModel(Brokerages.BrokerageModel.Create(this, brokerage, accountType));
         }
 
         /// <summary>

--- a/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
@@ -416,7 +416,7 @@ namespace QuantConnect.Brokerages.Alpaca
                 MarketPrice = position.AssetCurrentPrice,
                 MarketValue = position.MarketValue,
                 CurrencySymbol = "$",
-                Quantity = position.Side == PositionSide.Long ? position.Quantity : -position.Quantity
+                Quantity = position.Quantity
             };
         }
 

--- a/Brokerages/Alpaca/AlpacaBrokerageFactory.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerageFactory.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 
 namespace QuantConnect.Brokerages.Alpaca
@@ -59,8 +60,8 @@ namespace QuantConnect.Brokerages.Alpaca
         /// <summary>
         /// Gets a new instance of the <see cref="AlpacaBrokerageModel"/>
         /// </summary>
-        /// <param name="algorithm">The algorithm instance</param>
-        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new AlpacaBrokerageModel(algorithm);
+        /// <param name="orderProvider">The order provider</param>
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new AlpacaBrokerageModel(orderProvider);
 
         /// <summary>
         /// Creates a new <see cref="IBrokerage"/> instance

--- a/Brokerages/Alpaca/AlpacaBrokerageFactory.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerageFactory.cs
@@ -59,7 +59,8 @@ namespace QuantConnect.Brokerages.Alpaca
         /// <summary>
         /// Gets a new instance of the <see cref="AlpacaBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new AlpacaBrokerageModel();
+        /// <param name="algorithm">The algorithm instance</param>
+        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new AlpacaBrokerageModel(algorithm);
 
         /// <summary>
         /// Creates a new <see cref="IBrokerage"/> instance

--- a/Brokerages/Alpaca/Markets/Messages/JsonError.cs
+++ b/Brokerages/Alpaca/Markets/Messages/JsonError.cs
@@ -10,7 +10,7 @@ namespace QuantConnect.Brokerages.Alpaca.Markets
 {
     internal sealed class JsonError
     {
-        [JsonProperty(PropertyName = "code", Required = Required.Always)]
+        [JsonProperty(PropertyName = "code", Required = Required.Default)]
         public Int32 Code { get; set; }
 
         [JsonProperty(PropertyName = "message", Required = Required.Always)]

--- a/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,10 +39,8 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
-        {
-            get { return new InteractiveBrokersBrokerageModel(); }
-        }
+        /// <param name="algorithm">The algorithm instance</param>
+        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new InteractiveBrokersBrokerageModel();
 
         /// <summary>
         /// Creates a new IBrokerage instance
@@ -67,7 +65,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <summary>
         ///Initializes a new instance of the <see cref="BacktestingBrokerageFactory"/> class
         /// </summary>
-        public BacktestingBrokerageFactory() 
+        public BacktestingBrokerageFactory()
             : base(typeof(BacktestingBrokerage))
         {
         }

--- a/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerageFactory.cs
@@ -16,6 +16,7 @@
 using System.Collections.Generic;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Brokerages.Backtesting
 {
@@ -39,8 +40,8 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        /// <param name="algorithm">The algorithm instance</param>
-        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new InteractiveBrokersBrokerageModel();
+        /// <param name="orderProvider">The order provider</param>
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new InteractiveBrokersBrokerageModel();
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Brokerages/Bitfinex/BitfinexBrokerageFactory.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerageFactory.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 using RestSharp;
 
@@ -55,7 +56,8 @@ namespace QuantConnect.Brokerages.Bitfinex
         /// <summary>
         /// The brokerage model
         /// </summary>
-        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new BitfinexBrokerageModel();
+        /// <param name="orderProvider">The order provider</param>
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new BitfinexBrokerageModel();
 
         /// <summary>
         /// Create the Brokerage instance

--- a/Brokerages/Bitfinex/BitfinexBrokerageFactory.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerageFactory.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Brokerages.Bitfinex
         /// <summary>
         /// The brokerage model
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new BitfinexBrokerageModel();
+        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new BitfinexBrokerageModel();
 
         /// <summary>
         /// Create the Brokerage instance

--- a/Brokerages/BrokerageFactory.cs
+++ b/Brokerages/BrokerageFactory.cs
@@ -51,10 +51,10 @@ namespace QuantConnect.Brokerages
         public abstract Dictionary<string, string> BrokerageData { get; }
 
         /// <summary>
-        /// Gets a brokerage model that can be used to model this brokerage's unique
-        /// behaviors
+        /// Gets a brokerage model that can be used to model this brokerage's unique behaviors
         /// </summary>
-        public abstract IBrokerageModel BrokerageModel { get; }
+        /// <param name="algorithm">The algorithm instance</param>
+        public abstract IBrokerageModel GetBrokerageModel(IAlgorithm algorithm);
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Brokerages/BrokerageFactory.cs
+++ b/Brokerages/BrokerageFactory.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Brokerages
 {
@@ -53,8 +54,8 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Gets a brokerage model that can be used to model this brokerage's unique behaviors
         /// </summary>
-        /// <param name="algorithm">The algorithm instance</param>
-        public abstract IBrokerageModel GetBrokerageModel(IAlgorithm algorithm);
+        /// <param name="orderProvider">The order provider</param>
+        public abstract IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider);
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Brokerages/Fxcm/FxcmBrokerageFactory.cs
+++ b/Brokerages/Fxcm/FxcmBrokerageFactory.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 
 namespace QuantConnect.Brokerages.Fxcm
@@ -63,7 +64,8 @@ namespace QuantConnect.Brokerages.Fxcm
         /// <summary>
         /// Gets a new instance of the <see cref="FxcmBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new FxcmBrokerageModel();
+        /// <param name="orderProvider">The order provider</param>
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new FxcmBrokerageModel();
 
         /// <summary>
         /// Creates a new <see cref="IBrokerage"/> instance

--- a/Brokerages/Fxcm/FxcmBrokerageFactory.cs
+++ b/Brokerages/Fxcm/FxcmBrokerageFactory.cs
@@ -63,10 +63,7 @@ namespace QuantConnect.Brokerages.Fxcm
         /// <summary>
         /// Gets a new instance of the <see cref="FxcmBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
-        {
-            get { return new FxcmBrokerageModel(); }
-        }
+        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new FxcmBrokerageModel();
 
         /// <summary>
         /// Creates a new <see cref="IBrokerage"/> instance

--- a/Brokerages/GDAX/GDAXBrokerageFactory.cs
+++ b/Brokerages/GDAX/GDAXBrokerageFactory.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// <summary>
         /// The brokerage model
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new GDAXBrokerageModel();
+        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new GDAXBrokerageModel();
 
         /// <summary>
         /// Create the Brokerage instance

--- a/Brokerages/GDAX/GDAXBrokerageFactory.cs
+++ b/Brokerages/GDAX/GDAXBrokerageFactory.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 using RestSharp;
 
@@ -55,7 +56,8 @@ namespace QuantConnect.Brokerages.GDAX
         /// <summary>
         /// The brokerage model
         /// </summary>
-        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new GDAXBrokerageModel();
+        /// <param name="orderProvider">The order provider</param>
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new GDAXBrokerageModel();
 
         /// <summary>
         /// Create the Brokerage instance

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageFactory.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageFactory.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new InteractiveBrokersBrokerageModel();
+        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new InteractiveBrokersBrokerageModel();
 
         /// <summary>
         /// Creates a new IBrokerage instance and set ups the environment for the brokerage

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageFactory.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageFactory.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 
 namespace QuantConnect.Brokerages.InteractiveBrokers
@@ -54,7 +55,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new InteractiveBrokersBrokerageModel();
+        /// <param name="orderProvider">The order provider</param>
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new InteractiveBrokersBrokerageModel();
 
         /// <summary>
         /// Creates a new IBrokerage instance and set ups the environment for the brokerage

--- a/Brokerages/Oanda/OandaBrokerageFactory.cs
+++ b/Brokerages/Oanda/OandaBrokerageFactory.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 
 namespace QuantConnect.Brokerages.Oanda
@@ -66,7 +67,8 @@ namespace QuantConnect.Brokerages.Oanda
         /// <summary>
         /// Gets a new instance of the <see cref="OandaBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new OandaBrokerageModel();
+        /// <param name="orderProvider">The order provider</param>
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new OandaBrokerageModel();
 
         /// <summary>
         /// Creates a new <see cref="IBrokerage"/> instance

--- a/Brokerages/Oanda/OandaBrokerageFactory.cs
+++ b/Brokerages/Oanda/OandaBrokerageFactory.cs
@@ -66,10 +66,7 @@ namespace QuantConnect.Brokerages.Oanda
         /// <summary>
         /// Gets a new instance of the <see cref="OandaBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
-        {
-            get { return new OandaBrokerageModel(); }
-        }
+        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new OandaBrokerageModel();
 
         /// <summary>
         /// Creates a new <see cref="IBrokerage"/> instance

--- a/Brokerages/Paper/PaperBrokerageFactory.cs
+++ b/Brokerages/Paper/PaperBrokerageFactory.cs
@@ -36,7 +36,8 @@ namespace QuantConnect.Brokerages.Paper
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel => new DefaultBrokerageModel();
+        /// <param name="algorithm">The algorithm instance</param>
+        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new DefaultBrokerageModel();
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Brokerages/Paper/PaperBrokerageFactory.cs
+++ b/Brokerages/Paper/PaperBrokerageFactory.cs
@@ -16,6 +16,7 @@
 using System.Collections.Generic;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Brokerages.Paper
 {
@@ -36,8 +37,8 @@ namespace QuantConnect.Brokerages.Paper
         /// <summary>
         /// Gets a new instance of the <see cref="InteractiveBrokersBrokerageModel"/>
         /// </summary>
-        /// <param name="algorithm">The algorithm instance</param>
-        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new DefaultBrokerageModel();
+        /// <param name="orderProvider">The order provider</param>
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new DefaultBrokerageModel();
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Brokerages/Tradier/TradierBrokerageFactory.cs
+++ b/Brokerages/Tradier/TradierBrokerageFactory.cs
@@ -22,6 +22,7 @@ using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 
 namespace QuantConnect.Brokerages.Tradier
@@ -141,8 +142,8 @@ namespace QuantConnect.Brokerages.Tradier
         /// <summary>
         /// Gets a new instance of the <see cref="TradierBrokerageModel"/>
         /// </summary>
-        /// <param name="algorithm">The algorithm instance</param>
-        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new TradierBrokerageModel();
+        /// <param name="orderProvider">The order provider</param>
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new TradierBrokerageModel();
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Brokerages/Tradier/TradierBrokerageFactory.cs
+++ b/Brokerages/Tradier/TradierBrokerageFactory.cs
@@ -141,10 +141,8 @@ namespace QuantConnect.Brokerages.Tradier
         /// <summary>
         /// Gets a new instance of the <see cref="TradierBrokerageModel"/>
         /// </summary>
-        public override IBrokerageModel BrokerageModel
-        {
-            get { return new TradierBrokerageModel(); }
-        }
+        /// <param name="algorithm">The algorithm instance</param>
+        public override IBrokerageModel GetBrokerageModel(IAlgorithm algorithm) => new TradierBrokerageModel();
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
@@ -49,13 +48,9 @@ namespace QuantConnect.Brokerages
         /// </summary>
         /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="AccountType.Cash"/></param>
-        public AlpacaBrokerageModel(AccountType accountType = AccountType.Cash)
+        public AlpacaBrokerageModel(AccountType accountType = AccountType.Margin)
             : base(accountType)
         {
-            if (accountType == AccountType.Margin)
-            {
-                throw new ArgumentException("The Alpaca brokerage does not currently support Margin trading.");
-            }
         }
 
         /// <summary>

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -15,7 +15,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Fills;
@@ -31,7 +30,7 @@ namespace QuantConnect.Brokerages
     /// </summary>
     public class AlpacaBrokerageModel : DefaultBrokerageModel
     {
-        private readonly IAlgorithm _algorithm;
+        private readonly IOrderProvider _orderProvider;
 
         /// <summary>
         /// The default markets for the alpaca brokerage
@@ -50,13 +49,13 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="algorithm">The algorithm</param>
+        /// <param name="orderProvider">The order provider</param>
         /// <param name="accountType">The type of account to be modelled, defaults to
         /// <see cref="AccountType.Cash"/></param>
-        public AlpacaBrokerageModel(IAlgorithm algorithm, AccountType accountType = AccountType.Margin)
+        public AlpacaBrokerageModel(IOrderProvider orderProvider, AccountType accountType = AccountType.Margin)
             : base(accountType)
         {
-            _algorithm = algorithm;
+            _orderProvider = orderProvider;
         }
 
         /// <summary>
@@ -104,7 +103,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            var openOrders = _algorithm.Transactions.GetOpenOrders(order.Symbol);
+            var openOrders = _orderProvider.GetOpenOrders(x => x.Symbol == order.Symbol);
             if (security.Holdings.IsLong)
             {
                 var openSellQuantity = openOrders.Where(x => x.Direction == OrderDirection.Sell).Sum(x => x.Quantity);

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Fills;
@@ -163,10 +164,11 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Creates a new <see cref="IBrokerageModel"/> for the specified <see cref="BrokerageName"/>
         /// </summary>
+        /// <param name="algorithm">The algorithm</param>
         /// <param name="brokerage">The name of the brokerage</param>
         /// <param name="accountType">The account type</param>
         /// <returns>The model for the specified brokerage</returns>
-        public static IBrokerageModel Create(BrokerageName brokerage, AccountType accountType)
+        public static IBrokerageModel Create(IAlgorithm algorithm, BrokerageName brokerage, AccountType accountType)
         {
             switch (brokerage)
             {
@@ -192,7 +194,7 @@ namespace QuantConnect.Brokerages
                     return new GDAXBrokerageModel(accountType);
 
                 case BrokerageName.Alpaca:
-                    return new AlpacaBrokerageModel(accountType);
+                    return new AlpacaBrokerageModel(algorithm, accountType);
 
                 case BrokerageName.AlphaStreams:
                     return new AlphaStreamsBrokerageModel(accountType);

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using QuantConnect.Data.Market;
-using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Fills;
@@ -164,11 +163,11 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Creates a new <see cref="IBrokerageModel"/> for the specified <see cref="BrokerageName"/>
         /// </summary>
-        /// <param name="algorithm">The algorithm</param>
+        /// <param name="orderProvider">The order provider</param>
         /// <param name="brokerage">The name of the brokerage</param>
         /// <param name="accountType">The account type</param>
         /// <returns>The model for the specified brokerage</returns>
-        public static IBrokerageModel Create(IAlgorithm algorithm, BrokerageName brokerage, AccountType accountType)
+        public static IBrokerageModel Create(IOrderProvider orderProvider, BrokerageName brokerage, AccountType accountType)
         {
             switch (brokerage)
             {
@@ -194,7 +193,7 @@ namespace QuantConnect.Brokerages
                     return new GDAXBrokerageModel(accountType);
 
                 case BrokerageName.Alpaca:
-                    return new AlpacaBrokerageModel(algorithm, accountType);
+                    return new AlpacaBrokerageModel(orderProvider, accountType);
 
                 case BrokerageName.AlphaStreams:
                     return new AlphaStreamsBrokerageModel(accountType);

--- a/Common/Interfaces/IBrokerageFactory.cs
+++ b/Common/Interfaces/IBrokerageFactory.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using QuantConnect.Brokerages;
 using QuantConnect.Packets;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Interfaces
 {
@@ -44,8 +45,8 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Gets a brokerage model that can be used to model this brokerage's unique behaviors
         /// </summary>
-        /// <param name="algorithm">The algorithm instance</param>
-        IBrokerageModel GetBrokerageModel(IAlgorithm algorithm);
+        /// <param name="orderProvider">The order provider</param>
+        IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider);
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Common/Interfaces/IBrokerageFactory.cs
+++ b/Common/Interfaces/IBrokerageFactory.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,10 +42,10 @@ namespace QuantConnect.Interfaces
         Dictionary<string, string> BrokerageData { get; }
 
         /// <summary>
-        /// Gets a brokerage model that can be used to model this brokerage's unique
-        /// behaviors
+        /// Gets a brokerage model that can be used to model this brokerage's unique behaviors
         /// </summary>
-        IBrokerageModel BrokerageModel { get; }
+        /// <param name="algorithm">The algorithm instance</param>
+        IBrokerageModel GetBrokerageModel(IAlgorithm algorithm);
 
         /// <summary>
         /// Creates a new IBrokerage instance

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Lean.Engine.Setup
                     try
                     {
                         //Set the default brokerage model before initialize
-                        algorithm.SetBrokerageModel(_factory.BrokerageModel);
+                        algorithm.SetBrokerageModel(_factory.GetBrokerageModel(algorithm));
 
                         //Margin calls are disabled by default in live mode
                         algorithm.Portfolio.MarginCallModel = MarginCallModel.Null;

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Lean.Engine.Setup
                     try
                     {
                         //Set the default brokerage model before initialize
-                        algorithm.SetBrokerageModel(_factory.GetBrokerageModel(algorithm));
+                        algorithm.SetBrokerageModel(_factory.GetBrokerageModel(algorithm.Transactions));
 
                         //Margin calls are disabled by default in live mode
                         algorithm.Portfolio.MarginCallModel = MarginCallModel.Null;

--- a/Tests/Brokerages/Alpaca/AlpacaBrokerageDataQueueHandlerTests.cs
+++ b/Tests/Brokerages/Alpaca/AlpacaBrokerageDataQueueHandlerTests.cs
@@ -19,18 +19,41 @@ using System.Diagnostics;
 using System.Threading;
 using NUnit.Framework;
 using QuantConnect.Brokerages.Alpaca;
+using QuantConnect.Configuration;
 using QuantConnect.Data.Market;
 using QuantConnect.Logging;
 
 namespace QuantConnect.Tests.Brokerages.Alpaca
 {
-    [TestFixture]
-    public partial class AlpacaBrokerageTests
+    [TestFixture, Ignore("This test requires a configured and testable Alpaca practice account. Since it uses the Polygon API, the account needs to be funded.")]
+    public class AlpacaBrokerageDataQueueHandlerBrokerageTests
     {
+        private AlpacaBrokerage _brokerage;
+
+        [SetUp]
+        public void Setup()
+        {
+            Log.LogHandler = new ConsoleLogHandler();
+
+            var keyId = Config.Get("alpaca-key-id");
+            var secretKey = Config.Get("alpaca-secret-key");
+            var tradingMode = Config.Get("alpaca-trading-mode");
+
+            _brokerage = new AlpacaBrokerage(null, null, keyId, secretKey, tradingMode, true);
+            _brokerage.Connect();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _brokerage.Disconnect();
+            _brokerage.Dispose();
+        }
+
         [Test]
         public void GetsTickData()
         {
-            var brokerage = (AlpacaBrokerage)Brokerage;
+            var brokerage = _brokerage;
 
             brokerage.Subscribe(null, new List<Symbol>
             {
@@ -83,7 +106,7 @@ namespace QuantConnect.Tests.Brokerages.Alpaca
                 "AAPL", "FB", "MSFT", "GOOGL"
             };
 
-            var brokerage = (AlpacaBrokerage)Brokerage;
+            var brokerage = _brokerage;
 
             var stopwatch = Stopwatch.StartNew();
             foreach (var symbol in symbols)

--- a/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
@@ -26,7 +26,7 @@ using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Brokerages.Alpaca
 {
-    [TestFixture, Ignore("This test requires a configured and testable Alpaca practice account")]
+    [TestFixture, Ignore("This test requires a configured and testable Alpaca practice account. Since it uses the Polygon API, the account needs to be funded.")]
     public class AlpacaBrokerageHistoryProviderTests
     {
         public TestCaseData[] TestParameters
@@ -59,11 +59,13 @@ namespace QuantConnect.Tests.Brokerages.Alpaca
         [Test, TestCaseSource(nameof(TestParameters))]
         public void GetsHistory(Symbol symbol, Resolution resolution, TimeSpan period, bool shouldBeEmpty)
         {
+            Log.LogHandler = new ConsoleLogHandler();
+
             var keyId = Config.Get("alpaca-key-id");
             var secretKey = Config.Get("alpaca-secret-key");
             var tradingMode = Config.Get("alpaca-trading-mode");
 
-            using (var brokerage = new AlpacaBrokerage(null, null, keyId, secretKey, tradingMode, false))
+            using (var brokerage = new AlpacaBrokerage(null, null, keyId, secretKey, tradingMode, true))
             {
                 var historyProvider = new BrokerageHistoryProvider();
                 historyProvider.SetBrokerage(brokerage);

--- a/Tests/Brokerages/Alpaca/AlpacaBrokerageTests.cs
+++ b/Tests/Brokerages/Alpaca/AlpacaBrokerageTests.cs
@@ -31,7 +31,7 @@ using QuantConnect.Securities;
 namespace QuantConnect.Tests.Brokerages.Alpaca
 {
     [TestFixture, Ignore("This test requires a configured and testable Alpaca practice account")]
-    public partial class AlpacaBrokerageTests : BrokerageTests
+    public class AlpacaBrokerageTests : BrokerageTests
     {
         /// <summary>
         /// Creates the brokerage under test and connects it
@@ -113,27 +113,17 @@ namespace QuantConnect.Tests.Brokerages.Alpaca
         }
 
         [Test, TestCaseSource(nameof(OrderParameters))]
-        public override void ShortFromZero(OrderTestParameters parameters)
-        {
-            Assert.Ignore("Alpaca brokerage does not currently support shorting.");
-        }
-
-        [Test, TestCaseSource(nameof(OrderParameters))]
-        public override void CloseFromShort(OrderTestParameters parameters)
-        {
-            Assert.Ignore("Alpaca brokerage does not currently support shorting.");
-        }
-
-        [Test, TestCaseSource(nameof(OrderParameters))]
         public override void ShortFromLong(OrderTestParameters parameters)
         {
-            Assert.Ignore("Alpaca brokerage does not currently support shorting.");
+            // https://github.com/alpacahq/Alpaca-API/issues/90
+            Assert.Ignore("Alpaca brokerage does not currently support reversing a position with a single order.");
         }
 
         [Test, TestCaseSource(nameof(OrderParameters))]
         public override void LongFromShort(OrderTestParameters parameters)
         {
-            Assert.Ignore("Alpaca brokerage does not currently support shorting.");
+            // https://github.com/alpacahq/Alpaca-API/issues/90
+            Assert.Ignore("Alpaca brokerage does not currently support reversing a position with a single order.");
         }
 
         [Test]

--- a/Tests/Common/Brokerages/AlpacaBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/AlpacaBrokerageModelTests.cs
@@ -57,7 +57,7 @@ namespace QuantConnect.Tests.Common.Brokerages
 
             var order = Order.CreateOrder(request);
 
-            var model = new AlpacaBrokerageModel(algorithm);
+            var model = new AlpacaBrokerageModel(algorithm.Transactions);
 
             BrokerageMessageEvent messageEvent;
             Assert.AreEqual(isValid, model.CanSubmitOrder(security, order, out messageEvent));

--- a/Tests/Common/Brokerages/AlpacaBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/AlpacaBrokerageModelTests.cs
@@ -1,0 +1,125 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Brokerages
+{
+    [TestFixture]
+    public class AlpacaBrokerageModelTests
+    {
+        [TestCaseSource(nameof(GetOrderTestData))]
+        public void ValidatesOrders(OrderType orderType, Symbol symbol, decimal quantity, decimal stopPrice, decimal limitPrice, decimal existingPosition, decimal existingOrderQuantity, bool isValid)
+        {
+            var algorithm = new QCAlgorithm();
+            var mock = new Mock<ITransactionHandler>();
+            var request = new SubmitOrderRequest(orderType, symbol.SecurityType, symbol, quantity, stopPrice, limitPrice, DateTime.UtcNow, "");
+            mock.Setup(m => m.Process(It.IsAny<OrderRequest>())).Returns(new OrderTicket(null, request));
+
+            var existingOrders = new List<Order>();
+            if (existingOrderQuantity != 0)
+            {
+                existingOrders.Add(new LimitOrder(symbol, existingOrderQuantity, 1, DateTime.UtcNow));
+            }
+
+            mock.Setup(m => m.GetOpenOrders(It.IsAny<Func<Order, bool>>())).Returns(existingOrders);
+            algorithm.Transactions.SetOrderProcessor(mock.Object);
+
+            var security = CreateSecurity(symbol);
+            security.SetMarketPrice(new Tick { Value = 320m });
+
+            if (existingPosition != 0)
+            {
+                security.Holdings.SetHoldings(1, existingPosition);
+            }
+
+            var order = Order.CreateOrder(request);
+
+            var model = new AlpacaBrokerageModel(algorithm);
+
+            BrokerageMessageEvent messageEvent;
+            Assert.AreEqual(isValid, model.CanSubmitOrder(security, order, out messageEvent));
+        }
+
+        public TestCaseData[] GetOrderTestData()
+        {
+            return new[]
+            {
+                // valid security type
+                new TestCaseData(OrderType.Market, Symbols.SPY, 1m, 0m, 0m, 0m, 0m, true),
+
+                // invalid security type
+                new TestCaseData(OrderType.Market, Symbols.EURUSD, 1m, 0m, 0m, 0m, 0m, false),
+                new TestCaseData(OrderType.Market, Symbols.DE30EUR, 1m, 0m, 0m, 0m, 0m, false),
+                new TestCaseData(OrderType.Market, Symbols.BTCUSD, 1m, 0m, 0m, 0m, 0m, false),
+                new TestCaseData(OrderType.Market, Symbols.Fut_SPY_Feb19_2016, 1m, 0m, 0m, 0m, 0m, false),
+                new TestCaseData(OrderType.Market, Symbols.SPY_C_192_Feb19_2016, 1m, 0m, 0m, 0m, 0m, false),
+
+                // invalid order type
+                new TestCaseData(OrderType.MarketOnClose, Symbols.SPY, 1m, 0m, 0m, 0m, 0m, false),
+
+                // invalid reverse from long to short (with no open orders)
+                new TestCaseData(OrderType.Market, Symbols.SPY, -2m, 0m, 0m, 1m, 0m, false),
+
+                // invalid reverse from short to long (with no open orders)
+                new TestCaseData(OrderType.Market, Symbols.SPY, 2m, 0m, 0m, -1m, 0m, false),
+
+                // cannot open a short sell while a long buy order is open
+                new TestCaseData(OrderType.Market, Symbols.SPY, -1m, 0m, 0m, 0m, 1m, false),
+
+                // cannot open a long buy while a short sell order is open
+                new TestCaseData(OrderType.Market, Symbols.SPY, 1m, 0m, 0m, 0m, -1m, false),
+
+                // cannot submit sell order with long position and open sell order
+                new TestCaseData(OrderType.Market, Symbols.SPY, -1m, 0m, 0m, 1m, -1m, false),
+
+                // cannot submit buy order with short position and open buy order
+                new TestCaseData(OrderType.Market, Symbols.SPY, 1m, 0m, 0m, -1m, 1m, false)
+            };
+        }
+
+        private Security CreateSecurity(Symbol symbol)
+        {
+            return new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    symbol,
+                    Resolution.Minute,
+                    TimeZones.NewYork,
+                    TimeZones.NewYork,
+                    false,
+                    false,
+                    false
+                ),
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -296,6 +296,7 @@
     <Compile Include="Brokerages\DowngradeErrorCodeToWarningBrokerageMessageHandlerTests.cs" />
     <Compile Include="Brokerages\Paper\PaperBrokerageTests.cs" />
     <Compile Include="Common\Benchmarks\SecurityBenchmarkTests.cs" />
+    <Compile Include="Common\Brokerages\AlpacaBrokerageModelTests.cs" />
     <Compile Include="Common\Brokerages\BitfinexBrokerageModelTests.cs" />
     <Compile Include="Common\Brokerages\FxcmBrokerageModelTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileRowTests.cs" />


### PR DESCRIPTION

#### Description
- Enabled margin trading and shorting with Alpaca accounts
- Fixed a quantity sign bug in `ConvertHolding`
- Fixed deserialization error when the JSON response does not contain the code property
- Added order validation checks in `AlpacaBrokerageModel.CanSubmitOrder`
- Updated unit tests

#### Related Issue
Closes #3081 

#### Motivation and Context
- Previously AlpacaBrokerage only supported Alpaca cash accounts

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Updated unit tests
- Live testing

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`