### PR TITLE
Fixes issue where PortfolioLooper would crash generating certain reports

### DIFF
--- a/Report/ReportElements/SharpeRatioReportElement.cs
+++ b/Report/ReportElements/SharpeRatioReportElement.cs
@@ -45,13 +45,12 @@ namespace QuantConnect.Report.ReportElements
         /// </summary>
         public override string Render()
         {
-            var result = _live ?? (Result)_backtest;
-            if (result == null)
+            if (_live == null)
             {
-                return "-";
+                return _backtest?.TotalPerformance?.PortfolioStatistics?.SharpeRatio.ToString("F1") ?? "-";
             }
 
-            var equityPoints = ResultsUtil.EquityPoints(result);
+            var equityPoints = ResultsUtil.EquityPoints(_live);
             var performance = DeedleUtil.PercentChange(new Series<DateTime, double>(equityPoints).ResampleEquivalence(date => date.Date, s => s.LastValue()));
             if (performance.ValueCount == 0)
             {

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -656,6 +656,7 @@
     <Compile Include="Python\PandasConverterTests.cs" />
     <Compile Include="RegressionTests.cs" />
     <Compile Include="Report\CalculationTests.cs" />
+    <Compile Include="Report\PortfolioLooperTests.cs" />
     <Compile Include="Report\ResultDeserializationTests.cs" />
     <Compile Include="Report\PortfolioLooperAlgorithmTests.cs" />
     <Compile Include="Symbols.cs" />

--- a/Tests/Report/PortfolioLooperTests.cs
+++ b/Tests/Report/PortfolioLooperTests.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Deedle;
+using NUnit.Framework;
+using QuantConnect.Orders;
+using QuantConnect.Report;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Tests.Report
+{
+    [TestFixture]
+    public class PortfolioLooperTests
+    {
+        [Test]
+        public void EmptyEquitySeriesDoesNotCrash()
+        {
+            var equityPoints = new SortedList<DateTime, double>
+            {
+                { new DateTime(2019, 1, 3, 5, 0, 5), 100000 }
+            };
+            var series = new Series<DateTime, double>(equityPoints);
+            var order = new MarketOrder(Symbols.SPY, 1m, new DateTime(2019, 1, 3, 5, 0, 0));
+
+            // Force an order ID >= 1 on the order, otherwise the test will fail
+            // because the order will be filtered out.
+            order.GetType().GetProperty("Id").SetValue(order, 1);
+
+            var orders = new List<Order>
+            {
+                order
+            };
+
+            Assert.DoesNotThrow(() => PortfolioLooper.FromOrders(series, orders).ToList());
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
* Stops crashes from occurring due to empty collections in the report generator
* Updates Sharpe ratio calculation in SharpeRatioReportElement
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure report generation completes without exceptions
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
