### PR TITLE
IndicatorWarmup data type fixes

### DIFF
--- a/Algorithm.CSharp/AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs
@@ -25,7 +25,7 @@ using QuantConnect.Securities;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Algorithm which reproduces , related to GH issue 4205
+    /// Algorithm which tests indicator warm up using different data types, related to GH issue 4205
     /// </summary>
     public class AutomaticIndicatorWarmupDataTypeRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
@@ -40,7 +40,7 @@ namespace QuantConnect.Algorithm.CSharp
             var SP500 = QuantConnect.Symbol.Create(Futures.Indices.SP500EMini, SecurityType.Future, Market.USA);
             _symbol = FutureChainProvider.GetFutureContractList(SP500, StartDate).First();
 
-            // Test case: custom IndicatorBase<QuoteBar> indicator using unsubscribed symbol
+            // Test case: custom IndicatorBase<QuoteBar> indicator using Future unsubscribed symbol
             var indicator1 = new CustomIndicator();
             AssertIndicatorState(indicator1, isReady: false);
             WarmUpIndicator(_symbol, indicator1);
@@ -82,7 +82,8 @@ namespace QuantConnect.Algorithm.CSharp
 
             if (!sma11.Current.Equals(sma1.Current))
             {
-                throw new Exception("Expected Future SMA warmed up before and after adding the symbol to be equals");
+                throw new Exception("Expected SMAs warmed up before and after adding the Future to the algorithm to have the same current value. " +
+                                    "The result of 'WarmUpIndicator' shouldn't change if the symbol is or isn't subscribed");
             }
 
             // Test case: SimpleMovingAverage<IndicatorDataPoint> using Equity unsubscribed symbol
@@ -93,7 +94,8 @@ namespace QuantConnect.Algorithm.CSharp
 
             if (!smaSpy.Current.Equals(sma.Current))
             {
-                throw new Exception("Expected Equity SMA warmed up before and after adding the symbol to be equals");
+                throw new Exception("Expected SMAs warmed up before and after adding the Equity to the algorithm to have the same current value. " +
+                                    "The result of 'WarmUpIndicator' shouldn't change if the symbol is or isn't subscribed");
             }
         }
 

--- a/Algorithm.CSharp/AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs
@@ -1,0 +1,191 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Algorithm which reproduces , related to GH issue 4205
+    /// </summary>
+    public class AutomaticIndicatorWarmupDataTypeRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+        public override void Initialize()
+        {
+            UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw;
+            EnableAutomaticIndicatorWarmUp = true;
+            SetStartDate(2013, 10, 08);
+            SetEndDate(2013, 10, 09);
+
+            var SP500 = QuantConnect.Symbol.Create(Futures.Indices.SP500EMini, SecurityType.Future, Market.USA);
+            _symbol = FutureChainProvider.GetFutureContractList(SP500, StartDate).First();
+
+            // Test case: custom IndicatorBase<QuoteBar> indicator using unsubscribed symbol
+            var indicator1 = new CustomIndicator();
+            AssertIndicatorState(indicator1, isReady: false);
+            WarmUpIndicator(_symbol, indicator1);
+            AssertIndicatorState(indicator1, isReady: true);
+
+            // Test case: SimpleMovingAverage<IndicatorDataPoint> using Future unsubscribed symbol (should use TradeBar)
+            var sma1 = new SimpleMovingAverage(10);
+            AssertIndicatorState(sma1, isReady: false);
+            WarmUpIndicator(_symbol, sma1);
+            AssertIndicatorState(sma1, isReady: true);
+
+            // Test case: SimpleMovingAverage<IndicatorDataPoint> using Equity unsubscribed symbol
+            var spy = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+            var sma = new SimpleMovingAverage(10);
+            AssertIndicatorState(sma, isReady: false);
+            WarmUpIndicator(spy, sma);
+            AssertIndicatorState(sma, isReady: true);
+
+            // We add the symbol
+            AddFutureContract(_symbol);
+            AddEquity("SPY");
+            // force spy for use Raw data mode so that it matches the used when unsubscribed which uses the universe settings
+            SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(spy).SetDataNormalizationMode(DataNormalizationMode.Raw);
+
+            // Test case: custom IndicatorBase<QuoteBar> indicator using Future subscribed symbol
+            var indicator = new CustomIndicator();
+            var consolidator = CreateConsolidator(TimeSpan.FromMinutes(1), typeof(QuoteBar));
+            RegisterIndicator(_symbol, indicator, consolidator);
+
+            AssertIndicatorState(indicator, isReady: false);
+            WarmUpIndicator(_symbol, indicator);
+            AssertIndicatorState(indicator, isReady: true);
+
+            // Test case: SimpleMovingAverage<IndicatorDataPoint> using Future Subscribed symbol (should use TradeBar)
+            var sma11 = new SimpleMovingAverage(10);
+            AssertIndicatorState(sma11, isReady: false);
+            WarmUpIndicator(_symbol, sma11);
+            AssertIndicatorState(sma11, isReady: true);
+
+            if (!sma11.Current.Equals(sma1.Current))
+            {
+                throw new Exception("Expected Future SMA warmed up before and after adding the symbol to be equals");
+            }
+
+            // Test case: SimpleMovingAverage<IndicatorDataPoint> using Equity unsubscribed symbol
+            var smaSpy = new SimpleMovingAverage(10);
+            AssertIndicatorState(smaSpy, isReady: false);
+            WarmUpIndicator(spy, smaSpy);
+            AssertIndicatorState(smaSpy, isReady: true);
+
+            if (!smaSpy.Current.Equals(sma.Current))
+            {
+                throw new Exception("Expected Equity SMA warmed up before and after adding the symbol to be equals");
+            }
+        }
+
+        private void AssertIndicatorState(IIndicator indicator, bool isReady)
+        {
+            if (indicator.IsReady != isReady)
+            {
+                throw new Exception($"Expected indicator state, expected {isReady} but was {indicator.IsReady}");
+            }
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(_symbol, 0.5);
+            }
+        }
+
+        private class CustomIndicator : IndicatorBase<QuoteBar>, IIndicatorWarmUpPeriodProvider
+        {
+            private bool _isReady;
+            public int WarmUpPeriod => 1;
+            public override bool IsReady => _isReady;
+            public CustomIndicator() : base("Pepe")
+            { }
+            protected override decimal ComputeNextValue(QuoteBar input)
+            {
+                _isReady = true;
+                return input.Ask.High;
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "-99.999%"},
+            {"Drawdown", "16.100%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "-6.366%"},
+            {"Sharpe Ratio", "0.963"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "5.29"},
+            {"Beta", "-63.972"},
+            {"Annual Standard Deviation", "0.434"},
+            {"Annual Variance", "0.188"},
+            {"Information Ratio", "0.775"},
+            {"Tracking Error", "0.441"},
+            {"Treynor Ratio", "-0.007"},
+            {"Total Fees", "$20.35"},
+            {"Fitness Score", "0.138"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "-1.727"},
+            {"Return Over Maximum Drawdown", "-12.061"},
+            {"Portfolio Turnover", "4.916"},
+            {"Total Insights Generated", "1"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "1"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "-998933209"}
+        };
+    }
+}

--- a/Algorithm.CSharp/ConsolidateRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ConsolidateRegressionAlgorithm.cs
@@ -79,6 +79,7 @@ namespace QuantConnect.Algorithm.CSharp
                 // will try to use BaseDataConsolidator for which input is TradeBars not QuoteBars
             }
 
+            // Test using abstract T types, through defining a 'BaseData' handler
             var sma7 = new SimpleMovingAverage(10);
             Consolidate(_symbol, Resolution.Daily, null, (Action<BaseData>)(bar => UpdateBar(sma7, bar, 5)));
 

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -159,6 +159,7 @@
     <Compile Include="AltData\PsychSignalSentimentAlgorithm.cs" />
     <Compile Include="AltData\TradingEconomicsAlgorithm.cs" />
     <Compile Include="AltData\TiingoNewsAlgorithm.cs" />
+    <Compile Include="AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs" />
     <Compile Include="AutomaticIndicatorWarmupRegressionAlgorithm.cs" />
     <Compile Include="BasicTemplateConstituentUniverseAlgorithm.cs" />
     <Compile Include="ConsolidateRegressionAlgorithm.cs" />

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -660,7 +660,7 @@ namespace QuantConnect.Algorithm
             }
             else
             {
-                var timeZone = GetExchangeHours(symbol).TimeZone;
+                var entry = MarketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType);
                 resolution = GetResolution(symbol, resolution);
 
                 return SubscriptionManager
@@ -669,7 +669,8 @@ namespace QuantConnect.Algorithm
                         x.Item1,
                         symbol,
                         resolution.Value,
-                        timeZone, timeZone,
+                        entry.DataTimeZone,
+                        entry.ExchangeHours.TimeZone,
                         UniverseSettings.FillForward,
                         UniverseSettings.ExtendedMarketHours,
                         true,

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -2244,8 +2244,9 @@ namespace QuantConnect.Algorithm
         public IDataConsolidator Consolidate<T>(Symbol symbol, TimeSpan period, Action<T> handler)
             where T : class, IBaseData
         {
-            // only infer TickType from T if it's not abstract, else if will end up being TradeBar let's not take that decision here (default type)
-            // will be taken later by 'GetSubscription'
+            // only infer TickType from T if it's not abstract (for example IBaseData, BaseData), else if will end up being TradeBar let's not take that
+            // decision here (default type), it will be taken later by 'GetSubscription' so we keep it centralized
+            // An example of an abstract case can be found in the 'ConsolidateRegressionAlgorithm' where a 'Action<BaseData>' handler is used
             var tickType = typeof(T).IsAbstract ? (TickType?)null : LeanData.GetCommonTickTypeForCommonDataTypes(typeof(T), symbol.SecurityType);
             return Consolidate(symbol, period, tickType, handler);
         }
@@ -2341,8 +2342,9 @@ namespace QuantConnect.Algorithm
         public IDataConsolidator Consolidate<T>(Symbol symbol, Func<DateTime, CalendarInfo> calendar, Action<T> handler)
             where T : class, IBaseData
         {
-            // only infer TickType from T if it's not abstract, else if will end up being TradeBar let's not take that decision here (default type)
-            // will be taken later by 'GetSubscription'
+            // only infer TickType from T if it's not abstract (for example IBaseData, BaseData), else if will end up being TradeBar let's not take that
+            // decision here (default type), it will be taken later by 'GetSubscription' so we keep it centralized
+            // An example of an abstract case can be found in the 'ConsolidateRegressionAlgorithm' where a 'Action<BaseData>' handler is used
             var tickType = typeof(T).IsAbstract ? (TickType?)null : LeanData.GetCommonTickTypeForCommonDataTypes(typeof(T), symbol.SecurityType);
             return Consolidate(symbol, calendar, tickType, handler);
         }

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -2025,7 +2025,6 @@ namespace QuantConnect.Algorithm
             else
             {
                 var providedType = typeof(T);
-                // AutomaticIndicatorWarmupDataTypeRegressionAlgorithm executes both branches that follow
                 if (providedType.IsAbstract)
                 {
                     var dataType = SubscriptionManager.LookupSubscriptionConfigDataTypes(
@@ -2246,7 +2245,7 @@ namespace QuantConnect.Algorithm
         {
             // only infer TickType from T if it's not abstract (for example IBaseData, BaseData), else if will end up being TradeBar let's not take that
             // decision here (default type), it will be taken later by 'GetSubscription' so we keep it centralized
-            // An example of an abstract case can be found in the 'ConsolidateRegressionAlgorithm' where a 'Action<BaseData>' handler is used
+            // This could happen when a user passes in a generic 'Action<BaseData>' handler
             var tickType = typeof(T).IsAbstract ? (TickType?)null : LeanData.GetCommonTickTypeForCommonDataTypes(typeof(T), symbol.SecurityType);
             return Consolidate(symbol, period, tickType, handler);
         }
@@ -2344,7 +2343,7 @@ namespace QuantConnect.Algorithm
         {
             // only infer TickType from T if it's not abstract (for example IBaseData, BaseData), else if will end up being TradeBar let's not take that
             // decision here (default type), it will be taken later by 'GetSubscription' so we keep it centralized
-            // An example of an abstract case can be found in the 'ConsolidateRegressionAlgorithm' where a 'Action<BaseData>' handler is used
+            // This could happen when a user passes in a generic 'Action<BaseData>' handler
             var tickType = typeof(T).IsAbstract ? (TickType?)null : LeanData.GetCommonTickTypeForCommonDataTypes(typeof(T), symbol.SecurityType);
             return Consolidate(symbol, calendar, tickType, handler);
         }

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1954,7 +1954,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The given indicator</returns>
         public IndicatorBase<T> WarmUpIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, Resolution? resolution = null, Func<IBaseData, T> selector = null)
-            where T : IBaseData
+            where T : class, IBaseData
         {
             resolution = GetResolution(symbol, resolution);
             var period = resolution.Value.ToTimeSpan();
@@ -1970,7 +1970,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to a cast (x => (T)x)</param>
         /// <returns>The given indicator</returns>
         public IndicatorBase<T> WarmUpIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, TimeSpan period, Func<IBaseData, T> selector = null)
-            where T : IBaseData
+            where T : class, IBaseData
         {
             var history = GetIndicatorWarmUpHistory(symbol, indicator, period);
             if (history == Enumerable.Empty<Slice>()) return indicator;
@@ -1978,7 +1978,8 @@ namespace QuantConnect.Algorithm
             // assign default using cast
             selector = selector ?? (x => (T)x);
 
-            Action<IBaseData> onDataConsolidated = bar =>
+            // we expect T type as input
+            Action<T> onDataConsolidated = bar =>
             {
                 indicator.Update(selector(bar));
             };
@@ -2017,28 +2018,45 @@ namespace QuantConnect.Algorithm
             where T : class, IBaseData
         {
             IDataConsolidator consolidator;
-            if (SubscriptionManager.Subscriptions.Any(x => x.Symbol == symbol))
+            if (SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(symbol).Count > 0)
             {
                 consolidator = Consolidate(symbol, period, handler);
             }
             else
             {
-                var dataType = SubscriptionManager.LookupSubscriptionConfigDataTypes(
-                    symbol.SecurityType,
-                    Resolution.Daily,
-                    symbol.IsCanonical()).First();
+                var providedType = typeof(T);
+                // AutomaticIndicatorWarmupDataTypeRegressionAlgorithm executes both branches that follow
+                if (providedType.IsAbstract)
+                {
+                    var dataType = SubscriptionManager.LookupSubscriptionConfigDataTypes(
+                        symbol.SecurityType,
+                        Resolution.Daily,
+                        // order by tick type so that behavior is consistent with 'GetSubscription()'
+                        symbol.IsCanonical()).OrderBy(tuple => tuple.Item2).First();
 
-                consolidator = CreateConsolidator(period, dataType.Item1, dataType.Item2);
+                    consolidator = CreateConsolidator(period, dataType.Item1, dataType.Item2);
+                }
+                else
+                {
+                    // if the 'providedType' is not abstract we use it instead to determine which consolidator to use
+                    var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(providedType, symbol.SecurityType);
+                    consolidator = CreateConsolidator(period, providedType, tickType);
+                }
                 consolidator.DataConsolidated += (s, bar) => handler((T)bar);
             }
 
-            BaseData lastBar = null;
-            history.PushThrough(bar =>
+            var consolidatorInputType = consolidator.InputType;
+            IBaseData lastBar = null;
+            foreach (var slice in history)
+            {
+                var data = slice.Get(consolidatorInputType);
+                if (data.ContainsKey(symbol))
                 {
-                    lastBar = bar;
-                    consolidator.Update(bar);
+                    lastBar = (IBaseData)data[symbol];
+                    consolidator.Update(lastBar);
                 }
-            );
+            }
+
             // Scan for time after we've pumped all the data through for this consolidator
             if (lastBar != null)
             {
@@ -2226,7 +2244,9 @@ namespace QuantConnect.Algorithm
         public IDataConsolidator Consolidate<T>(Symbol symbol, TimeSpan period, Action<T> handler)
             where T : class, IBaseData
         {
-            var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(typeof(T), symbol.SecurityType);
+            // only infer TickType from T if it's not abstract, else if will end up being TradeBar let's not take that decision here (default type)
+            // will be taken later by 'GetSubscription'
+            var tickType = typeof(T).IsAbstract ? (TickType?)null : LeanData.GetCommonTickTypeForCommonDataTypes(typeof(T), symbol.SecurityType);
             return Consolidate(symbol, period, tickType, handler);
         }
 
@@ -2321,7 +2341,9 @@ namespace QuantConnect.Algorithm
         public IDataConsolidator Consolidate<T>(Symbol symbol, Func<DateTime, CalendarInfo> calendar, Action<T> handler)
             where T : class, IBaseData
         {
-            var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(typeof(T), symbol.SecurityType);
+            // only infer TickType from T if it's not abstract, else if will end up being TradeBar let's not take that decision here (default type)
+            // will be taken later by 'GetSubscription'
+            var tickType = typeof(T).IsAbstract ? (TickType?)null : LeanData.GetCommonTickTypeForCommonDataTypes(typeof(T), symbol.SecurityType);
             return Consolidate(symbol, calendar, tickType, handler);
         }
 

--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -250,6 +250,16 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
+        /// Gets the data of the specified type.
+        /// </summary>
+        /// <param name="type">The type of data we seek</param>
+        /// <returns>The <see cref="DataDictionary{T}"/> instance for the requested type</returns>
+        public dynamic Get(Type type)
+        {
+            return GetImpl(type, this);
+        }
+
+        /// <summary>
         /// Gets the data of the specified symbol and type.
         /// </summary>
         /// <remarks>Supports both C# and Python use cases</remarks>

--- a/Tests/Common/Data/SliceTests.cs
+++ b/Tests/Common/Data/SliceTests.cs
@@ -31,6 +31,20 @@ namespace QuantConnect.Tests.Common.Data
     public class SliceTests
     {
         [Test]
+        public void AccessesByDataType()
+        {
+            var tradeBar = new TradeBar { Symbol = Symbols.SPY, Time = DateTime.UtcNow };
+            var quandl = new Quandl { Symbol = Symbols.SPY, Time = DateTime.Now };
+            var quoteBar = new QuoteBar { Symbol = Symbols.SPY, Time = DateTime.Now };
+
+            var slice = new Slice(DateTime.UtcNow, new BaseData[] { tradeBar, quoteBar, quandl });
+
+            Assert.AreEqual(slice.Get(typeof(TradeBar))[Symbols.SPY], tradeBar);
+            Assert.AreEqual(slice.Get(typeof(Quandl))[Symbols.SPY], quandl);
+            Assert.AreEqual(slice.Get(typeof(QuoteBar))[Symbols.SPY], quoteBar);
+        }
+
+        [Test]
         public void AccessesBaseBySymbol()
         {
             IndicatorDataPoint tick = new IndicatorDataPoint(Symbols.SPY, DateTime.Now, 1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- WarmupIndicator will be able to determine the correct type to use
- Fix bug in `History.GetMatchingSubscriptions()` which would use the
same TZ for exchange and data. Covered by regression algorithm.
- Consolidate will only infer `TickType` from `T` is not abstract
- Adding regression algorithm
- Slice will expose `Get(Type)` to get data by type, adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/Lean/issues/4205
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Warmup indicator is able to determine the correct data type to use
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
