### PR TITLE
Fix thread safety in WebSocketClientWrapper.Send

### DIFF
--- a/Brokerages/WebSocketClientWrapper.cs
+++ b/Brokerages/WebSocketClientWrapper.cs
@@ -50,10 +50,13 @@ namespace QuantConnect.Brokerages
         /// Wraps send method
         /// </summary>
         /// <param name="data"></param>
-        public async void Send(string data)
+        public void Send(string data)
         {
-            var buffer = new ArraySegment<byte>(Encoding.UTF8.GetBytes(data));
-            await _client.SendAsync(buffer, WebSocketMessageType.Text, true, _cts.Token);
+            lock (_locker)
+            {
+                var buffer = new ArraySegment<byte>(Encoding.UTF8.GetBytes(data));
+                _client.SendAsync(buffer, WebSocketMessageType.Text, true, _cts.Token).SynchronouslyAwaitTask();
+            }
         }
 
         /// <summary>

--- a/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageAdditionalTests.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Brokerages;
@@ -83,6 +85,56 @@ namespace QuantConnect.Tests.Brokerages.GDAX
                 brokerage.Disconnect();
                 Assert.IsFalse(brokerage.IsConnected);
             }
+        }
+
+        [Test]
+        public void DataQueueHandlerConnectsAndSubscribes()
+        {
+            var symbols = new[]
+            {
+                "LTCUSD", "LTCEUR", "LTCBTC",
+                "BTCUSD", "BTCEUR", "BTCGBP",
+                "ETHBTC", "ETHUSD", "ETHEUR",
+                "BCHBTC", "BCHUSD", "BCHEUR",
+                "XRPUSD", "XRPEUR", "XRPBTC",
+                "EOSUSD", "EOSEUR", "EOSBTC",
+                "XLMUSD", "XLMEUR", "XLMBTC",
+                "ETCUSD", "ETCEUR", "ETCBTC",
+                "ZRXUSD", "ZRXEUR", "ZRXBTC"
+            }
+            .Select(ticker => Symbol.Create(ticker, SecurityType.Crypto, Market.GDAX))
+            .ToList();
+
+            using (var dqh = GetDataQueueHandler())
+            {
+                dqh.Connect();
+                Assert.IsTrue(dqh.IsConnected);
+
+                dqh.Subscribe(symbols);
+
+                Thread.Sleep(5000);
+
+                dqh.Unsubscribe(symbols);
+
+                dqh.Disconnect();
+                Assert.IsFalse(dqh.IsConnected);
+            }
+        }
+
+        private static GDAXDataQueueHandler GetDataQueueHandler()
+        {
+            var wssUrl = Config.Get("gdax-url", "wss://ws-feed.pro.coinbase.com");
+            var webSocketClient = new WebSocketClientWrapper();
+            var restClient = new RestClient("https://api.pro.coinbase.com");
+            var apiKey = Config.Get("gdax-api-key");
+            var apiSecret = Config.Get("gdax-api-secret");
+            var passPhrase = Config.Get("gdax-passphrase");
+            var algorithm = new QCAlgorithm();
+            var userId = Config.GetInt("job-user-id");
+            var userToken = Config.Get("api-access-token");
+            var priceProvider = new ApiPriceProvider(userId, userToken);
+
+            return new GDAXDataQueueHandler(wssUrl, webSocketClient, restClient, apiKey, apiSecret, passPhrase, algorithm, priceProvider);
         }
 
         private static GDAXBrokerage GetBrokerage()


### PR DESCRIPTION

#### Description
- Added missing `lock` statement in `WebSocketClientWrapper.Send`

#### Related Issue
#4431 

#### Motivation and Context
- `InvalidOperationException` when `Subscribe` called from multiple threads:
```
There is already one outstanding 'SendAsync' call for this WebSocket instance. 
ReceiveAsync and SendAsync can be called simultaneously, 
but at most one outstanding operation for each of them is allowed at the same time.
```

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Local + cloud testing
- GdaxDataQueueHandler usage in QC backend software

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`