### PR TITLE
Fix Symbol Equals emtpy

### DIFF
--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Data.Consolidators
         where TConsolidated : BaseData
     {
         // The symbol that we are consolidating for.
-        private Symbol symbol;
+        private Symbol _symbol;
         //The number of data updates between creating new bars.
         private readonly int? _maxCount;
         //
@@ -128,13 +128,13 @@ namespace QuantConnect.Data.Consolidators
         /// <param name="data">The new data for the consolidator</param>
         public override void Update(T data)
         {
-            if (symbol == null)
+            if (_symbol == null)
             {
-                symbol = data.Symbol;
+                _symbol = data.Symbol;
             }
-            else if (symbol != data.Symbol)
+            else if (_symbol != data.Symbol)
             {
-                throw new InvalidOperationException($"Consolidators can only be used with a single symbol. The previous consolidated symbol ({symbol}) is not the same as in the current data ({data.Symbol}).");
+                throw new InvalidOperationException($"Consolidators can only be used with a single symbol. The previous consolidated symbol ({_symbol}) is not the same as in the current data ({data.Symbol}).");
             }
 
             if (!ShouldProcess(data))

--- a/Common/Util/ConcurrentSet.cs
+++ b/Common/Util/ConcurrentSet.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 
 namespace QuantConnect.Util
 {
@@ -27,6 +28,7 @@ namespace QuantConnect.Util
     /// <typeparam name="T">The item type</typeparam>
     public class ConcurrentSet<T> : ISet<T>
     {
+        private readonly IEnumerator<T> _emptyEnumerator = Enumerable.Empty<T>().GetEnumerator();
         private readonly OrderedDictionary _set = new OrderedDictionary();
         // for performance we will keep a enumerator list which we will refresh only if required
         private readonly List<T> _enumerator = new List<T>();
@@ -374,7 +376,8 @@ namespace QuantConnect.Util
 
                     _refreshEnumerator = false;
                 }
-                return _enumerator.GetEnumerator();
+
+                return _enumerator.Count == 0 ? _emptyEnumerator : _enumerator.GetEnumerator();
             }
         }
 

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -325,6 +325,28 @@ namespace QuantConnect.Tests.Common
         }
 
         [Test]
+        public void EqualsAgainstNullOrEmpty()
+        {
+            var validSymbol = Symbols.SPY;
+            var emptySymbol = Symbol.Empty;
+            var emptySymbolInstance = new Symbol(SecurityIdentifier.Empty, string.Empty);
+            Symbol nullSymbol = null;
+
+            Assert.IsTrue(emptySymbol.Equals(nullSymbol));
+            Assert.IsTrue(Symbol.Empty.Equals(nullSymbol));
+            Assert.IsTrue(emptySymbolInstance.Equals(nullSymbol));
+
+            Assert.IsTrue(emptySymbol.Equals(emptySymbol));
+            Assert.IsTrue(Symbol.Empty.Equals(emptySymbol));
+            Assert.IsTrue(emptySymbolInstance.Equals(emptySymbol));
+
+            Assert.IsFalse(validSymbol.Equals(nullSymbol));
+            Assert.IsFalse(validSymbol.Equals(emptySymbol));
+            Assert.IsFalse(validSymbol.Equals(emptySymbolInstance));
+            Assert.IsFalse(Symbol.Empty.Equals(validSymbol));
+        }
+
+        [Test]
         public void ComparesAgainstNullOrEmpty()
         {
             var validSymbol = Symbols.SPY;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix Symbol Equals Empty implementation
- Improving the performance of Symbol comparison
- Small performance improvement in `ConcurrentSet`
- Adding unit test

`Performance test IndicatorRibbonBenchmark - No thermal nor power throttling`
PR
48.74 seconds at 16k data points per second. Processing total of 784,238 data points.
49.15 seconds at 16k data points per second. Processing total of 784,238 data points.
48.95 seconds at 16k data points per second. Processing total of 784,238 data points.
MASTER
55.76 seconds at 14k data points per second. Processing total of 784,238 data points.
55.97 seconds at 14k data points per second. Processing total of 784,238 data points.
55.41 seconds at 14k data points per second. Processing total of 784,238 data points.

`BasicTemplateBenchmark - ConcurrentSet.GetEnumerator()`
MASTER
![image](https://user-images.githubusercontent.com/18473240/72542148-6b843b80-3862-11ea-800f-09ad169a582e.png)

PR - **ConcurrentSet.GetEnumerator() not present**:

![image](https://user-images.githubusercontent.com/18473240/72542175-78a12a80-3862-11ea-8b55-dd725e66fd9c.png)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/4010
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Performance and bug fix
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit, regression and performance tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x]  My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
