### PR TITLE
Adds InitialMarginRequirement and MaintenanceMarginRequirement Properties to FutureMarginModel

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Future;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -81,6 +82,11 @@ namespace QuantConnect.Algorithm.CSharp
                     // if found, trade it
                     if (contract != null)
                     {
+                        // Get the margin requirements
+                        var model = Securities[contract.Symbol].BuyingPowerModel as FutureMarginModel;
+                        var initialOvernight = model?.InitialMarginRequirement;
+                        var maintenanceOvernight = model?.MaintenanceMarginRequirement;
+
                         MarketOrder(contract.Symbol, 1);
                     }
                 }

--- a/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
@@ -57,6 +57,12 @@ class BasicTemplateFuturesAlgorithm(QCAlgorithm):
                 # if there is any contract, trade the front contract
                 if len(contracts) == 0: continue
                 front = sorted(contracts, key = lambda x: x.Expiry, reverse=True)[0]
+
+                # Get the margin requirements
+                model = self.Securities[front.Symbol].BuyingPowerModel
+                initialMarginRequirement = model.InitialMarginRequirement
+                maintenanceMarginRequirement = model.MaintenanceMarginRequirement
+
                 self.MarketOrder(front.Symbol , 1)
         else:
             self.Liquidate()

--- a/Common/Brokerages/AlphaStreamsBrokerageModel.cs
+++ b/Common/Brokerages/AlphaStreamsBrokerageModel.cs
@@ -17,8 +17,6 @@ using System;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Slippage;
 using QuantConnect.Securities;
-using QuantConnect.Securities.Future;
-using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Brokerages
 {
@@ -30,7 +28,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="AlphaStreamsBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType"></param>
+        /// <param name="accountType">The type of account to be modelled, defaults to <see cref="AccountType.Margin"/> does not accept <see cref="AccountType.Cash"/>.</param>
         public AlphaStreamsBrokerageModel(AccountType accountType = AccountType.Margin)
             : base(accountType)
         {
@@ -39,63 +37,34 @@ namespace QuantConnect.Brokerages
                 throw new ArgumentException("The Alpha Streams brokerage does not currently support Cash trading.", nameof(accountType));
             }
         }
-        
+
         /// <summary>
         /// Gets a new fee model that represents this brokerage's fee structure
         /// </summary>
-        /// <param name="security"></param>
-        /// <returns></returns>
+        /// <param name="security">The security to get a fee model for</param>
+        /// <returns>The new fee model for this brokerage</returns>
         public override IFeeModel GetFeeModel(Security security) => new AlphaStreamsFeeModel();
+
         /// <summary>
-        /// Gets a new slippage model that represents this brokerage's slippage costs
+        /// Gets a new slippage model that represents this brokerage's fill slippage behavior
         /// </summary>
-        /// <param name="security"></param>
-        /// <returns></returns>
+        /// <param name="security">The security to get a slippage model for</param>
+        /// <returns>The new slippage model for this brokerage</returns>
         public override ISlippageModel GetSlippageModel(Security security) => new AlphaStreamsSlippageModel();
-        /// <summary>
+
         /// Force all security types to be restricted to 1.1x leverage
         ///     - Current restriction to 1.1x is for the AS competition
         ///     - Will be update in the future
         /// </summary>
         /// <param name="security"></param>
-        /// <returns></returns>
+        /// <returns>The leverage for the specified security</returns>
         public override decimal GetLeverage(Security security) => 1.1m;
-        /// <summary>
-        /// Gets a new settlement model
-        /// </summary>
-        /// <param name="security"></param>
-        /// <returns></returns>
-        public override ISettlementModel GetSettlementModel(Security security) => new ImmediateSettlementModel();
-        /// <summary>
-        /// Get buying power model for the specific security type
-        /// </summary>
-        /// <param name="security"></param>
-        /// <returns></returns>
-        public override IBuyingPowerModel GetBuyingPowerModel(Security security)
-        {
-            var leverage = GetLeverage(security);
-            IBuyingPowerModel model;
 
-            switch (security.Type)
-            {
-                case SecurityType.Crypto:
-                    model = new CashBuyingPowerModel();
-                    break;
-                case SecurityType.Forex:
-                case SecurityType.Cfd:
-                    model = new SecurityMarginModel(leverage, RequiredFreeBuyingPowerPercent);
-                    break;
-                case SecurityType.Option:
-                    model = new OptionMarginModel(RequiredFreeBuyingPowerPercent);
-                    break;
-                case SecurityType.Future:
-                    model = new FutureMarginModel(RequiredFreeBuyingPowerPercent);
-                    break;
-                default:
-                    model = new SecurityMarginModel(leverage, RequiredFreeBuyingPowerPercent);
-                    break;
-            }
-            return model;
-        }
+        /// <summary>
+        /// Gets a new settlement model for the security
+        /// </summary>
+        /// <param name="security">The security to get a settlement model for</param>
+        /// <returns>The settlement model for this brokerage</returns>
+        public override ISettlementModel GetSettlementModel(Security security) => new ImmediateSettlementModel();
     }
 }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -300,7 +300,7 @@ namespace QuantConnect.Brokerages
                     model = new OptionMarginModel(RequiredFreeBuyingPowerPercent);
                     break;
                 case SecurityType.Future:
-                    model = new FutureMarginModel(RequiredFreeBuyingPowerPercent);
+                    model = new FutureMarginModel(RequiredFreeBuyingPowerPercent, security);
                     break;
                 default:
                     model = new SecurityMarginModel(leverage, RequiredFreeBuyingPowerPercent);

--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -34,13 +34,27 @@ namespace QuantConnect.Securities.Future
         private MarginRequirementsEntry[] _marginRequirementsHistory;
         private int _marginCurrentIndex;
 
+        private readonly Security _security;
+
+        /// <summary>
+        /// Initial margin requirement for the contract effective from the date of change
+        /// </summary>
+        public decimal InitialMarginRequirement => GetCurrentMarginRequirements(_security)?.InitialOvernight ?? 0m;
+
+        /// <summary>
+        /// Maintenance margin requirement for the contract effective from the date of change
+        /// </summary>
+        public decimal MaintenanceMarginRequirement => GetCurrentMarginRequirements(_security)?.MaintenanceOvernight ?? 0m;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FutureMarginModel"/>
         /// </summary>
         /// <param name="requiredFreeBuyingPowerPercent">The percentage used to determine the required unused buying power for the account.</param>
-        public FutureMarginModel(decimal requiredFreeBuyingPowerPercent = 0)
+        /// <param name="security">The security that this model belongs to</param>
+        public FutureMarginModel(decimal requiredFreeBuyingPowerPercent = 0, Security security = null)
         {
             RequiredFreeBuyingPowerPercent = requiredFreeBuyingPowerPercent;
+            _security = security;
         }
 
         /// <summary>
@@ -101,9 +115,7 @@ namespace QuantConnect.Securities.Future
             if (security?.GetLastData() == null || security.Holdings.HoldingsCost == 0m)
                 return 0m;
 
-            var symbol = security.Symbol;
-            var date = security.GetLastData().Time.Date;
-            var marginReq = GetCurrentMarginRequirements(symbol, date);
+            var marginReq = GetCurrentMarginRequirements(security);
 
             return marginReq.MaintenanceOvernight * Math.Sign(security.Holdings.HoldingsCost);
         }
@@ -180,9 +192,7 @@ namespace QuantConnect.Securities.Future
             if (security?.GetLastData() == null || holdingValue == 0m)
                 return 0m;
 
-            var symbol = security.Symbol;
-            var date = security.GetLastData().Time.Date;
-            var marginReq = GetCurrentMarginRequirements(symbol, date);
+            var marginReq = GetCurrentMarginRequirements(security);
 
             return marginReq.InitialOvernight / holdingValue;
         }
@@ -195,20 +205,23 @@ namespace QuantConnect.Securities.Future
             if (security?.GetLastData() == null || holdingValue == 0m)
                 return 0m;
 
-            var symbol = security.Symbol;
-            var date = security.GetLastData().Time.Date;
-            var marginReq = GetCurrentMarginRequirements(symbol, date);
+            var marginReq = GetCurrentMarginRequirements(security);
 
             return marginReq.MaintenanceOvernight / holdingValue;
         }
 
-        private MarginRequirementsEntry GetCurrentMarginRequirements (Symbol symbol, DateTime date)
+        private MarginRequirementsEntry GetCurrentMarginRequirements(Security security)
         {
+            if (security?.GetLastData() == null)
+                return null;
+
             if (_marginRequirementsHistory == null)
             {
-                _marginRequirementsHistory = LoadMarginRequirementsHistory(symbol);
+                _marginRequirementsHistory = LoadMarginRequirementsHistory(security.Symbol);
                 _marginCurrentIndex = 0;
             }
+
+            var date = security.GetLastData().Time.Date;
 
             while (_marginCurrentIndex + 1 < _marginRequirementsHistory.Length &&
                 _marginRequirementsHistory[_marginCurrentIndex + 1].Date <= date )


### PR DESCRIPTION
#### Description
These properties expose the current margin requirements that can be used to compute the number of contracts manually.

#### Related Issue
Closes #4023 

#### Motivation and Context
Provide access to margin requirements of futures that change with time.

#### Requires Documentation Change
Yes. It would be interesting to show that these properties exist.

#### How Has This Been Tested?
Regression algorithm.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`