### PR TITLE
Update Mono version to 6.6.0.166

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: csharp
 mono:
-  - 6.6.0.166
+  - 6.6.0
 solution: QuantConnect.Lean.sln
 before_install:
   - export PATH="$HOME/miniconda3/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: csharp
 mono:
-  - 5.12.0
+  - 6.6.0.166
 solution: QuantConnect.Lean.sln
 before_install:
   - export PATH="$HOME/miniconda3/bin:$PATH"

--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -36,7 +36,7 @@ RUN wget http://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-lin
 # From https://github.com/mono/docker/blob/master/
 RUN apt-get update && rm -rf /var/lib/apt/lists/*
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/5.12.0.226 main" > /etc/apt/sources.list.d/mono-xamarin.list && \
+RUN echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/6.6.0.166 main" > /etc/apt/sources.list.d/mono-xamarin.list && \
     apt-get update && apt-get install -y binutils mono-complete ca-certificates-mono mono-vbnc nuget referenceassemblies-pcl && \
     apt-get install -y fsharp && rm -rf /var/lib/apt/lists/* /tmp/*
 


### PR DESCRIPTION
Update mono to version 6.6.0.166 from version 5.12

#### Description
On travis, the used version of mono was 5.12. Updating it is necessary to use newer versions of the .net framework and the C# language

#### Related Issue
#4216 

#### Motivation and Context
Updating it is necessary to use newer versions of the .net framework and the C# language

#### Requires Documentation Change
No changes needed

#### How Has This Been Tested?
Local machine running the same version

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
