### PR TITLE
WIP/To Discuss: Improve Implicit Conversion Failure Message

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -197,6 +197,7 @@
     <Compile Include="PortfolioRebalanceOnSecurityChangesRegressionAlgorithm.cs" />
     <Compile Include="ResolutionSwitchingAlgorithm.cs" />
     <Compile Include="SetHoldingsFutureRegressionAlgorithm.cs" />
+    <Compile Include="StringToSymbolImplicitConversionRegressionAlgorithm.cs" />
     <Compile Include="TimeRulesDefaultTimeZoneRegressionAlgorithm.cs" />
     <Compile Include="SetHoldingsMultipleTargetsRegressionAlgorithm.cs" />
     <Compile Include="SetHoldingsMarketOnOpenRegressionAlgorithm.cs" />

--- a/Algorithm.CSharp/StringToSymbolImplicitConversionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StringToSymbolImplicitConversionRegressionAlgorithm.cs
@@ -1,0 +1,116 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Related to GH issue 4275, reproduces a failed string to symbol implicit conversion asserting the exception
+    /// thrown contains the used ticker
+    /// </summary>
+    public class StringToSymbolImplicitConversionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 08);
+
+            AddEquity("SPY", Resolution.Minute);
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            try
+            {
+                MarketOrder("PEPE", 1);
+            }
+            catch (Exception exception)
+            {
+                if (exception.Message.Contains("This asset symbol (PEPE 0) was not found in your security list") && !Portfolio.Invested)
+                {
+                    SetHoldings("SPY", 1);
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$3.26"},
+            {"Fitness Score", "0.995"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0.995"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "491919591"}
+        };
+    }
+}

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -99,6 +99,7 @@
     <Content Include="RegisterIndicatorRegressionAlgorithm.py" />
     <Content Include="SectorWeightingFrameworkAlgorithm.py" />
     <Content Include="SetHoldingsMultipleTargetsRegressionAlgorithm.py" />
+    <Content Include="StringToSymbolImplicitConversionRegressionAlgorithm.py" />
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />
     <Content Include="SECReportDataAlgorithm.py" />

--- a/Algorithm.Python/StringToSymbolImplicitConversionRegressionAlgorithm.py
+++ b/Algorithm.Python/StringToSymbolImplicitConversionRegressionAlgorithm.py
@@ -1,0 +1,45 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+
+### <summary>
+### Related to GH issue 4275, reproduces a failed string to symbol implicit conversion asserting the exception
+### thrown contains the used ticker
+### </summary>
+class StringToSymbolImplicitConversionRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+        self.SetStartDate(2013,10, 7)
+        self.SetEndDate(2013,10, 8)
+
+        self.AddEquity("SPY", Resolution.Minute)
+
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+
+        Arguments:
+            data: Slice object keyed by symbol containing the stock data
+        '''
+        try:
+            self.MarketOrder("PEPE", 1)
+        except Exception as exception:
+            if "This asset symbol (PEPE 0) was not found in your security list" in str(exception) and not self.Portfolio.Invested:
+                self.SetHoldings("SPY", 1)

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -515,7 +515,7 @@ namespace QuantConnect
                 return new Symbol(sid, sid.Symbol);
             }
 
-            return Empty;
+            return new Symbol(new SecurityIdentifier(ticker, 0), ticker);
         }
 
         #endregion

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -422,8 +422,14 @@ namespace QuantConnect.Tests.Common
             string stringEurusd = eurusd;
             Assert.AreEqual(eurusd.ID.ToString(), stringEurusd);
 
-            Symbol notASymbol = "this will not resolve to a proper Symbol instance";
-            Assert.AreEqual(Symbol.Empty, notASymbol);
+            Assert.Throws<ArgumentException>(() =>
+            {
+                Symbol symbol = "this will not resolve to a proper Symbol instance";
+            });
+
+            Symbol notASymbol = "NotASymbol";
+            Assert.AreNotEqual(Symbol.Empty, notASymbol);
+            Assert.IsTrue(notASymbol.ToString().Contains("NotASymbol"));
 #pragma warning restore 0618
         }
 


### PR DESCRIPTION
Improve string to Symbol implicit conversion exceptions message when using a ticker instead of a symbol. Credit to @Martin-Molinero 

#### Description
Exceptions were not helpful if the symbol was not in the symbol cache. Using the ticker in the failure response allows sharing better messages from the throw.

Discuss possible risks in changing the `Empty` when Symbol not found. Review locations that rely on Empty response. 

#### Motivation and Context
Poor feedback on errors  

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests. Asserting Implicit conversion users.

#### Types of changes 
- [x] Bug fix (non-breaking change which fixes an issue)   
- [x] Breaking change (fix or feature that would cause existing functionality to change) 

#### Checklist: 
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
