### PR TITLE
Fixes Second, Tick Resolution history requests for Alpaca

### DIFF
--- a/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
+++ b/Tests/Brokerages/Alpaca/AlpacaBrokerageHistoryProviderTests.cs
@@ -38,8 +38,10 @@ namespace QuantConnect.Tests.Brokerages.Alpaca
                 return new[]
                 {
                     // valid parameters
-                    new TestCaseData(aapl, Resolution.Tick, TimeSpan.FromMinutes(15), false),
-                    new TestCaseData(aapl, Resolution.Second, TimeSpan.FromMinutes(15), false),
+                    // Setting TimeSpan to 18 hours ensures that the market is open when running
+                    // the test during weekdays
+                    new TestCaseData(aapl, Resolution.Tick, TimeSpan.FromHours(18), false),
+                    new TestCaseData(aapl, Resolution.Second, TimeSpan.FromHours(18), false),
                     new TestCaseData(aapl, Resolution.Minute, Time.OneDay, false),
                     new TestCaseData(aapl, Resolution.Hour, Time.OneDay, false),
                     new TestCaseData(aapl, Resolution.Daily, TimeSpan.FromDays(30), false),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fixes history requests with resolutions greater than Minute. Previously, the request would return 0 data points when deploying a live Alpaca instance (non-QC cloud).
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes bug
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran algorithm from master requesting ticks w/ various History methods, and received no data.
AlpacaBrokerageHistoryProviderTests were failing, they're now passing.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
