### PR TITLE
Fix DivideByZeroException in RSI indicator

### DIFF
--- a/Indicators/RelativeStrengthIndex.cs
+++ b/Indicators/RelativeStrengthIndex.cs
@@ -92,18 +92,19 @@ namespace QuantConnect.Indicators
             }
 
             _previousInput = input;
-            if (AverageLoss == 0m)
+
+            // make sure the difference averages are not negative
+            // (can happen with some types of moving averages -- e.g. DEMA)
+            var averageLoss = AverageLoss < 0 ? 0 : AverageLoss.Current.Value;
+            var averageGain = AverageGain < 0 ? 0 : AverageGain.Current.Value;
+
+            if (averageLoss == 0m)
             {
                 // all up days is 100
                 return 100m;
             }
 
-            var rs = AverageGain / AverageLoss;
-            if (rs == -1m)
-            {
-                // prevent division by zero
-                return 100m;
-            }
+            var rs = averageGain / averageLoss;
 
             return 100m - 100m / (1 + rs);
         }

--- a/Indicators/RelativeStrengthIndex.cs
+++ b/Indicators/RelativeStrengthIndex.cs
@@ -99,7 +99,13 @@ namespace QuantConnect.Indicators
             }
 
             var rs = AverageGain / AverageLoss;
-            return 100m - (100m / (1 + rs));
+            if (rs == -1m)
+            {
+                // prevent division by zero
+                return 100m;
+            }
+
+            return 100m - 100m / (1 + rs);
         }
 
         /// <summary>

--- a/Tests/Indicators/RelativeStrengthIndexTests.cs
+++ b/Tests/Indicators/RelativeStrengthIndexTests.cs
@@ -63,6 +63,9 @@ namespace QuantConnect.Tests.Indicators
             for (var i = 0; i < 500; i++)
             {
                 rsi.Update(DateTime.UtcNow, 102m);
+
+                // validate the expected range
+                Assert.That(rsi >= 0 && rsi <= 100);
             }
         }
     }

--- a/Tests/Indicators/RelativeStrengthIndexTests.cs
+++ b/Tests/Indicators/RelativeStrengthIndexTests.cs
@@ -51,5 +51,19 @@ namespace QuantConnect.Tests.Indicators
             TestHelper.AssertIndicatorIsInDefaultState(rsi.AverageGain);
             TestHelper.AssertIndicatorIsInDefaultState(rsi.AverageLoss);
         }
+
+        [Test]
+        public void DoesNotThrowDivisionByZero()
+        {
+            var rsi = new RelativeStrengthIndex(14, MovingAverageType.DoubleExponential);
+
+            rsi.Update(DateTime.UtcNow, 101m);
+            rsi.Update(DateTime.UtcNow, 103m);
+
+            for (var i = 0; i < 500; i++)
+            {
+                rsi.Update(DateTime.UtcNow, 102m);
+            }
+        }
     }
 }


### PR DESCRIPTION

#### Description
- Added a missing check for divide by zero in the `RelativeStrengthIndex (RSI)` indicator.

#### Related Issue
Closes #4007 

#### Motivation and Context
- `DivideByZeroException` 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- New unit test
- Test algorithm in #4007 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`