### PR TITLE
Adding overload to QCAlgo.EMA to support smoothing factor

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -467,8 +467,23 @@ namespace QuantConnect.Algorithm
         /// <returns>The ExponentialMovingAverage for the given parameters</returns>
         public ExponentialMovingAverage EMA(Symbol symbol, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
+            return EMA(symbol, period, ExponentialMovingAverage.SmoothingFactorDefault(period), resolution, selector);
+        }
+
+        /// <summary>
+        /// Creates an ExponentialMovingAverage indicator for the symbol. The indicator will be automatically
+        /// updated on the given resolution.
+        /// </summary>
+        /// <param name="symbol">The symbol whose EMA we want</param>
+        /// <param name="period">The period of the EMA</param>
+        /// <param name="smoothingFactor">The percentage of data from the previous value to be carried into the next value</param>
+        /// <param name="resolution">The resolution</param>
+        /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
+        /// <returns>The ExponentialMovingAverage for the given parameters</returns>
+        public ExponentialMovingAverage EMA(Symbol symbol, int period, decimal smoothingFactor, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        {
             var name = CreateIndicatorName(symbol, $"EMA({period})", resolution);
-            var exponentialMovingAverage = new ExponentialMovingAverage(name, period);
+            var exponentialMovingAverage = new ExponentialMovingAverage(name, period, smoothingFactor);
             RegisterIndicator(symbol, exponentialMovingAverage, resolution, selector);
 
             if (EnableAutomaticIndicatorWarmUp)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Overload added to QCAlgorithm.EMA() to allow for passing smoothing factor. Current signature then delegates to new method, passing ExponentialMovingAverage.SmoothingFactorDefault(period) as per the current construction.

#### Related Issue
Addresses #4229

#### Motivation and Context
We'd like to be able to specify a custom smoothing parameter for EMA calculations

#### Requires Documentation Change
None required.

#### How Has This Been Tested?
Successfully passing custom smoothing parameter.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
There were no regression tests covering the EMA calls
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
