### PR TITLE
Include full day of Saturday in IB scheduled server reset times

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2288,7 +2288,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             // During the Friday evening reset period, all services will be unavailable in all regions for the duration of the reset.
             if (time.DayOfWeek == DayOfWeek.Friday && timeOfDay > new TimeSpan(22, 45, 0) ||
-                time.DayOfWeek == DayOfWeek.Saturday && timeOfDay < new TimeSpan(3, 15, 0))
+                // Occasionally the disconnection due to the IB reset period might last
+                // much longer than expected during weekends (even up to the cash sync time).
+                time.DayOfWeek == DayOfWeek.Saturday)
             {
                 // Friday: 23:00 - 03:00 ET for all regions
                 result = true;


### PR DESCRIPTION

#### Description
- Update `IsWithinScheduledServerResetTimes()` to include the full date of Saturday (in NewYork time zone).

#### Related Issue
n/a

#### Motivation and Context
- Occasionally the disconnection due to the IB reset period might last much longer than expected during weekends (even up to the cash sync time).
- This causes the algorithm to be terminated at cash sync time.

#### Requires Documentation Change
n/a

#### How Has This Been Tested?
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`