### PR TITLE
IB Brokerage bug fixes

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -3191,27 +3191,27 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             if (_loginFailed)
             {
-                throw new Exception(
-                    "InteractiveBrokersBrokerage.CheckIbAutomaterErrors(): " +
-                    "Login failed. " +
-                    "Please check the validity of your login credentials.");
+                HandleIbAutomaterError("Login failed. Please check the validity of your login credentials.");
             }
 
             if (_existingSessionDetected)
             {
-                throw new Exception(
-                    "InteractiveBrokersBrokerage.CheckIbAutomaterErrors(): " +
-                    "An existing session was detected and will not be automatically disconnected. " +
-                    "Please close the existing session manually.");
+                HandleIbAutomaterError("An existing session was detected and will not be automatically disconnected. " +
+                                       "Please close the existing session manually.");
             }
 
             if (_securityDialogDetected)
             {
-                throw new Exception(
-                    "InteractiveBrokersBrokerage.CheckIbAutomaterErrors(): " +
-                    "A security dialog was detected for Second Factor/Code Card Authentication. " +
-                    "Please opt out of the Secure Login System: Manage Account > Security > Secure Login System > SLS Opt Out");
+                HandleIbAutomaterError("A security dialog was detected for Second Factor/Code Card Authentication. " +
+                                       "Please opt out of the Secure Login System: Manage Account > Security > Secure Login System > SLS Opt Out");
             }
+        }
+
+        private void HandleIbAutomaterError(string message)
+        {
+            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "IBAutomater", message));
+
+            throw new Exception($"InteractiveBrokersBrokerage.CheckIbAutomaterErrors(): {message}");
         }
 
         private void LoadIbServerInformation()

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1287,7 +1287,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// </summary>
         public void ResetGatewayConnection()
         {
+            // clear all error/status flags
             _disconnected1100Fired = false;
+            _previouslyInResetTime = false;
+            _loginFailed = false;
+            _existingSessionDetected = false;
+            _securityDialogDetected = false;
+            _performingRelogin = false;
 
             // notify the BrokerageMessageHandler before the restart, so it can stop polling
             OnMessage(BrokerageMessageEvent.Reconnected(string.Empty));

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1249,6 +1249,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 // we've reconnected
                 OnMessage(new BrokerageMessageEvent(brokerageMessageType, errorCode, errorMsg));
 
+                // do not restart after IBAutomater errors
+                CheckIbAutomaterErrors();
+
                 // With IB Gateway v960.2a in the cloud, we are not receiving order fill events after the nightly reset,
                 // so we execute the following sequence:
                 // disconnect, kill IB Gateway, restart IB Gateway, reconnect, restore data subscriptions
@@ -1366,6 +1369,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 if (_previouslyInResetTime)
                 {
+                    // do not restart after IBAutomater errors
+                    CheckIbAutomaterErrors();
+
                     // reset time finished and we're still disconnected, restart IB client
                     Log.Trace("InteractiveBrokersBrokerage.TryWaitForReconnect(): Reset time finished and still disconnected. Restarting...");
 

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -75,7 +75,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private bool _loginFailed;
         private bool _existingSessionDetected;
         private bool _securityDialogDetected;
-        private bool _performingRelogin;
         private string _ibServerName;
         private Region _ibServerRegion = Region.America;
 
@@ -1293,7 +1292,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             _loginFailed = false;
             _existingSessionDetected = false;
             _securityDialogDetected = false;
-            _performingRelogin = false;
 
             // notify the BrokerageMessageHandler before the restart, so it can stop polling
             OnMessage(BrokerageMessageEvent.Reconnected(string.Empty));
@@ -3136,8 +3134,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 _ibAutomaterInitializeEvent.Set();
             }
 
-            // an existing session was detected and IBAutomater clicked the "Exit Application" button
-            else if (e.Data.Contains("Existing session detected") && !_performingRelogin)
+            // an existing session was detected
+            else if (e.Data.Contains("Existing session detected"))
             {
                 _existingSessionDetected = true;
                 _ibAutomaterInitializeEvent.Set();
@@ -3156,18 +3154,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             else if (e.Data.Contains("Configuration settings updated"))
             {
                 _ibAutomaterInitializeEvent.Set();
-            }
-
-            // the IB session was disconnected by the user logging in from another location
-            else if (e.Data.Contains("Re-login is required"))
-            {
-                _performingRelogin = true;
-            }
-
-            // the IB session was disconnected by the user logging in from another location
-            else if (e.Data.Contains("Starting application"))
-            {
-                _performingRelogin = false;
             }
         }
 

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -684,6 +684,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 {
                     Log.Trace("InteractiveBrokersBrokerage.Connect(): Attempting to connect ({0}/{1}) ...", attempt, maxAttempts);
 
+                    // if we have errors from IBAutomater, exit immediately
+                    if (HasIbAutomaterErrors())
+                    {
+                        attempt = maxAttempts;
+                        CheckIbAutomaterErrors();
+                    }
+
                     // if message processing thread is still running, wait until it terminates
                     Disconnect();
 
@@ -3167,6 +3174,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private void OnIbAutomaterExited(object sender, ExitedEventArgs e)
         {
             Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): Exit code: {e.ExitCode}");
+        }
+
+        private bool HasIbAutomaterErrors()
+        {
+            return _loginFailed || _existingSessionDetected || _securityDialogDetected;
         }
 
         private void CheckIbAutomaterErrors()

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersStateManager.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersStateManager.cs
@@ -1,0 +1,130 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Brokerages.InteractiveBrokers
+{
+    /// <summary>
+    /// Holds the brokerage state information (connection status, error conditions, etc.)
+    /// </summary>
+    public class InteractiveBrokersStateManager
+    {
+        private volatile bool _disconnected1100Fired;
+        private volatile bool _previouslyInResetTime;
+        private volatile bool _loginFailed;
+        private volatile bool _existingSessionDetected;
+        private volatile bool _securityDialogDetected;
+
+        /// <summary>
+        /// Gets/sets whether the IB client has received a Disconnect (1100) message
+        /// </summary>
+        public bool Disconnected1100Fired
+        {
+            get
+            {
+                return _disconnected1100Fired;
+            }
+
+            set
+            {
+                _disconnected1100Fired = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets whether the previous reconnection attempt was performed during the IB reset period
+        /// </summary>
+        public bool PreviouslyInResetTime
+        {
+            get
+            {
+                return _previouslyInResetTime;
+            }
+
+            set
+            {
+                _previouslyInResetTime = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets whether a login failure was detected by IBAutomater
+        /// </summary>
+        public bool LoginFailed
+        {
+            get
+            {
+                return _loginFailed;
+            }
+
+            set
+            {
+                _loginFailed = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets whether an existing session was detected by IBAutomater
+        /// </summary>
+        public bool ExistingSessionDetected
+        {
+            get
+            {
+                return _existingSessionDetected;
+            }
+
+            set
+            {
+                _existingSessionDetected = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets whether a security dialog (2FA/code card) was detected by IBAutomater
+        /// </summary>
+        public bool SecurityDialogDetected
+        {
+            get
+            {
+                return _securityDialogDetected;
+            }
+
+            set
+            {
+                _securityDialogDetected = value;
+            }
+        }
+
+        /// <summary>
+        /// Checks if any IBAutomater error has occurred
+        /// </summary>
+        /// <returns>true if any IBAutomater error has occurred</returns>
+        public bool HasIbAutomaterErrors()
+        {
+            return _loginFailed || _existingSessionDetected || _securityDialogDetected;
+        }
+
+        /// <summary>
+        /// Resets the state to the default values
+        /// </summary>
+        public void Reset()
+        {
+            _disconnected1100Fired = false;
+            _previouslyInResetTime = false;
+            _loginFailed = false;
+            _existingSessionDetected = false;
+            _securityDialogDetected = false;
+        }
+    }
+}

--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -288,6 +288,7 @@
     <Compile Include="Bitfinex\BitfinexWebSocketWrapper.cs" />
     <Compile Include="Bitfinex\Messages.cs" />
     <Compile Include="Bitfinex\BitfinexSymbolMapper.cs" />
+    <Compile Include="InteractiveBrokers\InteractiveBrokersStateManager.cs" />
     <Compile Include="IOrderBookUpdater.cs" />
     <Compile Include="DefaultOrderBook.cs" />
     <Compile Include="Brokerage.cs" />


### PR DESCRIPTION

#### Description
- Refactored some IB state variables into the new `InteractiveBrokersStateManager` class.
- Fixed a bug where one of the state variables was not being reset between IBGateway restarts.
- Recovery from a disconnect caused by the user logging into TWS remotely (and ignoring the TWS warning message) will no longer be attempted: the algorithm will be terminated immediately with the `"Existing session detected"` error message.

#### Related Issue
Ref. #2799 #3395 

#### Motivation and Context
- Occasional cash sync errors reported by a few users

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Live testing in QC cloud

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`