### PR TITLE
SerializedOrderEvent will not serialize Null order fee

### DIFF
--- a/Common/Orders/OrderEvent.cs
+++ b/Common/Orders/OrderEvent.cs
@@ -271,6 +271,13 @@ namespace QuantConnect.Orders
             var sid = SecurityIdentifier.Parse(serializedOrderEvent.Symbol);
             var symbol = new Symbol(sid, sid.Symbol);
 
+            var orderFee = OrderFee.Zero;
+            if (serializedOrderEvent.OrderFeeAmount.HasValue)
+            {
+                orderFee = new OrderFee(new CashAmount(serializedOrderEvent.OrderFeeAmount.Value,
+                    serializedOrderEvent.OrderFeeCurrency));
+            }
+
             var orderEvent = new OrderEvent(serializedOrderEvent.OrderId,
                 symbol,
                 DateTime.SpecifyKind(Time.UnixTimeStampToDateTime(serializedOrderEvent.Time), DateTimeKind.Utc),
@@ -278,7 +285,7 @@ namespace QuantConnect.Orders
                 serializedOrderEvent.Direction,
                 serializedOrderEvent.FillPrice,
                 serializedOrderEvent.FillQuantity,
-                new OrderFee(new CashAmount(serializedOrderEvent.OrderFeeAmount, serializedOrderEvent.OrderFeeCurrency)),
+                orderFee,
                 serializedOrderEvent.Message)
             {
                 IsAssignment = serializedOrderEvent.IsAssignment,

--- a/Common/Orders/Serialization/SerializedOrderEvent.cs
+++ b/Common/Orders/Serialization/SerializedOrderEvent.cs
@@ -69,13 +69,13 @@ namespace QuantConnect.Orders.Serialization
         /// <summary>
         /// The fee amount associated with the order
         /// </summary>
-        [JsonProperty("order-fee-amount")]
-        public decimal OrderFeeAmount { get; set; }
+        [JsonProperty("order-fee-amount", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public decimal? OrderFeeAmount { get; set; }
 
         /// <summary>
         /// The fee currency associated with the order
         /// </summary>
-        [JsonProperty("order-fee-currency")]
+        [JsonProperty("order-fee-currency", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string OrderFeeCurrency { get; set; }
 
         /// <summary>
@@ -151,8 +151,11 @@ namespace QuantConnect.Orders.Serialization
             Symbol = orderEvent.Symbol.ID.ToString();
             Time = QuantConnect.Time.DateTimeToUnixTimeStamp(orderEvent.UtcTime);
             Status = orderEvent.Status;
-            OrderFeeAmount = orderEvent.OrderFee.Value.Amount;
-            OrderFeeCurrency = orderEvent.OrderFee.Value.Currency;
+            if (orderEvent.OrderFee.Value.Currency != Currencies.NullCurrency)
+            {
+                OrderFeeAmount = orderEvent.OrderFee.Value.Amount;
+                OrderFeeCurrency = orderEvent.OrderFee.Value.Currency;
+            }
             FillPrice = orderEvent.FillPrice;
             FillPriceCurrency = orderEvent.FillPriceCurrency;
             FillQuantity = orderEvent.FillQuantity;

--- a/Tests/Common/Orders/OrderEventTests.cs
+++ b/Tests/Common/Orders/OrderEventTests.cs
@@ -56,7 +56,6 @@ namespace QuantConnect.Tests.Common.Orders
             var order = new MarketOrder(Symbols.BTCUSD, 0.123m, DateTime.UtcNow);
             var orderEvent = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero)
             {
-                OrderFee = new OrderFee(new CashAmount(99, "EUR")),
                 Message = "Pepe",
                 Status = OrderStatus.PartiallyFilled,
                 StopPrice = 1,
@@ -70,6 +69,12 @@ namespace QuantConnect.Tests.Common.Orders
 
             var converter = new OrderEventJsonConverter("id");
             var serializeObject = JsonConvert.SerializeObject(orderEvent, converter);
+
+            // OrderFee zero uses null currency and should be ignored when serializing
+            Assert.IsFalse(serializeObject.Contains(Currencies.NullCurrency));
+            Assert.IsFalse(serializeObject.Contains("order-fee-amount"));
+            Assert.IsFalse(serializeObject.Contains("order-fee-currency"));
+
             var deserializeObject = JsonConvert.DeserializeObject<OrderEvent>(serializeObject, converter);
 
             Assert.AreEqual(orderEvent.Symbol, deserializeObject.Symbol);
@@ -88,6 +93,23 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(orderEvent.Message, deserializeObject.Message);
             Assert.AreEqual(orderEvent.Quantity, deserializeObject.Quantity);
             Assert.AreEqual(orderEvent.Status, deserializeObject.Status);
+            Assert.AreEqual(orderEvent.OrderFee.Value.Amount, deserializeObject.OrderFee.Value.Amount);
+            Assert.AreEqual(orderEvent.OrderFee.Value.Currency, deserializeObject.OrderFee.Value.Currency);
+        }
+
+        [Test]
+        public void NonNullOrderFee()
+        {
+            var order = new MarketOrder(Symbols.BTCUSD, 0.123m, DateTime.UtcNow);
+            var orderEvent = new OrderEvent(order, DateTime.UtcNow, new OrderFee(new CashAmount(88, Currencies.USD)));
+
+            var converter = new OrderEventJsonConverter("id");
+            var serializeObject = JsonConvert.SerializeObject(orderEvent, converter);
+            var deserializeObject = JsonConvert.DeserializeObject<OrderEvent>(serializeObject, converter);
+
+            Assert.IsTrue(serializeObject.Contains("order-fee-amount"));
+            Assert.IsTrue(serializeObject.Contains("order-fee-currency"));
+
             Assert.AreEqual(orderEvent.OrderFee.Value.Amount, deserializeObject.OrderFee.Value.Amount);
             Assert.AreEqual(orderEvent.OrderFee.Value.Currency, deserializeObject.OrderFee.Value.Currency);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- SerializedOrderEvent will ignore order fee with null currency. Adding
  unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to https://github.com/QuantConnect/Lean/issues/4135
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Serialization will ignore null order fee case
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
