### PR TITLE
Implements New PandasData Remapper

### DIFF
--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -87,7 +87,7 @@ namespace QuantConnect.Python
                     return _pandas.DataFrame();
                 }
                 var dataFrames = sliceDataDict.Select(x => x.Value.ToPandasDataFrame(maxLevels));
-                return PandasData.ApplySymbolMapper(_pandas.concat(dataFrames.ToArray(), Py.kw("sort", true)));
+                return _pandas.concat(dataFrames.ToArray(), Py.kw("sort", true));
             }
         }
 
@@ -118,7 +118,7 @@ namespace QuantConnect.Python
                 {
                     return _pandas.DataFrame();
                 }
-                return PandasData.ApplySymbolMapper(sliceData.ToPandasDataFrame());
+                return sliceData.ToPandasDataFrame();
             }
         }
 

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -73,7 +73,7 @@ from sys import modules
 
 from clr import AddReference
 AddReference(""QuantConnect.Common"")
-from QuantConnect import Symbol, SymbolCache
+from QuantConnect import *
 
 def mapper(key):
     '''Maps a Symbol object or a Symbol Ticker (string) to the string representation of

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -32,7 +32,6 @@ namespace QuantConnect.Python
     public class PandasData
     {
         private static dynamic _pandas;
-        private static dynamic _remapperFactory;
         private readonly static HashSet<string> _baseDataProperties = typeof(BaseData).GetProperties().ToHashSet(x => x.Name.ToLowerInvariant());
         private readonly static ConcurrentDictionary<Type, List<MemberInfo>> _membersByType = new ConcurrentDictionary<Type, List<MemberInfo>>();
 
@@ -60,199 +59,242 @@ namespace QuantConnect.Python
             {
                 using (Py.GIL())
                 {
-                    _pandas = Py.Import("pandas");
-
                     // this python Remapper class will work as a proxy and adjust the
                     // input to its methods using the provided 'mapper' callable object
-                    _remapperFactory = PythonEngine.ModuleFromString("remapper",
-                        @"import wrapt
-import pandas
+                    _pandas = PythonEngine.ModuleFromString("remapper",
+                        @"import pandas as pd
+from pandas.core.resample import Resampler, DatetimeIndexResampler, PeriodIndexResampler, TimedeltaIndexResampler
+from pandas.core.groupby.generic import DataFrameGroupBy, SeriesGroupBy
+from pandas.core.indexes.frozen import FrozenList as pdFrozenList
+from pandas.core.window import Expanding, EWM, Rolling, Window
+from inspect import getmembers, isfunction, isgenerator
+from functools import partial
+from sys import modules
+
 from clr import AddReference
 AddReference(""QuantConnect.Common"")
-from QuantConnect import *
+from QuantConnect import Symbol, SymbolCache
 
-originalConcat = pandas.concat
+def mapper(key):
+    '''Maps a Symbol object or a Symbol Ticker (string) to the string representation of
+    Symbol SecurityIdentifier. If cannot map, returns the object
+    '''
+    keyType = type(key)
+    if keyType is Symbol:
+        return str(key.ID)
+    if keyType is str:
+        kvp = SymbolCache.TryGetSymbol(key, None)
+        if kvp[0]:
+            return str(kvp[1].ID)
+    if keyType is tuple:
+        return tuple([mapper(x) for x in key])
+    if keyType is dict:
+        return {k:mapper(v) for k,v in key.items()}
+    return key
 
-def PandasConcatWrapper(objs, axis=0, join='outer', join_axes=None, ignore_index=False, keys=None, levels=None, names=None, verify_integrity=False, sort=None, copy=True):
-    return Remapper(originalConcat(objs, axis, join, join_axes, ignore_index, keys, levels, names, verify_integrity, sort, copy))
+def try_wrap_as_index(obj):
+    '''Tries to wrap object if it is one of pandas' index objects.'''
 
-pandas.concat = PandasConcatWrapper
+    objType = type(obj)
 
-class Remapper(wrapt.ObjectProxy):
-    def __init__(self, wrapped):
-        super(Remapper, self).__init__(wrapped)
+    if objType is pd.Index:
+        return True, Index(obj)
 
-    def _self_mapper(self, key):
-        ''' Our remapping method.
-        Originally implemented in C# but some cases were not working correctly and using Py did the trick.
-        This is to improve user experience, they can use Symbol as key and we convert it to string for pandas
-        '''
-        if isinstance(key, Symbol):
-            return str(key.ID)
+    if objType is pd.MultiIndex:
+        result = object.__new__(MultiIndex)
+        result._set_levels(obj.levels, copy=obj.copy, validate=False)
+        result._set_codes(obj.codes, copy=obj.copy, validate=False)
+        result._set_names(obj.names)
+        result.sortorder = obj.sortorder
+        return True, result
 
-        # this is the most normal use case
-        if isinstance(key, str):
-            tupleResult = SymbolCache.TryGetSymbol(key, None)
-            if tupleResult[0]:
-                return str(tupleResult[1].ID)
+    if objType is pdFrozenList:
+        return True, FrozenList(obj)
 
-        # If the key is a tuple, convert the items
-        if isinstance(key, tuple) and 2 >= len(key) >= 1:
-            item0 = self._self_mapper(key[0])
-            return (item0,) if len(key) == 1 else \
-                (item0, self._self_mapper(key[1]))
+    return False, obj
 
-        return key
+def try_wrap_as_pandas(obj):
+    '''Tries to wrap object if it is a pandas' object.'''
 
-    def __contains__(self, key):
-        key = self._self_mapper(key)
-        return self.__wrapped__.__contains__(key)
+    success, obj = try_wrap_as_index(obj)
+    if success:
+        return success, obj
 
-    def __getitem__(self, name):
-        name = self._self_mapper(name)
-        result = self.__wrapped__.__getitem__(name)
+    objType = type(obj)
 
-        if isinstance(result, (pandas.Series, pandas.Index, pandas.DataFrame)):
-            # For these cases we wrap the result too. Can't apply the wrap around all
-            # results because it causes issues in pandas for some of our use cases
-            # specifically pandas timestamp type
-            return Remapper(result)
+    if objType is pd.DataFrame:
+        return True, DataFrame(data=obj)
+
+    if objType is pd.Series:
+        return True, Series(data=obj)
+
+    if objType is tuple:
+        anySuccess = False
+        results = list()
+        for item in obj:
+            success, result = try_wrap_as_pandas(item)
+            anySuccess |= success
+            results.append(result)
+        if anySuccess:
+            return True, tuple(results)
+
+    return False, obj
+
+def try_wrap_resampler(obj, self):
+    '''Tries to wrap object if it is a pandas' Resampler object.'''
+
+    if not isinstance(obj, Resampler):
+        return False, obj
+
+    klass = CreateWrapperClass(type(obj))
+    return True, klass(self, groupby=obj.groupby, kind=obj.kind, axis=obj.axis)
+
+def wrap_function(f):
+    '''Wraps function f with g.
+    Function g converts the args/kwargs to use alternative index keys
+    and the result of the f function call to the wrapper objects
+    '''
+    def g(*args, **kwargs):
+
+        if len(args) > 1:
+            args = mapper(args)
+        if len(kwargs) > 0:
+            kwargs = mapper(kwargs)
+
+        result = f(*args, **kwargs)
+
+        success, result = try_wrap_as_pandas(result)
+        if success:
+            return result
+
+        success, result = try_wrap_resampler(result, args[0])
+        if success:
+            return result
+
+        if isgenerator(result):
+            return ( (k, try_wrap_as_pandas(v)[1]) for k, v in result)
+
         return result
 
-    def __setitem__(self, name, value):
-        name = self._self_mapper(name)
-        return self.__wrapped__.__setitem__(name, value)
+    g.__name__ = f.__name__
+    return g
 
-    def __delitem__(self, name):
-        name = self._self_mapper(name)
-        return self.__wrapped__.__delitem__(name)
+def wrap_special_function(name, cls, fcls, gcls = None):
+    '''Replaces the special function of a given class by g that wraps fcls
+    This is how pandas implements them.
+    gcls represents an alternative for fcls
+    if the keyword argument has 'win_type' key for the Rolling/Window case
+    '''
+    fcls = CreateWrapperClass(fcls)
+    if gcls is not None:
+        gcls = CreateWrapperClass(fcls)
 
-    def __str__(self):
-        return self.__wrapped__.__str__()
+    def g(*args, **kwargs):
+        if kwargs.get('win_type', None):
+            return gcls(*args, **kwargs)
+        return fcls(*args, **kwargs)
+    g.__name__ = name
+    setattr(cls, g.__name__, g)
 
-    def __repr__(self):
-        return self.__wrapped__.__repr__()
+def CreateWrapperClass(cls: type):
+    '''Creates wrapper classes.
+    Members of the original class are wrapped to allow alternative index look-up
+    '''
+    # Define a new class
+    klass = type(f'{cls.__name__}', (cls,) + cls.__bases__, dict(cls.__dict__))
 
-    # we wrap the result and input of 'xs'
-    def xs(self, key, axis=0, level=None, drop_level=True):
-        key = self._self_mapper(key)
-        result = self.__wrapped__.xs(key=key, axis=axis, level=level, drop_level=drop_level)
-        return Remapper(result)
+    def g(self, name):
+        '''Wrap '__getattribute__' to handle indices
+        Only need to wrap columns, index and levels attributes
+        '''
+        attr = object.__getattribute__(self, name)
+        if name in ['columns', 'index', 'levels']:
+            _, attr = try_wrap_as_index(attr)
+        return attr
+    g.__name__ =  '__getattribute__'
+    g.__qualname__ =  g.__name__
+    setattr(klass, g.__name__, g)
 
-    def get(self, key, default=None):
-        key = self._self_mapper(key)
-        return self.__wrapped__.get(key=key, default=default)
+    def wrap_union(f):
+        '''Wraps function f (union) with g.
+        Special case: The union method from index objects needs to
+        receive pandas' index objects to avoid infity recursion.
+        Function g converts the args/kwargs objects to one of pandas index objects
+        and the result of the f function call back to wrapper indexes objects
+        '''
+        def unwrap_index(obj):
+            '''Tries to unwrap object if it is one of this module wrapper's index objects.'''
+            objType = type(obj)
 
-    # we wrap the result of 'unstack'
-    def unstack(self, level=-1, fill_value=None):
-        result = self.__wrapped__.unstack(level=level, fill_value=fill_value)
-        return Remapper(result)
+            if objType is Index:
+                return pd.Index(obj)
 
-    def join(self, other, on=None, how='left', lsuffix='', rsuffix='', sort=False):
-        result = self.__wrapped__.join(other=other, on=on, how=how, lsuffix=lsuffix, rsuffix=rsuffix, sort=sort)
-        return Remapper(result)
+            if objType is MultiIndex:
+                result = object.__new__(pd.MultiIndex)
+                result._set_levels(obj.levels, copy=obj.copy, validate=False)
+                result._set_codes(obj.codes, copy=obj.copy, validate=False)
+                result._set_names(obj.names)
+                result.sortorder = obj.sortorder
+                return result
 
-    def append(self, other, ignore_index=False, verify_integrity=False, sort=None):
-        result = self.__wrapped__.append(other=other, ignore_index=ignore_index, verify_integrity=verify_integrity, sort=sort)
-        return Remapper(result)
+            if objType is FrozenList:
+                return pdFrozenList(obj)
 
-    def merge(self, right, how='inner', on=None, left_on=None, right_on=None, left_index=False, right_index=False, sort=False, suffixes=('_x', '_y'), copy=True, indicator=False, validate=None):
-        result = self.__wrapped__.merge(right=right, how=how, on=on, left_on=left_on, right_on=right_on, left_index=left_index, right_index=right_index, sort=sort, suffixes=suffixes, copy=copy, indicator=indicator, validate=validate)
-        return Remapper(result)
+            return obj
 
-    # we wrap 'loc' to cover the: df.loc['SPY'] case
-    @property
-    def loc(self):
-        return Remapper(self.__wrapped__.loc)
+        def g(*args, **kwargs):
 
-    @property
-    def ix(self):
-        return Remapper(self.__wrapped__.ix)
+            args = tuple([unwrap_index(x) for x in args])
+            result = f(*args, **kwargs)
+            _, result = try_wrap_as_index(result)
+            return result
 
-    @property
-    def iloc(self):
-        return Remapper(self.__wrapped__.iloc)
+        g.__name__ = f.__name__
+        return g
 
-    @property
-    def at(self):
-        return Remapper(self.__wrapped__.at)
+    # We allow the wraopping of slot methods that are not inherited from object
+    # It will include operation methods like __add__ and __contains__
+    allow_list = set(x for x in dir(klass) if x.startswith('__')) - set(dir(object))
 
-    @property
-    def index(self):
-        return Remapper(self.__wrapped__.index)
+    # Wrap class members of the newly created class 
+    for name, member in getmembers(klass):
+        if name.startswith('_') and name not in allow_list:
+            continue
 
-    @property
-    def levels(self):
-        return Remapper(self.__wrapped__.levels)
+        if isfunction(member):
+            if name == 'union':
+                member = wrap_union(member)
+            else:
+                member = wrap_function(member)
+            setattr(klass, name, member)
 
-    # we wrap the following properties so that when 'unstack', 'loc' are called we wrap them
-    @property
-    def open(self):
-        return Remapper(self.__wrapped__.open)
-    @property
-    def high(self):
-        return Remapper(self.__wrapped__.high)
-    @property
-    def close(self):
-        return Remapper(self.__wrapped__.close)
-    @property
-    def low(self):
-        return Remapper(self.__wrapped__.low)
-    @property
-    def lastprice(self):
-        return Remapper(self.__wrapped__.lastprice)
-    @property
-    def volume(self):
-        return Remapper(self.__wrapped__.volume)
-    @property
-    def askopen(self):
-        return Remapper(self.__wrapped__.askopen)
-    @property
-    def askhigh(self):
-        return Remapper(self.__wrapped__.askhigh)
-    @property
-    def asklow(self):
-        return Remapper(self.__wrapped__.asklow)
-    @property
-    def askclose(self):
-        return Remapper(self.__wrapped__.askclose)
-    @property
-    def askprice(self):
-        return Remapper(self.__wrapped__.askprice)
-    @property
-    def asksize(self):
-        return Remapper(self.__wrapped__.asksize)
-    @property
-    def quantity(self):
-        return Remapper(self.__wrapped__.quantity)
-    @property
-    def suspicious(self):
-        return Remapper(self.__wrapped__.suspicious)
-    @property
-    def bidopen(self):
-        return Remapper(self.__wrapped__.bidopen)
-    @property
-    def bidhigh(self):
-        return Remapper(self.__wrapped__.bidhigh)
-    @property
-    def bidlow(self):
-        return Remapper(self.__wrapped__.bidlow)
-    @property
-    def bidclose(self):
-        return Remapper(self.__wrapped__.bidclose)
-    @property
-    def bidprice(self):
-        return Remapper(self.__wrapped__.bidprice)
-    @property
-    def bidsize(self):
-        return Remapper(self.__wrapped__.bidsize)
-    @property
-    def exchange(self):
-        return Remapper(self.__wrapped__.exchange)
-    @property
-    def openinterest(self):
-        return Remapper(self.__wrapped__.openinterest)
-").GetAttr("Remapper");
+        elif type(member) is property:
+            if type(member.fget) is partial:
+                func = CreateWrapperClass(member.fget.func)
+                fget = partial(func, name)
+            else:
+                fget = wrap_function(member.fget)
+            member = property(fget, member.fset, member.fdel, member.__doc__)
+            setattr(klass, name, member)
+
+    return klass
+
+FrozenList = CreateWrapperClass(pdFrozenList)
+Index = CreateWrapperClass(pd.Index)
+MultiIndex = CreateWrapperClass(pd.MultiIndex)
+Series = CreateWrapperClass(pd.Series)
+DataFrame = CreateWrapperClass(pd.DataFrame)
+
+wrap_special_function('groupby', Series, SeriesGroupBy)
+wrap_special_function('groupby', DataFrame, DataFrameGroupBy)
+wrap_special_function('ewm', Series, EWM)
+wrap_special_function('ewm', DataFrame, EWM)
+wrap_special_function('expanding', Series, Expanding)
+wrap_special_function('expanding', DataFrame, Expanding)
+wrap_special_function('rolling', Series, Rolling, Window)
+wrap_special_function('rolling', DataFrame, Rolling, Window)
+
+setattr(modules[__name__], 'concat', wrap_function(pd.concat))");
                 }
             }
 
@@ -498,7 +540,7 @@ class Remapper(wrapt.ObjectProxy):
                     pyDict.SetItem(kvp.Key, _pandas.Series(values, index));
                 }
                 _series.Clear();
-                return ApplySymbolMapper(_pandas.DataFrame(pyDict));
+                return _pandas.DataFrame(pyDict);
             }
         }
 
@@ -535,14 +577,6 @@ class Remapper(wrapt.ObjectProxy):
             return baseType.IsAssignableFrom(type)
                 ? baseType.GetProperties().Select(x => x.Name.ToLowerInvariant())
                 : Enumerable.Empty<string>();
-        }
-
-        /// <summary>
-        /// Will wrap the provided pandas data frame using the <see cref="_remapperFactory"/>
-        /// </summary>
-        internal static dynamic ApplySymbolMapper(dynamic pandasDataFrame)
-        {
-            return _remapperFactory.Invoke(pandasDataFrame);
         }
     }
 }

--- a/Tests/Python/PandasConverterTests.BackwardsCompatibility.cs
+++ b/Tests/Python/PandasConverterTests.BackwardsCompatibility.cs
@@ -1,0 +1,355 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Python;
+using QuantConnect.Securities;
+using QuantConnect.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Tests.Python
+{
+    [TestFixture]
+    public partial class PandasConverterTests
+    {
+        [Test, TestCaseSource(nameof(TestDataFrameNonExceptionFunctions))]
+        public void BackwardsCompatibilityDataFrameDataFrameNonExceptionFunctions(string method, string index, bool cache)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(df, symbol):
+    df = df.lastprice.unstack(level=0){method}").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [Test, TestCaseSource(nameof(TestDataFrameParameterlessFunctions))]
+        public void BackwardsCompatibilityDataFrameParameterlessFunctions(string method, string index, bool cache)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(df, symbol):
+    df = df.lastprice.unstack(level=0){method}
+    # If not DataFrame, return
+    if not hasattr(df, 'columns'):
+        return
+    if df.iloc[-1][{index}] is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [Test, TestCaseSource(nameof(TestDataFrameOtherParameterFunctions))]
+        public void BackwardsCompatibilityDataFrameOtherParameterFunctions(string method, string index, bool cache)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(df, other, symbol):
+    df = df{method}
+    df = df.lastprice.unstack(level=0)
+    # If not DataFrame, return
+    if not hasattr(df, 'columns'):
+        return
+    if df.iloc[-1][{index}] is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [Test, TestCaseSource(nameof(TestSeriesNonExceptionFunctions))]
+        public void BackwardsCompatibilitySeriesNonExceptionFunctions(string method, string index, bool cache)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(df, symbol):
+    series = df.lastprice
+    series = series{method}").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [Test, TestCaseSource(nameof(TestSeriesParameterlessFunctions))]
+        public void BackwardsCompatibilitySeriesParameterlessFunctions(string method, string index, bool cache)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(df, symbol):
+    series = df.lastprice
+    series = series{method}
+    # If not Series, return
+    if not hasattr(series, 'index') or type(series) is tuple:
+        return
+    if series.loc[{index}].iloc[-1] is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [Test, TestCaseSource(nameof(TestSeriesOtherParameterFunctions))]
+        public void BackwardsCompatibilitySeriesOtherParameterFunctions(string method, string index, bool cache)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(df, other, symbol):
+    series, other = other.lastprice, df.lastprice
+    series = series{method}
+    # If not Series, return
+    if not hasattr(series, 'index') or type(series) is tuple:
+        return
+    if series.loc[{index}].iloc[-1] is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        private static TestCaseData[] TestDataFrameNonExceptionFunctions
+        {
+            get
+            {
+                var functions = new[]
+                {
+                    ".agg('mean', axis=0)",
+                    ".aggregate('mean', axis=0)",
+                    ".clip(100, 200)",
+                    ".clip_lower(100)",
+                    ".clip_upper(200)",
+                    ".fillna(value=999)",
+                    ".first('2S')",
+                    ".isin([100])",
+                    ".last('2S')",
+                    ".melt()"
+                }
+                .SelectMany(x => new[]
+                {
+                    new TestCaseData(x, "'SPY'", true),
+                    new TestCaseData(x, "symbol", false),
+                    new TestCaseData(x, "str(symbol.ID)", false)
+                }).ToList();
+
+                functions.AddRange(_parameterlessFunctions["DataFrame"]);
+                return functions.ToArray();
+            }
+        }
+
+        private static TestCaseData[] TestSeriesNonExceptionFunctions
+        {
+            get
+            {
+                var functions = new[]
+                {
+                    ".add_suffix('lean')",
+                    ".add_prefix('lean')",
+                    ".agg('mean', axis=0)",
+                    ".aggregate('mean', axis=0)",
+                    ".clip(100, 200)",
+                    ".clip_lower(100)",
+                    ".clip_upper(200)",
+                    ".fillna(value=999)",
+                    ".isin([100])",
+                    ".searchsorted(200)",
+                    ".value_counts()"
+                }
+                .SelectMany(x => new[]
+                {
+                    new TestCaseData(x, "'SPY'", true),
+                    new TestCaseData(x, "symbol", false),
+                    new TestCaseData(x, "str(symbol.ID)", false)
+                })
+                .ToList();
+
+                functions.AddRange(_parameterlessFunctions["Series"]);
+                return functions.ToArray();
+            }
+        }
+
+        private static TestCaseData[] TestDataFrameParameterlessFunctions => _parameterlessFunctions["DataFrameParameterless"];
+
+        private static TestCaseData[] TestSeriesParameterlessFunctions => _parameterlessFunctions["SeriesParameterless"];
+
+        private static TestCaseData[] TestDataFrameOtherParameterFunctions
+        {
+            get
+            {
+                var functions = new[]
+                {
+                    "+",
+                    "-",
+                    "/",
+                    "*",
+                    "%",
+                    "**",
+                    "//"
+                }
+                .SelectMany(x => new[]
+                {
+                    new TestCaseData($" {x} other", "'SPY'", true),
+                    new TestCaseData($" {x} other", "symbol", false),
+                    new TestCaseData($" {x} other", "str(symbol.ID)", false)
+                }).ToList();
+
+                functions.AddRange(_parameterlessFunctions["DataFrameOtherParameter"]);
+                return functions.ToArray();
+            }
+        }
+
+        private static TestCaseData[] TestSeriesOtherParameterFunctions
+        {
+            get
+            {
+                var functions = new[]
+                {
+                    "+",
+                    "-",
+                    "/",
+                    "*",
+                    "%",
+                    "**",
+                    "//"
+                }
+                .SelectMany(x => new[]
+                {
+                    new TestCaseData($" {x} other", "'SPY'", true),
+                    new TestCaseData($" {x} other", "symbol", false),
+                    new TestCaseData($" {x} other", "str(symbol.ID)", false)
+                }).ToList();
+
+                functions.AddRange(_parameterlessFunctions["SeriesOtherParameter"]);
+                return functions.ToArray();
+            }
+        }
+
+        private static Dictionary<string, TestCaseData[]> _parameterlessFunctions = GetParameterlessFunctions();
+
+        private static Dictionary<string, TestCaseData[]> GetParameterlessFunctions()
+        {
+            // Initialize the Python engine and begin allow thread
+            PythonInitializer.Initialize();
+
+            var functionsByType = new Dictionary<string, TestCaseData[]>();
+
+            using (Py.GIL())
+            {
+                var module = PythonEngine.ModuleFromString("Test",
+                    @"import pandas
+from inspect import getmembers, isfunction, signature
+
+skipped = [ 'boxplot', 'hist', 'plot',        # <- Graphics
+    'agg', 'aggregate', 'align', 'bool','combine', 'corrwith', 'dot', 'drop',
+    'equals', 'ewm', 'fillna', 'filter', 'groupby', 'join', 'mask', 'melt',
+    'pivot', 'pivot_table', 'reindex_like', 'rename', 'reset_index', 'select_dtypes',
+    'slice_shift', 'swaplevel', 'to_clipboard', 'to_excel', 'to_feather', 'to_gbq',
+    'to_hdf', 'to_list', 'tolist', 'to_parquet', 'to_period', 'to_pickle', 'to_sql',
+    'to_stata', 'to_timestamp', 'to_xarray', 'tshift', 'update', 'value_counts', 'where']
+
+def getSimpleExceptionTestFunctions(cls):
+    functions = [ 'describe', 'get_dtype_counts', 'get_ftype_counts', 'mode' ]
+    for name, member in getmembers(cls):
+        if isfunction(member) and name.startswith('to') and name not in skipped:
+            functions.append(name)
+    return functions
+
+DataFrame = getSimpleExceptionTestFunctions(pandas.DataFrame)
+Series = getSimpleExceptionTestFunctions(pandas.Series)
+skipped += set(DataFrame + Series)
+
+def getParameterlessFunctions(cls):
+    functions = list()
+    for name, member in getmembers(cls):
+        if isfunction(member) and not name.startswith('_') and name not in skipped:
+            parameters = signature(member).parameters
+            count = 0
+            for parameter in parameters.values():
+                if parameter.default is parameter.empty:
+                    count += 1
+                else:
+                    break
+            if count < 2:
+                functions.append(name)
+    return functions
+
+def getOtherParameterFunctions(cls):
+    functions = list()
+    for name, member in getmembers(pandas.DataFrame):
+        if isfunction(member) and not name.startswith('_') and name not in skipped:
+            parameters = signature(member).parameters
+            for parameter in parameters.values():
+                if parameter.name == 'other':
+                    functions.append(name)
+                    break
+    return functions
+
+DataFrameParameterless = getParameterlessFunctions(pandas.DataFrame)
+SeriesParameterless = getParameterlessFunctions(pandas.Series)
+DataFrameOtherParameter = getOtherParameterFunctions(pandas.DataFrame)
+SeriesOtherParameter = getOtherParameterFunctions(pandas.Series)
+");
+                Func<string, string, TestCaseData[]> converter = (s, p) =>
+                {
+                    var list = (List<string>)module.GetAttr(s).AsManagedObject(typeof(List<string>));
+                    return list.SelectMany(x => new[]
+                    {
+                        new TestCaseData($".{x}{p}", "'SPY'", true),
+                        new TestCaseData($".{x}{p}", "symbol", false),
+                        new TestCaseData($".{x}{p}", "str(symbol.ID)", false)
+                    }
+                    ).ToArray();
+                };
+
+                functionsByType.Add("DataFrame", converter("DataFrame", "()"));
+                functionsByType.Add("Series", converter("Series", "()"));
+                functionsByType.Add("DataFrameParameterless", converter("DataFrameParameterless", "()"));
+                functionsByType.Add("SeriesParameterless", converter("SeriesParameterless", "()"));
+                functionsByType.Add("DataFrameOtherParameter", converter("DataFrameOtherParameter", "(other)"));
+                functionsByType.Add("SeriesOtherParameter", converter("SeriesOtherParameter", "(other)"));
+            }
+
+            return functionsByType;
+        }
+    }
+}

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -33,8 +33,10 @@ using QuantConnect.Util;
 namespace QuantConnect.Tests.Python
 {
     [TestFixture]
-    public class PandasConverterTests
+    public partial class PandasConverterTests
     {
+        private PandasConverter _converter = new PandasConverter();
+
         [SetUp]
         public void Setup()
         {
@@ -184,7 +186,136 @@ namespace QuantConnect.Tests.Python
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
-        public void BackwardsCompatibilityDataFrame_append(string index, bool cache = false)
+        public void BackwardsCompatibilityDataFrame_add_prefix(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.add_prefix('price_')['price_lastprice'].unstack(level=0)
+    data = data.iloc[-1][{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_add_suffix(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.add_suffix('_tick')['lastprice_tick'].unstack(level=0)
+    data = data.iloc[-1][{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_align(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, other, symbol):
+    data = dataFrame.lastprice.unstack(level=0)
+    other = other.lastprice.unstack(level=0)
+    data, other = data.align(other, axis=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_apply(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).apply(np.sqrt)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_applymap(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).applymap(lambda x: x*2)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_asfreq(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).asfreq(freq='30S')
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_asof(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
@@ -193,14 +324,56 @@ namespace QuantConnect.Tests.Python
                 dynamic test = PythonEngine.ModuleFromString("testModule",
                     $@"
 import pandas as pd
-
-def Test(dataFrame, dataFrame2, symbol):
-    newDataFrame = dataFrame.append(dataFrame2)
-    data = newDataFrame['lastprice'].unstack(level=0).ix[-1][{index}]
+def Test(dataFrame, symbol):
+    idx = pd.DatetimeIndex(['2018-02-27 09:03:30'])
+    data = dataFrame.lastprice.unstack(level=0).asof(idx)
+    data = data[{index}]
     if data is 0:
         raise Exception('Data is zero')").GetAttr("Test");
 
-                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_assign(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.assign(tmp=lambda x: x.lastprice * 1.1)['tmp'].unstack(level=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_astype(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).astype('float16')
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
             }
         }
 
@@ -225,6 +398,112 @@ def Test(dataFrame, symbol):
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_at_time(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).at_time('04:00')
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_axes(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    axes = dataFrame.axes[0]
+    if {index} not in axes.levels[0]:
+        raise ValueError('SPY was not found')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_between_time(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).between_time('02:00', '06:00')
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_columns(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    columns = dataFrame.lastprice.unstack(level=0).columns
+    if {index} not in columns:
+        raise ValueError('SPY was not found')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_combine(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, other, symbol):
+    dataFrame = dataFrame.lastprice.unstack(level=0)
+    other = other.lastprice.unstack(level=0)
+    data = dataFrame.combine(other, np.minimum)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_concat(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
@@ -234,7 +513,6 @@ def Test(dataFrame, symbol):
                 dynamic test = PythonEngine.ModuleFromString("testModule",
                     $@"
 import pandas as pd
-
 def Test(dataFrame, dataFrame2, symbol):
     newDataFrame = pd.concat([dataFrame, dataFrame2])
     data = newDataFrame['lastprice'].unstack(level=0).ix[-1][{index}]
@@ -242,6 +520,240 @@ def Test(dataFrame, dataFrame2, symbol):
         raise Exception('Data is zero')").GetAttr("Test");
 
                 Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_corrwith(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, other, symbol):
+    other = other.lastprice.unstack(level=0)
+    data = dataFrame.lastprice.unstack(level=0).corrwith(other)
+    data = data.loc[{index}]
+    if not np.isnan(data):
+        raise Exception('Data should be NaN')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_drop(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.drop(columns=['exchange']).lastprice.unstack(level=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_droplevel(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.droplevel('time').lastprice
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_dtypes(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).dtypes
+    data = data.loc[{index}]
+    if data != np.float64:
+        raise Exception('Data type is ' + str(data))").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_eval(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.eval('tmp=lastprice * 1.1')['tmp'].unstack(level=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_equals(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, other, symbol):
+    if not dataFrame.equals(other):
+        raise Exception('Dataframe are not equal')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_ewm(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0)
+    data = data.ewm(com=0.5).mean()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_expanding(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0)
+    data = data.expanding(2).sum()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_explode(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.explode('lastprice').lastprice.unstack(level=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_filter(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.filter(items=['lastprice']).lastprice.unstack(level=0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_ftypes(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0).ftypes
+    data = data.loc[{index}]
+    if str(data) != 'float64:dense':
+        raise Exception('Data type is ' + str(data))").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
             }
         }
 
@@ -286,6 +798,71 @@ def Test(dataFrame, symbol):
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_get_value_index(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.get_value(({index},), 'lastprice')
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_get_value_column(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0)
+    idx = data.index[0]
+    data = data.get_value(idx, {index})
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_groupby(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import pandas as pd
+def Test(df, other, symbol):
+    df = pd.concat([df, other])
+    df = df.groupby(level=0).mean()
+    data = df.lastprice.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), GetTestDataFrame(Symbols.AAPL, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_iloc(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
@@ -306,6 +883,27 @@ def Test(dataFrame, symbol):
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_insert(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(level=0)
+    data.insert(0, 'nine', 999)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_index_levels_contains(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
@@ -317,6 +915,54 @@ def Test(dataFrame, symbol):
 def Test(dataFrame, symbol):
     if {index} not in dataFrame.index.levels[0]:
         raise ValueError('SPY was not found')").GetAttr("Test");
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+
+        [TestCase("items", "'SPY'", true)]
+        [TestCase("items", "symbol")]
+        [TestCase("items", "str(symbol.ID)")]
+        [TestCase("iteritems", "'SPY'", true)]
+        [TestCase("iteritems", "symbol")]
+        [TestCase("iteritems", "str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_items(string method, string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    for index, data in dataFrame.{method}():
+        pass
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_iterrows(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    for index, data in dataFrame.lastprice.unstack(level=0).iterrows():
+        pass
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
                 Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
             }
         }
@@ -352,8 +998,6 @@ def Test(dataFrame, symbol):
             {
                 dynamic test = PythonEngine.ModuleFromString("testModule",
                     $@"
-import pandas as pd
-
 def Test(dataFrame, dataFrame2, symbol):
     newDataFrame = dataFrame.join(dataFrame2, lsuffix='_')
     data = newDataFrame['lastprice'].unstack(level=0).ix[-1][{index}]
@@ -441,7 +1085,29 @@ def Test(dataFrame, symbol):
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
-        public void BackwardsCompatibilityDataFrame_merge(string index, bool cache = false)
+        public void BackwardsCompatibilityDataFrame_mask(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(0)
+    data = data.mask(data > 0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_pivot_table(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
@@ -450,7 +1116,29 @@ def Test(dataFrame, symbol):
                 dynamic test = PythonEngine.ModuleFromString("testModule",
                     $@"
 import pandas as pd
+def Test(dataFrame, symbol):
+    df = dataFrame.reset_index()
+    table = pd.pivot_table(df, index=['symbol', 'time'])
+    data = table.lastprice.unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
 
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_merge(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
 def Test(dataFrame, dataFrame2, symbol):
     newDataFrame = dataFrame.merge(dataFrame2, on='symbol', how='outer')
     data = newDataFrame.loc[{index}]
@@ -461,10 +1149,13 @@ def Test(dataFrame, dataFrame2, symbol):
             }
         }
 
-        [TestCase("'SPY'", true)]
-        [TestCase("symbol")]
-        [TestCase("str(symbol.ID)")]
-        public void BackwardsCompatibilityDataFrame_unstack(string index, bool cache = false)
+        [TestCase("nlargest", "'SPY'", true)]
+        [TestCase("nlargest", "symbol")]
+        [TestCase("nlargest", "str(symbol.ID)")]
+        [TestCase("nsmallest", "'SPY'", true)]
+        [TestCase("nsmallest", "symbol")]
+        [TestCase("nsmallest", "str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_nlarg_smallest(string method, string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
@@ -473,8 +1164,463 @@ def Test(dataFrame, dataFrame2, symbol):
                 dynamic test = PythonEngine.ModuleFromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
-    df2 = dataFrame.lastprice.unstack(level=0)
-    data = df2[{index}]").GetAttr("Test");
+    data = dataFrame.{method}(3, 'lastprice')
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_pipe(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import pandas as pd
+def Test(dataFrame, other, symbol):
+    def mean_by_group(dataframe, level):
+        return dataframe.groupby(level=level).mean()
+
+    df = pd.concat([dataFrame, other])
+    data = df.pipe(mean_by_group, level=0)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), GetTestDataFrame(Symbols.AAPL, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_pop(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.pop('lastprice')
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_query(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.query('lastprice > 100').lastprice.unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_reindex_like(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, other, symbol):
+    data = other.reindex_like(dataFrame)
+    data = data.lastprice.unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_rename(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            var rename = "columns={'lastprice': 'price', 'B': 'c'}";
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.rename({rename})['price'].unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_reorder_levels(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.reorder_levels(['time', 'symbol']).lastprice.unstack(1)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_resample(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(0) 
+    data = data.resample('2S').sum()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_reset_index(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(0).reset_index('time')
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_rolling(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.rolling(2).sum()
+    data = data.lastprice.unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_select_dtypes(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.select_dtypes(exclude=['int']).lastprice.unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_set_value(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    idx = dataFrame.first_valid_index()
+    data = dataFrame.set_value(idx, 'lastprice', 100).lastprice.unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 3), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_slice_shift(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.slice_shift().lastprice.unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_sort_values(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.sort_values(by=['lastprice']).lastprice.unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_swapaxes(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(0).swapaxes('index', 'columns')
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_swaplevel(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.swaplevel().lastprice.unstack(1)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_take(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.take([0, 3]).lastprice.unstack(0)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_transform(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.unstack(0).transform(np.sqrt)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_T(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.T.iloc[0]
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_transpose(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.transpose().iloc[0]
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_tshift(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+from datetime import timedelta as d
+def Test(dataFrame, symbol):
+    series = dataFrame.droplevel(0)
+    data = series.tshift(freq=d(1))").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_tz_localize_convert(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.tz_localize('UTC', level=1)
+    data = data.tz_convert('America/New_York', level=1)
+    data = data.lastprice.unstack(0)[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
 
                 Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
             }
@@ -536,6 +1682,53 @@ def Test(dataFrame, symbol):
         raise Exception('Data is empty')").GetAttr("Test");
 
                 Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_update(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            var other = "{'lastprice': ['d', 'e', 'f']}";
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import pandas as pd
+def Test(dataFrame, symbol):
+    other = pd.DataFrame({other}, index=dataFrame.index)
+    dataFrame.update(other)
+    data = dataFrame.lastprice.unstack(0)[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 3), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_where(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    dataFrame = dataFrame.lastprice.unstack(0)
+    data = dataFrame.where(dataFrame > 167)
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 3), Symbols.SPY));
             }
         }
 
@@ -606,6 +1799,962 @@ def Test(dataFrame, symbol):
                 Assert.False(result.Contains("Remapper"));
             }
         }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_align(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, other, symbol):
+    data = dataFrame.lastprice
+    other = other.lastprice
+    data, other = data.align(other, axis=0)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_apply(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.apply(np.sqrt)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_asfreq(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice.droplevel(0) 
+    data = series.asfreq(freq='30S')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_asof(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import pandas as pd
+def Test(dataFrame, symbol):
+    idx = pd.DatetimeIndex(['2018-02-27 09:03:30'])
+    series = dataFrame.lastprice.droplevel(0)
+    data = series.asof(idx)").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_astype(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.astype('float16')
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_at_time(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice.droplevel(0) 
+    data = series.at_time('04:00')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_between(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.between(100, 200)").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_between_time(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice.droplevel(0) 
+    data = series.between_time('02:00', '06:00')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_combine(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, other, symbol):
+    series = dataFrame.lastprice
+    other = other.lastprice
+    data = series.combine(other, np.minimum)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_drop(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    dt = series.first_valid_index()[1]
+    data = series.drop(dt, level=1)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 2), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_droplevel(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.droplevel('time')
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_equals(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, other, symbol):
+    series = dataFrame.lastprice
+    other = other.lastprice
+    if not series.equals(other):
+        raise Exception('Dataframe are not equal')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_ewm(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.ewm(com=0.5).mean()
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_expanding(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.expanding(2).sum()
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_filter(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.filter(like='04:00')
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_first(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice.droplevel(0) 
+    data = series.first('2S')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_get(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.get({index})
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_get_value(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    dt = series.first_valid_index()[1]
+    data = series.get_value(({index}, dt))
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_groupby(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import pandas as pd
+def Test(df, other, symbol):
+    series = pd.concat([df, other]).lastprice
+    data = series.groupby(level=0).mean()
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), GetTestDataFrame(Symbols.AAPL, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_last(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice.droplevel(0) 
+    data = series.last('2S')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_map(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            var map = "map({167: 100})";
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.{map}
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_mask(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.mask(series > 0)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_pipe(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import pandas as pd
+def Test(dataFrame, other, symbol):
+    def mean_by_group(dataframe, level):
+        return dataframe.groupby(level=level).mean()
+
+    df = pd.concat([dataFrame, other]).lastprice
+    data = df.pipe(mean_by_group, level=0)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), GetTestDataFrame(Symbols.AAPL, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_pop(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    data = dataFrame.lastprice.pop({index})
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_reindex_like(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, other, symbol):
+    series = dataFrame.lastprice
+    other = other.lastprice
+    data = other.reindex_like(series)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), GetTestDataFrame(Symbols.AAPL), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_rename(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.rename('price')
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_repeat(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.repeat(3)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_reorder_levels(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.reorder_levels(['time', 'symbol'])
+    data = data.unstack(1)[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_resample(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.resample('2S', level=1).mean()").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_reset_index(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.reset_index('time')
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_rolling(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.rolling(2).sum()
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_set_value(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    idx = series.first_valid_index()
+    data = series.set_value(idx, 100)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_slice_shift(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.slice_shift()
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_swapaxes(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.swapaxes('index', 'index')
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_swaplevel(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.swaplevel()
+    data = data.unstack(0).loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_take(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.take([0, 3])
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_transform(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import numpy as np
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.transform([np.sqrt, np.exp])
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_T(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.T
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_transpose(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.transpose()
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_tshift(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+from datetime import timedelta as d
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice.droplevel(0)
+    data = series.tshift(freq=d(1))").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_tz_localize_convert(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.tz_localize('UTC', level=1)
+    data = data.tz_convert('America/New_York', level=1)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_update(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+import pandas as pd
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    other = pd.Series(['d', 'e', 'f'], index=series.index)
+    series.update(other)
+    data = series.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 3), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_where(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.where(series > 167)
+    data = data.loc[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 3), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilitySeries_xs(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    series = dataFrame.lastprice
+    data = series.xs({index})").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY), Symbols.SPY));
+            }
+        }
+
 
         [Test]
         public void NotBackwardsCompatibilityDataFrame_index_levels_contains_ticker_notInCache()
@@ -934,7 +3083,7 @@ def Test(dataFrame, symbol):
             }
         }
 
-        private static  object[] SpotMarketCases => LeanDataReaderTests.SpotMarketCases;
+        private static object[] SpotMarketCases => LeanDataReaderTests.SpotMarketCases;
         private static object[] OptionAndFuturesCases => LeanDataReaderTests.OptionAndFuturesCases;
 
         [Test, TestCaseSource(nameof(SpotMarketCases))]
@@ -1034,14 +3183,13 @@ def Test(dataFrame, symbol):
             );
         }
 
-        private dynamic GetTestDataFrame(Symbol symbol)
+        private dynamic GetTestDataFrame(Symbol symbol, int count = 1)
         {
-            var converter = new PandasConverter();
             var rawBars = Enumerable
-                .Range(0, 1)
-                .Select(i => new Tick(symbol, $"1440{i:D2}00,167{i:D2}00,1{i:D2},T,T,0", new DateTime(2013, 10, 7)))
+                .Range(0, count)
+                .Select(i => new Tick(symbol, $"144{i:D2}000,167{i:D2}00,1{i:D2},T,T,0", new DateTime(2013, 10, 7)))
                 .ToArray();
-            return converter.GetDataFrame(rawBars);
+            return _converter.GetDataFrame(rawBars);
         }
 
         internal class SubTradeBar : TradeBar

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -872,7 +872,7 @@ def Test(df, other, symbol):
                 dynamic test = PythonEngine.ModuleFromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
-    data = dataFrame['lastprice'].unstack(level=0).ix[-1][{index}]
+    data = dataFrame['lastprice'].unstack(level=0).iloc[-1][{index}]
     if data is 0:
         raise Exception('Data is zero')").GetAttr("Test");
 
@@ -979,7 +979,7 @@ def Test(dataFrame, symbol):
                 dynamic test = PythonEngine.ModuleFromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
-    data = dataFrame['lastprice'].unstack(level=0).iloc[-1][{index}]
+    data = dataFrame['lastprice'].unstack(level=0).ix[-1][{index}]
     if data is 0:
         raise Exception('Data is zero')").GetAttr("Test");
 

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -657,6 +657,7 @@
     <Compile Include="Messaging\StreamingMessageHandlerTests.cs" />
     <Compile Include="Python\AlgorithmPythonWrapperTests.cs" />
     <Compile Include="Python\MethodOverloadTests.cs" />
+    <Compile Include="Python\PandasConverterTests.BackwardsCompatibility.cs" />
     <Compile Include="Python\PortfolioCustomModelTests.cs" />
     <Compile Include="Python\PythonPackagesTests.cs" />
     <Compile Include="Python\PythonSliceGetByTypeTest.cs" />


### PR DESCRIPTION
#### Description
In this implementation, we dynamically create new classes that wrap key functions and properties. The wrappers will map/convert any parameters that are convertible to the string representation of Symbol.ID before they are used by the original function/property.

#### Related Issue
Closes #4284 

#### Motivation and Context
Improve user experience by providing a reliable way to access variables of pandas.DataFrame that are created by Historical data requests by Symbol object or its Ticker.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
New unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`