### PR TITLE
Implements Wrappers for __str__ and __repr__ in PandasData.Remapper

### DIFF
--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -140,6 +140,12 @@ class Remapper(wrapt.ObjectProxy):
         name = self._self_mapper(name)
         return self.__wrapped__.__delitem__(name)
 
+    def __str__(self):
+        return self.__wrapped__.__str__()
+
+    def __repr__(self):
+        return self.__wrapped__.__repr__()
+
     # we wrap the result and input of 'xs'
     def xs(self, key, axis=0, level=None, drop_level=True):
         key = self._self_mapper(key)

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -913,6 +913,50 @@ def Test(dataFrame, symbol):
         }
 
         [Test]
+        public void BackwardsCompatibilitySeries__str__()
+        {
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    @"
+import pandas as pd
+from datetime import datetime as dt
+def Test(dataFrame, symbol):
+    close = dataFrame.lastprice.unstack(0)
+    to_append = pd.Series([100], name=str(symbol), index=pd.Index([dt.now()], name='time'))
+    result = pd.concat([close, to_append], ignore_index=True)
+    return str([result[x] for x in [symbol]])").GetAttr("Test");
+                var result = "Remapper";
+                Assert.DoesNotThrow(() => result = test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+                // result should not contain "Remapper" string because the test
+                // returns the string representation of a Series object
+                Assert.False(result.Contains("Remapper"));
+            }
+        }
+
+        [Test]
+        public void BackwardsCompatibilitySeries__repr__()
+        {
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    @"
+import pandas as pd
+from datetime import datetime as dt
+def Test(dataFrame, symbol):
+    close = dataFrame.lastprice.unstack(0)
+    to_append = pd.Series([100], name=str(symbol), index=pd.Index([dt.now()], name='time'))
+    result = pd.concat([close, to_append], ignore_index=True)
+    return repr([result[x] for x in [symbol]])").GetAttr("Test");
+                var result = "Remapper";
+                Assert.DoesNotThrow(() => result = test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+                // result should not contain "Remapper" string because the test
+                // returns the string representation of a Series object
+                Assert.False(result.Contains("Remapper"));
+            }
+        }
+
+        [Test]
         public void NotBackwardsCompatibilityDataFrame_index_levels_contains_ticker_notInCache()
         {
             using (Py.GIL())


### PR DESCRIPTION
#### Description
Implements wrappers for `__str__` and `__repr__` in `PandasData.Remapper`.

#### Related Issue
Closes #4083 

#### Motivation and Context
`PandasData.Remapper` should give the same results of a pandas Series/DataFrame operation.

#### How Has This Been Tested?
Unit test and algorithm from the Github issue.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`