### PR TITLE
Fix IB Historical Data Request Error "HMDS query returned no data"

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1194,6 +1194,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 errorMsg += ". Origin: " + requestMessage;
             }
 
+            // historical data request with no data returned
+            if (errorCode == 162 && errorMsg.Contains("HMDS query returned no data"))
+            {
+                return;
+            }
+
             Log.Trace($"InteractiveBrokersBrokerage.HandleError(): RequestId: {requestId} ErrorCode: {errorCode} - {errorMsg}");
 
             // figure out the message type based on our code collections below


### PR DESCRIPTION

#### Description
- The IB error for no data returned by a historical data request has been filtered out.

#### Related Issue
Closes #4344 

#### Motivation and Context
- Error message displayed when in fact it is expected for some tyes of history requests.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Verified that the example code in #4344 no longer shows the error after the fix.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`