### PR TITLE
Redirect Alpaca WebSocketSharp log output to Lean logging system

### DIFF
--- a/Brokerages/Alpaca/Markets/SockClient.cs
+++ b/Brokerages/Alpaca/Markets/SockClient.cs
@@ -14,6 +14,8 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using WebSocketSharp;
 using System.Security.Authentication;
+using QuantConnect.Configuration;
+using QuantConnect.Logging;
 
 namespace QuantConnect.Brokerages.Alpaca.Markets
 {
@@ -76,7 +78,16 @@ namespace QuantConnect.Brokerages.Alpaca.Markets
             };
             uriBuilder.Path += "/stream";
 
-            _webSocket = new WebSocket(uriBuilder.Uri.ToString());
+            _webSocket = new WebSocket(uriBuilder.Uri.ToString())
+            {
+                Log =
+                {
+                    Level = Config.GetBool("websocket-log-trace") ? LogLevel.Trace : LogLevel.Error,
+
+                    // The stack frame number of 3 was derived from the usage of the Logger class in the WebSocketSharp library
+                    Output = (data, file) => { Log.Trace($"{WhoCalledMe.GetMethodName(3)}(): {data.Message}", true); }
+                }
+            };
 
             _webSocket.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12;
 


### PR DESCRIPTION

#### Description
- The `WebSocketSharp` library by default outputs log traces to the console, which end up being written to the user algorithm logs. The WebSocketSharp logging is now redirected to a `Log.Trace` call, as already done in the `GdaxBrokerage`.

#### Related Issue
n/a

#### Motivation and Context
- Unnecessary web socket trace output in user algorithm logs.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
> Pending cloud test to verify WebSocketSharp logs are written to the syslog instead of the user log,
the last cloud overnight test did not produce websocket errors, so the solution is not confirmed yet.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`