### PR TITLE
Fixes issue when parsing LiveResult JSON with string OrderType values

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -73,6 +73,23 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Converts the provided string into pascal case notation
+        /// </summary>
+        public static string ToPascalCase(this string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            if (value.Length == 1)
+            {
+                return value.ToUpperInvariant();
+            }
+            return char.ToUpperInvariant(value[0]) + value.Substring(1);
+        }
+
+        /// <summary>
         /// Helper method to batch a collection of <see cref="AlphaResultPacket"/> into 1 single instance.
         /// Will return null if the provided list is empty. Will keep the last Order instance per order id,
         /// which is the latest. Implementations trusts the provided 'resultPackets' list to batch is in order

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -73,23 +73,6 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Converts the provided string into pascal case notation
-        /// </summary>
-        public static string ToPascalCase(this string value)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                return value;
-            }
-
-            if (value.Length == 1)
-            {
-                return value.ToUpperInvariant();
-            }
-            return char.ToUpperInvariant(value[0]) + value.Substring(1);
-        }
-
-        /// <summary>
         /// Helper method to batch a collection of <see cref="AlphaResultPacket"/> into 1 single instance.
         /// Will return null if the provided list is empty. Will keep the last Order instance per order id,
         /// which is the latest. Implementations trusts the provided 'resultPackets' list to batch is in order

--- a/Report/NullResultValueTypeJsonConverter.cs
+++ b/Report/NullResultValueTypeJsonConverter.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.Report
             // Deserialize with OrderJsonConverter, otherwise it will fail. We convert the token back
             // to its JSON representation and use the `JsonConvert.DeserializeObject<T>(...)` method instead
             // of using `token.ToObject<T>()` since it can be provided a JsonConverter in its arguments.
-            return JsonConvert.DeserializeObject<T>(token.ToString(), new Orders.OrderJsonConverter());
+            return JsonConvert.DeserializeObject<T>(token.ToString(), new OrderTypeNormalizingJsonConverter());
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/Report/OrderTypeNormalizingJsonConverter.cs
+++ b/Report/OrderTypeNormalizingJsonConverter.cs
@@ -1,0 +1,111 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Report
+{
+    /// <summary>
+    /// Normalizes the "Type" field to a value that will allow for
+    /// successful deserialization in the <see cref="OrderJsonConverter"/> class.
+    /// </summary>
+    /// <example>
+    /// All of these values should result in the same object:
+    /// <code>
+    /// [
+    ///     { "Type": "marketOnOpen", ... },
+    ///     { "Type": "MarketOnOpen", ... },
+    ///     { "Type": 4, ... },
+    /// ]
+    /// </code>
+    /// </example>
+    /// <typeparam name="T">Result type to deserialize into</typeparam>
+    public class OrderTypeNormalizingJsonConverter : JsonConverter
+    {
+        private readonly JsonConverter _converter;
+
+        /// <summary>
+        /// Creates an instance of the class
+        /// </summary>
+        public OrderTypeNormalizingJsonConverter()
+        {
+            _converter = new OrderJsonConverter();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(Order).IsAssignableFrom(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var token = JToken.ReadFrom(reader);
+            // Takes the Type field and selects the correct OrderType instance
+            var orderTypeValue = token["Type"].Value<string>();
+            int orderTypeNumber;
+            var orderType = Parse.TryParse(orderTypeValue, NumberStyles.Any, out orderTypeNumber) ?
+                (OrderType)orderTypeNumber :
+                (OrderType)Enum.Parse(typeof(OrderType), orderTypeValue.ToPascalCase());
+
+            var typeOfOrder = TypeFromOrderTypeEnum(orderType);
+            token["Type"] = (int)orderType;
+            return JsonConvert.DeserializeObject(token.ToString(), typeOfOrder, _converter);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns the object type belonging to the provided OrderType
+        /// </summary>
+        /// <param name="orderType">Order type</param>
+        /// <returns>Class type that supports the given OrderType</returns>
+        public static Type TypeFromOrderTypeEnum(OrderType orderType)
+        {
+            switch (orderType)
+            {
+                case OrderType.Market:
+                    return typeof(MarketOrder);
+
+                case OrderType.Limit:
+                    return typeof(LimitOrder);
+
+                case OrderType.StopMarket:
+                    return typeof(StopMarketOrder);
+
+                case OrderType.StopLimit:
+                    return typeof(StopLimitOrder);
+
+                case OrderType.MarketOnOpen:
+                    return typeof(MarketOnOpenOrder);
+
+                case OrderType.MarketOnClose:
+                    return typeof(MarketOnCloseOrder);
+
+                case OrderType.OptionExercise:
+                    return typeof(OptionExerciseOrder);
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/Report/OrderTypeNormalizingJsonConverter.cs
+++ b/Report/OrderTypeNormalizingJsonConverter.cs
@@ -38,16 +38,6 @@ namespace QuantConnect.Report
     /// <typeparam name="T">Result type to deserialize into</typeparam>
     public class OrderTypeNormalizingJsonConverter : JsonConverter
     {
-        private readonly JsonConverter _converter;
-
-        /// <summary>
-        /// Creates an instance of the class
-        /// </summary>
-        public OrderTypeNormalizingJsonConverter()
-        {
-            _converter = new OrderJsonConverter();
-        }
-
         public override bool CanConvert(Type objectType)
         {
             return typeof(Order).IsAssignableFrom(objectType);

--- a/Report/OrderTypeNormalizingJsonConverter.cs
+++ b/Report/OrderTypeNormalizingJsonConverter.cs
@@ -60,52 +60,16 @@ namespace QuantConnect.Report
             var orderTypeValue = token["Type"].Value<string>();
             int orderTypeNumber;
             var orderType = Parse.TryParse(orderTypeValue, NumberStyles.Any, out orderTypeNumber) ?
-                (OrderType)orderTypeNumber :
-                (OrderType)Enum.Parse(typeof(OrderType), orderTypeValue.ToPascalCase());
+                orderTypeNumber :
+                (int)(OrderType)Enum.Parse(typeof(OrderType), orderTypeValue, true);
 
-            var typeOfOrder = TypeFromOrderTypeEnum(orderType);
-            token["Type"] = (int)orderType;
-            return JsonConvert.DeserializeObject(token.ToString(), typeOfOrder, _converter);
+            token["Type"] = orderType;
+            return OrderJsonConverter.CreateOrderFromJObject((JObject)token);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Returns the object type belonging to the provided OrderType
-        /// </summary>
-        /// <param name="orderType">Order type</param>
-        /// <returns>Class type that supports the given OrderType</returns>
-        public static Type TypeFromOrderTypeEnum(OrderType orderType)
-        {
-            switch (orderType)
-            {
-                case OrderType.Market:
-                    return typeof(MarketOrder);
-
-                case OrderType.Limit:
-                    return typeof(LimitOrder);
-
-                case OrderType.StopMarket:
-                    return typeof(StopMarketOrder);
-
-                case OrderType.StopLimit:
-                    return typeof(StopLimitOrder);
-
-                case OrderType.MarketOnOpen:
-                    return typeof(MarketOnOpenOrder);
-
-                case OrderType.MarketOnClose:
-                    return typeof(MarketOnCloseOrder);
-
-                case OrderType.OptionExercise:
-                    return typeof(OptionExerciseOrder);
-
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
         }
     }
 }

--- a/Report/QuantConnect.Report.csproj
+++ b/Report/QuantConnect.Report.csproj
@@ -121,6 +121,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="OrderTypeNormalizingJsonConverter.cs" />
     <Compile Include="NullResultValueTypeJsonConverter.cs" />
     <Compile Include="PortfolioLooper\MockDataFeed.cs" />
     <Compile Include="PortfolioLooper\PortfolioLooperAlgorithm.cs" />

--- a/Tests/Report/ResultDeserializationTests.cs
+++ b/Tests/Report/ResultDeserializationTests.cs
@@ -114,41 +114,41 @@ namespace QuantConnect.Tests.Report
             {
                 //var orderObjectType = OrderTypeNormalizingJsonConverter.TypeFromOrderTypeEnum(orderType);
                 var intValueJson = OrderJson.Replace(OrderTypeStringReplace, ((int)orderType).ToStringInvariant());
-                var pascalCaseJson = OrderJson.Replace(OrderTypeStringReplace, $"'{orderType.ToStringInvariant().ToPascalCase()}'");
+                var upperCaseJson = OrderJson.Replace(OrderTypeStringReplace, $"'{orderType.ToStringInvariant().ToUpperInvariant()}'");
                 var camelCaseJson = OrderJson.Replace(OrderTypeStringReplace, $"'{orderType.ToStringInvariant().ToCamelCase()}'");
 
                 var intValueLiveResult = InvalidLiveResultJson.Replace(OrderStringReplace, intValueJson);
-                var pascalCaseLiveResult = InvalidLiveResultJson.Replace(OrderStringReplace, pascalCaseJson);
+                var upperCaseLiveResult = InvalidLiveResultJson.Replace(OrderStringReplace, upperCaseJson);
                 var camelCaseLiveResult = InvalidLiveResultJson.Replace(OrderStringReplace, camelCaseJson);
 
                 var intInstance = JsonConvert.DeserializeObject<LiveResult>(intValueLiveResult, settings).Orders.Values.Single();
-                var pascalCaseInstance = JsonConvert.DeserializeObject<LiveResult>(pascalCaseLiveResult, settings).Orders.Values.Single();
+                var upperCaseInstance = JsonConvert.DeserializeObject<LiveResult>(upperCaseLiveResult, settings).Orders.Values.Single();
                 var camelCaseInstance = JsonConvert.DeserializeObject<LiveResult>(camelCaseLiveResult, settings).Orders.Values.Single();
 
-                CollectionAssert.AreEqual(intInstance.BrokerId, pascalCaseInstance.BrokerId);
-                Assert.AreEqual(intInstance.ContingentId, pascalCaseInstance.ContingentId);
-                Assert.AreEqual(intInstance.Direction, pascalCaseInstance.Direction);
-                Assert.AreEqual(intInstance.TimeInForce.GetType(), pascalCaseInstance.TimeInForce.GetType());
-                Assert.AreEqual(intInstance.Id, pascalCaseInstance.Id);
-                Assert.AreEqual(intInstance.Price, pascalCaseInstance.Price);
-                Assert.AreEqual(intInstance.PriceCurrency, pascalCaseInstance.PriceCurrency);
-                Assert.AreEqual(intInstance.SecurityType, pascalCaseInstance.SecurityType);
-                Assert.AreEqual(intInstance.Status, pascalCaseInstance.Status);
-                Assert.AreEqual(intInstance.Symbol, pascalCaseInstance.Symbol);
-                Assert.AreEqual(intInstance.Tag, pascalCaseInstance.Tag);
-                Assert.AreEqual(intInstance.Time, pascalCaseInstance.Time);
-                Assert.AreEqual(intInstance.CreatedTime, pascalCaseInstance.CreatedTime);
-                Assert.AreEqual(intInstance.LastFillTime, pascalCaseInstance.LastFillTime);
-                Assert.AreEqual(intInstance.LastUpdateTime, pascalCaseInstance.LastUpdateTime);
-                Assert.AreEqual(intInstance.CanceledTime, pascalCaseInstance.CanceledTime);
-                Assert.AreEqual(intInstance.Type, pascalCaseInstance.Type);
-                Assert.AreEqual(intInstance.Value, pascalCaseInstance.Value);
-                Assert.AreEqual(intInstance.Quantity, pascalCaseInstance.Quantity);
-                Assert.AreEqual(intInstance.TimeInForce.GetType(), pascalCaseInstance.TimeInForce.GetType());
-                Assert.AreEqual(intInstance.Symbol.ID.Market, pascalCaseInstance.Symbol.ID.Market);
-                Assert.AreEqual(intInstance.OrderSubmissionData?.AskPrice, pascalCaseInstance.OrderSubmissionData?.AskPrice);
-                Assert.AreEqual(intInstance.OrderSubmissionData?.BidPrice, pascalCaseInstance.OrderSubmissionData?.BidPrice);
-                Assert.AreEqual(intInstance.OrderSubmissionData?.LastPrice, pascalCaseInstance.OrderSubmissionData?.LastPrice);
+                CollectionAssert.AreEqual(intInstance.BrokerId, upperCaseInstance.BrokerId);
+                Assert.AreEqual(intInstance.ContingentId, upperCaseInstance.ContingentId);
+                Assert.AreEqual(intInstance.Direction, upperCaseInstance.Direction);
+                Assert.AreEqual(intInstance.TimeInForce.GetType(), upperCaseInstance.TimeInForce.GetType());
+                Assert.AreEqual(intInstance.Id, upperCaseInstance.Id);
+                Assert.AreEqual(intInstance.Price, upperCaseInstance.Price);
+                Assert.AreEqual(intInstance.PriceCurrency, upperCaseInstance.PriceCurrency);
+                Assert.AreEqual(intInstance.SecurityType, upperCaseInstance.SecurityType);
+                Assert.AreEqual(intInstance.Status, upperCaseInstance.Status);
+                Assert.AreEqual(intInstance.Symbol, upperCaseInstance.Symbol);
+                Assert.AreEqual(intInstance.Tag, upperCaseInstance.Tag);
+                Assert.AreEqual(intInstance.Time, upperCaseInstance.Time);
+                Assert.AreEqual(intInstance.CreatedTime, upperCaseInstance.CreatedTime);
+                Assert.AreEqual(intInstance.LastFillTime, upperCaseInstance.LastFillTime);
+                Assert.AreEqual(intInstance.LastUpdateTime, upperCaseInstance.LastUpdateTime);
+                Assert.AreEqual(intInstance.CanceledTime, upperCaseInstance.CanceledTime);
+                Assert.AreEqual(intInstance.Type, upperCaseInstance.Type);
+                Assert.AreEqual(intInstance.Value, upperCaseInstance.Value);
+                Assert.AreEqual(intInstance.Quantity, upperCaseInstance.Quantity);
+                Assert.AreEqual(intInstance.TimeInForce.GetType(), upperCaseInstance.TimeInForce.GetType());
+                Assert.AreEqual(intInstance.Symbol.ID.Market, upperCaseInstance.Symbol.ID.Market);
+                Assert.AreEqual(intInstance.OrderSubmissionData?.AskPrice, upperCaseInstance.OrderSubmissionData?.AskPrice);
+                Assert.AreEqual(intInstance.OrderSubmissionData?.BidPrice, upperCaseInstance.OrderSubmissionData?.BidPrice);
+                Assert.AreEqual(intInstance.OrderSubmissionData?.LastPrice, upperCaseInstance.OrderSubmissionData?.LastPrice);
 
                 CollectionAssert.AreEqual(intInstance.BrokerId, camelCaseInstance.BrokerId);
                 Assert.AreEqual(intInstance.ContingentId, camelCaseInstance.ContingentId);

--- a/Tests/Report/ResultDeserializationTests.cs
+++ b/Tests/Report/ResultDeserializationTests.cs
@@ -15,8 +15,10 @@
 
 using Newtonsoft.Json;
 using NUnit.Framework;
+using QuantConnect.Orders;
 using QuantConnect.Packets;
 using QuantConnect.Report;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -25,8 +27,31 @@ namespace QuantConnect.Tests.Report
     [TestFixture]
     public class ResultDeserializationTests
     {
-        public const string InvalidBacktestResultJson = "{\"RollingWindow\":{},\"TotalPerformance\":null,\"Charts\":{\"Equity\":{\"Name\":\"Equity\",\"ChartType\":0,\"Series\":{\"Performance\":{\"Name\":\"Performance\",\"Unit\":\"$\",\"Index\":0,\"Values\":[{\"x\":1583704925,\"y\":5.0},{\"x\":1583791325,\"y\":null},{\"x\":1583877725,\"y\":7.0},{\"x\":1583964125,\"y\":8.0},{\"x\":1584050525,\"y\":9.0}],\"SeriesType\":0,\"Color\":\"\",\"ScatterMarkerSymbol\":\"none\"}}}},\"Orders\":{},\"ProfitLoss\":{},\"Statistics\":{},\"RuntimeStatistics\":{}}";
-        public const string InvalidLiveResultJson = "{\"Holdings\":{},\"Cash\":{\"USD\":{\"SecuritySymbol\":{\"Value\":\"\",\"ID\":\" 0\",\"Permtick\":\"\"},\"Symbol\":\"USD\",\"Amount\":0.0,\"ConversionRate\":1.0,\"CurrencySymbol\":\"$\",\"ValueInAccountCurrency\":0.0}},\"ServerStatistics\":{\"CPU Usage\":\"0.0%\",\"Used RAM (MB)\":\"68\",\"Total RAM (MB)\":\"\",\"Used Disk Space (MB)\":\"1\",\"Total Disk Space (MB)\":\"5\",\"Hostname\":\"LEAN\",\"LEAN Version\":\"v2.4.0.0\"},\"Charts\":{\"Equity\":{\"Name\":\"Equity\",\"ChartType\":0,\"Series\":{\"Performance\":{\"Name\":\"Performance\",\"Unit\":\"$\",\"Index\":0,\"Values\":[{\"x\":1583705127,\"y\":5.0},{\"x\":1583791527,\"y\":null},{\"x\":1583877927,\"y\":7.0},{\"x\":1583964327,\"y\":8.0},{\"x\":1584050727,\"y\":9.0}],\"SeriesType\":0,\"Color\":\"\",\"ScatterMarkerSymbol\":\"none\"}}}},\"Orders\":{},\"ProfitLoss\":{},\"Statistics\":{},\"RuntimeStatistics\":{}}";
+        public const string OrderStringReplace = "{{orderStringReplace}}";
+        public const string OrderTypeStringReplace = "{{marketOrderType}}";
+        public const string EmptyJson = "{}";
+
+        public const string InvalidBacktestResultJson = "{\"RollingWindow\":{},\"TotalPerformance\":null,\"Charts\":{\"Equity\":{\"Name\":\"Equity\",\"ChartType\":0,\"Series\":{\"Performance\":{\"Name\":\"Performance\",\"Unit\":\"$\",\"Index\":0,\"Values\":[{\"x\":1583704925,\"y\":5.0},{\"x\":1583791325,\"y\":null},{\"x\":1583877725,\"y\":7.0},{\"x\":1583964125,\"y\":8.0},{\"x\":1584050525,\"y\":9.0}],\"SeriesType\":0,\"Color\":\"\",\"ScatterMarkerSymbol\":\"none\"}}}},\"Orders\":" + OrderStringReplace + ",\"ProfitLoss\":{},\"Statistics\":{},\"RuntimeStatistics\":{}}";
+        public const string InvalidLiveResultJson = "{\"Holdings\":{},\"Cash\":{\"USD\":{\"SecuritySymbol\":{\"Value\":\"\",\"ID\":\" 0\",\"Permtick\":\"\"},\"Symbol\":\"USD\",\"Amount\":0.0,\"ConversionRate\":1.0,\"CurrencySymbol\":\"$\",\"ValueInAccountCurrency\":0.0}},\"ServerStatistics\":{\"CPU Usage\":\"0.0%\",\"Used RAM (MB)\":\"68\",\"Total RAM (MB)\":\"\",\"Used Disk Space (MB)\":\"1\",\"Total Disk Space (MB)\":\"5\",\"Hostname\":\"LEAN\",\"LEAN Version\":\"v2.4.0.0\"},\"Charts\":{\"Equity\":{\"Name\":\"Equity\",\"ChartType\":0,\"Series\":{\"Performance\":{\"Name\":\"Performance\",\"Unit\":\"$\",\"Index\":0,\"Values\":[{\"x\":1583705127,\"y\":5.0},{\"x\":1583791527,\"y\":null},{\"x\":1583877927,\"y\":7.0},{\"x\":1583964327,\"y\":8.0},{\"x\":1584050727,\"y\":9.0}],\"SeriesType\":0,\"Color\":\"\",\"ScatterMarkerSymbol\":\"none\"}}}},\"Orders\":" + OrderStringReplace + ",\"ProfitLoss\":{},\"Statistics\":{},\"RuntimeStatistics\":{}}";
+        public const string OrderJson = @"{'1': {
+    'Type':" + OrderTypeStringReplace + @",
+    'Value':99986.827413672,
+    'Id':1,
+    'ContingentId':0,
+    'BrokerId':[1],
+    'Symbol':{'Value':'SPY',
+    'Permtick':'SPY'},
+    'Price':100.086914328,
+    'Time':'2010-03-04T14:31:00Z',
+    'Quantity':999,
+    'Status':3,
+    'Duration':2,
+    'DurationValue':'2010-04-04T14:31:00Z',
+    'Tag':'',
+    'SecurityType':1,
+    'Direction':0,
+    'AbsoluteQuantity':999
+}}";
 
         [Test]
         public void BacktestResult_NullChartPoint_IsSkipped()
@@ -37,8 +62,8 @@ namespace QuantConnect.Tests.Report
                 NullValueHandling = NullValueHandling.Ignore
             };
 
-            var deWithoutConverter = JsonConvert.DeserializeObject<BacktestResult>(InvalidBacktestResultJson, settings);
-            var deWithConverter = JsonConvert.DeserializeObject<BacktestResult>(InvalidBacktestResultJson, converter);
+            var deWithoutConverter = JsonConvert.DeserializeObject<BacktestResult>(InvalidBacktestResultJson.Replace(OrderStringReplace, EmptyJson), settings);
+            var deWithConverter = JsonConvert.DeserializeObject<BacktestResult>(InvalidBacktestResultJson.Replace(OrderStringReplace, EmptyJson), converter);
 
             var noConverterPoints = GetChartPoints(deWithoutConverter).ToList();
             var withConverterPoints = GetChartPoints(deWithConverter).ToList();
@@ -61,8 +86,8 @@ namespace QuantConnect.Tests.Report
                 NullValueHandling = NullValueHandling.Ignore
             };
 
-            var deWithoutConverter = JsonConvert.DeserializeObject<LiveResult>(InvalidLiveResultJson, settings);
-            var deWithConverter = JsonConvert.DeserializeObject<LiveResult>(InvalidLiveResultJson, converter);
+            var deWithoutConverter = JsonConvert.DeserializeObject<LiveResult>(InvalidLiveResultJson.Replace(OrderStringReplace, EmptyJson), settings);
+            var deWithConverter = JsonConvert.DeserializeObject<LiveResult>(InvalidLiveResultJson.Replace(OrderStringReplace, EmptyJson), converter);
 
             var noConverterPoints = GetChartPoints(deWithoutConverter).ToList();
             var withConverterPoints = GetChartPoints(deWithConverter).ToList();
@@ -74,6 +99,82 @@ namespace QuantConnect.Tests.Report
             var roundtripDeserialization = JsonConvert.DeserializeObject<LiveResult>(convertedSerialized);
 
             Assert.IsTrue(withConverterPoints.SequenceEqual(GetChartPoints(roundtripDeserialization).ToList()));
+        }
+
+        [Test]
+        public void OrderTypeEnumStringAndValueDeserialization()
+        {
+
+            var settings = new JsonSerializerSettings
+            {
+                Converters = new[] { new NullResultValueTypeJsonConverter<LiveResult>() }
+            };
+
+            foreach (var orderType in (OrderType[])Enum.GetValues(typeof(OrderType)))
+            {
+                //var orderObjectType = OrderTypeNormalizingJsonConverter.TypeFromOrderTypeEnum(orderType);
+                var intValueJson = OrderJson.Replace(OrderTypeStringReplace, ((int)orderType).ToStringInvariant());
+                var pascalCaseJson = OrderJson.Replace(OrderTypeStringReplace, $"'{orderType.ToStringInvariant().ToPascalCase()}'");
+                var camelCaseJson = OrderJson.Replace(OrderTypeStringReplace, $"'{orderType.ToStringInvariant().ToCamelCase()}'");
+
+                var intValueLiveResult = InvalidLiveResultJson.Replace(OrderStringReplace, intValueJson);
+                var pascalCaseLiveResult = InvalidLiveResultJson.Replace(OrderStringReplace, pascalCaseJson);
+                var camelCaseLiveResult = InvalidLiveResultJson.Replace(OrderStringReplace, camelCaseJson);
+
+                var intInstance = JsonConvert.DeserializeObject<LiveResult>(intValueLiveResult, settings).Orders.Values.Single();
+                var pascalCaseInstance = JsonConvert.DeserializeObject<LiveResult>(pascalCaseLiveResult, settings).Orders.Values.Single();
+                var camelCaseInstance = JsonConvert.DeserializeObject<LiveResult>(camelCaseLiveResult, settings).Orders.Values.Single();
+
+                CollectionAssert.AreEqual(intInstance.BrokerId, pascalCaseInstance.BrokerId);
+                Assert.AreEqual(intInstance.ContingentId, pascalCaseInstance.ContingentId);
+                Assert.AreEqual(intInstance.Direction, pascalCaseInstance.Direction);
+                Assert.AreEqual(intInstance.TimeInForce.GetType(), pascalCaseInstance.TimeInForce.GetType());
+                Assert.AreEqual(intInstance.Id, pascalCaseInstance.Id);
+                Assert.AreEqual(intInstance.Price, pascalCaseInstance.Price);
+                Assert.AreEqual(intInstance.PriceCurrency, pascalCaseInstance.PriceCurrency);
+                Assert.AreEqual(intInstance.SecurityType, pascalCaseInstance.SecurityType);
+                Assert.AreEqual(intInstance.Status, pascalCaseInstance.Status);
+                Assert.AreEqual(intInstance.Symbol, pascalCaseInstance.Symbol);
+                Assert.AreEqual(intInstance.Tag, pascalCaseInstance.Tag);
+                Assert.AreEqual(intInstance.Time, pascalCaseInstance.Time);
+                Assert.AreEqual(intInstance.CreatedTime, pascalCaseInstance.CreatedTime);
+                Assert.AreEqual(intInstance.LastFillTime, pascalCaseInstance.LastFillTime);
+                Assert.AreEqual(intInstance.LastUpdateTime, pascalCaseInstance.LastUpdateTime);
+                Assert.AreEqual(intInstance.CanceledTime, pascalCaseInstance.CanceledTime);
+                Assert.AreEqual(intInstance.Type, pascalCaseInstance.Type);
+                Assert.AreEqual(intInstance.Value, pascalCaseInstance.Value);
+                Assert.AreEqual(intInstance.Quantity, pascalCaseInstance.Quantity);
+                Assert.AreEqual(intInstance.TimeInForce.GetType(), pascalCaseInstance.TimeInForce.GetType());
+                Assert.AreEqual(intInstance.Symbol.ID.Market, pascalCaseInstance.Symbol.ID.Market);
+                Assert.AreEqual(intInstance.OrderSubmissionData?.AskPrice, pascalCaseInstance.OrderSubmissionData?.AskPrice);
+                Assert.AreEqual(intInstance.OrderSubmissionData?.BidPrice, pascalCaseInstance.OrderSubmissionData?.BidPrice);
+                Assert.AreEqual(intInstance.OrderSubmissionData?.LastPrice, pascalCaseInstance.OrderSubmissionData?.LastPrice);
+
+                CollectionAssert.AreEqual(intInstance.BrokerId, camelCaseInstance.BrokerId);
+                Assert.AreEqual(intInstance.ContingentId, camelCaseInstance.ContingentId);
+                Assert.AreEqual(intInstance.Direction, camelCaseInstance.Direction);
+                Assert.AreEqual(intInstance.TimeInForce.GetType(), camelCaseInstance.TimeInForce.GetType());
+                Assert.AreEqual(intInstance.Id, camelCaseInstance.Id);
+                Assert.AreEqual(intInstance.Price, camelCaseInstance.Price);
+                Assert.AreEqual(intInstance.PriceCurrency, camelCaseInstance.PriceCurrency);
+                Assert.AreEqual(intInstance.SecurityType, camelCaseInstance.SecurityType);
+                Assert.AreEqual(intInstance.Status, camelCaseInstance.Status);
+                Assert.AreEqual(intInstance.Symbol, camelCaseInstance.Symbol);
+                Assert.AreEqual(intInstance.Tag, camelCaseInstance.Tag);
+                Assert.AreEqual(intInstance.Time, camelCaseInstance.Time);
+                Assert.AreEqual(intInstance.CreatedTime, camelCaseInstance.CreatedTime);
+                Assert.AreEqual(intInstance.LastFillTime, camelCaseInstance.LastFillTime);
+                Assert.AreEqual(intInstance.LastUpdateTime, camelCaseInstance.LastUpdateTime);
+                Assert.AreEqual(intInstance.CanceledTime, camelCaseInstance.CanceledTime);
+                Assert.AreEqual(intInstance.Type, camelCaseInstance.Type);
+                Assert.AreEqual(intInstance.Value, camelCaseInstance.Value);
+                Assert.AreEqual(intInstance.Quantity, camelCaseInstance.Quantity);
+                Assert.AreEqual(intInstance.TimeInForce.GetType(), camelCaseInstance.TimeInForce.GetType());
+                Assert.AreEqual(intInstance.Symbol.ID.Market, camelCaseInstance.Symbol.ID.Market);
+                Assert.AreEqual(intInstance.OrderSubmissionData?.AskPrice, camelCaseInstance.OrderSubmissionData?.AskPrice);
+                Assert.AreEqual(intInstance.OrderSubmissionData?.BidPrice, camelCaseInstance.OrderSubmissionData?.BidPrice);
+                Assert.AreEqual(intInstance.OrderSubmissionData?.LastPrice, camelCaseInstance.OrderSubmissionData?.LastPrice);
+            }
         }
 
         public IEnumerable<KeyValuePair<long, decimal>> GetChartPoints(Result result)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Supports different styles for the OrderType (Market, Limit, etc.) in serialized `Result` data.

Examples of the kinds of input data for the OrderType we can now support:
```
"Type": 4
"Type": "4"
"Type": "MarketOnOpen"
"Type": "marketOnOpen"
```

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure report generator consistency
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test and local report generation
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
