### PR TITLE
Fix OrderFee round trip serialization

### DIFF
--- a/Common/Orders/Fees/OrderFee.cs
+++ b/Common/Orders/Fees/OrderFee.cs
@@ -24,7 +24,7 @@ namespace QuantConnect.Orders.Fees
         /// <summary>
         /// Gets the order fee
         /// </summary>
-        public CashAmount Value { get; }
+        public CashAmount Value { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OrderFee"/> class

--- a/Tests/Common/Orders/OrderEventTests.cs
+++ b/Tests/Common/Orders/OrderEventTests.cs
@@ -18,6 +18,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Orders
 {
@@ -45,6 +46,44 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.IsTrue(json.Contains("This is a message"));
             Assert.IsTrue(json.Contains("LimitPrice"));
             Assert.IsTrue(json.Contains("StopPrice"));
+        }
+
+        [Test]
+        public void RoundTripSerialization()
+        {
+            var order = new MarketOrder(Symbols.BTCUSD, 0.123m, DateTime.UtcNow);
+            var orderEvent = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero)
+            {
+                OrderFee = new OrderFee(new CashAmount(99, "EUR")),
+                Message = "Pepe",
+                Status = OrderStatus.PartiallyFilled,
+                StopPrice = 1,
+                LimitPrice = 2,
+                FillPrice = 11,
+                FillQuantity = 12,
+                FillPriceCurrency = "USD"
+            };
+
+            var serializeObject = JsonConvert.SerializeObject(orderEvent);
+            var deserializeObject = JsonConvert.DeserializeObject<OrderEvent>(serializeObject);
+
+            Assert.AreEqual(orderEvent.Symbol, deserializeObject.Symbol);
+            Assert.AreEqual(orderEvent.StopPrice, deserializeObject.StopPrice);
+            Assert.AreEqual(orderEvent.UtcTime, deserializeObject.UtcTime);
+            Assert.AreEqual(orderEvent.OrderId, deserializeObject.OrderId);
+            Assert.AreEqual(orderEvent.AbsoluteFillQuantity, deserializeObject.AbsoluteFillQuantity);
+            Assert.AreEqual(orderEvent.Direction, deserializeObject.Direction);
+            Assert.AreEqual(orderEvent.FillPrice, deserializeObject.FillPrice);
+            Assert.AreEqual(orderEvent.FillPriceCurrency, deserializeObject.FillPriceCurrency);
+            Assert.AreEqual(orderEvent.FillQuantity, deserializeObject.FillQuantity);
+            Assert.AreEqual(orderEvent.Id, deserializeObject.Id);
+            Assert.AreEqual(orderEvent.IsAssignment, deserializeObject.IsAssignment);
+            Assert.AreEqual(orderEvent.LimitPrice, deserializeObject.LimitPrice);
+            Assert.AreEqual(orderEvent.Message, deserializeObject.Message);
+            Assert.AreEqual(orderEvent.Quantity, deserializeObject.Quantity);
+            Assert.AreEqual(orderEvent.Status, deserializeObject.Status);
+            Assert.AreEqual(orderEvent.OrderFee.Value.Amount, deserializeObject.OrderFee.Value.Amount);
+            Assert.AreEqual(orderEvent.OrderFee.Value.Currency, deserializeObject.OrderFee.Value.Currency);
         }
     }
 }

--- a/Tests/Common/Securities/CashAmountTests.cs
+++ b/Tests/Common/Securities/CashAmountTests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Securities;
 
@@ -105,6 +106,17 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsNotNull(cashAmount);
             Assert.AreEqual(0, cashAmount.Amount);
             Assert.AreEqual(null, cashAmount.Currency);
+        }
+
+        [Test]
+        public void RoundTripSerialization()
+        {
+            var cashAmount = new CashAmount(1000m, "EUR");
+
+            var serialized = JsonConvert.SerializeObject(cashAmount);
+            var deserialize = JsonConvert.DeserializeObject<CashAmount>(serialized);
+
+            Assert.AreEqual(cashAmount, deserialize);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Making OrderFee.Value setter public to fix deserialization
- Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/Lean/issues/4135
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
OrderFees are deserialized correctly
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
