### PR TITLE
Update Oanda brokerage connection handling

### DIFF
--- a/Brokerages/DefaultConnectionHandler.cs
+++ b/Brokerages/DefaultConnectionHandler.cs
@@ -70,6 +70,11 @@ namespace QuantConnect.Brokerages
         public string ConnectionId { get; private set; }
 
         /// <summary>
+        /// Returns true if the connection has been lost
+        /// </summary>
+        public bool IsConnectionLost => _connectionLost;
+
+        /// <summary>
         /// Initializes the connection handler
         /// </summary>
         /// <param name="connectionId">The connection id</param>

--- a/Brokerages/IConnectionHandler.cs
+++ b/Brokerages/IConnectionHandler.cs
@@ -38,6 +38,11 @@ namespace QuantConnect.Brokerages
         event EventHandler ReconnectRequested;
 
         /// <summary>
+        /// Returns true if the connection has been lost
+        /// </summary>
+        bool IsConnectionLost { get; }
+
+        /// <summary>
         /// Initializes the connection handler
         /// </summary>
         /// <param name="connectionId">The connection id</param>

--- a/Brokerages/Oanda/OandaRestApiV1.cs
+++ b/Brokerages/Oanda/OandaRestApiV1.cs
@@ -627,10 +627,7 @@ namespace QuantConnect.Brokerages.Oanda
         {
             if (data.IsHeartbeat())
             {
-                lock (LockerConnectionMonitor)
-                {
-                    LastHeartbeatUtcTime = DateTime.UtcNow;
-                }
+                TransactionsConnectionHandler.KeepAlive(DateTime.UtcNow);
                 return;
             }
 
@@ -684,10 +681,7 @@ namespace QuantConnect.Brokerages.Oanda
         {
             if (data.IsHeartbeat())
             {
-                lock (LockerConnectionMonitor)
-                {
-                    LastHeartbeatUtcTime = DateTime.UtcNow;
-                }
+                PricingConnectionHandler.KeepAlive(DateTime.UtcNow);
                 return;
             }
 

--- a/Brokerages/Oanda/OandaRestApiV20.cs
+++ b/Brokerages/Oanda/OandaRestApiV20.cs
@@ -344,10 +344,7 @@ namespace QuantConnect.Brokerages.Oanda
             switch (type)
             {
                 case "HEARTBEAT":
-                    lock (LockerConnectionMonitor)
-                    {
-                        LastHeartbeatUtcTime = DateTime.UtcNow;
-                    }
+                    TransactionsConnectionHandler.KeepAlive(DateTime.UtcNow);
                     break;
 
                 case "ORDER_FILL":
@@ -396,10 +393,7 @@ namespace QuantConnect.Brokerages.Oanda
             switch (type)
             {
                 case "HEARTBEAT":
-                    lock (LockerConnectionMonitor)
-                    {
-                        LastHeartbeatUtcTime = DateTime.UtcNow;
-                    }
+                    PricingConnectionHandler.KeepAlive(DateTime.UtcNow);
                     break;
 
                 case "PRICE":


### PR DESCRIPTION

#### Description
- Fixed detection of no pricing data with two separate connection handlers
- Removed code duplication by reusing the `DefaultConnectionHandler`

#### Related Issue
Closes #4045 

#### Motivation and Context
- Data feed outages should always be detected

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Local/cloud testing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`