### PR TITLE
Adds Warm Up Logic for Volatility Model with Options

### DIFF
--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -75,6 +75,7 @@ namespace QuantConnect.Algorithm
                     if (Securities.Any(skvp => skvp.Key.SecurityType != SecurityType.Base && skvp.Key.HasUnderlyingSymbol(security.Symbol)))
                     {
                         // set data mode raw and default volatility model
+                        // we are changing the data mode of an existing security, see GitHub issue #4031
                         ConfigureUnderlyingSecurity(security);
                     }
 
@@ -100,7 +101,8 @@ namespace QuantConnect.Algorithm
                         }
 
                         // set data mode raw and default volatility model
-                        ConfigureUnderlyingSecurity(underlyingSecurity, !hasValue);
+                        // this should be '!hasValue' but using 'true' instead, see GitHub issue #4031
+                        ConfigureUnderlyingSecurity(underlyingSecurity, true);
 
                         if (LiveMode && underlyingSecurity.GetLastData() == null)
                         {

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1613,14 +1613,15 @@ namespace QuantConnect.Algorithm
             Security underlying;
             var underlyingSymbol = option.Symbol.Underlying;
 
-            if (!Securities.TryGetValue(underlyingSymbol, out underlying))
+            var hasValue = Securities.TryGetValue(underlyingSymbol, out underlying);
+            if (!hasValue)
             {
                 underlying = AddEquity(underlyingSymbol.Value, resolution, underlyingSymbol.ID.Market, false);
             }
 
             option.Underlying = underlying;
 
-            ConfigureUnderlyingSecurity(underlying);
+            ConfigureUnderlyingSecurity(underlying, !hasValue);
 
             AddToUserDefinedUniverse(option, configs);
 


### PR DESCRIPTION
#### Description
Adds warm-up logic for volatility model with options in `ConfigureUnderlyingSecurity` method.
Refactors `AddOptionContract` to use `ConfigureUnderlyingSecurity` so that this fix also covers the `OptionChainProvider` case.

#### Related Issue
Closes #4009 

#### Motivation and Context
Bug fix. When the algorithm is using the default volatility model, it should be ready to use (initialized).

#### How Has This Been Tested?
Regression test. A test for non-zero greek delta was added to the regression algorithm `OptionChainProviderAlgorithm`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`