### PR TITLE
Adds talib indicators example algorithm

### DIFF
--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -104,6 +104,7 @@
     <Content Include="SetHoldingsMultipleTargetsRegressionAlgorithm.py" />
     <Content Include="SliceGetByTypeRegressionAlgorithm.py" />
     <Content Include="StringToSymbolImplicitConversionRegressionAlgorithm.py" />
+    <Content Include="TalibIndicatorsAlgorithm.py" />
     <Content Include="TradingEconomicsCalendarIndicatorAlgorithm.py" />
     <Content Include="OnEndOfDayRegressionAlgorithm.py" />
     <Content Include="SECReportDataAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -155,6 +155,7 @@
     <Compile Include="SmaCrossUniverseSelectionAlgorithm.py" />
     <Compile Include="SmartInsiderDataAlgorithm.py" />
     <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />
+    <Compile Include="TalibIndicatorsAlgorithm.py" />
     <Compile Include="TensorFlowNeuralNetworkAlgorithm.py" />
     <Compile Include="TiingoPriceAlgorithm.py" />
     <Compile Include="TimeInForceAlgorithm.py" />

--- a/Algorithm.Python/TalibIndicatorsAlgorithm.py
+++ b/Algorithm.Python/TalibIndicatorsAlgorithm.py
@@ -1,0 +1,76 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import QCAlgorithm
+import pandas as pd
+import numpy as np
+import talib
+
+class CalibratedResistanceAtmosphericScrubbers(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2020, 1, 2)
+        self.SetEndDate(2020, 1, 6) 
+        self.SetCash(100000) 
+        self.AddEquity("SPY", Resolution.Hour)
+        
+        self.rolling_window = pd.DataFrame()
+        self.dema_period = 3
+        self.sma_period = 3
+        self.wma_period = 3
+        self.window_size = self.dema_period * 2
+        self.SetWarmUp(self.window_size)
+        
+    def OnData(self, data):
+        if "SPY" not in data.Bars:
+            return
+        
+        close = data["SPY"].Close
+        
+        if self.IsWarmingUp:
+            # Add latest close to rolling window
+            row = pd.DataFrame({"close": [close]}, index=[data.Time])
+            self.rolling_window = self.rolling_window.append(row).iloc[-self.window_size:]
+            
+            # If we have enough closing data to start calculating indicators...
+            if self.rolling_window.shape[0] == self.window_size:
+                closes = self.rolling_window['close'].values
+                
+                # Add indicator columns to DataFrame
+                self.rolling_window['DEMA'] = talib.DEMA(closes, self.dema_period)
+                self.rolling_window['EMA'] = talib.EMA(closes, self.sma_period)
+                self.rolling_window['WMA'] = talib.WMA(closes, self.wma_period)
+            return
+        
+        closes = np.append(self.rolling_window['close'].values, close)[-self.window_size:]
+        
+        # Update talib indicators time series with the latest close
+        row = pd.DataFrame({"close": close,
+                            "DEMA" : talib.DEMA(closes, self.dema_period)[-1],
+                            "EMA"  : talib.EMA(closes, self.sma_period)[-1],
+                            "WMA"  : talib.WMA(closes, self.wma_period)[-1]},
+                            index=[data.Time])
+        
+        self.rolling_window = self.rolling_window.append(row).iloc[-self.window_size:]
+
+        
+    def OnEndOfAlgorithm(self):
+        self.Log(f"\nRolling Window:\n{self.rolling_window.to_string()}\n")
+        self.Log(f"\nLatest Values:\n{self.rolling_window.iloc[-1].to_string()}\n")


### PR DESCRIPTION
#### Description
Adds an example algorithm written in Python that demonstrates using multiple talib indicators.

#### Related Issue
[Related Issue](https://github.com/QuantConnect/Lean/issues/4378)

#### Motivation and Context
There were no example python algorithms that demonstrated the talib indicators.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Running with the LEAN backtester through the QC web interface.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. No tests need -- example algorithm.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
