### PR TITLE
Fixes Typo OptionContract.Style

### DIFF
--- a/Common/Data/Market/OptionContract.cs
+++ b/Common/Data/Market/OptionContract.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// Gets the option style
         /// </summary>
-        public OptionStyle Stype => Symbol.ID.OptionStyle;
+        public OptionStyle Style => Symbol.ID.OptionStyle;
 
         /// <summary>
         /// Gets the theoretical price of this option contract as computed by the <see cref="IOptionPriceModel"/>


### PR DESCRIPTION
#### Description
Correct typo in `OptionContract.Style`.

#### Related Issue
Ref.: #4427

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`