### PR TITLE
Fix GetCashBalance for Bitfinex margin trading

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -59,7 +59,22 @@ namespace QuantConnect.Brokerages.Bitfinex
         /// <param name="algorithm">the algorithm instance is required to retrieve account type</param>
         /// <param name="priceProvider">The price provider for missing FX conversion rates</param>
         public BitfinexBrokerage(string wssUrl, string restUrl, string apiKey, string apiSecret, IAlgorithm algorithm, IPriceProvider priceProvider)
-            : base(wssUrl, new WebSocketWrapper(), new RestClient(restUrl), apiKey, apiSecret, Market.Bitfinex, "Bitfinex")
+            : this(wssUrl, new WebSocketWrapper(), new RestClient(restUrl), apiKey, apiSecret, algorithm, priceProvider)
+        {
+        }
+
+        /// <summary>
+        /// Constructor for brokerage
+        /// </summary>
+        /// <param name="wssUrl">websockets url</param>
+        /// <param name="websocket">instance of websockets client</param>
+        /// <param name="restClient">instance of rest client</param>
+        /// <param name="apiKey">api key</param>
+        /// <param name="apiSecret">api secret</param>
+        /// <param name="algorithm">the algorithm instance is required to retrieve account type</param>
+        /// <param name="priceProvider">The price provider for missing FX conversion rates</param>
+        public BitfinexBrokerage(string wssUrl, IWebSocket websocket, IRestClient restClient, string apiKey, string apiSecret, IAlgorithm algorithm, IPriceProvider priceProvider)
+            : base(wssUrl, websocket, restClient, apiKey, apiSecret, Market.Bitfinex, "Bitfinex")
         {
             _subscriptionManager = new BitfinexSubscriptionManager(this, wssUrl, _symbolMapper);
             _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();

--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -42,6 +42,7 @@ namespace QuantConnect.Brokerages.Bitfinex
         private readonly RateGate _restRateLimiter = new RateGate(8, TimeSpan.FromMinutes(1));
         private readonly ConcurrentDictionary<int, decimal> _fills = new ConcurrentDictionary<int, decimal>();
         private readonly BitfinexSubscriptionManager _subscriptionManager;
+        private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase;
 
         /// <summary>
         /// Locking object for the Ticks list in the data queue handler
@@ -61,6 +62,7 @@ namespace QuantConnect.Brokerages.Bitfinex
             : base(wssUrl, new WebSocketWrapper(), new RestClient(restUrl), apiKey, apiSecret, Market.Bitfinex, "Bitfinex")
         {
             _subscriptionManager = new BitfinexSubscriptionManager(this, wssUrl, _symbolMapper);
+            _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
             _algorithm = algorithm;
 
             WebSocket.Open += (sender, args) =>

--- a/Tests/Brokerages/Bitfinex/BitfinexBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/Bitfinex/BitfinexBrokerageAdditionalTests.cs
@@ -1,0 +1,104 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Linq;
+using System.Net;
+using Moq;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+using QuantConnect.Brokerages.Bitfinex;
+using QuantConnect.Interfaces;
+using RestSharp;
+
+namespace QuantConnect.Tests.Brokerages.Bitfinex
+{
+    [TestFixture]
+    public class BitfinexBrokerageAdditionalTests
+    {
+        private BitfinexBrokerage _brokerage;
+        private readonly Mock<IWebSocket> _webSocket = new Mock<IWebSocket>();
+        private readonly Mock<IRestClient> _restClient = new Mock<IRestClient>();
+        private readonly IAlgorithm _algorithm = new QCAlgorithm();
+
+        [SetUp]
+        public void Setup()
+        {
+            var priceProvider = new Mock<IPriceProvider>();
+            priceProvider.Setup(x => x.GetLastPrice(It.IsAny<Symbol>())).Returns(1.234m);
+
+            _brokerage = new BitfinexBrokerage(
+                "wss://localhost",
+                _webSocket.Object,
+                _restClient.Object,
+                "apikey",
+                "apisecret",
+                _algorithm,
+                priceProvider.Object);
+
+            _algorithm.SetBrokerageModel(new BitfinexBrokerageModel());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _brokerage.Disconnect();
+            _brokerage.Dispose();
+        }
+
+        [Test]
+        public void ReturnsCorrectCashBalancesWithMarginPositions()
+        {
+            _restClient.Setup(m => m.Execute(It.Is<IRestRequest>(r => r.Resource == "/v1/balances")))
+                .Returns(new RestResponse
+                {
+                    Content = @"
+[
+  { 'type':'trading', 'currency':'btc', 'amount':'0.0', 'available':'0.0' },
+  { 'type':'trading', 'currency':'eth', 'amount':'1.0', 'available':'0.5' },
+  { 'type':'trading', 'currency':'usd', 'amount':'0.0', 'available':'0.0' }
+]",
+                    StatusCode = HttpStatusCode.OK
+                });
+
+            _restClient.Setup(m => m.Execute(It.Is<IRestRequest>(r => r.Resource == "/v1/positions")))
+                .Returns(new RestResponse
+                {
+                    Content = "[{'id':142974855,'symbol':'btcusd','status':'ACTIVE','base':'7995.0','amount':'0.05','timestamp':'1583871936.0','swap':'-0.00648185','pl':'-2.48113'}]",
+                    StatusCode = HttpStatusCode.OK
+                });
+
+            _restClient.Setup(m => m.Execute(It.Is<IRestRequest>(r => r.Resource == "/v1/pubticker/BTCUSD")))
+                .Returns(new RestResponse
+                {
+                    Content = "{'mid':'7964.5','bid':'7963.2','ask':'7965.8','last_price':'7957.4','low':'7776.6','high':'8180.0','volume':'9934.81070662000002805','timestamp':'1583887538.695179'}",
+                    StatusCode = HttpStatusCode.OK
+                });
+
+            var balances = _brokerage.GetCashBalance();
+
+            Assert.AreEqual(3, balances.Count);
+
+            var eth = balances.Single(a => a.Currency == "ETH");
+            var btc = balances.Single(a => a.Currency == "BTC");
+            var usd = balances.Single(a => a.Currency == "USD");
+
+            Assert.AreEqual(1.0, eth.Amount);
+            Assert.AreEqual(0.05, btc.Amount);
+            // 7995 * 0.05
+            Assert.AreEqual(-399.75, usd.Amount);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -299,6 +299,7 @@
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
     <Compile Include="Algorithm\Framework\Selection\QC500UniverseSelectionModelTests.cs" />
+    <Compile Include="Brokerages\Bitfinex\BitfinexBrokerageAdditionalTests.cs" />
     <Compile Include="Brokerages\Bitfinex\BitfinexFeeModelTests.cs" />
     <Compile Include="Brokerages\Bitfinex\BitfinexSymbolMapperTests.cs" />
     <Compile Include="Brokerages\Bitfinex\BitfinexBrokerageHistoryProviderTests.cs" />


### PR DESCRIPTION

#### Description
- Updated `BitfinexBrokerage.GetCashBalance()` to take into account open positions with margin trading.

#### Related Issue
Closes #4178 

#### Motivation and Context
- Incorrect `TotalPortfolioValue` and `CashBook` with existing open positions and cash sync.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Verified the test case in #4178 is fixed with the update.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`