### PR TITLE
Adds EmaCrossFuturesFrontMonthAlgorithm

### DIFF
--- a/Algorithm.CSharp/EmaCrossFuturesFrontMonthAlgorithm.cs
+++ b/Algorithm.CSharp/EmaCrossFuturesFrontMonthAlgorithm.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Algorithm.CSharp
             // Add a custom chart to track the EMA cross
             var chart = new Chart("EMA Cross");
             chart.AddSeries(new Series("Fast", SeriesType.Line, 0));
-            chart.AddSeries(new Series("Slow", SeriesType.Line, 1));
+            chart.AddSeries(new Series("Slow", SeriesType.Line, 0));
             AddChart(chart);
         }
 

--- a/Algorithm.CSharp/EmaCrossFuturesFrontMonthAlgorithm.cs
+++ b/Algorithm.CSharp/EmaCrossFuturesFrontMonthAlgorithm.cs
@@ -1,0 +1,128 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Indicators;
+using QuantConnect.Securities;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This example demonstrates how to implement a cross moving average for the futures front contract
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="indicator" />
+    /// <meta name="tag" content="futures" />
+    public class EmaCrossFuturesFrontMonthAlgorithm : QCAlgorithm
+    {
+        private const decimal _tolerance = 0.001m;
+        private Symbol _symbol;
+        private ExponentialMovingAverage _fast;
+        private ExponentialMovingAverage _slow;
+        private IDataConsolidator _consolidator;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 08);
+            SetEndDate(2013, 10, 10);
+            SetCash(1000000);
+
+            var future = AddFuture(Futures.Metals.Gold);
+
+            // Only consider the front month contract
+            future.SetFilter(x => x.FrontMonth().OnlyApplyFilterAtMarketOpen());
+
+            // Create two exponential moving averages
+            _fast = new ExponentialMovingAverage(100);
+            _slow = new ExponentialMovingAverage(300);
+
+            // Add a custom chart to track the EMA cross
+            var chart = new Chart("EMA Cross");
+            chart.AddSeries(new Series("Fast", SeriesType.Line, 1));
+            chart.AddSeries(new Series("Slow", SeriesType.Line, 1));
+            AddChart(chart);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            SecurityHolding holding;
+            if (Portfolio.TryGetValue(_symbol, out holding))
+            {
+                // Buy the futures' front contract when the fast EMA is above the slow one
+                if (_fast > _slow * (1 + _tolerance))
+                {
+                    if (!holding.Invested)
+                    {
+                        SetHoldings(_symbol, .1);
+                        PlotEma();
+                    }
+                }
+                else if (holding.Invested)
+                {
+                    Liquidate(_symbol);
+                    PlotEma();
+                }
+            }
+        }
+
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            if (changes.RemovedSecurities.Count > 0)
+            {
+                // Remove the consolidator for the previous contract
+                // and reset the indicators
+                if (_symbol != null && _consolidator != null)
+                {
+                    SubscriptionManager.RemoveConsolidator(_symbol, _consolidator);
+                    _fast.Reset();
+                    _slow.Reset();
+                }
+                // We don't need to call Liquidate(_symbol),
+                // since its positions are liquidated because the contract has expired.
+            }
+
+            // Only one security will be added: the new front contract
+            _symbol = changes.AddedSecurities.SingleOrDefault().Symbol;
+
+            // Create a new consolidator and register the indicators to it
+            _consolidator = ResolveConsolidator(_symbol, Resolution.Minute);
+            RegisterIndicator(_symbol, _fast, _consolidator);
+            RegisterIndicator(_symbol, _slow, _consolidator);
+
+            // Update the consolidator with historical data
+            // This will update the registered indicators
+            History(new[] { _symbol }, _slow.WarmUpPeriod)
+                .PushThrough(bar =>
+                {
+                    if (bar.DataType == MarketDataType.TradeBar)
+                    {
+                        _consolidator.Update(bar);
+                    }
+                });
+
+            PlotEma();
+        }
+
+        private void PlotEma()
+        {
+            Plot("EMA Cross", "Fast", _fast);
+            Plot("EMA Cross", "Slow", _slow);
+        }
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -158,6 +158,7 @@
     <Compile Include="AltData\TiingoNewsAlgorithm.cs" />
     <Compile Include="AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs" />
     <Compile Include="AutomaticIndicatorWarmupRegressionAlgorithm.cs" />
+    <Compile Include="EmaCrossFuturesFrontMonthAlgorithm.cs" />
     <Compile Include="OpenInterestFuturesRegressionAlgorithm.cs" />
     <Compile Include="CustomPartialFillModelAlgorithm.cs" />
     <Compile Include="EquityTradeAndQuotesRegressionAlgorithm.cs" />

--- a/Algorithm.Python/EmaCrossFuturesFrontMonthAlgorithm.py
+++ b/Algorithm.Python/EmaCrossFuturesFrontMonthAlgorithm.py
@@ -55,7 +55,7 @@ class EmaCrossFuturesFrontMonthAlgorithm(QCAlgorithm):
         # Add a custom chart to track the EMA cross
         chart = Chart('EMA Cross')
         chart.AddSeries(Series('Fast', SeriesType.Line, 0))
-        chart.AddSeries(Series('Slow', SeriesType.Line, 1))
+        chart.AddSeries(Series('Slow', SeriesType.Line, 0))
         self.AddChart(chart)
 
     def OnData(self,slice):

--- a/Algorithm.Python/EmaCrossFuturesFrontMonthAlgorithm.py
+++ b/Algorithm.Python/EmaCrossFuturesFrontMonthAlgorithm.py
@@ -40,6 +40,7 @@ class EmaCrossFuturesFrontMonthAlgorithm(QCAlgorithm):
         future = self.AddFuture(Futures.Metals.Gold);
 
         # Only consider the front month contract
+        # Update the universe once per day to improve performance
         future.SetFilter(lambda x: x.FrontMonth().OnlyApplyFilterAtMarketOpen())
 
         # Symbol of the current contract
@@ -53,7 +54,7 @@ class EmaCrossFuturesFrontMonthAlgorithm(QCAlgorithm):
 
         # Add a custom chart to track the EMA cross
         chart = Chart('EMA Cross')
-        chart.AddSeries(Series('Fast', SeriesType.Line, 1))
+        chart.AddSeries(Series('Fast', SeriesType.Line, 0))
         chart.AddSeries(Series('Slow', SeriesType.Line, 1))
         self.AddChart(chart)
 
@@ -89,13 +90,9 @@ class EmaCrossFuturesFrontMonthAlgorithm(QCAlgorithm):
         self.RegisterIndicator(self.symbol, self.fast, self.consolidator)
         self.RegisterIndicator(self.symbol, self.slow, self.consolidator)
 
-        # Update the consolidator with historical data
-        # This will update the registered indicators
-        history = self.History(self.symbol, self.slow.WarmUpPeriod)
-        for index, row in history.iterrows():
-            time = index[2]
-            bar = TradeBar(time, self.symbol, row.open, row.high, row.low, row.close, 0)
-            self.consolidator.Update(bar)
+        #  Warm up the indicators
+        self.WarmUpIndicator(self.symbol, self.fast, Resolution.Minute)
+        self.WarmUpIndicator(self.symbol, self.slow, Resolution.Minute)
 
         self.PlotEma()
 

--- a/Algorithm.Python/EmaCrossFuturesFrontMonthAlgorithm.py
+++ b/Algorithm.Python/EmaCrossFuturesFrontMonthAlgorithm.py
@@ -1,0 +1,104 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Indicators")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Data.Market import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Indicators import *
+from QuantConnect.Securities import *
+
+### <summary>
+### This example demonstrates how to implement a cross moving average for the futures front contract
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="indicator" />
+### <meta name="tag" content="futures" />
+class EmaCrossFuturesFrontMonthAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 8)
+        self.SetEndDate(2013, 10, 10)
+        self.SetCash(1000000)
+
+        future = self.AddFuture(Futures.Metals.Gold);
+
+        # Only consider the front month contract
+        future.SetFilter(lambda x: x.FrontMonth().OnlyApplyFilterAtMarketOpen())
+
+        # Symbol of the current contract
+        self.symbol = None
+
+        # Create two exponential moving averages
+        self.fast = ExponentialMovingAverage(100)
+        self.slow = ExponentialMovingAverage(300)
+        self.tolerance = 0.001
+        self.consolidator = None
+
+        # Add a custom chart to track the EMA cross
+        chart = Chart('EMA Cross')
+        chart.AddSeries(Series('Fast', SeriesType.Line, 1))
+        chart.AddSeries(Series('Slow', SeriesType.Line, 1))
+        self.AddChart(chart)
+
+    def OnData(self,slice):
+
+        holding = None if self.symbol is None else self.Portfolio.get(self.symbol)
+        if holding is not None:
+            # Buy the futures' front contract when the fast EMA is above the slow one
+            if self.fast.Current.Value > self.slow.Current.Value * (1 + self.tolerance):
+                if not holding.Invested:
+                    self.SetHoldings(self.symbol, .1)
+                    self.PlotEma()
+            elif holding.Invested:
+                self.Liquidate(self.symbol)
+                self.PlotEma()
+
+    def OnSecuritiesChanged(self, changes):
+        if len(changes.RemovedSecurities) > 0:
+            # Remove the consolidator for the previous contract
+            # and reset the indicators
+            if self.symbol is not None and self.consolidator is not None:
+                self.SubscriptionManager.RemoveConsolidator(self.symbol, self.consolidator)
+                self.fast.Reset()
+                self.slow.Reset()
+            # We don't need to call Liquidate(_symbol),
+            # since its positions are liquidated because the contract has expired.
+
+        # Only one security will be added: the new front contract
+        self.symbol = changes.AddedSecurities[0].Symbol
+
+        # Create a new consolidator and register the indicators to it
+        self.consolidator = self.ResolveConsolidator(self.symbol, Resolution.Minute)
+        self.RegisterIndicator(self.symbol, self.fast, self.consolidator)
+        self.RegisterIndicator(self.symbol, self.slow, self.consolidator)
+
+        # Update the consolidator with historical data
+        # This will update the registered indicators
+        history = self.History(self.symbol, self.slow.WarmUpPeriod)
+        for index, row in history.iterrows():
+            time = index[2]
+            bar = TradeBar(time, self.symbol, row.open, row.high, row.low, row.close, 0)
+            self.consolidator.Update(bar)
+
+        self.PlotEma()
+
+    def PlotEma(self):
+        self.Plot('EMA Cross', 'Fast', self.fast.Current.Value)
+        self.Plot('EMA Cross', 'Slow', self.slow.Current.Value)

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -181,6 +181,7 @@
     <None Include="DropboxBaseDataUniverseSelectionAlgorithm.py" />
     <None Include="DropboxUniverseSelectionAlgorithm.py" />
     <None Include="DropboxCoarseFineAlgorithm.py" />
+    <None Include="EmaCrossFuturesFrontMonthAlgorithm.py" />
     <None Include="EmaCrossUniverseSelectionAlgorithm.py" />
     <None Include="EmaCrossUniverseSelectionFrameworkAlgorithm.py" />
     <None Include="ETFGlobalRotationAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -88,6 +88,7 @@
     <Compile Include="DropboxCoarseFineAlgorithm.py" />
     <Compile Include="DropboxUniverseSelectionAlgorithm.py" />
     <Compile Include="DynamicSecurityDataAlgorithm.py" />
+    <Compile Include="EmaCrossFuturesFrontMonthAlgorithm.py" />
     <Compile Include="EmaCrossUniverseSelectionAlgorithm.py" />
     <Compile Include="EmaCrossUniverseSelectionFrameworkAlgorithm.py" />
     <Compile Include="ETFGlobalRotationAlgorithm.py" />
@@ -133,7 +134,6 @@
     <Compile Include="PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py" />
     <Compile Include="PortfolioRebalanceOnCustomFuncRegressionAlgorithm.py" />
     <Compile Include="PortfolioRebalanceOnDateRulesRegressionAlgorithm.py" />
-    <Compile Include="PsychSignalSentimentRegressionAlgorithm.py" />
     <Compile Include="PythonDictionaryFeatureRegressionAlgorithm.py" />
     <Compile Include="PytorchNeuralNetworkAlgorithm.py" />
     <Compile Include="QuandlFuturesDataAlgorithm.py" />


### PR DESCRIPTION
#### Description
This example shows how to create an EMA cross algorithm for a futures' front contract. Once the contract is added, the indicators are registered to a new consolidator and warmed up with historical data. When a contract is removed, the consolidator is removed and the indicators are reset. We don't need to liquidate it, because it's liquidated automatically since it has expired.

#### Motivation and Context
Provide an example for common user requests. 

#### Requires Documentation Change
Yes. I can be featured at [Futures' section](https://www.quantconnect.com/docs/data-library/futures).

#### How Has This Been Tested?
Locally and in QuantConnect Cloud using 20190101-2020603 date range.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`