### PR TITLE
Fixes History Request Data Time Zone

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFuturesHistoryAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesHistoryAlgorithm.cs
@@ -20,6 +20,9 @@ using QuantConnect.Data;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Util;
+using QuantConnect.Interfaces;
+using System.Collections.Generic;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -32,7 +35,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="history and warm up" />
     /// <meta name="tag" content="history" />
     /// <meta name="tag" content="futures" />
-    public class BasicTemplateFuturesHistoryAlgorithm : QCAlgorithm
+    public class BasicTemplateFuturesHistoryAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         // S&P 500 EMini futures
         private string [] roots = new []
@@ -54,6 +57,17 @@ namespace QuantConnect.Algorithm.CSharp
             }
 
             SetBenchmark(d => 1000000);
+
+            Schedule.On(DateRules.EveryDay(), TimeRules.Every(TimeSpan.FromHours(1)), MakeHistoryCall);
+        }
+
+        private void MakeHistoryCall()
+        {
+            var history = History(10, Resolution.Minute);
+            if (history.IsNullOrEmpty())
+            {
+                throw new Exception($"Empty history at {Time}");
+            }
         }
 
         /// <summary>
@@ -100,5 +114,62 @@ namespace QuantConnect.Algorithm.CSharp
         {
             Log(orderEvent.ToString());
         }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "371857150"}
+        };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFuturesHistoryAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesHistoryAlgorithm.cs
@@ -20,7 +20,6 @@ using QuantConnect.Data;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Data.UniverseSelection;
-using QuantConnect.Util;
 using QuantConnect.Interfaces;
 using System.Collections.Generic;
 
@@ -44,6 +43,8 @@ namespace QuantConnect.Algorithm.CSharp
             Futures.Metals.Gold,
         };
 
+        private int _successCount = 0;
+
         public override void Initialize()
         {
             SetStartDate(2013, 10, 8);
@@ -64,9 +65,18 @@ namespace QuantConnect.Algorithm.CSharp
         private void MakeHistoryCall()
         {
             var history = History(10, Resolution.Minute);
-            if (history.IsNullOrEmpty())
+            if (history.Count() < 10)
             {
                 throw new Exception($"Empty history at {Time}");
+            }
+            _successCount++;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_successCount < 49)
+            {
+                throw new Exception($"Scheduled Event did not assert history call as many times as expected: {_successCount}/49");
             }
         }
 

--- a/Algorithm.Python/BasicTemplateFuturesHistoryAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesHistoryAlgorithm.py
@@ -50,11 +50,17 @@ class BasicTemplateFuturesHistoryAlgorithm(QCAlgorithm):
         self.SetBenchmark(lambda x: 1000000)
 
         self.Schedule.On(self.DateRules.EveryDay(), self.TimeRules.Every(timedelta(hours=1)), self.MakeHistoryCall)
+        self.successCount = 0
 
     def MakeHistoryCall(self):
         history = self.History(self.Securities.keys(), 10, Resolution.Minute)
-        if history.empty:
+        if len(history) < 10:
             raise Exception(f'Empty history at {self.Time}')
+        self.successCount += 1
+
+    def OnEndOfAlgorithm(self):
+        if self.successCount < 49:
+            raise Exception(f'Scheduled Event did not assert history call as many times as expected: {_successCount}/49')
 
     def OnData(self,slice):
         if self.Portfolio.Invested: return

--- a/Algorithm.Python/BasicTemplateFuturesHistoryAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesHistoryAlgorithm.py
@@ -46,32 +46,34 @@ class BasicTemplateFuturesHistoryAlgorithm(QCAlgorithm):
 
         futureGC = self.AddFuture(Futures.Metals.Gold, Resolution.Minute)
         futureGC.SetFilter(timedelta(0), timedelta(182))
-        
+
         self.SetBenchmark(lambda x: 1000000)
+
+        self.Schedule.On(self.DateRules.EveryDay(), self.TimeRules.Every(timedelta(hours=1)), self.MakeHistoryCall)
+
+    def MakeHistoryCall(self):
+        history = self.History(self.Securities.keys(), 10, Resolution.Minute)
+        if history.empty:
+            raise Exception(f'Empty history at {self.Time}')
 
     def OnData(self,slice):
         if self.Portfolio.Invested: return
         for chain in slice.FutureChains:
             for contract in chain.Value:
-                self.Log("{0},Bid={1} Ask={2} Last={3} OI={4}".format(
-                        contract.Symbol.Value,
-                        contract.BidPrice,
-                        contract.AskPrice,
-                        contract.LastPrice,
-                        contract.OpenInterest))
-
+                self.Log(f'{contract.Symbol.Value},' +
+                         f'Bid={contract.BidPrice} ' +
+                         f'Ask={contract.AskPrice} ' +
+                         f'Last={contract.LastPrice} ' +
+                         f'OI={contract.OpenInterest}')
 
     def OnSecuritiesChanged(self, changes):
         for change in changes.AddedSecurities:
             history = self.History(change.Symbol, 10, Resolution.Minute).sort_index(level='time', ascending=False)[:3]
-            
+
             for index, row in history.iterrows():
-                self.Log("History: " + str(index[1])
-                        + ": " + index[2].strftime("%m/%d/%Y %I:%M:%S %p")
-                        + " > " + str(row.close))
-                        
+                self.Log(f'History: {index[1]} : {index[2]:%m/%d/%Y %I:%M:%S %p} > {row.close}')
+
     def OnOrderEvent(self, orderEvent):
         # Order fill event handler. On an order fill update the resulting information is passed to this method.
         # Order event details containing details of the events
-        self.Log(str(orderEvent))
-
+        self.Log(f'{orderEvent}')

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -79,6 +79,11 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         /// </summary>
         protected virtual Subscription CreateSubscription(HistoryRequest request, DateTime start, DateTime end)
         {
+            // Tradable dates are defined with the data time zone to access the right source
+            var tradableDates = Time.EachTradeableDay(request.ExchangeHours,
+                start.ConvertFromUtc(request.DataTimeZone),
+                end.ConvertFromUtc(request.DataTimeZone));
+
             // data reader expects these values in local times
             start = start.ConvertFromUtc(request.ExchangeHours.TimeZone);
             end = end.ConvertFromUtc(request.ExchangeHours.TimeZone);
@@ -120,7 +125,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 end,
                 mapFileResolver,
                 _factorFileProvider,
-                Time.EachTradeableDay(request.ExchangeHours, start, end),
+                tradableDates,
                 false,
                 _dataCacheProvider
                 );


### PR DESCRIPTION
#### Description
The tradable days of the history request should respect the data time zone since the data source files also do.

Upgrade `BasicTemplateFuturesHistoryAlgorithm` to a regression algorithm and add a scheduled event to test history requests every hour.

#### Related Issue
Closes #4471

#### Motivation and Context
Bug fix.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New regression tests.
Run algorithm from the community forum, [History Bug when using Futures Contracts](https://www.quantconnect.com/forum/discussion/8238), in QuantConnect Cloud.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`