### PR TITLE
Refactors QC500 Universe and Universe Selection Model

### DIFF
--- a/Algorithm.Framework/Selection/QC500UniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/QC500UniverseSelectionModel.cs
@@ -78,11 +78,10 @@ namespace QuantConnect.Algorithm.Framework.Selection
                 _dollarVolumeBySymbol[x.Symbol] = x.DollarVolume;
             }
 
+            // If no security has met the QC500 criteria, the universe is unchanged.
+            // A new selection will be attempted on the next trading day as _lastMonth is not updated
             if (_dollarVolumeBySymbol.Count == 0)
             {
-                algorithm.Debug($@"QC500UniverseSelectionModel.SelectCoarse: Since no security has met the QC500 criteria,
-the current universe is unchanged. A new selection will be attempted on the next trading day.
-CoarseFundamental Count: {coarse.Count()}");
                 return Universe.Unchanged;
             }
 
@@ -108,11 +107,10 @@ CoarseFundamental Count: {coarse.Count()}");
 
             var count = filteredFine.Count;
 
+            // If no security has met the QC500 criteria, the universe is unchanged.
+            // A new selection will be attempted on the next trading day as _lastMonth is not updated
             if (count == 0)
             {
-                algorithm.Debug($@"QC500UniverseSelectionModel.SelectFine: Since no security has met the QC500 criteria,
-the current universe is unchanged.A new selection will be attempted on the next trading day.
-FineFundamental Count: {fine.Count()}");
                 return Universe.Unchanged;
             }
 

--- a/Algorithm.Framework/Selection/QC500UniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/QC500UniverseSelectionModel.cs
@@ -66,9 +66,6 @@ namespace QuantConnect.Algorithm.Framework.Selection
                 return Universe.Unchanged;
             }
 
-            // The stocks must have fundamental data
-            // The stock must have positive previous-day close price
-            // The stock must have positive volume on the previous trading day
             var sortedByDollarVolume =
                 (from x in coarse
                  where x.HasFundamentalData && x.Volume > 0 && x.Price > 0
@@ -76,10 +73,19 @@ namespace QuantConnect.Algorithm.Framework.Selection
                  select x).Take(_numberOfSymbolsCoarse).ToList();
 
             _dollarVolumeBySymbol.Clear();
-            foreach (var i in sortedByDollarVolume)
+            foreach (var x in sortedByDollarVolume)
             {
-                _dollarVolumeBySymbol[i.Symbol] = i.DollarVolume;
+                _dollarVolumeBySymbol[x.Symbol] = x.DollarVolume;
             }
+
+            if (_dollarVolumeBySymbol.Count == 0)
+            {
+                algorithm.Debug($@"QC500UniverseSelectionModel.SelectCoarse: Since no security has met the QC500 criteria,
+the current universe is unchanged. A new selection will be attempted on the next trading day.
+CoarseFundamental Count: {coarse.Count()}");
+                return Universe.Unchanged;
+            }
+
             return _dollarVolumeBySymbol.Keys;
         }
 
@@ -92,26 +98,28 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// </summary>
         public override IEnumerable<Symbol> SelectFine(QCAlgorithm algorithm, IEnumerable<FineFundamental> fine)
         {
-            if (algorithm.Time.Month == _lastMonth)
-            {
-                return Universe.Unchanged;
-            }
-            _lastMonth = algorithm.Time.Month;
-
-            // The company's headquarter must in the U.S.
-            // The stock must be traded on either the NYSE or NASDAQ
-            // At least half a year since its initial public offering
-            // The stock's market cap must be greater than 500 million
             var filteredFine =
                 (from x in fine
                  where x.CompanyReference.CountryId == "USA" &&
                        (x.CompanyReference.PrimaryExchangeID == "NYS" || x.CompanyReference.PrimaryExchangeID == "NAS") &&
                        (algorithm.Time - x.SecurityReference.IPODate).Days > 180 &&
-                       x.EarningReports.BasicAverageShares.ThreeMonths *
-                       x.EarningReports.BasicEPS.TwelveMonths * x.ValuationRatios.PERatio > 500000000m
+                       x.MarketCap > 500000000m
                  select x).ToList();
 
-            var percent = _numberOfSymbolsFine / (double)filteredFine.Count;
+            var count = filteredFine.Count;
+
+            if (count == 0)
+            {
+                algorithm.Debug($@"QC500UniverseSelectionModel.SelectFine: Since no security has met the QC500 criteria,
+the current universe is unchanged.A new selection will be attempted on the next trading day.
+FineFundamental Count: {fine.Count()}");
+                return Universe.Unchanged;
+            }
+
+            // Update _lastMonth after all QC500 criteria checks passed
+            _lastMonth = algorithm.Time.Month;
+
+            var percent = _numberOfSymbolsFine / (double)count;
 
             // select stocks with top dollar volume in every single sector
             var topFineBySector =

--- a/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
@@ -46,10 +46,9 @@ class QC500UniverseSelectionModel(FundamentalUniverseSelectionModel):
 
         self.dollarVolumeBySymbol = {x.Symbol:x.DollarVolume for x in sortedByDollarVolume}
 
+        # If no security has met the QC500 criteria, the universe is unchanged.
+        # A new selection will be attempted on the next trading day as self.lastMonth is not updated
         if len(self.dollarVolumeBySymbol) == 0:
-            algorithm.Debug(f'''QC500UniverseSelectionModel.SelectCoarse: Since no security has met the QC500 criteria,
-the current universe is unchanged. A new selection will be attempted on the next trading day.
-CoarseFundamental Count: {len(list(coarse))}''')
             return Universe.Unchanged
 
         # return the symbol objects our sorted collection
@@ -70,10 +69,9 @@ CoarseFundamental Count: {len(list(coarse))}''')
 
         count = len(sortedBySector)
 
+        # If no security has met the QC500 criteria, the universe is unchanged.
+        # A new selection will be attempted on the next trading day as self.lastMonth is not updated
         if count == 0:
-            algorithm.Debug(f'''QC500UniverseSelectionModel.SelectFine: Since no security has met the QC500 criteria,
-the current universe is unchanged. A new selection will be attempted on the next trading day.
-FineFundamental Count: {len(list(fine))}''')
             return Universe.Unchanged
 
         # Update self.lastMonth after all QC500 criteria checks passed

--- a/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/QC500UniverseSelectionModel.py
@@ -72,7 +72,10 @@ class QC500UniverseSelectionModel(FundamentalUniverseSelectionModel):
         sortedByDollarVolume = []
         sortedBySector = sorted(filteredFine, key = lambda x: x.CompanyReference.IndustryTemplateCode)
 
-        percent = self.numberOfSymbolsFine/float(len(sortedBySector))
+        if len(sortedBySector) != 0:
+            percent = self.numberOfSymbolsFine/float(len(sortedBySector))
+        else:
+            percent = 1
 
         # select stocks with top dollar volume in every single sector
         for code, g in groupby(sortedBySector, lambda x: x.CompanyReference.IndustryTemplateCode):

--- a/Algorithm/IndexUniverseDefinitions.cs
+++ b/Algorithm/IndexUniverseDefinitions.cs
@@ -79,11 +79,10 @@ namespace QuantConnect.Algorithm
                             dollarVolumeBySymbol[x.Symbol] = x.DollarVolume;
                         }
 
+                        // If no security has met the QC500 criteria, the universe is unchanged.
+                        // A new selection will be attempted on the next trading day as lastMonth is not updated
                         if (dollarVolumeBySymbol.Count == 0)
                         {
-                            _algorithm.Debug($@"QC500UniverseSelectionModel.SelectCoarse: Since no security has met the QC500 criteria,
-the current universe is unchanged. A new selection will be attempted on the next trading day.
-CoarseFundamental Count: {coarse.Count()}");
                             return Universe.Unchanged;
                         }
 
@@ -108,11 +107,10 @@ CoarseFundamental Count: {coarse.Count()}");
 
                         var count = filteredFine.Count;
 
+                        // If no security has met the QC500 criteria, the universe is unchanged.
+                        // A new selection will be attempted on the next trading day as lastMonth is not updated
                         if (count == 0)
                         {
-                            _algorithm.Debug($@"QC500UniverseSelectionModel.SelectFine: Since no security has met the QC500 criteria,
-the current universe is unchanged.A new selection will be attempted on the next trading day.
-FineFundamental Count: {fine.Count()}");
                             return Universe.Unchanged;
                         }
 

--- a/Tests/Algorithm/Framework/Selection/QC500UniverseSelectionModelTests.cs
+++ b/Tests/Algorithm/Framework/Selection/QC500UniverseSelectionModelTests.cs
@@ -35,6 +35,10 @@ namespace QuantConnect.Tests.Algorithm.Framework.Selection
                 {'0', "B"}, {'1', "I"}, {'2', "M"}, {'3', "N"}, {'4', "T"}, {'5', "U"}
             };
 
+        private readonly List<Symbol> _symbols = Enumerable.Range(0, 6000)
+            .Select(x => Symbol.Create($"{x:0000}", SecurityType.Equity, Market.USA))
+            .ToList();
+
         [TestCase(Language.CSharp)]
         [TestCase(Language.Python)]
         public void FiltersUniverseCorrectlyWithValidData(Language language)
@@ -80,8 +84,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Selection
                 out coarseCountByDateTime,
                 out fineCountByDateTime); ;
 
-            // No debug messages
-            Assert.AreEqual(0, algorithm.DebugMessages.Count);
             // Universe Changed 4 times
             Assert.AreEqual(4, coarseCountByDateTime.Count);
             Assert.AreEqual(4, fineCountByDateTime.Count);
@@ -135,12 +137,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Selection
                 out coarseCountByDateTime,
                 out fineCountByDateTime); ;
 
-            // 1 debug message
-            Assert.AreEqual(1, algorithm.DebugMessages.Count);
-            Assert.IsTrue(algorithm.DebugMessages.Single()
-                .Contains("QC500UniverseSelectionModel.SelectCoarse: Since no security has met the QC500 criteria"));
-            Assert.IsTrue(algorithm.DebugMessages.Single()
-                .Contains("CoarseFundamental Count: 6000"));
             // No Universe Changes
             Assert.AreEqual(0, coarseCountByDateTime.Count);
             Assert.AreEqual(0, fineCountByDateTime.Count);
@@ -174,12 +170,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Selection
                 out coarseCountByDateTime,
                 out fineCountByDateTime); ;
 
-            // 1 debug message
-            Assert.AreEqual(1, algorithm.DebugMessages.Count);
-            Assert.IsTrue(algorithm.DebugMessages.Single()
-                .Contains("QC500UniverseSelectionModel.SelectFine: Since no security has met the QC500 criteria"));
-            Assert.IsTrue(algorithm.DebugMessages.Single()
-                .Contains("FineFundamental Count: 1000"));
             // Coarse Fundamental called every day.
             Assert.Greater(coarseCountByDateTime.Count, 4);
             Assert.IsTrue(coarseCountByDateTime.All(kvp => kvp.Value == 1000));
@@ -210,9 +200,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Selection
             {
                 var time = algorithm.UtcTime;
 
-                var coarse = Enumerable.Range(0, 6000).Select(x =>
-                    getCoarseFundamental(Symbol.Create($"{x:0000}", SecurityType.Equity, Market.USA), time));
-
+                var coarse = _symbols.Select(x => getCoarseFundamental(x, time));
+                
                 var selectSymbolsResult = SelectCoarse(algorithm, coarse);
 
                 if (!ReferenceEquals(selectSymbolsResult, Universe.Unchanged))

--- a/Tests/Algorithm/Framework/Selection/QC500UniverseSelectionModelTests.cs
+++ b/Tests/Algorithm/Framework/Selection/QC500UniverseSelectionModelTests.cs
@@ -1,0 +1,271 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Selection
+{
+    [TestFixture]
+    public class QC500UniverseSelectionModelTests
+    {
+        private readonly Dictionary<char, string> _industryTemplateCodeDict =
+            new Dictionary<char, string>
+            {
+                {'0', "B"}, {'1', "I"}, {'2', "M"}, {'3', "N"}, {'4', "T"}, {'5', "U"}
+            };
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void FiltersUniverseCorrectlyWithValidData(Language language)
+        {
+            QCAlgorithm algorithm;
+            Dictionary<DateTime, int> coarseCountByDateTime;
+            Dictionary<DateTime, int> fineCountByDateTime;
+
+            RunSimulation(language,
+                (symbol, time) => new CoarseFundamental
+                {
+                    Symbol = symbol,
+                    EndTime = time,
+                    Value = 100,
+                    Volume = 1000,
+                    DollarVolume = 100000 * symbol.Value.Substring(3).ToDecimal(),
+                    HasFundamentalData = true
+                },
+                (symbol, time) => new FineFundamental
+                {
+                    Symbol = symbol,
+                    EndTime = time,
+                    Value = 100,
+                    CompanyReference = new CompanyReference
+                    {
+                        CountryId = "USA",
+                        PrimaryExchangeID = "NYS",
+                        IndustryTemplateCode = _industryTemplateCodeDict[symbol.Value[0]]
+                    },
+                    SecurityReference = new SecurityReference
+                    {
+                        IPODate = time.AddDays(-200)
+                    },
+                    EarningReports = new EarningReports
+                    {
+                        BasicAverageShares = new BasicAverageShares
+                        {
+                            ThreeMonths = 5000000.01m
+                        }
+                    }
+                },
+                out algorithm,
+                out coarseCountByDateTime,
+                out fineCountByDateTime); ;
+
+            // No debug messages
+            Assert.AreEqual(0, algorithm.DebugMessages.Count);
+            // Universe Changed 4 times
+            Assert.AreEqual(4, coarseCountByDateTime.Count);
+            Assert.AreEqual(4, fineCountByDateTime.Count);
+            // Universe Changed on the 1st. Coarse returned 1000 and Fine 500
+            Assert.IsTrue(coarseCountByDateTime.All(kvp => kvp.Key.Day == 1 && kvp.Value == 1000));
+            Assert.IsTrue(fineCountByDateTime.All(kvp => kvp.Key.Day == 1 && kvp.Value == 500));
+        }
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void DoesNotFilterUniverseWithCoarseDataHasFundamentalFalse(Language language)
+        {
+            QCAlgorithm algorithm;
+            Dictionary<DateTime, int> coarseCountByDateTime;
+            Dictionary<DateTime, int> fineCountByDateTime;
+
+            RunSimulation(language,
+                (symbol, time) => new CoarseFundamental
+                {
+                    Symbol = symbol,
+                    EndTime = time,
+                    Value = 100,
+                    Volume = 1000,
+                    DollarVolume = 100000 * symbol.Value.Substring(3).ToDecimal(),
+                    HasFundamentalData = false
+                },
+                (symbol, time) => new FineFundamental
+                {
+                    Symbol = symbol,
+                    EndTime = time,
+                    Value = 100,
+                    CompanyReference = new CompanyReference
+                    {
+                        CountryId = "USA",
+                        PrimaryExchangeID = "NYS",
+                        IndustryTemplateCode = _industryTemplateCodeDict[symbol.Value[0]]
+                    },
+                    SecurityReference = new SecurityReference
+                    {
+                        IPODate = time.AddDays(-200)
+                    },
+                    EarningReports = new EarningReports
+                    {
+                        BasicAverageShares = new BasicAverageShares
+                        {
+                            ThreeMonths = 5000000.01m
+                        }
+                    }
+                },
+                out algorithm,
+                out coarseCountByDateTime,
+                out fineCountByDateTime); ;
+
+            // 1 debug message
+            Assert.AreEqual(1, algorithm.DebugMessages.Count);
+            Assert.IsTrue(algorithm.DebugMessages.Single()
+                .Contains("QC500UniverseSelectionModel.SelectCoarse: Since no security has met the QC500 criteria"));
+            Assert.IsTrue(algorithm.DebugMessages.Single()
+                .Contains("CoarseFundamental Count: 6000"));
+            // No Universe Changes
+            Assert.AreEqual(0, coarseCountByDateTime.Count);
+            Assert.AreEqual(0, fineCountByDateTime.Count);
+        }
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void DoesNotFilterUniverseWithInvalidFineData(Language language)
+        {
+            QCAlgorithm algorithm;
+            Dictionary<DateTime, int> coarseCountByDateTime;
+            Dictionary<DateTime, int> fineCountByDateTime;
+
+            RunSimulation(language,
+                (symbol, time) => new CoarseFundamental
+                {
+                    Symbol = symbol,
+                    EndTime = time,
+                    Value = 100,
+                    Volume = 1000,
+                    DollarVolume = 100000 * symbol.Value.Substring(3).ToDecimal(),
+                    HasFundamentalData = true
+                },
+                (symbol, time) => new FineFundamental()
+                {
+                    Symbol = symbol,
+                    EndTime = time,
+                    Value = 100
+                },
+                out algorithm,
+                out coarseCountByDateTime,
+                out fineCountByDateTime); ;
+
+            // 1 debug message
+            Assert.AreEqual(1, algorithm.DebugMessages.Count);
+            Assert.IsTrue(algorithm.DebugMessages.Single()
+                .Contains("QC500UniverseSelectionModel.SelectFine: Since no security has met the QC500 criteria"));
+            Assert.IsTrue(algorithm.DebugMessages.Single()
+                .Contains("FineFundamental Count: 1000"));
+            // Coarse Fundamental called every day.
+            Assert.Greater(coarseCountByDateTime.Count, 4);
+            Assert.IsTrue(coarseCountByDateTime.All(kvp => kvp.Value == 1000));
+            // No Universe Changes
+            Assert.AreEqual(0, fineCountByDateTime.Count);
+        }
+
+        private void RunSimulation(Language language, 
+            Func<Symbol, DateTime, CoarseFundamental> getCoarseFundamental,
+            Func<Symbol, DateTime, FineFundamental> getFineFundamental,
+            out QCAlgorithm algorithm,
+            out Dictionary<DateTime, int> coarseCountByDateTime,
+            out Dictionary<DateTime, int> fineCountByDateTime)
+        {
+            algorithm = new QCAlgorithm();
+            algorithm.SetStartDate(2019, 10, 1);
+            algorithm.SetEndDate(2020, 2, 1);
+            algorithm.SetDateTime(algorithm.StartDate.AddHours(6));
+
+            coarseCountByDateTime = new Dictionary<DateTime, int>();
+            fineCountByDateTime = new Dictionary<DateTime, int>();
+
+            Func<QCAlgorithm, IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> SelectCoarse;
+            Func<QCAlgorithm, IEnumerable<FineFundamental>, IEnumerable<Symbol>> SelectFine;
+            GetUniverseSelectionModel(language, out SelectCoarse, out SelectFine);
+
+            while (algorithm.EndDate > algorithm.UtcTime)
+            {
+                var time = algorithm.UtcTime;
+
+                var coarse = Enumerable.Range(0, 6000).Select(x =>
+                    getCoarseFundamental(Symbol.Create($"{x:0000}", SecurityType.Equity, Market.USA), time));
+
+                var selectSymbolsResult = SelectCoarse(algorithm, coarse);
+
+                if (!ReferenceEquals(selectSymbolsResult, Universe.Unchanged))
+                {
+                    coarseCountByDateTime[time] = selectSymbolsResult.Count();
+
+                    var fine = selectSymbolsResult.Select(x => getFineFundamental(x, time));
+
+                    selectSymbolsResult = SelectFine(algorithm, fine);
+                    if (!ReferenceEquals(selectSymbolsResult, Universe.Unchanged))
+                    {
+                        fineCountByDateTime[time] = selectSymbolsResult.Count();
+                    }
+                }
+
+                algorithm.SetDateTime(time.AddDays(1));
+            }
+        }
+
+        private void GetUniverseSelectionModel(
+            Language language,
+            out Func<QCAlgorithm, IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> SelectCoarse,
+            out Func<QCAlgorithm, IEnumerable<FineFundamental>, IEnumerable<Symbol>> SelectFine)
+        {
+            if (language == Language.CSharp)
+            {
+                var model = new QC500UniverseSelectionModel();
+                SelectCoarse = model.SelectCoarse;
+                SelectFine = model.SelectFine;
+                return;
+            }
+
+            using (Py.GIL())
+            {
+                var name = "QC500UniverseSelectionModel";
+                dynamic model = Py.Import(name).GetAttr(name).Invoke();
+                SelectCoarse = ConvertToUniverseSelectionSymbolDelegate<IEnumerable<CoarseFundamental>>(model.SelectCoarse);
+                SelectFine = ConvertToUniverseSelectionSymbolDelegate<IEnumerable<FineFundamental>>(model.SelectFine);
+            }
+        }
+
+        public static Func<QCAlgorithm, T, IEnumerable<Symbol>> ConvertToUniverseSelectionSymbolDelegate<T>(PyObject pySelector)
+        {
+            Func<QCAlgorithm, T, object> selector;
+            pySelector.TryConvertToDelegate(out selector);
+
+            return (algorithm, data) =>
+            {
+                var result = selector(algorithm, data);
+                return ReferenceEquals(result, Universe.Unchanged)
+                    ? Universe.Unchanged
+                    : ((object[])result).Select(x => (Symbol)x);
+            };
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -290,6 +290,7 @@
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
+    <Compile Include="Algorithm\Framework\Selection\QC500UniverseSelectionModelTests.cs" />
     <Compile Include="Brokerages\Bitfinex\BitfinexFeeModelTests.cs" />
     <Compile Include="Brokerages\Bitfinex\BitfinexSymbolMapperTests.cs" />
     <Compile Include="Brokerages\Bitfinex\BitfinexBrokerageHistoryProviderTests.cs" />


### PR DESCRIPTION
#### Description
The class field that tracks the current month is updated only if there are securities that passed the selection criteria. It prevents division by zero and allows the universe selection a new attempt on the next trading day while keeps the universe unchanged
Also, updates the Fine Universe Selection to use `FineFundamental.MarketCap` introduced in #3970.

#### Related Issue
Closes #3964 #3965
Thank you for https://github.com/QuantConnect/Lean/commit/721e8c2c13efb0a762fb76dd8bebe87de4657582, @fcnorman.  

#### Motivation and Context
QuantConnect's built-in models should not throw unhandled exceptions.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests and algorithm execution in QC Cloud from 1998 to date.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`