### PR TITLE
Revert GetBuyingPower removal

### DIFF
--- a/Common/Python/BuyingPowerModelPythonWrapper.cs
+++ b/Common/Python/BuyingPowerModelPythonWrapper.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Python
         {
             using (Py.GIL())
             {
-                foreach (var attributeName in new[] { "GetMaximumOrderQuantityForDeltaBuyingPower", "GetLeverage", "GetMaximumOrderQuantityForTargetBuyingPower", "GetReservedBuyingPowerForPosition", "HasSufficientBuyingPowerForOrder", "SetLeverage" })
+                foreach (var attributeName in new[] { "GetBuyingPower", "GetMaximumOrderQuantityForDeltaBuyingPower", "GetLeverage", "GetMaximumOrderQuantityForTargetBuyingPower", "GetReservedBuyingPowerForPosition", "HasSufficientBuyingPowerForOrder", "SetLeverage" })
                 {
                     if (!model.HasAttr(attributeName))
                     {
@@ -43,6 +43,19 @@ namespace QuantConnect.Python
                 }
             }
             _model = model;
+        }
+
+        /// <summary>
+        /// Gets the buying power available for a trade
+        /// </summary>
+        /// <param name="parameters">A parameters object containing the algorithm's potrfolio, security, and order direction</param>
+        /// <returns>The buying power available for the trade</returns>
+        public BuyingPower GetBuyingPower(BuyingPowerParameters parameters)
+        {
+            using (Py.GIL())
+            {
+                return (_model.GetBuyingPower(parameters) as PyObject).GetAndDispose<BuyingPower>();
+            }
         }
 
         /// <summary>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -346,8 +346,10 @@
     <Compile Include="Python\PythonWrapper.cs" />
     <Compile Include="RealTimeProvider.cs" />
     <Compile Include="Scheduling\ScheduledEventException.cs" />
+    <Compile Include="Securities\BuyingPower.cs" />
     <Compile Include="Securities\BuyingPowerModel.cs" />
     <Compile Include="Securities\BuyingPowerModelExtensions.cs" />
+    <Compile Include="Securities\BuyingPowerParameters.cs" />
     <Compile Include="Securities\GetMaximumOrderQuantityForDeltaBuyingPowerParameters.cs" />
     <Compile Include="Securities\RegisteredSecurityDataTypesProvider.cs" />
     <Compile Include="Securities\ErrorCurrencyConverter.cs" />

--- a/Common/Securities/BuyingPower.cs
+++ b/Common/Securities/BuyingPower.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Defines the result for <see cref="IBuyingPowerModel.GetBuyingPower"/>
+    /// </summary>
+    public class BuyingPower
+    {
+        /// <summary>
+        /// Gets the buying power
+        /// </summary>
+        public decimal Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BuyingPower"/> class
+        /// </summary>
+        /// <param name="buyingPower">The buying power</param>
+        public BuyingPower(decimal buyingPower)
+        {
+            Value = buyingPower;
+        }
+    }
+}

--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -500,5 +500,16 @@ namespace QuantConnect.Securities
             var maintenanceMargin = GetMaintenanceMargin(parameters.Security);
             return parameters.ResultInAccountCurrency(maintenanceMargin);
         }
+
+        /// <summary>
+        /// Gets the buying power available for a trade
+        /// </summary>
+        /// <param name="parameters">A parameters object containing the algorithm's portfolio, security, and order direction</param>
+        /// <returns>The buying power available for the trade</returns>
+        public virtual BuyingPower GetBuyingPower(BuyingPowerParameters parameters)
+        {
+            var marginRemaining = GetMarginRemaining(parameters.Portfolio, parameters.Security, parameters.Direction);
+            return parameters.ResultInAccountCurrency(marginRemaining);
+        }
     }
 }

--- a/Common/Securities/BuyingPowerModelExtensions.cs
+++ b/Common/Securities/BuyingPowerModelExtensions.cs
@@ -74,5 +74,27 @@ namespace QuantConnect.Securities
 
             return model.GetMaximumOrderQuantityForTargetBuyingPower(parameters);
         }
+
+        /// <summary>
+        /// Gets the buying power available for a trade
+        /// </summary>
+        /// <param name="model">The <see cref="IBuyingPowerModel"/></param>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="security">The security to be traded</param>
+        /// <param name="direction">The direction of the trade</param>
+        /// <returns>The buying power available for the trade</returns>
+        public static decimal GetBuyingPower(
+            this IBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            Security security,
+            OrderDirection direction
+        )
+        {
+            var context = new BuyingPowerParameters(portfolio, security, direction);
+            var buyingPower = model.GetBuyingPower(context);
+
+            // existing implementations assume certain non-account currency units, so return raw value
+            return buyingPower.Value;
+        }
     }
 }

--- a/Common/Securities/BuyingPowerParameters.cs
+++ b/Common/Securities/BuyingPowerParameters.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Orders;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Defines the parameters for <see cref="IBuyingPowerModel.GetBuyingPower"/>
+    /// </summary>
+    public class BuyingPowerParameters
+    {
+        /// <summary>
+        /// Gets the security
+        /// </summary>
+        public Security Security { get; }
+
+        /// <summary>
+        /// Gets the algorithm's portfolio
+        /// </summary>
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Gets the direction in which buying power is to be computed
+        /// </summary>
+        public OrderDirection Direction { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BuyingPowerParameters"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="security">The security</param>
+        /// <param name="direction">The direction to compute buying power in</param>
+        public BuyingPowerParameters(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)
+        {
+            Portfolio = portfolio;
+            Security = security;
+            Direction = direction;
+        }
+
+        /// <summary>
+        /// Creates the result using the specified buying power
+        /// </summary>
+        /// <param name="buyingPower">The buying power</param>
+        /// <param name="currency">The units the buying power is denominated in</param>
+        /// <returns>The buying power</returns>
+        public BuyingPower Result(decimal buyingPower, string currency)
+        {
+            // TODO: Properly account for 'currency' - not accounted for currently as only performing mechanical refactoring
+            return new BuyingPower(buyingPower);
+        }
+
+        /// <summary>
+        /// Creates the result using the specified buying power in units of the account currency
+        /// </summary>
+        /// <param name="buyingPower">The buying power</param>
+        /// <returns>The buying power</returns>
+        public BuyingPower ResultInAccountCurrency(decimal buyingPower)
+        {
+            return new BuyingPower(buyingPower);
+        }
+    }
+}

--- a/Common/Securities/IBuyingPowerModel.cs
+++ b/Common/Securities/IBuyingPowerModel.cs
@@ -67,5 +67,12 @@ namespace QuantConnect.Securities
         /// <param name="parameters">A parameters object containing the security</param>
         /// <returns>The reserved buying power in account currency</returns>
         ReservedBuyingPowerForPosition GetReservedBuyingPowerForPosition(ReservedBuyingPowerForPositionParameters parameters);
+
+        /// <summary>
+        /// Gets the buying power available for a trade
+        /// </summary>
+        /// <param name="parameters">A parameters object containing the algorithm's potrfolio, security, and order direction</param>
+        /// <returns>The buying power available for the trade</returns>
+        BuyingPower GetBuyingPower(BuyingPowerParameters parameters);
     }
 }

--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -105,7 +105,7 @@ namespace QuantConnect.Securities.Option
                         * security.SymbolProperties.ContractMultiplier
                         * security.Price
                         * quantity;
-            return value * GetMarginRequirement(security, security.Holdings.HoldingsValue);
+            return value * GetMarginRequirement(security, value);
         }
 
         /// <summary>

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -603,6 +603,31 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Gets the margin available for trading a specific symbol in a specific direction.
+        /// </summary>
+        /// <param name="symbol">The symbol to compute margin remaining for</param>
+        /// <param name="direction">The order/trading direction</param>
+        /// <returns>The maximum order size that is currently executable in the specified direction</returns>
+        public decimal GetMarginRemaining(Symbol symbol, OrderDirection direction = OrderDirection.Buy)
+        {
+            var security = Securities[symbol];
+            var context = new BuyingPowerParameters(this, security, direction);
+            return security.BuyingPowerModel.GetBuyingPower(context).Value;
+        }
+
+        /// <summary>
+        /// Gets the margin available for trading a specific symbol in a specific direction.
+        /// Alias for <see cref="GetMarginRemaining"/>
+        /// </summary>
+        /// <param name="symbol">The symbol to compute margin remaining for</param>
+        /// <param name="direction">The order/trading direction</param>
+        /// <returns>The maximum order size that is currently executable in the specified direction</returns>
+        public decimal GetBuyingPower(Symbol symbol, OrderDirection direction = OrderDirection.Buy)
+        {
+            return GetMarginRemaining(symbol, direction);
+        }
+
+        /// <summary>
         /// Calculate the new average price after processing a partial/complete order fill event.
         /// </summary>
         /// <remarks>
@@ -796,8 +821,13 @@ namespace QuantConnect.Securities
                     new ReservedBuyingPowerForPositionParameters(security)
                 );
 
+                var marginRemaining = security.BuyingPowerModel.GetBuyingPower(
+                    new BuyingPowerParameters(this, security, direction)
+                );
+
                 Log.Trace("Order request margin information: " +
-                    Invariant($"MarginUsed: {marginUsed.AbsoluteUsedBuyingPower:F2}")
+                    Invariant($"MarginUsed: {marginUsed.AbsoluteUsedBuyingPower:F2}") +
+                    Invariant($"MarginRemaining: {marginRemaining.Value:F2}")
                 );
             }
         }

--- a/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
@@ -20,7 +20,6 @@ using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
-using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Option;
 using QuantConnect.Tests.Engine.DataFeeds;
 
@@ -397,6 +396,26 @@ namespace QuantConnect.Tests.Common.Securities
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (4.68 + 0.2 * 200) = 8936
             Assert.AreEqual(8936, (double)buyingPowerModel.GetMaintenanceMargin(optionPut), 0.01);
+        }
+
+        [TestCase(0)]
+        [TestCase(10000)]
+        public void NonAccountCurrency_GetBuyingPower(decimal nonAccountCurrencyCash)
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+            algorithm.Portfolio.SetAccountCurrency("EUR");
+            algorithm.Portfolio.SetCash(10000);
+            algorithm.Portfolio.SetCash(Currencies.USD, nonAccountCurrencyCash, 0.88m);
+
+            var option = algorithm.AddOption("SPY");
+
+            var buyingPowerModel = new OptionMarginModel();
+            var quantity = buyingPowerModel.GetBuyingPower(new BuyingPowerParameters(
+                algorithm.Portfolio, option, OrderDirection.Buy));
+
+            Assert.AreEqual(10000m + algorithm.Portfolio.CashBook[Currencies.USD].ValueInAccountCurrency,
+                quantity.Value);
         }
     }
 }

--- a/Tests/Common/Securities/SecurityMarginModelTests.cs
+++ b/Tests/Common/Securities/SecurityMarginModelTests.cs
@@ -16,13 +16,17 @@
 using System;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Option;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;
+using Option = QuantConnect.Securities.Option.Option;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -358,6 +362,270 @@ namespace QuantConnect.Tests.Common.Securities
             // (100000 * -2.1 * 0.9975 setHoldingsBuffer) / 25 =  -8379m
             Assert.AreEqual(-8379m, actual);
             Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual, security, algo));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentDefault_Equity()
+        {
+            var algo = GetAlgorithm();
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Equity);
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 2 * 0.9975) / 25 - 1 order due to fees
+            Assert.AreEqual(7979m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.AreEqual(algo.Portfolio.Cash, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentAppliesForCashAccount_Equity()
+        {
+            var algo = GetAlgorithm();
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Cash);
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Equity);
+            var requiredFreeBuyingPowerPercent = 0.05m;
+            var model = security.BuyingPowerModel = new SecurityMarginModel(1, requiredFreeBuyingPowerPercent);
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 1 * 0.95 * 0.9975) / 25 - 1 order due to fees
+            Assert.AreEqual(3790m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual * 1.0025m, security, algo));
+            Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual * 1.0025m + security.SymbolProperties.LotSize + 9, security, algo));
+            var expectedBuyingPower = algo.Portfolio.Cash * (1 - requiredFreeBuyingPowerPercent);
+            Assert.AreEqual(expectedBuyingPower, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentAppliesForMarginAccount_Equity()
+        {
+            var algo = GetAlgorithm();
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Margin);
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Equity);
+            var requiredFreeBuyingPowerPercent = 0.05m;
+            var model = security.BuyingPowerModel = new SecurityMarginModel(2, requiredFreeBuyingPowerPercent);
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 2 * 0.95 * 0.9975) / 25 - 1 order due to fees
+            Assert.AreEqual(7580m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual * 1.0025m, security, algo));
+            Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual * 1.0025m + security.SymbolProperties.LotSize + 9, security, algo));
+            var expectedBuyingPower = algo.Portfolio.Cash * (1 - requiredFreeBuyingPowerPercent);
+            Assert.AreEqual(expectedBuyingPower, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentCashAccountWithLongHoldings_Equity()
+        {
+            var algo = GetAlgorithm();
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Cash);
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Equity);
+            var requiredFreeBuyingPowerPercent = 0.05m;
+            var model = security.BuyingPowerModel = new SecurityMarginModel(1, requiredFreeBuyingPowerPercent);
+            security.Holdings.SetHoldings(25, 2000);
+            security.SettlementModel.ApplyFunds(
+                algo.Portfolio, security, DateTime.UtcNow.AddDays(-10), Currencies.USD, -2000 * 25);
+
+            // Margin remaining 50k + used 50k + initial margin 50k - 5k free buying power percent (5% of 100k)
+            Assert.AreEqual(145000, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Sell));
+            // Margin remaining 50k - 5k free buying power percent (5% of 100k)
+            Assert.AreEqual(45000, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+
+            var actual = algo.CalculateOrderQuantity(_symbol, -1m * model.GetLeverage(security));
+            // ((100k - 5) * -1 * 0.95 * 0.9975 - (50k holdings)) / 25 - 1 order due to fees
+            Assert.AreEqual(-5790m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual * 1.0025m, security, algo));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentMarginAccountWithLongHoldings_Equity()
+        {
+            var algo = GetAlgorithm();
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Margin);
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Equity);
+            var requiredFreeBuyingPowerPercent = 0.05m;
+            var model = security.BuyingPowerModel = new SecurityMarginModel(2, requiredFreeBuyingPowerPercent);
+            security.Holdings.SetHoldings(25, 2000);
+            security.SettlementModel.ApplyFunds(
+                algo.Portfolio, security, DateTime.UtcNow.AddDays(-10), Currencies.USD, -2000 * 25);
+
+            // Margin remaining 75k + used 25k + initial margin 25k - 5k free buying power percent (5% of 100k)
+            Assert.AreEqual(120000, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Sell));
+            // Margin remaining 75k - 5k free buying power percent
+            Assert.AreEqual(70000, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+
+            var actual = algo.CalculateOrderQuantity(_symbol, -1m * model.GetLeverage(security));
+            // ((100k - 5) * -2 * 0.95 * 0.9975 - (50k holdings)) / 25 - 1 order due to fees
+            Assert.AreEqual(-9580m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual * 1.0025m, security, algo));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentMarginAccountWithShortHoldings_Equity()
+        {
+            var algo = GetAlgorithm();
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Margin);
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Equity);
+            var requiredFreeBuyingPowerPercent = 0.05m;
+            var model = security.BuyingPowerModel = new SecurityMarginModel(2, requiredFreeBuyingPowerPercent);
+            security.Holdings.SetHoldings(25, -2000);
+            security.SettlementModel.ApplyFunds(
+                algo.Portfolio, security, DateTime.UtcNow.AddDays(-10), Currencies.USD, 2000 * 25);
+
+            // Margin remaining 75k + used 25k + initial margin 25k - 5k free buying power percent (5% of 100k)
+            Assert.AreEqual(120000, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+            // Margin remaining 75k - 5k free buying power percent
+            Assert.AreEqual(70000, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Sell));
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // ((100k - 5) * 2 * 0.95 * 0.9975 - (-50k holdings)) / 25 - 1 order due to fees
+            Assert.AreEqual(9580m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.IsFalse(HasSufficientBuyingPowerForOrder(actual * 1.0025m, security, algo));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentDefault_Option()
+        {
+            const decimal price = 25m;
+            const decimal underlyingPrice = 25m;
+
+            var tz = TimeZones.NewYork;
+            var equity = new QuantConnect.Securities.Equity.Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
+
+            var optionPutSymbol = Symbol.CreateOption(Symbols.SPY, Market.USA, OptionStyle.American, OptionRight.Put, 207m, new DateTime(2015, 02, 27));
+            var security = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), optionPutSymbol, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(Currencies.USD, 0, 1m),
+                new OptionSymbolProperties("", Currencies.USD, 100, 0.01m, 1),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+            security.SetMarketPrice(new Tick { Value = price });
+            security.Underlying = equity;
+
+            var algo = GetAlgorithm();
+            security.SetLocalTimeKeeper(algo.TimeKeeper.GetLocalTimeKeeper(tz));
+            var actual = security.BuyingPowerModel.GetMaximumOrderQuantityForTargetBuyingPower(
+                new GetMaximumOrderQuantityForTargetBuyingPowerParameters(algo.Portfolio, security, 1)).Quantity;
+
+            // (100000 * 1) / (25 * 100 contract multiplier) - 1 order due to fees
+            Assert.AreEqual(39m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.AreEqual(algo.Portfolio.Cash, security.BuyingPowerModel.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentAppliesForCashAccount_Option()
+        {
+            var algo = GetAlgorithm();
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Cash);
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Option);
+            var requiredFreeBuyingPowerPercent = 0.05m;
+            var model = security.BuyingPowerModel = new SecurityMarginModel(1, requiredFreeBuyingPowerPercent);
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 1 * 0.95) / (25 * 100 contract multiplier) - 1 order due to fees
+            Assert.AreEqual(37m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            var expectedBuyingPower = algo.Portfolio.Cash * (1 - requiredFreeBuyingPowerPercent);
+            Assert.AreEqual(expectedBuyingPower, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentAppliesForMarginAccount_Option()
+        {
+            var algo = GetAlgorithm();
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Margin);
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Option);
+            var requiredFreeBuyingPowerPercent = 0.05m;
+            var model = security.BuyingPowerModel = new SecurityMarginModel(2, requiredFreeBuyingPowerPercent);
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 2 * 0.95) / (25 * 100 contract multiplier) - 1 order due to fees
+            Assert.AreEqual(75m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            var expectedBuyingPower = algo.Portfolio.Cash * (1 - requiredFreeBuyingPowerPercent);
+            Assert.AreEqual(expectedBuyingPower, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentDefault_Future()
+        {
+            var algo = GetAlgorithm();
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Future, "ES");
+            var model = security.BuyingPowerModel;
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // (100000 * 1 * 0.9975 ) / 5200 - 1 order due to fees
+            Assert.AreEqual(18m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            Assert.AreEqual(algo.Portfolio.Cash, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentAppliesForCashAccount_Future()
+        {
+            var algo = GetAlgorithm();
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Cash);
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Future);
+            var requiredFreeBuyingPowerPercent = 0.05m;
+            var model = security.BuyingPowerModel = new SecurityMarginModel(1, requiredFreeBuyingPowerPercent);
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // ((100000 - 5) * 1 * 0.95 * 0.9975 / (25)
+            Assert.AreEqual(3790m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            var expectedBuyingPower = algo.Portfolio.Cash * (1 - requiredFreeBuyingPowerPercent);
+            Assert.AreEqual(expectedBuyingPower, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+        }
+
+        [Test]
+        public void FreeBuyingPowerPercentAppliesForMarginAccount_Future()
+        {
+            var algo = GetAlgorithm();
+            algo.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Margin);
+            var security = InitAndGetSecurity(algo, 5, SecurityType.Future);
+            var requiredFreeBuyingPowerPercent = 0.05m;
+            var model = security.BuyingPowerModel = new SecurityMarginModel(2, requiredFreeBuyingPowerPercent);
+
+            var actual = algo.CalculateOrderQuantity(_symbol, 1m * model.GetLeverage(security));
+            // ((100000 - 5) * 2 * 0.95 * 0.9975 / (25)
+            Assert.AreEqual(7580m, actual);
+            Assert.IsTrue(HasSufficientBuyingPowerForOrder(actual, security, algo));
+            var expectedBuyingPower = algo.Portfolio.Cash * (1 - requiredFreeBuyingPowerPercent);
+            Assert.AreEqual(expectedBuyingPower, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));
+        }
+
+        [TestCase(0)]
+        [TestCase(10000)]
+        public void NonAccountCurrency_GetBuyingPower(decimal nonAccountCurrencyCash)
+        {
+            var algo = GetAlgorithm();
+            algo.Portfolio.CashBook.Clear();
+            algo.Portfolio.SetAccountCurrency("EUR");
+            algo.Portfolio.SetCash(10000);
+            algo.Portfolio.SetCash(Currencies.USD, nonAccountCurrencyCash, 0.88m);
+            var security = InitAndGetSecurity(algo, 0);
+            Assert.AreEqual(10000m + algo.Portfolio.CashBook[Currencies.USD].ValueInAccountCurrency,
+                algo.Portfolio.TotalPortfolioValue);
+
+            var quantity = security.BuyingPowerModel.GetBuyingPower(
+                new BuyingPowerParameters(algo.Portfolio, security, OrderDirection.Buy)).Value;
+
+            Assert.AreEqual(10000m + algo.Portfolio.CashBook[Currencies.USD].ValueInAccountCurrency,
+                quantity);
         }
 
         [Test]

--- a/Tests/Python/SecurityCustomModelTests.cs
+++ b/Tests/Python/SecurityCustomModelTests.cs
@@ -95,6 +95,9 @@ class CustomBuyingPowerModel:
     def __init__(self):
         self.margin = 1.0
 
+    def GetBuyingPower(self, context):
+        return BuyingPower(context.Portfolio.MarginRemaining)
+
     def GetMaximumOrderQuantityForDeltaBuyingPower(self, context):
         return GetMaximumOrderQuantityResult(200)
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Revert GetBuyingPower removal on https://github.com/QuantConnect/Lean/pull/4059
- Fix bug where OptioMarginModel would return 0 initial margin required if had no holdings. Tested by `FreeBuyingPowerPercentDefault_Option` same behavior as previous to https://github.com/QuantConnect/Lean/pull/4059.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/Lean/issues/4027
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve user experience
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
