### PR TITLE
Adds pandas Methods (Part V)

### DIFF
--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -365,7 +365,63 @@ class Remapper(wrapt.ObjectProxy):
         result = self.__wrapped__.duplicated(subset=subset, keep=keep)
         return Remapper(result)
 
+    def eq(self, other, axis='columns', level=None):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.eq.html'''
+        result = self.__wrapped__.eq(other, axis=axis, level=level)
+        return Remapper(result)
+
+    def eval(self, expr, inplace=False, **kwargs):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.eval.html'''
+        result = self.__wrapped__.eval(expr, inplace=inplace, **kwargs)
+        return Remapper(result)
+
+    def explode(self, column):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.explode.html'''
+        result = self.__wrapped__.explode(column)
+        return Remapper(result)
+
+    def ffill(self, axis=None, inplace=False, limit=None, downcast=None):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.ffill.html'''
+        result = self.__wrapped__.ffill(axis=axis, inplace=inplace, limit=limit, downcast=downcast)
+        return Remapper(result)
+
+    def fillna(self, value=None, method=None, axis=None, inplace=False, limit=None, downcast=None, **kwargs):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.fillna.html'''
+        result = self.__wrapped__.fillna(value=value, method=method, axis=axis, inplace=inplace, limit=limit, downcast=downcast, **kwargs)
+        return Remapper(result)
+
+    def filter(self, items=None, like=None, regex=None, axis=None):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.fillna.html'''
+        result = self.__wrapped__.filter(items=items, like=like, regex=regex, axis=axis)
+        return self._wrap_if_pandas_object(result)
+
+    def first(self, offset):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.first.html'''
+        result = self.__wrapped__.first(offset)
+        return self._wrap_if_pandas_object(result)
+
+    def first_valid_index(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.first_valid_index.html'''
+        result = self.__wrapped__.first_valid_index()
+        return self._self_mapper(result)
+
+    def floordiv(self, other, axis='columns', level=None, fill_value=None):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.floordiv.html'''
+        result = self.__wrapped__.floordiv(other, axis=axis, level=level, fill_value=fill_value)
+        return Remapper(result)
+
+    @property
+    def ftypes(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.ftypes.html'''
+        return Remapper(self.__wrapped__.ftypes)
+
+    def ge(self, other, axis='columns', level=None):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.ge.html'''
+        result = self.__wrapped__.ge(other, axis=axis, level=level)
+        return Remapper(result)
+
     def get(self, key, default=None):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.get.html'''
         key = self._self_mapper(key)
         return self.__wrapped__.get(key=key, default=default)
 

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -320,6 +320,51 @@ class Remapper(wrapt.ObjectProxy):
         result = self.__wrapped__.cumsum(axis=axis, skipna=skipna, *args, **kwargs)
         return Remapper(result)
 
+    def diff(self, periods=1, axis=0):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.diff.html'''
+        result = self.__wrapped__.diff(periods=periods, axis=axis)
+        return Remapper(result)
+
+    def div(self, other, axis='columns', level=None, fill_value=None):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.div.html'''
+        result = self.__wrapped__.div(other, axis=axis, level=level, fill_value=fill_value)
+        return Remapper(result)
+
+    def divide(self, other, axis='columns', level=None, fill_value=None):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.divide.html'''
+        result = self.__wrapped__.divide(other, axis=axis, level=level, fill_value=fill_value)
+        return Remapper(result)
+
+    def drop(self, labels=None, axis=0, index=None, columns=None, level=None, inplace=False, errors='raise'):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.drop.html'''
+        result = self.__wrapped__.drop(labels=labels, axis=axis, index=index, columns=columns, level=level, inplace=inplace, errors=errors)
+        return Remapper(result)
+
+    def drop_duplicates(self, subset=None, keep='first', inplace=False):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.drop_duplicates.html'''
+        result = self.__wrapped__.drop_duplicates(subset=subset, keep=keep, inplace=inplace)
+        return Remapper(result)
+
+    def droplevel(self, level, axis=0):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.droplevel.html'''
+        result = self.__wrapped__.droplevel(level, axis=axis)
+        return Remapper(result)
+
+    def dropna(self, axis=0, how='any', thresh=None, subset=None, inplace=False):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.dropna.html'''
+        result = self.__wrapped__.dropna(axis=axis, how=how, thresh=thresh, subset=subset, inplace=inplace)
+        return Remapper(result)
+
+    @property
+    def dtypes(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.dtypes.html'''
+        return Remapper(self.__wrapped__.dtypes)
+
+    def duplicated(self, subset=None, keep='first'):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.duplicated.html'''
+        result = self.__wrapped__.duplicated(subset=subset, keep=keep)
+        return Remapper(result)
+
     def get(self, key, default=None):
         key = self._self_mapper(key)
         return self.__wrapped__.get(key=key, default=default)

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -391,7 +391,7 @@ class Remapper(wrapt.ObjectProxy):
         return Remapper(result)
 
     def filter(self, items=None, like=None, regex=None, axis=None):
-        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.fillna.html'''
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.filter.html'''
         result = self.__wrapped__.filter(items=items, like=like, regex=regex, axis=axis)
         return self._wrap_if_pandas_object(result)
 
@@ -399,11 +399,6 @@ class Remapper(wrapt.ObjectProxy):
         '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.first.html'''
         result = self.__wrapped__.first(offset)
         return self._wrap_if_pandas_object(result)
-
-    def first_valid_index(self):
-        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.first_valid_index.html'''
-        result = self.__wrapped__.first_valid_index()
-        return self._self_mapper(result)
 
     def floordiv(self, other, axis='columns', level=None, fill_value=None):
         '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.floordiv.html'''

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -619,6 +619,9 @@ def Test(dataFrame, symbol):
         [TestCase("divide", "'SPY'", true)]
         [TestCase("divide", "symbol")]
         [TestCase("divide", "str(symbol.ID)")]
+        [TestCase("floordiv", "'SPY'", true)]
+        [TestCase("floordiv", "symbol")]
+        [TestCase("floordiv", "str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_binary_operator(string method, string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
@@ -633,6 +636,32 @@ def Test(dataFrame, other, symbol):
     data = data.{method}(other)
     data = data.iloc[-1][{index}]
     if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [TestCase("eq", "'SPY'", true)]
+        [TestCase("eq", "symbol")]
+        [TestCase("eq", "str(symbol.ID)")]
+        [TestCase("ge", "'SPY'", true)]
+        [TestCase("ge", "symbol")]
+        [TestCase("ge", "str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_binary_operator_comparison(string method, string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, other, symbol):
+    data = dataFrame.lastprice.unstack(level=0)
+    other = other.lastprice.unstack(level=0)
+    data = data.{method}(other)
+    data = data.iloc[-1][{index}]
+    if data:
         raise Exception('Data is zero')").GetAttr("Test");
 
                 Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
@@ -1096,6 +1125,154 @@ def Test(dataFrame, symbol):
     data = data.loc[{index}]
     if data:
         raise Exception('Data has duplicates')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_eval(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.eval('tmp=lastprice * 1.1')['tmp'].unstack(level=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_explode(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.explode('lastprice').lastprice.unstack(level=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_ffill(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).ffill()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_fillna(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).fillna(value=999)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_filter(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.filter(items=['lastprice']).lastprice.unstack(level=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_first(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).first('2S')
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_ftypes(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).ftypes
+    data = data.loc[{index}]
+    if str(data) != 'float64:dense':
+        raise Exception('Data type is ' + str(data))").GetAttr("Test");
 
                 Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
             }
@@ -1890,12 +2067,12 @@ def Test(dataFrame, symbol):
             );
         }
 
-        private dynamic GetTestDataFrame(Symbol symbol)
+        private dynamic GetTestDataFrame(Symbol symbol, int count=1)
         {
             var converter = new PandasConverter();
             var rawBars = Enumerable
-                .Range(0, 1)
-                .Select(i => new Tick(symbol, $"1440{i:D2}00,167{i:D2}00,1{i:D2},T,T,0", new DateTime(2013, 10, 7)))
+                .Range(0, count)
+                .Select(i => new Tick(symbol, $"144{i:D2}000,167{i:D2}00,1{i:D2},T,T,0", new DateTime(2013, 10, 7)))
                 .ToArray();
             return converter.GetDataFrame(rawBars);
         }

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -205,29 +205,6 @@ def Test(dataFrame, symbol):
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
-        public void BackwardsCompatibilityDataFrame_add(string index, bool cache = false)
-        {
-            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
-
-            using (Py.GIL())
-            {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
-                    $@"
-def Test(dataFrame, other, symbol):
-    data = dataFrame.lastprice.unstack(level=0)
-    other = other.lastprice.unstack(level=0)
-    data = data.add(other)
-    data = data.iloc[-1][{index}]
-    if data is 0:
-        raise Exception('Data is zero')").GetAttr("Test");
-
-                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
-            }
-        }
-
-        [TestCase("'SPY'", true)]
-        [TestCase("symbol")]
-        [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_add_prefix(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
@@ -633,6 +610,35 @@ def Test(dataFrame, symbol):
             }
         }
 
+        [TestCase("add", "'SPY'", true)]
+        [TestCase("add", "symbol")]
+        [TestCase("add", "str(symbol.ID)")]
+        [TestCase("div", "'SPY'", true)]
+        [TestCase("div", "symbol")]
+        [TestCase("div", "str(symbol.ID)")]
+        [TestCase("divide", "'SPY'", true)]
+        [TestCase("divide", "symbol")]
+        [TestCase("divide", "str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_binary_operator(string method, string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, other, symbol):
+    data = dataFrame.lastprice.unstack(level=0)
+    other = other.lastprice.unstack(level=0)
+    data = data.{method}(other)
+    data = data.iloc[-1][{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
@@ -942,6 +948,154 @@ def Test(dataFrame, symbol):
     data = data[{index}]
     if data is 0:
         raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_diff(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).diff()
+    data = data[{index}]
+    if not data.isna().all():
+        raise Exception('Data should be NaN')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_drop(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.drop(columns=['exchange']).lastprice.unstack(level=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_drop_duplicates(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).drop_duplicates()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_droplevel(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.droplevel('time').lastprice
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_dropna(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).dropna()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_dtypes(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).dtypes
+    data = data.loc[{index}]
+    if data != np.float64:
+        raise Exception('Data type is ' + str(data))").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_duplicated(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=1).duplicated()
+    data = data.loc[{index}]
+    if data:
+        raise Exception('Data has duplicates')").GetAttr("Test");
 
                 Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
             }


### PR DESCRIPTION
#### Description
Methods: 'eq', 'eval', 'explode', 'ffill', 'fillna', 'filter', 'first', 'floordiv', 'ftypes', 'ge'

#### Related Issue
Ref.: #4284 

#### Motivation and Context
Improve index support for pandas.DataFrame for history request.

#### How Has This Been Tested?
New unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`