### PR TITLE
Do not throw runtime errors during IB reset times

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -3145,11 +3145,18 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             if (result.HasError)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, result.ErrorCode.ToString(), result.ErrorMessage));
-
-                if (throwException)
+                if (IsWithinScheduledServerResetTimes())
                 {
-                    throw new Exception($"InteractiveBrokersBrokerage.CheckIbAutomaterError(): {result.ErrorCode} - {result.ErrorMessage}");
+                    Log.Trace($"IBAutomater error during server reset times: {result.ErrorCode} - {result.ErrorMessage}, restarting after reset time.");
+                }
+                else
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, result.ErrorCode.ToString(), result.ErrorMessage));
+
+                    if (throwException)
+                    {
+                        throw new Exception($"InteractiveBrokersBrokerage.CheckIbAutomaterError(): {result.ErrorCode} - {result.ErrorMessage}");
+                    }
                 }
             }
         }


### PR DESCRIPTION

#### Description
- IBAutomater errors returned during IB reset times will no longer cause runtime errors.

#### Related Issue
Closes #4480 

#### Motivation and Context
- Live algorithm termination

#### Requires Documentation Change
No

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.