### PR TITLE
Adds pandas Methods (Part VI)

### DIFF
--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -420,7 +420,89 @@ class Remapper(wrapt.ObjectProxy):
         key = self._self_mapper(key)
         return self.__wrapped__.get(key=key, default=default)
 
+    def get_value(self, index, col, takeable=False):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.get_value.html'''
+        index = self._self_mapper(index)
+        col = self._self_mapper(col)
+        return self.__wrapped__.get_value(index, col, takeable=takeable)
+
+    def gt(self, other, axis='columns', level=None):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.gt.html'''
+        result = self.__wrapped__.gt(other, axis=axis, level=level)
+        return Remapper(result)
+
+    def head(self, n=5):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.head.html'''
+        result = self.__wrapped__.head(n=n)
+        return Remapper(result)
+
+    def idxmax(self, axis=0, skipna=True):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.idxmax.html'''
+        result = self.__wrapped__.idxmax(axis=axis, skipna=skipna)
+        return Remapper(result)
+
+    def idxmin(self, axis=0, skipna=True):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.idxmin.html'''
+        result = self.__wrapped__.idxmin(axis=axis, skipna=skipna)
+        return Remapper(result)
+
+    @property
+    def iloc(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.iloc.html'''
+        return Remapper(self.__wrapped__.iloc)
+
+    @property
+    def index(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.index.html'''
+        return Remapper(self.__wrapped__.index)
+
+    def infer_objects(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.infer_objects.html'''
+        result = self.__wrapped__.infer_objects()
+        return Remapper(result)
+
+    def interpolate(self, method='linear', axis=0, limit=None, inplace=False, limit_direction='forward', limit_area=None, downcast=None, **kwargs):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.interpolate.html'''
+        result = self.__wrapped__.interpolate(method=method, axis=axis, limit=limit, inplace=inplace, limit_direction=limit_direction, limit_area=limit_area, downcast=downcast, **kwargs)
+        return Remapper(result)
+
+    def isin(self, values):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.isin.html'''
+        result = self.__wrapped__.isin(values)
+        return Remapper(result)
+
+    def isna(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.isna.html'''
+        result = self.__wrapped__.isna()
+        return Remapper(result)
+
+    def isnull(self):
+        '''Alias of isna
+        https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.isnull.html'''
+        return self.isna()
+
+    def items(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.items.html'''
+        for index, value in self.__wrapped__.items():
+            yield self._wrap_if_pandas_object(index), self._wrap_if_pandas_object(value)
+
+    def iteritems(self):
+        '''Alias of items
+        https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.iteritems.html'''
+        return self.items()
+
+    def iterrows(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.iterrows.html'''
+        for index, value in self.__wrapped__.iterrows():
+            yield self._wrap_if_pandas_object(index), self._wrap_if_pandas_object(value)
+
+    @property
+    def ix(self):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.ix.html'''
+        return Remapper(self.__wrapped__.ix)
+
     def join(self, other, on=None, how='left', lsuffix='', rsuffix='', sort=False):
+        '''https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.DataFrame.join.html'''
         result = self.__wrapped__.join(other=other, on=on, how=how, lsuffix=lsuffix, rsuffix=rsuffix, sort=sort)
         return Remapper(result)
 
@@ -443,18 +525,6 @@ class Remapper(wrapt.ObjectProxy):
     @property
     def loc(self):
         return Remapper(self.__wrapped__.loc)
-
-    @property
-    def ix(self):
-        return Remapper(self.__wrapped__.ix)
-
-    @property
-    def iloc(self):
-        return Remapper(self.__wrapped__.iloc)
-
-    @property
-    def index(self):
-        return Remapper(self.__wrapped__.index)
 
     @property
     def levels(self):

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -648,6 +648,9 @@ def Test(dataFrame, other, symbol):
         [TestCase("ge", "'SPY'", true)]
         [TestCase("ge", "symbol")]
         [TestCase("ge", "str(symbol.ID)")]
+        [TestCase("gt", "'SPY'", true)]
+        [TestCase("gt", "symbol")]
+        [TestCase("gt", "str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_binary_operator_comparison(string method, string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
@@ -1319,6 +1322,93 @@ def Test(dataFrame, symbol):
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_get_value_index(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.get_value(({index},), 'lastprice')
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_get_value_column(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0)
+    idx = data.index[0]
+    data = data.get_value(idx, {index})
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_head(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).head()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("idxmax", "'SPY'", true)]
+        [TestCase("idxmax", "symbol")]
+        [TestCase("idxmax", "str(symbol.ID)")]
+        [TestCase("idxmin", "'SPY'", true)]
+        [TestCase("idxmin", "symbol")]
+        [TestCase("idxmin", "str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_idx_(string method, string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).{method}()
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('No index found for ' + {index})").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_iloc(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
@@ -1350,6 +1440,141 @@ def Test(dataFrame, symbol):
 def Test(dataFrame, symbol):
     if {index} not in dataFrame.index.levels[0]:
         raise ValueError('SPY was not found')").GetAttr("Test");
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_infer_objects(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).infer_objects().dtypes
+    data = data.loc[{index}]
+    if data != np.float64:
+        raise Exception('Data type is ' + str(data))").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_interpolate(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).interpolate()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_isin(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).isin([100])
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("isna", "'SPY'", true)]
+        [TestCase("isna", "symbol")]
+        [TestCase("isna", "str(symbol.ID)")]
+        [TestCase("isnull", "'SPY'", true)]
+        [TestCase("isnull", "symbol")]
+        [TestCase("isnull", "str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_isna_isnull(string method, string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).{method}()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("items", "'SPY'", true)]
+        [TestCase("items", "symbol")]
+        [TestCase("items", "str(symbol.ID)")]
+        [TestCase("iteritems", "'SPY'", true)]
+        [TestCase("iteritems", "symbol")]
+        [TestCase("iteritems", "str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_items(string method, string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    for index, data in dataFrame.{method}():
+        pass
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_iterrows(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    for index, data in dataFrame.lastprice.unstack(level=0).iterrows():
+        pass
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
                 Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
             }
         }

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -1722,6 +1722,27 @@ def Test(dataFrame, dataFrame2, symbol):
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_T(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.T.iloc[0]
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_unstack(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
@@ -1862,6 +1883,27 @@ def Test(dataFrame, symbol):
                 // result should not contain "Remapper" string because the test
                 // returns the string representation of a Series object
                 Assert.False(result.Contains("Remapper"));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_dropna(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.T.iloc[0].dropna()
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
             }
         }
 


### PR DESCRIPTION
#### Description
Methods: 'get_value', 'gt', 'head', 'idxmax', 'idxmin', 'infer_objects', 'interpolate', 'isin', 'isna', 'isnull', 'items', 'iteritems', 'iterrows', 'T'

#### Related Issue
Ref.: #4284 

#### Motivation and Context
Improve index support for pandas.DataFrame for history request.

#### How Has This Been Tested?
New unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`