### PR TITLE
Fixes IndicatorBase.Update Method Time-stamping

### DIFF
--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Diagnostics;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
 using QuantConnect.Logging;
 
 namespace QuantConnect.Indicators
@@ -76,10 +75,10 @@ namespace QuantConnect.Indicators
         /// <returns>True if this indicator is ready, false otherwise</returns>
         public bool Update(IBaseData input)
         {
-            if (_previousInput != null && input.Time < _previousInput.Time)
+            if (_previousInput != null && input.EndTime < _previousInput.EndTime)
             {
                 // if we receive a time in the past, log and return
-                Log.Error($"This is a forward only indicator: {Name} Input: {input.Time:u} Previous: {_previousInput.Time:u}. It will not be updated with this input.");
+                Log.Error($"This is a forward only indicator: {Name} Input: {input.EndTime:u} Previous: {_previousInput.EndTime:u}. It will not be updated with this input.");
                 return IsReady;
             }
             if (!ReferenceEquals(input, _previousInput))
@@ -96,7 +95,7 @@ namespace QuantConnect.Indicators
                 var nextResult = ValidateAndComputeNextValue((T)input);
                 if (nextResult.Status == IndicatorStatus.Success)
                 {
-                    Current = new IndicatorDataPoint(input.Time, nextResult.Value);
+                    Current = new IndicatorDataPoint(input.EndTime, nextResult.Value);
 
                     // let others know we've produced a new data point
                     OnUpdated(Current);
@@ -253,8 +252,7 @@ namespace QuantConnect.Indicators
         /// <param name="consolidated">This is the new piece of data produced by this indicator</param>
         protected virtual void OnUpdated(IndicatorDataPoint consolidated)
         {
-            var handler = Updated;
-            if (handler != null) handler(this, consolidated);
+            Updated?.Invoke(this, consolidated);
         }
     }
 }

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -14,14 +14,17 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NUnit.Framework;
+using QuantConnect.Algorithm;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 using QuantConnect.Logging;
+using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Indicators
 {
@@ -185,7 +188,41 @@ namespace QuantConnect.Tests.Indicators
             }
             Log.Trace($"{counter} indicators out of {indicators.Count} were tested.");
         }
-        
+
+        [Test]
+        public void IndicatorsOfDifferentTypeDiplaySameCurrentTime()
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+            var spy = algorithm.AddEquity("SPY");
+
+            var indicatorTimeList = new List<DateTime>();
+            // RSI is a DataPointIndicator
+            algorithm.RSI(spy.Symbol, 14).Updated += (_, e) => indicatorTimeList.Add(e.EndTime);
+            // STO is a BarIndicator
+            algorithm.STO(spy.Symbol, 14, 2, 2).Updated += (_, e) => indicatorTimeList.Add(e.EndTime);
+            // MFI is a TradeBarIndicator
+            algorithm.MFI(spy.Symbol, 14).Updated += (_, e) => indicatorTimeList.Add(e.EndTime);
+
+            var consolidators = spy.Subscriptions.SelectMany(x => x.Consolidators).ToList();
+            Assert.AreEqual(3, consolidators.Count);   // One consolidator for each indicator
+
+            var bars = new[] { 30, 31 }.Select(d =>
+                new TradeBar(new DateTime(2020, 03, 04, 9, d, 0),
+                             spy.Symbol, 100, 100, 100, 100, 1000));
+
+            foreach (var bar in bars)
+            {
+                foreach (var consolidator in consolidators)
+                {
+                    consolidator.Update(bar);
+                }
+            }
+
+            // All indicators should have the same EndTime
+            Assert.AreEqual(1, indicatorTimeList.Distinct().Count());
+        }
+
         private static void TestComparisonOperators<TValue>()
         {
             var indicator = new TestIndicator();


### PR DESCRIPTION
#### Description
`IndicatorBase.Update` use `input.EndTime` instead of `input.Time` so that `input.Current.Time` (and `EndTime`) matches the `input.EndTime` and achieve consistent behavior across different indicator types (`IndicatorDataPoint`, `IBaseDataBar` and `TradeBar`)

#### Related Issue
Closes #4271

#### Motivation and Context
Bug fix.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`