### PR TITLE
Fix serialization of BenzingaNews Time and EndTime properties

### DIFF
--- a/Common/Data/Custom/Benzinga/BenzingaNews.cs
+++ b/Common/Data/Custom/Benzinga/BenzingaNews.cs
@@ -24,7 +24,6 @@ namespace QuantConnect.Data.Custom.Benzinga
     /// <summary>
     /// News data powered by Benzinga - https://docs.benzinga.io/benzinga/newsfeed-v2.html
     /// </summary>
-    [JsonObject(MemberSerialization.OptIn)]
     public class BenzingaNews : IndexedBaseData
     {
         /// <summary>
@@ -49,7 +48,11 @@ namespace QuantConnect.Data.Custom.Benzinga
         /// Date that the article was revised on
         /// </summary>
         [JsonProperty("updated")]
-        public DateTime UpdatedAt { get; set; }
+        public DateTime UpdatedAt
+        {
+            get { return Time; }
+            set { Time = value; }
+        }
 
         /// <summary>
         /// Title of the article published
@@ -89,6 +92,11 @@ namespace QuantConnect.Data.Custom.Benzinga
         /// </summary>
         [JsonProperty("tags")]
         public List<string> Tags { get; set; }
+
+        /// <summary>
+        /// Date that the article was revised on
+        /// </summary>
+        public override DateTime EndTime => UpdatedAt;
 
         /// <summary>
         /// Determines the actual source from an index contained within a ticker folder

--- a/Common/Data/Custom/Benzinga/BenzingaNewsJsonConverter.cs
+++ b/Common/Data/Custom/Benzinga/BenzingaNewsJsonConverter.cs
@@ -105,7 +105,7 @@ namespace QuantConnect.Data.Custom.Benzinga
         {
             var article = value as BenzingaNews;
 
-            var token = JToken.FromObject(article);
+            var token = JToken.FromObject(article, new JsonSerializer { NullValueHandling = NullValueHandling.Ignore });
             var categoryTokens = new List<JObject>(article.Categories.Count);
             var symbolTokens = new List<JObject>(article.Symbols.Count);
             var tagTokens = new List<JObject>(article.Tags.Count);

--- a/Tests/Common/Data/Custom/BenzingaNewsJsonConverterTests.cs
+++ b/Tests/Common/Data/Custom/BenzingaNewsJsonConverterTests.cs
@@ -190,7 +190,19 @@ namespace QuantConnect.Tests.Common.Data.Custom
 
             var instanceRoundTripActual = JsonConvert.DeserializeObject<BenzingaNews>(actualSerialized, converter);
 
-            Assert.AreEqual(instance.Author, instanceRoundTripActual.Author);            Assert.IsTrue(instance.Categories.SequenceEqual(instanceRoundTripActual.Categories));            Assert.AreEqual(instance.Contents, instanceRoundTripActual.Contents);            Assert.AreEqual(instance.CreatedAt, instanceRoundTripActual.CreatedAt);            Assert.AreEqual(instance.Id, instanceRoundTripActual.Id);            Assert.AreEqual(instance.Symbol, instanceRoundTripActual.Symbol);            Assert.IsTrue(instance.Symbols.SequenceEqual(instanceRoundTripActual.Symbols));            Assert.IsTrue(instance.Tags.SequenceEqual(instanceRoundTripActual.Tags));            Assert.AreEqual(instance.Teaser, instanceRoundTripActual.Teaser);            Assert.AreEqual(instance.Time, instanceRoundTripActual.Time);            Assert.AreEqual(instance.Title, instanceRoundTripActual.Title);            Assert.AreEqual(instance.UpdatedAt, instanceRoundTripActual.UpdatedAt);        }
+            Assert.AreEqual(instance.Author, instanceRoundTripActual.Author);
+            Assert.IsTrue(instance.Categories.SequenceEqual(instanceRoundTripActual.Categories));
+            Assert.AreEqual(instance.Contents, instanceRoundTripActual.Contents);
+            Assert.AreEqual(instance.CreatedAt, instanceRoundTripActual.CreatedAt);
+            Assert.AreEqual(instance.Id, instanceRoundTripActual.Id);
+            Assert.AreEqual(instance.Symbol, instanceRoundTripActual.Symbol);
+            Assert.IsTrue(instance.Symbols.SequenceEqual(instanceRoundTripActual.Symbols));
+            Assert.IsTrue(instance.Tags.SequenceEqual(instanceRoundTripActual.Tags));
+            Assert.AreEqual(instance.Teaser, instanceRoundTripActual.Teaser);
+            Assert.AreEqual(instance.Time, instanceRoundTripActual.Time);
+            Assert.AreEqual(instance.Title, instanceRoundTripActual.Title);
+            Assert.AreEqual(instance.UpdatedAt, instanceRoundTripActual.UpdatedAt);
+        }
 
         [Test]
         public void ReaderDeserializesInUtc()
@@ -242,7 +254,19 @@ namespace QuantConnect.Tests.Common.Data.Custom
             var news = new BenzingaNews();
             var instanceRoundTripActual = (BenzingaNews)news.Reader(config, serialized, default(DateTime), false);
 
-            Assert.AreEqual(instance.Author, instanceRoundTripActual.Author);            Assert.IsTrue(instance.Categories.SequenceEqual(instanceRoundTripActual.Categories));            Assert.AreEqual(instance.Contents, instanceRoundTripActual.Contents);            Assert.AreEqual(instance.CreatedAt, instanceRoundTripActual.CreatedAt);            Assert.AreEqual(instance.Id, instanceRoundTripActual.Id);            Assert.AreEqual(instance.Symbol, instanceRoundTripActual.Symbol);            Assert.IsTrue(instance.Symbols.SequenceEqual(instanceRoundTripActual.Symbols));            Assert.IsTrue(instance.Tags.SequenceEqual(instanceRoundTripActual.Tags));            Assert.AreEqual(instance.Teaser, instanceRoundTripActual.Teaser);            Assert.AreEqual(instance.Time, instanceRoundTripActual.Time);            Assert.AreEqual(instance.Title, instanceRoundTripActual.Title);            Assert.AreEqual(instance.UpdatedAt, instanceRoundTripActual.UpdatedAt);
+            Assert.AreEqual(instance.Author, instanceRoundTripActual.Author);
+            Assert.IsTrue(instance.Categories.SequenceEqual(instanceRoundTripActual.Categories));
+            Assert.AreEqual(instance.Contents, instanceRoundTripActual.Contents);
+            Assert.AreEqual(instance.CreatedAt, instanceRoundTripActual.CreatedAt);
+            Assert.AreEqual(instance.Id, instanceRoundTripActual.Id);
+            Assert.AreEqual(instance.Symbol, instanceRoundTripActual.Symbol);
+            Assert.IsTrue(instance.Symbols.SequenceEqual(instanceRoundTripActual.Symbols));
+            Assert.IsTrue(instance.Tags.SequenceEqual(instanceRoundTripActual.Tags));
+            Assert.AreEqual(instance.Teaser, instanceRoundTripActual.Teaser);
+            Assert.AreEqual(instance.Time, instanceRoundTripActual.Time);
+            Assert.AreEqual(instance.Title, instanceRoundTripActual.Title);
+            Assert.AreEqual(instance.UpdatedAt, instanceRoundTripActual.UpdatedAt);
+
         }
     }
 }

--- a/Tests/Common/Data/Custom/BenzingaNewsJsonConverterTests.cs
+++ b/Tests/Common/Data/Custom/BenzingaNewsJsonConverterTests.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
                 ""stocks"": [
                     {
                         ""name"": ""AAPL""
-                    },
+                    }
                 ],
                 ""tags"": [
                     {
@@ -57,7 +57,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             }";
 
             // Put in a single line to avoid potential failure due to platform-specific behavior (\r\n vs. \n)
-            var expectedSerialized = @"{""id"":1,""author"":""Gerardo"",""created"":""2018-01-25T12:00:00Z"",""updated"":""2018-01-26T12:00:00Z"",""title"":""Unit Test Beats Expectations"",""teaser"":""The unit test beat reviewer's expectations, reporters say"",""body"":"" The unit test beat reviewer's expectations, reporters say - 'This is the best test I've ever seen' says Martin "",""channels"":[{""name"":""earnings""}],""stocks"":[{""name"":""AAPL""}],""tags"":[{""name"":""unit test""},{""name"":""testing""}]}";
+            var expectedSerialized = @"{""id"":1,""author"":""Gerardo"",""created"":""2018-01-25T12:00:00Z"",""updated"":""2018-01-26T12:00:00Z"",""title"":""Unit Test Beats Expectations"",""teaser"":""The unit test beat reviewer's expectations, reporters say"",""body"":"" The unit test beat reviewer's expectations, reporters say - 'This is the best test I've ever seen' says Martin "",""channels"":[{""name"":""earnings""}],""stocks"":[{""name"":""AAPL""}],""tags"":[{""name"":""unit test""},{""name"":""testing""}],""EndTime"":""2018-01-26T12:00:00Z"",""DataType"":0,""IsFillForward"":false,""Time"":""2018-01-26T12:00:00Z"",""Symbol"":{""Value"":""AAPL"",""ID"":""AAPL.BenzingaNews R735QTJ8XC9W"",""Permtick"":""AAPL""},""Value"":0.0,""Price"":0.0}";
             var expectedSymbol = new Symbol(
                 SecurityIdentifier.GenerateEquity(
                     "AAPL",
@@ -94,6 +94,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
                 result.UpdatedAt);
 
             Assert.AreEqual(result.UpdatedAt, result.EndTime);
+            Assert.AreEqual(result.UpdatedAt, result.Time);
 
             Assert.AreEqual("Gerardo", result.Author);
             Assert.AreEqual("Unit Test Beats Expectations", result.Title);

--- a/Tests/Common/Data/Custom/BenzingaNewsJsonConverterTests.cs
+++ b/Tests/Common/Data/Custom/BenzingaNewsJsonConverterTests.cs
@@ -117,5 +117,34 @@ namespace QuantConnect.Tests.Common.Data.Custom
             Assert.AreEqual(result.Symbols, resultFromSerialized.Symbols);
             Assert.AreEqual(result.Tags, resultFromSerialized.Tags);
         }
+
+        [Test]
+        public void SerializeRoundTrip()
+        {
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
+            var createdAt = new DateTime(2020, 3, 19, 10, 0, 0);
+            var updatedAt = new DateTime(2020, 3, 19, 10, 15, 0);
+
+            var item = new BenzingaNews
+            {
+                Id = 1,
+                Symbol = Symbols.SPY,
+                Title = "title",
+                CreatedAt = createdAt,
+                UpdatedAt = updatedAt,
+            };
+
+            var serialized = JsonConvert.SerializeObject(item, settings);
+            var deserialized = JsonConvert.DeserializeObject<BenzingaNews>(serialized, settings);
+
+            Assert.AreEqual(1, deserialized.Id);
+            Assert.AreEqual(Symbols.SPY, deserialized.Symbol);
+            Assert.AreEqual("title", deserialized.Title);
+            Assert.AreEqual(createdAt, deserialized.CreatedAt);
+            Assert.AreEqual(updatedAt, deserialized.UpdatedAt);
+            Assert.AreEqual(updatedAt, deserialized.Time);
+            Assert.AreEqual(updatedAt, deserialized.EndTime);
+        }
     }
 }

--- a/ToolBox/Benzinga/BenzingaNewsDataConverter.cs
+++ b/ToolBox/Benzinga/BenzingaNewsDataConverter.cs
@@ -152,6 +152,12 @@ namespace QuantConnect.ToolBox.Benzinga
             // We will write files from memory to disk without the need of temporary files.
             var filteredCollection = new Dictionary<DateTime, BenzingaNewsFiltered>();
             var contentsZip = new Dictionary<DateTime, Dictionary<string, string>>();
+            var serializerSettings = new JsonSerializerSettings
+            {
+                Converters = new[] { new BenzingaNewsJsonConverter() },
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                Formatting = Formatting.None
+            };
 
             foreach (var article in news)
             {
@@ -252,7 +258,7 @@ namespace QuantConnect.ToolBox.Benzinga
                 }
 
                 // Batch all the articles so that we can write it all in one shot
-                filtered.ArticleContents[$"{article.Id}.json"] = JsonConvert.SerializeObject(article, Formatting.None, new BenzingaNewsJsonConverter());
+                filtered.ArticleContents[$"{article.Id}.json"] = JsonConvert.SerializeObject(article, serializerSettings);
             }
 
             return filteredCollection;


### PR DESCRIPTION

#### Description
- The `BenzingaNews` class has been updated to allow serialization of all required properties.

#### Related Issue
Closes #4203

#### Motivation and Context
- The `Time` and `EndTime` properties were not serialized.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Updated unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`