### PR TITLE
Fix Alpaca partial fill quantity bug

### DIFF
--- a/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
@@ -140,7 +140,7 @@ namespace QuantConnect.Brokerages.Alpaca
                     {
                         Status = status,
                         FillPrice = trade.Price.Value,
-                        FillQuantity = fillQuantity * (order.Direction == OrderDirection.Buy ? +1 : -1)
+                        FillQuantity = fillQuantity * (order.Direction == OrderDirection.Buy ? 1 : -1)
                     });
                 }
                 else if (trade.Event == TradeEvent.Canceled)

--- a/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
@@ -131,7 +131,7 @@ namespace QuantConnect.Brokerages.Alpaca
                     var status = trade.Event == TradeEvent.Fill ? OrderStatus.Filled : OrderStatus.PartiallyFilled;
 
                     // The Alpaca API does not return the individual quantity for each partial fill, but the cumulative filled quantity
-                    var fillQuantity = Convert.ToInt64(trade.Order.FilledQuantity) - Math.Abs(ticket.QuantityFilled);
+                    var fillQuantity = trade.Order.FilledQuantity - Math.Abs(ticket.QuantityFilled);
 
                     OnOrderEvent(new OrderEvent(order,
                         DateTime.UtcNow,


### PR DESCRIPTION

#### Description
- Fixed incorrect quantity in Alpaca partial order fill events.

#### Related Issue
Closes #4014 

#### Motivation and Context
- Incorrect quantity in order events causes holding mismatches.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Ran the test algorithm in #4014 and verified partial fills had the correct quantities (in both buy and sell directions)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`