### PR TITLE
FillModel.StopLimitFill should use prices.Current instead…

### DIFF
--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -260,10 +260,10 @@ namespace QuantConnect.Orders.Fills
 
                         // Fill the limit order, using closing price of bar:
                         // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
-                        if (asset.Price < order.LimitPrice)
+                        if (prices.Current < order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
-                            fill.FillPrice = Math.Min(prices.High, order.LimitPrice);;
+                            fill.FillPrice = Math.Min(prices.High, order.LimitPrice);
                             // assume the order completely filled
                             fill.FillQuantity = order.Quantity;
                         }
@@ -278,7 +278,7 @@ namespace QuantConnect.Orders.Fills
 
                         // Fill the limit order, using minimum price of the bar
                         // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
-                        if (asset.Price > order.LimitPrice)
+                        if (prices.Current > order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
                             fill.FillPrice = Math.Max(prices.Low, order.LimitPrice);

--- a/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
+++ b/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
@@ -219,7 +219,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var model = new TestFillModelInheritBaseClass();
             var result = model.Fill(
                 new FillModelParameters(_security,
-                    new StopLimitOrder(_security.Symbol, 1, 12345, 12346, orderDateTime),
+                    new StopLimitOrder(_security.Symbol, 1, 12344, 12346, orderDateTime),
                     new MockSubscriptionDataConfigProvider(_config),
                     Time.OneHour));
 

--- a/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
+++ b/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
@@ -219,14 +219,14 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var model = new TestFillModelInheritBaseClass();
             var result = model.Fill(
                 new FillModelParameters(_security,
-                    new StopLimitOrder(_security.Symbol, 1, 1, 1, orderDateTime),
+                    new StopLimitOrder(_security.Symbol, 1, 12345, 12346, orderDateTime),
                     new MockSubscriptionDataConfigProvider(_config),
                     Time.OneHour));
 
             Assert.True(model.StopLimitFillWasCalled);
             Assert.IsNotNull(result);
             Assert.True(model.GetPricesWasCalled);
-            Assert.AreEqual(1, result.OrderEvent.FillPrice);
+            Assert.AreEqual(12345, result.OrderEvent.FillPrice);
         }
 
         [Test]


### PR DESCRIPTION
… of asset.Price to see if fill has occured


<!--- Provide a general summary of your changes in the Title above -->

#### Description
Fixes #4363 

#### Related Issue
See #4363

#### Motivation and Context
Back test prices for stop limit orders are incorrect.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Unit tests pass

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
