### PR TITLE
GDAX brokerage updates

### DIFF
--- a/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
@@ -30,6 +30,7 @@ namespace QuantConnect.Tests.Brokerages.GDAX
         {
             using (var brokerage = GetBrokerage())
             {
+                brokerage.Connect();
                 Assert.IsTrue(brokerage.IsConnected);
 
                 for (var i = 0; i < 50; i++)
@@ -44,12 +45,29 @@ namespace QuantConnect.Tests.Brokerages.GDAX
         {
             using (var brokerage = GetBrokerage())
             {
+                brokerage.Connect();
                 Assert.IsTrue(brokerage.IsConnected);
 
                 for (var i = 0; i < 50; i++)
                 {
                     Assert.DoesNotThrow(() => brokerage.GetOpenOrders());
                 }
+            }
+        }
+
+        [Test]
+        public void ClientConnects()
+        {
+            using (var brokerage = GetBrokerage())
+            {
+                var hasError = false;
+
+                brokerage.Message += (s, e) => { hasError = true; };
+
+                brokerage.Connect();
+                Assert.IsTrue(brokerage.IsConnected);
+
+                Assert.IsFalse(hasError);
             }
         }
 
@@ -66,10 +84,7 @@ namespace QuantConnect.Tests.Brokerages.GDAX
             var userToken = Config.Get("api-access-token");
             var priceProvider = new ApiPriceProvider(userId, userToken);
 
-            var brokerage = new GDAXBrokerage(wssUrl, webSocketClient, restClient, apiKey, apiSecret, passPhrase, algorithm, priceProvider);
-            brokerage.Connect();
-
-            return brokerage;
+            return new GDAXBrokerage(wssUrl, webSocketClient, restClient, apiKey, apiSecret, passPhrase, algorithm, priceProvider);
         }
     }
 }


### PR DESCRIPTION

#### Description
- Fixed websocket authentication failure for `"user"` channel
- Removed `"matches"` channel, now using authenticated `"user"` channel for order fills
- Send `BrokerageMessageEvent` as `Error` instead of `Warning` for subscription and authentication failures

#### Related Issue
Closes #3709 
Closes #3527 

#### Motivation and Context
- Occasionally missing order fills
- Error in algorithm logs: `Failed to subscribe - user channel requires authentication`

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Local and cloud testing with real trades with both total and partial fills.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`