### PR TITLE
Fix Estimize processing issues that prevented two downloaders from completing

### DIFF
--- a/Tests/Common/Data/Custom/EstimizeTests.cs
+++ b/Tests/Common/Data/Custom/EstimizeTests.cs
@@ -375,8 +375,12 @@ namespace QuantConnect.Tests.Common.Data.Custom
         }
 
         [TestCase("ENRN-defunct", "ENRN", true)]
+        [TestCase("ENRN - defunct", "ENRN", true)]
         [TestCase("SUNE_defunct", "SUNE", true)]
+        [TestCase("SUNE -defunct", "SUNE", true)]
+        [TestCase("SHLD -- defunct", "SHLD", true)]
         [TestCase("SHLD defunct", "", false)]
+        [TestCase("AAPL", "AAPL", true)]
         public void NormalizesDefunctTickerValues(string ticker, string expectedTicker, bool expectedSuccess)
         {
             string actualTicker;

--- a/Tests/Common/Data/Custom/EstimizeTests.cs
+++ b/Tests/Common/Data/Custom/EstimizeTests.cs
@@ -373,5 +373,17 @@ namespace QuantConnect.Tests.Common.Data.Custom
             Assert.AreEqual(time, deserialized.Time);
             Assert.AreEqual(time, deserialized.EndTime);
         }
+
+        [TestCase("ENRN-defunct", "ENRN", true)]
+        [TestCase("SUNE_defunct", "SUNE", true)]
+        [TestCase("SHLD defunct", "", false)]
+        public void NormalizesDefunctTickerValues(string ticker, string expectedTicker, bool expectedSuccess)
+        {
+            string actualTicker;
+            var actualSuccess = EstimizeDataDownloader.TryNormalizeDefunctTicker(ticker, out actualTicker);
+
+            Assert.AreEqual(expectedSuccess, actualSuccess);
+            Assert.AreEqual(expectedTicker, actualTicker);
+        }
     }
 }

--- a/ToolBox/EstimizeDataDownloader/EstimizeEstimateDataDownloader.cs
+++ b/ToolBox/EstimizeDataDownloader/EstimizeEstimateDataDownloader.cs
@@ -70,26 +70,21 @@ namespace QuantConnect.ToolBox.EstimizeDataDownloader
 
                 foreach (var company in companies)
                 {
-                    var ticker = company.Ticker;
-
                     // Include tickers that are "defunct".
                     // Remove the tag because it cannot be part of the API endpoint.
                     // This is separate from the NormalizeTicker(...) method since
                     // we don't convert tickers with `-`s into the format we can successfully
                     // index mapfiles with.
-                    if (ticker.IndexOf("defunct", StringComparison.OrdinalIgnoreCase) > 0)
-                    {
-                        var length = ticker.IndexOf('-');
-                        length = length == -1 ? ticker.IndexOf('_') : length;
-                        if (length == -1)
-                        {
-                            Log.Error($"EstimizeEstimateDataDownloader(): Defunct ticker {ticker} is unable to be parsed. Continuing...");
-                            continue;
-                        }
+                    var estimizeTicker = company.Ticker;
+                    string ticker;
 
-                        ticker = ticker.Substring(0, length).Trim();
+                    if (!TryNormalizeDefunctTicker(estimizeTicker, out ticker))
+                    {
+                        Log.Error($"EstimizeEstimateDataDownloader(): Defunct ticker {estimizeTicker} is unable to be parsed. Continuing...");
+                        continue;
                     }
 
+                    // Begin processing ticker with a normalized value
                     Log.Trace($"EstimizeEstimateDataDownloader.Run(): Processing {ticker}");
 
                     // Makes sure we don't overrun Estimize rate limits accidentally

--- a/ToolBox/EstimizeDataDownloader/EstimizeEstimateDataDownloader.cs
+++ b/ToolBox/EstimizeDataDownloader/EstimizeEstimateDataDownloader.cs
@@ -80,6 +80,13 @@ namespace QuantConnect.ToolBox.EstimizeDataDownloader
                     if (ticker.IndexOf("defunct", StringComparison.OrdinalIgnoreCase) > 0)
                     {
                         var length = ticker.IndexOf('-');
+                        length = length == -1 ? ticker.IndexOf('_') : length;
+                        if (length == -1)
+                        {
+                            Log.Error($"EstimizeEstimateDataDownloader(): Defunct ticker {ticker} is unable to be parsed. Continuing...");
+                            continue;
+                        }
+
                         ticker = ticker.Substring(0, length).Trim();
                     }
 

--- a/ToolBox/EstimizeDataDownloader/EstimizeReleaseDataDownloader.cs
+++ b/ToolBox/EstimizeDataDownloader/EstimizeReleaseDataDownloader.cs
@@ -84,6 +84,7 @@ namespace QuantConnect.ToolBox.EstimizeDataDownloader
                     if (!TryNormalizeDefunctTicker(estimizeTicker, out ticker))
                     {
                         Log.Error($"EstimizeReleaseDataDownloader(): Defunct ticker {estimizeTicker} is unable to be parsed. Continuing...");
+                        continue;
                     }
 
                     // Begin processing ticker with a normalized value

--- a/ToolBox/EstimizeDataDownloader/EstimizeReleaseDataDownloader.cs
+++ b/ToolBox/EstimizeDataDownloader/EstimizeReleaseDataDownloader.cs
@@ -78,20 +78,15 @@ namespace QuantConnect.ToolBox.EstimizeDataDownloader
                     // This is separate from the NormalizeTicker(...) method since
                     // we don't convert tickers with `-`s into the format we can successfully
                     // index mapfiles with.
-                    var ticker = company.Ticker;
-                    if (ticker.IndexOf("defunct", StringComparison.OrdinalIgnoreCase) > 0)
-                    {
-                        var length = ticker.IndexOf('-');
-                        length = length == -1 ? ticker.IndexOf('_') : length;
-                        if (length == -1)
-                        {
-                            Log.Error($"EstimizeReleaseDataDownloader(): Defunct ticker {ticker} is unable to be parsed. Continuing...");
-                            continue;
-                        }
+                    var estimizeTicker = company.Ticker;
+                    string ticker;
 
-                        ticker = ticker.Substring(0, length).Trim();
+                    if (!TryNormalizeDefunctTicker(estimizeTicker, out ticker))
+                    {
+                        Log.Error($"EstimizeReleaseDataDownloader(): Defunct ticker {estimizeTicker} is unable to be parsed. Continuing...");
                     }
 
+                    // Begin processing ticker with a normalized value
                     Log.Trace($"EstimizeReleaseDataDownloader.Run(): Processing {ticker}");
 
                     tasks.Add(

--- a/ToolBox/EstimizeDataDownloader/EstimizeReleaseDataDownloader.cs
+++ b/ToolBox/EstimizeDataDownloader/EstimizeReleaseDataDownloader.cs
@@ -82,6 +82,13 @@ namespace QuantConnect.ToolBox.EstimizeDataDownloader
                     if (ticker.IndexOf("defunct", StringComparison.OrdinalIgnoreCase) > 0)
                     {
                         var length = ticker.IndexOf('-');
+                        length = length == -1 ? ticker.IndexOf('_') : length;
+                        if (length == -1)
+                        {
+                            Log.Error($"EstimizeReleaseDataDownloader(): Defunct ticker {ticker} is unable to be parsed. Continuing...");
+                            continue;
+                        }
+
                         ticker = ticker.Substring(0, length).Trim();
                     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Prevents the `EstimizeEstimatesDataDownloader`, `EstimizeReleaseDataDownloader` types from crashing when encountering a ticker with a "defunct" indicator, but we are unable to determine the delimiter.

~Note: I think we should move this shared behavior into the abstract class both of the Downloaders inherit from to avoid code duplication. Willing to do it as part of this PR.~

Done 😃 
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensures Estimize processes successfully
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Processed data for both `EstimizeEstimatesDataDownloader` and `EstimizeReleaseDataDownloader` successfully
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
