### PR TITLE
Fix WarmupIndicator duplicate consolidator

### DIFF
--- a/Algorithm.CSharp/AutomaticIndicatorWarmupRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AutomaticIndicatorWarmupRegressionAlgorithm.cs
@@ -1,0 +1,155 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Algorithm which reproduces GH issue 3861, where in some cases 2 consolidators were added when
+    /// using the automatic indicator warmup feature
+    /// </summary>
+    public class AutomaticIndicatorWarmupRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _spy;
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+
+            EnableAutomaticIndicatorWarmUp = true;
+
+            // Test case 1
+            _spy = AddEquity("SPY").Symbol;
+            var sma = SMA(_spy, 10);
+            if (!sma.IsReady)
+            {
+                throw new Exception("Expected SMA to be warmed up");
+            }
+
+            // Test case 2
+            var indicator = new CustomIndicator(10);
+            RegisterIndicator(_spy, indicator, Resolution.Minute, (Func<IBaseData, decimal>) null);
+
+            if (indicator.IsReady)
+            {
+                throw new Exception("Expected CustomIndicator Not to be warmed up");
+            }
+            WarmUpIndicator(_spy, indicator);
+            if (!indicator.IsReady)
+            {
+                throw new Exception("Expected CustomIndicator to be warmed up");
+            }
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                var subscription = SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(_spy).Single();
+
+                // we expect 1 consolidator per indicator
+                if (subscription.Consolidators.Count != 2)
+                {
+                    throw new Exception($"Unexpected consolidator count for subscription: {subscription.Consolidators.Count}");
+                }
+                SetHoldings(_spy, 1);
+            }
+        }
+
+        private class CustomIndicator : SimpleMovingAverage
+        {
+            private IndicatorDataPoint _previous;
+            public CustomIndicator(int period) : base(period)
+            {
+            }
+            protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
+            {
+                if (_previous != null && input.EndTime == _previous.EndTime)
+                {
+                    throw new Exception($"Unexpected indicator double data point call: {_previous}");
+                }
+                _previous = input;
+                return base.ComputeNextValue(window, input);
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "263.153%"},
+            {"Drawdown", "2.200%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "1.663%"},
+            {"Sharpe Ratio", "4.824"},
+            {"Probabilistic Sharpe Ratio", "66.954%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0.996"},
+            {"Annual Standard Deviation", "0.219"},
+            {"Annual Variance", "0.048"},
+            {"Information Ratio", "-4.864"},
+            {"Tracking Error", "0.001"},
+            {"Treynor Ratio", "1.061"},
+            {"Total Fees", "$3.26"},
+            {"Fitness Score", "0.248"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "94.3"},
+            {"Portfolio Turnover", "0.248"},
+            {"Total Insights Generated", "1"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "1"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "-148851580"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -159,6 +159,7 @@
     <Compile Include="AltData\PsychSignalSentimentAlgorithm.cs" />
     <Compile Include="AltData\TradingEconomicsAlgorithm.cs" />
     <Compile Include="AltData\TiingoNewsAlgorithm.cs" />
+    <Compile Include="AutomaticIndicatorWarmupRegressionAlgorithm.cs" />
     <Compile Include="BasicTemplateConstituentUniverseAlgorithm.cs" />
     <Compile Include="DefaultResolutionRegressionAlgorithm.cs" />
     <Compile Include="BasicPythonIntegrationTemplateAlgorithm.cs" />

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1916,16 +1916,7 @@ namespace QuantConnect.Algorithm
                 indicator.Update(input);
             };
 
-            var consolidator = GetIndicatorWarmUpConsolidator(symbol, period, onDataConsolidated);
-            history.PushThrough(bar => consolidator.Update(bar));
-
-            // Scan for time after we've pumped all the data through for this consolidator
-            var lastBar = history.LastOrDefault();
-            if (lastBar != null && lastBar.ContainsKey(symbol))
-            {
-                consolidator.Scan(((IBaseData)lastBar[symbol]).EndTime);
-            }
-
+            WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history);
             return indicator;
         }
 
@@ -1967,15 +1958,7 @@ namespace QuantConnect.Algorithm
                 indicator.Update(selector(bar));
             };
 
-            // Push the historical data through a consolidator
-            var consolidator = GetIndicatorWarmUpConsolidator(symbol, period, onDataConsolidated);
-            history.PushThrough(bar => consolidator.Update(bar));
-
-            // Scan for time after we've pumped all the data through for this consolidator
-            var lastBar = history.LastOrDefault();
-            var lastTime = lastBar == null ? DateTime.MinValue : lastBar[symbol].EndTime;
-            consolidator.Scan(lastTime);
-
+            WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history);
             return indicator;
         }
 
@@ -2005,22 +1988,39 @@ namespace QuantConnect.Algorithm
             return Enumerable.Empty<Slice>();
         }
 
-        private IDataConsolidator GetIndicatorWarmUpConsolidator<T>(Symbol symbol, TimeSpan period, Action<T> handler)
+        private void WarmUpIndicatorImpl<T>(Symbol symbol, TimeSpan period, Action<T> handler, IEnumerable<Slice> history)
             where T : class, IBaseData
         {
+            IDataConsolidator consolidator;
             if (SubscriptionManager.Subscriptions.Any(x => x.Symbol == symbol))
             {
-                return Consolidate(symbol, period, handler);
+                consolidator = Consolidate(symbol, period, handler);
+            }
+            else
+            {
+                var dataType = SubscriptionManager.LookupSubscriptionConfigDataTypes(
+                    symbol.SecurityType,
+                    Resolution.Daily,
+                    symbol.IsCanonical()).First();
+
+                consolidator = CreateConsolidator(period, dataType.Item1, dataType.Item2);
+                consolidator.DataConsolidated += (s, bar) => handler((T)bar);
             }
 
-            var dataType = SubscriptionManager.LookupSubscriptionConfigDataTypes(
-                symbol.SecurityType,
-                Resolution.Daily,
-                symbol.IsCanonical()).First();
+            BaseData lastBar = null;
+            history.PushThrough(bar =>
+                {
+                    lastBar = bar;
+                    consolidator.Update(bar);
+                }
+            );
+            // Scan for time after we've pumped all the data through for this consolidator
+            if (lastBar != null)
+            {
+                consolidator.Scan(lastBar.EndTime);
+            }
 
-            var consolidator = CreateConsolidator(period, dataType.Item1, dataType.Item2);
-            consolidator.DataConsolidated += (s, bar) => handler((T)bar);
-            return consolidator;
+            SubscriptionManager.RemoveConsolidator(symbol, consolidator);
         }
 
         /// <summary>

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -188,7 +188,7 @@ namespace QuantConnect.Data
         public void RemoveConsolidator(Symbol symbol, IDataConsolidator consolidator)
         {
             // remove consolidator from each subscription
-            foreach (var subscription in Subscriptions.Where(x => x.Symbol == symbol))
+            foreach (var subscription in _subscriptionManager.GetSubscriptionDataConfigs(symbol))
             {
                 subscription.Consolidators.Remove(consolidator);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- WarmupIndicator will remove and dispose of added consolidators
- Consolidating duplicated implementation
- Adding regression test

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3861
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Warmup indicator does not leave residual consolidators since this causes indicators to get updated twice
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
