### PR TITLE
MapFileResolver returns null if asked for delisted tickers

### DIFF
--- a/Common/Data/Auxiliary/MapFileResolver.cs
+++ b/Common/Data/Auxiliary/MapFileResolver.cs
@@ -148,6 +148,7 @@ namespace QuantConnect.Data.Auxiliary
                     {
                         // the searched date is greater than the last date in the list, return the last entry
                         indexOf = entries.Keys.Count - 1;
+                        if (indexOf == 0) return null;
                     }
                     else
                     {

--- a/Common/SecurityIdentifier.cs
+++ b/Common/SecurityIdentifier.cs
@@ -541,11 +541,13 @@ namespace QuantConnect
         {
             var resolver = mapFileProvider.Get(market);
             var mapFile = resolver.ResolveMapFile(tickerToday, mappingResolveDate ?? DateTime.Today);
-
+            
             // if we have mapping data, use the first ticker/date from there, otherwise use provided ticker and DefaultDate
-            return mapFile.Any()
-                ? Tuple.Create(mapFile.FirstTicker, mapFile.FirstDate)
-                : Tuple.Create(tickerToday, DefaultDate);
+            if (mapFile != null && mapFile.Any())
+            {
+                return Tuple.Create(mapFile.FirstTicker, mapFile.FirstDate);
+            }
+            return Tuple.Create(tickerToday, DefaultDate);
         }
 
         /// <summary>

--- a/Tests/Engine/DataFeeds/Auxiliary/MapFileResolverTests.cs
+++ b/Tests/Engine/DataFeeds/Auxiliary/MapFileResolverTests.cs
@@ -140,10 +140,25 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Auxiliary
             Assert.AreEqual("TWX", mapFile.GetMappedSymbol(new DateTime(2014, 1, 1)));
         }
 
+        [Test]
+        public void ResolvesDelistedTickerAsNull()
+        {
+            var date = new DateTime(2007, 01, 03);
+            var ticker = "AMZ";
+            Assert.IsNull(_resolver.ResolveMapFile(ticker, date));
+        }
+
         private static MapFileResolver CreateMapFileResolver()
         {
             return new MapFileResolver(new List<MapFile>
             {
+                new MapFile("amz", new List<MapFileRow>
+                {
+                    new MapFileRow(new DateTime(1998, 01, 02), "uwz"),
+                    new MapFileRow(new DateTime(1998, 09, 11), "uwz"),
+                    new MapFileRow(new DateTime(2004, 12, 31), "amz")
+                }),
+
                 // remapped
                 new MapFile("goog", new List<MapFileRow>
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Update dates logic in `MapFileResolver.ResolveMapFile(symbol, date)` for cases where asked `date` is posterior to delisting date.

Also, check for `null `at `SecurityIdentifier.GetFirstTickerAndDate`. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4049 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If we ask for a ticker for a date posterior to its delisting, `MapResolver` shouldn't return any map at all.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test was added, all tests are green.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
