### PR TITLE
Implements SectorWeightingPortfolioConstructionModel

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -180,6 +180,7 @@
     <Compile Include="MarginRemainingRegressionAlgorithm.cs" />
     <Compile Include="NoMarginCallExpectedRegressionAlgorithm.cs" />
     <Compile Include="ObjectStoreExampleAlgorithm.cs" />
+    <Compile Include="SectorWeightingFrameworkAlgorithm.cs" />
     <Compile Include="OnEndOfDayAddDataRegressionAlgorithm.cs" />
     <Compile Include="PortfolioRebalanceOnCustomFuncRegressionAlgorithm.cs" />
     <Compile Include="PortfolioRebalanceOnDateRulesRegressionAlgorithm.cs" />

--- a/Algorithm.CSharp/SectorWeightingFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/SectorWeightingFrameworkAlgorithm.cs
@@ -1,0 +1,125 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Orders;
+using QuantConnect.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This example algorithm defines its own custom coarse/fine fundamental selection model
+    /// with sector weighted portfolio
+    /// </summary>
+    public class SectorWeightingFrameworkAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            // Set requested data resolution
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            SetStartDate(2014, 03, 25);
+            SetEndDate(2014, 04, 07);
+            SetCash(100000);
+
+            SetUniverseSelection(new FineFundamentalUniverseSelectionModel(SelectCoarse, SelectFine));
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, QuantConnect.Time.OneDay));
+            SetPortfolioConstruction(new SectorWeightingPortfolioConstructionModel());
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status.IsFill())
+            {
+                Debug($"Order event: {orderEvent}. Holding value: {Securities[orderEvent.Symbol].Holdings.AbsoluteHoldingsValue}");
+            }
+        }
+
+        private IEnumerable<Symbol> SelectCoarse(IEnumerable<CoarseFundamental> coarse)
+        {
+            var tickers = Time.Date < new DateTime(2014, 4, 1)
+                // IndustryTemplateCode of AAPL and IBM is N and AIG is I 
+                ? new[] { "AAPL", "AIG", "IBM" }
+                // IndustryTemplateCode of GOOG is N and BAC is B. SPY have no fundamentals
+                : new[] { "GOOG", "BAC", "SPY" };
+
+            return tickers.Select(x => QuantConnect.Symbol.Create(x, SecurityType.Equity, Market.USA));
+        }
+
+        private IEnumerable<Symbol> SelectFine(IEnumerable<FineFundamental> fine) => fine.Select(f => f.Symbol);
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "19"},
+            {"Average Win", "0.29%"},
+            {"Average Loss", "-0.05%"},
+            {"Compounding Annual Return", "-78.953%"},
+            {"Drawdown", "6.600%"},
+            {"Expectancy", "0.310"},
+            {"Net Profit", "-5.802%"},
+            {"Sharpe Ratio", "-5.76"},
+            {"Loss Rate", "82%"},
+            {"Win Rate", "18%"},
+            {"Profit-Loss Ratio", "6.21"},
+            {"Alpha", "-1.233"},
+            {"Beta", "-0.008"},
+            {"Annual Standard Deviation", "0.214"},
+            {"Annual Variance", "0.046"},
+            {"Information Ratio", "-4.235"},
+            {"Tracking Error", "0.237"},
+            {"Treynor Ratio", "147.325"},
+            {"Total Fees", "$73.27"},
+            {"Fitness Score", "0.022"},
+            {"Kelly Criterion Estimate", "-11.683"},
+            {"Kelly Criterion Probability Value", "0.792"},
+            {"Sortino Ratio", "-3.782"},
+            {"Return Over Maximum Drawdown", "-11.953"},
+            {"Portfolio Turnover", "0.337"},
+            {"Total Insights Generated", "24"},
+            {"Total Insights Closed", "22"},
+            {"Total Insights Analysis Completed", "22"},
+            {"Long Insight Count", "24"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$-1906811"},
+            {"Total Accumulated Estimated Alpha Value", "$-900438.4"},
+            {"Mean Population Estimated Insight Value", "$-40929.02"},
+            {"Mean Population Direction", "27.2727%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "57.4228%"},
+            {"Rolling Averaged Population Magnitude", "0%"}
+        };
+    }
+}

--- a/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.cs
@@ -1,0 +1,170 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.Framework.Portfolio
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IPortfolioConstructionModel"/> that generates percent targets based on the
+    /// <see cref="CompanyReference.IndustryTemplateCode"/>. 
+    /// The target percent holdings of each sector is 1/S where S is the number of sectors and
+    /// the target percent holdings of each security is 1/N where N is the number of securities of each sector.
+    /// For insights of direction <see cref="InsightDirection.Up"/>, long targets are returned and for insights of direction
+    /// <see cref="InsightDirection.Down"/>, short targets are returned.
+    /// It will ignore <see cref="Insight"/> that have no <see cref="CompanyReference.IndustryTemplateCode"/> value.
+    /// </summary>
+    public class SectorWeightingPortfolioConstructionModel : EqualWeightingPortfolioConstructionModel
+    {
+        private readonly Dictionary<Symbol, string> _sectorCodeBySymbol = new Dictionary<Symbol, string>();
+
+        /// <summary>
+        /// Initialize a new instance of <see cref="SectorWeightingPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="rebalancingFunc">For a given algorithm UTC DateTime returns the next expected rebalance time</param>
+        public SectorWeightingPortfolioConstructionModel(Func<DateTime, DateTime> rebalancingFunc)
+            : base(rebalancingFunc)
+        {
+        }
+
+        /// <summary>
+        /// Initialize a new instance of <see cref="SectorWeightingPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="timeSpan">Rebalancing frequency</param>
+        public SectorWeightingPortfolioConstructionModel(TimeSpan timeSpan)
+            : base(timeSpan)
+        {
+        }
+
+        /// <summary>
+        /// Initialize a new instance of <see cref="SectorWeightingPortfolioConstructionModel"/>
+        /// </summary>
+        /// <param name="resolution">Rebalancing frequency</param>
+        public SectorWeightingPortfolioConstructionModel(Resolution resolution = Resolution.Daily)
+            : base(resolution)
+        {
+        }
+
+        /// <summary>
+        /// Method that will determine if the portfolio construction model should create a
+        /// target for this insight
+        /// </summary>
+        /// <param name="insight">The insight to create a target for</param>
+        /// <returns>True if the portfolio should create a target for the insight</returns>
+        public override bool ShouldCreateTargetForInsight(Insight insight)
+        {
+            return _sectorCodeBySymbol.ContainsKey(insight.Symbol);
+        }
+
+        /// <summary>
+        /// Will determine the target percent for each insight
+        /// </summary>
+        /// <param name="activeInsights">The active insights to generate a target for</param>
+        /// <returns>A target percent for each insight</returns>
+        public override Dictionary<Insight, double> DetermineTargetPercent(ICollection<Insight> activeInsights)
+        {
+            var result = new Dictionary<Insight, double>();
+
+            var insightBySectorCode = new Dictionary<string, List<Insight>>();
+            var sectorsCount = 0;
+
+            foreach (var insight in activeInsights)
+            {
+                if (insight.Direction == InsightDirection.Flat)
+                {
+                    result[insight] = 0;
+                    continue;
+                }
+
+                List<Insight> insights;
+                var sectorCode = _sectorCodeBySymbol[insight.Symbol];
+                if (insightBySectorCode.TryGetValue(sectorCode, out insights))
+                {
+                    insights.Add(insight);
+                }
+                else
+                {
+                    insightBySectorCode[sectorCode] = new List<Insight> { insight };
+                    sectorsCount++;
+                }
+            }
+
+            // give equal weighting to each sector
+            var sectorPercent = sectorsCount == 0 ? 0 : 1m / sectorsCount;
+
+            foreach (var kvp in insightBySectorCode)
+            {
+                var insights = kvp.Value;
+
+                // give equal weighting to each security
+                var count = insights.Count();
+                var percent = count == 0 ? 0 : sectorPercent / count;
+
+                foreach (var insight in insights)
+                {
+                    result[insight] = (double)((int)insight.Direction * percent);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Event fired each time the we add/remove securities from the data feed
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance that experienced the change in securities</param>
+        /// <param name="changes">The security additions and removals from the algorithm</param>
+        public override void OnSecuritiesChanged(QCAlgorithm algorithm, SecurityChanges changes)
+        {
+            foreach (var security in changes.RemovedSecurities)
+            {
+                // Removes the symbol from the _sectorCodeBySymbol dictionary
+                // since we cannot emit PortfolioTarget for removed securities
+                var symbol = security.Symbol;
+                if (_sectorCodeBySymbol.ContainsKey(symbol))
+                {
+                    _sectorCodeBySymbol.Remove(symbol);
+                }
+            }
+
+            foreach (var security in changes.AddedSecurities)
+            {
+                var sectorCode = GetSectorCode(security);
+                if (!string.IsNullOrEmpty(sectorCode))
+                {
+                    _sectorCodeBySymbol[security.Symbol] = sectorCode;
+                }
+            }
+            base.OnSecuritiesChanged(algorithm, changes);
+        }
+
+        /// <summary>
+        /// Gets the sector code
+        /// </summary>
+        /// <param name="security">The security to create a sector code for</param>
+        /// <returns>The value of the sector code for the security</returns>
+        /// <remarks>Other sectors can be defined using <see cref="AssetClassification"/></remarks>
+        protected virtual string GetSectorCode(Security security)
+        {
+            return security.Fundamentals?.CompanyReference?.IndustryTemplateCode;
+        }
+    }
+}

--- a/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
     /// the target percent holdings of each security is 1/N where N is the number of securities of each sector.
     /// For insights of direction <see cref="InsightDirection.Up"/>, long targets are returned and for insights of direction
     /// <see cref="InsightDirection.Down"/>, short targets are returned.
-    /// It will ignore <see cref="Insight"/> that have no <see cref="CompanyReference.IndustryTemplateCode"/> value.
+    /// It will ignore <see cref="Insight"/> for symbols that have no <see cref="CompanyReference.IndustryTemplateCode"/> value.
     /// </summary>
     public class SectorWeightingPortfolioConstructionModel : EqualWeightingPortfolioConstructionModel
     {
@@ -123,7 +123,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             var result = new Dictionary<Insight, double>();
 
             var insightBySectorCode = new Dictionary<string, List<Insight>>();
-            var sectorsCount = 0;
 
             foreach (var insight in activeInsights)
             {
@@ -142,12 +141,11 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 else
                 {
                     insightBySectorCode[sectorCode] = new List<Insight> { insight };
-                    sectorsCount++;
                 }
             }
 
             // give equal weighting to each sector
-            var sectorPercent = sectorsCount == 0 ? 0 : 1m / sectorsCount;
+            var sectorPercent = insightBySectorCode.Count == 0 ? 0 : 1m / insightBySectorCode.Count;
 
             foreach (var kvp in insightBySectorCode)
             {

--- a/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.py
@@ -32,8 +32,11 @@ class SectorWeightingPortfolioConstructionModel(EqualWeightingPortfolioConstruct
     def __init__(self, rebalancingParam = Resolution.Daily):
         '''Initialize a new instance of InsightWeightingPortfolioConstructionModel
         Args:
-            rebalancingParam: Rebalancing parameter. If it is a timedelta or Resolution, it will be converted into a function.
-                              The function returns the next expected rebalance time for a given algorithm UTC DateTime'''
+            rebalancingParam: Rebalancing parameter. If it is a timedelta, date rules or Resolution, it will be converted into a function.
+                              If None will be ignored.
+                              The function returns the next expected rebalance time for a given algorithm UTC DateTime.
+                              The function returns null if unknown, in which case the function will be called again in the
+                              next loop. Returning current time will trigger rebalance.'''
         super().__init__(rebalancingParam)
         self.sectorCodeBySymbol = dict()
 

--- a/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.py
@@ -27,7 +27,7 @@ class SectorWeightingPortfolioConstructionModel(EqualWeightingPortfolioConstruct
    the target percent holdings of each security is 1/N where N is the number of securities of each sector.
    For insights of direction InsightDirection.Up, long targets are returned and for insights of direction
    InsightDirection.Down, short targets are returned.
-   It will ignore Insight that have no CompanyReference.IndustryTemplateCode'''
+   It will ignore Insight for symbols that have no CompanyReference.IndustryTemplateCode'''
 
     def __init__(self, rebalancingParam = Resolution.Daily):
         '''Initialize a new instance of InsightWeightingPortfolioConstructionModel
@@ -54,7 +54,6 @@ class SectorWeightingPortfolioConstructionModel(EqualWeightingPortfolioConstruct
         result = dict()
 
         insightBySectorCode = dict()
-        sectorsCount = 0
 
         for insight in activeInsights:
             if insight.Direction == InsightDirection.Flat:
@@ -64,15 +63,11 @@ class SectorWeightingPortfolioConstructionModel(EqualWeightingPortfolioConstruct
             sectorCode = self.sectorCodeBySymbol.get(insight.Symbol)
             insights = insightBySectorCode.pop(sectorCode, list())
 
-            # Count sectors that any insight is not flat
-            if not insights:
-                sectorsCount += 1
-
             insights.append(insight)
             insightBySectorCode[sectorCode] = insights
 
         # give equal weighting to each sector
-        sectorPercent = 0 if sectorsCount == 0 else 1.0 / sectorsCount
+        sectorPercent = 0 if len(insightBySectorCode) == 0 else 1.0 / len(insightBySectorCode)
 
         for _, insights in insightBySectorCode.items():
             # give equal weighting to each security

--- a/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/SectorWeightingPortfolioConstructionModel.py
@@ -1,0 +1,110 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm.Framework")
+
+from QuantConnect import Resolution
+from QuantConnect.Algorithm.Framework.Alphas import *
+from EqualWeightingPortfolioConstructionModel import EqualWeightingPortfolioConstructionModel
+from itertools import groupby
+
+class SectorWeightingPortfolioConstructionModel(EqualWeightingPortfolioConstructionModel):
+    '''Provides an implementation of IPortfolioConstructionModel that
+   generates percent targets based on the CompanyReference.IndustryTemplateCode.
+   The target percent holdings of each sector is 1/S where S is the number of sectors and
+   the target percent holdings of each security is 1/N where N is the number of securities of each sector.
+   For insights of direction InsightDirection.Up, long targets are returned and for insights of direction
+   InsightDirection.Down, short targets are returned.
+   It will ignore Insight that have no CompanyReference.IndustryTemplateCode'''
+
+    def __init__(self, rebalancingParam = Resolution.Daily):
+        '''Initialize a new instance of InsightWeightingPortfolioConstructionModel
+        Args:
+            rebalancingParam: Rebalancing parameter. If it is a timedelta or Resolution, it will be converted into a function.
+                              The function returns the next expected rebalance time for a given algorithm UTC DateTime'''
+        super().__init__(rebalancingParam)
+        self.sectorCodeBySymbol = dict()
+
+    def ShouldCreateTargetForInsight(self, insight):
+        '''Method that will determine if the portfolio construction model should create a
+        target for this insight
+        Args:
+            insight: The insight to create a target for'''
+        return insight.Symbol in self.sectorCodeBySymbol
+
+    def DetermineTargetPercent(self, activeInsights):
+        '''Will determine the target percent for each insight
+        Args:
+            activeInsights: The active insights to generate a target for'''
+        result = dict()
+
+        insightBySectorCode = dict()
+        sectorsCount = 0
+
+        for insight in activeInsights:
+            if insight.Direction == InsightDirection.Flat:
+                result[insight] = 0
+                continue
+
+            sectorCode = self.sectorCodeBySymbol.get(insight.Symbol)
+            insights = insightBySectorCode.pop(sectorCode, list())
+
+            # Count sectors that any insight is not flat
+            if not insights:
+                sectorsCount += 1
+
+            insights.append(insight)
+            insightBySectorCode[sectorCode] = insights
+
+        # give equal weighting to each sector
+        sectorPercent = 0 if sectorsCount == 0 else 1.0 / sectorsCount
+
+        for _, insights in insightBySectorCode.items():
+            # give equal weighting to each security
+            count = len(insights)
+            percent = 0 if count == 0 else sectorPercent / count
+            for insight in insights:
+                result[insight] = insight.Direction * percent
+
+        return result
+
+    def OnSecuritiesChanged(self, algorithm, changes):
+        '''Event fired each time the we add/remove securities from the data feed
+        Args:
+            algorithm: The algorithm instance that experienced the change in securities
+            changes: The security additions and removals from the algorithm'''
+        for security in changes.RemovedSecurities:
+            # Removes the symbol from the self.sectorCodeBySymbol dictionary
+            # since we cannot emit PortfolioTarget for removed securities
+            self.sectorCodeBySymbol.pop(security.Symbol, None)
+
+        for security in changes.AddedSecurities:
+            sectorCode = self.GetSectorCode(security)
+            if sectorCode:
+                self.sectorCodeBySymbol[security.Symbol] = sectorCode
+
+        super().OnSecuritiesChanged(algorithm, changes)
+
+    def GetSectorCode(self, security):
+        '''Gets the sector code
+        Args:
+            security: The security to create a sector code for
+        Returns:
+            The value of the sector code for the security
+        Remarks:
+            Other sectors can be defined using AssetClassification'''
+        fundamentals = security.Fundamentals
+        companyReference = security.Fundamentals.CompanyReference if fundamentals else None
+        return companyReference.IndustryTemplateCode if companyReference else None

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -125,6 +125,7 @@
     <Compile Include="NotifiedSecurityChanges.cs" />
     <Compile Include="Portfolio\BlackLittermanOptimizationPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\ConfidenceWeightedPortfolioConstructionModel.cs" />
+    <Compile Include="Portfolio\SectorWeightingPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\InsightWeightingPortfolioConstructionModel.cs" />
     <Compile Include="Portfolio\UnconstrainedMeanVariancePortfolioOptimizer.cs" />
     <Compile Include="Portfolio\MaximumSharpeRatioPortfolioOptimizer.cs" />
@@ -182,6 +183,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Portfolio\AccumulativeInsightPortfolioConstructionModel.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Portfolio\SectorWeightingPortfolioConstructionModel.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Portfolio\InsightWeightingPortfolioConstructionModel.py">

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -92,6 +92,7 @@
     <Content Include="LiveFeaturesAlgorithm.py" />
     <Content Include="PortfolioRebalanceOnCustomFuncRegressionAlgorithm.py" />
     <Content Include="PortfolioRebalanceOnDateRulesRegressionAlgorithm.py" />
+    <Content Include="SectorWeightingFrameworkAlgorithm.py" />
     <Content Include="SetHoldingsMultipleTargetsRegressionAlgorithm.py" />
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />

--- a/Algorithm.Python/SectorWeightingFrameworkAlgorithm.py
+++ b/Algorithm.Python/SectorWeightingFrameworkAlgorithm.py
@@ -40,8 +40,8 @@ class SectorWeightingFrameworkAlgorithm(QCAlgorithm):
         # Set requested data resolution
         self.UniverseSettings.Resolution = Resolution.Daily
 
-        self.SetStartDate(2014, 3, 25)
-        self.SetEndDate(2014, 4, 7)
+        self.SetStartDate(2014, 4, 3)
+        self.SetEndDate(2014, 4, 6)
         self.SetCash(100000)
 
         # set algorithm framework models
@@ -55,7 +55,7 @@ class SectorWeightingFrameworkAlgorithm(QCAlgorithm):
 
     def SelectCoarse(self, coarse):
         # IndustryTemplateCode of AAPL, IBM and GOOG is N, AIG is I, BAC is B. SPY have no fundamentals
-        tickers = ["AAPL", "AIG", "IBM"] if self.Time.date() < date(2014, 4, 1) else [ "GOOG", "BAC", "SPY" ]
+        tickers = ["AAPL", "AIG", "IBM"] if self.Time.date() < date(2014, 4, 4) else [ "GOOG", "BAC", "SPY" ]
         return [Symbol.Create(x, SecurityType.Equity, Market.USA) for x in tickers]
 
     def SelectFine(self, fine):

--- a/Algorithm.Python/SectorWeightingFrameworkAlgorithm.py
+++ b/Algorithm.Python/SectorWeightingFrameworkAlgorithm.py
@@ -1,0 +1,62 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Algorithm.Framework")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Orders import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Algorithm.Framework.Alphas import *
+from QuantConnect.Algorithm.Framework.Selection import *
+from Portfolio.SectorWeightingPortfolioConstructionModel import SectorWeightingPortfolioConstructionModel
+from datetime import date, timedelta
+
+### <summary>
+### This example algorithm defines its own custom coarse/fine fundamental selection model
+### with sector weighted portfolio.
+### </summary>
+class SectorWeightingFrameworkAlgorithm(QCAlgorithm):
+    '''This example algorithm defines its own custom coarse/fine fundamental selection model
+    with sector weighted portfolio.'''
+
+    def Initialize(self):
+
+        # Set requested data resolution
+        self.UniverseSettings.Resolution = Resolution.Daily
+
+        self.SetStartDate(2014, 3, 25)
+        self.SetEndDate(2014, 4, 7)
+        self.SetCash(100000)
+
+        # set algorithm framework models
+        self.SetUniverseSelection(FineFundamentalUniverseSelectionModel(self.SelectCoarse, self.SelectFine))
+        self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(1)))
+        self.SetPortfolioConstruction(SectorWeightingPortfolioConstructionModel())
+
+    def OnOrderEvent(self, orderEvent):
+        if orderEvent.Status == OrderStatus.Filled:
+            self.Debug(f"Order event: {orderEvent}. Holding value: {self.Securities[orderEvent.Symbol].Holdings.AbsoluteHoldingsValue}")
+
+    def SelectCoarse(self, coarse):
+        # IndustryTemplateCode of AAPL, IBM and GOOG is N, AIG is I, BAC is B. SPY have no fundamentals
+        tickers = ["AAPL", "AIG", "IBM"] if self.Time.date() < date(2014, 4, 1) else [ "GOOG", "BAC", "SPY" ]
+        return [Symbol.Create(x, SecurityType.Equity, Market.USA) for x in tickers]
+
+    def SelectFine(self, fine):
+        return [f.Symbol for f in fine]

--- a/Tests/Algorithm/Framework/Portfolio/BaseWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BaseWeightingPortfolioConstructionModelTests.cs
@@ -1,0 +1,242 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Equity;
+using QuantConnect.Tests.Engine.DataFeeds;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
+{
+    [TestFixture]
+    public abstract class BaseWeightingPortfolioConstructionModelTests
+    {
+        private const double _weight = 0.01;
+
+        protected decimal StartingCash => 100000;
+
+        protected QCAlgorithm Algorithm { get; set; }
+
+        public virtual double? Weight => Algorithm.Securities.Count == 0 ? default(double) : 1d / Algorithm.Securities.Count;
+
+        [TestFixtureSetUp]
+        public virtual void SetUp()
+        {
+            Algorithm = new QCAlgorithm();
+            Algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(Algorithm));
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void AutomaticallyRemoveInvestedWithoutNewInsights(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            // Let's create a position for SPY
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, Algorithm.UtcTime) };
+
+            foreach (var target in Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights))
+            {
+                var holding = Algorithm.Portfolio[target.Symbol];
+                holding.SetHoldings(holding.Price, target.Quantity);
+                Algorithm.Portfolio.SetCash(StartingCash - holding.HoldingsValue);
+            }
+
+            SetUtcTime(Algorithm.UtcTime.AddDays(2));
+
+            var expectedTargets = new List<IPortfolioTarget> { new PortfolioTarget(Symbols.SPY, 0) };
+
+            // Create target from an empty insights array
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, new Insight[0]);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void DelistedSecurityEmitsFlatTargetWithoutNewInsights(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, Algorithm.UtcTime) };
+            var targets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights).ToList();
+            Assert.AreEqual(1, targets.Count);
+
+            var changes = SecurityChanges.Removed(Algorithm.Securities[Symbols.SPY]);
+            Algorithm.PortfolioConstruction.OnSecuritiesChanged(Algorithm, changes);
+
+            var expectedTargets = new List<IPortfolioTarget> { new PortfolioTarget(Symbols.SPY, 0) };
+
+            // Create target from an empty insights array
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, new Insight[0]);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void DoesNotReturnTargetsIfSecurityPriceIsZero(Language language)
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+            algorithm.AddEquity(Symbols.SPY.Value);
+            algorithm.SetDateTime(DateTime.MinValue.ConvertToUtc(Algorithm.TimeZone));
+
+            SetPortfolioConstruction(language);
+
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, algorithm.UtcTime) };
+            var actualTargets = algorithm.PortfolioConstruction.CreateTargets(algorithm, insights);
+
+            Assert.AreEqual(0, actualTargets.Count());
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void DoesNotThrowWithAlternativeOverloads(Language language)
+        {
+            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, Resolution.Minute));
+            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, TimeSpan.FromDays(1)));
+            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, Expiry.EndOfWeek));
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void EmptyInsightsReturnsEmptyTargets(Language language)
+        {
+            SetPortfolioConstruction(language);
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, new Insight[0]);
+            Assert.AreEqual(0, actualTargets.Count());
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void LongTermInsightPreservesPosition(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            // First emit long term insight
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, Algorithm.UtcTime) };
+            var targets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights).ToList();
+            Assert.AreEqual(1, targets.Count);
+
+            // One minute later, emits short term insight
+            SetUtcTime(Algorithm.UtcTime.AddMinutes(1));
+            insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, Algorithm.UtcTime, Time.OneMinute) };
+            targets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights).ToList();
+            Assert.AreEqual(1, targets.Count);
+
+            // One minute later, emit empty insights array
+            SetUtcTime(Algorithm.UtcTime.AddMinutes(1.1));
+
+            var expectedTargets = GetTargetsForSPY();
+
+            // Create target from an empty insights array
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, new Insight[0]);
+
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public abstract void AutomaticallyRemoveInvestedWithNewInsights(Language language, InsightDirection direction);
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public abstract void DelistedSecurityEmitsFlatTargetWithNewInsights(Language language, InsightDirection direction);
+
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public abstract void FlatDirectionNotAccountedToAllocation(Language language, InsightDirection direction);
+
+        public abstract IPortfolioConstructionModel GetPortfolioConstructionModel(Language language, dynamic paramenter = null);
+
+        public abstract Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? weight = _weight);
+
+        public void AssertTargets(IEnumerable<IPortfolioTarget> expectedTargets, IEnumerable<IPortfolioTarget> actualTargets)
+        {
+            var list = actualTargets.ToList();
+            Assert.AreEqual(expectedTargets.Count(), list.Count);
+
+            foreach (var expected in expectedTargets)
+            {
+                var actual = list.FirstOrDefault(x => x.Symbol == expected.Symbol);
+                Assert.IsNotNull(actual);
+                Assert.AreEqual(expected.Quantity, actual.Quantity);
+            }
+        }
+
+        protected Security GetSecurity(Symbol symbol) =>
+            new Equity(
+                symbol,
+                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                new Cash(Currencies.USD, 0, 1),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+                );
+
+        public virtual List<IPortfolioTarget> GetTargetsForSPY()
+        {
+            return new List<IPortfolioTarget> { PortfolioTarget.Percent(Algorithm, Symbols.SPY, -1m) };
+        }
+
+        protected void SetPortfolioConstruction(Language language, dynamic paramenter = null)
+        {
+            var model = GetPortfolioConstructionModel(language, paramenter ?? Resolution.Daily);
+            Algorithm.SetPortfolioConstruction(model);
+
+            foreach (var kvp in Algorithm.Portfolio)
+            {
+                kvp.Value.SetHoldings(kvp.Value.Price, 0);
+            }
+            Algorithm.Portfolio.SetCash(StartingCash);
+            SetUtcTime(new DateTime(2018, 7, 31));
+
+            var changes = SecurityChanges.Added(Algorithm.Securities.Values.ToArray());
+            Algorithm.PortfolioConstruction.OnSecuritiesChanged(Algorithm, changes);
+        }
+
+        protected void SetUtcTime(DateTime dateTime) => Algorithm.SetDateTime(dateTime.ConvertToUtc(Algorithm.TimeZone));
+    }
+}

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using NodaTime;
 using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Algorithm.Framework.Alphas;
@@ -21,27 +20,23 @@ using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
-using QuantConnect.Securities.Equity;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using QuantConnect.Algorithm;
-using QuantConnect.Orders.Fees;
-using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 {
     [TestFixture]
-    public class EqualWeightingPortfolioConstructionModelTests
+    public class EqualWeightingPortfolioConstructionModelTests : BaseWeightingPortfolioConstructionModelTests
     {
-        private QCAlgorithm _algorithm;
-        private const decimal _startingCash = 100000;
+        private const double _weight = 0.01;
+
+        public override double? Weight => Algorithm.Securities.Count == 0 ? default(double) : 1d / Algorithm.Securities.Count;
 
         [TestFixtureSetUp]
-        public void SetUp()
+        public override void SetUp()
         {
-            _algorithm = new QCAlgorithm();
-            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
+            base.SetUp();
 
             var prices = new Dictionary<Symbol, decimal>
             {
@@ -54,203 +49,49 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             {
                 var symbol = kvp.Key;
                 var security = GetSecurity(symbol);
-                security.SetMarketPrice(new Tick(_algorithm.Time, symbol, kvp.Value, kvp.Value));
-                _algorithm.Securities.Add(symbol, security);
+                security.SetMarketPrice(new Tick(Algorithm.Time, symbol, kvp.Value, kvp.Value));
+                Algorithm.Securities.Add(symbol, security);
             }
         }
 
         [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void EmptyInsightsReturnsEmptyTargets(Language language)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
-
-            Assert.AreEqual(0, actualTargets.Count());
-        }
-
-        [Test]
         [TestCase(Language.CSharp, InsightDirection.Up)]
         [TestCase(Language.CSharp, InsightDirection.Down)]
         [TestCase(Language.CSharp, InsightDirection.Flat)]
         [TestCase(Language.Python, InsightDirection.Up)]
         [TestCase(Language.Python, InsightDirection.Down)]
         [TestCase(Language.Python, InsightDirection.Flat)]
-        public void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction)
+        public override void AutomaticallyRemoveInvestedWithNewInsights(Language language, InsightDirection direction)
         {
-            SetPortfolioConstruction(language, _algorithm);
-
-            // Equity will be divided by all securities
-            var amount = _algorithm.Portfolio.TotalPortfolioValue / _algorithm.Securities.Count;
-            var expectedTargets = _algorithm.Securities
-                .Select(x => new PortfolioTarget(x.Key, (int)direction
-                                                        * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
-                                                                     / x.Value.Price)));
-
-            var insights = _algorithm.Securities.Keys.Select(x => GetInsight(x, direction, _algorithm.UtcTime));
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [TestCase(Language.CSharp, InsightDirection.Up)]
-        [TestCase(Language.CSharp, InsightDirection.Down)]
-        [TestCase(Language.CSharp, InsightDirection.Flat)]
-        [TestCase(Language.Python, InsightDirection.Up)]
-        [TestCase(Language.Python, InsightDirection.Down)]
-        [TestCase(Language.Python, InsightDirection.Flat)]
-        public void FlatDirectionNotAccountedToAllocation(Language language, InsightDirection direction)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            // Modifying fee model for a constant one so numbers are simplified
-            foreach (var security in _algorithm.Securities)
-            {
-                security.Value.FeeModel = new ConstantFeeModel(1);
-            }
-
-            // Equity, minus $1 for fees, will be divided by all securities minus 1, since its insight will have flat direction
-            var amount = (_algorithm.Portfolio.TotalPortfolioValue - 1 * (_algorithm.Securities.Count - 1))
-                         / (_algorithm.Securities.Count - 1);
-            var expectedTargets = _algorithm.Securities.Select(x =>
-            {
-                // Expected target quantity for SPY is zero, since its insight will have flat direction
-                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction
-                                                          * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
-                                                                       / x.Value.Price);
-                return new PortfolioTarget(x.Key, quantity);
-            });
-
-            var insights = _algorithm.Securities.Keys.Select(x =>
-            {
-                // SPY insight direction is flat
-                var actualDirection = x.Value == "SPY" ? InsightDirection.Flat : direction;
-                return GetInsight(x, actualDirection, _algorithm.UtcTime);
-            });
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [Test]
-        [TestCase(Language.CSharp, InsightDirection.Up)]
-        [TestCase(Language.CSharp, InsightDirection.Down)]
-        [TestCase(Language.CSharp, InsightDirection.Flat)]
-        [TestCase(Language.Python, InsightDirection.Up)]
-        [TestCase(Language.Python, InsightDirection.Down)]
-        [TestCase(Language.Python, InsightDirection.Flat)]
-        public void AutomaticallyRemoveInvestedWithNewInsights(Language language, InsightDirection direction)
-        {
-            SetPortfolioConstruction(language, _algorithm);
+            SetPortfolioConstruction(language);
 
             // Let's create a position for SPY
-            var insights = new[] { GetInsight(Symbols.SPY, direction, _algorithm.UtcTime) };
+            var insights = new[] { GetInsight(Symbols.SPY, direction, Algorithm.UtcTime) };
 
-            foreach (var target in _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights))
+            foreach (var target in Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights))
             {
-                var holding = _algorithm.Portfolio[target.Symbol];
+                var holding = Algorithm.Portfolio[target.Symbol];
                 holding.SetHoldings(holding.Price, target.Quantity);
-                _algorithm.Portfolio.SetCash(_startingCash - holding.HoldingsValue);
+                Algorithm.Portfolio.SetCash(StartingCash - holding.HoldingsValue);
             }
 
-            SetUtcTime(_algorithm.UtcTime.AddDays(2));
+            SetUtcTime(Algorithm.UtcTime.AddDays(2));
 
             // Equity will be divided by all securities minus 1, since SPY is already invested and we want to remove it
-            var amount = _algorithm.Portfolio.TotalPortfolioValue / (_algorithm.Securities.Count - 1);
-            var expectedTargets = _algorithm.Securities.Select(x =>
+            var amount = Algorithm.Portfolio.TotalPortfolioValue / (decimal)(1 / Weight - 1) *
+                (1 - Algorithm.Settings.FreePortfolioValuePercentage);
+            var expectedTargets = Algorithm.Securities.Select(x =>
             {
                 // Expected target quantity for SPY is zero, since it will be removed
-                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction
-                                                          * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
-                                                                       / x.Value.Price);
+                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction * Math.Floor(amount / x.Value.Price);
                 return new PortfolioTarget(x.Key, quantity);
             });
 
             // Do no include SPY in the insights
-            insights = _algorithm.Securities.Keys.Where(x=> x.Value != "SPY")
-                .Select(x => GetInsight(x, direction, _algorithm.UtcTime)).ToArray();
+            insights = Algorithm.Securities.Keys.Where(x => x.Value != "SPY")
+                .Select(x => GetInsight(x, direction, Algorithm.UtcTime)).ToArray();
 
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void AutomaticallyRemoveInvestedWithoutNewInsights(Language language)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            // Let's create a position for SPY
-            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, _algorithm.UtcTime) };
-
-            foreach (var target in _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights))
-            {
-                var holding = _algorithm.Portfolio[target.Symbol];
-                holding.SetHoldings(holding.Price, target.Quantity);
-                _algorithm.Portfolio.SetCash(_startingCash - holding.HoldingsValue);
-            }
-
-            SetUtcTime(_algorithm.UtcTime.AddDays(2));
-
-            var expectedTargets = new List<IPortfolioTarget> { new PortfolioTarget(Symbols.SPY, 0) };
-
-            // Create target from an empty insights array
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void LongTermInsightPreservesPosition(Language language)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            // First emit long term insight
-            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
-            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
-            Assert.AreEqual(1, targets.Count);
-
-            // One minute later, emits short term insight
-            SetUtcTime(_algorithm.UtcTime.AddMinutes(1));
-            insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, _algorithm.UtcTime, Time.OneMinute) };
-            targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
-            Assert.AreEqual(1, targets.Count);
-
-            // One minute later, emit empty insights array
-            SetUtcTime(_algorithm.UtcTime.AddMinutes(1.1));
-
-            var expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, -1m) };
-
-            // Create target from an empty insights array
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void DelistedSecurityEmitsFlatTargetWithoutNewInsights(Language language)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
-            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
-            Assert.AreEqual(1, targets.Count);
-
-            var changes = SecurityChanges.Removed(_algorithm.Securities[Symbols.SPY]);
-            _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
-
-            var expectedTargets = new List<IPortfolioTarget> { new PortfolioTarget(Symbols.SPY, 0) };
-
-            // Create target from an empty insights array
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights);
 
             AssertTargets(expectedTargets, actualTargets);
         }
@@ -262,132 +103,116 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python, InsightDirection.Up)]
         [TestCase(Language.Python, InsightDirection.Down)]
         [TestCase(Language.Python, InsightDirection.Flat)]
-        public void DelistedSecurityEmitsFlatTargetWithNewInsights(Language language, InsightDirection direction)
+        public override void DelistedSecurityEmitsFlatTargetWithNewInsights(Language language, InsightDirection direction)
         {
-            SetPortfolioConstruction(language, _algorithm);
+            SetPortfolioConstruction(language);
 
-            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
-            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, Algorithm.UtcTime) };
+            var targets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights).ToList();
             Assert.AreEqual(1, targets.Count);
 
             // Removing SPY should clear the key in the insight collection
-            var changes = SecurityChanges.Removed(_algorithm.Securities[Symbols.SPY]);
-            _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
+            var changes = SecurityChanges.Removed(Algorithm.Securities[Symbols.SPY]);
+            Algorithm.PortfolioConstruction.OnSecuritiesChanged(Algorithm, changes);
 
             // Equity will be divided by all securities minus 1, since SPY is already invested and we want to remove it
-            var amount = _algorithm.Portfolio.TotalPortfolioValue / (_algorithm.Securities.Count - 1);
-            var expectedTargets = _algorithm.Securities.Select(x =>
+            var amount = Algorithm.Portfolio.TotalPortfolioValue / (decimal)(1 / Weight - 1) *
+                (1 - Algorithm.Settings.FreePortfolioValuePercentage);
+
+            var expectedTargets = Algorithm.Securities.Select(x =>
             {
                 // Expected target quantity for SPY is zero, since it will be removed
-                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction
-                                                          * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
-                                                                       / x.Value.Price);
+                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction * Math.Floor(amount / x.Value.Price);
                 return new PortfolioTarget(x.Key, quantity);
             });
 
             // Do no include SPY in the insights
-            insights = _algorithm.Securities.Keys.Where(x => x.Value != "SPY")
-                .Select(x => GetInsight(x, direction, _algorithm.UtcTime)).ToArray();
+            insights = Algorithm.Securities.Keys.Where(x => x.Value != "SPY")
+                .Select(x => GetInsight(x, direction, Algorithm.UtcTime)).ToArray();
 
             // Create target from an empty insights array
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights);
 
             AssertTargets(expectedTargets, actualTargets);
         }
 
-        private void AssertTargets(IEnumerable<IPortfolioTarget> expectedTargets, IEnumerable<IPortfolioTarget> actualTargets)
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public override void FlatDirectionNotAccountedToAllocation(Language language, InsightDirection direction)
         {
-            var list = actualTargets.ToList();
-            Assert.AreEqual(expectedTargets.Count(), list.Count);
+            SetPortfolioConstruction(language);
 
-            foreach (var expected in expectedTargets)
+            // Equity, minus $1 for fees, will be divided by all securities minus 1, since its insight will have flat direction
+            var amount = (Algorithm.Portfolio.TotalPortfolioValue - 1 * (Algorithm.Securities.Count - 1)) * 1 /
+                         (decimal)((1 / Weight) - 1) * (1 - Algorithm.Settings.FreePortfolioValuePercentage);
+
+            var expectedTargets = Algorithm.Securities.Select(x =>
             {
-                var actual = list.FirstOrDefault(x => x.Symbol == expected.Symbol);
-                Assert.IsNotNull(actual);
-                Assert.AreEqual(expected.Quantity, actual.Quantity);
-            }
+                // Expected target quantity for SPY is zero, since its insight will have flat direction
+                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction * Math.Floor(amount / x.Value.Price);
+                return new PortfolioTarget(x.Key, quantity);
+            });
+
+            var insights = Algorithm.Securities.Keys.Select(x =>
+            {
+                // SPY insight direction is flat
+                var actualDirection = x.Value == "SPY" ? InsightDirection.Flat : direction;
+                return GetInsight(x, actualDirection, Algorithm.UtcTime);
+            });
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights.ToArray());
+
+            AssertTargets(expectedTargets, actualTargets);
         }
 
         [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void DoesNotReturnTargetsIfSecurityPriceIsZero(Language language)
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public virtual void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction)
         {
-            var algorithm = new QCAlgorithm();
-            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
-            algorithm.AddEquity(Symbols.SPY.Value);
-            algorithm.SetDateTime(DateTime.MinValue.ConvertToUtc(_algorithm.TimeZone));
+            SetPortfolioConstruction(language);
 
-            SetPortfolioConstruction(language, algorithm);
+            // Equity will be divided by all securities
+            var amount = Algorithm.Portfolio.TotalPortfolioValue * (decimal)Weight *
+                (1 - Algorithm.Settings.FreePortfolioValuePercentage);
+            var expectedTargets = Algorithm.Securities
+                .Select(x => new PortfolioTarget(x.Key, (int)direction * Math.Floor(amount / x.Value.Price)));
 
-            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, algorithm.UtcTime) };
-            var actualTargets = algorithm.PortfolioConstruction.CreateTargets(algorithm, insights);
+            var insights = Algorithm.Securities.Keys.Select(x => GetInsight(x, direction, Algorithm.UtcTime));
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights.ToArray());
 
-            Assert.AreEqual(0, actualTargets.Count());
+            AssertTargets(expectedTargets, actualTargets);
         }
 
-        [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void DoesNotThrowWithAlternativeOverloads(Language language)
-        {
-            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Resolution.Minute));
-            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, TimeSpan.FromDays(1)));
-            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Expiry.EndOfWeek));
-        }
-
-        private Security GetSecurity(Symbol symbol)
-        {
-            var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);
-            return new Equity(
-                symbol,
-                config,
-                new Cash(Currencies.USD, 0, 1),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null,
-                new SecurityCache()
-            );
-        }
-
-        private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null)
+        public override Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? weight = _weight)
         {
             period = period ?? TimeSpan.FromDays(1);
-            var insight = Insight.Price(symbol, period.Value, direction);
+            var insight = Insight.Price(symbol, period.Value, direction, weight: Math.Max(_weight, Algorithm.Securities.Count));
             insight.GeneratedTimeUtc = generatedTimeUtc;
             insight.CloseTimeUtc = generatedTimeUtc.Add(period.Value);
             return insight;
         }
 
-        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, dynamic paramenter = null)
+        public override IPortfolioConstructionModel GetPortfolioConstructionModel(Language language, dynamic paramenter = null)
         {
-            paramenter = paramenter ?? Resolution.Daily;
-            algorithm.SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel(paramenter));
-            if (language == Language.Python)
+            if (language == Language.CSharp)
             {
-                using (Py.GIL())
-                {
-                    var name = nameof(EqualWeightingPortfolioConstructionModel);
-                    var instance = Py.Import(name).GetAttr(name).Invoke(((object) paramenter).ToPython());
-                    var model = new PortfolioConstructionModelPythonWrapper(instance);
-                    algorithm.SetPortfolioConstruction(model);
-                }
+                return new EqualWeightingPortfolioConstructionModel(paramenter);
             }
 
-            foreach (var kvp in _algorithm.Portfolio)
+            using (Py.GIL())
             {
-                kvp.Value.SetHoldings(kvp.Value.Price, 0);
+                const string name = nameof(EqualWeightingPortfolioConstructionModel);
+                var instance = Py.Import(name).GetAttr(name).Invoke(((object)paramenter).ToPython());
+                return new PortfolioConstructionModelPythonWrapper(instance);
             }
-            _algorithm.Portfolio.SetCash(_startingCash);
-            SetUtcTime(new DateTime(2018, 7, 31));
-
-            var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
-            algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
-        }
-
-        private void SetUtcTime(DateTime dateTime)
-        {
-            _algorithm.SetDateTime(dateTime.ConvertToUtc(_algorithm.TimeZone));
         }
     }
 }

--- a/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
@@ -13,311 +13,48 @@
  * limitations under the License.
 */
 
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NodaTime;
-using NUnit.Framework;
-using Python.Runtime;
-using QuantConnect.Algorithm;
-using QuantConnect.Algorithm.Framework.Alphas;
-using QuantConnect.Algorithm.Framework.Portfolio;
-using QuantConnect.Data.Market;
-using QuantConnect.Data.UniverseSelection;
-using QuantConnect.Orders.Fees;
-using QuantConnect.Securities;
-using QuantConnect.Securities.Equity;
-using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 {
     [TestFixture]
-    public class InsightWeightingPortfolioConstructionModelTests
+    public class InsightWeightingPortfolioConstructionModelTests : EqualWeightingPortfolioConstructionModelTests
     {
-        private QCAlgorithm _algorithm;
-        private const decimal _startingCash = 100000;
-        private const double Weight = 0.01;
+        private const double _weight = 0.01;
 
-        [TestFixtureSetUp]
-        public void SetUp()
-        {
-            _algorithm = new QCAlgorithm();
-            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
-
-            var prices = new Dictionary<Symbol, decimal>
-            {
-                { Symbol.Create("AIG", SecurityType.Equity, Market.USA), 55.22m },
-                { Symbol.Create("IBM", SecurityType.Equity, Market.USA), 145.17m },
-                { Symbol.Create("SPY", SecurityType.Equity, Market.USA), 281.79m },
-            };
-
-            foreach (var kvp in prices)
-            {
-                var symbol = kvp.Key;
-                var security = GetSecurity(symbol);
-                security.SetMarketPrice(new Tick(_algorithm.Time, symbol, kvp.Value, kvp.Value));
-                _algorithm.Securities.Add(symbol, security);
-            }
-        }
-
-
-        [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void EmptyInsightsReturnsEmptyTargets(Language language)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
-
-            Assert.AreEqual(0, actualTargets.Count());
-        }
-
-        [Test]
-        [TestCase(Language.CSharp, InsightDirection.Up)]
-        [TestCase(Language.CSharp, InsightDirection.Down)]
-        [TestCase(Language.CSharp, InsightDirection.Flat)]
-        [TestCase(Language.Python, InsightDirection.Up)]
-        [TestCase(Language.Python, InsightDirection.Down)]
-        [TestCase(Language.Python, InsightDirection.Flat)]
-        public void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)Weight;
-            var expectedTargets = _algorithm.Securities
-                .Select(x => new PortfolioTarget(x.Key, (int)direction
-                                                        * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
-                                                                     / x.Value.Price)));
-
-            var insights = _algorithm.Securities.Keys.Select(x => GetInsight(x, direction, _algorithm.UtcTime));
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [TestCase(Language.CSharp, InsightDirection.Up)]
-        [TestCase(Language.CSharp, InsightDirection.Down)]
-        [TestCase(Language.CSharp, InsightDirection.Flat)]
-        [TestCase(Language.Python, InsightDirection.Up)]
-        [TestCase(Language.Python, InsightDirection.Down)]
-        [TestCase(Language.Python, InsightDirection.Flat)]
-        public void FlatDirectionNotAccountedToAllocation(Language language, InsightDirection direction)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            // Modifying fee model for a constant one so numbers are simplified
-            foreach (var security in _algorithm.Securities)
-            {
-                security.Value.FeeModel = new ConstantFeeModel(1);
-            }
-
-            // Equity, minus $1 for fees
-            var amount = (_algorithm.Portfolio.TotalPortfolioValue - 1 * (_algorithm.Securities.Count - 1)) * (decimal)Weight;
-            var expectedTargets = _algorithm.Securities.Select(x =>
-            {
-                // Expected target quantity for SPY is zero, since its insight will have flat direction
-                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction
-                                                          * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
-                                                                       / x.Value.Price);
-                return new PortfolioTarget(x.Key, quantity);
-            });
-
-            var insights = _algorithm.Securities.Keys.Select(x =>
-            {
-                // SPY insight direction is flat
-                var actualDirection = x.Value == "SPY" ? InsightDirection.Flat : direction;
-                return GetInsight(x, actualDirection, _algorithm.UtcTime);
-            });
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [Test]
-        [TestCase(Language.CSharp, InsightDirection.Up)]
-        [TestCase(Language.CSharp, InsightDirection.Down)]
-        [TestCase(Language.CSharp, InsightDirection.Flat)]
-        [TestCase(Language.Python, InsightDirection.Up)]
-        [TestCase(Language.Python, InsightDirection.Down)]
-        [TestCase(Language.Python, InsightDirection.Flat)]
-        public void AutomaticallyRemoveInvestedWithNewInsights(Language language, InsightDirection direction)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            // Let's create a position for SPY
-            var insights = new[] { GetInsight(Symbols.SPY, direction, _algorithm.UtcTime) };
-
-            foreach (var target in _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights))
-            {
-                var holding = _algorithm.Portfolio[target.Symbol];
-                holding.SetHoldings(holding.Price, target.Quantity);
-                _algorithm.Portfolio.SetCash(_startingCash - holding.HoldingsValue);
-            }
-
-            SetUtcTime(_algorithm.UtcTime.AddDays(2));
-
-            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)Weight;
-            var expectedTargets = _algorithm.Securities.Select(x =>
-            {
-                // Expected target quantity for SPY is zero, since it will be removed
-                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction
-                                                          * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
-                                                                       / x.Value.Price);
-                return new PortfolioTarget(x.Key, quantity);
-            });
-
-            // Do no include SPY in the insights
-            insights = _algorithm.Securities.Keys.Where(x => x.Value != "SPY")
-                .Select(x => GetInsight(x, direction, _algorithm.UtcTime)).ToArray();
-
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void AutomaticallyRemoveInvestedWithoutNewInsights(Language language)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            // Let's create a position for SPY
-            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, _algorithm.UtcTime) };
-
-            foreach (var target in _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights))
-            {
-                var holding = _algorithm.Portfolio[target.Symbol];
-                holding.SetHoldings(holding.Price, target.Quantity);
-                _algorithm.Portfolio.SetCash(_startingCash - holding.HoldingsValue);
-            }
-
-            SetUtcTime(_algorithm.UtcTime.AddDays(2));
-
-            var expectedTargets = new List<IPortfolioTarget> { new PortfolioTarget(Symbols.SPY, 0) };
-
-            // Create target from an empty insights array
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void LongTermInsightPreservesPosition(Language language)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            // First emit long term insight
-            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
-            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
-            Assert.AreEqual(1, targets.Count);
-
-            // One minute later, emits short term insight
-            SetUtcTime(_algorithm.UtcTime.AddMinutes(1));
-            insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Up, _algorithm.UtcTime, Time.OneMinute) };
-            targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
-            Assert.AreEqual(1, targets.Count);
-
-            // One minute later, emit empty insights array
-            SetUtcTime(_algorithm.UtcTime.AddMinutes(1.1));
-
-            var expectedTargets = new List<IPortfolioTarget> { PortfolioTarget.Percent(_algorithm, Symbols.SPY, -1m * (decimal)Weight) };
-
-            // Create target from an empty insights array
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void DelistedSecurityEmitsFlatTargetWithoutNewInsights(Language language)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
-            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
-            Assert.AreEqual(1, targets.Count);
-
-            var changes = SecurityChanges.Removed(_algorithm.Securities[Symbols.SPY]);
-            _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
-
-            var expectedTargets = new List<IPortfolioTarget> { new PortfolioTarget(Symbols.SPY, 0) };
-
-            // Create target from an empty insights array
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, new Insight[0]);
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
-
-        [Test]
-        [TestCase(Language.CSharp, InsightDirection.Up)]
-        [TestCase(Language.CSharp, InsightDirection.Down)]
-        [TestCase(Language.CSharp, InsightDirection.Flat)]
-        [TestCase(Language.Python, InsightDirection.Up)]
-        [TestCase(Language.Python, InsightDirection.Down)]
-        [TestCase(Language.Python, InsightDirection.Flat)]
-        public void DelistedSecurityEmitsFlatTargetWithNewInsights(Language language, InsightDirection direction)
-        {
-            SetPortfolioConstruction(language, _algorithm);
-
-            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime) };
-            var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
-            Assert.AreEqual(1, targets.Count);
-
-            // Removing SPY should clear the key in the insight collection
-            var changes = SecurityChanges.Removed(_algorithm.Securities[Symbols.SPY]);
-            _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
-
-            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)Weight;
-            var expectedTargets = _algorithm.Securities.Select(x =>
-            {
-                // Expected target quantity for SPY is zero, since it will be removed
-                var quantity = x.Key.Value == "SPY" ? 0 : (int)direction
-                                                          * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
-                                                                       / x.Value.Price);
-                return new PortfolioTarget(x.Key, quantity);
-            });
-
-            // Do no include SPY in the insights
-            insights = _algorithm.Securities.Keys.Where(x => x.Value != "SPY")
-                .Select(x => GetInsight(x, direction, _algorithm.UtcTime)).ToArray();
-
-            // Create target from an empty insights array
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);
-
-            AssertTargets(expectedTargets, actualTargets);
-        }
+        public override double? Weight => _weight;
 
         [Test]
         [TestCase(Language.CSharp)]
         [TestCase(Language.Python)]
         public void WeightsProportionally(Language language)
         {
-            SetPortfolioConstruction(language, _algorithm);
+            SetPortfolioConstruction(language);
 
             // create two insights whose weights sums up to 2
             var insights = new[]
             {
-                GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime, weight:1),
+                GetInsight(Symbols.SPY, InsightDirection.Up, Algorithm.UtcTime, weight:1),
                 GetInsight(Symbol.Create("IBM", SecurityType.Equity, Market.USA),
-                    InsightDirection.Down, _algorithm.UtcTime, weight:1)
+                    InsightDirection.Up, Algorithm.UtcTime, weight:1)
             };
 
             // they will each share, proportionally, the total portfolio value
-            var amount = _algorithm.Portfolio.TotalPortfolioValue * (decimal)0.5;
-            var expectedTargets = _algorithm.Securities.Where(pair => insights.Any(insight => pair.Key == insight.Symbol))
-                .Select(x => new PortfolioTarget(x.Key, (int)InsightDirection.Down
-                    * Math.Floor(amount * (1 - _algorithm.Settings.FreePortfolioValuePercentage)
+            var amount = Algorithm.Portfolio.TotalPortfolioValue * (decimal)0.5;
+            var expectedTargets = Algorithm.Securities.Where(pair => insights.Any(insight => pair.Key == insight.Symbol))
+                .Select(x => new PortfolioTarget(x.Key, (int)InsightDirection.Up
+                    * Math.Floor(amount * (1 - Algorithm.Settings.FreePortfolioValuePercentage)
                         / x.Value.Price)));
 
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights).ToList();
             Assert.AreEqual(2, actualTargets.Count);
-
             AssertTargets(expectedTargets, actualTargets);
         }
 
@@ -326,14 +63,14 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python)]
         public void GeneratesNoTargetsForInsightsWithNoWeight(Language language)
         {
-            SetPortfolioConstruction(language, _algorithm);
+            SetPortfolioConstruction(language);
 
             var insights = new[]
             {
-                GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime, weight:null)
+                GetInsight(Symbols.SPY, InsightDirection.Down, Algorithm.UtcTime, weight:null)
             };
 
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights).ToList();
             Assert.AreEqual(0, actualTargets.Count);
         }
 
@@ -342,43 +79,34 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python)]
         public void GeneratesZeroTargetForZeroInsightWeight(Language language)
         {
-            SetPortfolioConstruction(language, _algorithm);
+            SetPortfolioConstruction(language);
 
             var insights = new[]
             {
-                GetInsight(Symbols.SPY, InsightDirection.Down, _algorithm.UtcTime, weight:0)
+                GetInsight(Symbols.SPY, InsightDirection.Down, Algorithm.UtcTime, weight:0)
             };
 
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToList();
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights).ToList();
             Assert.AreEqual(1, actualTargets.Count);
             AssertTargets(actualTargets, new[] {new PortfolioTarget(Symbols.SPY, 0)});
         }
 
-        [Test]
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void DoesNotThrowWithAlternativeOverloads(Language language)
+        public override IPortfolioConstructionModel GetPortfolioConstructionModel(Language language, dynamic paramenter = null)
         {
-            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Resolution.Minute));
-            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, TimeSpan.FromDays(1)));
-            Assert.DoesNotThrow(() => SetPortfolioConstruction(language, _algorithm, Expiry.EndOfWeek));
+            if (language == Language.CSharp)
+            {
+                return new InsightWeightingPortfolioConstructionModel(paramenter);
+            }
+
+            using (Py.GIL())
+            {
+                const string name = nameof(InsightWeightingPortfolioConstructionModel);
+                var instance = Py.Import(name).GetAttr(name).Invoke(((object)paramenter).ToPython());
+                return new PortfolioConstructionModelPythonWrapper(instance);
+            }
         }
 
-        private Security GetSecurity(Symbol symbol)
-        {
-            var config = SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc);
-            return new Equity(
-                symbol,
-                config,
-                new Cash(Currencies.USD, 0, 1),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null,
-                new SecurityCache()
-            );
-        }
-
-        private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? weight = Weight)
+        public override Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? weight = _weight)
         {
             period = period ?? TimeSpan.FromDays(1);
             var insight = Insight.Price(symbol, period.Value, direction, weight: weight);
@@ -387,48 +115,9 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             return insight;
         }
 
-        private void SetPortfolioConstruction(Language language, QCAlgorithm algorithm, dynamic paramenter = null)
+        public override List<IPortfolioTarget> GetTargetsForSPY()
         {
-            paramenter = paramenter ?? Resolution.Daily;
-            algorithm.SetPortfolioConstruction(new InsightWeightingPortfolioConstructionModel(paramenter));
-            if (language == Language.Python)
-            {
-                using (Py.GIL())
-                {
-                    var name = nameof(InsightWeightingPortfolioConstructionModel);
-                    var instance = Py.Import(name).GetAttr(name).Invoke(((object)paramenter).ToPython());
-                    var model = new PortfolioConstructionModelPythonWrapper(instance);
-                    algorithm.SetPortfolioConstruction(model);
-                }
-            }
-
-            foreach (var kvp in _algorithm.Portfolio)
-            {
-                kvp.Value.SetHoldings(kvp.Value.Price, 0);
-            }
-            _algorithm.Portfolio.SetCash(_startingCash);
-            SetUtcTime(new DateTime(2018, 7, 31));
-
-            var changes = SecurityChanges.Added(_algorithm.Securities.Values.ToArray());
-            algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, changes);
-        }
-
-        private void SetUtcTime(DateTime dateTime)
-        {
-            _algorithm.SetDateTime(dateTime.ConvertToUtc(_algorithm.TimeZone));
-        }
-
-        private void AssertTargets(IEnumerable<IPortfolioTarget> expectedTargets, IEnumerable<IPortfolioTarget> actualTargets)
-        {
-            var list = actualTargets.ToList();
-            Assert.AreEqual(expectedTargets.Count(), list.Count);
-
-            foreach (var expected in expectedTargets)
-            {
-                var actual = list.FirstOrDefault(x => x.Symbol == expected.Symbol);
-                Assert.IsNotNull(actual);
-                Assert.AreEqual(expected.Quantity, actual.Quantity);
-            }
+            return new List<IPortfolioTarget> { PortfolioTarget.Percent(Algorithm, Symbols.SPY, -_weight) };
         }
     }
 }

--- a/Tests/Algorithm/Framework/Portfolio/SectorWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/SectorWeightingPortfolioConstructionModelTests.cs
@@ -1,0 +1,295 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NodaTime;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Equity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
+{
+    [TestFixture]
+    public class SectorWeightingPortfolioConstructionModelTests : BaseWeightingPortfolioConstructionModelTests
+    {
+        private const double _weight = 0.01;
+
+        public override double? Weight => Algorithm.Securities.Count == 0 ? default(double) : 1d / Algorithm.Securities.Count;
+
+        [TestFixtureSetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            var prices = new Dictionary<Symbol, Tuple<decimal, string>>
+            {
+                { Symbol.Create("XXX", SecurityType.Equity, Market.USA), Tuple.Create(55.22m, "") },
+                { Symbol.Create("B01", SecurityType.Equity, Market.USA), Tuple.Create(55.22m, "B") },
+                { Symbol.Create("B02", SecurityType.Equity, Market.USA), Tuple.Create(55.22m, "B") },
+                { Symbol.Create("B03", SecurityType.Equity, Market.USA), Tuple.Create(55.22m, "B") },
+                { Symbol.Create("T01", SecurityType.Equity, Market.USA), Tuple.Create(145.17m, "T") },
+                { Symbol.Create("T02", SecurityType.Equity, Market.USA), Tuple.Create(145.17m, "T") },
+                { Symbol.Create("SPY", SecurityType.Equity, Market.USA), Tuple.Create(281.79m, "X") },
+            };
+
+            Func<Symbol, Security> GetSecurity = symbol =>
+                new Equity(
+                    symbol,
+                    SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
+                    new Cash(Currencies.USD, 0, 1),
+                    SymbolProperties.GetDefault(Currencies.USD),
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null,
+                    new SecurityCache()
+                    );
+
+            foreach (var kvp in prices)
+            {
+                var symbol = kvp.Key;
+                var security = GetSecurity(symbol);
+                var price = kvp.Value.Item1;
+                var sectorCode = kvp.Value.Item2;
+                // The first item does not have a valid sector code,
+                // This procedure shows that the model ignores the securities without it
+                if (!string.IsNullOrEmpty(sectorCode))
+                {
+                    security.SetMarketPrice(new Fundamentals
+                    {
+                        Symbol = symbol,
+                        Time = Algorithm.Time,
+                        Value = price,
+                        CompanyReference = new CompanyReference() { IndustryTemplateCode = kvp.Value.Item2 }
+                    });
+                }
+                security.SetMarketPrice(new Tick(Algorithm.Time, symbol, price, price));
+                Algorithm.Securities.Add(symbol, security);
+            }
+        }
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public override void AutomaticallyRemoveInvestedWithNewInsights(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language);
+
+            // Let's create a position for SPY
+            var insights = new[] { GetInsight(Symbols.SPY, direction, Algorithm.UtcTime) };
+
+            foreach (var target in Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights))
+            {
+                var holding = Algorithm.Portfolio[target.Symbol];
+                holding.SetHoldings(holding.Price, target.Quantity);
+                Algorithm.Portfolio.SetCash(StartingCash - holding.HoldingsValue);
+            }
+
+            SetUtcTime(Algorithm.UtcTime.AddDays(2));
+
+            // Since we have 3 B, 2 T and 1 X, each security in each sector will get 
+            // B => .166%, T => .25, X => 0% (removed)
+            var sectorCount = 2;
+            var groupedBySector = Algorithm.Securities
+                .Where(pair => pair.Value.Fundamentals?.CompanyReference?.IndustryTemplateCode != null)
+                .GroupBy(pair => pair.Value.Fundamentals.CompanyReference.IndustryTemplateCode);
+
+            var expectedTargets = new List<PortfolioTarget>();
+
+            foreach (var securities in groupedBySector)
+            {
+                var list = securities.ToList();
+                var amount = Algorithm.Portfolio.TotalPortfolioValue / list.Count / sectorCount *
+                    (1 - Algorithm.Settings.FreePortfolioValuePercentage);
+
+                expectedTargets.AddRange(list
+                    .Select(x => new PortfolioTarget(x.Key, x.Key.Value == "SPY" ? 0
+                        : (int)direction * Math.Floor(amount / x.Value.Price))));
+            }
+
+            // Do no include SPY in the insights
+            insights = Algorithm.Securities.Keys.Where(x => x.Value != "SPY")
+                .Select(x => GetInsight(x, direction, Algorithm.UtcTime)).ToArray();
+
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights);
+
+            Assert.Greater(Algorithm.Securities.Count, expectedTargets.Count);
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public override void DelistedSecurityEmitsFlatTargetWithNewInsights(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language);
+
+            var insights = new[] { GetInsight(Symbols.SPY, InsightDirection.Down, Algorithm.UtcTime) };
+            var targets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights).ToList();
+            Assert.AreEqual(1, targets.Count);
+
+            // Removing SPY should clear the key in the insight collection
+            var changes = SecurityChanges.Removed(Algorithm.Securities[Symbols.SPY]);
+            Algorithm.PortfolioConstruction.OnSecuritiesChanged(Algorithm, changes);
+
+            // Since we have 3 B, 2 T and 1 X, each security in each sector will get 
+            // B => .166%, T => .25, X => 0% (removed)
+            var sectorCount = 2;
+            var groupedBySector = Algorithm.Securities
+                .Where(pair => pair.Value.Fundamentals?.CompanyReference?.IndustryTemplateCode != null)
+                .GroupBy(pair => pair.Value.Fundamentals.CompanyReference.IndustryTemplateCode);
+
+            var expectedTargets = new List<PortfolioTarget>();
+
+            foreach (var securities in groupedBySector)
+            {
+                var list = securities.ToList();
+                var amount = Algorithm.Portfolio.TotalPortfolioValue / list.Count / sectorCount *
+                    (1 - Algorithm.Settings.FreePortfolioValuePercentage);
+
+                expectedTargets.AddRange(list
+                    .Select(x => new PortfolioTarget(x.Key, x.Key.Value == "SPY" ? 0
+                        : (int)direction * Math.Floor(amount / x.Value.Price))));
+            }
+
+            // Do no include SPY in the insights
+            insights = Algorithm.Securities.Keys.Where(x => x.Value != "SPY")
+                .Select(x => GetInsight(x, direction, Algorithm.UtcTime)).ToArray();
+
+            // Create target from an empty insights array
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights);
+
+            Assert.Greater(Algorithm.Securities.Count, expectedTargets.Count);
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [TestCase(Language.CSharp, InsightDirection.Up)]
+        [TestCase(Language.CSharp, InsightDirection.Down)]
+        [TestCase(Language.CSharp, InsightDirection.Flat)]
+        [TestCase(Language.Python, InsightDirection.Up)]
+        [TestCase(Language.Python, InsightDirection.Down)]
+        [TestCase(Language.Python, InsightDirection.Flat)]
+        public override void FlatDirectionNotAccountedToAllocation(Language language, InsightDirection direction)
+        {
+            SetPortfolioConstruction(language);
+
+            // Since we have 3 B, 2 T and 1 X, each security in each sector will get 
+            // B => .166%, T => .25, X => 0% (removed)
+            var sectorCount = 2;
+            var groupedBySector = Algorithm.Securities
+                .Where(pair => pair.Value.Fundamentals?.CompanyReference?.IndustryTemplateCode != null)
+                .GroupBy(pair => pair.Value.Fundamentals.CompanyReference.IndustryTemplateCode);
+
+            var expectedTargets = new List<PortfolioTarget>();
+
+            foreach (var securities in groupedBySector)
+            {
+                var list = securities.ToList();
+                var amount = Algorithm.Portfolio.TotalPortfolioValue / list.Count / sectorCount *
+                    (1 - Algorithm.Settings.FreePortfolioValuePercentage);
+
+                expectedTargets.AddRange(list
+                    .Select(x => new PortfolioTarget(x.Key, x.Key.Value == "SPY" ? 0
+                        : (int)direction * Math.Floor(amount / x.Value.Price))));
+            }
+
+            var insights = Algorithm.Securities.Keys.Select(x =>
+            {
+                // SPY insight direction is flat
+                var actualDirection = x.Value == "SPY" ? InsightDirection.Flat : direction;
+                return GetInsight(x, actualDirection, Algorithm.UtcTime);
+            });
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights.ToArray());
+
+            Assert.Greater(Algorithm.Securities.Count, expectedTargets.Count);
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void WeightsBySectorProportionally(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            // create two insights whose weights sums up to 2
+            var insights = Algorithm.Securities
+                .Select(x => GetInsight(x.Key, InsightDirection.Up, Algorithm.UtcTime))
+                .ToArray();
+
+            // Since we have 3 B, 2 T and 1 X, each security in each secotr will get B => .11%, T => .165, X => .33%
+            var sectorCount = 3;
+            var groupedBySector = Algorithm.Securities
+                .Where(pair => pair.Value.Fundamentals?.CompanyReference?.IndustryTemplateCode != null)
+                .Where(pair => insights.Any(insight => pair.Key == insight.Symbol))
+                .GroupBy(pair => pair.Value.Fundamentals.CompanyReference.IndustryTemplateCode);
+
+            var expectedTargets = new List<PortfolioTarget>();
+
+            foreach (var securities in groupedBySector)
+            {
+                var list = securities.ToList();
+                var amount = Algorithm.Portfolio.TotalPortfolioValue / list.Count / sectorCount *
+                    (1 - Algorithm.Settings.FreePortfolioValuePercentage);
+
+                expectedTargets.AddRange(list
+                    .Select(x => new PortfolioTarget(x.Key, (int)InsightDirection.Up * Math.Floor(amount / x.Value.Price))));
+            }
+
+            var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights).ToList();
+            Assert.AreEqual(6, actualTargets.Count);
+            Assert.Greater(Algorithm.Securities.Count, expectedTargets.Count);
+            AssertTargets(expectedTargets, actualTargets);
+        }
+
+        public override Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? weight = _weight)
+        {
+            period = period ?? TimeSpan.FromDays(1);
+            var insight = Insight.Price(symbol, period.Value, direction, weight: weight);
+            insight.GeneratedTimeUtc = generatedTimeUtc;
+            insight.CloseTimeUtc = generatedTimeUtc.Add(period.Value);
+            return insight;
+        }
+
+        public override IPortfolioConstructionModel GetPortfolioConstructionModel(Language language, dynamic paramenter = null)
+        {
+            if (language == Language.CSharp)
+            {
+                return new SectorWeightingPortfolioConstructionModel(paramenter);
+            }
+
+            using (Py.GIL())
+            {
+                const string name = nameof(SectorWeightingPortfolioConstructionModel);
+                var instance = Py.Import(name).GetAttr(name).Invoke(((object)paramenter).ToPython());
+                return new PortfolioConstructionModelPythonWrapper(instance);
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -287,6 +287,8 @@
     <Compile Include="Algorithm\Framework\Portfolio\BlackLittermanOptimizationPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\AccumulativeInsightPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\ConfidenceWeightedPortfolioConstructionModelTests.cs" />
+    <Compile Include="Algorithm\Framework\Portfolio\BaseWeightingPortfolioConstructionModelTests.cs" />
+    <Compile Include="Algorithm\Framework\Portfolio\SectorWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\InsightWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />


### PR DESCRIPTION
#### Description
Provides an implementation of `IPortfolioConstructionModel` that generates percent targets based on the `CompanyReference.IndustryTemplateCode`.

- Adds Unit Tests
  - Creates `BaseWeightingPortfolioConstructionModelTests`
  - Refactors EWPCMTests and IWPCMTests to inherit `BaseWeightingPortfolioConstructionModelTests` and prevent code duplication.
  - Adds `SectorWeightingPortfolioConstructionModelTests`

#### Related Issue
Closes #3984

#### Motivation and Context
Add Framework Models.

#### Requires Documentation Change
Yes. List this model in [Portfolio Construction Model](https://www.quantconnect.com/docs/algorithm-framework/portfolio-construction) section.

#### How Has This Been Tested?
Unit tests and algorithm regression.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`