### PR TITLE
Fixes issue in Report project where decimal.MaxValue made Json.NET deserialization fail

### DIFF
--- a/Report/NullResultValueTypeJsonConverter.cs
+++ b/Report/NullResultValueTypeJsonConverter.cs
@@ -28,6 +28,16 @@ namespace QuantConnect.Report
     public class NullResultValueTypeJsonConverter<T> : JsonConverter
         where T : Result
     {
+        private JsonSerializerSettings _settings;
+
+        public NullResultValueTypeJsonConverter()
+        {
+            _settings = new JsonSerializerSettings
+            {
+                Converters = new List<JsonConverter> { new OrderTypeNormalizingJsonConverter() },
+                FloatParseHandling = FloatParseHandling.Decimal
+            };
+        }
         public override bool CanConvert(Type objectType)
         {
             return true;
@@ -60,7 +70,7 @@ namespace QuantConnect.Report
             // Deserialize with OrderJsonConverter, otherwise it will fail. We convert the token back
             // to its JSON representation and use the `JsonConvert.DeserializeObject<T>(...)` method instead
             // of using `token.ToObject<T>()` since it can be provided a JsonConverter in its arguments.
-            return JsonConvert.DeserializeObject<T>(token.ToString(), new OrderTypeNormalizingJsonConverter());
+            return JsonConvert.DeserializeObject<T>(token.ToString(), _settings);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/Report/Program.cs
+++ b/Report/Program.cs
@@ -48,8 +48,12 @@ namespace QuantConnect.Report
 
             // Parse content from source files into result objects
             Log.Trace($"QuantConnect.Report.Main(): Parsing source files...{backtestDataFile}, {liveDataFile}");
-            var backtestConverter = new NullResultValueTypeJsonConverter<BacktestResult>();
-            var backtest = JsonConvert.DeserializeObject<BacktestResult>(File.ReadAllText(backtestDataFile), backtestConverter);
+            var backtestSettings = new JsonSerializerSettings
+            {
+                Converters = new List<JsonConverter> { new NullResultValueTypeJsonConverter<BacktestResult>() },
+                FloatParseHandling = FloatParseHandling.Decimal
+            };
+            var backtest = JsonConvert.DeserializeObject<BacktestResult>(File.ReadAllText(backtestDataFile), backtestSettings);
 
             LiveResult live = null;
             if (liveDataFile != string.Empty)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fixes application crash when deserializing a very large decimal (decimal.MaxValue)
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4424 - Partial fix
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Processed previously failing report.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
