### PR TITLE
Add support for saving Futures/Options data in LeanDataWriter

### DIFF
--- a/Common/Interfaces/IDataQueueUniverseProvider.cs
+++ b/Common/Interfaces/IDataQueueUniverseProvider.cs
@@ -28,10 +28,11 @@ namespace QuantConnect.Interfaces
         /// </summary>
         /// <param name="lookupName">String representing the name to lookup</param>
         /// <param name="securityType">Expected security type of the returned symbols (if any)</param>
+        /// <param name="includeExpired">Include expired contracts</param>
         /// <param name="securityCurrency">Expected security currency(if any)</param>
         /// <param name="securityExchange">Expected security exchange name(if any)</param>
         /// <returns></returns>
-        IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, string securityCurrency = null, string securityExchange = null);
+        IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, bool includeExpired, string securityCurrency = null, string securityExchange = null);
 
         /// <summary>
         /// Returns whether the time can be advanced or not.

--- a/Engine/DataFeeds/Enumerators/DataQueueFuturesChainUniverseDataCollectionEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/DataQueueFuturesChainUniverseDataCollectionEnumerator.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     .ConvertFromUtc(_subscriptionRequest.Configuration.ExchangeTimeZone);
 
                 // loading the list of futures contracts and converting them into zip entries
-                var symbols = _universeProvider.LookupSymbols(_subscriptionRequest.Security.Symbol.ID.Symbol, _subscriptionRequest.Security.Type);
+                var symbols = _universeProvider.LookupSymbols(_subscriptionRequest.Security.Symbol.ID.Symbol, _subscriptionRequest.Security.Type, false);
                 var zipEntries = symbols.Select(x => new ZipEntryName { Time = localTime, Symbol = x } as BaseData).ToList();
                 var current = new FuturesChainUniverseDataCollection
                 {

--- a/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumerator.cs
@@ -110,7 +110,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     .ConvertFromUtc(_subscriptionRequest.Configuration.ExchangeTimeZone);
 
                 // loading the list of futures contracts and converting them into zip entries
-                var symbols = _universeProvider.LookupSymbols(_subscriptionRequest.Security.Symbol.ID.Symbol, _subscriptionRequest.Security.Type);
+                var symbols = _universeProvider.LookupSymbols(_subscriptionRequest.Security.Symbol.ID.Symbol, _subscriptionRequest.Security.Type, false);
                 var zipEntries = symbols.Select(x => new ZipEntryName { Time = localTime, Symbol = x } as BaseData).ToList();
                 _currentData = new OptionChainUniverseDataCollection
                 {

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FuturesChainUniverseSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FuturesChainUniverseSubscriptionEnumeratorFactoryTests.cs
@@ -132,7 +132,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 _timeProvider = timeProvider;
             }
 
-            public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, string securityCurrency = null, string securityExchange = null)
+            public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, bool includeExpired, string securityCurrency = null, string securityExchange = null)
             {
                 TotalLookupCalls++;
 

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
@@ -263,7 +263,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 _timeProvider = timeProvider;
             }
 
-            public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, string securityCurrency = null, string securityExchange = null)
+            public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, bool includeExpired, string securityCurrency = null, string securityExchange = null)
             {
                 TotalLookupCalls++;
 

--- a/Tests/Engine/DataFeeds/FuncDataQueueHandlerUniverseProvider.cs
+++ b/Tests/Engine/DataFeeds/FuncDataQueueHandlerUniverseProvider.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
     /// </summary>
     public class FuncDataQueueHandlerUniverseProvider : FuncDataQueueHandler, IDataQueueUniverseProvider
     {
-        private readonly Func<string, SecurityType, string, string, IEnumerable<Symbol>> _lookupSymbolsFunction;
+        private readonly Func<string, SecurityType, bool, string, string, IEnumerable<Symbol>> _lookupSymbolsFunction;
         private readonly Func<SecurityType, bool> _canAdvanceTimeFunction;
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         /// <param name="canAdvanceTimeFunction">The functional implementation for the <see cref="IDataQueueUniverseProvider.CanAdvanceTime"/> function</param>
         public FuncDataQueueHandlerUniverseProvider(
             Func<FuncDataQueueHandler, IEnumerable<BaseData>> getNextTicksFunction,
-            Func<string, SecurityType, string, string, IEnumerable<Symbol>> lookupSymbolsFunction,
+            Func<string, SecurityType, bool, string, string, IEnumerable<Symbol>> lookupSymbolsFunction,
             Func<SecurityType, bool> canAdvanceTimeFunction)
             : base(getNextTicksFunction)
         {
@@ -51,12 +51,13 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         /// </summary>
         /// <param name="lookupName">String representing the name to lookup</param>
         /// <param name="securityType">Expected security type of the returned symbols (if any)</param>
+        /// <param name="includeExpired">Include expired contracts</param>
         /// <param name="securityCurrency">Expected security currency(if any)</param>
         /// <param name="securityExchange">Expected security exchange name(if any)</param>
         /// <returns></returns>
-        public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, string securityCurrency = null, string securityExchange = null)
+        public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, bool includeExpired, string securityCurrency = null, string securityExchange = null)
         {
-            return _lookupSymbolsFunction(lookupName, securityType, securityCurrency, securityExchange);
+            return _lookupSymbolsFunction(lookupName, securityType, includeExpired, securityCurrency, securityExchange);
         }
 
         /// <summary>

--- a/Tests/Engine/DataFeeds/IQFeedRealtimeDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/IQFeedRealtimeDataFeedTests.cs
@@ -30,17 +30,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds
     [TestFixture, Ignore("Tests are dependent on network and are long")]
     public class IQFeedRealtimeDataFeedTests
     {
-
         [Test]
-        public void IQFeedSanityCheckIfDataIsLoaded ()
+        public void IQFeedSanityCheckIfDataIsLoaded()
         {
             var symbolUniverse = new IQFeedDataQueueUniverseProvider();
 
             var lookup = symbolUniverse as IDataQueueUniverseProvider;
             var mapper = symbolUniverse as ISymbolMapper;
 
-            Assert.IsTrue(lookup.LookupSymbols("SPY", SecurityType.Option).Any());
-            Assert.IsTrue(lookup.LookupSymbols("SPY", SecurityType.Equity).Count() == 1);
+            Assert.IsTrue(lookup.LookupSymbols("SPY", SecurityType.Option, false).Any());
+            Assert.IsTrue(lookup.LookupSymbols("SPY", SecurityType.Equity, false).Count() == 1);
             Assert.IsTrue(!string.IsNullOrEmpty(mapper.GetBrokerageSymbol(Symbols.SPY)));
             Assert.IsTrue(mapper.GetLeanSymbol("SPY", SecurityType.Equity, "") != Symbol.Empty);
 

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -1995,7 +1995,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 },
 
                 // LookupSymbols
-                (lookupName, secType, securityCurrency, securityExchange) =>
+                (lookupName, secType, includeExpired, securityCurrency, securityExchange) =>
                 {
                     lookupCount++;
 

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -674,6 +674,7 @@
     <Compile Include="TestExtensions.cs" />
     <Compile Include="Indicators\LinearWeightedMovingAverageTests.cs" />
     <Compile Include="ToolBox\EstimizeTests.cs" />
+    <Compile Include="ToolBox\IBDownloader\IBDataDownloaderTests.cs" />
     <Compile Include="ToolBox\PsychSignalDataTests.cs" />
     <Compile Include="ToolBox\CoinApiSymbolMapperTests.cs" />
     <Compile Include="ToolBox\ForexVolume\FxcmVolumeDownloaderTest.cs" />

--- a/Tests/ToolBox/IBDownloader/IBDataDownloaderTests.cs
+++ b/Tests/ToolBox/IBDownloader/IBDataDownloaderTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using QuantConnect.Logging;
 using QuantConnect.ToolBox.IBDownloader;
 
 namespace QuantConnect.Tests.ToolBox.IBDownloader
@@ -24,16 +25,20 @@ namespace QuantConnect.Tests.ToolBox.IBDownloader
     [Ignore("These tests require the IBGateway to be installed.")]
     public class IBDataDownloaderTests
     {
-        [TestCase("ES", Resolution.Minute)]
-        public void DownloadsFuturesData(string ticker, Resolution resolution)
+        [TestCase("ES", Resolution.Daily, 15)]
+        [TestCase("ES", Resolution.Hour, 15)]
+        [TestCase("ES", Resolution.Minute, 15)]
+        public void DownloadsFuturesData(string ticker, Resolution resolution, int days)
         {
+            Log.LogHandler = new ConsoleLogHandler();
+
             const SecurityType securityType = SecurityType.Future;
 
             using (var downloader = new IBDataDownloader())
             {
                 var symbols = downloader.GetChainSymbols(ticker, securityType, true).ToList();
 
-                var startDate = DateTime.UtcNow.Date.AddDays(-15);
+                var startDate = DateTime.UtcNow.Date.AddDays(-days);
                 var endDate = DateTime.UtcNow.Date;
 
                 downloader.DownloadAndSave(symbols, resolution, securityType, TickType.Trade, startDate, endDate);

--- a/Tests/ToolBox/IBDownloader/IBDataDownloaderTests.cs
+++ b/Tests/ToolBox/IBDownloader/IBDataDownloaderTests.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.ToolBox.IBDownloader;
+
+namespace QuantConnect.Tests.ToolBox.IBDownloader
+{
+    [TestFixture]
+    [Ignore("These tests require the IBGateway to be installed.")]
+    public class IBDataDownloaderTests
+    {
+        [TestCase("ES", Resolution.Minute)]
+        public void DownloadsFuturesData(string ticker, Resolution resolution)
+        {
+            const SecurityType securityType = SecurityType.Future;
+
+            using (var downloader = new IBDataDownloader())
+            {
+                var symbols = downloader.GetChainSymbols(ticker, securityType, true).ToList();
+
+                var startDate = DateTime.UtcNow.Date.AddDays(-15);
+                var endDate = DateTime.UtcNow.Date;
+
+                downloader.DownloadAndSave(symbols, resolution, securityType, TickType.Trade, startDate, endDate);
+                downloader.DownloadAndSave(symbols, resolution, securityType, TickType.Quote, startDate, endDate);
+            }
+        }
+    }
+}

--- a/ToolBox/IBDownloader/IBDataDownloader.cs
+++ b/ToolBox/IBDownloader/IBDataDownloader.cs
@@ -75,7 +75,32 @@ namespace QuantConnect.ToolBox.IBDownloader
             var data = _brokerage.GetHistory(historyRequest);
 
             return data;
+        }
 
+        /// <summary>
+        /// Returns an IEnumerable of Future/Option contract symbols for the given root ticker
+        /// </summary>
+        /// <param name="ticker">The root ticker</param>
+        /// <param name="securityType">Expected security type of the returned symbols (if any)</param>
+        /// <param name="includeExpired">Include expired contracts</param>
+        public IEnumerable<Symbol> GetChainSymbols(string ticker, SecurityType securityType, bool includeExpired)
+        {
+            return _brokerage.LookupSymbols(ticker, securityType, includeExpired);
+        }
+
+        /// <summary>
+        /// Downloads historical data from the brokerage and saves it in LEAN format.
+        /// </summary>
+        /// <param name="symbols">The list of symbols</param>
+        /// <param name="tickType">The tick type</param>
+        /// <param name="resolution">The resolution</param>
+        /// <param name="securityType">The security type</param>
+        /// <param name="startTimeUtc">The starting date/time (UTC)</param>
+        /// <param name="endTimeUtc">The ending date/time (UTC)</param>
+        public void DownloadAndSave(List<Symbol> symbols, Resolution resolution, SecurityType securityType, TickType tickType, DateTime startTimeUtc, DateTime endTimeUtc)
+        {
+            var writer = new LeanDataWriter(Globals.DataFolder, resolution, securityType, tickType);
+            writer.DownloadAndSave(_brokerage, symbols, startTimeUtc, endTimeUtc);
         }
 
         /// <summary>
@@ -155,6 +180,11 @@ namespace QuantConnect.ToolBox.IBDownloader
             Console.Write($"\r[{bar}] {(p * 100).ToStringInvariant("N2")}%");
         }
 
+        #endregion
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
         public void Dispose()
         {
             if (_brokerage != null)
@@ -163,7 +193,5 @@ namespace QuantConnect.ToolBox.IBDownloader
                 _brokerage.Dispose();
             }
         }
-
-        #endregion
     }
 }

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -314,12 +314,13 @@ namespace QuantConnect.ToolBox.IQFeed
         /// </summary>
         /// <param name="lookupName">String representing the name to lookup</param>
         /// <param name="securityType">Expected security type of the returned symbols (if any)</param>
+        /// <param name="includeExpired">Include expired contracts</param>
         /// <param name="securityCurrency">Expected security currency(if any)</param>
         /// <param name="securityExchange">Expected security exchange name(if any)</param>
         /// <returns></returns>
-        public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, string securityCurrency = null, string securityExchange = null)
+        public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, bool includeExpired, string securityCurrency = null, string securityExchange = null)
         {
-            return _symbolUniverse.LookupSymbols(lookupName, securityType, securityCurrency, securityExchange);
+            return _symbolUniverse.LookupSymbols(lookupName, securityType, includeExpired, securityCurrency, securityExchange);
         }
 
         /// <summary>

--- a/ToolBox/IQFeed/IQFeedDataQueueUniverseProvider.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueUniverseProvider.cs
@@ -124,10 +124,11 @@ namespace QuantConnect.ToolBox.IQFeed
         /// </summary>
         /// <param name="lookupName">String representing the name to lookup</param>
         /// <param name="securityType">Expected security type of the returned symbols (if any)</param>
+        /// <param name="includeExpired">Include expired contracts</param>
         /// <param name="securityCurrency">Expected security currency(if any)</param>
         /// <param name="securityExchange">Expected security exchange name(if any)</param>
         /// <returns></returns>
-        public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, string securityCurrency = null, string securityExchange = null)
+        public IEnumerable<Symbol> LookupSymbols(string lookupName, SecurityType securityType, bool includeExpired, string securityCurrency = null, string securityExchange = null)
         {
             Func<Symbol, string> lookupFunc;
 

--- a/ToolBox/LeanDataWriter.cs
+++ b/ToolBox/LeanDataWriter.cs
@@ -145,7 +145,7 @@ namespace QuantConnect.ToolBox
                     exchangeHours,
                     dataTimeZone,
                     _resolution == Resolution.Tick ? (Resolution?)null : _resolution,
-                    false,
+                    true,
                     false,
                     DataNormalizationMode.Raw,
                     _tickType


### PR DESCRIPTION

#### Description
- Added new `includeExpired` flag to `IDataQueueUniverseProvider.Lookup`, to enable history requests for **expired** futures and options contracts. 
- Updated the IB brokerage implementation to handle expired contracts in history requests.
- Added a new `DownloadAndSave()` method in `LeanDataWriter` to allow downloading futures/options data from any `IBrokerage` implementation and saving in LEAN format.
- Added new method in the `IBDataDownloader` class for downloading options/futures data.

#### Motivation and Context
- History requests for expired futures/options contracts are not supported
- `LeanDataWriter` does not support writing Futures/Options data

#### How Has This Been Tested?
- Tested downloading historical data from IB

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
