### PR TITLE
PandasData Speed Improvement

### DIFF
--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -294,6 +294,8 @@ wrap_special_function('expanding', DataFrame, Expanding)
 wrap_special_function('rolling', Series, Rolling, Window)
 wrap_special_function('rolling', DataFrame, Rolling, Window)
 
+CreateSeries = pd.Series
+
 setattr(modules[__name__], 'concat', wrap_function(pd.concat))");
                 }
             }
@@ -537,9 +539,18 @@ setattr(modules[__name__], 'concat', wrap_function(pd.concat))");
                         indexCache[kvp.Value.Item1] = index;
                     }
 
-                    pyDict.SetItem(kvp.Key, _pandas.Series(values, index));
+                    // Adds pandas.Series value keyed by the column name
+                    // CreateSeries will create an original pandas.Series
+                    // We are not using the wrapper class to avoid unnecessary and expensive
+                    // index wrapping operations when the Series are packed into a DataFrame
+                    pyDict.SetItem(kvp.Key, _pandas.CreateSeries(values, index));
                 }
                 _series.Clear();
+
+                // Create a DataFrame with wrapper class.
+                // This is the starting point. The types of all DataFrame and Series that result from any operation will
+                // be wrapper classes. Index and MultiIndex will be converted when required by index operations such as 
+                // stack, unstack, merge, union, etc.
                 return _pandas.DataFrame(pyDict);
             }
         }


### PR DESCRIPTION
#### Description
Use the original `pandas.Series` to create `Series` objects before `DataFrame` (wrapper version) creation.
It improves the speed because it avoids unnecessary and expensive index wrapping operations of the `DataFrame` creation.

#### Related Issue
Ref: #4284 #4422

#### Motivation and Context
Need 4 Speed.

#### How Has This Been Tested?
Using HistoryRequestBenchmark:
master:
`(347.19 + 339.13 + 351.56) / 3 = 345.96 secs`
This PR:
`(242.44 + 242.92 + 248.16) / 3 = 244.51 secs` 
   **29.3% faster**: `1 - 244.51 / 345.96 = 0.293`
Before #4422:
`(200.98 + 215.96 + 217.62) / 3 = 211.52 secs`
   **13.3% slower**: `1 - 211.52 /244.51 = 0133`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`