### PR TITLE
Performance improvements for Options

### DIFF
--- a/Common/Data/UniverseSelection/BaseDataCollection.cs
+++ b/Common/Data/UniverseSelection/BaseDataCollection.cs
@@ -68,11 +68,23 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="symbol">A common identifier for all data in this packet</param>
         /// <param name="data">The data to add to this collection</param>
         public BaseDataCollection(DateTime time, DateTime endTime, Symbol symbol, IEnumerable<BaseData> data = null)
+            : this(time, endTime, symbol, data != null ? data.ToList() : new List<BaseData>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseDataCollection"/> class
+        /// </summary>
+        /// <param name="time">The start time of this data</param>
+        /// <param name="endTime">The end time of this data</param>
+        /// <param name="symbol">A common identifier for all data in this packet</param>
+        /// <param name="data">The data to add to this collection</param>
+        public BaseDataCollection(DateTime time, DateTime endTime, Symbol symbol, List<BaseData> data)
         {
             Symbol = symbol;
             Time = time;
             _endTime = endTime;
-            Data = data != null ? data.ToList() : new List<BaseData>();
+            Data = data ?? new List<BaseData>();
         }
 
         /// <summary>

--- a/Common/Data/UniverseSelection/FuturesChainUniverseDataCollection.cs
+++ b/Common/Data/UniverseSelection/FuturesChainUniverseDataCollection.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="time">The time of this data</param>
         /// <param name="symbol">A common identifier for all data in this packet</param>
         /// <param name="data">The data to add to this collection</param>
-        public FuturesChainUniverseDataCollection(DateTime time, Symbol symbol, IEnumerable<BaseData> data = null)
+        public FuturesChainUniverseDataCollection(DateTime time, Symbol symbol, List<BaseData> data = null)
             : this(time, time, symbol, data)
         {
         }
@@ -56,7 +56,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="endTime">The end time of this data</param>
         /// <param name="symbol">A common identifier for all data in this packet</param>
         /// <param name="data">The data to add to this collection</param>
-        public FuturesChainUniverseDataCollection(DateTime time, DateTime endTime, Symbol symbol, IEnumerable<BaseData> data = null)
+        public FuturesChainUniverseDataCollection(DateTime time, DateTime endTime, Symbol symbol, List<BaseData> data = null)
             : base(time, endTime, symbol, data)
         {
         }

--- a/Common/Data/UniverseSelection/OptionChainUniverseDataCollection.cs
+++ b/Common/Data/UniverseSelection/OptionChainUniverseDataCollection.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="symbol">A common identifier for all data in this packet</param>
         /// <param name="data">The data to add to this collection</param>
         /// <param name="underlying">The option chain's underlying price data</param>
-        public OptionChainUniverseDataCollection(DateTime time, Symbol symbol, IEnumerable<BaseData> data = null, BaseData underlying = null)
+        public OptionChainUniverseDataCollection(DateTime time, Symbol symbol, List<BaseData> data = null, BaseData underlying = null)
             : this(time, time, symbol, data, underlying)
         {
         }
@@ -63,7 +63,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="symbol">A common identifier for all data in this packet</param>
         /// <param name="data">The data to add to this collection</param>
         /// <param name="underlying">The option chain's underlying price data</param>
-        public OptionChainUniverseDataCollection(DateTime time, DateTime endTime, Symbol symbol, IEnumerable<BaseData> data = null, BaseData underlying = null)
+        public OptionChainUniverseDataCollection(DateTime time, DateTime endTime, Symbol symbol, List<BaseData> data = null, BaseData underlying = null)
             : base(time, endTime, symbol, data)
         {
             Underlying = underlying;

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1356,6 +1356,50 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Asserts the specified <paramref name="securityType"/> value is valid
+        /// </summary>
+        /// <remarks>This method provides faster performance than <see cref="Enum.IsDefined"/> which uses reflection</remarks>
+        /// <param name="securityType">The SecurityType value</param>
+        /// <returns>True if valid security type value</returns>
+        public static bool IsValid(this SecurityType securityType)
+        {
+            switch (securityType)
+            {
+                case SecurityType.Base:
+                case SecurityType.Equity:
+                case SecurityType.Option:
+                case SecurityType.Commodity:
+                case SecurityType.Forex:
+                case SecurityType.Future:
+                case SecurityType.Cfd:
+                case SecurityType.Crypto:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Converts the specified <paramref name="optionRight"/> value to its corresponding string representation
+        /// </summary>
+        /// <remarks>This method provides faster performance than enum <see cref="ToString"/></remarks>
+        /// <param name="optionRight">The optionRight value</param>
+        /// <returns>A string representation of the specified OptionRight value</returns>
+        public static string ToStringPerformance(this OptionRight optionRight)
+        {
+            switch (optionRight)
+            {
+                case OptionRight.Call:
+                    return "Call";
+                case OptionRight.Put:
+                    return "Put";
+                default:
+                    // just in case
+                    return optionRight.ToString();
+            }
+        }
+
+        /// <summary>
         /// Converts the specified <paramref name="securityType"/> value to its corresponding lower-case string representation
         /// </summary>
         /// <remarks>This method provides faster performance than <see cref="ToLower"/></remarks>

--- a/Common/Securities/Future/FutureFilterUniverse.cs
+++ b/Common/Securities/Future/FutureFilterUniverse.cs
@@ -69,8 +69,8 @@ namespace QuantConnect.Securities
         /// <returns></returns>
         public FutureFilterUniverse FrontMonth()
         {
-            if (_allSymbols.Count() == 0) return this;
             var ordered = this.OrderBy(x => x.ID.Date).ToList();
+            if (ordered.Count == 0) return this;
             var frontMonth = ordered.TakeWhile(x => ordered[0].ID.Date == x.ID.Date);
 
             _allSymbols = frontMonth.ToList();
@@ -83,8 +83,8 @@ namespace QuantConnect.Securities
         /// <returns></returns>
         public FutureFilterUniverse BackMonths()
         {
-            if (_allSymbols.Count() == 0) return this;
             var ordered = this.OrderBy(x => x.ID.Date).ToList();
+            if (ordered.Count == 0) return this;
             var backMonths = ordered.SkipWhile(x => ordered[0].ID.Date == x.ID.Date);
 
             _allSymbols = backMonths.ToList();

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -394,7 +394,7 @@ namespace QuantConnect.Securities
                 {
                     decimal totalHoldingsValueWithoutForexCryptoFutureCfd = 0;
                     decimal totalFuturesAndCfdHoldingsValue = 0;
-                    foreach (var kvp in Securities)
+                    foreach (var kvp in Securities.Where((pair, i) => pair.Value.Holdings.Quantity != 0))
                     {
                         var position = kvp.Value;
                         var securityType = position.Type;
@@ -477,13 +477,9 @@ namespace QuantConnect.Securities
             get
             {
                 decimal sum = 0;
-                foreach (var kvp in Securities)
+                foreach (var kvp in Securities.Where((pair, i) => pair.Value.Holdings.Quantity != 0))
                 {
                     var security = kvp.Value;
-                    if (security.Holdings.Quantity == 0)
-                    {
-                        continue;
-                    }
                     var context = new ReservedBuyingPowerForPositionParameters(security);
                     var reservedBuyingPower = security.BuyingPowerModel.GetReservedBuyingPowerForPosition(context);
                     sum += reservedBuyingPower.AbsoluteUsedBuyingPower;

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -161,7 +161,7 @@ namespace QuantConnect
 
             if (expiry == SecurityIdentifier.DefaultDate)
             {
-                alias = alias ?? "?" + underlyingSymbol.Value.LazyToUpper();
+                alias = alias ?? $"?{underlyingSymbol.Value.LazyToUpper()}";
             }
             else
             {

--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -187,7 +187,7 @@ namespace QuantConnect
         public static string GenerateOptionTickerOSI(string underlying, OptionRight right, decimal strikePrice, DateTime expiration)
         {
             if (underlying.Length > 5) underlying += " ";
-            return Invariant($"{underlying,-6}{expiration.ToStringInvariant(DateFormat.SixCharacter)}{right.ToString()[0]}{(strikePrice * 1000m):00000000}");
+            return Invariant($"{underlying,-6}{expiration.ToStringInvariant(DateFormat.SixCharacter)}{right.ToStringPerformance()[0]}{(strikePrice * 1000m):00000000}");
         }
 
         /// <summary>

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -176,7 +176,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                     }
                                     else
                                     {
-                                        collection = new BaseDataCollection(frontierUtc, subscription.Configuration.Symbol, packetData);
+                                        collection = new BaseDataCollection(frontierUtc, frontierUtc, subscription.Configuration.Symbol, packetData);
                                     }
 
                                     if (universeData == null)

--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -233,8 +233,16 @@ namespace QuantConnect.Jupyter
                         allSymbols.AddRange(OptionChainProvider.GetOptionContractList(symbol.Underlying, date));
                     }
                 }
+
+                var optionFilterUniverse = new OptionFilterUniverse();
+                var distinctSymbols = allSymbols.Distinct();
                 symbols = base.History(symbol.Underlying, start, end.Value, resolution)
-                    .SelectMany(x => option.ContractFilter.Filter(new OptionFilterUniverse(allSymbols.Distinct(), x)))
+                    .SelectMany(x =>
+                    {
+                        // the option chain symbols wont change so we can set 'exchangeDateChange' to false always
+                        optionFilterUniverse.Refresh(distinctSymbols, x, exchangeDateChange:false);
+                        return option.ContractFilter.Filter(optionFilterUniverse);
+                    })
                     .Distinct().Concat(new[] { symbol.Underlying });
             }
             else

--- a/Tests/Common/Securities/SecurityIdentifierTests.cs
+++ b/Tests/Common/Securities/SecurityIdentifierTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Algorithm.CSharp;
@@ -158,6 +159,24 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var sid = new SecurityIdentifier("some-symbol", 0357960000000009901);
             Assert.AreEqual("99", sid.Market);
+        }
+
+        [Test]
+        public void InvalidSecurityType()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var sid = new SecurityIdentifier("some-symbol", 0357960000000009915);
+            }, $"The provided properties do not match with a valid {nameof(SecurityType)}");
+        }
+
+        [TestCaseSource(nameof(ValidSecurityTypes))]
+        public void ValidSecurityType(ulong properties)
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var sid = new SecurityIdentifier("some-symbol", properties);
+            });
         }
 
         [Test]
@@ -374,5 +393,8 @@ namespace QuantConnect.Tests.Common.Securities
         {
             public SecurityIdentifier sid;
         }
+        private static List<TestCaseData> ValidSecurityTypes =>
+            (from object value in Enum.GetValues(typeof(SecurityType)) select new TestCaseData((ulong)(0357960000000009900 + (int)value))).ToList();
+
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Commit 1
- Replace Enum to string operations on Options enums, since it's
  expensive
- Replace Enum IsDefined check since it uses reflection
- Improve OptionFilterUniverse linq operations
- Improve performance of SecurityIdentifier properties to avoid having
  to extract them from properties always
- Avoid calling ToList for already list data collections (it creates a copy)
- Avoid iterating over securities for which we have no holdings when
  calculating TPV or MarginUsed

Commit 2
- `OptionFilterUniverse` has a unique strike cache list that wasn't being used because `OptionChainUniverse` always created a new instance, now it will use the same instance

Performance algorithm used at https://github.com/QuantConnect/Lean/issues/4347
MASTER
1651.05 seconds at 1578k data points per second.
PR commit 1
1389.28 seconds at 1875k data points per second.
PR commit 2
1155.66 seconds at 2255k data points per second.

**AlgorithmManager improvements:**
MASTER
![image](https://user-images.githubusercontent.com/18473240/81126745-aa71f600-8f12-11ea-9913-13d3511c54ac.png)
PR **commit 1**
![image](https://user-images.githubusercontent.com/18473240/81126728-9a5a1680-8f12-11ea-9b74-a31af7f0fe6d.png)
PR **commit 2**
![image](https://user-images.githubusercontent.com/18473240/81198541-f87d0d00-8f97-11ea-8f2a-e29a5c97a870.png)

**Option creation improvements:** (data feed stack, parallel)
MASTER
![image](https://user-images.githubusercontent.com/18473240/81125304-21f15680-8f0e-11ea-9634-0a8c9263e578.png)
PR
![image](https://user-images.githubusercontent.com/18473240/81125328-359cbd00-8f0e-11ea-9b10-94bd9e0e78ce.png)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3283, Related to https://github.com/QuantConnect/Lean/issues/4347
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve option algorithms performance
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Performance, unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
