### PR TITLE
Adds Integer Overload to SetFilter and Expiration Methods

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -57,8 +57,10 @@ namespace QuantConnect.Algorithm.CSharp
             var futureGold = AddFuture(RootGold);
 
             // set our expiry filter for this futures chain
+            // SetFilter method accepts TimeSpan objects or integer for days.
+            // The following statements yeild the same filtering criteria 
             futureSP500.SetFilter(TimeSpan.Zero, TimeSpan.FromDays(182));
-            futureGold.SetFilter(TimeSpan.Zero, TimeSpan.FromDays(182));
+            futureGold.SetFilter(0, 182);
 
             var benchmark = AddEquity("SPY");
             SetBenchmark(benchmark.Symbol);

--- a/Algorithm.CSharp/BasicTemplateFuturesConsolidationAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesConsolidationAlgorithm.cs
@@ -43,7 +43,11 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(1000000);
 
             var futureSP500 = AddFuture(RootSP500);
-            futureSP500.SetFilter(TimeSpan.Zero, TimeSpan.FromDays(182));
+            // set our expiry filter for this future chain
+            // SetFilter method accepts TimeSpan objects or integer for days.
+            // The following statements yeild the same filtering criteria
+            futureSP500.SetFilter(0, 182);
+            // futureSP500.SetFilter(TimeSpan.Zero, TimeSpan.FromDays(182));
 
             SetBenchmark(x => 0);
         }

--- a/Algorithm.CSharp/BasicTemplateMultiAssetAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateMultiAssetAlgorithm.cs
@@ -58,7 +58,10 @@ namespace QuantConnect.Algorithm.CSharp
             _futureSymbol = futureSP500.Symbol;
 
             // set our expiry filter for this futures chain
-            futureSP500.SetFilter(TimeSpan.FromDays(10), TimeSpan.FromDays(182));
+            // SetFilter method accepts TimeSpan objects or integer for days.
+            // The following statements yeild the same filtering criteria
+            futureSP500.SetFilter(10, 182);
+            // futureSP500.SetFilter(TimeSpan.FromDays(10), TimeSpan.FromDays(182));
 
             // setting up Dow Jones ETF Options
             var option = AddOption("DIA");
@@ -66,8 +69,11 @@ namespace QuantConnect.Algorithm.CSharp
 
             option.PriceModel = OptionPriceModels.BinomialCoxRossRubinstein();
             // option.EnableGreekApproximation = true;
-            // set our expiry filter for this option chain
-            option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
+            // set our strike/expiry filter for this option chain
+            // SetFilter method accepts TimeSpan objects or integer for days.
+            // The following statements yeild the same filtering criteria
+            option.SetFilter(-2, +2, 0, 180);
+            // option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
 
             // specifying zero benchmark
             SetBenchmark(date => 0m);

--- a/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
@@ -48,7 +48,10 @@ namespace QuantConnect.Algorithm.CSharp
             _optionSymbol = option.Symbol;
 
             // set our strike/expiry filter for this option chain
-            option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
+            // SetFilter method accepts TimeSpan objects or integer for days.
+            // The following statements yeild the same filtering criteria
+            option.SetFilter(-2, +2, 0, 180);
+            // option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
 
             // Adding this to reproduce GH issue #2314
             SetWarmup(TimeSpan.FromMinutes(1));

--- a/Algorithm.CSharp/BasicTemplateOptionTradesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionTradesAlgorithm.cs
@@ -41,7 +41,10 @@ namespace QuantConnect.Algorithm.CSharp
             _optionSymbol = option.Symbol;
 
             // set our strike/expiry filter for this option chain
-            option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(10));
+            // SetFilter method accepts TimeSpan objects or integer for days.
+            // The following statements yeilds the same filtering criteria
+            option.SetFilter(-2, +2, 0, 10);
+            // option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(10));
 
             // use the underlying equity as the benchmark
             SetBenchmark("GOOG");

--- a/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
@@ -49,7 +49,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // set our strike/expiry filter for this option chain
             option.SetFilter(u => u.Strikes(-2, +2)
-                                   .Expiration(TimeSpan.Zero, TimeSpan.FromDays(180)));
+                                   // Expiration method accepts TimeSpan objects or integer for days.
+                                   // The following statements yeild the same filtering criteria
+                                   .Expiration(0, 180));
+                                   // .Expiration(TimeSpan.Zero, TimeSpan.FromDays(180)));
 
             // use the underlying equity as the benchmark
             SetBenchmark(equity.Symbol);

--- a/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
@@ -49,7 +49,10 @@ namespace QuantConnect.Algorithm.CSharp
             // set our custom filter for this option chain
             option.SetFilter(universe => from symbol in universe
                                                           .WeeklysOnly()
-                                                          .Expiration(TimeSpan.Zero, TimeSpan.FromDays(10))
+                                                           // Expiration method accepts TimeSpan objects or integer for days.
+                                                           // The following statements yeild the same filtering criteria
+                                                          .Expiration(0, 10)
+                                                          // .Expiration(TimeSpan.Zero, TimeSpan.FromDays(10))
                                          where symbol.ID.OptionRight != OptionRight.Put &&
                                               universe.Underlying.Price - symbol.ID.StrikePrice < 60
                                          select symbol);

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -80,7 +80,10 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 return filter
                     .Strikes(+1, +1)
-                    .Expiration(TimeSpan.Zero, TimeSpan.FromDays(7))
+                    // Expiration method accepts TimeSpan objects or integer for days.
+                    // The following statements yeild the same filtering criteria
+                    .Expiration(0, 7)
+                    //.Expiration(TimeSpan.Zero, TimeSpan.FromDays(7))
                     .WeeklysOnly()
                     .PutsOnly()
                     .OnlyApplyFilterAtMarketOpen();

--- a/Algorithm.CSharp/BasicTemplateOptionsHistoryAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsHistoryAlgorithm.cs
@@ -40,7 +40,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             var option = AddOption("GOOG");
             // add the initial contract filter
-            option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
+            // SetFilter method accepts TimeSpan objects or integer for days.
+            // The following statements yeild the same filtering criteria
+            option.SetFilter(-2, +2, 0, 180);
+            // option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
 
             // set the pricing model for Greeks and volatility
             // find more pricing models https://www.quantconnect.com/lean/documentation/topic27704.html

--- a/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
@@ -41,9 +41,12 @@ class BasicTemplateFuturesAlgorithm(QCAlgorithm):
 
         # Subscribe and set our expiry filter for the futures chain
         futureES = self.AddFuture(Futures.Indices.SP500EMini)
-        futureES.SetFilter(timedelta(0), timedelta(182))
-
         futureGC = self.AddFuture(Futures.Metals.Gold)
+
+        # set our expiry filter for this futures chain
+        # SetFilter method accepts timedelta objects or integer for days.
+        # The following statements yeild the same filtering criteria 
+        futureES.SetFilter(0, 182)
         futureGC.SetFilter(timedelta(0), timedelta(182))
 
         benchmark = self.AddEquity("SPY");

--- a/Algorithm.Python/BasicTemplateFuturesConsolidationAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesConsolidationAlgorithm.py
@@ -41,7 +41,11 @@ class BasicTemplateFuturesConsolidationAlgorithm(QCAlgorithm):
 
         # Subscribe and set our expiry filter for the futures chain
         future = self.AddFuture(Futures.Indices.SP500EMini)
-        future.SetFilter(timedelta(0), timedelta(182))
+        # set our expiry filter for this future chain
+        # SetFilter method accepts timedelta objects or integer for days.
+        # The following statements yeild the same filtering criteria
+        future.SetFilter(0, 182);
+        # future.SetFilter(timedelta(0), timedelta(182))
 
         self.consolidators = dict()
 

--- a/Algorithm.Python/BasicTemplateOptionStrategyAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionStrategyAlgorithm.py
@@ -46,7 +46,10 @@ class BasicTemplateOptionStrategyAlgorithm(QCAlgorithm):
         self.option_symbol = option.Symbol
 
         # set our strike/expiry filter for this option chain
-        option.SetFilter(-2, +2, timedelta(0), timedelta(180))
+        # SetFilter method accepts timedelta objects or integer for days.
+        # The following statements yeild the same filtering criteria
+        option.SetFilter(-2, +2, 0, 180)
+        # option.SetFilter(-2,2, timedelta(0), timedelta(180))
 
         # use the underlying equity as the benchmark
         self.SetBenchmark("GOOG")

--- a/Algorithm.Python/BasicTemplateOptionTradesAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionTradesAlgorithm.py
@@ -38,8 +38,11 @@ class BasicTemplateOptionTradesAlgorithm(QCAlgorithm):
 
         option = self.AddOption("GOOG")
 
-        # set our strike/expiry filter for this option chain
-        option.SetFilter(-2, +2, timedelta(0), timedelta(30))
+        # add the initial contract filter 
+        # SetFilter method accepts timedelta objects or integer for days.
+        # The following statements yeild the same filtering criteria
+        option.SetFilter(-2, +2, 0, 30)
+        # option.SetFilter(-2, +2, timedelta(0), timedelta(30))
 
         # use the underlying equity as the benchmark
         self.SetBenchmark("GOOG")

--- a/Algorithm.Python/BasicTemplateOptionsAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsAlgorithm.py
@@ -40,7 +40,10 @@ class BasicTemplateOptionsAlgorithm(QCAlgorithm):
         self.option_symbol = option.Symbol
 
         # set our strike/expiry filter for this option chain
-        option.SetFilter(-2, +2, timedelta(0), timedelta(180))
+        # SetFilter method accepts timedelta objects or integer for days.
+        # The following statements yeild the same filtering criteria
+        option.SetFilter(-2, +2, 0, 180)
+        # option.SetFilter(-2, +2, timedelta(0), timedelta(180))
 
         # use the underlying equity as the benchmark
         self.SetBenchmark("GOOG")

--- a/Algorithm.Python/BasicTemplateOptionsConsolidationAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsConsolidationAlgorithm.py
@@ -40,7 +40,11 @@ class BasicTemplateOptionsConsolidationAlgorithm(QCAlgorithm):
 
         # Subscribe and set our filter for the options chain
         option = self.AddOption('SPY')
-        option.SetFilter(-2, 2, timedelta(0), timedelta(180))
+        # set our strike/expiry filter for this option chain
+        # SetFilter method accepts timedelta objects or integer for days.
+        # The following statements yeild the same filtering criteria
+        option.SetFilter(-2, +2, 0, 180)
+        # option.SetFilter(-2, +2, timedelta(0), timedelta(180))
         self.consolidators = dict()
     
     def OnData(self,slice):

--- a/Algorithm.Python/BasicTemplateOptionsFilterUniverseAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsFilterUniverseAlgorithm.py
@@ -40,7 +40,10 @@ class BasicTemplateOptionsFilterUniverseAlgorithm(QCAlgorithm):
         self.option_symbol = option.Symbol
 
         # set our strike/expiry filter for this option chain
-        option.SetFilter(-10, 10, timedelta(0), timedelta(10))
+        # SetFilter method accepts timedelta objects or integer for days.
+        # The following statements yeild the same filtering criteria
+        option.SetFilter(-10, +10, 0, 10)
+        # option.SetFilter(-10, 10, timedelta(0), timedelta(10))
 
         # use the underlying equity as the benchmark
         self.SetBenchmark("GOOG")

--- a/Algorithm.Python/BasicTemplateOptionsFrameworkAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsFrameworkAlgorithm.py
@@ -68,7 +68,7 @@ class EarliestExpiringWeeklyAtTheMoneyPutOptionUniverseSelectionModel(OptionUniv
         '''Defines the option chain universe filter'''
         return (filter.Strikes(+1, +1)
                       # Expiration method accepts timedelta objects or integer for days.
-                      # The following statements yeild the same filtering criteria
+                      # The following statements yield the same filtering criteria
                       .Expiration(0, 7)
                       # .Expiration(timedelta(0), timedelta(7))
                       .WeeklysOnly()

--- a/Algorithm.Python/BasicTemplateOptionsFrameworkAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsFrameworkAlgorithm.py
@@ -67,7 +67,10 @@ class EarliestExpiringWeeklyAtTheMoneyPutOptionUniverseSelectionModel(OptionUniv
     def Filter(self, filter):
         '''Defines the option chain universe filter'''
         return (filter.Strikes(+1, +1)
-                      .Expiration(timedelta(0), timedelta(7))
+                      # Expiration method accepts timedelta objects or integer for days.
+                      # The following statements yeild the same filtering criteria
+                      .Expiration(0, 7)
+                      # .Expiration(timedelta(0), timedelta(7))
                       .WeeklysOnly()
                       .PutsOnly()
                       .OnlyApplyFilterAtMarketOpen())

--- a/Algorithm.Python/BasicTemplateOptionsHistoryAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsHistoryAlgorithm.py
@@ -41,7 +41,10 @@ class BasicTemplateOptionsHistoryAlgorithm(QCAlgorithm):
 
         option = self.AddOption("GOOG")
         # add the initial contract filter 
-        option.SetFilter(-2,2, timedelta(0), timedelta(180))
+        # SetFilter method accepts timedelta objects or integer for days.
+        # The following statements yeild the same filtering criteria
+        option.SetFilter(-2, +2, 0, 180)
+        # option.SetFilter(-2,2, timedelta(0), timedelta(180))
 
         # set the pricing model for Greeks and volatility
         # find more pricing models https://www.quantconnect.com/lean/documentation/topic27704.html

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -78,6 +78,7 @@
     <None Include="CustomDataAddDataRegressionAlgorithm.py" />
     <None Include="TrainingExampleAlgorithm.py" />
     <Content Include="BasicTemplateConstituentUniverseAlgorithm.py" />
+    <Content Include="BasicTemplateOptionsConsolidationAlgorithm.py" />
     <Content Include="Benchmarks\SECReportBenchmarkAlgorithm.py" />
     <Content Include="Benchmarks\SmartInsiderEventBenchmarkAlgorithm.py" />
     <Content Include="CustomDataAddDataOnSecuritiesChangedRegressionAlgorithm.py" />
@@ -88,6 +89,7 @@
     <None Include="PsychSignalSentimentRegressionAlgorithm.py" />
     <Content Include="CustomDataUsingMapFileRegressionAlgorithm.py" />
     <Content Include="LiquidETFUniverseFrameworkAlgorithm.py" />
+    <Content Include="LiveFeaturesAlgorithm.py" />
     <Content Include="SetHoldingsMultipleTargetsRegressionAlgorithm.py" />
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -174,12 +174,25 @@ namespace QuantConnect.Securities.Future
         /// using the specified expiration range values
         /// </summary>
         /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
-        /// would exclude contracts expiring in less than 10 days</param>
-        /// <param name="maxExpiry">The maximum time until expiry to include, for example, TimeSpan.FromDays(10)
         /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiry">The maximum time until expiry to include, for example, TimeSpan.FromDays(10)
+        /// would exclude contracts expiring in less than 10 days</param>
         public void SetFilter(TimeSpan minExpiry, TimeSpan maxExpiry)
         {
             SetFilter(universe => universe.Expiration(minExpiry, maxExpiry));
+        }
+
+        /// <summary>
+        /// Sets the <see cref="ContractFilter"/> to a new instance of the filter
+        /// using the specified expiration range values
+        /// </summary>
+        /// <param name="minExpiryDays">The minimum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiryDays">The maximum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in less than 10 days</param>
+        public void SetFilter(int minExpiryDays, int maxExpiryDays)
+        {
+            SetFilter(universe => universe.Expiration(minExpiryDays, maxExpiryDays));
         }
 
         /// <summary>

--- a/Common/Securities/Future/FutureFilterUniverse.cs
+++ b/Common/Securities/Future/FutureFilterUniverse.cs
@@ -104,9 +104,9 @@ namespace QuantConnect.Securities
         /// Applies filter selecting futures contracts based on a range of expiration dates relative to the current day
         /// </summary>
         /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
-        /// would exclude contracts expiring in less than 10 days</param>
-        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
         /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
+        /// would exclude contracts expiring in less than 10 days</param>
         /// <returns></returns>
         public FutureFilterUniverse Expiration(TimeSpan minExpiry, TimeSpan maxExpiry)
         {
@@ -129,6 +129,19 @@ namespace QuantConnect.Securities
 
             _allSymbols = filtered.ToList();
             return this;
+        }
+
+        /// <summary>
+        /// Applies filter selecting futures contracts based on a range of expiration dates relative to the current day
+        /// </summary>
+        /// <param name="minExpiryDays">The minimum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiryDays">The maximum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in less than 10 days</param>
+        /// <returns></returns>
+        public FutureFilterUniverse Expiration(int minExpiryDays, int maxExpiryDays)
+        {
+            return Expiration(TimeSpan.FromDays(minExpiryDays), TimeSpan.FromDays(maxExpiryDays));
         }
 
         /// <summary>

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -365,9 +365,9 @@ namespace QuantConnect.Securities.Option
         /// using the specified min and max strike and expiration range values
         /// </summary>
         /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
-        /// would exclude contracts expiring in less than 10 days</param>
-        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
         /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
+        /// would exclude contracts expiring in less than 10 days</param>
         public void SetFilter(TimeSpan minExpiry, TimeSpan maxExpiry)
         {
             SetFilter(universe => universe.Expiration(minExpiry, maxExpiry));
@@ -384,14 +384,35 @@ namespace QuantConnect.Securities.Option
         /// an upper bound of on strike under market price, where a +1 would be an upper bound of one strike
         /// over market price</param>
         /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
-        /// would exclude contracts expiring in less than 10 days</param>
-        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
         /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
+        /// would exclude contracts expiring in less than 10 days</param>
         public void SetFilter(int minStrike, int maxStrike, TimeSpan minExpiry, TimeSpan maxExpiry)
         {
             SetFilter(universe => universe
                 .Strikes(minStrike, maxStrike)
                 .Expiration(minExpiry, maxExpiry));
+        }
+
+        /// <summary>
+        /// Sets the <see cref="ContractFilter"/> to a new instance of the filter
+        /// using the specified min and max strike and expiration range values
+        /// </summary>
+        /// <param name="minStrike">The min strike rank relative to market price, for example, -1 would put
+        /// a lower bound of one strike under market price, where a +1 would put a lower bound of one strike
+        /// over market price</param>
+        /// <param name="maxStrike">The max strike rank relative to market place, for example, -1 would put
+        /// an upper bound of on strike under market price, where a +1 would be an upper bound of one strike
+        /// over market price</param>
+        /// <param name="minExpiryDays">The minimum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiryDays">The maximum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in less than 10 days</param>
+        public void SetFilter(int minStrike, int maxStrike, int minExpiryDays, int maxExpiryDays)
+        {
+            SetFilter(universe => universe
+                .Strikes(minStrike, maxStrike)
+                .Expiration(minExpiryDays, maxExpiryDays));
         }
 
         /// <summary>

--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -296,9 +296,9 @@ namespace QuantConnect.Securities
         /// Applies filter selecting options contracts based on a range of expiration dates relative to the current day
         /// </summary>
         /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
-        /// would exclude contracts expiring in less than 10 days</param>
-        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
         /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
+        /// would exclude contracts expiring in less than 10 days</param>
         /// <returns></returns>
         public OptionFilterUniverse Expiration(TimeSpan minExpiry, TimeSpan maxExpiry)
         {
@@ -317,6 +317,19 @@ namespace QuantConnect.Securities
                 .ToList();
 
             return this;
+        }
+
+        /// <summary>
+        /// Applies filter selecting options contracts based on a range of expiration dates relative to the current day
+        /// </summary>
+        /// <param name="minExpiryDays">The minimum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiryDays">The maximum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in less than 10 days</param>
+        /// <returns></returns>
+        public OptionFilterUniverse Expiration(int minExpiryDays, int maxExpiryDays)
+        {
+            return Expiration(TimeSpan.FromDays(minExpiryDays), TimeSpan.FromDays(maxExpiryDays));
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description
- Adds the following method overloads:
  - `Future.SetFilter(int, int)`
  - `Option.SetFilter(int, int, int, int)`
  - `FutureFilterUniverse.Expitarion(int, int)`
  - `OptionFilterUniverse.Expitarion(int, int)`

to simplify the API since the original methods accept `TimeSpan` that are most used with `AddDays(int)` method.

- Changes Basic Template Algorithms With Options and Futures to Show The New Overloads
  Keeps the original overloads in the comments.
#### Related Issue
Closes #4091 

#### Motivation and Context
Improve the API to make it more user-friendly. 

#### Requires Documentation Change
Yes. Add examples with the new overload in the Options and Futures docs.

#### How Has This Been Tested?
Regression algorithms.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`