### PR TITLE
Remove incorrect IB mapping for Sugar Future N.11

### DIFF
--- a/Brokerages/InteractiveBrokers/IB-symbol-map.json
+++ b/Brokerages/InteractiveBrokers/IB-symbol-map.json
@@ -14,6 +14,5 @@
   "MXP": "6M",
   "RUR": "6R",
   "ZAR": "6Z",
-  "BRR": "BTC",
-  "SB": "YO"
+  "BRR": "BTC"
 }


### PR DESCRIPTION
- IB supports the `SB` symbol on `ICE/NYBOT`
  https://www.theice.com/products/23/Sugar-No-11-Futures

- IB does not support the `YO` symbol on `CME/NYMEX`
  https://www.cmegroup.com/trading/agricultural/softs/sugar-no11_contract_specifications.html