### PR TITLE
Adds Integer Overload to SetFilter and Expiration Methods (II)

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             // set our expiry filter for this futures chain
             // SetFilter method accepts TimeSpan objects or integer for days.
-            // The following statements yeild the same filtering criteria 
+            // The following statements yield the same filtering criteria 
             futureSP500.SetFilter(TimeSpan.Zero, TimeSpan.FromDays(182));
             futureGold.SetFilter(0, 182);
 

--- a/Algorithm.CSharp/BasicTemplateFuturesConsolidationAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesConsolidationAlgorithm.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.Algorithm.CSharp
             var futureSP500 = AddFuture(RootSP500);
             // set our expiry filter for this future chain
             // SetFilter method accepts TimeSpan objects or integer for days.
-            // The following statements yeild the same filtering criteria
+            // The following statements yield the same filtering criteria
             futureSP500.SetFilter(0, 182);
             // futureSP500.SetFilter(TimeSpan.Zero, TimeSpan.FromDays(182));
 

--- a/Algorithm.CSharp/BasicTemplateMultiAssetAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateMultiAssetAlgorithm.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             // set our expiry filter for this futures chain
             // SetFilter method accepts TimeSpan objects or integer for days.
-            // The following statements yeild the same filtering criteria
+            // The following statements yield the same filtering criteria
             futureSP500.SetFilter(10, 182);
             // futureSP500.SetFilter(TimeSpan.FromDays(10), TimeSpan.FromDays(182));
 
@@ -71,7 +71,7 @@ namespace QuantConnect.Algorithm.CSharp
             // option.EnableGreekApproximation = true;
             // set our strike/expiry filter for this option chain
             // SetFilter method accepts TimeSpan objects or integer for days.
-            // The following statements yeild the same filtering criteria
+            // The following statements yield the same filtering criteria
             option.SetFilter(-2, +2, 0, 180);
             // option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
 

--- a/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             // set our strike/expiry filter for this option chain
             // SetFilter method accepts TimeSpan objects or integer for days.
-            // The following statements yeild the same filtering criteria
+            // The following statements yield the same filtering criteria
             option.SetFilter(-2, +2, 0, 180);
             // option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
 

--- a/Algorithm.CSharp/BasicTemplateOptionTradesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionTradesAlgorithm.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             // set our strike/expiry filter for this option chain
             // SetFilter method accepts TimeSpan objects or integer for days.
-            // The following statements yeilds the same filtering criteria
+            // The following statements yields the same filtering criteria
             option.SetFilter(-2, +2, 0, 10);
             // option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(10));
 

--- a/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
@@ -35,8 +35,7 @@ namespace QuantConnect.Algorithm.CSharp
     public class BasicTemplateOptionsAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private const string UnderlyingTicker = "GOOG";
-        public readonly Symbol Underlying = QuantConnect.Symbol.Create(UnderlyingTicker, SecurityType.Equity, Market.USA);
-        public readonly Symbol OptionSymbol = QuantConnect.Symbol.Create(UnderlyingTicker, SecurityType.Option, Market.USA);
+        public Symbol OptionSymbol;
 
         public override void Initialize()
         {
@@ -46,11 +45,12 @@ namespace QuantConnect.Algorithm.CSharp
 
             var equity = AddEquity(UnderlyingTicker);
             var option = AddOption(UnderlyingTicker);
+            OptionSymbol = option.Symbol;
 
             // set our strike/expiry filter for this option chain
             option.SetFilter(u => u.Strikes(-2, +2)
                                    // Expiration method accepts TimeSpan objects or integer for days.
-                                   // The following statements yeild the same filtering criteria
+                                   // The following statements yield the same filtering criteria
                                    .Expiration(0, 180));
                                    // .Expiration(TimeSpan.Zero, TimeSpan.FromDays(180)));
 

--- a/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
@@ -34,8 +34,7 @@ namespace QuantConnect.Algorithm.CSharp
     public class BasicTemplateOptionsFilterUniverseAlgorithm : QCAlgorithm
     {
         private const string UnderlyingTicker = "GOOG";
-        public readonly Symbol Underlying = QuantConnect.Symbol.Create(UnderlyingTicker, SecurityType.Equity, Market.USA);
-        public readonly Symbol OptionSymbol = QuantConnect.Symbol.Create(UnderlyingTicker, SecurityType.Option, Market.USA);
+        public Symbol OptionSymbol;
 
         public override void Initialize()
         {
@@ -50,7 +49,7 @@ namespace QuantConnect.Algorithm.CSharp
             option.SetFilter(universe => from symbol in universe
                                                           .WeeklysOnly()
                                                            // Expiration method accepts TimeSpan objects or integer for days.
-                                                           // The following statements yeild the same filtering criteria
+                                                           // The following statements yield the same filtering criteria
                                                           .Expiration(0, 10)
                                                           // .Expiration(TimeSpan.Zero, TimeSpan.FromDays(10))
                                          where symbol.ID.OptionRight != OptionRight.Put &&

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return filter
                     .Strikes(+1, +1)
                     // Expiration method accepts TimeSpan objects or integer for days.
-                    // The following statements yeild the same filtering criteria
+                    // The following statements yield the same filtering criteria
                     .Expiration(0, 7)
                     //.Expiration(TimeSpan.Zero, TimeSpan.FromDays(7))
                     .WeeklysOnly()

--- a/Algorithm.CSharp/BasicTemplateOptionsHistoryAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsHistoryAlgorithm.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
             var option = AddOption("GOOG");
             // add the initial contract filter
             // SetFilter method accepts TimeSpan objects or integer for days.
-            // The following statements yeild the same filtering criteria
+            // The following statements yield the same filtering criteria
             option.SetFilter(-2, +2, 0, 180);
             // option.SetFilter(-2, +2, TimeSpan.Zero, TimeSpan.FromDays(180));
 

--- a/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesAlgorithm.py
@@ -40,14 +40,14 @@ class BasicTemplateFuturesAlgorithm(QCAlgorithm):
         self.contractSymbol = None
 
         # Subscribe and set our expiry filter for the futures chain
-        futureES = self.AddFuture(Futures.Indices.SP500EMini)
-        futureGC = self.AddFuture(Futures.Metals.Gold)
+        futureSP500 = self.AddFuture(Futures.Indices.SP500EMini)
+        futureGold = self.AddFuture(Futures.Metals.Gold)
 
         # set our expiry filter for this futures chain
         # SetFilter method accepts timedelta objects or integer for days.
-        # The following statements yeild the same filtering criteria 
-        futureES.SetFilter(0, 182)
-        futureGC.SetFilter(timedelta(0), timedelta(182))
+        # The following statements yield the same filtering criteria 
+        futureSP500.SetFilter(timedelta(0), timedelta(182))
+        futureGold.SetFilter(0, 182)
 
         benchmark = self.AddEquity("SPY");
         self.SetBenchmark(benchmark.Symbol);

--- a/Algorithm.Python/BasicTemplateFuturesConsolidationAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesConsolidationAlgorithm.py
@@ -40,11 +40,11 @@ class BasicTemplateFuturesConsolidationAlgorithm(QCAlgorithm):
         self.SetCash(1000000)
 
         # Subscribe and set our expiry filter for the futures chain
-        future = self.AddFuture(Futures.Indices.SP500EMini)
+        futureSP500 = self.AddFuture(Futures.Indices.SP500EMini)
         # set our expiry filter for this future chain
         # SetFilter method accepts timedelta objects or integer for days.
-        # The following statements yeild the same filtering criteria
-        future.SetFilter(0, 182);
+        # The following statements yield the same filtering criteria
+        futureSP500.SetFilter(0, 182);
         # future.SetFilter(timedelta(0), timedelta(182))
 
         self.consolidators = dict()

--- a/Algorithm.Python/BasicTemplateOptionStrategyAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionStrategyAlgorithm.py
@@ -47,7 +47,7 @@ class BasicTemplateOptionStrategyAlgorithm(QCAlgorithm):
 
         # set our strike/expiry filter for this option chain
         # SetFilter method accepts timedelta objects or integer for days.
-        # The following statements yeild the same filtering criteria
+        # The following statements yield the same filtering criteria
         option.SetFilter(-2, +2, 0, 180)
         # option.SetFilter(-2,2, timedelta(0), timedelta(180))
 

--- a/Algorithm.Python/BasicTemplateOptionTradesAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionTradesAlgorithm.py
@@ -40,9 +40,9 @@ class BasicTemplateOptionTradesAlgorithm(QCAlgorithm):
 
         # add the initial contract filter 
         # SetFilter method accepts timedelta objects or integer for days.
-        # The following statements yeild the same filtering criteria
-        option.SetFilter(-2, +2, 0, 30)
-        # option.SetFilter(-2, +2, timedelta(0), timedelta(30))
+        # The following statements yield the same filtering criteria
+        option.SetFilter(-2, +2, 0, 10)
+        # option.SetFilter(-2, +2, timedelta(0), timedelta(10))
 
         # use the underlying equity as the benchmark
         self.SetBenchmark("GOOG")

--- a/Algorithm.Python/BasicTemplateOptionsAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsAlgorithm.py
@@ -30,23 +30,26 @@ from datetime import timedelta
 ### <meta name="tag" content="options" />
 ### <meta name="tag" content="filter selection" />
 class BasicTemplateOptionsAlgorithm(QCAlgorithm):
+    UnderlyingTicker = "GOOG"
 
     def Initialize(self):
         self.SetStartDate(2015, 12, 24)
         self.SetEndDate(2015, 12, 24)
         self.SetCash(100000)
 
-        option = self.AddOption("GOOG")
+        equity = self.AddEquity(self.UnderlyingTicker)
+        option = self.AddOption(self.UnderlyingTicker)
         self.option_symbol = option.Symbol
 
         # set our strike/expiry filter for this option chain
-        # SetFilter method accepts timedelta objects or integer for days.
-        # The following statements yeild the same filtering criteria
-        option.SetFilter(-2, +2, 0, 180)
-        # option.SetFilter(-2, +2, timedelta(0), timedelta(180))
+        option.SetFilter(lambda u: (u.Strikes(-2, +2)
+                                     # Expiration method accepts TimeSpan objects or integer for days.
+                                     # The following statements yield the same filtering criteria
+                                     .Expiration(0, 180)))
+                                     #.Expiration(TimeSpan.Zero, TimeSpan.FromDays(180))))
 
         # use the underlying equity as the benchmark
-        self.SetBenchmark("GOOG")
+        self.SetBenchmark(equity.Symbol)
 
     def OnData(self,slice):
         if self.Portfolio.Invested: return

--- a/Algorithm.Python/BasicTemplateOptionsConsolidationAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsConsolidationAlgorithm.py
@@ -42,7 +42,7 @@ class BasicTemplateOptionsConsolidationAlgorithm(QCAlgorithm):
         option = self.AddOption('SPY')
         # set our strike/expiry filter for this option chain
         # SetFilter method accepts timedelta objects or integer for days.
-        # The following statements yeild the same filtering criteria
+        # The following statements yield the same filtering criteria
         option.SetFilter(-2, +2, 0, 180)
         # option.SetFilter(-2, +2, timedelta(0), timedelta(180))
         self.consolidators = dict()

--- a/Algorithm.Python/BasicTemplateOptionsFilterUniverseAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsFilterUniverseAlgorithm.py
@@ -30,23 +30,25 @@ from datetime import timedelta
 ### <meta name="tag" content="options" />
 ### <meta name="tag" content="filter selection" />
 class BasicTemplateOptionsFilterUniverseAlgorithm(QCAlgorithm):
+    UnderlyingTicker = "GOOG"
 
     def Initialize(self):
         self.SetStartDate(2015, 12, 16)
         self.SetEndDate(2015, 12, 24)
         self.SetCash(100000)
 
-        option = self.AddOption("GOOG")
+        equity = self.AddEquity(self.UnderlyingTicker);
+        option = self.AddOption(self.UnderlyingTicker)
         self.option_symbol = option.Symbol
 
         # set our strike/expiry filter for this option chain
         # SetFilter method accepts timedelta objects or integer for days.
-        # The following statements yeild the same filtering criteria
+        # The following statements yield the same filtering criteria
         option.SetFilter(-10, +10, 0, 10)
         # option.SetFilter(-10, 10, timedelta(0), timedelta(10))
 
         # use the underlying equity as the benchmark
-        self.SetBenchmark("GOOG")
+        self.SetBenchmark(equity.Symbol)
 
     def OnData(self,slice):
         if self.Portfolio.Invested: return

--- a/Algorithm.Python/BasicTemplateOptionsHistoryAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsHistoryAlgorithm.py
@@ -42,7 +42,7 @@ class BasicTemplateOptionsHistoryAlgorithm(QCAlgorithm):
         option = self.AddOption("GOOG")
         # add the initial contract filter 
         # SetFilter method accepts timedelta objects or integer for days.
-        # The following statements yeild the same filtering criteria
+        # The following statements yield the same filtering criteria
         option.SetFilter(-2, +2, 0, 180)
         # option.SetFilter(-2,2, timedelta(0), timedelta(180))
 


### PR DESCRIPTION
#### Description
Addresses Peer-Review
- Standardizes basic template algorithms for options and futures
- Fix typo

#### Related Issue
Closes #4091 #4092

#### How Has This Been Tested?
See #4092

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`