### PR TITLE
New data feed work scheduling system

### DIFF
--- a/Common/Util/WorkerThread.cs
+++ b/Common/Util/WorkerThread.cs
@@ -68,7 +68,11 @@ namespace QuantConnect.Util
                     // pass, when the token gets cancelled
                 }
             })
-            { IsBackground = true, Name = "Isolator Thread" };
+            {
+                IsBackground = true,
+                Name = "Isolator Thread",
+                Priority = ThreadPriority.Highest
+            };
             _workerThread.Start();
         }
 

--- a/Engine/DataFeeds/WorkScheduling/WeightedWorkScheduler.cs
+++ b/Engine/DataFeeds/WorkScheduling/WeightedWorkScheduler.cs
@@ -1,0 +1,144 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.WorkScheduling
+{
+    /// <summary>
+    /// This singleton class will create a thread pool to processes work
+    /// that will be prioritized based on it's weight
+    /// </summary>
+    /// <remarks>The threads in the pool will take ownership of the
+    /// <see cref="WorkItem"/> and not share it with another thread.
+    /// This is required because the data enumerator stack yields, which state
+    /// depends on the thread id</remarks>
+    public class WeightedWorkScheduler
+    {
+        /// <summary>
+        /// This is the size of each work sprint
+        /// </summary>
+        internal const int WorkBatchSize = 50;
+
+        /// <summary>
+        /// This is the maximum size a work item can weigh,
+        /// if reached, it will be ignored and not executed until its less
+        /// </summary>
+        /// <remarks>This is useful to limit RAM and CPU usage</remarks>
+        internal static int MaxWorkWeight;
+
+        private readonly ConcurrentQueue<WorkItem> _newWork;
+
+        /// <summary>
+        /// Singleton instance
+        /// </summary>
+        public static WeightedWorkScheduler Instance = new WeightedWorkScheduler();
+
+        private WeightedWorkScheduler()
+        {
+            _newWork = new ConcurrentQueue<WorkItem>();
+
+            var work = new List<WorkQueue>();
+            var queueManager = new Thread(() =>
+            {
+                var workersCount = Configuration.Config.GetInt("data-feed-workers-count", Environment.ProcessorCount);
+                MaxWorkWeight = Configuration.Config.GetInt("data-feed-max-work-weight", 400);
+                Logging.Log.Trace($"WeightedWorkScheduler(): will use {workersCount} workers and MaxWorkWeight is {MaxWorkWeight}");
+
+                for (var i = 0; i < workersCount; i++)
+                {
+                    var workQueue = new WorkQueue();
+                    work.Add(workQueue);
+                    var thread = new Thread(() => WorkerThread(workQueue, _newWork))
+                    {
+                        IsBackground = true,
+                        Priority = ThreadPriority.Lowest,
+                        Name = $"WeightedWorkThread{i}"
+                    };
+                    thread.Start();
+                }
+
+                // make sure that the WorkQueue are kept sorted and the weights up to date
+                while (true)
+                {
+                    Thread.Sleep(TimeSpan.FromMilliseconds(1));
+                    foreach (var queue in work)
+                    {
+                        queue.Sort();
+                    }
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "WeightedWorkManager"
+            };
+            queueManager.Start();
+        }
+
+        /// <summary>
+        /// Add a new work item to the queue
+        /// </summary>
+        /// <param name="workFunc">The work function to run</param>
+        /// <param name="weightFunc">The weight function.
+        /// Work will be sorted in ascending order based on this weight</param>
+        public void QueueWork(Func<int, bool> workFunc, Func<int> weightFunc)
+        {
+            _newWork.Enqueue(new WorkItem(workFunc, weightFunc));
+        }
+
+        /// <summary>
+        /// This is the worker thread loop.
+        /// It will first try to take a work item from the new work queue else will check his own queue.
+        /// </summary>
+        private static void WorkerThread(WorkQueue workQueue, ConcurrentQueue<WorkItem> newWork)
+        {
+            while (true)
+            {
+                WorkItem workItem;
+                if (!newWork.TryDequeue(out workItem))
+                {
+                    workItem = workQueue.Get();
+                    if (workItem == null)
+                    {
+                        // no work to do, lets sleep and try again
+                        Thread.Sleep(TimeSpan.FromMilliseconds(1));
+                        continue;
+                    }
+                }
+                else
+                {
+                    workQueue.Add(workItem);
+                }
+
+                try
+                {
+                    if (!workItem.Work(WorkBatchSize))
+                    {
+                        workQueue.Remove(workItem);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    workQueue.Remove(workItem);
+                    Logging.Log.Error(exception);
+                }
+            }
+        }
+    }
+}

--- a/Engine/DataFeeds/WorkScheduling/WorkItem.cs
+++ b/Engine/DataFeeds/WorkScheduling/WorkItem.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.WorkScheduling
                 return 1;
             }
 
-            return obj.Weight.CompareTo(other.Weight);
+            return other.Weight.CompareTo(obj.Weight);
         }
     }
 }

--- a/Engine/DataFeeds/WorkScheduling/WorkItem.cs
+++ b/Engine/DataFeeds/WorkScheduling/WorkItem.cs
@@ -1,0 +1,79 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.WorkScheduling
+{
+    internal class WorkItem
+    {
+        private readonly Func<int> _weightFunc;
+
+        /// <summary>
+        /// The current weight
+        /// </summary>
+        public int Weight { get; private set; }
+
+        /// <summary>
+        /// The work function to execute
+        /// </summary>
+        public Func<int, bool> Work { get; }
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="work">The work function, takes an int, the amount of work to do
+        /// and returns a bool, false if this work item is finished</param>
+        /// <param name="weightFunc">The function used to determine the current weight</param>
+        public WorkItem(Func<int, bool> work, Func<int> weightFunc)
+        {
+            Work = work;
+            _weightFunc = weightFunc;
+        }
+
+        /// <summary>
+        /// Updates the weight of this work item
+        /// </summary>
+        public void UpdateWeight()
+        {
+            var newWeight = _weightFunc();
+
+            Weight = newWeight >= WeightedWorkScheduler.MaxWorkWeight ? WeightedWorkScheduler.MaxWorkWeight : newWeight;
+        }
+
+        /// <summary>
+        /// Compares two work items based on their weights
+        /// </summary>
+        public static int Compare(WorkItem obj, WorkItem other)
+        {
+            if (ReferenceEquals(obj, other))
+            {
+                return 0;
+            }
+            // By definition, any object compares greater than null
+            if (ReferenceEquals(obj, null))
+            {
+                return -1;
+            }
+            if (ReferenceEquals(null, other))
+            {
+                return 1;
+            }
+
+            return obj.Weight.CompareTo(other.Weight);
+        }
+    }
+}

--- a/Engine/DataFeeds/WorkScheduling/WorkQueue.cs
+++ b/Engine/DataFeeds/WorkScheduling/WorkQueue.cs
@@ -1,0 +1,95 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.WorkScheduling
+{
+    internal class WorkQueue
+    {
+        private readonly List<WorkItem> _workQueue;
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        public WorkQueue()
+        {
+            _workQueue = new List<WorkItem>();
+        }
+
+        /// <summary>
+        /// Adds a new item to this work queue
+        /// </summary>
+        /// <param name="work">The work to add</param>
+        public void Add(WorkItem work)
+        {
+            lock (_workQueue)
+            {
+                _workQueue.Add(work);
+            }
+        }
+
+        /// <summary>
+        /// Updates the weights and sorts the work in the queue
+        /// </summary>
+        public void Sort()
+        {
+            lock (_workQueue)
+            {
+                foreach (var item in _workQueue)
+                {
+                    item.UpdateWeight();
+                }
+                _workQueue.Sort(WorkItem.Compare);
+            }
+        }
+
+        /// <summary>
+        /// Removes an item from the work queue
+        /// </summary>
+        /// <param name="workItem">The work item to remove</param>
+        public void Remove(WorkItem workItem)
+        {
+            lock (_workQueue)
+            {
+                _workQueue.Remove(workItem);
+            }
+        }
+
+        /// <summary>
+        /// Gets the next work item to execute, null if none is available
+        /// </summary>
+        public WorkItem Get()
+        {
+            WorkItem potentialWorkItem = null;
+            lock (_workQueue)
+            {
+                if (_workQueue.Count != 0)
+                {
+                    potentialWorkItem = _workQueue[0];
+
+                    // if the weight is at its maximum value return null
+                    // this is useful to space out in time this work
+                    if (potentialWorkItem.Weight == WeightedWorkScheduler.MaxWorkWeight)
+                    {
+                        potentialWorkItem = null;
+                    }
+                }
+            }
+            return potentialWorkItem;
+        }
+    }
+}

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -200,6 +200,7 @@
     <Compile Include="DataFeeds\LiveOptionChainProvider.cs" />
     <Compile Include="DataFeeds\NullDataFeed.cs" />
     <Compile Include="DataFeeds\PendingRemovalsManager.cs" />
+    <Compile Include="DataFeeds\WorkScheduling\WeightedWorkScheduler.cs" />
     <Compile Include="DataFeeds\RealTimeScheduleEventService.cs" />
     <Compile Include="DataFeeds\PredicateTimeProvider.cs" />
     <Compile Include="DataFeeds\SubscriptionFrontierTimeProvider.cs" />
@@ -258,6 +259,8 @@
     <Compile Include="DataFeeds\Transport\RestSubscriptionStreamReader.cs" />
     <Compile Include="DataFeeds\UniverseSelection.cs" />
     <Compile Include="DataFeeds\UpdateData.cs" />
+    <Compile Include="DataFeeds\WorkScheduling\WorkItem.cs" />
+    <Compile Include="DataFeeds\WorkScheduling\WorkQueue.cs" />
     <Compile Include="DataFeeds\ZipDataCacheProvider.cs" />
     <Compile Include="DataFeeds\ZipEntryNameSubscriptionDataSourceReader.cs" />
     <Compile Include="HistoricalData\SineHistoryProvider.cs" />
@@ -370,6 +373,7 @@
     <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.3\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.3\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <PropertyGroup>

--- a/Tests/Engine/DataFeeds/SubscriptionUtilsTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionUtilsTests.cs
@@ -54,49 +54,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 true, true, false);
         }
 
-        [TestCase(1)]
-        [TestCase(5)]
-        [TestCase(20)]
-        public void FirstLoopLimit(int firstLoopLimit)
-        {
-            var dataPoints = 10;
-            var enumerator = new TestDataEnumerator { MoveNextTrueCount = dataPoints };
-
-            var subscription = SubscriptionUtils.CreateAndScheduleWorker(
-                new SubscriptionRequest(
-                    false,
-                    null,
-                    _security,
-                    _config,
-                    DateTime.UtcNow,
-                    Time.EndOfTime
-                ),
-                enumerator,
-                firstLoopLimit: firstLoopLimit);
-
-            var count = 0;
-            var expectedValue = dataPoints - firstLoopLimit - 1;
-            expectedValue = expectedValue > 0 ? expectedValue : -1;
-            while (enumerator.MoveNextTrueCount != expectedValue)
-            {
-                if (count++ > 100)
-                {
-                    Assert.Fail("Timeout waiting for producer");
-                }
-                Thread.Sleep(1);
-            }
-            // producer should only have produced 'firstLoopLimit' data points, lets assert remaining to produce
-            Assert.AreEqual(expectedValue, enumerator.MoveNextTrueCount);
-
-            for (var j = 0; j < dataPoints; j++)
-            {
-                Assert.IsTrue(subscription.MoveNext());
-            }
-            Assert.IsFalse(subscription.MoveNext());
-            subscription.DisposeSafely();
-            Assert.IsTrue(enumerator.Disposed);
-        }
-
         [Test]
         public void SubscriptionIsDisposed()
         {
@@ -112,15 +69,14 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     DateTime.UtcNow,
                     Time.EndOfTime
                 ),
-                enumerator,
-                firstLoopLimit: 1);
+                enumerator);
 
             var count = 0;
-            while (enumerator.MoveNextTrueCount != 8)
+            while (enumerator.MoveNextTrueCount > 8)
             {
                 if (count++ > 100)
                 {
-                    Assert.Fail("Timeout waiting for producer");
+                    Assert.Fail($"Timeout waiting for producer. {enumerator.MoveNextTrueCount}");
                 }
                 Thread.Sleep(1);
             }
@@ -143,8 +99,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     DateTime.UtcNow,
                     Time.EndOfTime
                 ),
-                enumerator,
-                firstLoopLimit: 1);
+                enumerator);
 
             var count = 0;
             while (enumerator.MoveNextTrueCount != 9)
@@ -180,8 +135,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                         DateTime.UtcNow,
                         Time.EndOfTime
                     ),
-                    enumerator,
-                    firstLoopLimit: dataPoints / 2);
+                    enumerator);
 
                 for (var j = 0; j < dataPoints; j++)
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- The new scheduler will create a dedicated thread pool
- Work will be prioritized based on their weight and new items will have
highest priority. The weight will be determined by the size of the
subscription enqueueable.
- The work queue will be sorted and the weights updated by a dedicated
thread
- There will be a maximum weight value that will 'disable' a work item
until their weight comes down
- The consumer will not know about workers or anything alike anymore.
- Applying a general max work queue size of 400 items, this will reduce
CPU and RAM usage. Can be set by config.

**Cloud performance tests**
MASTER
596.56 seconds at 2k data points per second. Processing total of 897,569 data points.
526.65 seconds at 2k data points per second. Processing total of 897,569 data points.
513.98 seconds at 2k data points per second. Processing total of 897,569 data points.
*Ram usage for the 3 backtests peaked at ~3GB*
PR
544.06 seconds at 2k data points per second. Processing total of 897,569 data points.
552.59 seconds at 2k data points per second. Processing total of 897,569 data points.
495.34 seconds at 2k data points per second. Processing total of 897,569 data points.
*Ram usage for the 3 backtests peaked at ~2.8GB*

<details><summary>Algorithm used for cloud performance tests</summary>
<p>

```
public class CoarseFineFundamentalRegressionAlgorithm : QCAlgorithm
{
    private const int NumberOfSymbolsCoarse = 500;
    private const int NumberOfSymbolsFine = 10;
    private readonly Dictionary<Symbol, Symbol> _symbols = new Dictionary<Symbol, Symbol>();

    public override void Initialize()
    {
        UniverseSettings.Resolution = Resolution.Daily;

        SetStartDate(2018, 1, 1);
        SetEndDate(2019, 1, 1);
        SetCash(1000000);

        AddUniverse(CoarseSelectionFunction, FineSelectionFunction);
        Schedule.On(DateRules.EveryDay(), TimeRules.Every(TimeSpan.FromDays(1)), PlotRam);
    }

    public void PlotRam()
    {
        Plot("RAM", "Managed", (double)GC.GetTotalMemory(false) / (1024 * 1024));
        Plot("RAM", "Total", (double)OS.ApplicationMemoryUsed);
    }

    public IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
    {
        var sortedByDollarVolume = coarse
            .Where(x => x.HasFundamentalData)
            .OrderByDescending(x => x.DollarVolume);

        var top5 = sortedByDollarVolume.Take(NumberOfSymbolsCoarse);

        return top5.Select(x => x.Symbol);
    }

    public IEnumerable<Symbol> FineSelectionFunction(IEnumerable<FineFundamental> fine)
    {
        var sortedByPeRatio = fine.OrderByDescending(x => x.ValuationRatios.PERatio);

        var topFine = sortedByPeRatio
            .Where(fundamental =>
                fundamental.AssetClassification.MorningstarIndustryGroupCode == MorningstarIndustryGroupCode.Biotechnology
                ||
                fundamental.AssetClassification.MorningstarIndustryGroupCode == MorningstarIndustryGroupCode.DrugManufacturers)
            .Take(NumberOfSymbolsFine)
            .Select(x => x.Symbol)
            .ToList();

        foreach (var symbol in topFine)
        {
            _symbols[symbol] = AddData<TiingoNews>(symbol).Symbol;
        }
        return topFine;
    }

    public override void OnSecuritiesChanged(SecurityChanges changes)
    {
        foreach (var changesRemovedSecurity in changes.RemovedSecurities)
        {
            if (_symbols.ContainsKey(changesRemovedSecurity.Symbol))
            {
                RemoveSecurity(_symbols[changesRemovedSecurity.Symbol]);
                _symbols.Remove(changesRemovedSecurity.Symbol);
            }
        }
    }
}
```

</p>
</details>

**Local windows performance tests were executed with:**
    - Max frequency limited. Boost frequency disabled. No thermal nor power limit throttling.
    - `Ticks` and `TradeBars` returning `SPY` symbol in their source

**Test 1:**
```
public override void Initialize()
{
    SetStartDate(2015, 11, 10);
    SetEndDate(2015, 11, 11);
    foreach (var symbol in Symbols.Equity.All.Take(50))
    {
        AddSecurity(SecurityType.Equity, symbol, Resolution.Tick);
    }
}
```
MASTER
43.46 seconds at 618k data points per second. Processing total of 26,841,371 data points.
45.00 seconds at 596k data points per second. Processing total of 26,841,371 data points.
43.83 seconds at 612k data points per second. Processing total of 26,841,371 data points.
Commit 1
42.81 seconds at 627k data points per second. Processing total of 26,841,371 data points.
43.13 seconds at 622k data points per second. Processing total of 26,841,371 data points.
42.48 seconds at 632k data points per second. Processing total of 26,841,371 data points.
Commit 2
42.39 seconds at 633k data points per second. Processing total of 26,841,371 data points.

**Test 2:**
```
public override void Initialize()
{
    SetStartDate(2015, 11, 10);
    SetEndDate(2015, 11, 11);
    foreach (var symbol in Symbols.Equity.All.Take(100))
    {
        AddSecurity(SecurityType.Equity, symbol, Resolution.Tick);
    }
}
```
MASTER 
93.60 seconds at 574k data points per second. Processing total of 53,682,738 data points.
92.75 seconds at 579k data points per second. Processing total of 53,682,738 data points.
93.49 seconds at 574k data points per second. Processing total of 53,682,738 data points.
Commit 1
86.74 seconds at 619k data points per second. Processing total of 53,682,738 data points.
88.27 seconds at 608k data points per second. Processing total of 53,682,738 data points.
89.48 seconds at 600k data points per second. Processing total of 53,682,738 data points.
Commit 2
88.70 seconds at 605k data points per second. Processing total of 53,682,738 data points.

**Test 3:**
```
public override void Initialize()
{
    SetStartDate(2015, 8, 10);
    SetEndDate(2015, 11, 11);
    foreach (var symbol in Symbols.Equity.All.Take(400))
    {
        AddSecurity(SecurityType.Equity, symbol, Resolution.Minute);
    }
}
```
MASTER
45.21 seconds at 197k data points per second. Processing total of 8,910,675 data points.
43.91 seconds at 203k data points per second. Processing total of 8,910,674 data points.
45.17 seconds at 197k data points per second. Processing total of 8,910,674 data points.
Commit 1
38.35 seconds at 232k data points per second. Processing total of 8,910,674 data points.
38.09 seconds at 234k data points per second. Processing total of 8,910,673 data points.
38.20 seconds at 233k data points per second. Processing total of 8,910,673 data points.
Commit 2
37.45 seconds at 238k data points per second. Processing total of 8,910,674 data points.

**Test 4:**
```
public override void Initialize()
{
    SetStartDate(2010, 1, 1);
    SetEndDate(2018, 1, 1);
    foreach (var symbol in Symbols.Equity.All.Take(400))
    {
        AddSecurity(SecurityType.Equity, symbol, Resolution.Daily);
    }
}
```
MASTER
7.43 seconds at 90k data points per second. Processing total of 669,511 data points.
7.22 seconds at 93k data points per second. Processing total of 669,511 data points.
7.23 seconds at 93k data points per second. Processing total of 669,479 data points.
Commit 1
6.28 seconds at 107k data points per second. Processing total of 669,543 data points.   
6.04 seconds at 111k data points per second. Processing total of 669,479 data points.
6.48 seconds at 103k data points per second. Processing total of 669,511 data points.
Commit 2
6.04 seconds at 111k data points per second. Processing total of 669,479 data points.

**Test 5:**
```
public override void Initialize()
{
    UniverseSettings.Resolution = Resolution.Daily;
    SetStartDate(2015, 1, 1);
    SetEndDate(2018, 1, 1);
    AddUniverse(CoarseSelectionFunction);
}
public static IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
{
    var sortedByDollarVolume = coarse.OrderByDescending(x => x.DollarVolume);
    var top = sortedByDollarVolume.Take(400);
    return top.Select(x => x.Symbol);
}
```
MASTER
46.02 seconds at 128k data points per second. Processing total of 5,894,398 data points.
45.07 seconds at 131k data points per second. Processing total of 5,894,390 data points.
45.06 seconds at 131k data points per second. Processing total of 5,894,374 data points.
Commit 1
31.99 seconds at 184k data points per second. Processing total of 5,894,374 data points.
31.51 seconds at 187k data points per second. Processing total of 5,894,395 data points.
31.39 seconds at 188k data points per second. Processing total of 5,894,410 data points.
Commit 2
31.15 seconds at 189k data points per second. Processing total of 5,894,384 data points.

**Test 6:**
```
public override void Initialize()
{
    UniverseSettings.Resolution = Resolution.Minute;
    SetStartDate(2017, 10, 1);
    SetEndDate(2018, 1, 1);
    AddUniverse(CoarseSelectionFunction);
}
public static IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
{
    var sortedByDollarVolume = coarse.OrderByDescending(x => x.DollarVolume);
    var top = sortedByDollarVolume.Take(400);
    return top.Select(x => x.Symbol);
}
```
MASTER
70.78 seconds at 145k data points per second. Processing total of 10,230,414 data points.
69.98 seconds at 146k data points per second. Processing total of 10,230,414 data points.
74.70 seconds at 137k data points per second. Processing total of 10,230,413 data points.
Commit 1
48.91 seconds at 209k data points per second. Processing total of 10,230,412 data points.
48.40 seconds at 211k data points per second. Processing total of 10,230,413 data points.
47.98 seconds at 213k data points per second. Processing total of 10,230,413 data points.
Commit 2
46.52 seconds at 220k data points per second. Processing total of 10,230,413 data points.
CLOUD MASTER - SetStartDate(2017, 9, 1);
94.91 seconds at 142k data points per second. Processing total of 13,475,195 data points.
92.07 seconds at 146k data points per second. Processing total of 13,475,195 data points.
CLOUD PR commit 2 - SetStartDate(2017, 9, 1);
58.69 seconds at 230k data points per second. Processing total of 13,475,195 data points.
53.69 seconds at 251k data points per second. Processing total of 13,475,195 data points.
**Test 7:**
```
public override void Initialize()
{
    SetStartDate(2017, 6, 1);
    SetEndDate(2018, 1, 1);
    foreach (var symbol in Symbols.Equity.All.Take(400))
    {
        AddData<TiingoNews>(AddSecurity(SecurityType.Equity, symbol, Resolution.Daily).Symbol);
    }
}
```
MASTER
63.61 seconds at 302k data points per second. Processing total of 19,195,228 data points.
64.15 seconds at 299k data points per second. Processing total of 19,195,225 data points.
65.52 seconds at 293k data points per second. Processing total of 19,195,223 data points.
Commit 1
58.06 seconds at 326k data points per second. Processing total of 18,907,289 data points.
58.07 seconds at 326k data points per second. Processing total of 18,907,289 data points.
58.84 seconds at 321k data points per second. Processing total of 18,907,289 data points.
Commit 2
57.11 seconds at 336k data points per second. Processing total of 19,195,223 data points.

**Test 8:**
```
HistoryRequestBenchmark
```
MASTER
22.08 seconds at 41k data points per second. Processing total of 907,031 data points.
22.08 seconds at 41k data points per second. Processing total of 907,031 data points.
Commit 1
26.09 seconds at 35k data points per second. Processing total of 907,031 data points.
25.69 seconds at 35k data points per second. Processing total of 907,031 data points.
Commit 2
21.68 seconds at 42k data points per second. Processing total of 907,031 data points.
21.69 seconds at 42k data points per second. Processing total of 907,031 data points.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3976
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Faster is better but efficient and faster is the sky
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests, performance tests.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
