### PR TITLE
Fix unhandled exception in ZipDataCacheProvider

### DIFF
--- a/Engine/DataFeeds/ZipDataCacheProvider.cs
+++ b/Engine/DataFeeds/ZipDataCacheProvider.cs
@@ -190,7 +190,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
             finally
             {
-                _cacheCleaner.Change(TimeSpan.FromSeconds(CacheSeconds), Timeout.InfiniteTimeSpan);
+                try
+                {
+                    _cacheCleaner.Change(TimeSpan.FromSeconds(CacheSeconds), Timeout.InfiniteTimeSpan);
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
             }
         }
 


### PR DESCRIPTION

#### Description
- Added missing `try...catch` block in `ZipDataCacheProvider.CleanCache()`

#### Motivation and Context
- Unhandled exception (`ObjectDisposedException`) 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
