### PR TITLE
Exposing ADX from within ADXR

### DIFF
--- a/Indicators/AverageDirectionalMovementIndexRating.cs
+++ b/Indicators/AverageDirectionalMovementIndexRating.cs
@@ -25,7 +25,6 @@ namespace QuantConnect.Indicators
     public class AverageDirectionalMovementIndexRating : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly int _period;
-        private readonly AverageDirectionalIndex _adx;
         private readonly RollingWindow<decimal> _adxHistory;
 
         /// <summary>
@@ -37,7 +36,7 @@ namespace QuantConnect.Indicators
             : base(name)
         {
             _period = period;
-            _adx = new AverageDirectionalIndex(name + "_ADX", period);
+            ADX = new AverageDirectionalIndex(name + "_ADX", period);
             _adxHistory = new RollingWindow<decimal>(period);
         }
 
@@ -49,6 +48,8 @@ namespace QuantConnect.Indicators
             : this($"ADXR({period})", period)
         {
         }
+
+        public AverageDirectionalIndex ADX { get; }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
@@ -67,14 +68,14 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
-            _adx.Update(input);
+            ADX.Update(input);
 
-            if (_adx.IsReady)
+            if (ADX.IsReady)
             {
-                _adxHistory.Add(_adx);
+                _adxHistory.Add(ADX);
             }
 
-            return IsReady ? (_adx + _adxHistory[_period - 1]) / 2 : 50m;
+            return IsReady ? (ADX + _adxHistory[_period - 1]) / 2 : 50m;
         }
 
         /// <summary>
@@ -82,7 +83,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         public override void Reset()
         {
-            _adx.Reset();
+            ADX.Reset();
             _adxHistory.Reset();
             base.Reset();
         }

--- a/Indicators/AverageDirectionalMovementIndexRating.cs
+++ b/Indicators/AverageDirectionalMovementIndexRating.cs
@@ -49,6 +49,9 @@ namespace QuantConnect.Indicators
         {
         }
 
+        /// <summary>
+        /// The Average Directional Index indicator instance being used
+        /// </summary>
         public AverageDirectionalIndex ADX { get; }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Simple change to convert _adx parameter contained within AverageDirectionalMovementIndexRating class to an autoproperty to allow it's value be exposed (along with being able to access the PositiveDirectionalIndex and NegativeDirectionalIndex.

#### Related Issue
Addresses issue #4221

#### Motivation and Context
Many interpretations of the ADXR indicator look at its value and compare it to either the underlying  ADX value or the PDI/NDI values from the underlying ADX indicator. This exposes the ADX used by the ADXR, removing the need for a second ADX indicator from being needed.

#### Requires Documentation Change
None required

#### How Has This Been Tested?
Variable successfully accessed from Alpha Model

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. 
Existing AverageDirectionalIndex tests using spy_with_adx.txt cover this
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
