### PR TITLE
Fix FiltersUniverseCorrectlyWithValidData unit test

### DIFF
--- a/Tests/Algorithm/Framework/Selection/QC500UniverseSelectionModelTests.cs
+++ b/Tests/Algorithm/Framework/Selection/QC500UniverseSelectionModelTests.cs
@@ -19,7 +19,6 @@ using QuantConnect.Algorithm;
 using QuantConnect.Algorithm.Framework.Selection;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
-using QuantConnect.Util;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -86,11 +85,12 @@ namespace QuantConnect.Tests.Algorithm.Framework.Selection
                 },
                 out algorithm,
                 out coarseCountByDateTime,
-                out fineCountByDateTime); ;
+                out fineCountByDateTime);
 
+            var months = (algorithm.EndDate - algorithm.StartDate).Days / 30;
             // Universe Changed 4 times
-            Assert.AreEqual(4, coarseCountByDateTime.Count);
-            Assert.AreEqual(4, fineCountByDateTime.Count);
+            Assert.AreEqual(months, coarseCountByDateTime.Count);
+            Assert.AreEqual(months, fineCountByDateTime.Count);
             // Universe Changed on the 1st. Coarse returned 1000 and Fine 500
             Assert.IsTrue(coarseCountByDateTime.All(kvp => kvp.Key.Day == 1 && kvp.Value == 1000));
             Assert.IsTrue(fineCountByDateTime.All(kvp => kvp.Key.Day == 1 && kvp.Value == 500));
@@ -190,7 +190,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Selection
         {
             algorithm = new QCAlgorithm();
             algorithm.SetStartDate(2019, 10, 1);
-            algorithm.SetEndDate(2020, 2, 1);
+            algorithm.SetEndDate(2020, 1, 30);
             algorithm.SetDateTime(algorithm.StartDate.AddHours(6));
 
             coarseCountByDateTime = new Dictionary<DateTime, int>();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Unit test started failing because it was using a future end-time at
the time of the merge (https://github.com/QuantConnect/Lean/pull/3980) and once it passed the end time it started failing
because it performed 1 extra selection. Note that `algorithm.SetEndDate()` adjusts end time based on now.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/4057
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix failing unit test
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running failing unit test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
