### PR TITLE
Add Dispose and IsConnected to IDataQueueHandler

### DIFF
--- a/Common/Interfaces/IDataQueueHandler.cs
+++ b/Common/Interfaces/IDataQueueHandler.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,6 +14,7 @@
  *
 */
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using QuantConnect.Data;
@@ -25,7 +26,7 @@ namespace QuantConnect.Interfaces
     /// Task requestor interface with cloud system
     /// </summary>
     [InheritedExport(typeof(IDataQueueHandler))]
-    public interface IDataQueueHandler
+    public interface IDataQueueHandler : IDisposable
     {
         /// <summary>
         /// Get the next ticks from the live trading data queue
@@ -46,5 +47,11 @@ namespace QuantConnect.Interfaces
         /// <param name="job">Job we're processing.</param>
         /// <param name="symbols">The symbols to be removed keyed by SecurityType</param>
         void Unsubscribe(LiveNodePacket job, IEnumerable<Symbol> symbols);
+
+        /// <summary>
+        /// Returns whether the data provider is connected
+        /// </summary>
+        /// <returns>True if the data provider is connected</returns>
+        bool IsConnected { get; }
     }
 }

--- a/Engine/DataFeeds/Queues/DataQueue.cs
+++ b/Engine/DataFeeds/Queues/DataQueue.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ using QuantConnect.Packets;
 namespace QuantConnect.Lean.Engine.DataFeeds.Queues
 {
     /// <summary>
-    /// Live Data Queue is the cut out implementation of how to bind a custom live data source 
+    /// Live Data Queue is the cut out implementation of how to bind a custom live data source
     /// </summary>
     public class LiveDataQueue : IDataQueueHandler
     {
@@ -49,6 +49,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Queues
         public virtual void Unsubscribe(LiveNodePacket job, IEnumerable<Symbol> symbols)
         {
             throw new NotImplementedException("QuantConnect.Queues.LiveDataQueue has not implemented live data.");
+        }
+
+        /// <summary>
+        /// Returns whether the data provider is connected
+        /// </summary>
+        /// <returns>true if the data provider is connected</returns>
+        public bool IsConnected => false;
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
         }
     }
 }

--- a/Engine/DataFeeds/Queues/FakeDataQueue.cs
+++ b/Engine/DataFeeds/Queues/FakeDataQueue.cs
@@ -121,6 +121,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Queues
         }
 
         /// <summary>
+        /// Returns whether the data provider is connected
+        /// </summary>
+        /// <returns>true if the data provider is connected</returns>
+        public bool IsConnected => true;
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+        }
+
+        /// <summary>
         /// Pumps a bunch of ticks into the queue
         /// </summary>
         private void PopulateQueue()

--- a/Engine/DataFeeds/Queues/FakeDataQueue.cs
+++ b/Engine/DataFeeds/Queues/FakeDataQueue.cs
@@ -23,6 +23,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
+using QuantConnect.Util;
 using Timer = System.Timers.Timer;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Queues
@@ -131,6 +132,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Queues
         /// </summary>
         public void Dispose()
         {
+            _timer.Stop();
+            _timer.DisposeSafely();
         }
 
         /// <summary>

--- a/Tests/Engine/DataFeeds/FuncDataQueueHandler.cs
+++ b/Tests/Engine/DataFeeds/FuncDataQueueHandler.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,6 +83,19 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             {
                 lock (_lock) _subscriptions.Remove(symbol);
             }
+        }
+
+        /// <summary>
+        /// Returns whether the data provider is connected
+        /// </summary>
+        /// <returns>true if the data provider is connected</returns>
+        public bool IsConnected => true;
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
         }
     }
 }

--- a/ToolBox/CoinApi/CoinApiDataQueueHandler.cs
+++ b/ToolBox/CoinApi/CoinApiDataQueueHandler.cs
@@ -125,6 +125,12 @@ namespace QuantConnect.ToolBox.CoinApi
         }
 
         /// <summary>
+        /// Returns whether the data provider is connected
+        /// </summary>
+        /// <returns>true if the data provider is connected</returns>
+        public bool IsConnected => true;
+
+        /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -208,10 +208,7 @@ namespace QuantConnect.ToolBox.IQFeed
         /// <summary>
         /// Indicates the connection is live.
         /// </summary>
-        private bool IsConnected
-        {
-            get { return _isConnected; }
-        }
+        public bool IsConnected => _isConnected;
 
         /// <summary>
         /// Connect to the IQ Feed using supplied username and password information.
@@ -331,6 +328,13 @@ namespace QuantConnect.ToolBox.IQFeed
         public bool CanAdvanceTime(SecurityType securityType)
         {
             return _symbolUniverse.CanAdvanceTime(securityType);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
         }
     }
 


### PR DESCRIPTION

#### Description
- The `IDataQueueHandler` interface has been extended to include `Dispose` and `IsConnected` methods

#### Related Issue
Closes #4348 

#### Motivation and Context
- `IDataQueueHandler` implementations should be able to perform cleanup (e.g. closing connections) and also have a method to test for connectivity.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Deployed live algorithms in QC cloud

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`