### PR TITLE
Make Insight.Clone() virtual to proper cloning

### DIFF
--- a/Common/Algorithm/Framework/Alphas/Insight.cs
+++ b/Common/Algorithm/Framework/Alphas/Insight.cs
@@ -288,7 +288,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// Creates a deep clone of this insight instance
         /// </summary>
         /// <returns>A new insight with identical values, but new instances</returns>
-        public Insight Clone()
+        public virtual Insight Clone()
         {
             return new Insight(Symbol, Period, Type, Direction, Magnitude, Confidence, weight:Weight)
             {

--- a/Tests/Algorithm/Framework/Alphas/GeneratedInsightsCollectionTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/GeneratedInsightsCollectionTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework.Alphas;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Alphas
+{
+    [TestFixture]
+    public class GeneratedInsightsCollectionTests
+    {
+        [Test]
+        public void CheckCloneRespectsDerivedTypes()
+        {
+            var insights = new List<DerivedInsight>
+            {
+                new DerivedInsight(Symbol.Empty, TimeSpan.Zero, InsightType.Price, InsightDirection.Flat),
+                new DerivedInsight(Symbol.Empty, TimeSpan.Zero, InsightType.Price, InsightDirection.Flat),
+                new DerivedInsight(Symbol.Empty, TimeSpan.Zero, InsightType.Price, InsightDirection.Flat),
+                new DerivedInsight(Symbol.Empty, TimeSpan.Zero, InsightType.Price, InsightDirection.Flat),
+            };
+
+            var generatedInsightsCollection = new GeneratedInsightsCollection(DateTime.UtcNow, insights, clone: true);
+
+            Assert.True(generatedInsightsCollection.Insights.TrueForAll(x => x.GetType() == typeof(DerivedInsight)));
+        }
+
+        public class DerivedInsight : Insight
+        {
+            public DerivedInsight(Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction)
+                : base(symbol, period, type, direction)
+            {
+            }
+
+            public override Insight Clone()
+            {
+                return new DerivedInsight(Symbol, Period, Type, Direction);
+            }
+        }
+    }
+}

--- a/Tests/Algorithm/Framework/Alphas/GeneratedInsightsCollectionTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/GeneratedInsightsCollectionTests.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using QuantConnect.Algorithm.Framework.Alphas;
@@ -24,7 +39,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
             Assert.True(generatedInsightsCollection.Insights.TrueForAll(x => x.GetType() == typeof(DerivedInsight)));
         }
 
-        public class DerivedInsight : Insight
+        private class DerivedInsight : Insight
         {
             public DerivedInsight(Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction)
                 : base(symbol, period, type, direction)

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -271,6 +271,7 @@
     <Compile Include="Algorithm\Framework\Alphas\CommonAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\ConstantAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\EmaCrossAlphaModelTests.cs" />
+    <Compile Include="Algorithm\Framework\Alphas\GeneratedInsightsCollectionTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\MacdAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\BasePairsTradingAlphaModelTests.cs" />
     <Compile Include="Algorithm\Framework\Alphas\RsiAlphaModelTests.cs" />


### PR DESCRIPTION
#### Description
Change Insight.Clone() to virtual so that the call to Clone in the GeneratedInsightsCollection respects derived types

#### Related Issue
Closes #4291 

#### Motivation and Context
Derived insights get converted to instances of type Insight whilst cloning, so derived type is lost to the InsightAnalysisContext

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Unit tests have been written to ensure that the Clone works as expected.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
