### PR TITLE
Improve AlphaResultPacket order batching

### DIFF
--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -69,6 +69,39 @@ namespace QuantConnect.Tests.Common.Util
         }
 
         [Test]
+        public void BatchAlphaResultPacketDuplicateOrder()
+        {
+            var btcusd = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX);
+            var orders = new List<Order>
+            {
+                new MarketOrder(btcusd, 1000, DateTime.UtcNow, "ExpensiveOrder") { Id = 1 },
+                new MarketOrder(btcusd, 100, DateTime.UtcNow, "ExpensiveOrder") { Id = 2 },
+                new MarketOrder(btcusd, 2000, DateTime.UtcNow, "ExpensiveOrder") { Id = 1 },
+                new MarketOrder(btcusd, 10, DateTime.UtcNow, "ExpensiveOrder") { Id = 3 },
+                new MarketOrder(btcusd, 3000, DateTime.UtcNow, "ExpensiveOrder") { Id = 1 }
+            };
+            var orders2 = new List<Order>
+            {
+                new MarketOrder(btcusd, 200, DateTime.UtcNow, "ExpensiveOrder") { Id = 2 },
+                new MarketOrder(btcusd, 20, DateTime.UtcNow, "ExpensiveOrder") { Id = 3 }
+            };
+
+            var packet1 = new AlphaResultPacket("1", 1, orders: orders);
+            var packet2 = new AlphaResultPacket("1", 1, orders: orders2);
+
+            var result = new List<AlphaResultPacket> { packet1, packet2 }.Batch();
+
+            // we expect just 1 order instance per order id
+            Assert.AreEqual(3, result.Orders.Count);
+            Assert.IsTrue(result.Orders.Any(order => order.Id == 1 && order.Quantity == 3000));
+            Assert.IsTrue(result.Orders.Any(order => order.Id == 2 && order.Quantity == 200));
+            Assert.IsTrue(result.Orders.Any(order => order.Id == 3 && order.Quantity == 20));
+
+            var expected = new List<Order> { orders[4], orders2[0], orders2[1] };
+            Assert.IsTrue(result.Orders.SequenceEqual(expected));
+        }
+
+        [Test]
         public void SeriesIsNotEmpty()
         {
             var series = new Series("SadSeries")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- AlphaResultPacket Order batching will just keep the last Order
instance per Order id, which is the latest. Adding unit test

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/Lean/issues/4135
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When batching AlphaResultPackets we are interested in keeping the last Order instance per order id, which is the latest
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
