### PR TITLE
Adjust Algorithm.Python PostBuildEvent location and ensure scripts pass

### DIFF
--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -311,10 +311,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent Condition="'$(OS)' == 'Windows_NT' ">
-      build
+      $(ProjectDir)build
     </PostBuildEvent>
     <PostBuildEvent Condition="'$(OS)' != 'Windows_NT'">
-      ./build.sh
+      $(ProjectDir)build.sh
     </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.30\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.30\build\QuantConnect.pythonnet.targets')" />

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -155,8 +155,12 @@
     <None Include="BasicTemplateOptionTradesAlgorithm.py" />
     <None Include="BrokerageModelAlgorithm.py" />
     <None Include="BubbleAlgorithm.py" />
-    <None Include="build.sh" />
-    <None Include="build.bat" />
+    <None Include="build.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="build.bat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="CoarseFineFundamentalComboAlgorithm.py" />
     <None Include="CoarseFineFundamentalRegressionAlgorithm.py" />
     <None Include="CoarseFundamentalTop3Algorithm.py" />
@@ -311,10 +315,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent Condition="'$(OS)' == 'Windows_NT' ">
-      $(ProjectDir)build
+      build
     </PostBuildEvent>
     <PostBuildEvent Condition="'$(OS)' != 'Windows_NT'">
-      $(ProjectDir)build.sh
+      ./build.sh
     </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\QuantConnect.pythonnet.1.0.5.30\build\QuantConnect.pythonnet.targets" Condition="Exists('..\packages\QuantConnect.pythonnet.1.0.5.30\build\QuantConnect.pythonnet.targets')" />

--- a/Algorithm.Python/build.bat
+++ b/Algorithm.Python/build.bat
@@ -1,12 +1,9 @@
-REM QuantConnect Lean Engine -- Python Build Script.
-del Python.Runtime.dll
-
 REM Python Compile the Algorithm with all the files in current directory
-nPython -m compileall -lq .
+nPython -m compileall -lq ..\..\
 
 REM Copy to the Lean Algorithm Project
-copy *.pyc ..\..\..\Launcher\bin\Debug >NUL
-copy *.pyc ..\..\..\Launcher\bin\Release >NUL
-copy *.pyc ..\..\..\Tests\bin\Debug >NUL
+copy ..\..\__pycache__\*.pyc ..\..\..\Launcher\bin\Debug >NUL
+copy ..\..\__pycache__\*.pyc ..\..\..\Launcher\bin\Release >NUL
+copy ..\..\__pycache__\*.pyc ..\..\..\Tests\bin\Debug >NUL
 
 REM Script intentionally discards errors. This line ensures the exit code is 0.

--- a/Algorithm.Python/build.bat
+++ b/Algorithm.Python/build.bat
@@ -8,3 +8,5 @@ REM Copy to the Lean Algorithm Project
 copy *.pyc ..\..\..\Launcher\bin\Debug >NUL
 copy *.pyc ..\..\..\Launcher\bin\Release >NUL
 copy *.pyc ..\..\..\Tests\bin\Debug >NUL
+
+REM Script intentionally discards errors. This line ensures the exit code is 0.

--- a/Algorithm.Python/build.sh
+++ b/Algorithm.Python/build.sh
@@ -4,3 +4,6 @@ mono nPython.exe -m compileall -lq .
 cp *.pyc ../../../Launcher/bin/Debug/
 cp *.pyc ../../../Launcher/bin/Release/
 cp *.pyc ../../../Tests/bin/Debug/
+
+# Script intentionally discards errors. The line below ensures the exit code is 0.
+exit 0

--- a/Algorithm.Python/build.sh
+++ b/Algorithm.Python/build.sh
@@ -1,9 +1,9 @@
 ﻿#!/bin/bash
-mono nPython.exe -m compileall -lq .
+mono nPython.exe -m compileall -lq ../../
 
-cp *.pyc ../../../Launcher/bin/Debug/
-cp *.pyc ../../../Launcher/bin/Release/
-cp *.pyc ../../../Tests/bin/Debug/
+cp ../../__pycache__/*.pyc ../../../Launcher/bin/Debug > /dev/null
+cp ../../__pycache__/*.pyc ../../../Launcher/bin/Release > /dev/null
+cp ../../__pycache__/*.pyc ../../../Tests/bin/Debug > /dev/null
 
 # Script intentionally discards errors. The line below ensures the exit code is 0.
 exit 0


### PR DESCRIPTION
#### Description
Changes the location of the PostBuildEvent script in `Algorithm.Python`.

#### Related Issue
Closes https://github.com/QuantConnect/Lean/issues/4459

#### Motivation and Context
Allows the Python project to be referenced in other solution files.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Windows yes.
Mono, no.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. *Not required for this change.*
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`