### PR TITLE
Sets the Security BuyingPowerModel Before SetLeverage is Called in BrokerageModelSecurityInitializer

### DIFF
--- a/Common/Securities/BrokerageModelSecurityInitializer.cs
+++ b/Common/Securities/BrokerageModelSecurityInitializer.cs
@@ -55,13 +55,14 @@ namespace QuantConnect.Securities
         /// <param name="security">The security to be initialized</param>
         public virtual void Initialize(Security security)
         {
-            // set leverage and models
-            security.SetLeverage(_brokerageModel.GetLeverage(security));
+            // Sets the security models
             security.FillModel = _brokerageModel.GetFillModel(security);
             security.FeeModel = _brokerageModel.GetFeeModel(security);
             security.SlippageModel = _brokerageModel.GetSlippageModel(security);
             security.SettlementModel = _brokerageModel.GetSettlementModel(security);
             security.BuyingPowerModel = _brokerageModel.GetBuyingPowerModel(security);
+            // Sets the leverage after the buying power model. Otherwise we would set the leverage of the default model. 
+            security.SetLeverage(_brokerageModel.GetLeverage(security));
 
             _securitySeeder.SeedSecurity(security);
         }


### PR DESCRIPTION
#### Description
Sets the `Security` object `BuyingPowerModel` before its `SetLeverage` method is called in the `BrokerageModelSecurityInitializer`.

Updates `BitfinexBrokerageModelTests` to test the new behavior.

#### Related Issue
Closes #4067

#### Motivation and Context
Bug fix.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests and running the algorithm from issue #4067 locally and in the cloud. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`