### PR TITLE
Fix Estimize time zone bug in timestamp deserialization

### DIFF
--- a/Tests/Common/Data/Custom/EstimizeTests.cs
+++ b/Tests/Common/Data/Custom/EstimizeTests.cs
@@ -30,6 +30,11 @@ namespace QuantConnect.Tests.Common.Data.Custom
     [TestFixture]
     public class EstimizeTests
     {
+        private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings
+        {
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc
+        };
+
         [Test, Ignore]
         public void EstimizeDownloadDoesNotThrow()
         {
@@ -59,29 +64,29 @@ namespace QuantConnect.Tests.Common.Data.Custom
                           "\"release_date\":\"2019-10-23T16:00:00-04:00\"," +
                           "\"id\":\"155842\"}";
 
-            var data = JsonConvert.DeserializeObject<EstimizeRelease>(content);
+            var data = JsonConvert.DeserializeObject<EstimizeRelease>(content, _jsonSerializerSettings);
 
             Assert.NotNull(data);
-            Assert.AreEqual(data.Id, "155842");
-            Assert.AreEqual(data.FiscalYear, 2020);
-            Assert.AreEqual(data.FiscalQuarter, 1);
+            Assert.AreEqual("155842", data.Id);
+            Assert.AreEqual(2020, data.FiscalYear);
+            Assert.AreEqual(1, data.FiscalQuarter);
             Assert.IsFalse(data.Eps.HasValue);
-            Assert.AreEqual(data.WallStreetEpsEstimate, 1.188);
-            Assert.AreEqual(data.ConsensusEpsEstimate, 1.20507936507937);
-            Assert.AreEqual(data.ConsensusWeightedEpsEstimate, 1.21545656570188);
+            Assert.AreEqual(1.188, data.WallStreetEpsEstimate);
+            Assert.AreEqual(1.20507936507937, data.ConsensusEpsEstimate);
+            Assert.AreEqual(1.21545656570188, data.ConsensusWeightedEpsEstimate);
             Assert.IsFalse(data.Revenue.HasValue);
-            Assert.AreEqual(data.WallStreetRevenueEstimate, 31966.964);
-            Assert.AreEqual(data.ConsensusRevenueEstimate, 31872.2258064516);
-            Assert.AreEqual(data.ConsensusWeightedRevenueEstimate, 31966.6230263867);
-            Assert.AreEqual(data.ReleaseDate, new DateTime(2019, 10, 23, 20, 0, 0).ToLocalTime());
+            Assert.AreEqual(31966.964, data.WallStreetRevenueEstimate);
+            Assert.AreEqual(31872.2258064516, data.ConsensusRevenueEstimate);
+            Assert.AreEqual(31966.6230263867, data.ConsensusWeightedRevenueEstimate);
+            Assert.AreEqual(new DateTime(2019, 10, 23, 20, 0, 0), data.ReleaseDate);
             Assert.AreEqual(data.ReleaseDate, data.EndTime);
             Assert.AreEqual(data.ReleaseDate, data.Time);
 
             content = content.Replace("\"eps\":null,", "\"eps\":1.2,");
-            data = JsonConvert.DeserializeObject<EstimizeRelease>(content);
+            data = JsonConvert.DeserializeObject<EstimizeRelease>(content, _jsonSerializerSettings);
             Assert.NotNull(data);
-            Assert.AreEqual(data.Eps, 1.2);
-            Assert.AreEqual(data.Value, 1.2);
+            Assert.AreEqual(1.2, data.Eps);
+            Assert.AreEqual(1.2, data.Value);
         }
 
         [Test]
@@ -93,14 +98,14 @@ namespace QuantConnect.Tests.Common.Data.Custom
                 ReleaseDate = new DateTime(2019,6,10)
             };
 
-            var content = JsonConvert.SerializeObject(data);
+            var content = JsonConvert.SerializeObject(data, _jsonSerializerSettings);
 
             Assert.IsTrue(content.Contains("\"id\":\"0\""));
-            Assert.IsTrue(content.Contains("\"release_date\":\"2019-06-10T00:00:00\""));
+            Assert.IsTrue(content.Contains("\"release_date\":\"2019-06-10T00:00:00Z\""));
             Assert.IsTrue(content.Contains("\"eps\":null"));
 
             data.Eps = 1.2m;
-            content = JsonConvert.SerializeObject(data);
+            content = JsonConvert.SerializeObject(data, _jsonSerializerSettings);
             Assert.IsTrue(content.Contains("\"eps\":1.2"));
         }
 
@@ -166,26 +171,26 @@ namespace QuantConnect.Tests.Common.Data.Custom
                           "\"analyst_id\":\"657836\"," +
                           "\"flagged\":false}";
 
-            var data = JsonConvert.DeserializeObject<EstimizeEstimate>(content);
+            var data = JsonConvert.DeserializeObject<EstimizeEstimate>(content, _jsonSerializerSettings);
 
             Assert.NotNull(data);
-            Assert.AreEqual(data.Id, "2857028");
-            Assert.AreEqual(data.Ticker, "AAPL");
-            Assert.AreEqual(data.FiscalYear, 2020);
-            Assert.AreEqual(data.FiscalQuarter, 2);
-            Assert.AreEqual(data.CreatedAt, new DateTime(2019, 6, 7, 14, 40, 36).ToLocalTime());
-            Assert.AreEqual(data.CreatedAt, data.EndTime);
-            Assert.AreEqual(data.CreatedAt, data.Time);
-            Assert.AreEqual(data.Eps, 2.81);
-            Assert.AreEqual(data.Revenue, 61413.0);
-            Assert.AreEqual(data.UserName, "Dominantstock");
-            Assert.AreEqual(data.AnalystId, "657836");
+            Assert.AreEqual("2857028", data.Id);
+            Assert.AreEqual("AAPL", data.Ticker);
+            Assert.AreEqual(2020, data.FiscalYear);
+            Assert.AreEqual(2, data.FiscalQuarter);
+            Assert.AreEqual(new DateTime(2019, 6, 7, 14, 40, 36), data.CreatedAt);
+            Assert.AreEqual(data.EndTime, data.CreatedAt);
+            Assert.AreEqual(data.Time, data.CreatedAt);
+            Assert.AreEqual(2.81, data.Eps);
+            Assert.AreEqual(61413.0, data.Revenue);
+            Assert.AreEqual("Dominantstock", data.UserName);
+            Assert.AreEqual("657836", data.AnalystId);
             Assert.IsFalse(data.Flagged);
             content = content.Replace("\"eps\":2.81,", "\"eps\":null,");
-            data = JsonConvert.DeserializeObject<EstimizeEstimate>(content);
+            data = JsonConvert.DeserializeObject<EstimizeEstimate>(content, _jsonSerializerSettings);
             Assert.NotNull(data);
             Assert.IsFalse(data.Eps.HasValue);
-            Assert.AreEqual(data.Value, 0);
+            Assert.AreEqual(0, data.Value);
         }
 
         [Test]
@@ -197,14 +202,14 @@ namespace QuantConnect.Tests.Common.Data.Custom
                 CreatedAt = new DateTime(2019, 6, 10)
             };
 
-            var content = JsonConvert.SerializeObject(data);
+            var content = JsonConvert.SerializeObject(data, _jsonSerializerSettings);
 
             Assert.IsTrue(content.Contains("\"id\":\"0\""));
-            Assert.IsTrue(content.Contains("\"created_at\":\"2019-06-10T00:00:00\""));
+            Assert.IsTrue(content.Contains("\"created_at\":\"2019-06-10T00:00:00Z\""));
             Assert.IsTrue(content.Contains("\"eps\":null"));
 
             data.Eps = 1.2m;
-            content = JsonConvert.SerializeObject(data);
+            content = JsonConvert.SerializeObject(data, _jsonSerializerSettings);
             Assert.IsTrue(content.Contains("\"eps\":1.2"));
         }
 
@@ -234,7 +239,6 @@ namespace QuantConnect.Tests.Common.Data.Custom
 
             Assert.IsTrue(rows.Count > 0);
         }
-
 
         [Test, Ignore("Requires Estimize data")]
         public void EstimizeConsensusReaderTest()

--- a/ToolBox/EstimizeDataDownloader/EstimizeConsensusDataDownloader.cs
+++ b/ToolBox/EstimizeDataDownloader/EstimizeConsensusDataDownloader.cs
@@ -164,9 +164,9 @@ namespace QuantConnect.ToolBox.EstimizeDataDownloader
 
             var consensuses = revisionsJToken == null
                 ? new List<EstimizeConsensus>()
-                : JsonConvert.DeserializeObject<List<EstimizeConsensus>>(revisionsJToken.ToString());
+                : JsonConvert.DeserializeObject<List<EstimizeConsensus>>(revisionsJToken.ToString(), JsonSerializerSettings);
 
-            consensuses.Add(JsonConvert.DeserializeObject<EstimizeConsensus>(jToken.ToString()));
+            consensuses.Add(JsonConvert.DeserializeObject<EstimizeConsensus>(jToken.ToString(), JsonSerializerSettings));
 
             foreach (var consensus in consensuses)
             {

--- a/ToolBox/EstimizeDataDownloader/EstimizeDataDownloader.cs
+++ b/ToolBox/EstimizeDataDownloader/EstimizeDataDownloader.cs
@@ -41,6 +41,11 @@ namespace QuantConnect.ToolBox.EstimizeDataDownloader
         /// </summary>
         public RateGate IndexGate { get; }
 
+        protected readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
+        {
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc
+        };
+
         protected EstimizeDataDownloader()
         {
             _clientKey = Config.Get("estimize-economics-auth-token");

--- a/ToolBox/EstimizeDataDownloader/EstimizeEstimateDataDownloader.cs
+++ b/ToolBox/EstimizeDataDownloader/EstimizeEstimateDataDownloader.cs
@@ -115,7 +115,7 @@ namespace QuantConnect.ToolBox.EstimizeDataDownloader
                                         return;
                                     }
 
-                                    var estimates = JsonConvert.DeserializeObject<List<EstimizeEstimate>>(result)
+                                    var estimates = JsonConvert.DeserializeObject<List<EstimizeEstimate>>(result, JsonSerializerSettings)
                                         .GroupBy(estimate =>
                                         {
                                             var oldTicker = ticker;

--- a/ToolBox/EstimizeDataDownloader/EstimizeReleaseDataDownloader.cs
+++ b/ToolBox/EstimizeDataDownloader/EstimizeReleaseDataDownloader.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.ToolBox.EstimizeDataDownloader
                                     // instead of having "forecasts" that will change in the future taint our
                                     // data and make backtests non-deterministic. We want to have
                                     // consistency with our data in live trading historical requests as well
-                                    var releases = JsonConvert.DeserializeObject<List<EstimizeRelease>>(result)
+                                    var releases = JsonConvert.DeserializeObject<List<EstimizeRelease>>(result, JsonSerializerSettings)
                                         .Where(x => x.Eps != null)
                                         .GroupBy(x =>
                                         {


### PR DESCRIPTION

#### Description
- The `Estimize` `DateTime `properties are now deserialized as UTC instead of local time.

#### Related Issue
Closes #4197 

#### Motivation and Context
- `Estimize` `DateTime` properties are expected to be in UTC.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Updated unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`