### PR TITLE
Fixes Expiry.EndOfMonth and Expiry.EndOfYear Methods

### DIFF
--- a/Common/Expiry.cs
+++ b/Common/Expiry.cs
@@ -68,8 +68,8 @@ namespace QuantConnect
             {
                 return dt =>
                 {
-                    var value = 1 - dt.Day;
-                    return OneMonth(dt).AddDays(value).Date;
+                    var value = OneMonth(dt);
+                    return new DateTime(value.Year, value.Month, 1);
                 };
             }
         }
@@ -93,16 +93,6 @@ namespace QuantConnect
         /// <summary>
         /// Computes the end of year (1st of the next year) of given date/time
         /// </summary>
-        public static Func<DateTime, DateTime> EndOfYear
-        {
-            get
-            {
-                return dt =>
-                {
-                    var value = 1 - dt.DayOfYear;
-                    return OneYear(dt).AddDays(value).Date;
-                };
-            }
-        }
+        public static Func<DateTime, DateTime> EndOfYear => dt => new DateTime(dt.Year + 1, 1, 1);
     }
 }

--- a/Tests/Common/Data/CalendarConsolidatorsTests.cs
+++ b/Tests/Common/Data/CalendarConsolidatorsTests.cs
@@ -514,7 +514,7 @@ def Monthly(dt):
             var calendarInfo = quarterly(new DateTime(2020, 5, 1));
 
             Assert.AreEqual(new DateTime(2020, 1, 1), calendarInfo.Start);
-            Assert.AreEqual(TimeSpan.FromDays(365), calendarInfo.Period);
+            Assert.AreEqual(TimeSpan.FromDays(366), calendarInfo.Period);   // leap year
 
             calendarInfo = quarterly(new DateTime(2021, 11, 1));
 

--- a/Tests/Common/ExpiryTests.cs
+++ b/Tests/Common/ExpiryTests.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Tests.Common
+{
+    [TestFixture]
+    public class ExpiryTests
+    {
+        [Test]
+        public void ExpiryEndOfWeekTests()
+        {
+            var endOfWeekList = new List<DateTime>();
+
+            var current = new DateTime(2019, 1, 1);
+            var end = new DateTime(2020, 1, 1);
+            while (current < end)
+            {
+                var endOfWeek = Expiry.EndOfWeek(current);
+                endOfWeekList.Add(endOfWeek);
+                Assert.AreEqual(DayOfWeek.Monday, endOfWeek.DayOfWeek);
+                Assert.Greater(endOfWeek, current);
+                current = current.AddDays(1);
+            }
+
+            var actual = endOfWeekList.Distinct().Count();
+            Assert.AreEqual(53, actual);
+        }
+
+        [Test]
+        public void ExpiryEndOfMonthTests()
+        {
+            var endOfMonthList = new List<DateTime>();
+
+            var current = new DateTime(2019, 1, 1);
+            var end = new DateTime(2020, 1, 1);
+            while (current < end)
+            {
+                var endOfMonth = Expiry.EndOfMonth(current);
+                endOfMonthList.Add(endOfMonth);
+                Assert.AreEqual(1, endOfMonth.Day);
+                Assert.Greater(endOfMonth, current);
+                current = current.AddDays(1);
+            }
+
+            var actual = endOfMonthList.Distinct().Count();
+            Assert.AreEqual(12, actual);
+        }
+
+        [Test]
+        public void ExpiryEndOfQuarterTests()
+        {
+            var endOfQuarterList = new List<DateTime>();
+
+            var current = new DateTime(2019, 1, 1);
+            var end = new DateTime(2020, 1, 1);
+            while (current < end)
+            {
+                var endOfQuarter = Expiry.EndOfQuarter(current);
+                endOfQuarterList.Add(endOfQuarter);
+                Assert.AreEqual(1, endOfQuarter.Day);
+                Assert.AreEqual(1, endOfQuarter.Month % 3);
+                Assert.Greater(endOfQuarter, current);
+                current = current.AddDays(1);
+            }
+
+            var actual = endOfQuarterList.Distinct().Count();
+            Assert.AreEqual(4, actual);
+        }
+
+        [Test]
+        public void ExpiryEndOfYearTests()
+        {
+            var endOfYearList = new List<DateTime>();
+
+            var current = new DateTime(2019, 1, 1);
+            var end = new DateTime(2020, 1, 1);
+            while (current < end)
+            {
+                var endOfYear = Expiry.EndOfYear(current);
+                endOfYearList.Add(endOfYear);
+                Assert.AreEqual(1, endOfYear.Day);
+                Assert.AreEqual(end.Year, endOfYear.Year);
+                Assert.Greater(endOfYear, current);
+                current = current.AddDays(1);
+            }
+
+            var actual = endOfYearList.Distinct().Count();
+            Assert.AreEqual(1, actual);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -323,6 +323,7 @@
     <Compile Include="Common\Orders\OrderEventTests.cs" />
     <Compile Include="Common\ExtendedDictionaryTests.cs" />
     <Compile Include="Common\Orders\OrderSizingTests.cs" />
+    <Compile Include="Common\ExpiryTests.cs" />
     <Compile Include="Common\Securities\TestDefaultMarginCallModel.cs" />
     <Compile Include="Common\Statistics\AnnualPerformanceTests.cs" />
     <Compile Include="Common\Statistics\StatisticsBuilderTests.cs" />


### PR DESCRIPTION
#### Description
- Fixes `Expiry.EndOfMonth` and `Expiry.EndOfYear` Methods
- Adds unit tests for `Expiry.EndOf*` methods.

#### Related Issue
Closes #4267 

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
New unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`