### PR TITLE
AddUniverse will be deferred to EndOfTimeStep

### DIFF
--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -167,7 +167,7 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Gets a helper that provides pre-defined universe defintions, such as top dollar volume
+        /// Gets a helper that provides pre-defined universe definitions, such as top dollar volume
         /// </summary>
         public UniverseDefinitions Universe
         {
@@ -181,7 +181,9 @@ namespace QuantConnect.Algorithm
         /// <param name="universe">The universe to be added</param>
         public void AddUniverse(Universe universe)
         {
-            UniverseManager.Add(universe.Configuration.Symbol, universe);
+            // The universe will be added at the end of time step, same as the AddData user defined universes.
+            // This is required to be independent of the start and end date set during initialize
+            _pendingUniverseAdditions.Add(universe);
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
+++ b/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
@@ -39,6 +39,8 @@ namespace QuantConnect.Tests.Algorithm
             var symbol = Symbols.SPY;
             algorithm.UniverseSettings.DataNormalizationMode = dataNormalizationMode;
             algorithm.AddUniverse(coarse => new[] { symbol });
+            // OnEndOfTimeStep will add all pending universe additions
+            algorithm.OnEndOfTimeStep();
 
             var changes = dataManager.UniverseSelection
                 .ApplyUniverseSelection(
@@ -67,6 +69,8 @@ namespace QuantConnect.Tests.Algorithm
             var symbol = spy.Symbol;
             algorithm.UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw;
             algorithm.AddUniverse(coarse => new[] { symbol });
+            // OnEndOfTimeStep will add all pending universe additions
+            algorithm.OnEndOfTimeStep();
 
             var changes = dataManager.UniverseSelection
                 .ApplyUniverseSelection(

--- a/Tests/Common/Packets/BacktestNodePacketTests.cs
+++ b/Tests/Common/Packets/BacktestNodePacketTests.cs
@@ -72,6 +72,42 @@ namespace QuantConnect.Tests.Common.Packets
         }
 
         [Test]
+        public void JobDatesAreRespectedByAddUniverseAtInitialize()
+        {
+            var parameter = new RegressionTests.AlgorithmStatisticsTestParameters(nameof(CoarseFundamentalTop3Algorithm),
+                new Dictionary<string, string> {
+                    { "Total Trades", "3" },
+                    {"Average Win", "0%"},
+                    { "Average Loss", "0%"},
+                    { "Compounding Annual Return", "-40.620%"},
+                    { "Drawdown", "0.300%"},
+                    { "Expectancy", "0"},
+                    { "Net Profit", "-0.285%"},
+                    { "Sharpe Ratio", "-9.165"},
+                    { "Loss Rate", "0%"},
+                    { "Win Rate", "0%"},
+                    { "Profit-Loss Ratio", "0"},
+                    { "Alpha", "-0.221"},
+                    { "Beta", "-0.314"},
+                    { "Annual Standard Deviation", "0.026"},
+                    { "Annual Variance", "0.001"},
+                    { "Information Ratio", "-3.063"},
+                    { "Tracking Error", "0.098"},
+                    { "Treynor Ratio", "0.764"},
+                    { "Total Fees", "$3.00"} },
+                Language.CSharp,
+                AlgorithmStatus.Completed);
+
+            AlgorithmRunner.RunLocalBacktest(parameter.Algorithm,
+                parameter.Statistics,
+                parameter.AlphaStatistics,
+                parameter.Language,
+                parameter.ExpectedFinalStatus,
+                startDate: new DateTime(2014, 03, 24),
+                endDate: new DateTime(2014, 03, 25));
+        }
+
+        [Test]
         public void RoundTripNullJobDates()
         {
             var job = new BacktestNodePacket(1, 2, "3", null, 9m, $"{nameof(BacktestNodePacketTests)}.Pepe");

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -636,7 +636,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                         Time = currentTime - Time.OneDay, // hard-coded coarse period of one day
                     });
                 }
-            }, lck, TimeSpan.FromSeconds(0.5), TimeSpan.FromMilliseconds(-1));
+            },
+            lck,
+            // we need to give the universe time to be added
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromMilliseconds(-1));
 
             var yieldedUniverseData = false;
             var feed = RunDataFeed(getNextTicksFunction: fdqh =>
@@ -661,7 +665,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             _algorithm.AddUniverse(coarse => coarse.Take(10).Select(x => x.Symbol));
 
             var receivedCoarseData = false;
-            ConsumeBridge(feed, TimeSpan.FromSeconds(2), ts =>
+            ConsumeBridge(feed, TimeSpan.FromSeconds(1.5), ts =>
             {
                 if (ts.UniverseData.Count > 0 &&
                     ts.UniverseData.First().Value.Data.First() is CoarseFundamental)
@@ -709,6 +713,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             });
 
             _algorithm.AddUniverse(coarse => coarse.Take(10).Select(x => x.Symbol));
+            _algorithm.OnEndOfTimeStep();
 
             var receivedCoarseData = false;
             ConsumeBridge(feed, TimeSpan.FromSeconds(5), ts =>
@@ -762,7 +767,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                         HasFundamentalData = true
                     });
                 }
-            }, lck, TimeSpan.FromSeconds(0.5), TimeSpan.FromMilliseconds(-1));
+            },
+            lck,
+            // we need to give the universe time to be added
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromMilliseconds(-1));
 
             var yieldedUniverseData = false;
             var feed = RunDataFeed(getNextTicksFunction: fdqh =>
@@ -797,7 +806,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 });
 
             var receivedFundamentalsData = false;
-            ConsumeBridge(feed, TimeSpan.FromSeconds(2), ts =>
+            ConsumeBridge(feed, TimeSpan.FromSeconds(1.5), ts =>
             {
                 if (ts.UniverseData.Count > 0 &&
                     ts.UniverseData.First().Value.Data.First() is Fundamentals)

--- a/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
+++ b/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
@@ -41,6 +41,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             algorithm.SetEndDate(Time.EndOfTime);
             algorithm.SetStartDate(DateTime.UtcNow.Subtract(TimeSpan.FromDays(10)));
             algorithm.AddUniverse(CoarseSelectionFunction, FineSelectionFunction);
+            // OnEndOfTimeStep will add all pending universe additions
+            algorithm.OnEndOfTimeStep();
             var universe = algorithm.UniverseManager.Values.First();
             var securityChanges = algorithm.DataManager.UniverseSelection.ApplyUniverseSelection(
                 universe,
@@ -82,6 +84,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             algorithm.SetStartDate(2012, 3, 27);
             algorithm.SetEndDate(2012, 3, 30);
             algorithm.AddUniverse("my-custom-universe", dt => dt.Day < 30 ? new List<string> { "CPRT" } : Enumerable.Empty<string>());
+            // OnEndOfTimeStep will add all pending universe additions
+            algorithm.OnEndOfTimeStep();
             var universe = algorithm.UniverseManager.Values.First();
 
             var securityChanges = algorithm.DataManager.UniverseSelection.ApplyUniverseSelection(
@@ -128,6 +132,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 coarse => coarse.Select(c => c.Symbol),
                 fine => fine.Select(f => f.Symbol)
             );
+            // OnEndOfTimeStep will add all pending universe additions
+            algorithm.OnEndOfTimeStep();
 
             var universe = algorithm.UniverseManager.Values.First();
             var securityChanges = algorithm.DataManager.UniverseSelection.ApplyUniverseSelection(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `AddUniverse` call will add new Universe to the pending collection which
will be consumed at the `OnEndOfTimeStep` where it will be added to the
data feed, same as we do for the `UserDefinedUniverses`. This is
required since the start and end date, during initialize, is consumed by
these universe subscriptions.
- Adding unit test.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3989
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Universes added during initialize use the correct end and start time
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
