### PR TITLE
Refactor QCAlgorithm.Indicators - Add WarmUpIndicator warning

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1748,12 +1748,12 @@ namespace QuantConnect.Algorithm
                     .OrderBy(x => x.TickType)
                     .ToList();
 
-                // find our subscription to this symbol
-                subscription = subscriptions.FirstOrDefault(x => x.Symbol == symbol && (tickType == null || tickType == x.TickType));
+                // find our subscription
+                subscription = subscriptions.FirstOrDefault(x => tickType == null || tickType == x.TickType);
                 if (subscription == null)
                 {
                     // if we can't locate the exact subscription by tick type just grab the first one we find
-                    subscription = subscriptions.First(x => x.Symbol == symbol);
+                    subscription = subscriptions.First();
                 }
             }
             catch (InvalidOperationException)
@@ -2003,14 +2003,11 @@ namespace QuantConnect.Algorithm
                     Debug($"{indicator.Name} could not be warmed up. Reason: {e.Message}");
                 }
             }
-            else
+            else if (!_isEmitWarmupInsightWarningSent)
             {
-                if (!_isEmitWarmupInsightWarningSent)
-                {
-                    Debug($"Warning: the 'WarmUpIndicator' feature only works with indicators which inherit from '{nameof(IIndicatorWarmUpPeriodProvider)}' and define a warm up period." +
-                          $" The provided indicator of type '{indicator.GetType().Name}' will not be warmed up.");
-                    _isEmitWarmupInsightWarningSent = true;
-                }
+                Debug($"Warning: the 'WarmUpIndicator' feature only works with indicators which inherit from '{nameof(IIndicatorWarmUpPeriodProvider)}' and define a warm up period." +
+                      $" The provided indicator of type '{indicator.GetType().Name}' will not be warmed up.");
+                _isEmitWarmupInsightWarningSent = true;
             }
 
             return Enumerable.Empty<Slice>();

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -25,6 +25,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Tests.Engine.DataFeeds;
+using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Algorithm
@@ -114,11 +115,12 @@ namespace QuantConnect.Tests.Algorithm
             var algorithm = new QCAlgorithm();
             algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
             algorithm.HistoryProvider = new SubscriptionDataReaderHistoryProvider();
+            var cacheProvider = new ZipDataCacheProvider(new DefaultDataProvider());
             algorithm.HistoryProvider.Initialize(new HistoryProviderInitializeParameters(
                 null,
                 null,
                 new DefaultDataProvider(),
-                new ZipDataCacheProvider(new DefaultDataProvider()),
+                cacheProvider,
                 new LocalDiskMapFileProvider(),
                 new LocalDiskFactorFileProvider(),
                 null,
@@ -135,6 +137,8 @@ namespace QuantConnect.Tests.Algorithm
 
             // Data gap of more than 15 minutes
             Assert.Greater((algorithm.Time - lastKnownPrice.EndTime).TotalMinutes, 15);
+
+            cacheProvider.DisposeSafely();
         }
 
 

--- a/Tests/Engine/HistoricalData/SubscriptionDataReaderHistoryProviderTests.cs
+++ b/Tests/Engine/HistoricalData/SubscriptionDataReaderHistoryProviderTests.cs
@@ -23,6 +23,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Securities;
+using QuantConnect.Util;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Engine.HistoricalData
@@ -34,11 +35,12 @@ namespace QuantConnect.Tests.Engine.HistoricalData
         public void OptionsAreMappedCorrectly()
         {
             var historyProvider = new SubscriptionDataReaderHistoryProvider();
+            var zipCache = new ZipDataCacheProvider(new DefaultDataProvider());
             historyProvider.Initialize(new HistoryProviderInitializeParameters(
                 null,
                 null,
                 new DefaultDataProvider(),
-                new ZipDataCacheProvider(new DefaultDataProvider()), 
+                zipCache,
                 new LocalDiskMapFileProvider(),
                 new LocalDiskFactorFileProvider(),
                 null,
@@ -79,17 +81,19 @@ namespace QuantConnect.Tests.Engine.HistoricalData
             Assert.AreEqual(28, firstBar.Time.Date.Day);
             Assert.IsTrue(lastBar.Symbol.Value.Contains("FOXA"));
             Assert.AreEqual(2, lastBar.Time.Date.Day);
+            zipCache.DisposeSafely();
         }
 
         [Test]
         public void EquitiesAreMappedCorrectly()
         {
             var historyProvider = new SubscriptionDataReaderHistoryProvider();
+            var zipCache = new ZipDataCacheProvider(new DefaultDataProvider());
             historyProvider.Initialize(new HistoryProviderInitializeParameters(
                 null,
                 null,
                 new DefaultDataProvider(),
-                new ZipDataCacheProvider(new DefaultDataProvider()),
+                zipCache,
                 new LocalDiskMapFileProvider(),
                 new LocalDiskFactorFileProvider(),
                 null,
@@ -117,6 +121,7 @@ namespace QuantConnect.Tests.Engine.HistoricalData
             var firstBar = result.First().Values.Single();
             Assert.IsTrue(firstBar.Symbol.Value.Contains("WMI"));
             Assert.IsNotEmpty(result);
+            zipCache.DisposeSafely();
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Make `GetSubscription` private and remove unrequired overload
- Add warning message when trying to warm up an indicator which does not
have a warm-up period
- Dispose of `ZipDataCacheProvider` used in unit tests.
To avoid issues with other tests since zip files could remain open.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/Lean/issues/4205
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Refactor, improve user experience
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests.
Backtesting in cloud asserting expected warning message is shown
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
