### PR TITLE
Move IObjectStore Extension Methods to Interface

### DIFF
--- a/Common/Interfaces/IObjectStore.cs
+++ b/Common/Interfaces/IObjectStore.cs
@@ -16,6 +16,8 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Text;
+using Newtonsoft.Json;
 using QuantConnect.Packets;
 
 namespace QuantConnect.Interfaces
@@ -56,12 +58,82 @@ namespace QuantConnect.Interfaces
         byte[] ReadBytes(string key);
 
         /// <summary>
+        /// Returns the string object data for the specified key
+        /// </summary>
+        /// <param name="key">The object key</param>
+        /// <param name="encoding">The string encoding used</param>
+        /// <returns>A string containing the data</returns>
+        string Read(string key, Encoding encoding = null);
+
+        /// <summary>
+        /// Returns the string object data for the specified key
+        /// </summary>
+        /// <param name="key">The object key</param>
+        /// <param name="encoding">The string encoding used</param>
+        /// <returns>A string containing the data</returns>
+        string ReadString(string key, Encoding encoding = null);
+
+        /// <summary>
+        /// Returns the JSON deserialized object data for the specified key
+        /// </summary>
+        /// <param name="key">The object key</param>
+        /// <param name="encoding">The string encoding used</param>
+        /// <param name="settings">The settings used by the JSON deserializer</param>
+        /// <returns>An object containing the data</returns>
+        T ReadJson<T>(string key, Encoding encoding = null, JsonSerializerSettings settings = null);
+
+        /// <summary>
+        /// Returns the XML deserialized object data for the specified key
+        /// </summary>
+        /// <param name="key">The object key</param>
+        /// <param name="encoding">The string encoding used</param>
+        /// <returns>An object containing the data</returns>
+        T ReadXml<T>(string key, Encoding encoding = null);
+
+        /// <summary>
         /// Saves the object data for the specified key
         /// </summary>
         /// <param name="key">The object key</param>
         /// <param name="contents">The object data</param>
         /// <returns>True if the save operation was successful</returns>
         bool SaveBytes(string key, byte[] contents);
+
+        /// <summary>
+        /// Saves the object data in text format for the specified key
+        /// </summary>
+        /// <param name="key">The object key</param>
+        /// <param name="text">The string object to be saved</param>
+        /// <param name="encoding">The string encoding used</param>
+        /// <returns>True if the object was saved successfully</returns>
+        bool Save(string key, string text, Encoding encoding = null);
+
+        /// <summary>
+        /// Saves the object data in text format for the specified key
+        /// </summary>
+        /// <param name="key">The object key</param>
+        /// <param name="text">The string object to be saved</param>
+        /// <param name="encoding">The string encoding used</param>
+        /// <returns>True if the object was saved successfully</returns>
+        bool SaveString(string key, string text, Encoding encoding = null);
+
+        /// <summary>
+        /// Saves the object data in JSON format for the specified key
+        /// </summary>
+        /// <param name="key">The object key</param>
+        /// <param name="obj">The object to be saved</param>
+        /// <param name="encoding">The string encoding used</param>
+        /// <param name="settings">The settings used by the JSON serializer</param>
+        /// <returns>True if the object was saved successfully</returns>
+        bool SaveJson<T>(string key, T obj, Encoding encoding = null, JsonSerializerSettings settings = null);
+
+        /// <summary>
+        /// Saves the object data in XML format for the specified key
+        /// </summary>
+        /// <param name="key">The object key</param>
+        /// <param name="obj">The object to be saved</param>
+        /// <param name="encoding">The string encoding used</param>
+        /// <returns>True if the object was saved successfully</returns>
+        bool SaveXml<T>(string key, T obj, Encoding encoding = null);
 
         /// <summary>
         /// Deletes the object data for the specified key

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -747,7 +747,7 @@
     <Compile Include="Statistics\TradeStatistics.cs" />
     <Compile Include="Statistics\Statistics.cs" />
     <Compile Include="RealTimeSynchronizedTimer.cs" />
-    <Compile Include="Storage\ObjectStore.cs" />
+    <Compile Include="Storage\BaseObjectStore.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="Parse.cs" />
     <Compile Include="Symbol.cs" />

--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -14,7 +14,6 @@
 */
 
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -24,6 +23,7 @@ using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Packets;
+using QuantConnect.Storage;
 using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.Storage
@@ -31,14 +31,14 @@ namespace QuantConnect.Lean.Engine.Storage
     /// <summary>
     /// A local disk implementation of <see cref="IObjectStore"/>.
     /// </summary>
-    public class LocalObjectStore : IObjectStore
+    public class LocalObjectStore : BaseObjectStore
     {
         private static string StorageRoot => Path.GetFullPath(Config.Get("object-store-root", "./storage"));
 
         /// <summary>
         /// Event raised each time there's an error
         /// </summary>
-        public event EventHandler<ObjectStoreErrorRaisedEventArgs> ErrorRaised;
+        public override event EventHandler<ObjectStoreErrorRaisedEventArgs> ErrorRaised;
 
         /// <summary>
         /// Flag indicating the state of this object storage has changed since the last <seealso cref="Persist"/> invocation
@@ -67,7 +67,7 @@ namespace QuantConnect.Lean.Engine.Storage
         /// <param name="projectId">The project id</param>
         /// <param name="userToken">The user token</param>
         /// <param name="controls">The job controls instance</param>
-        public virtual void Initialize(string algorithmName, int userId, int projectId, string userToken, Controls controls)
+        public override void Initialize(string algorithmName, int userId, int projectId, string userToken, Controls controls)
         {
             // absolute path including algorithm name
             AlgorithmStorageRoot = Path.Combine(StorageRoot, algorithmName);
@@ -94,7 +94,7 @@ namespace QuantConnect.Lean.Engine.Storage
         /// </summary>
         /// <param name="key">The object key</param>
         /// <returns>True if the key was found</returns>
-        public bool ContainsKey(string key)
+        public override bool ContainsKey(string key)
         {
             if (key == null)
             {
@@ -109,7 +109,7 @@ namespace QuantConnect.Lean.Engine.Storage
         /// </summary>
         /// <param name="key">The object key</param>
         /// <returns>A byte array containing the data</returns>
-        public byte[] ReadBytes(string key)
+        public override byte[] ReadBytes(string key)
         {
             if (key == null)
             {
@@ -133,7 +133,7 @@ namespace QuantConnect.Lean.Engine.Storage
         /// <param name="key">The object key</param>
         /// <param name="contents">The object data</param>
         /// <returns>True if the save operation was successful</returns>
-        public bool SaveBytes(string key, byte[] contents)
+        public override bool SaveBytes(string key, byte[] contents)
         {
             if (key == null)
             {
@@ -178,7 +178,7 @@ namespace QuantConnect.Lean.Engine.Storage
         /// </summary>
         /// <param name="key">The object key</param>
         /// <returns>True if the delete operation was successful</returns>
-        public bool Delete(string key)
+        public override bool Delete(string key)
         {
             if (key == null)
             {
@@ -200,7 +200,7 @@ namespace QuantConnect.Lean.Engine.Storage
         /// </summary>
         /// <param name="key">The object key</param>
         /// <returns>The path for the file</returns>
-        public string GetFilePath(string key)
+        public override string GetFilePath(string key)
         {
             if (key == null)
             {
@@ -220,7 +220,7 @@ namespace QuantConnect.Lean.Engine.Storage
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
-        public virtual void Dispose()
+        public override void Dispose()
         {
             try
             {
@@ -245,17 +245,9 @@ namespace QuantConnect.Lean.Engine.Storage
         /// <summary>Returns an enumerator that iterates through the collection.</summary>
         /// <returns>A <see cref="T:System.Collections.Generic.IEnumerator`1" /> that can be used to iterate through the collection.</returns>
         /// <filterpriority>1</filterpriority>
-        public IEnumerator<KeyValuePair<string, byte[]>> GetEnumerator()
+        public override IEnumerator<KeyValuePair<string, byte[]>> GetEnumerator()
         {
             return _storage.GetEnumerator();
-        }
-
-        /// <summary>Returns an enumerator that iterates through a collection.</summary>
-        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
-        /// <filterpriority>2</filterpriority>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
         }
 
         /// <summary>

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -20,7 +20,6 @@ using NUnit.Framework;
 using QuantConnect.Configuration;
 using QuantConnect.Lean.Engine.Storage;
 using QuantConnect.Packets;
-using QuantConnect.Storage;
 
 namespace QuantConnect.Tests.Common.Storage
 {


### PR DESCRIPTION
#### Description
Moves IObjectStore extension methods to interface.
Creates abstract class to implement common methods.

#### Related Issue
Closes #3952

#### Motivation and Context
Pythonnet does not support extension methods, therefore using helper methods would require a different API call in C# and Python.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Existing unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`