### PR TITLE
Fix deserialization of Estimize Time property

### DIFF
--- a/Common/Data/Custom/Estimize/EstimizeConsensus.cs
+++ b/Common/Data/Custom/Estimize/EstimizeConsensus.cs
@@ -84,7 +84,11 @@ namespace QuantConnect.Data.Custom.Estimize
         /// The timestamp of this consensus (UTC)
         /// </summary>
         [JsonProperty(PropertyName = "updated_at")]
-        public DateTime UpdatedAt { get; set; }
+        public DateTime UpdatedAt
+        {
+            get { return Time; }
+            set { Time = value; }
+        }
 
         /// <summary>
         /// The fiscal year for the release
@@ -120,7 +124,6 @@ namespace QuantConnect.Data.Custom.Estimize
             var csv = csvLine.Split(',');
 
             UpdatedAt = Parse.DateTimeExact(csv[0], "yyyyMMdd HH:mm:ss");
-            Time = UpdatedAt;
             Id = csv[1];
             Source = (Source)Enum.Parse(typeof(Source), csv[2]);
             Type = csv[3].IfNotNullOrEmpty(s => (Type)Enum.Parse(typeof(Type), s));

--- a/Common/Data/Custom/Estimize/EstimizeEstimate.cs
+++ b/Common/Data/Custom/Estimize/EstimizeEstimate.cs
@@ -54,7 +54,11 @@ namespace QuantConnect.Data.Custom.Estimize
         /// The time that the estimate was created (UTC)
         /// </summary>
         [JsonProperty(PropertyName = "created_at")]
-        public DateTime CreatedAt { get; set; }
+        public DateTime CreatedAt
+        {
+            get { return Time; }
+            set { Time = value; }
+        }
 
         /// <summary>
         /// The time that the estimate was created (UTC)

--- a/Common/Data/Custom/Estimize/EstimizeRelease.cs
+++ b/Common/Data/Custom/Estimize/EstimizeRelease.cs
@@ -48,7 +48,11 @@ namespace QuantConnect.Data.Custom.Estimize
         /// The date of the release
         /// </summary>
         [JsonProperty(PropertyName = "release_date")]
-        public DateTime ReleaseDate { get; set; }
+        public DateTime ReleaseDate
+        {
+            get { return Time; }
+            set { Time = value; }
+        }
 
         /// <summary>
         /// The date of the release
@@ -126,7 +130,6 @@ namespace QuantConnect.Data.Custom.Estimize
             var csv = csvLine.Split(',');
 
             ReleaseDate = Parse.DateTimeExact(csv[0].Trim(), "yyyyMMdd HH:mm:ss");
-            Time = ReleaseDate;
             Id = csv[1];
             FiscalYear = Parse.Int(csv[2]);
             FiscalQuarter = Parse.Int(csv[3]);

--- a/Tests/Common/Data/Custom/EstimizeTests.cs
+++ b/Tests/Common/Data/Custom/EstimizeTests.cs
@@ -75,6 +75,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             Assert.AreEqual(data.ConsensusWeightedRevenueEstimate, 31966.6230263867);
             Assert.AreEqual(data.ReleaseDate, new DateTime(2019, 10, 23, 20, 0, 0).ToLocalTime());
             Assert.AreEqual(data.ReleaseDate, data.EndTime);
+            Assert.AreEqual(data.ReleaseDate, data.Time);
 
             content = content.Replace("\"eps\":null,", "\"eps\":1.2,");
             data = JsonConvert.DeserializeObject<EstimizeRelease>(content);
@@ -151,7 +152,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
         }
 
         [Test]
-        public void DeserializeEstimateReleaseSuccessfully()
+        public void DeserializeEstimizeEstimateSuccessfully()
         {
             var content = "{" +
                           "\"ticker\":\"AAPL\"," +
@@ -174,6 +175,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             Assert.AreEqual(data.FiscalQuarter, 2);
             Assert.AreEqual(data.CreatedAt, new DateTime(2019, 6, 7, 14, 40, 36).ToLocalTime());
             Assert.AreEqual(data.CreatedAt, data.EndTime);
+            Assert.AreEqual(data.CreatedAt, data.Time);
             Assert.AreEqual(data.Eps, 2.81);
             Assert.AreEqual(data.Revenue, 61413.0);
             Assert.AreEqual(data.UserName, "Dominantstock");


### PR DESCRIPTION

#### Description
- Updated the `Estimize` classes to handle deserialization of the `Time` property.

#### Related Issue
Closes #4191 

#### Motivation and Context
- The `Time` property of `Estimize` objects is set to the default value of `DateTime.MinValue`.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Updated unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`