### PR TITLE
QuantBook Future History Filter

### DIFF
--- a/Jupyter/QuantBook.cs
+++ b/Jupyter/QuantBook.cs
@@ -279,7 +279,10 @@ namespace QuantConnect.Jupyter
                 {
                     if (future.Exchange.DateIsOpen(date))
                     {
-                        allSymbols.UnionWith(FutureChainProvider.GetFutureContractList(future.Symbol, date));
+                        var underlying = new Tick { Time = date };
+                        var allList = FutureChainProvider.GetFutureContractList(future.Symbol, date);
+
+                        allSymbols.UnionWith(future.ContractFilter.Filter(new FutureFilterUniverse(allList, underlying)));
                     }
                 }
             }

--- a/Tests/Jupyter/QuantBookHistoryTests.cs
+++ b/Tests/Jupyter/QuantBookHistoryTests.cs
@@ -181,8 +181,9 @@ namespace QuantConnect.Tests.Jupyter
             }
         }
 
-        [Test]
-        public void CanonicalFutureQuantBookHistory()
+        [TestCase(182, 2)]
+        [TestCase(120, 1)]
+        public void CanonicalFutureQuantBookHistory(int maxFilter, int numberOfFutureContracts)
         {
             using (Py.GIL())
             {
@@ -191,15 +192,20 @@ namespace QuantConnect.Tests.Jupyter
                 var securityTestHistory = _module.FutureHistoryTest(startDate, SecurityType.Future, symbol);
 
                 // Get the one day of data, ending on start date
-                var startEndHistory = securityTestHistory.test_daterange_overload(startDate);
+                var startEndHistory = securityTestHistory.test_daterange_overload(startDate, startDate.AddDays(-1), maxFilter);
+
+                Console.WriteLine(startEndHistory.index.levels[1].size.ToString());
+                Assert.AreEqual(numberOfFutureContracts, (int)startEndHistory.index.levels[1].size);
+
                 Console.WriteLine(startEndHistory.ToString());
                 var firstIndex = (DateTime)(startEndHistory.index.values[0][2] as PyObject).AsManagedObject(typeof(DateTime));
                 Assert.GreaterOrEqual(startDate.AddDays(-1).Date, firstIndex.Date);
             }
         }
 
-        [Test]
-        public void CanonicalFutureIntradayQuantBookHistory()
+        [TestCase(182, 2)]
+        [TestCase(120, 1)]
+        public void CanonicalFutureIntradayQuantBookHistory(int maxFilter, int numberOfFutureContracts)
         {
             using (Py.GIL())
             {
@@ -207,7 +213,11 @@ namespace QuantConnect.Tests.Jupyter
                 var currentDate = new DateTime(2013, 10, 11, 18, 0, 0);
                 var securityTestHistory = _module.FutureHistoryTest(new DateTime(2013, 10, 12), SecurityType.Future, symbol);
 
-                var startEndHistory = securityTestHistory.test_daterange_overload(currentDate, new DateTime(2013, 10, 11, 10, 0, 0));
+                var startEndHistory = securityTestHistory.test_daterange_overload(currentDate, new DateTime(2013, 10, 11, 10, 0, 0), maxFilter);
+
+                Console.WriteLine(startEndHistory.index.levels[1].size.ToString());
+                Assert.AreEqual(numberOfFutureContracts, (int)startEndHistory.index.levels[1].size);
+
                 Console.WriteLine(startEndHistory.ToString());
                 Assert.IsFalse((bool)startEndHistory.empty);
             }

--- a/Tests/Jupyter/RegressionScripts/Test_QuantBookHistory.py
+++ b/Tests/Jupyter/RegressionScripts/Test_QuantBookHistory.py
@@ -52,9 +52,10 @@ class OptionHistoryTest(SecurityHistoryTest):
         return history.GetAllData()
 
 class FutureHistoryTest(SecurityHistoryTest):
-    def test_daterange_overload(self, end, start = None):
+    def test_daterange_overload(self, end, start = None, maxFilter = 182):
         if start is None:
             start = end - timedelta(1)
+        self.qb.Securities[self.symbol].SetFilter(0, maxFilter) # default is 35 days
         history = self.qb.GetFutureHistory(self.symbol, start, end)
         return history.GetAllData()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- QuantBook future history request will now apply contract filtering.
  Adding unit tests

**Note: since the default filter is 35 days this will change behavior of existing history requests which were returning all future contracts.**

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/4032
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix for QuantBook
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
