### PR TITLE
Remove ToUniversalTime - Fix LocalObjectStore limit

### DIFF
--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -206,7 +206,6 @@ namespace QuantConnect.Lean.Engine.Results
                     foreach (var order in deltaOrders)
                     {
                         order.Value.Price = order.Value.Price.SmartRounding();
-                        order.Value.Time = order.Value.Time.ToUniversalTime();
                     }
 
                     //Reset loop variables:
@@ -1045,12 +1044,6 @@ namespace QuantConnect.Lean.Engine.Results
             result.Orders = result.Orders.Values.Where(x => x.Time >= start && x.Time <= stop).ToDictionary(x => x.Id);
 
             //Log.Trace("LiveTradingResultHandler.Truncate: Truncate Outgoing: " + result.Charts["Strategy Equity"].Series["Equity"].Values.Count);
-
-            //For live charting convert to UTC
-            foreach (var order in result.Orders)
-            {
-                order.Value.Time = order.Value.Time.ToUniversalTime();
-            }
         }
 
         private string CreateKey(string suffix, string dateFormat = "yyyy-MM-dd")

--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -147,7 +147,8 @@ namespace QuantConnect.Lean.Engine.Storage
                 fileCount++;
                 if (string.Equals(kvp.Key, key))
                 {
-                    expectedStorageSizeBytes += contents.Length - kvp.Value.Length;
+                    // we use the New content size
+                    expectedStorageSizeBytes += contents.Length;
                 }
                 else
                 {

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -86,6 +86,20 @@ namespace QuantConnect.Tests.Common.Storage
         }
 
         [Test]
+        public void SizeLimitIsRespected()
+        {
+            {
+                var validData = new byte[1024 * 1024 * 4];
+                Assert.IsTrue(_store.SaveBytes("my_settings_text", validData));
+            }
+            {
+                var invalidData = new byte[1024 * 1024 * 6];
+                Assert.IsFalse(_store.SaveBytes("my_settings_text", invalidData));
+            }
+            _store.Delete("my_settings_text");
+        }
+
+        [Test]
         public void SavesAndLoadsJson()
         {
             var expected = new TestSettings { EmaFastPeriod = 12, EmaSlowPeriod = 26 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Removing unnecessary call to `ToUniversalTime()` in the LTRH
- Fix bug in the `LocalObjectStore` limit check. Adding unit test

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3961
Related to https://github.com/QuantConnect/Lean/pull/3911
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix, clean up
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
