### PR TITLE
Adds Python Example of ObjectStoreExampleAlgorithm

### DIFF
--- a/Algorithm.CSharp/ObjectStoreExampleAlgorithm.cs
+++ b/Algorithm.CSharp/ObjectStoreExampleAlgorithm.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Algorithm.CSharp
     public class ObjectStoreExampleAlgorithm : QCAlgorithm
     {
         private const string SPY_Close_ObjectStore_Key = "spy_close";
-        private Security SPY;
+        private Symbol SPY;
         private Identity SPY_Close;
         private ExponentialMovingAverage SPY_Close_EMA10;
         private ExponentialMovingAverage SPY_Close_EMA50;
@@ -49,10 +49,10 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2013, 10, 07);
             SetEndDate(2013, 10, 11);
 
-            SPY = AddEquity("SPY", Resolution.Minute);
+            SPY = AddEquity("SPY", Resolution.Minute).Symbol;
 
             // define indicators on SPY daily closing prices
-            SPY_Close = Identity(SPY.Symbol, Resolution.Daily);
+            SPY_Close = Identity(SPY, Resolution.Daily);
             SPY_Close_EMA10 = SPY_Close.EMA(10);
             SPY_Close_EMA50 = SPY_Close.EMA(50);
 
@@ -84,7 +84,7 @@ namespace QuantConnect.Algorithm.CSharp
 
                 // if our object store doesn't have our data, fetch the history to initialize
                 // we're pulling the last year's worth of SPY daily trade bars to fee into our indicators
-                var history = History(new[] {SPY.Symbol}, TimeSpan.FromDays(365), Resolution.Daily).Get(SPY.Symbol);
+                var history = History(SPY, TimeSpan.FromDays(365), Resolution.Daily);
 
                 foreach (var tradeBar in history.OrderBy(x => x.EndTime))
                 {
@@ -108,24 +108,24 @@ namespace QuantConnect.Algorithm.CSharp
         {
             if (SPY_Close_EMA10 > SPY_Close && SPY_Close_EMA10 > SPY_Close_EMA50)
             {
-                SetHoldings(SPY.Symbol, 1m);
+                SetHoldings(SPY, 1m);
             }
             else if (SPY_Close_EMA10 < SPY_Close && SPY_Close_EMA10 < SPY_Close_EMA50)
             {
-                SetHoldings(SPY.Symbol, -1m);
+                SetHoldings(SPY, -1m);
             }
-            else if (Portfolio[SPY.Symbol].IsLong)
+            else if (Portfolio[SPY].IsLong)
             {
                 if (SPY_Close_EMA10 < SPY_Close_EMA50)
                 {
-                    Liquidate(SPY.Symbol);
+                    Liquidate(SPY);
                 }
             }
-            else if (Portfolio[SPY.Symbol].IsShort)
+            else if (Portfolio[SPY].IsShort)
             {
                 if (SPY_Close_EMA10 > SPY_Close_EMA50)
                 {
-                    Liquidate(SPY.Symbol);
+                    Liquidate(SPY);
                 }
             }
         }

--- a/Algorithm.CSharp/ObjectStoreExampleAlgorithm.cs
+++ b/Algorithm.CSharp/ObjectStoreExampleAlgorithm.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Algorithm.CSharp
                 var values = ObjectStore.ReadJson<IndicatorDataPoint[]>(SPY_Close_ObjectStore_Key);
                 Debug($"{SPY_Close_ObjectStore_Key} key exists in object store. Count: {values.Length}");
 
-                foreach (var value in values.OrderBy(x => x.EndTime))
+                foreach (var value in values)
                 {
                     SPY_Close.Update(value);
                 }
@@ -86,13 +86,13 @@ namespace QuantConnect.Algorithm.CSharp
                 // we're pulling the last year's worth of SPY daily trade bars to fee into our indicators
                 var history = History(SPY, TimeSpan.FromDays(365), Resolution.Daily);
 
-                foreach (var tradeBar in history.OrderBy(x => x.EndTime))
+                foreach (var tradeBar in history)
                 {
                     SPY_Close.Update(tradeBar.EndTime, tradeBar.Close);
                 }
 
                 // save our warm up data so next time we don't need to issue the history request
-                var array = SPY_Close_History.OrderBy(x => x.EndTime).ToArray();
+                var array = SPY_Close_History.Reverse().ToArray();
                 ObjectStore.SaveJson(SPY_Close_ObjectStore_Key, array);
 
                 // Can also use ObjectStore.SaveBytes(key, byte[])

--- a/Algorithm.Python/ObjectStoreExampleAlgorithm.py
+++ b/Algorithm.Python/ObjectStoreExampleAlgorithm.py
@@ -74,7 +74,7 @@ class ObjectStoreExampleAlgorithm(QCAlgorithm):
 
             # save our warm up data so next time we don't need to issue the history request
             self.ObjectStore.Save(self.SPY_Close_ObjectStore_Key,
-                '\n'.join([f'{x.EndTime},{x.Value}' for x in sorted(self.SPY_Close_History, key=lambda x: x.EndTime)]))
+                '\n'.join(reversed([f'{x.EndTime},{x.Value}' for x in self.SPY_Close_History])))
 
             # Can also use ObjectStore.SaveBytes(key, byte[])
             # and to read  ObjectStore.ReadBytes(key) => byte[]

--- a/Algorithm.Python/ObjectStoreExampleAlgorithm.py
+++ b/Algorithm.Python/ObjectStoreExampleAlgorithm.py
@@ -1,0 +1,102 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import QCAlgorithm
+from QuantConnect.Indicators import IndicatorDataPoint, RollingWindow
+from datetime import timedelta
+from io import StringIO
+import pandas as pd
+
+class ObjectStoreExampleAlgorithm(QCAlgorithm):
+    '''This algorithm showcases some features of the IObjectStore feature.
+    One use case is to make consecutive backtests run faster by caching the results of
+    potentially time consuming operations. In this example, we save the results of a
+    history call. This pattern can be equally applied to a machine learning model being
+    trained and then saving the model weights in the object store.
+    '''
+    SPY_Close_ObjectStore_Key = "spy_close"
+    SPY_Close_History = RollingWindow[IndicatorDataPoint](252)
+    SPY_Close_EMA10_History = RollingWindow[IndicatorDataPoint](252)
+    SPY_Close_EMA50_History = RollingWindow[IndicatorDataPoint](252)
+
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 7)
+        self.SetEndDate(2013, 10, 11)
+
+        self.SPY = self.AddEquity("SPY", Resolution.Minute).Symbol
+
+        self.SPY_Close = self.Identity(self.SPY, Resolution.Daily)
+        self.SPY_Close_EMA10 = self.EMA(self.SPY, 10, Resolution.Daily)
+        self.SPY_Close_EMA50 = self.EMA(self.SPY, 50, Resolution.Daily)
+
+        # track last year of close and EMA10/EMA50
+        self.SPY_Close.Updated += lambda _, args: self.SPY_Close_History.Add(args)
+        self.SPY_Close_EMA10.Updated += lambda _, args: self.SPY_Close_EMA10_History.Add(args)
+        self.SPY_Close_EMA50.Updated += lambda _, args: self.SPY_Close_EMA50_History.Add(args)
+
+        if self.ObjectStore.ContainsKey(self.SPY_Close_ObjectStore_Key):
+            # our object store has our historical data saved, read the data
+            # and push it through the indicators to warm everything up
+            values = self.ObjectStore.Read(self.SPY_Close_ObjectStore_Key)
+            self.Debug(f'{self.SPY_Close_ObjectStore_Key} key exists in object store.')
+
+            history = pd.read_csv(StringIO(values), header=None, index_col=0, squeeze=True)
+            history.index = pd.to_datetime(history.index)
+            for time, close in history.iteritems():
+                self.SPY_Close.Update(time, close)
+
+        else:
+            self.Debug(f'{self.SPY_Close_ObjectStore_Key} key does not exist in object store. Fetching history...')
+
+            # if our object store doesn't have our data, fetch the history to initialize
+            # we're pulling the last year's worth of SPY daily trade bars to fee into our indicators
+            history = self.History(self.SPY, timedelta(365), Resolution.Daily).close.unstack(0).squeeze()
+
+            for time, close in history.iteritems():
+                self.SPY_Close.Update(time, close)
+
+            # save our warm up data so next time we don't need to issue the history request
+            self.ObjectStore.Save(self.SPY_Close_ObjectStore_Key,
+                '\n'.join([f'{x.EndTime},{x.Value}' for x in sorted(self.SPY_Close_History, key=lambda x: x.EndTime)]))
+
+            # Can also use ObjectStore.SaveBytes(key, byte[])
+            # and to read  ObjectStore.ReadBytes(key) => byte[]
+
+            # we can also get a file path for our data. some ML libraries require model
+            # weights to be loaded directly from a file path. The object store can provide
+            # a file path for any key by: ObjectStore.GetFilePath(key) => string (file path)
+
+    def OnData(self, slice):
+
+        close = self.SPY_Close
+        ema10 = self.SPY_Close_EMA10
+        ema50 = self.SPY_Close_EMA50
+
+        if ema10 > close and ema10 > ema50:
+            self.SetHoldings(self.SPY, 1)
+
+        elif ema10 < close and ema10 < ema50:
+            self.SetHoldings(self.SPY, -1);
+
+        elif ema10 < ema50 and self.Portfolio[self.SPY].IsLong:
+            self.Liquidate(self.SPY);
+
+        elif ema10 > ema50 and self.Portfolio[self.SPY].IsShort:
+            self.Liquidate(self.SPY)

--- a/Algorithm.Python/ObjectStoreExampleAlgorithm.py
+++ b/Algorithm.Python/ObjectStoreExampleAlgorithm.py
@@ -43,8 +43,8 @@ class ObjectStoreExampleAlgorithm(QCAlgorithm):
         self.SPY = self.AddEquity("SPY", Resolution.Minute).Symbol
 
         self.SPY_Close = self.Identity(self.SPY, Resolution.Daily)
-        self.SPY_Close_EMA10 = self.EMA(self.SPY, 10, Resolution.Daily)
-        self.SPY_Close_EMA50 = self.EMA(self.SPY, 50, Resolution.Daily)
+        self.SPY_Close_EMA10 = IndicatorExtensions.EMA(self.SPY_Close, 10)
+        self.SPY_Close_EMA50 = IndicatorExtensions.EMA(self.SPY_Close, 50)
 
         # track last year of close and EMA10/EMA50
         self.SPY_Close.Updated += lambda _, args: self.SPY_Close_History.Add(args)

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -87,6 +87,7 @@
     <None Include="PsychSignalSentimentRegressionAlgorithm.py" />
     <Content Include="CustomDataUsingMapFileRegressionAlgorithm.py" />
     <Content Include="LiquidETFUniverseFrameworkAlgorithm.py" />
+    <Content Include="ObjectStoreExampleAlgorithm.py" />
     <Content Include="SetHoldingsMultipleTargetsRegressionAlgorithm.py" />
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />


### PR DESCRIPTION
#### Description
Adds python example of `ObjectStoreExampleAlgorithm`
Minor change in C# version to keep consistency between examples.

#### Related Issue
Ref.: #3952 #3955 #3956 

#### Motivation and Context
Keep examples in C# and Python if possible.

#### Requires Documentation Change
Yes. This PR provides an example that can be added to the docs.

#### How Has This Been Tested?
Executing the new algorithm. Results match C# version.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`