### PR TITLE
Fix EstimizeConsensus.Symbol serialization

### DIFF
--- a/Common/Data/Custom/Estimize/EstimizeConsensus.cs
+++ b/Common/Data/Custom/Estimize/EstimizeConsensus.cs
@@ -24,7 +24,6 @@ namespace QuantConnect.Data.Custom.Estimize
     /// <summary>
     /// Consensus of the specified release
     /// </summary>
-    [JsonObject(MemberSerialization.OptIn)]
     public class EstimizeConsensus : BaseData
     {
         /// <summary>

--- a/Tests/Common/Data/Custom/EstimizeTests.cs
+++ b/Tests/Common/Data/Custom/EstimizeTests.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Lean.Engine.DataFeeds;
+using Type = QuantConnect.Data.Custom.Estimize.Type;
 
 namespace QuantConnect.Tests.Common.Data.Custom
 {
@@ -265,6 +266,112 @@ namespace QuantConnect.Tests.Common.Data.Custom
             var rows = factory.Read(source).ToList();
 
             Assert.IsTrue(rows.Count > 0);
+        }
+
+        [Test]
+        public void SerializeRoundTripEstimizeRelease()
+        {
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
+            var time = new DateTime(2020, 3, 19, 10, 0, 0);
+            var underlyingSymbol = Symbols.AAPL;
+            var symbol = Symbol.CreateBase(typeof(EstimizeRelease), underlyingSymbol, QuantConnect.Market.USA);
+
+            var item = new EstimizeRelease
+            {
+                Id = "123",
+                Symbol = symbol,
+                FiscalYear = 2020,
+                FiscalQuarter = 1,
+                Eps = 2,
+                Revenue = null,
+                ReleaseDate = time
+            };
+
+            var serialized = JsonConvert.SerializeObject(item, settings);
+            var deserialized = JsonConvert.DeserializeObject<EstimizeRelease>(serialized, settings);
+
+            Assert.AreEqual("123", deserialized.Id);
+            Assert.AreEqual(symbol, deserialized.Symbol);
+            Assert.AreEqual(2020, deserialized.FiscalYear);
+            Assert.AreEqual(1, deserialized.FiscalQuarter);
+            Assert.AreEqual(2, deserialized.Eps);
+            Assert.AreEqual(null, deserialized.Revenue);
+            Assert.AreEqual(time, deserialized.ReleaseDate);
+            Assert.AreEqual(time, deserialized.Time);
+            Assert.AreEqual(time, deserialized.EndTime);
+        }
+
+        [Test]
+        public void SerializeRoundTripEstimizeConsensus()
+        {
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
+            var time = new DateTime(2020, 3, 19, 10, 0, 0);
+            var underlyingSymbol = Symbols.AAPL;
+            var symbol = Symbol.CreateBase(typeof(EstimizeConsensus), underlyingSymbol, QuantConnect.Market.USA);
+
+            var item = new EstimizeConsensus
+            {
+                Id = "123",
+                Symbol = symbol,
+                FiscalYear = 2020,
+                FiscalQuarter = 1,
+                Source = Source.WallStreet,
+                Type = Type.Eps,
+                Count = 3,
+                Mean = 2,
+                UpdatedAt = time
+            };
+
+            var serialized = JsonConvert.SerializeObject(item, settings);
+            var deserialized = JsonConvert.DeserializeObject<EstimizeConsensus>(serialized, settings);
+
+            Assert.AreEqual("123", deserialized.Id);
+            Assert.AreEqual(symbol, deserialized.Symbol);
+            Assert.AreEqual(2020, deserialized.FiscalYear);
+            Assert.AreEqual(1, deserialized.FiscalQuarter);
+            Assert.AreEqual(Source.WallStreet, deserialized.Source);
+            Assert.AreEqual(Type.Eps, deserialized.Type);
+            Assert.AreEqual(3, deserialized.Count);
+            Assert.AreEqual(2, deserialized.Mean);
+            Assert.AreEqual(time, deserialized.UpdatedAt);
+            Assert.AreEqual(time, deserialized.Time);
+            Assert.AreEqual(time, deserialized.EndTime);
+        }
+
+        [Test]
+        public void SerializeRoundTripEstimizeEstimate()
+        {
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
+            var time = new DateTime(2020, 3, 19, 10, 0, 0);
+            var underlyingSymbol = Symbols.AAPL;
+            var symbol = Symbol.CreateBase(typeof(EstimizeEstimate), underlyingSymbol, QuantConnect.Market.USA);
+
+            var item = new EstimizeEstimate
+            {
+                Id = "123",
+                Symbol = symbol,
+                FiscalYear = 2020,
+                FiscalQuarter = 1,
+                Eps = 2,
+                Revenue = null,
+                CreatedAt = time
+            };
+
+            var serialized = JsonConvert.SerializeObject(item, settings);
+            var deserialized = JsonConvert.DeserializeObject<EstimizeEstimate>(serialized, settings);
+
+            Assert.AreEqual("123", deserialized.Id);
+            Assert.AreEqual(symbol, deserialized.Symbol);
+            Assert.AreEqual(2020, deserialized.FiscalYear);
+            Assert.AreEqual(1, deserialized.FiscalQuarter);
+            Assert.AreEqual(2, deserialized.Eps);
+            Assert.AreEqual(null, deserialized.Revenue);
+            Assert.AreEqual(time, deserialized.CreatedAt);
+            Assert.AreEqual(time, deserialized.Time);
+            Assert.AreEqual(time, deserialized.EndTime);
         }
     }
 }

--- a/Tests/Common/Data/Custom/PsychSignalTests.cs
+++ b/Tests/Common/Data/Custom/PsychSignalTests.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using QuantConnect.Data.Custom.PsychSignal;
+
+namespace QuantConnect.Tests.Common.Data.Custom
+{
+    [TestFixture]
+    public class PsychSignalTests
+    {
+        [Test]
+        public void SerializeRoundTrip()
+        {
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
+            var time = new DateTime(2020, 3, 19, 10, 0, 0);
+            var underlyingSymbol = Symbols.AAPL;
+            var symbol = Symbol.CreateBase(typeof(PsychSignalSentiment), underlyingSymbol, QuantConnect.Market.USA);
+
+            var item = new PsychSignalSentiment
+            {
+                Symbol = symbol,
+                Time = time,
+                BullIntensity = 1,
+                BearIntensity = 2,
+                BullMinusBear = 3,
+                BullScoredMessages = 4,
+                BearScoredMessages = 5,
+                BullBearMessageRatio = 6,
+                TotalScoredMessages = 7
+            };
+
+            var serialized = JsonConvert.SerializeObject(item, settings);
+            var deserialized = JsonConvert.DeserializeObject<PsychSignalSentiment>(serialized, settings);
+
+            Assert.AreEqual(symbol, deserialized.Symbol);
+            Assert.AreEqual(1, deserialized.BullIntensity);
+            Assert.AreEqual(2, deserialized.BearIntensity);
+            Assert.AreEqual(3, deserialized.BullMinusBear);
+            Assert.AreEqual(4, deserialized.BullScoredMessages);
+            Assert.AreEqual(5, deserialized.BearScoredMessages);
+            Assert.AreEqual(6, deserialized.BullBearMessageRatio);
+            Assert.AreEqual(7, deserialized.TotalScoredMessages);
+            Assert.AreEqual(time, deserialized.Time);
+            Assert.AreEqual(time.AddMinutes(1).AddSeconds(15), deserialized.EndTime);
+        }
+    }
+}

--- a/Tests/Common/Data/Custom/SmartInsiderTests.cs
+++ b/Tests/Common/Data/Custom/SmartInsiderTests.cs
@@ -16,6 +16,7 @@
 using NUnit.Framework;
 using QuantConnect.Data.Custom.SmartInsider;
 using System;
+using Newtonsoft.Json;
 
 namespace QuantConnect.Tests.Common.Data.Custom
 {
@@ -54,6 +55,80 @@ namespace QuantConnect.Tests.Common.Data.Custom
             {
                 SmartInsiderEvent.ParseDate("05/21/2019 00:00:00");
             });
+        }
+
+        [Test]
+        public void SerializeRoundTripSmartInsiderIntention()
+        {
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
+            var time = new DateTime(2020, 3, 19, 10, 0, 0);
+            var underlyingSymbol = Symbols.AAPL;
+            var symbol = Symbol.CreateBase(typeof(SmartInsiderIntention), underlyingSymbol, QuantConnect.Market.USA);
+
+            var item = new SmartInsiderIntention
+            {
+                Symbol = symbol,
+                LastUpdate = time,
+                Time = time,
+                TransactionID = "123",
+                EventType = SmartInsiderEventType.Intention,
+                Execution = SmartInsiderExecution.Market,
+                ExecutionEntity = SmartInsiderExecutionEntity.Issuer,
+                ExecutionHolding = SmartInsiderExecutionHolding.NotReported,
+                Amount = null
+            };
+
+            var serialized = JsonConvert.SerializeObject(item, settings);
+            var deserialized = JsonConvert.DeserializeObject<SmartInsiderIntention>(serialized, settings);
+
+            Assert.AreEqual(symbol, deserialized.Symbol);
+            Assert.AreEqual("123", deserialized.TransactionID);
+            Assert.AreEqual(SmartInsiderEventType.Intention, deserialized.EventType);
+            Assert.AreEqual(SmartInsiderExecution.Market, deserialized.Execution);
+            Assert.AreEqual(SmartInsiderExecutionEntity.Issuer, deserialized.ExecutionEntity);
+            Assert.AreEqual(SmartInsiderExecutionHolding.NotReported, deserialized.ExecutionHolding);
+            Assert.AreEqual(null, deserialized.Amount);
+            Assert.AreEqual(time, deserialized.LastUpdate);
+            Assert.AreEqual(time, deserialized.Time);
+            Assert.AreEqual(time, deserialized.EndTime);
+        }
+
+        [Test]
+        public void SerializeRoundTripSmartInsiderTransaction()
+        {
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
+            var time = new DateTime(2020, 3, 19, 10, 0, 0);
+            var underlyingSymbol = Symbols.AAPL;
+            var symbol = Symbol.CreateBase(typeof(SmartInsiderTransaction), underlyingSymbol, QuantConnect.Market.USA);
+
+            var item = new SmartInsiderTransaction
+            {
+                Symbol = symbol,
+                LastUpdate = time,
+                Time = time,
+                TransactionID = "123",
+                EventType = SmartInsiderEventType.Transaction,
+                Execution = SmartInsiderExecution.Market,
+                ExecutionEntity = SmartInsiderExecutionEntity.Issuer,
+                ExecutionHolding = SmartInsiderExecutionHolding.SatisfyEmployeeTax,
+                Amount = 1234
+            };
+
+            var serialized = JsonConvert.SerializeObject(item, settings);
+            var deserialized = JsonConvert.DeserializeObject<SmartInsiderTransaction>(serialized, settings);
+
+            Assert.AreEqual(symbol, deserialized.Symbol);
+            Assert.AreEqual("123", deserialized.TransactionID);
+            Assert.AreEqual(SmartInsiderEventType.Transaction, deserialized.EventType);
+            Assert.AreEqual(SmartInsiderExecution.Market, deserialized.Execution);
+            Assert.AreEqual(SmartInsiderExecutionEntity.Issuer, deserialized.ExecutionEntity);
+            Assert.AreEqual(SmartInsiderExecutionHolding.SatisfyEmployeeTax, deserialized.ExecutionHolding);
+            Assert.AreEqual(1234, deserialized.Amount);
+            Assert.AreEqual(time, deserialized.LastUpdate);
+            Assert.AreEqual(time, deserialized.Time);
+            Assert.AreEqual(time, deserialized.EndTime);
         }
     }
 }

--- a/Tests/Common/Data/Custom/TiingoNewsJsonConverterTests.cs
+++ b/Tests/Common/Data/Custom/TiingoNewsJsonConverterTests.cs
@@ -108,5 +108,40 @@ namespace QuantConnect.Tests.Common.Data.Custom
             }
             Assert.AreEqual(result[0].EndTime, result[0].Time);
         }
+
+        [Test]
+        public void SerializeRoundTrip()
+        {
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+
+            var crawlDate = new DateTime(2020, 3, 19, 10, 0, 0);
+            var underlyingSymbol = Symbols.AAPL;
+            var symbol = Symbol.CreateBase(typeof(TiingoNews), underlyingSymbol, QuantConnect.Market.USA);
+            var symbolList = new List<Symbol> { underlyingSymbol };
+            var tags = new List<string> { "Stock", "Technology" };
+
+            var item = new TiingoNews
+            {
+                ArticleID = "123456",
+                Symbol = symbol,
+                Symbols = symbolList,
+                Tags = tags,
+                Title = "title",
+                CrawlDate = crawlDate,
+                Time = crawlDate
+            };
+
+            var serialized = JsonConvert.SerializeObject(item, settings);
+            var deserialized = JsonConvert.DeserializeObject<TiingoNews>(serialized, settings);
+
+            Assert.AreEqual("123456", deserialized.ArticleID);
+            Assert.AreEqual(symbol, deserialized.Symbol);
+            Assert.AreEqual(symbolList, deserialized.Symbols);
+            Assert.AreEqual(tags, deserialized.Tags);
+            Assert.AreEqual("title", deserialized.Title);
+            Assert.AreEqual(crawlDate, deserialized.CrawlDate);
+            Assert.AreEqual(crawlDate, deserialized.Time);
+            Assert.AreEqual(crawlDate, deserialized.EndTime);
+        }
     }
 }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -317,6 +317,7 @@
     <Compile Include="Brokerages\Alpaca\AlpacaBrokerageTests.cs" />
     <Compile Include="Common\Data\Auxiliary\FactorFileTests.cs" />
     <Compile Include="Common\Data\Auxiliary\MapFileTests.cs" />
+    <Compile Include="Common\Data\Custom\PsychSignalTests.cs" />
     <Compile Include="Common\Data\Custom\TradingEconomicsTests.cs" />
     <Compile Include="Common\Data\Fundamental\FineFundamentalTests.cs" />
     <Compile Include="Common\Orders\OrderSizingTests.cs" />


### PR DESCRIPTION

#### Description
- Updates the `EstimizeConsensus` class to enable round-trip serialization.

#### Related Issue
Closes #4258 

#### Motivation and Context
- The `Symbol` property is not serialized.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- New unit tests included.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`