### PR TITLE
Revert FuturesExpiryFunctions.FuturesExpiryFunction

### DIFF
--- a/Common/Securities/Future/FuturesExpiryFunctions.cs
+++ b/Common/Securities/Future/FuturesExpiryFunctions.cs
@@ -34,8 +34,8 @@ namespace QuantConnect.Securities.Future
                 return FuturesExpiryDictionary[symbol.ToUpperInvariant()];
             }
 
-            // If the function cannot be found, throw an exception as it hasn't yet been implemented
-            throw new ArgumentException($"Expiry function not implemented for {symbol} in FuturesExpiryFunctions.FuturesExpiryDictionary");
+            // If the expiry function hasn't yet been implemented, pass the date through
+            return date => date;
         }
 
         /// <summary>

--- a/Tests/Common/Securities/Futures/FuturesExpiryFunctionsTests.cs
+++ b/Tests/Common/Securities/Futures/FuturesExpiryFunctionsTests.cs
@@ -61,14 +61,6 @@ namespace QuantConnect.Tests.Common.Securities.Futures
         }
 
         [TestCase]
-        public void FuturesExpiryFunction_MissingSymbol_ShouldThrowArgumentException()
-        {
-            const string badSymbol = "AAAAA";
-            Assert.Throws<ArgumentException>(() => { FuturesExpiryFunctions.FuturesExpiryFunction(badSymbol); },
-                                             $"Expiry function not implemented for {badSymbol} in FuturesExpiryFunctions.FuturesExpiryDictionary");
-        }
-
-        [TestCase]
         public void FuturesExpiryFunctions_AllFutures_ShouldHaveExpiryFunction()
         {
             var missingFutures = new List<string>();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
If the expiry function hasn't yet been implemented, pass the date through

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4076 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because the implementation with ArgumentException, broke the production processing system.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
