### PR TITLE
add Tls12 support on websocket

### DIFF
--- a/Brokerages/WebSocketWrapper.cs
+++ b/Brokerages/WebSocketWrapper.cs
@@ -51,6 +51,9 @@ namespace QuantConnect.Brokerages
                 }
             };
 
+            // Some API only support SslProtocols Tls12
+            _wrapped.SslConfiguration.EnabledSslProtocols |= System.Security.Authentication.SslProtocols.Tls12;
+
             _wrapped.OnOpen += (sender, args) => OnOpen();
             _wrapped.OnMessage += (sender, args) => OnMessage(new WebSocketMessage(args.Data));
             _wrapped.OnError += (sender, args) => OnError(new WebSocketError(args.Message, args.Exception));


### PR DESCRIPTION
I am trying to implement a new crypto brokerage which needs WebSocket to support SslProtocols Tls12.

#### Expected Behavior
Tls12 support on the WebSocket client wrapped into WebSocketWrapper

#### Actual Behavior
no Tls12 support

#### Potential Solution
I tried to globally set the SecurityProtocol but it didn't help

`ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12
`

The solution was to set the value on the WebSocket in the WebSocketWrapper.Initialize(string) method :

`_wrapped.SslConfiguration.EnabledSslProtocols |= System.Security.Authentication.SslProtocols.Tls12;
`

#### System Information
irrelevant

#### Checklist
<!--- Confirm that you've provided all the required information. -->
<!--- Required fields --->
- [X] I have completely filled out this template
- [X] I have confirmed that this issue exists on the current `master` branch
- [X] I have confirmed that this is not a duplicate issue by searching [issues](https://github.com/QuantConnect/Lean/issues)
