### PR TITLE
add TradierOrderClass Oto, Oco, Otoco

### DIFF
--- a/Brokerages/Tradier/Common.cs
+++ b/Brokerages/Tradier/Common.cs
@@ -154,7 +154,16 @@ namespace QuantConnect.Brokerages.Tradier
         Multileg,
         /// TradierOrderClass: Combo
         [EnumMember(Value = "combo")]
-        Combo
+        Combo,
+        /// TradierOrderClass: Oto
+        [EnumMember(Value = "oto")]
+        Oto,
+        /// TradierOrderClass: Oco
+        [EnumMember(Value = "oco")]
+        Oco,
+        /// TradierOrderClass: Otoco
+        [EnumMember(Value = "otoco")]
+        Otoco
     }
 
     /// <summary>


### PR DESCRIPTION
#### Description
add TradierOrderClass Oto, Oco, Otoco

#### Related Issue
n.a.

#### Motivation and Context

https://www.quantconnect.com/forum/discussion/7791/how-to-get-the-brokerage-object-in-the-algorithm-object/p1

One example:

https://documentation.tradier.com/brokerage-api/trading/advanced-orders 

Tradier has many advanced order types, which may not be supported by other brokerages at all, hence won't be avaliable in a common Brokerage interface in the current framework.

And the user may also want to call some Tradier specfic api that are not be captured by the common Brokerage interface (which can only be the least common denominator of all the supporeted Brokerages as always when you have abstraction layer).

So expose the brokerage object directly to the Algorithm object will give user more freedom and flexibility. Most of the time, a user only use one or two brokerages, the ability to switch between all these brokages is not a big concern. And the user is more concerned about the ability to call vendor specific api of their already selected brokerage.
https://github.com/QuantConnect/Lean/tree/master/Brokerages

 


#### Requires Documentation Change
Not yet.

#### How Has This Been Tested?

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
