### PR TITLE
Changes GetLastKnownPrice Logic to Increase History Look-back

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -489,12 +489,12 @@ namespace QuantConnect.Algorithm
             var configs = SubscriptionManager.SubscriptionDataConfigService
                 .GetSubscriptionDataConfigs(security.Symbol);
 
+            var dataTimeZone = MarketHoursDatabase
+                .GetDataTimeZone(security.Symbol.ID.Market, security.Symbol, security.Symbol.SecurityType);
+
             // For speed and memory usage, use Resolution.Minute as the minimum resolution
             var resolution = (Resolution)Math.Max((int)Resolution.Minute, (int)configs.GetHighestResolution());
             var isExtendedMarketHours = configs.IsExtendedMarketHours();
-
-            var startTime = _historyRequestFactory.GetStartTimeAlgoTz(security.Symbol, 1, resolution, security.Exchange.Hours);
-            var endTime   = Time;
 
             // request QuoteBar for Options and Futures
             var dataType = typeof(BaseData);
@@ -506,43 +506,78 @@ namespace QuantConnect.Algorithm
             // Get the config with the largest resolution
             var subscriptionDataConfig = GetMatchingSubscription(security.Symbol, dataType);
 
-            // if subscription resolution is Tick, we also need to update the data type from Tick to TradeBar/QuoteBar
-            if (subscriptionDataConfig != null && subscriptionDataConfig.Resolution == Resolution.Tick)
+            TickType tickType;
+
+            if (subscriptionDataConfig == null)
             {
-                dataType = LeanData.GetDataType(resolution, subscriptionDataConfig.TickType);
-                subscriptionDataConfig = new SubscriptionDataConfig(subscriptionDataConfig, dataType, resolution: resolution);
+                dataType = typeof(TradeBar);
+                tickType = LeanData.GetCommonTickTypeForCommonDataTypes(dataType, security.Type);
+            }
+            else
+            {
+                // if subscription resolution is Tick, we also need to update the data type from Tick to TradeBar/QuoteBar
+                if (subscriptionDataConfig.Resolution == Resolution.Tick)
+                {
+                    dataType = LeanData.GetDataType(resolution, subscriptionDataConfig.TickType);
+                    subscriptionDataConfig = new SubscriptionDataConfig(subscriptionDataConfig, dataType, resolution: resolution);
+                }
+
+                dataType = subscriptionDataConfig.Type;
+                tickType = subscriptionDataConfig.TickType;
             }
 
-            var request = new HistoryRequest(
-                startTime.ConvertToUtc(_localTimeKeeper.TimeZone),
-                endTime.ConvertToUtc(_localTimeKeeper.TimeZone),
-                subscriptionDataConfig == null ? typeof(TradeBar) : subscriptionDataConfig.Type,
-                security.Symbol,
-                resolution,
-                security.Exchange.Hours,
-                MarketHoursDatabase.FromDataFolder().GetDataTimeZone(security.Symbol.ID.Market, security.Symbol, security.Symbol.SecurityType),
-                resolution,
-                isExtendedMarketHours,
-                configs.IsCustomData(),
-                configs.DataNormalizationMode(),
-                subscriptionDataConfig == null ? LeanData.GetCommonTickTypeForCommonDataTypes(typeof(TradeBar), security.Type) : subscriptionDataConfig.TickType
-            );
-
-            var history = History(new List<HistoryRequest> { request }).ToList();
-
-            if (history.Any() && history.First().Values.Any())
+            Func<int, BaseData> getLastKnownPriceForPeriods = backwardsPeriods =>
             {
-                return history.First().Values.First();
+                var startTimeUtc = _historyRequestFactory
+                    .GetStartTimeAlgoTz(security.Symbol, backwardsPeriods, resolution, security.Exchange.Hours)
+                    .ConvertToUtc(_localTimeKeeper.TimeZone);
+
+                var request = new HistoryRequest(
+                    startTimeUtc,
+                    UtcTime,
+                    dataType,
+                    security.Symbol,
+                    resolution,
+                    security.Exchange.Hours,
+                    dataTimeZone,
+                    resolution,
+                    isExtendedMarketHours,
+                    configs.IsCustomData(),
+                    configs.DataNormalizationMode(),
+                    tickType
+                );
+
+                BaseData result = null;
+                History(new List<HistoryRequest> { request })
+                    .PushThrough(bar =>
+                    {
+                        if (!bar.IsFillForward)
+                            result = bar;
+                    });
+
+                return result;
+            };
+
+            var lastKnownPrice = getLastKnownPriceForPeriods(1);
+            if (lastKnownPrice != null)
+            {
+                return lastKnownPrice;
             }
 
-            return null;
+            // If the first attempt to get the last know price returns null, it maybe the case of an iliquid security.
+            // We increase the look-back period for this case accordingly to the resolution to cover 3 trading days
+            var periods =
+                resolution == Resolution.Daily ? 3 :
+                resolution == Resolution.Hour ? 24 : 1440;
+
+            return getLastKnownPriceForPeriods(periods);
         }
 
         private IEnumerable<Slice> History(IEnumerable<HistoryRequest> requests, DateTimeZone timeZone)
         {
             var sentMessage = false;
             // filter out any universe securities that may have made it this far
-            var reqs = requests.Where(hr => !UniverseManager.ContainsKey(hr.Symbol)) .ToList();
+            var reqs = requests.Where(hr => !UniverseManager.ContainsKey(hr.Symbol)).ToList();
             foreach (var request in reqs)
             {
                 // prevent future requests

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -564,7 +564,7 @@ namespace QuantConnect.Algorithm
                 return lastKnownPrice;
             }
 
-            // If the first attempt to get the last know price returns null, it maybe the case of an iliquid security.
+            // If the first attempt to get the last know price returns null, it maybe the case of an illiquid security.
             // We increase the look-back period for this case accordingly to the resolution to cover 3 trading days
             var periods =
                 resolution == Resolution.Daily ? 3 :

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
-        public void GetLastKnownPriceOfIliquidAsset_RealData()
+        public void GetLastKnownPriceOfIlliquidAsset_RealData()
         {
             var algorithm = new QCAlgorithm();
             algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
@@ -139,7 +139,7 @@ namespace QuantConnect.Tests.Algorithm
 
 
         [Test]
-        public void GetLastKnownPriceOfIliquidAsset_TestData()
+        public void GetLastKnownPriceOfIlliquidAsset_TestData()
         {
             // Set the start date on Tuesday
             _algorithm.SetStartDate(2014, 6, 10);


### PR DESCRIPTION
#### Description
Changes `GetLastKnownPrice` logic to retry to get non-null data after a first attempt. Previously, it would return null in the first attempt and illiquid securities would not have valid data to set its market price. In the second attempt, we increase the look-back period to the equivalent of three trading days worth of data.

#### Related Issue
Closes #4041 

#### Motivation and Context
`GetLastKnownPrice` was unable to fetch non-null valid data for illiquid assets.

#### Requires Documentation Change
No. However, `GetLastKnownPrice` deserves an entry in the docs.

#### How Has This Been Tested?
New unit tests.
Live test:
```python
class GetLastKnownPriceTest(QCAlgorithm):

    def Initialize(self):
        self.SetStartDate(2020, 1, 27)  # Set Start Date
        self.SetSecurityInitializer(lambda x: x.SetMarketPrice(self.GetLastKnownPrice(x)))

        self.underlying = self.AddEquity("HOLD")
        self.underlying.SetDataNormalizationMode(DataNormalizationMode.Raw)
        self.symbol = self.underlying.Symbol

        bar = self.underlying.GetLastData()
        if bar is None:
            self.Quit('No last known data')
            return

        self.Debug(f'{self.Time} :: {self.symbol.Value}: {bar.Price} from {bar.EndTime}')
```
`master`
> 13:19:21: Quit(): No last known data

`pr`
> 13:13:49: 2020-01-30 13:13:22.833035 :: HOLD: 99.8683 from 2020-01-30 12:46:00

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`