### PR TITLE
Adds MarketCap Member to FineFundamental Class

### DIFF
--- a/Algorithm.CSharp/CoarseFineFundamentalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseFineFundamentalRegressionAlgorithm.cs
@@ -74,14 +74,14 @@ namespace QuantConnect.Algorithm.CSharp
             };
         }
 
-        // sort the data by P/E ratio and take the top 'NumberOfSymbolsFine'
+        // sort the data by market capitalization and take the top 'NumberOfSymbolsFine'
         public IEnumerable<Symbol> FineSelectionFunction(IEnumerable<FineFundamental> fine)
         {
-            // sort descending by P/E ratio
-            var sortedByPeRatio = fine.OrderByDescending(x => x.ValuationRatios.PERatio);
+            // sort descending by market capitalization
+            var sortedByMarketCap = fine.OrderByDescending(x => x.MarketCap);
 
             // take the top entries from our sorted collection
-            var topFine = sortedByPeRatio.Take(NumberOfSymbolsFine);
+            var topFine = sortedByMarketCap.Take(NumberOfSymbolsFine);
 
             // we need to return only the symbol objects
             return topFine.Select(x => x.Symbol);

--- a/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
+++ b/Algorithm.Python/CoarseFineFundamentalRegressionAlgorithm.py
@@ -56,13 +56,13 @@ class CoarseFineFundamentalRegressionAlgorithm(QCAlgorithm):
         return [ Symbol.Create(x, SecurityType.Equity, Market.USA) for x in tickers ]
 
 
-    # sort the data by P/E ratio and take the top 'NumberOfSymbolsFine'
+    # sort the data by market capitalization and take the top 'NumberOfSymbolsFine'
     def FineSelectionFunction(self, fine):
-        # sort descending by P/E ratio
-        sortedByPeRatio = sorted(fine, key=lambda x: x.ValuationRatios.PERatio, reverse=True)
+        # sort descending by market capitalization
+        sortedByMarketCap = sorted(fine, key=lambda x: x.MarketCap, reverse=True)
 
         # take the top entries from our sorted collection
-        return [ x.Symbol for x in sortedByPeRatio[:self.numberOfSymbolsFine] ]
+        return [ x.Symbol for x in sortedByMarketCap[:self.numberOfSymbolsFine] ]
 
     def OnData(self, data):
         # if we have no changes, do nothing

--- a/Common/Data/Fundamental/FineFundamental.cs
+++ b/Common/Data/Fundamental/FineFundamental.cs
@@ -36,6 +36,15 @@ namespace QuantConnect.Data.Fundamental
         }
 
         /// <summary>
+        /// Market capitalization is the aggregate market value of a company represented in dollar amount.
+        /// </summary>
+        /// <remarks>
+        /// Returns zero if <see cref="BasicAverageShares"/> is null
+        /// </remarks>
+        [JsonIgnore]
+        public decimal MarketCap => EarningReports?.BasicAverageShares?.ThreeMonths * Value ?? 0;
+
+        /// <summary>
         /// Creates the universe symbol used for fine fundamental data
         /// </summary>
         /// <param name="market">The market</param>

--- a/Common/Data/Fundamental/Generated/FineFundamental.cs
+++ b/Common/Data/Fundamental/Generated/FineFundamental.cs
@@ -76,9 +76,12 @@ namespace QuantConnect.Data.Fundamental
 		/// <summary>
 		/// Market capitalization is the aggregate market value of a company represented in dollar amount.
 		/// </summary>
-		public decimal MarketCap => ValuationRatios.PERatio *
-									EarningReports.BasicEPS.TwelveMonths *
-									EarningReports.BasicAverageShares.ThreeMonths;
+		/// <remarks>
+		/// Returns zero if any of the members is null
+		/// </remarks>
+		public decimal MarketCap => ValuationRatios?.PERatio *
+									EarningReports?.BasicEPS?.TwelveMonths *
+									EarningReports?.BasicAverageShares?.ThreeMonths ?? 0;
 
 		/// <summary>
 		/// Creates an instance of the FineFundamental class

--- a/Common/Data/Fundamental/Generated/FineFundamental.cs
+++ b/Common/Data/Fundamental/Generated/FineFundamental.cs
@@ -74,16 +74,6 @@ namespace QuantConnect.Data.Fundamental
 		public AssetClassification AssetClassification { get; set; }
 
 		/// <summary>
-		/// Market capitalization is the aggregate market value of a company represented in dollar amount.
-		/// </summary>
-		/// <remarks>
-		/// Returns zero if any of the members is null
-		/// </remarks>
-		public decimal MarketCap => ValuationRatios?.PERatio *
-									EarningReports?.BasicEPS?.TwelveMonths *
-									EarningReports?.BasicAverageShares?.ThreeMonths ?? 0;
-
-		/// <summary>
 		/// Creates an instance of the FineFundamental class
 		/// </summary>
 		public FineFundamental()

--- a/Common/Data/Fundamental/Generated/FineFundamental.cs
+++ b/Common/Data/Fundamental/Generated/FineFundamental.cs
@@ -74,6 +74,13 @@ namespace QuantConnect.Data.Fundamental
 		public AssetClassification AssetClassification { get; set; }
 
 		/// <summary>
+		/// Market capitalization is the aggregate market value of a company represented in dollar amount.
+		/// </summary>
+		public decimal MarketCap => ValuationRatios.PERatio *
+									EarningReports.BasicEPS.TwelveMonths *
+									EarningReports.BasicAverageShares.ThreeMonths;
+
+		/// <summary>
 		/// Creates an instance of the FineFundamental class
 		/// </summary>
 		public FineFundamental()

--- a/Tests/Common/Data/Fundamental/FineFundamentalTests.cs
+++ b/Tests/Common/Data/Fundamental/FineFundamentalTests.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data.Fundamental;
+
+namespace QuantConnect.Tests.Common.Data.Fundamental
+{
+    [TestFixture]
+    public class FineFundamentalTests
+    {
+        [Test]
+        public void ComputesMarketCapCorrectly()
+        {
+            var fine = new FineFundamental
+            {
+                Symbol = Symbols.AAPL,
+                EndTime = DateTime.Now,
+                Value = 267.18m,
+                CompanyReference = new CompanyReference
+                {
+                    CountryId = "USA",
+                    PrimaryExchangeID = "NYS",
+                    IndustryTemplateCode = "N"
+                },
+                SecurityReference = new SecurityReference
+                {
+                    IPODate = new DateTime(1980,12,12)
+                },
+                ValuationRatios = new ValuationRatios
+                {
+                    PERatio = 22.476871m
+                },
+                EarningReports = new EarningReports
+                {
+                    BasicAverageShares = new BasicAverageShares
+                    {
+                        ThreeMonths = 449081100m
+                    },
+                    BasicEPS = new BasicEPS
+                    {
+                        TwelveMonths = 11.97m
+                    }
+                }
+            };
+
+            Assert.AreEqual(119985488298m, fine.MarketCap);
+        }
+
+        [Test]
+        public void ZeroMarketCapForDefaultBasicAverageShares()
+        {
+            var fine = new FineFundamental
+            {
+                Symbol = Symbols.AAPL,
+                EndTime = DateTime.Now,
+                Value = 267.18m,
+            };
+            fine.EarningReports.BasicAverageShares = null;
+
+            Assert.AreEqual(267.18m, fine.Price);
+            Assert.IsNull(fine.EarningReports.BasicAverageShares);
+            Assert.AreEqual(0, fine.MarketCap);
+        }
+
+        [Test]
+        public void ZeroMarketCapForDefaultObject()
+        {
+            var fine = new FineFundamental();
+            fine.EarningReports.BasicAverageShares = null;
+
+            Assert.AreEqual(0, fine.Price);
+            Assert.IsNull(fine.EarningReports.BasicAverageShares);
+            Assert.AreEqual(0, fine.MarketCap);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -306,6 +306,7 @@
     <Compile Include="Brokerages\Alpaca\AlpacaBrokerageTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileTests.cs" />
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
+    <Compile Include="Common\Data\Fundamental\FineFundamentalTests.cs" />
     <Compile Include="Common\Storage\LocalObjectStoreTests.cs" />
     <Compile Include="Common\Data\BaseDataTests.cs" />
     <Compile Include="Common\Data\CalendarConsolidatorsTests.cs" />


### PR DESCRIPTION
#### Description
Adds `MarketCap` member to `FineFundamental` class that represents the aggregate market value of a company represented in dollar amount.

Changes `CoarseFineFundamentalRegressionAlgorithm` (C# and Python) to select securities based on its market capitalization. Same result as selecting by P/E ratio.

#### Related Issue
Closes #3969 

#### Motivation and Context
Market capitalization is a popular fundamental that should be calculated internally by Lean.

#### Requires Documentation Change
Yes. Show that this parameter is available.

#### How Has This Been Tested?
Changed regression test. Used market cap instead of P/E ratio. The results are the same.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`