### PR TITLE
Add a futures universe selection model that uses open interest

### DIFF
--- a/Algorithm.CSharp/OpenInterestFuturesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OpenInterestFuturesRegressionAlgorithm.cs
@@ -1,0 +1,139 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Futures framework algorithm that uses open interest to select the active contract.
+    /// </summary>
+    /// <meta name="tag" content="regression test" />
+    /// <meta name="tag" content="futures" />
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="filter selection" />
+    public class OpenInterestFuturesRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private static readonly HashSet<DateTime> ExpectedExpiryDates = new HashSet<DateTime>
+        {
+            new DateTime(2013, 12, 27),
+            new DateTime(2014, 02, 26)
+        };
+
+        public override void Initialize()
+        {
+            UniverseSettings.Resolution = Resolution.Tick;
+
+            SetStartDate(2013, 10, 08);
+            SetEndDate(2013, 10, 11);
+            SetCash(10000000);
+
+            // set framework models
+            SetUniverseSelection(
+                new OpenInterestFutureUniverseSelectionModel(
+                    this,
+                    t => new[] {QuantConnect.Symbol.Create(Futures.Metals.Gold, SecurityType.Future, Market.COMEX)},
+                    null,
+                    ExpectedExpiryDates.Count
+                )
+            );
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (Transactions.OrdersCount == 0 && slice.HasData)
+            {
+                var matched = slice.Keys.Where(s => !ExpectedExpiryDates.Contains(s.ID.Date)).ToList();
+                if (matched.Count != 0)
+                {
+                    throw new Exception($"{matched.Count}/{slice.Keys.Count} were unexpected expiry date(s): " + string.Join(", ", matched.Select(x => x.ID.Date)));
+                }
+
+                foreach (var symbol in slice.Keys)
+                {
+                    MarketOrder(symbol, 1);
+                }
+            }
+            else if (Portfolio.Any(p => p.Value.Invested))
+            {
+                Liquidate();
+            }
+        }
+
+        /// <summary>
+        ///     This is used by the regression test system to indicate if the open source Lean repository has the required data to
+        ///     run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        ///     This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = {Language.CSharp};
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "4"},
+            {"Average Win", "0.00%"},
+            {"Average Loss", "0.00%"},
+            {"Compounding Annual Return", "0.003%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0.351"},
+            {"Net Profit", "0.000%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "50%"},
+            {"Win Rate", "50%"},
+            {"Profit-Loss Ratio", "1.70"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-58.133"},
+            {"Tracking Error", "0.173"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$7.40"},
+            {"Fitness Score", "0.017"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0.017"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "824503313"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -161,6 +161,7 @@
     <Compile Include="AltData\TiingoNewsAlgorithm.cs" />
     <Compile Include="AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs" />
     <Compile Include="AutomaticIndicatorWarmupRegressionAlgorithm.cs" />
+    <Compile Include="OpenInterestFuturesRegressionAlgorithm.cs" />
     <Compile Include="CustomPartialFillModelAlgorithm.cs" />
     <Compile Include="EquityTradeAndQuotesRegressionAlgorithm.cs" />
     <Compile Include="BasicTemplateConstituentUniverseAlgorithm.cs" />

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Alphas\ConstantAlphaModel.cs" />
     <Compile Include="Alphas\MacdAlphaModel.cs" />
     <Compile Include="Selection\FutureUniverseSelectionModel.cs" />
+    <Compile Include="Selection\OpenInterestFutureUniverseSelectionModel.cs" />
     <Compile Include="Selection\OptionUniverseSelectionModel.cs" />
     <Compile Include="Selection\ScheduledUniverseSelectionModel.cs" />
     <Compile Include="Selection\QC500UniverseSelectionModel.cs" />

--- a/Algorithm.Framework/Selection/OpenInterestFutureUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/OpenInterestFutureUniverseSelectionModel.cs
@@ -1,0 +1,123 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NodaTime;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.Framework.Selection
+{
+    /// <summary>
+    ///     Selects contracts in a futures universe, sorted by open interest.  This allows the selection to identifiy current
+    ///     active contract.
+    /// </summary>
+    public class OpenInterestFutureUniverseSelectionModel : FutureUniverseSelectionModel
+    {
+        private readonly int? _chainContractsLookupLimit;
+        private readonly IAlgorithm _algorithm;
+        private readonly int? _resultsLimit;
+        private readonly MarketHoursDatabase _marketHoursDatabase;
+
+        /// <summary>
+        ///     Creates a new instance of <see cref="OpenInterestFutureUniverseSelectionModel" />
+        /// </summary>
+        /// <param name="algorithm">Algorithm</param>
+        /// <param name="futureChainSymbolSelector">Selects symbols from the provided future chain</param>
+        /// <param name="chainContractsLookupLimit">Limit on how many contracts to query for open interest</param>
+        /// <param name="resultsLimit">Limit on how many contracts will be part of the universe</param>
+        public OpenInterestFutureUniverseSelectionModel(IAlgorithm algorithm, Func<DateTime, IEnumerable<Symbol>> futureChainSymbolSelector, int? chainContractsLookupLimit = 6,
+            int? resultsLimit = 1) : base(TimeSpan.FromDays(1), futureChainSymbolSelector)
+        {
+            _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+            if (algorithm == null)
+            {
+                throw new ArgumentNullException(nameof(algorithm));
+            }
+
+            _algorithm = algorithm;
+            _resultsLimit = resultsLimit;
+            _chainContractsLookupLimit = chainContractsLookupLimit;
+        }
+
+        /// <summary>
+        ///     Defines the future chain universe filter
+        /// </summary>
+        protected override FutureFilterUniverse Filter(FutureFilterUniverse filter)
+        {
+            return filter.Contracts(FilterByOpenInterest(filter.ToDictionary(x => x, x => _marketHoursDatabase.GetEntry(x.ID.Market, x, x.ID.SecurityType).ExchangeHours)));
+        }
+
+        /// <summary>
+        ///     Filters a set of contracts based on open interest.
+        /// </summary>
+        /// <param name="contracts">Contracts to filter</param>
+        /// <returns>Filtered set</returns>
+        public IEnumerable<Symbol> FilterByOpenInterest(IReadOnlyDictionary<Symbol, SecurityExchangeHours> contracts)
+        {
+            var symbols = new List<Symbol>(_chainContractsLookupLimit.HasValue ? contracts.Keys.OrderBy(x => x.ID.Date).Take(_chainContractsLookupLimit.Value) : contracts.Keys);
+            var openInterest = symbols.GroupBy(x => contracts[x]).SelectMany(g => GetOpenInterest(g.Key, g.Select(i => i))).ToDictionary(x => x.Key, x => x.Value);
+
+            if (openInterest.Count == 0)
+            {
+                _algorithm.Error(
+                    $"{nameof(OpenInterestFutureUniverseSelectionModel)}.{nameof(FilterByOpenInterest)}: Failed to get historical open interest, no symbol will be selected."
+                );
+                return Enumerable.Empty<Symbol>();
+            }
+
+            var filtered = openInterest.OrderByDescending(x => x.Value).ThenBy(x => x.Key.ID.Date).Select(x => x.Key);
+            if (_resultsLimit.HasValue)
+            {
+                filtered = filtered.Take(_resultsLimit.Value);
+            }
+
+            return filtered;
+        }
+
+        private Dictionary<Symbol, decimal> GetOpenInterest(SecurityExchangeHours exchangeHours, IEnumerable<Symbol> symbols)
+        {
+            var current = _algorithm.UtcTime;
+            var endTime = Instant.FromDateTimeUtc(_algorithm.UtcTime).InZone(exchangeHours.TimeZone).ToDateTimeUnspecified();
+            var previousDay = Time.GetStartTimeForTradeBars(exchangeHours, endTime, Time.OneDay, 1, true);
+            var requests = symbols.Select(
+                    symbol => new HistoryRequest(
+                        previousDay,
+                        current,
+                        typeof(Tick),
+                        symbol,
+                        Resolution.Tick,
+                        exchangeHours,
+                        exchangeHours.TimeZone,
+                        null,
+                        true,
+                        false,
+                        DataNormalizationMode.Raw,
+                        TickType.OpenInterest
+                    )
+                )
+                .ToArray();
+            return _algorithm.HistoryProvider.GetHistory(requests, exchangeHours.TimeZone)
+                .Where(s => s.HasData && s.Ticks.Keys.Count > 0)
+                .SelectMany(s => s.Ticks.Select(x => new Tuple<Symbol, Tick>(x.Key, x.Value.LastOrDefault())))
+                .GroupBy(x => x.Item1)
+                .ToDictionary(x => x.Key, x => x.OrderByDescending(i => i.Item2.Time).LastOrDefault().Item2.Value);
+        }
+    }
+}

--- a/Tests/Algorithm/Framework/Selection/OpenInterestFutureUniverseSelectionModelTests.cs
+++ b/Tests/Algorithm/Framework/Selection/OpenInterestFutureUniverseSelectionModelTests.cs
@@ -1,0 +1,159 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Selection
+{
+    [TestFixture]
+    public class OpenInterestFutureUniverseSelectionModelTests
+    {
+        private static readonly Symbol Jan = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2020, 01, 01));
+        private static readonly Symbol Feb = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2020, 02, 01));
+        private static readonly Symbol March = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2020, 03, 01));
+        private static readonly Symbol April = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2020, 04, 01));
+        private static readonly DateTime TestDate = new DateTime(2020, 05, 11, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime ExpectedPreviousDate = new DateTime(2020, 05, 08, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly IReadOnlyDictionary<Symbol, decimal> OpenInterestData = new Dictionary<Symbol, decimal>
+        {
+            [Jan] = 3,
+            [Feb] = 6,
+            [March] = 3, // Same as Jan.
+            [April] = 1
+        };
+        private static readonly SecurityExchangeHours Exchange = MarketHoursDatabase.FromDataFolder().GetExchangeHours(Jan.ID.Market, Jan, Jan.SecurityType);
+        private Mock<IHistoryProvider> _mockHistoryProvider;
+        private OpenInterestFutureUniverseSelectionModel _underTest;
+
+        [Test]
+        public void No_Open_Interest_Returns_Empty()
+        {
+            SetupSubject(OpenInterestData.Count, OpenInterestData.Count);
+            _mockHistoryProvider.Setup(x => x.GetHistory(It.IsAny<IEnumerable<HistoryRequest>>(), It.IsAny<DateTimeZone>()))
+                .Returns<IEnumerable<HistoryRequest>, DateTimeZone>((r, tz) => new Slice[0])
+                .Verifiable();
+
+            var data = OpenInterestData.Keys.ToDictionary(x => x, x => Exchange);
+            var results = _underTest.FilterByOpenInterest(data).ToList();
+            _mockHistoryProvider.Verify();
+            Assert.IsEmpty(results);
+        }
+
+        [Test]
+        public void Can_Sort_By_Open_Interest()
+        {
+            SetupSubject(OpenInterestData.Count, OpenInterestData.Count);
+            _mockHistoryProvider.Setup(x => x.GetHistory(It.IsAny<IEnumerable<HistoryRequest>>(), It.IsAny<DateTimeZone>()))
+                .Returns<IEnumerable<HistoryRequest>, DateTimeZone>(
+                    (r, tz) =>
+                    {
+                        var requests = r.ToList();
+                        Assert.AreEqual(4, requests.Count);
+                        var slices = new List<Slice>(requests.Count);
+                        foreach (var request in requests)
+                        {
+                            Assert.NotNull(request.Symbol);
+                            Assert.AreEqual(typeof(Tick), request.DataType);
+                            Assert.AreEqual(DataNormalizationMode.Raw, request.DataNormalizationMode);
+                            Assert.AreEqual(ExpectedPreviousDate, request.StartTimeUtc);
+                            Assert.AreEqual(TestDate, request.EndTimeUtc);
+                            Assert.AreEqual(Resolution.Tick, request.Resolution);
+                            Assert.AreEqual(TickType.OpenInterest, request.TickType);
+                            Assert.AreEqual(tz, Exchange.TimeZone);
+                            slices.Add(CreateReplySlice(request.Symbol, OpenInterestData[request.Symbol]));
+                        }
+
+                        return slices;
+                    }
+                )
+                .Verifiable();
+
+            var data = OpenInterestData.Keys.ToDictionary(x => x, x => Exchange);
+            var results = _underTest.FilterByOpenInterest(data).ToList();
+
+            // Results should be sorted by open interest (descending), and then by the date.
+            _mockHistoryProvider.Verify();
+            Assert.AreEqual(4, results.Count);
+            Assert.AreEqual(Feb, results[0]);
+            Assert.AreEqual(Jan, results[1]);
+            Assert.AreEqual(March, results[2]);
+            Assert.AreEqual(April, results[3]);
+        }
+
+        [Test]
+        public void Can_Limit_Number_Of_Contracts()
+        {
+            SetupSubject(6, 4);
+            var expected = Enumerable.Range(1, 4).Select(d => Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2020, 01, d))).ToList();
+
+            // Create 7 requests.  Reverse the list so the order isn't correct, but remains consistent for tests.
+            var data = expected.Concat(Enumerable.Range(5, 3).Select(d => Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2020, 01, d))))
+                .Reverse()
+                .ToDictionary(x => x, _ => Exchange);
+
+            // 7 input requests, but the look-up should be limited to only 6.
+            _mockHistoryProvider.Setup(x => x.GetHistory(It.IsAny<IEnumerable<HistoryRequest>>(), It.IsAny<DateTimeZone>()))
+                .Returns<IEnumerable<HistoryRequest>, DateTimeZone>((rq, tz) => rq.Select(r => CreateReplySlice(r.Symbol, 1)).ToArray());
+
+            // Run the test.
+            var results = _underTest.FilterByOpenInterest(data).ToList();
+
+            // Verify the chain limit was applied.
+            _mockHistoryProvider.Verify(x => x.GetHistory(It.Is<IEnumerable<HistoryRequest>>(r => r.Count() == 6), Exchange.TimeZone), Times.Once);
+
+            // Verify the results.
+            CollectionAssert.AreEqual(expected, results);
+        }
+
+        [Test]
+        public void Limits_Do_Not_Need_To_Be_Provided()
+        {
+            SetupSubject(null, null);
+            var startDate = new DateTime(2020, 01, 01);
+            var items = Enumerable.Range(0, 100).ToDictionary(d => Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, startDate.AddDays(d)), _ => Exchange);
+            _mockHistoryProvider.Setup(x => x.GetHistory(It.IsAny<IEnumerable<HistoryRequest>>(), It.IsAny<DateTimeZone>()))
+                .Returns<IEnumerable<HistoryRequest>, DateTimeZone>((rq, tz) => rq.Select(r => CreateReplySlice(r.Symbol, 1)).ToArray());
+            var results = _underTest.FilterByOpenInterest(items).ToList();
+            _mockHistoryProvider.Verify(x => x.GetHistory(It.Is<IEnumerable<HistoryRequest>>(r => r.Count() == 100), Exchange.TimeZone), Times.Once);
+            Assert.AreEqual(items.Keys, results);
+        }
+
+        private static Slice CreateReplySlice(Symbol symbol, decimal openInterest)
+        {
+            var ticks = new Ticks {{symbol, new List<Tick> {new OpenInterest(TestDate, symbol, openInterest)}}};
+            return new Slice(TestDate, null, null, null, ticks, null, null, null, null, null, null, true);
+        }
+
+        private void SetupSubject(int? testChainContractLookupLimit, int? testResultsLimit)
+        {
+            _mockHistoryProvider = new Mock<IHistoryProvider>();
+
+            var mockAlgorithm = new Mock<IAlgorithm>();
+            mockAlgorithm.SetupGet(x => x.HistoryProvider).Returns(_mockHistoryProvider.Object);
+            mockAlgorithm.SetupGet(x => x.UtcTime).Returns(TestDate);
+            _underTest = new OpenInterestFutureUniverseSelectionModel(mockAlgorithm.Object, _ => OpenInterestData.Keys, testChainContractLookupLimit, testResultsLimit);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -299,6 +299,7 @@
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetCollectionTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\EqualWeightingPortfolioConstructionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Portfolio\PortfolioTargetTests.cs" />
+    <Compile Include="Algorithm\Framework\Selection\OpenInterestFutureUniverseSelectionModelTests.cs" />
     <Compile Include="Algorithm\Framework\Selection\QC500UniverseSelectionModelTests.cs" />
     <Compile Include="Brokerages\Bitfinex\BitfinexBrokerageAdditionalTests.cs" />
     <Compile Include="Brokerages\Bitfinex\BitfinexFeeModelTests.cs" />


### PR DESCRIPTION
Adds a purposed futures universe selection model, that will assist with identifying the current active contract / contracts.

#### Description
Universe selection is done by obtaining the last open interest for each contract.  The contracts are then sorted by this value, and provided back for use.

#### Related Issue
N/A

#### Motivation and Context
While the front month in a futures chain is often also the most outstanding orders, this isn't always the case. In order to select the right contract in the chain, open interest should be used to sort the contracts.

This model provides an easy way for that to be done.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Yes using a broker, and comparing the broker's expected active contract to the returned results.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>` - *it is missing the issue, does that matter?*

Credits also to @StefanoRaggi for his assistance in this model, and the original version of this class.
