### PR TITLE
Added Quarterly & Yearly Calendar Types

### DIFF
--- a/Algorithm.CSharp/DataConsolidationAlgorithm.cs
+++ b/Algorithm.CSharp/DataConsolidationAlgorithm.cs
@@ -103,6 +103,14 @@ namespace QuantConnect.Algorithm.CSharp
             Consolidate("SPY", CalendarType.Monthly, CalendarTradeBarHandler);
             Consolidate("EURUSD", CalendarType.Monthly, CalendarQuoteBarHandler);
 
+            // API convenience method for easily receiving quarterly-consolidated data
+            Consolidate("SPY", CalendarType.Quarterly, CalendarTradeBarHandler);
+            Consolidate("EURUSD", CalendarType.Quarterly, CalendarQuoteBarHandler);
+
+            // API convenience method for easily receiving yearly-consolidated data
+            Consolidate("SPY", CalendarType.Yearly, CalendarTradeBarHandler);
+            Consolidate("EURUSD", CalendarType.Yearly, CalendarQuoteBarHandler);
+
             // requires quote data subscription
             //Consolidate<QuoteBar>("EURUSD", TimeSpan.FromMinutes(45), FortyFiveMinuteBarHandler);
             //Consolidate<QuoteBar>("EURUSD", Resolution.Hour, HourBarHandler);

--- a/Algorithm.Python/DataConsolidationAlgorithm.py
+++ b/Algorithm.Python/DataConsolidationAlgorithm.py
@@ -101,6 +101,14 @@ class DataConsolidationAlgorithm(QCAlgorithm):
         self.Consolidate("SPY", CalendarType.Monthly, self.CalendarTradeBarHandler);
         self.Consolidate("EURUSD", CalendarType.Monthly, self.CalendarQuoteBarHandler);
 
+        # API convenience method for easily receiving quarterly-consolidated data
+        self.Consolidate("SPY", CalendarType.Quarterly, self.CalendarTradeBarHandler)
+        self.Consolidate("EURUSD", CalendarType.Quarterly, self.CalendarQuoteBarHandler)
+
+        # API convenience method for easily receiving yearly-consolidated data
+        self.Consolidate("SPY", CalendarType.Yearly, self.CalendarTradeBarHandler);
+        self.Consolidate("EURUSD", CalendarType.Yearly, self.CalendarQuoteBarHandler);
+
         # some securities may have trade and quote data available, so we can choose it based on TickType:
         #self.Consolidate("BTCUSD", Resolution.Hour, TickType.Trade, self.HourBarHandler)   # to get TradeBar
         #self.Consolidate("BTCUSD", Resolution.Hour, TickType.Quote, self.HourBarHandler)   # to get QuoteBar (default)

--- a/Common/Data/Consolidators/CalendarType.cs
+++ b/Common/Data/Consolidators/CalendarType.cs
@@ -49,6 +49,40 @@ namespace QuantConnect.Data.Consolidators
                 };
             }
         }
+
+        /// <summary>
+        /// Computes the start of quarter (1st of the starting month of current quarter) of given date/time
+        /// </summary>
+        public static Func<DateTime, CalendarInfo> Quarterly
+        {
+            get
+            {
+                return dt =>
+                {
+                    var nthQuarter = (dt.Month - 1) / 3;
+                    var firstMonthOfQuarter = nthQuarter * 3 + 1;
+                    var start = new DateTime(dt.Year, firstMonthOfQuarter, 1);
+                    var end = Expiry.EndOfQuarter(dt);
+                    return new CalendarInfo(start, end - start);
+                };
+            }
+        }
+
+        /// <summary>
+        /// Computes the start of year (1st of the current year) of given date/time
+        /// </summary>
+        public static Func<DateTime, CalendarInfo> Yearly
+        {
+            get
+            {
+                return dt =>
+                {
+                    var start = dt.AddDays(1 - dt.DayOfYear).Date;
+                    var end = Expiry.EndOfYear(dt);
+                    return new CalendarInfo(start, end - start);
+                };
+            }
+        }
     }
 
     public struct CalendarInfo

--- a/Common/Expiry.cs
+++ b/Common/Expiry.cs
@@ -29,6 +29,16 @@ namespace QuantConnect
         public static Func<DateTime, DateTime> OneMonth => dt => dt.AddMonths(1);
 
         /// <summary>
+        /// Computes a date/time one quarter after a given date/time (nth day to nth day)
+        /// </summary>
+        public static Func<DateTime, DateTime> OneQuarter => dt => dt.AddMonths(3);
+
+        /// <summary>
+        /// Computes a date/time one year after a given date/time (nth day to nth day)
+        /// </summary>
+        public static Func<DateTime, DateTime> OneYear => dt => dt.AddYears(1);
+
+        /// <summary>
         /// Computes the end of day (mid-night of the next day) of given date/time
         /// </summary>
         public static Func<DateTime, DateTime> EndOfDay => dt => dt.AddDays(1).Date;
@@ -60,6 +70,37 @@ namespace QuantConnect
                 {
                     var value = 1 - dt.Day;
                     return OneMonth(dt).AddDays(value).Date;
+                };
+            }
+        }
+
+        /// <summary>
+        /// Computes the end of quarter (1st of the starting month of next quarter) of given date/time
+        /// </summary>
+        public static Func<DateTime, DateTime> EndOfQuarter
+        {
+            get
+            {
+                return dt =>
+                {
+                    var nthQuarter = (dt.Month - 1) / 3;
+                    var firstMonthOfQuarter = nthQuarter * 3 + 1;
+                    return OneQuarter(new DateTime(dt.Year, firstMonthOfQuarter, 1));
+                };
+            }
+        }
+
+        /// <summary>
+        /// Computes the end of year (1st of the next year) of given date/time
+        /// </summary>
+        public static Func<DateTime, DateTime> EndOfYear
+        {
+            get
+            {
+                return dt =>
+                {
+                    var value = 1 - dt.DayOfYear;
+                    return OneYear(dt).AddDays(value).Date;
                 };
             }
         }


### PR DESCRIPTION
Calendar Support Expanded for Quarterly & Yearly Calendar Types.


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
For long term traders may need long term consolidators like quarterly or yearly consolidators. Beucase of that do some changes related files for support these consolidators too.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It's related with that [issue.](https://github.com/QuantConnect/Lean/issues/3945)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Needed for long term technical analysis for both data and indicators.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

If i'm right, in a documentation not mentioning weekly&monthly consolidators. Maybe hereafter documentation can be expanded in this direction and also quarterly&yearly consolidators can be add to documentation too.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Write simple test algorith and in initialize method created condolidators and when data consolidated log consolidatoed data's time and end time properties;

`
using QuantConnect.Data;
using QuantConnect.Data.Consolidators;

namespace QuantConnect.Algorithm.CSharp
{
    public class TestAlgorithm : QCAlgorithm
    {
        private TradeBarConsolidator quarterlyConsolidator;
        private TradeBarConsolidator yearlyConsolidator;

        public override void Initialize()
        {
            SetCash(100000);
            SetStartDate(2000, 01, 01);
            SetEndDate(2010, 01, 01);

            AddEquity("SPY", Resolution.Daily, Market.USA);

            quarterlyConsolidator = new TradeBarConsolidator(CalendarType.Quarterly);
            quarterlyConsolidator.DataConsolidated += (sender, tradeBar) =>
            {
                //Log($"{tradeBar.Time} ~ {tradeBar.EndTime}");
            };

            yearlyConsolidator = new TradeBarConsolidator(CalendarType.Yearly);
            yearlyConsolidator.DataConsolidated += (sender, tradeBar) =>
            {
                Log($"{tradeBar.Time} ~ {tradeBar.EndTime}");
            };
        }

        public override void OnData(Slice slice)
        {
            if (slice.Bars.ContainsKey("SPY"))
            {
                var tradeBar = slice.Bars["SPY"];
                quarterlyConsolidator.Update(tradeBar);
                yearlyConsolidator.Update(tradeBar);
            }
        }
    }
}
`

2000-01-01 00:00:00 Launching analysis for TestAlgorithm with LEAN Engine v2.4.0.0
2000-01-04 00:00:00 10/1/1999 12:00:00 AM ~ 1/1/2000 12:00:00 AM
2000-04-04 00:00:00 1/1/2000 12:00:00 AM ~ 4/1/2000 12:00:00 AM
2000-07-04 00:00:00 4/1/2000 12:00:00 AM ~ 7/1/2000 12:00:00 AM
2000-10-03 00:00:00 7/1/2000 12:00:00 AM ~ 10/1/2000 12:00:00 AM
2001-01-03 00:00:00 10/1/2000 12:00:00 AM ~ 1/1/2001 12:00:00 AM
2001-04-03 00:00:00 1/1/2001 12:00:00 AM ~ 4/1/2001 12:00:00 AM
2001-07-03 00:00:00 4/1/2001 12:00:00 AM ~ 7/1/2001 12:00:00 AM
2001-10-02 00:00:00 7/1/2001 12:00:00 AM ~ 10/1/2001 12:00:00 AM
2002-01-03 00:00:00 10/1/2001 12:00:00 AM ~ 1/1/2002 12:00:00 AM
2002-04-02 00:00:00 1/1/2002 12:00:00 AM ~ 4/1/2002 12:00:00 AM
2002-07-02 00:00:00 4/1/2002 12:00:00 AM ~ 7/1/2002 12:00:00 AM
2002-10-02 00:00:00 7/1/2002 12:00:00 AM ~ 10/1/2002 12:00:00 AM
2003-01-03 00:00:00 10/1/2002 12:00:00 AM ~ 1/1/2003 12:00:00 AM
2003-04-02 00:00:00 1/1/2003 12:00:00 AM ~ 4/1/2003 12:00:00 AM
2003-07-02 00:00:00 4/1/2003 12:00:00 AM ~ 7/1/2003 12:00:00 AM
2003-10-02 00:00:00 7/1/2003 12:00:00 AM ~ 10/1/2003 12:00:00 AM
2004-01-03 00:00:00 10/1/2003 12:00:00 AM ~ 1/1/2004 12:00:00 AM
2004-04-02 00:00:00 1/1/2004 12:00:00 AM ~ 4/1/2004 12:00:00 AM
2004-07-02 00:00:00 4/1/2004 12:00:00 AM ~ 7/1/2004 12:00:00 AM
2004-10-02 00:00:00 7/1/2004 12:00:00 AM ~ 10/1/2004 12:00:00 AM
2005-01-04 00:00:00 10/1/2004 12:00:00 AM ~ 1/1/2005 12:00:00 AM
2005-04-02 00:00:00 1/1/2005 12:00:00 AM ~ 4/1/2005 12:00:00 AM
2005-07-02 00:00:00 4/1/2005 12:00:00 AM ~ 7/1/2005 12:00:00 AM
2005-10-04 00:00:00 7/1/2005 12:00:00 AM ~ 10/1/2005 12:00:00 AM
2006-01-04 00:00:00 10/1/2005 12:00:00 AM ~ 1/1/2006 12:00:00 AM
2006-04-04 00:00:00 1/1/2006 12:00:00 AM ~ 4/1/2006 12:00:00 AM
2006-07-04 00:00:00 4/1/2006 12:00:00 AM ~ 7/1/2006 12:00:00 AM
2006-10-03 00:00:00 7/1/2006 12:00:00 AM ~ 10/1/2006 12:00:00 AM
2007-01-04 00:00:00 10/1/2006 12:00:00 AM ~ 1/1/2007 12:00:00 AM
2007-04-03 00:00:00 1/1/2007 12:00:00 AM ~ 4/1/2007 12:00:00 AM
2007-07-03 00:00:00 4/1/2007 12:00:00 AM ~ 7/1/2007 12:00:00 AM
2007-10-02 00:00:00 7/1/2007 12:00:00 AM ~ 10/1/2007 12:00:00 AM
2008-01-03 00:00:00 10/1/2007 12:00:00 AM ~ 1/1/2008 12:00:00 AM
2008-04-02 00:00:00 1/1/2008 12:00:00 AM ~ 4/1/2008 12:00:00 AM
2008-07-02 00:00:00 4/1/2008 12:00:00 AM ~ 7/1/2008 12:00:00 AM
2008-10-02 00:00:00 7/1/2008 12:00:00 AM ~ 10/1/2008 12:00:00 AM
2009-01-03 00:00:00 10/1/2008 12:00:00 AM ~ 1/1/2009 12:00:00 AM
2009-04-02 00:00:00 1/1/2009 12:00:00 AM ~ 4/1/2009 12:00:00 AM
2009-07-02 00:00:00 4/1/2009 12:00:00 AM ~ 7/1/2009 12:00:00 AM
2009-10-02 00:00:00 7/1/2009 12:00:00 AM ~ 10/1/2009 12:00:00 AM
2010-01-01 00:00:00 Algorithm Id:(TestAlgorithm) completed in 1.47 seconds at 14k data points per second. Processing total of 20,135 data points.

2000-01-01 00:00:00 Launching analysis for TestAlgorithm with LEAN Engine v2.4.0.0
2000-01-04 00:00:00 1/1/1999 12:00:00 AM ~ 1/2/2000 12:00:00 AM
2001-01-03 00:00:00 1/1/2000 12:00:00 AM ~ 1/1/2001 12:00:00 AM
2002-01-03 00:00:00 1/1/2001 12:00:00 AM ~ 1/1/2002 12:00:00 AM
2003-01-03 00:00:00 1/1/2002 12:00:00 AM ~ 1/1/2003 12:00:00 AM
2004-01-03 00:00:00 1/1/2003 12:00:00 AM ~ 1/1/2004 12:00:00 AM
2005-01-04 00:00:00 1/1/2004 12:00:00 AM ~ 1/1/2005 12:00:00 AM
2006-01-04 00:00:00 1/1/2005 12:00:00 AM ~ 1/1/2006 12:00:00 AM
2007-01-04 00:00:00 1/1/2006 12:00:00 AM ~ 1/1/2007 12:00:00 AM
2008-01-03 00:00:00 1/1/2007 12:00:00 AM ~ 1/1/2008 12:00:00 AM
2009-01-03 00:00:00 1/1/2008 12:00:00 AM ~ 1/1/2009 12:00:00 AM
2010-01-01 00:00:00 Algorithm Id:(TestAlgorithm) completed in 1.27 seconds at 16k data points per second. Processing total of 20,135 data points.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
