### PR TITLE
Adds Style Property to OptionContract

### DIFF
--- a/Common/Data/Market/OptionContract.cs
+++ b/Common/Data/Market/OptionContract.cs
@@ -58,6 +58,11 @@ namespace QuantConnect.Data.Market
         public OptionRight Right => Symbol.ID.OptionRight;
 
         /// <summary>
+        /// Gets the option style
+        /// </summary>
+        public OptionStyle Stype => Symbol.ID.OptionStyle;
+
+        /// <summary>
         /// Gets the theoretical price of this option contract as computed by the <see cref="IOptionPriceModel"/>
         /// </summary>
         public decimal TheoreticalPrice => _optionPriceModelResult.Value.TheoreticalPrice;


### PR DESCRIPTION
#### Description
The information on the option style type was not present in `OptionContract` object.

#### Motivation and Context
Other option information properties can be accessed directly at the `OptionContract` object while OptionStyle can not. I can be in the `Option` object.

#### Requires Documentation Change
Yes. Add the new property in `Option` section. 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`