### PR TITLE
Fixes PandasData Wrapper Support for Query Method

### DIFF
--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -1244,6 +1244,28 @@ def Test(dataFrame, symbol):
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]
+        public void BackwardsCompatibilityDataFrame_query_index(string index, bool cache = false)
+        {
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            using (Py.GIL())
+            {
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+                    $@"
+def Test(dataFrame, symbol):
+    time = '2011-02-01'
+    data = dataFrame.lastprice.unstack(0).query('index > @time')
+    data = data[{index}]
+    if data is 0:
+        raise Exception('Data is zero')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(GetTestDataFrame(Symbols.SPY, 10), Symbols.SPY));
+            }
+        }
+
+        [TestCase("'SPY'", true)]
+        [TestCase("symbol")]
+        [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_reindex_like(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);


### PR DESCRIPTION
#### Description
query/eval methods need to look for a scope variable at a higher level since the wrapper classes are children of pandas classes.

#### Related Issue
Closes #4453 

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
New unit test.
Test algorithm in QC Cloud:
```python
class Issue4453Algorithm(QCAlgorithm):
    def Initialize(self):
        self.SetStartDate(2011, 2, 5)
        self.SetCash(100000)
        symbol = self.AddEquity("SPY", Resolution.Minute).Symbol
        time = datetime(2011,2,1)
        df = self.History(self.AddEquity(symbol, 10, Resolution.Daily).close.unstack(0)
        df2 = df.query('index > @time')
        self.Quit(df2)
```
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`