### PR TITLE
Fix bug in AlpacaBrokerageModel.CanSubmitOrder

### DIFF
--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -103,7 +103,8 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            var openOrders = _orderProvider.GetOpenOrders(x => x.Symbol == order.Symbol);
+            var openOrders = _orderProvider.GetOpenOrders(x => x.Symbol == order.Symbol && x.Id != order.Id);
+
             if (security.Holdings.IsLong)
             {
                 var openSellQuantity = openOrders.Where(x => x.Direction == OrderDirection.Sell).Sum(x => x.Quantity);


### PR DESCRIPTION

#### Description
- The `AlpacaBrokerageModel` requires a call to `GetOpenOrders()` to determine if a new order can be submitted and was not taking the current order into account (which is added to the open orders before `CanSubmitOrder()` is called).

#### Related Issue
#3081 

#### Motivation and Context
- Incorrect error message from the brokerage model when trying to close a position.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- New unit test cases + live algorithm testing

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`