### PR TITLE
Fix deserialization of TradingEconomicsCalendar Time property

### DIFF
--- a/Common/Data/Custom/TradingEconomics/TradingEconomicsCalendar.cs
+++ b/Common/Data/Custom/TradingEconomics/TradingEconomicsCalendar.cs
@@ -16,9 +16,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using QuantConnect.Data.UniverseSelection;
-using QuantConnect.Configuration;
 using QuantConnect.Logging;
-using QuantConnect.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -62,7 +60,11 @@ namespace QuantConnect.Data.Custom.TradingEconomics
         /// Release time and date in UTC
         /// </summary>
         [JsonProperty(PropertyName = "Date"), JsonConverter(typeof(TradingEconomicsDateTimeConverter))]
-        public override DateTime EndTime { get; set; }
+        public override DateTime EndTime
+        {
+            get { return Time; }
+            set { Time = value; }
+        }
 
         /// <summary>
         /// Country name

--- a/Tests/Common/Data/Custom/TradingEconomicsTests.cs
+++ b/Tests/Common/Data/Custom/TradingEconomicsTests.cs
@@ -20,9 +20,7 @@ using QuantConnect.Data.Custom.TradingEconomics;
 using QuantConnect.Data.UniverseSelection;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace QuantConnect.Tests.Common.Data.Custom
 {
@@ -53,7 +51,6 @@ namespace QuantConnect.Tests.Common.Data.Custom
   ""IsPercentage"": true,
   ""DataType"": 0,
   ""IsFillForward"": false,
-  ""Time"": ""0001-01-01T00:00:00"",
   ""Value"": 0.0,
   ""Price"": 0.0
 }]";
@@ -82,7 +79,6 @@ namespace QuantConnect.Tests.Common.Data.Custom
   ""Symbol"": ""US"",
   ""DataType"": 0,
   ""IsFillForward"": false,
-  ""Time"": ""0001-01-01T00:00:00"",
   ""Value"": 0.0,
   ""Price"": 0.0
 }]";
@@ -131,6 +127,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             var calendar = (TradingEconomicsCalendar)result;
 
             Assert.AreEqual("0", calendar.CalendarId);
+            Assert.AreEqual(new DateTime(2019, 1, 1), calendar.Time.Date);
             Assert.AreEqual(new DateTime(2019, 1, 1), calendar.EndTime.Date);
             Assert.AreEqual("United States", calendar.Country);
             Assert.AreEqual("PPI PCE", calendar.Category);
@@ -176,6 +173,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             var calendar = (TradingEconomicsCalendar)((BaseDataCollection)result).Data.Single();
 
             Assert.AreEqual("0", calendar.CalendarId);
+            Assert.AreEqual(new DateTime(2019, 1, 1), calendar.Time.Date);
             Assert.AreEqual(new DateTime(2019, 1, 1), calendar.EndTime.Date);
             Assert.AreEqual("United States", calendar.Country);
             Assert.AreEqual("PPI PCE", calendar.Category);
@@ -241,6 +239,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             var calendarLive = (TradingEconomicsCalendar)((BaseDataCollection)resultLive).Data.Single();
 
             Assert.AreEqual(calendarBacktest.CalendarId, calendarLive.CalendarId);
+            Assert.AreEqual(calendarBacktest.Time.Date, calendarLive.Time.Date);
             Assert.AreEqual(calendarBacktest.EndTime.Date, calendarLive.EndTime.Date);
             Assert.AreEqual(calendarBacktest.Country, calendarLive.Country);
             Assert.AreEqual(calendarBacktest.Category, calendarLive.Category);
@@ -336,6 +335,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
                     false
                 );
                 Assert.AreEqual("0", calendar.CalendarId);
+                Assert.AreEqual(new DateTime(2019, 1, 1), calendar.Time.Date);
                 Assert.AreEqual(new DateTime(2019, 1, 1), calendar.EndTime.Date);
                 Assert.AreEqual("United States", calendar.Country);
                 Assert.AreEqual("PPI PCE", calendar.Category);


### PR DESCRIPTION
#### Description
- Updated the `TradingEconomicsCalendar` class to handle deserialization of the `Time` property.

#### Related Issue
Closes #4193 

#### Motivation and Context
- The `Time` property of `TradingEconomicsCalendar` objects is set to the default value of `DateTime.MinValue`.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Updated unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`