### PR TITLE
Add StreamingDataPermissions for streaming custom data

### DIFF
--- a/Common/Packets/Controls.cs
+++ b/Common/Packets/Controls.cs
@@ -120,7 +120,7 @@ namespace QuantConnect.Packets
         /// <summary>
         /// Gets list of streaming data permissions
         /// </summary>
-        [JsonProperty(PropertyName = "StreamingDataPermissions")]
+        [JsonProperty(PropertyName = "streamingDataPermissions")]
         public HashSet<string> StreamingDataPermissions;
 
         /// <summary>

--- a/Common/Packets/Controls.cs
+++ b/Common/Packets/Controls.cs
@@ -14,6 +14,7 @@
  *
 */
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using QuantConnect.Interfaces;
 
@@ -117,6 +118,12 @@ namespace QuantConnect.Packets
         public int PersistenceIntervalSeconds;
 
         /// <summary>
+        /// Gets list of streaming data permissions
+        /// </summary>
+        [JsonProperty(PropertyName = "StreamingDataPermissions")]
+        public HashSet<string> StreamingDataPermissions;
+
+        /// <summary>
         /// Initializes a new default instance of the <see cref="Controls"/> class
         /// </summary>
         public Controls()
@@ -138,6 +145,8 @@ namespace QuantConnect.Packets
 
             // initialize to default leaky bucket values in case they're not specified
             TrainingLimits = new LeakyBucketControlParameters();
+
+            StreamingDataPermissions = new HashSet<string>();
         }
 
         /// <summary>

--- a/Common/Packets/LiveNodePacket.cs
+++ b/Common/Packets/LiveNodePacket.cs
@@ -61,6 +61,12 @@ namespace QuantConnect.Packets
         public bool DisableAcknowledgement;
 
         /// <summary>
+        /// Gets list of user data subscriptions
+        /// </summary>
+        [JsonProperty(PropertyName = "UserDataSubscriptions")]
+        public HashSet<string> UserDataSubscriptions = new HashSet<string>();
+
+        /// <summary>
         /// Default constructor for JSON of the Live Task Packet
         /// </summary>
         public LiveNodePacket()

--- a/Common/Packets/LiveNodePacket.cs
+++ b/Common/Packets/LiveNodePacket.cs
@@ -61,12 +61,6 @@ namespace QuantConnect.Packets
         public bool DisableAcknowledgement;
 
         /// <summary>
-        /// Gets list of user data subscriptions
-        /// </summary>
-        [JsonProperty(PropertyName = "UserDataSubscriptions")]
-        public HashSet<string> UserDataSubscriptions = new HashSet<string>();
-
-        /// <summary>
         /// Default constructor for JSON of the Live Task Packet
         /// </summary>
         public LiveNodePacket()

--- a/Engine/DataFeeds/DataChannelProvider.cs
+++ b/Engine/DataFeeds/DataChannelProvider.cs
@@ -15,6 +15,7 @@
 
 using System;
 using QuantConnect.Data;
+using QuantConnect.Packets;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -26,7 +27,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// True if this subscription request should be streamed
         /// </summary>
-        public virtual bool ShouldStreamSubscription(SubscriptionDataConfig config)
+        public virtual bool ShouldStreamSubscription(LiveNodePacket job, SubscriptionDataConfig config)
         {
             return IsStreamingType(config) || !config.IsCustomData;
         }

--- a/Engine/DataFeeds/IDataChannelProvider.cs
+++ b/Engine/DataFeeds/IDataChannelProvider.cs
@@ -16,6 +16,7 @@
 
 
 using QuantConnect.Data;
+using QuantConnect.Packets;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -27,6 +28,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// True if this subscription configuration should be streamed
         /// </summary>
-        bool ShouldStreamSubscription(SubscriptionDataConfig config);
+        bool ShouldStreamSubscription(LiveNodePacket job, SubscriptionDataConfig config);
     }
 }

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -120,7 +120,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             if (subscription != null)
             {
                 // send the subscription for the new symbol through to the data queuehandler
-                if (_channelProvider.ShouldStreamSubscription(subscription.Configuration))
+                if (_channelProvider.ShouldStreamSubscription(_job, subscription.Configuration))
                 {
                     _dataQueueHandler.Subscribe(_job, new[] { request.Security.Symbol });
                 }
@@ -138,7 +138,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var symbol = subscription.Configuration.Symbol;
 
             // remove the subscriptions
-            if (!_channelProvider.ShouldStreamSubscription(subscription.Configuration))
+            if (!_channelProvider.ShouldStreamSubscription(_job, subscription.Configuration))
             {
                 _customExchange.RemoveEnumerator(symbol);
                 _customExchange.RemoveDataHandler(symbol);
@@ -202,7 +202,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Security.Exchange.TimeZone, request.StartTimeUtc, request.EndTimeUtc);
 
                 IEnumerator<BaseData> enumerator;
-                if (!_channelProvider.ShouldStreamSubscription(request.Configuration))
+                if (!_channelProvider.ShouldStreamSubscription(_job, request.Configuration))
                 {
                     if (!Quandl.IsAuthCodeSet)
                     {

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -2159,13 +2159,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
     internal class TestDataChannelProvider : DataChannelProvider
     {
-        public override bool ShouldStreamSubscription(SubscriptionDataConfig config)
+        public override bool ShouldStreamSubscription(LiveNodePacket job, SubscriptionDataConfig config)
         {
             if (config.Type == typeof(TiingoNews))
             {
                 return true;
             }
-            return base.ShouldStreamSubscription(config);
+            return base.ShouldStreamSubscription(job, config);
         }
     }
 


### PR DESCRIPTION
#### Description
- Added `StreamingDataPermissions` to `Controls`
- Added `LiveNodePacket` argument to `IDataChannelProvider.ShouldStreamSubscription`

#### Related Issue
#3785 

#### Motivation and Context
- Enable configurable data types for live custom data streaming

#### Requires Documentation Change
No.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`